### PR TITLE
Reading Settings: Update Related Content preview dates to use last year instead of 2015

### DIFF
--- a/client/my-sites/site-settings/related-posts/related-content-preview.jsx
+++ b/client/my-sites/site-settings/related-posts/related-content-preview.jsx
@@ -40,6 +40,7 @@ const RelatedContentPreview = ( {
 			} ),
 		},
 	];
+	const postDate = `August 8, ${ new Date().getFullYear() - 1 }`;
 
 	return (
 		<div className="related-posts__preview">
@@ -63,7 +64,7 @@ const RelatedContentPreview = ( {
 								<h4 className="related-posts__preview-post-title">
 									<a className="related-posts__preview-post-a">{ post.title }</a>
 								</h4>
-								{ showDate && <span>{ `August 8, ${ new Date().getFullYear() - 1 }` }</span> }
+								{ showDate && <span>{ postDate }</span> }
 								{ showContext && (
 									<p className="related-posts__preview-post-context">{ post.topic }</p>
 								) }

--- a/client/my-sites/site-settings/related-posts/related-content-preview.jsx
+++ b/client/my-sites/site-settings/related-posts/related-content-preview.jsx
@@ -15,7 +15,6 @@ const RelatedContentPreview = ( {
 				textOnly: true,
 				context: 'Demo content for related posts',
 			} ),
-			date: 'August 8, 2005',
 			topic: translate( 'In "Mobile"', {
 				context: 'topic post is located in',
 			} ),
@@ -26,7 +25,6 @@ const RelatedContentPreview = ( {
 				textOnly: true,
 				context: 'Demo content for related posts',
 			} ),
-			date: 'August 8, 2005',
 			topic: translate( 'In "Mobile"', {
 				context: 'topic post is located in',
 			} ),
@@ -37,7 +35,6 @@ const RelatedContentPreview = ( {
 				textOnly: true,
 				context: 'Demo content for related posts',
 			} ),
-			date: 'August 8, 2005',
 			topic: translate( 'In "Upgrade"', {
 				context: 'topic post is located in',
 			} ),
@@ -66,7 +63,7 @@ const RelatedContentPreview = ( {
 								<h4 className="related-posts__preview-post-title">
 									<a className="related-posts__preview-post-a">{ post.title }</a>
 								</h4>
-								{ showDate && <span>{ post.date }</span> }
+								{ showDate && <span>{ `August 8, ${ new Date().getFullYear() - 1 }` }</span> }
 								{ showContext && (
 									<p className="related-posts__preview-post-context">{ post.topic }</p>
 								) }


### PR DESCRIPTION
#### Proposed Changes

* Update the date displayed on the preview placeholder posts in the `RelatedContentPreview` component.

Fixes https://github.com/Automattic/wp-calypso/issues/72997.

| Before | After |
| ------------- | ------------- |
| ![Markup on 2023-02-06 at 11:31:17](https://user-images.githubusercontent.com/25105483/216949058-38816382-ffe3-4057-8e3d-0e624c280f57.png) | ![Markup on 2023-02-06 at 11:30:04](https://user-images.githubusercontent.com/25105483/216949017-3a726701-239f-43b8-88f1-29e83e016988.png) |

#### Testing Instructions

1. Apply the PR to your staging environment and build it.
2. Navigate to `http://calypso.localhost:3000/settings/reading/[site-address]`.
3. Enable "_Show related content after posts_" and "_Show post publish date_" toggles.
4. All three posts should use `August 8, 2022` date (where 2022 matches the last calendar year).

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->