### PR TITLE
Marketplace: Add Jetpack Search free plan

### DIFF
--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -1,5 +1,6 @@
 import {
 	PRODUCT_JETPACK_SEARCH,
+	PRODUCT_JETPACK_SEARCH_FREE,
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
 	WPCOM_FEATURES_INSTANT_SEARCH,
 } from '@automattic/calypso-products';
@@ -19,6 +20,7 @@ export const PREINSTALLED_PREMIUM_PLUGINS = {
 		feature: WPCOM_FEATURES_INSTANT_SEARCH,
 		jetpack_module: 'search',
 		products: {
+			free: PRODUCT_JETPACK_SEARCH_FREE,
 			monthly: PRODUCT_JETPACK_SEARCH_MONTHLY,
 			yearly: PRODUCT_JETPACK_SEARCH,
 		},

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -172,7 +172,6 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	if ( isPreinstalledPremiumPlugin ) {
 		return (
 			<div className="plugin-details-cta__container">
-				<QuerySitePurchases siteId={ selectedSite?.ID } />
 				<PluginDetailsCTAPreinstalledPremiumPlugins
 					isPluginInstalledOnsite={ isPluginInstalledOnsiteWithSubscription }
 					plugin={ plugin }

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -172,6 +172,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	if ( isPreinstalledPremiumPlugin ) {
 		return (
 			<div className="plugin-details-cta__container">
+				<QuerySitePurchases siteId={ selectedSite } />
 				<PluginDetailsCTAPreinstalledPremiumPlugins
 					isPluginInstalledOnsite={ isPluginInstalledOnsiteWithSubscription }
 					plugin={ plugin }

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -172,7 +172,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	if ( isPreinstalledPremiumPlugin ) {
 		return (
 			<div className="plugin-details-cta__container">
-				<QuerySitePurchases siteId={ selectedSite } />
+				<QuerySitePurchases siteId={ selectedSite?.ID } />
 				<PluginDetailsCTAPreinstalledPremiumPlugins
 					isPluginInstalledOnsite={ isPluginInstalledOnsiteWithSubscription }
 					plugin={ plugin }

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
@@ -33,8 +33,11 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 	);
 
 	const billingPeriod = useSelector( getBillingInterval );
-	const { isPreinstalledPremiumPluginUpgraded, preinstalledPremiumPluginProduct } =
-		usePreinstalledPremiumPlugin( plugin.slug );
+	const {
+		preinstalledPremiumPluginProduct,
+		isPreinstalledPremiumPluginFreeInstalled,
+		isPreinstalledPremiumPluginPaidInstalled,
+	} = usePreinstalledPremiumPlugin( plugin.slug );
 
 	const managedPluginMessage = (
 		<span className="plugin-details-cta__preinstalled">
@@ -62,6 +65,18 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 		</>
 	);
 
+	const startForFreeButton = (
+		<div className="plugin-details-cta__install">
+			<Button
+				className="plugin-details-cta__install-button"
+				href={ `/checkout/${ selectedSiteSlug }/${ preinstalledPremiumPluginProduct }` }
+				primary
+			>
+				{ translate( 'Start for Free' ) }
+			</Button>
+		</div>
+	);
+
 	const upgradeButton = (
 		<div className="plugin-details-cta__install">
 			<Button
@@ -85,10 +100,15 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 		</div>
 	);
 
-	if ( isSimple && isPreinstalledPremiumPluginUpgraded ) {
+	if ( isPreinstalledPremiumPluginPaidInstalled ) {
 		return managedPluginMessage;
 	}
-	if ( isSimple && ! isPreinstalledPremiumPluginUpgraded ) {
+
+	if ( ! isPreinstalledPremiumPluginFreeInstalled ) {
+		return startForFreeButton;
+	}
+
+	if ( isSimple ) {
 		return (
 			<>
 				{ pluginPrice }
@@ -98,7 +118,7 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 		);
 	}
 
-	if ( ! isSimple && ! isPluginInstalledOnsite && ! isPreinstalledPremiumPluginUpgraded ) {
+	if ( ! isPluginInstalledOnsite ) {
 		return (
 			<>
 				{ pluginPrice }
@@ -107,14 +127,10 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 		);
 	}
 
-	if ( ! isSimple && isPluginInstalledOnsite && ! isPreinstalledPremiumPluginUpgraded ) {
-		return (
-			<>
-				{ pluginPrice }
-				{ upgradeButton }
-			</>
-		);
-	}
-
-	return null;
+	return (
+		<>
+			{ pluginPrice }
+			{ upgradeButton }
+		</>
+	);
 }

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
@@ -37,7 +37,6 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 		preinstalledPremiumPluginProduct,
 		isPreinstalledPremiumPluginFreeInstalled,
 		isPreinstalledPremiumPluginPaidInstalled,
-		isFetchingPreinstalledPremiumPluginData,
 	} = usePreinstalledPremiumPlugin( plugin.slug );
 
 	const managedPluginMessage = (
@@ -100,10 +99,6 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 			/>
 		</div>
 	);
-
-	if ( isFetchingPreinstalledPremiumPluginData ) {
-		return null;
-	}
 
 	if ( isPreinstalledPremiumPluginPaidInstalled ) {
 		return managedPluginMessage;

--- a/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/preinstalled-premium-plugins-CTA.jsx
@@ -37,6 +37,7 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 		preinstalledPremiumPluginProduct,
 		isPreinstalledPremiumPluginFreeInstalled,
 		isPreinstalledPremiumPluginPaidInstalled,
+		isFetchingPreinstalledPremiumPluginData,
 	} = usePreinstalledPremiumPlugin( plugin.slug );
 
 	const managedPluginMessage = (
@@ -99,6 +100,10 @@ export default function PluginDetailsCTAPreinstalledPremiumPlugins( {
 			/>
 		</div>
 	);
+
+	if ( isFetchingPreinstalledPremiumPluginData ) {
+		return null;
+	}
 
 	if ( isPreinstalledPremiumPluginPaidInstalled ) {
 		return managedPluginMessage;

--- a/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
+++ b/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
@@ -4,7 +4,7 @@ import { useQuerySitePurchases } from 'calypso/components/data/query-site-purcha
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import { getSitesWithPlugin } from 'calypso/state/plugins/installed/selectors';
-import { getSitePurchases, isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
 import isPluginActive from 'calypso/state/selectors/is-plugin-active';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -21,8 +21,6 @@ export default function usePreinstalledPremiumPlugin( pluginSlug ) {
 	const billingPeriod = useSelector( getBillingInterval );
 
 	useQuerySitePurchases( selectedSiteId );
-
-	const isFetchingPreinstalledPremiumPluginData = useSelector( isFetchingSitePurchases );
 
 	const isPreinstalledPremiumPluginUpgraded = useSelector(
 		( state ) =>
@@ -101,6 +99,5 @@ export default function usePreinstalledPremiumPlugin( pluginSlug ) {
 		sitesWithPreinstalledPremiumPlugin,
 		isPreinstalledPremiumPluginFreeInstalled,
 		isPreinstalledPremiumPluginPaidInstalled,
-		isFetchingPreinstalledPremiumPluginData,
 	};
 }

--- a/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
+++ b/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
@@ -4,7 +4,7 @@ import { useQuerySitePurchases } from 'calypso/components/data/query-site-purcha
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import { getSitesWithPlugin } from 'calypso/state/plugins/installed/selectors';
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { getSitePurchases, isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 import getSelectedOrAllSitesJetpackCanManage from 'calypso/state/selectors/get-selected-or-all-sites-jetpack-can-manage';
 import isPluginActive from 'calypso/state/selectors/is-plugin-active';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -21,6 +21,8 @@ export default function usePreinstalledPremiumPlugin( pluginSlug ) {
 	const billingPeriod = useSelector( getBillingInterval );
 
 	useQuerySitePurchases( selectedSiteId );
+
+	const isFetchingPreinstalledPremiumPluginData = useSelector( isFetchingSitePurchases );
 
 	const isPreinstalledPremiumPluginUpgraded = useSelector(
 		( state ) =>
@@ -99,5 +101,6 @@ export default function usePreinstalledPremiumPlugin( pluginSlug ) {
 		sitesWithPreinstalledPremiumPlugin,
 		isPreinstalledPremiumPluginFreeInstalled,
 		isPreinstalledPremiumPluginPaidInstalled,
+		isFetchingPreinstalledPremiumPluginData,
 	};
 }

--- a/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
+++ b/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
@@ -20,7 +20,7 @@ export default function usePreinstalledPremiumPlugin( pluginSlug ) {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const billingPeriod = useSelector( getBillingInterval );
 
-	useQuerySitePurchases( selectedSiteId ?? -1 );
+	useQuerySitePurchases( selectedSiteId );
 
 	const isPreinstalledPremiumPluginUpgraded = useSelector(
 		( state ) =>
@@ -56,10 +56,7 @@ export default function usePreinstalledPremiumPlugin( pluginSlug ) {
 
 	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
 	const hasPurchasedFree = sitePurchases.some( isJetpackSearchFree );
-
 	const hasPurchasedPaid = sitePurchases.some( isJetpackSearch );
-
-	const preinstalledPremiumPluginFeature = preinstalledPremiumPlugin?.feature;
 
 	// Does the preinstalled premium plugin have a free tier?
 	const hasPreinstalledPremiumPluginFreeTier = !! preinstalledPremiumPlugin?.products?.free;
@@ -98,7 +95,6 @@ export default function usePreinstalledPremiumPlugin( pluginSlug ) {
 		isPreinstalledPremiumPlugin: !! preinstalledPremiumPlugin,
 		isPreinstalledPremiumPluginActive,
 		isPreinstalledPremiumPluginUpgraded,
-		preinstalledPremiumPluginFeature,
 		preinstalledPremiumPluginProduct,
 		sitesWithPreinstalledPremiumPlugin,
 		isPreinstalledPremiumPluginFreeInstalled,


### PR DESCRIPTION
#### Proposed Changes

* This PR adds the Jetpack Search free plan option when installing the `Jetpack Search` plugin. The new flow is described below. Described in text should be as described in the parent issue:

We should update the CTA logic with these two states:

- If neither version of the product is purchased/installed yet:
  - CTA should have the text “Start for Free”
  - Clicking it should redirect to checkout with `PRODUCT_JETPACK_SEARCH_FREE`
- If the free plan is purchased/installed:
  - CTA should have the text “Upgrade Jetpack Search”
  - Clicking it should redirect to checkout with `PRODUCT_JETPACK_SEARCH` or `PRODUCT_JETPACK_SEARCH _MONTHLY`)

```mermaid
flowchart TD 
	A[Start] --> B{Is Jetpack\nPaid installed?} 
	B --->|Yes| C[Plugin managed for you]
	B -->|No| D{Is Jetpack\nFree installed?}
	D -->|Yes| E[Upgrade Jetpack Search]
	D --> |No| F[Start for Free]
```
![CleanShot 2023-02-06 at 17 38 36@2x](https://user-images.githubusercontent.com/3519124/217030741-83c3ae7c-958d-446d-86f5-0a9737d84eae.png)

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Repeat the following steps on both a Simple site and an Atomic site
- Navigate to `/plugins/jetpack-search/:siteId`
- Make sure the CTA button reads `Start for Free`
- Click on the CTA button
- Make sure the system navigates to the checkout and the `Jetpack Search` is added to the Cart as a **free purchase**
- Proceed to checkout
- Check the checkout is successful
- Navigate to `/plugins/jetpack-search/:siteId`
- Make sure the CTA button reads `Upgrade Jetpack Search ` and the price is correctly displayed
- Click on the CTA button
- Make sure the system navigates to the checkout and the `Jetpack Search` is added to the Cart as a **paid products**. At this point, the user can select Monthly or Yearly
- Proceed to checkout
- Check the checkout is successful
- Navigate to `/plugins/jetpack-search/:siteId`
- Make sure there is no CTA button and a message is displayed instead indicating that the plugin is automatically managed for you.

#### Note: 
The following issue has been identified during development, and it will be done as a follow-up 
- https://github.com/Automattic/wp-calypso/issues/73009

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #70333
