### PR TITLE
Add sensei checklist task

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -178,6 +178,21 @@ export const getTask = (
 				isSkippable: true,
 			};
 			break;
+		case CHECKLIST_KNOWN_TASKS.SENSEI_SETUP:
+			taskData = {
+				timing: 15,
+				title: translate( 'Finish Sensei setup' ),
+				description: translate(
+					'Customize your course templates, create your first course, and more!'
+				),
+				actionText: task.isCompleted
+					? translate( 'Go to Sensei Home' )
+					: translate( 'Finish Sensei setup' ),
+				actionUrl: taskUrls?.sensei_setup,
+				actionDisableOnComplete: false,
+				isSkippable: true,
+			};
+			break;
 		case CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED: {
 			const description = isBlogger
 				? translate(

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -12,6 +12,7 @@ export const CHECKLIST_KNOWN_TASKS = {
 	BLOGNAME_SET: 'blogname_set',
 	MOBILE_APP_INSTALLED: 'mobile_app_installed',
 	WOOCOMMERCE_SETUP: 'woocommerce_setup',
+	SENSEI_SETUP: 'sensei_setup',
 	SITE_LAUNCHED: 'site_launched',
 	FRONT_PAGE_UPDATED: 'front_page_updated',
 	SITE_MENU_UPDATED: 'site_menu_updated',

--- a/client/state/selectors/get-checklist-task-urls.js
+++ b/client/state/selectors/get-checklist-task-urls.js
@@ -47,6 +47,7 @@ export default createSelector(
 			staff_info_added: frontPageUrl,
 			product_list_added: frontPageUrl,
 			woocommerce_setup: getSiteUrl( state, siteId ) + '/wp-admin/admin.php?page=wc-admin',
+			sensei_setup: getSiteUrl( state, siteId ) + '/wp-admin/admin.php?page=sensei',
 		};
 	},
 	( state, siteId ) => [


### PR DESCRIPTION
#### Proposed Changes

* Adds a Sensei task to the onboarding checklist

#### Testing Instructions

* Check out this patch to your WPCOM sandbox: D98792-code
* Make sure to point `public-api.wordpress.com` to your Sandbox IP through your hosts file
* Go through the Sensei Flow and ensure you see the checklist item on the onboarding checklist
* Make sure the CTA link sends you to the Sensei Home page.
* Note:  currently it does not complete.

<img width="1000" alt="Screenshot 2023-01-19 at 3 14 03 PM" src="https://user-images.githubusercontent.com/3220162/213583070-1f801987-130f-43f2-b144-9e7026678da4.png">
