### PR TITLE
Copy Site: Include Marketplace Themes when copying a site

### DIFF
--- a/client/landing/stepper/hooks/use-site-copy.tsx
+++ b/client/landing/stepper/hooks/use-site-copy.tsx
@@ -67,11 +67,13 @@ export const useSiteCopy = (
 		clearSignupDestinationCookie();
 		setPlanCartItem( { product_slug: plan?.product_slug as string } );
 
-		const marketplacePluginProducts = purchases
-			.filter( ( purchase ) => purchase.productType === 'marketplace_plugin' )
+		const marketplaceProducts = purchases
+			.filter( ( purchase ) =>
+				[ 'marketplace_plugin', 'marketplace_theme' ].includes( purchase.productType )
+			)
 			.map( ( purchase ) => ( { product_slug: purchase.productSlug } ) );
 
-		setProductCartItems( marketplacePluginProducts );
+		setProductCartItems( marketplaceProducts );
 	}, [ plan, setPlanCartItem, purchases, shouldShowSiteCopyItem, setProductCartItems ] );
 
 	return useMemo(


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1514

## Proposed Changes

Includes any Marketplace Themes when copying a site:

<img width="1112" alt="image" src="https://user-images.githubusercontent.com/36432/217087413-b9187ee8-d5b2-41a5-83e2-bc4da3ed15a2.png">

## Testing Instructions

1. Create a new Business site and take it Atomic.
2. Activate a premium theme on the site.
3. Copy the site.
4. Verify the premium theme is included in checkout.
5. Complete the checkout process.
6. Verify the premium theme is active on the site.
