### PR TITLE
Plans 2023: Fix action buttons in comparison grid

### DIFF
--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -27,7 +27,7 @@ type PlanFeaturesActionsButtonProps = {
 	isPopular?: boolean;
 	isInSignup: boolean;
 	isLaunchPage?: boolean;
-	onUpgradeClick?: () => void;
+	onUpgradeClick: () => void;
 	planName: TranslateResult;
 	planType: string;
 	flowName: string;

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -246,6 +246,7 @@ export class PlanFeatures2023Grid extends Component<
 							manageHref={ manageHref }
 							canUserPurchasePlan={ canUserPurchasePlan }
 							selectedSiteSlug={ selectedSiteSlug }
+							onUpgradeClick={ this.handleUpgradeClick }
 						/>
 						<div className="plan-features-2023-grid__toggle-plan-comparison-button-container">
 							<Button onClick={ this.toggleShowPlansComparisonGrid }>
@@ -535,7 +536,7 @@ export class PlanFeatures2023Grid extends Component<
 		} );
 	}
 
-	handleUpgradeClick( singlePlanProperties: PlanProperties ) {
+	handleUpgradeClick = ( singlePlanProperties: PlanProperties ) => {
 		const { onUpgradeClick: ownPropsOnUpgradeClick, selectedSiteSlug } = this.props;
 		const { cartItemForPlan, planName } = singlePlanProperties;
 
@@ -552,7 +553,7 @@ export class PlanFeatures2023Grid extends Component<
 		const planPath = getPlanPath( planName ) || '';
 		const checkoutUrlWithArgs = `/checkout/${ selectedSiteSlug }/${ planPath }`;
 		page( checkoutUrlWithArgs );
-	}
+	};
 
 	renderTopButtons( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
 		const {

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -228,6 +228,7 @@ type PlanComparisonGridProps = {
 	manageHref: string;
 	canUserPurchasePlan: boolean;
 	selectedSiteSlug: string | null;
+	onUpgradeClick: ( properties: PlanProperties ) => void;
 };
 type PlanComparisonGridHeaderProps = {
 	displayedPlansProperties: Array< PlanProperties >;
@@ -241,6 +242,7 @@ type PlanComparisonGridHeaderProps = {
 	manageHref: string;
 	canUserPurchasePlan: boolean;
 	selectedSiteSlug: string | null;
+	onUpgradeClick: ( properties: PlanProperties ) => void;
 };
 
 const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
@@ -255,6 +257,7 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 	manageHref,
 	canUserPurchasePlan,
 	selectedSiteSlug,
+	onUpgradeClick,
 } ) => {
 	const translate = useTranslate();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
@@ -266,106 +269,105 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 				className="plan-comparison-grid__header plan-comparison-grid__interval-toggle"
 				isInSignup={ isInSignup }
 			/>
-			{ visiblePlansProperties.map(
-				( { planName, planConstantObj, availableForPurchase, current, ...planPropertiesObj } ) => {
-					const headerClasses = classNames(
-						'plan-comparison-grid__header',
-						getPlanClass( planName ),
-						{
-							'popular-plan-parent-class': isBusinessPlan( planName ),
-							'plan-is-footer': isFooter,
-						}
-					);
+			{ visiblePlansProperties.map( ( planProperties ) => {
+				const { planName, planConstantObj, availableForPurchase, current, ...planPropertiesObj } =
+					planProperties;
+				const headerClasses = classNames(
+					'plan-comparison-grid__header',
+					getPlanClass( planName ),
+					{
+						'popular-plan-parent-class': isBusinessPlan( planName ),
+						'plan-is-footer': isFooter,
+					}
+				);
 
-					const rawPrice = planPropertiesObj.rawPrice;
-					const isLargeCurrency = rawPrice ? rawPrice > 99000 : false;
+				const rawPrice = planPropertiesObj.rawPrice;
+				const isLargeCurrency = rawPrice ? rawPrice > 99000 : false;
 
-					const showPlanSelect = ! allVisible && ! current;
+				const showPlanSelect = ! allVisible && ! current;
 
-					return (
-						<Cell
-							key={ planName }
-							isInSignup={ isInSignup }
-							className={ headerClasses }
-							textAlign="left"
-						>
-							{ isBusinessPlan( planName ) && (
-								<div className="plan-features-2023-grid__popular-badge">
-									<PlanPill isInSignup={ isInSignup }>{ translate( 'Popular' ) }</PlanPill>
-								</div>
-							) }
-							<PlanSelector>
-								{ showPlanSelect && (
-									<select
-										onChange={ ( event: ChangeEvent ) => onPlanChange( planName, event ) }
-										className="plan-comparison-grid__title-select"
-										value={ planName }
-									>
-										{ displayedPlansProperties.map(
-											( { planName: otherPlan, planConstantObj } ) => {
-												const isVisiblePlan = visiblePlansProperties.find(
-													( { planName } ) => planName === otherPlan
-												);
-
-												if ( isVisiblePlan && otherPlan !== planName ) {
-													return null;
-												}
-
-												return (
-													<option key={ otherPlan } value={ otherPlan }>
-														{ planConstantObj.getTitle() }
-													</option>
-												);
-											}
-										) }
-									</select>
-								) }
-								<h4 className="plan-comparison-grid__title">
-									{ planConstantObj.getTitle() }
-
-									{ showPlanSelect && <Gridicon icon="chevron-down" size={ 12 } color="#0675C4" /> }
-								</h4>
-							</PlanSelector>
-							<PlanFeatures2023GridHeaderPrice
-								currencyCode={ currencyCode }
-								discountPrice={ planPropertiesObj.discountPrice }
-								rawPrice={ rawPrice || 0 }
-								planName={ planName }
-								is2023OnboardingPricingGrid={ true }
-								isLargeCurrency={ isLargeCurrency }
-							/>
-							<div className="plan-comparison-grid__billing-info">
-								<PlanFeatures2023GridBillingTimeframe
-									rawPrice={ rawPrice }
-									rawPriceAnnual={ planPropertiesObj.rawPriceAnnual }
-									currencyCode={ planPropertiesObj.currencyCode }
-									annualPricePerMonth={ planPropertiesObj.annualPricePerMonth }
-									isMonthlyPlan={ planPropertiesObj.isMonthlyPlan }
-									translate={ translate }
-									billingTimeframe={ planConstantObj.getBillingTimeFrame() }
-								/>
+				return (
+					<Cell
+						key={ planName }
+						isInSignup={ isInSignup }
+						className={ headerClasses }
+						textAlign="left"
+					>
+						{ isBusinessPlan( planName ) && (
+							<div className="plan-features-2023-grid__popular-badge">
+								<PlanPill isInSignup={ isInSignup }>{ translate( 'Popular' ) }</PlanPill>
 							</div>
-							<PlanFeatures2023GridActions
-								currentSitePlanSlug={ currentSitePlanSlug }
-								manageHref={ manageHref }
-								canUserPurchasePlan={ canUserPurchasePlan }
-								current={ current ?? false }
-								availableForPurchase={ availableForPurchase }
-								className={ getPlanClass( planName ) }
-								freePlan={ isFreePlan( planName ) }
-								isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planName ) }
-								isPlaceholder={ planPropertiesObj.isPlaceholder }
-								isInSignup={ isInSignup }
-								isLaunchPage={ isLaunchPage }
-								planName={ planConstantObj.getTitle() }
-								planType={ planName }
-								flowName={ flowName }
-								selectedSiteSlug={ selectedSiteSlug }
+						) }
+						<PlanSelector>
+							{ showPlanSelect && (
+								<select
+									onChange={ ( event: ChangeEvent ) => onPlanChange( planName, event ) }
+									className="plan-comparison-grid__title-select"
+									value={ planName }
+								>
+									{ displayedPlansProperties.map( ( { planName: otherPlan, planConstantObj } ) => {
+										const isVisiblePlan = visiblePlansProperties.find(
+											( { planName } ) => planName === otherPlan
+										);
+
+										if ( isVisiblePlan && otherPlan !== planName ) {
+											return null;
+										}
+
+										return (
+											<option key={ otherPlan } value={ otherPlan }>
+												{ planConstantObj.getTitle() }
+											</option>
+										);
+									} ) }
+								</select>
+							) }
+							<h4 className="plan-comparison-grid__title">
+								{ planConstantObj.getTitle() }
+
+								{ showPlanSelect && <Gridicon icon="chevron-down" size={ 12 } color="#0675C4" /> }
+							</h4>
+						</PlanSelector>
+						<PlanFeatures2023GridHeaderPrice
+							currencyCode={ currencyCode }
+							discountPrice={ planPropertiesObj.discountPrice }
+							rawPrice={ rawPrice || 0 }
+							planName={ planName }
+							is2023OnboardingPricingGrid={ true }
+							isLargeCurrency={ isLargeCurrency }
+						/>
+						<div className="plan-comparison-grid__billing-info">
+							<PlanFeatures2023GridBillingTimeframe
+								rawPrice={ rawPrice }
+								rawPriceAnnual={ planPropertiesObj.rawPriceAnnual }
+								currencyCode={ planPropertiesObj.currencyCode }
+								annualPricePerMonth={ planPropertiesObj.annualPricePerMonth }
+								isMonthlyPlan={ planPropertiesObj.isMonthlyPlan }
+								translate={ translate }
+								billingTimeframe={ planConstantObj.getBillingTimeFrame() }
 							/>
-						</Cell>
-					);
-				}
-			) }
+						</div>
+						<PlanFeatures2023GridActions
+							currentSitePlanSlug={ currentSitePlanSlug }
+							manageHref={ manageHref }
+							canUserPurchasePlan={ canUserPurchasePlan }
+							current={ current ?? false }
+							availableForPurchase={ availableForPurchase }
+							className={ getPlanClass( planName ) }
+							freePlan={ isFreePlan( planName ) }
+							isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planName ) }
+							isPlaceholder={ planPropertiesObj.isPlaceholder }
+							isInSignup={ isInSignup }
+							isLaunchPage={ isLaunchPage }
+							planName={ planConstantObj.getTitle() }
+							planType={ planName }
+							flowName={ flowName }
+							selectedSiteSlug={ selectedSiteSlug }
+							onUpgradeClick={ () => onUpgradeClick( planProperties ) }
+						/>
+					</Cell>
+				);
+			} ) }
 		</Row>
 	);
 };
@@ -381,6 +383,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 	manageHref,
 	canUserPurchasePlan,
 	selectedSiteSlug,
+	onUpgradeClick,
 } ) => {
 	const translate = useTranslate();
 	const featureGroupMap = getPlanFeaturesGrouped();
@@ -541,6 +544,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 					manageHref={ manageHref }
 					canUserPurchasePlan={ canUserPurchasePlan }
 					selectedSiteSlug={ selectedSiteSlug }
+					onUpgradeClick={ onUpgradeClick }
 				/>
 				{ Object.values( featureGroupMap ).map( ( featureGroup: FeatureGroup ) => {
 					const features = featureGroup.get2023PricingGridSignupWpcomFeatures();
@@ -698,6 +702,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 					manageHref={ manageHref }
 					canUserPurchasePlan={ canUserPurchasePlan }
 					selectedSiteSlug={ selectedSiteSlug }
+					onUpgradeClick={ onUpgradeClick }
 				/>
 			</Grid>
 		</div>


### PR DESCRIPTION
#### Proposed Changes

* Adds the missing `onUpgradeClick` to the `PlanComparisonGrid` component which is passed down to the `PlanFeatures2023GridActions`.
* Also made the `onUpgradeClick` a mandatory prop for the `PlanFeatures2023GridActions` component.

#### Testing Instructions

<!--
Could you add as many details as possible to help others reproduce the issue and test the fix?
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/{SITE_ID}?flags=onboarding/2023-pricing-grid`
* Open the comparison grid by clicking on the "Compare Plans" button.
* Confirm that clicking on any of the action buttons in the comparison grid (both header and footer) add the correct plan to cart and that you are taken to the checkout page.
* Go to `/start/plans?flags=onboarding/2023-pricing-grid` and repeat the above two steps.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1474
