### PR TITLE
Copy Site: Customize text used on initial Processing screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
@@ -13,8 +13,8 @@ export function useProcessingLoadingMessages( flow?: string ) {
 
 	if ( flow === 'copy-site' ) {
 		return [
-			{ title: __( 'Laying the foundations' ), duration: 5000 },
-			{ title: __( 'Securing your data' ), duration: 4000 },
+			{ title: __( 'Laying the foundations' ), duration: 3500 },
+			{ title: __( 'Securing your data' ), duration: 4500 },
 			{ title: __( 'Enabling encryption' ), duration: 5000 },
 			{ title: __( 'Applying a shiny top coat' ), duration: 4000 },
 		];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
@@ -5,20 +5,22 @@ import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
 
 const SiteIntent = Onboard.SiteIntent;
 
-export function useProcessingLoadingMessages() {
+export function useProcessingLoadingMessages( flow?: string ) {
 	const { __ } = useI18n();
 	let loadingMessages = [];
 
 	const stepData = useSelect( ( select ) => select( STEPPER_INTERNAL_STORE ).getStepData() );
+
+	if ( flow === 'copy-site' ) {
+		return [
+			{ title: __( 'Laying the foundations' ), duration: 5000 },
+			{ title: __( 'Securing your data' ), duration: 4000 },
+			{ title: __( 'Enabling encryption' ), duration: 5000 },
+			{ title: __( 'Applying a shiny top coat' ), duration: 4000 },
+		];
+	}
+
 	switch ( stepData.intent ) {
-		case SiteIntent.Copy:
-			loadingMessages = [
-				{ title: __( 'Laying the foundations' ), duration: 5000 },
-				{ title: __( 'Securing your data' ), duration: 4000 },
-				{ title: __( 'Enabling encryption' ), duration: 5000 },
-				{ title: __( 'Applying a shiny top coat' ), duration: 4000 },
-			];
-			break;
 		case SiteIntent.DIFM:
 			loadingMessages = [
 				{ title: __( 'Securing your data' ), duration: 5000 },

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
@@ -11,6 +11,14 @@ export function useProcessingLoadingMessages() {
 
 	const stepData = useSelect( ( select ) => select( STEPPER_INTERNAL_STORE ).getStepData() );
 	switch ( stepData.intent ) {
+		case SiteIntent.Copy:
+			loadingMessages = [
+				{ title: __( 'Laying the foundations' ), duration: 5000 },
+				{ title: __( 'Securing your data' ), duration: 4000 },
+				{ title: __( 'Enabling encryption' ), duration: 5000 },
+				{ title: __( 'Applying a shiny top coat' ), duration: 4000 },
+			];
+			break;
 		case SiteIntent.DIFM:
 			loadingMessages = [
 				{ title: __( 'Securing your data' ), duration: 5000 },

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
@@ -5,7 +5,7 @@ import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
 
 const SiteIntent = Onboard.SiteIntent;
 
-export function useProcessingLoadingMessages( flow?: string ) {
+export function useProcessingLoadingMessages( flow?: string | null ) {
 	const { __ } = useI18n();
 	let loadingMessages = [];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -39,7 +39,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 
 	const { __ } = useI18n();
 	const videoPressLoadingMessages = useVideoPressLoadingMessages();
-	const defaultLoadingMessages = useProcessingLoadingMessages();
+	const defaultLoadingMessages = useProcessingLoadingMessages( flow );
 	const loadingMessages =
 		'videopress' === flow ? videoPressLoadingMessages : defaultLoadingMessages;
 

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -13,6 +13,7 @@ export enum SiteIntent {
 	Write = 'write',
 	Sell = 'sell',
 	Build = 'build',
+	Copy = 'copy',
 	DIFM = 'difm', // "Do It For Me"
 	WpAdmin = 'wpadmin',
 	Import = 'import', // deprecated

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -13,7 +13,6 @@ export enum SiteIntent {
 	Write = 'write',
 	Sell = 'sell',
 	Build = 'build',
-	Copy = 'copy',
 	DIFM = 'difm', // "Do It For Me"
 	WpAdmin = 'wpadmin',
 	Import = 'import', // deprecated


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1589

## Proposed Changes

Customizes the text used on the initial `Copy Site i1` Processing screen (pre-checkout):

<img width="1712" alt="CleanShot 2023-02-06 at 12 15 48@2x" src="https://user-images.githubusercontent.com/36432/217076544-01cce1ec-adb8-4991-9dc6-ef229c6a7a79.png">

## Testing Instructions

1. Visit `/sites`.
2. Click on 'Copy site' from the triple dot menu.
3. Verify the strings are used in the expected order.