### PR TITLE
Fix bug where centered paragraphs show up left aligned on reader full post view

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -158,8 +158,12 @@
 	color: var(--color-neutral-70);
 	font-size: rem(17px);
 	line-height: 28px;
+
 	figure.wp-block-table {
 		overflow: auto;
+	}
+	.has-text-align-center {
+		text-align: center;
 	}
 }
 


### PR DESCRIPTION
## Description

When a post is published with center aligned text, it currently shows up as left aligned in the reader full page view. It should show us as left aligned in the feed, but in the full-page view we should try and keep the post as 1:1 to the actual post as possible.

### Before

![CleanShot 2023-02-06 at 10 37 28](https://user-images.githubusercontent.com/5634774/217017192-451d8fda-2c33-4504-8b0a-6ebc228778bf.png)

### After

![CleanShot 2023-02-06 at 10 41 30](https://user-images.githubusercontent.com/5634774/217017245-f4547f69-d6cb-4fdd-a19c-f0876928aed9.png)

### Note

Text in feed should still show up left aligned:

![CleanShot 2023-02-06 at 10 45 54](https://user-images.githubusercontent.com/5634774/217017611-782824c6-ddb0-4908-9c23-f655ba304e6b.png)

## Related

#44992, #73014