### PR TITLE
E2E: Fix the Welcome Tour popup handler error 

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-welcome-tour-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-welcome-tour-component.ts
@@ -34,20 +34,28 @@ export class EditorWelcomeTourComponent {
 			return;
 		}
 
-		await editorFrame.waitForFunction(
-			async () =>
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				await ( window as any ).wp.data
-					.select( 'automattic/wpcom-welcome-guide' )
-					.isWelcomeGuideStatusLoaded()
-		);
+		await editorFrame.waitForFunction( async () => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const welcomeGuide = ( window as any )?.wp?.data?.select( 'automattic/wpcom-welcome-guide' );
+
+			if ( typeof welcomeGuide?.isWelcomeGuideStatusLoaded !== 'function' ) {
+				return false;
+			}
+
+			return await welcomeGuide.isWelcomeGuideStatusLoaded();
+		} );
 
 		await editorFrame.waitForFunction( async () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const actionPayload = await ( window as any ).wp.data
-				.dispatch( 'automattic/wpcom-welcome-guide' )
-				.setShowWelcomeGuide( false );
+			const welcomeGuide = ( window as any )?.wp?.data?.dispatch(
+				'automattic/wpcom-welcome-guide'
+			);
 
+			if ( typeof welcomeGuide?.setShowWelcomeGuide !== 'function' ) {
+				return false;
+			}
+
+			const actionPayload = await welcomeGuide.setShowWelcomeGuide( false );
 			return actionPayload.show === false;
 		} );
 	}


### PR DESCRIPTION
### Proposed Changes

Fix the issue where the Welcome Tour popup handler cannot access the store to read the popup status: 

```
frame.waitForFunction: TypeError: Cannot read properties of undefined (reading 'isWelcomeGuideStatusLoaded')
at eval (eval at predicate (eval at evaluate (:191:30)), <anonymous>:2:66)
    at predicate (eval at evaluate (:191:30), <anonymous>:10:20)
    at eval (eval at evaluate (:191:30), <anonymous>:19:82)
    at next (<anonymous>:4563:27)
    at <anonymous>:4573:7
    at Object.run (<anonymous>:4617:22)
    at eval (eval at evaluate (:191:30), <anonymous>:1:14)
    at UtilityScript.evaluate (<anonymous>:193:17)
    at UtilityScript.<anonymous> (<anonymous>:1:44)
    at EditorWelcomeTourComponent.forceDismissWelcomeTour (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/components/editor-welcome-tour-component.ts:37:21)
    at EditorPage.waitUntilLoaded (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/pages/editor-page.ts:160:3)
    at EditorPage.visit (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/pages/editor-page.ts:143:3)
    at Object.<anonymous> (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/editor/shared/privacy-testing.ts:53:5)
```

See example failures in [this job](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_atomic_production_desktop/9431022?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true).

### How?

We were expecting the wp data store to be fully initialized when calling `forceDismissWelcomeTour()`, hence the `Cannot read properties of undefined` error. All we need is to wait until the required properties are defined, which is what I've done in this PR.

### Testing Instructions

CI tests should pass.