### PR TITLE
Social: show purchased item as owned in product lightbox

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -256,6 +256,11 @@ export const useStoreItemInfo = ( {
 		( item: SelectorProduct ) => {
 			const shouldShowCart = getShouldShowCart( item );
 			const isProductInCart = getIsProductInCart( item );
+			const isOwned = getIsOwned( item );
+
+			if ( isOwned ) {
+				return <>{ translate( 'Manage Subscription' ) }</>;
+			}
 
 			if ( ! shouldShowCart ) {
 				return <>{ translate( 'Proceed to checkout' ) }</>;


### PR DESCRIPTION
#### Proposed Changes

* Fixed text to show product ownership in the product lightbox

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox this D100413-code patch
* Buy Jetpack Social Basic Plan on your site
* Append `pricing/you-siteurl.site?site=you-siteurl.site` to https://cloud.jetpack.com`
and you will see "proceed to checkout" when you click on manage subscription against the jetpack social basic plan
<img width="1268" alt="Screenshot 2023-02-06 at 16 06 35" src="https://user-images.githubusercontent.com/6594561/216950066-3d5430d8-f711-418f-aec8-75dbb0762faf.png">
* Append `pricing/you-siteurl.site?site=you-siteurl.site` to your localhost or live site, and click on manage subscription against the social product and confirm that you see the updated text "manage subscription", clicking on which will take you to calypso
<img width="1218" alt="Screenshot 2023-02-06 at 16 13 42" src="https://user-images.githubusercontent.com/6594561/216951560-431b2592-2b20-4f4c-ac5b-078a1fabafc3.png">

* You will see the text, add to cart for the Jetpack Social Advanced plan since your site doesn't have that subscription. 

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #