### PR TITLE
Pull Request Template: Use <h2> for description headings, move issue reference to the top

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
-#### Proposed Changes
+## Proposed Changes
 
 *
 
-#### Testing Instructions
+## Testing Instructions
 
 <!--
 Add as many details as possible to help others reproduce the issue and test the fix.
@@ -11,7 +11,7 @@ Add as many details as possible to help others reproduce the issue and test the 
 
 *
 
-#### Pre-merge Checklist
+## Pre-merge Checklist
 
 <!--
 Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
 the linked issue.
 -->
 
-See #
+Related to #
 ## Proposed Changes
 
 *

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,11 @@
+<!--
+Link a related issue to this PR. If the PR does not immediately resolve the issue,
+for example, it requires a separate deployment to production, avoid
+using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
+the linked issue.
+-->
+
+See #
 ## Proposed Changes
 
 *
@@ -26,11 +34,3 @@ Both the PR author and reviewer are responsible for ensuring the checklist is co
 - [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
 - [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
 - [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
-<!--
-Link a related issue to this PR. If the PR does not immediately resolve the issue,
-for example, it requires a separate deployment to production, avoid
-using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
-the linked issue.
--->
-
-Related to #


### PR DESCRIPTION
1. Switches to `<h2>` instead of `<h4>` for description headings (related https://github.com/Automattic/jetpack/pull/28205)
2. Moves the issue reference to the top so it's easier to find context

![image](https://user-images.githubusercontent.com/6549265/217095866-3987675b-8efc-4dce-b478-2ae41469f0af.png)
