### PR TITLE
Exclude cache seralization messages from webpack log

### DIFF
--- a/bin/check-log-for-cache-invalidation.sh
+++ b/bin/check-log-for-cache-invalidation.sh
@@ -13,8 +13,10 @@ fi
 
 if grep "resolving of build dependencies is invalid" $build_file ; then
 	echo "##teamcity[message text='Webpack cache invalidated!' errorDetails='This commit invalidated the webpack cache. Base image will be updated with new cache contents if on trunk.' status='warning']"
-	echo "Relevant details:"
-	grep "cache.PackFileCacheStrategy" $build_file
-
 	echo "##teamcity[setParameter name='env.WEBPACK_CACHE_INVALIDATED' value='true']"
+
+	echo "Relevant details:"
+	# Exclude the vast number of files that get serialized.
+	grep "cache.PackFileCacheStrategy" $build_file | grep -v "Serialization of"
+
 fi


### PR DESCRIPTION
#### Proposed Changes
Fixes another issue related to #73019, which is that the log of messages related to the webpack cache hit an internal docker rate limit, since there are too many logs and we show them instantly via grep.

To avoid this causing issues:
1. Write service message before showing the logfile
2. Exclude messages related to seralization, since they aren't useful and there are too many of them
