### PR TITLE
Run cache check in separate Dockerfile step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,10 @@ RUN yarn install --immutable --check-cache
 # This contains built environments of Calypso. It will
 # change any time any of the Calypso source-code changes.
 ENV NODE_ENV production
-RUN yarn run build 2>&1 | tee build_log.txt && \
-	./bin/check-log-for-cache-invalidation.sh build_log.txt
+RUN yarn run build 2>&1 | tee /tmp/build_log.txt
+
+# This will output a service message to TeamCity if the build cache was invalidated as seen in the build_log file.
+RUN ./bin/check-log-for-cache-invalidation.sh /tmp/build_log.txt
 
 # Delete any sourcemaps which may have been generated to avoid creating a large artifact.
 RUN find /calypso/build /calypso/public -name "*.*.map" -exec rm {} \;


### PR DESCRIPTION
#### Proposed Changes
When we merged the initial PR (#72975), we noticed that the output of this script is never shown, since the log reaches Docker's internal logfile size limit. Easy fix is to run the script as a separate step, and since the bit about cache invalidation is early on in the file, it will still work.

#### Testing Instructions
Check that the build param `env.WEBPACK_CACHE_INVALIDATED` is ultimately set by the build. See https://teamcity.a8c.com/buildConfiguration/calypso_BuildDockerImage/9434853?buildTab=log&focusLine=1526&logView=flowAware&linesState=186

