### PR TITLE
Checkout: Support setting quantity of cart items by URL

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -432,12 +432,12 @@ function getProductPartsFromAlias( productAlias: string ): {
 } {
 	const [ slug, ...productParts ] = productAlias.split( ':' );
 
-	let meta = null;
-	let quantity = null;
+	let meta: string | null = null;
+	let quantity: number | null = null;
 
 	productParts.forEach( ( part ) => {
 		if ( /^-q-\d+$/.test( part ) ) {
-			quantity = part.replace( /^-q-/, '' );
+			quantity = parseInt( part.replace( /^-q-/, '' ), 10 );
 			return;
 		}
 		meta = part;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -406,9 +406,53 @@ function useAddProductFromSlug( {
 	] );
 }
 
+/**
+ * Split up a product alias (typically used in a URL string) into its parts.
+ *
+ * An alias like `personal` refers to a simple Personal plan.
+ *
+ * An alias like `domain_map:example.com` refers to a domain mapping product
+ * for the domain `example.com`.
+ *
+ * An alias like `theme:ovation` refers to a Premium theme with the theme slug
+ * `ovation`.
+ *
+ * An alias like `wp_google_workspace_business_starter_yearly:example.com:-q-12`
+ * refers to a Google Workspace subscription with a quantity of 12.
+ *
+ * To add support for additional metadata in the future, follow the pattern
+ * implemented by quantity: use a string code surrounded by hyphens
+ * (`-label-DATA`). Since domain names cannot start with a hyphen we will know
+ * that the label refers to something else.
+ */
+function getProductPartsFromAlias( productAlias: string ): {
+	slug: string;
+	meta: null | string;
+	quantity: null | number;
+} {
+	const [ slug, ...productParts ] = productAlias.split( ':' );
+
+	let meta = null;
+	let quantity = null;
+
+	productParts.forEach( ( part ) => {
+		if ( /^-q-\d+$/.test( part ) ) {
+			quantity = part.replace( /^-q-/, '' );
+			return;
+		}
+		meta = part;
+	} );
+
+	return {
+		slug,
+		meta,
+		quantity,
+	};
+}
+
 // Transform a fake slug like 'theme:ovation' into a real slug like 'premium_theme'
 function getProductSlugFromAlias( productAlias: string ): string {
-	const [ encodedAlias ] = productAlias.split( ':' );
+	const { slug: encodedAlias } = getProductPartsFromAlias( productAlias );
 	// Some product slugs contain slashes, so we decode them
 	const decodedAlias = decodeProductFromUrl( encodedAlias );
 	if ( decodedAlias === 'domain-mapping' ) {
@@ -437,7 +481,8 @@ function createRenewalItemToAddToCart( {
 	purchaseId: string | number | undefined | null;
 	isGiftPurchase?: boolean;
 } ): RequestCartProduct | null {
-	const [ slug, meta ] = productAlias.split( ':' );
+	const { slug, meta, quantity } = getProductPartsFromAlias( productAlias );
+
 	// Some product slugs contain slashes, so we decode them
 	const productSlug = decodeProductFromUrl( slug );
 
@@ -450,10 +495,11 @@ function createRenewalItemToAddToCart( {
 		purchaseType: 'renewal',
 		isGiftPurchase,
 	};
+
 	return {
 		// Some meta values include slashes, so we decode them
 		meta: meta ? decodeProductFromUrl( meta ) : '',
-		quantity: null,
+		quantity,
 		volume: 1,
 		product_slug: productSlug,
 		extra: renewalItemExtra,
@@ -477,14 +523,25 @@ function createItemToAddToCart( {
 } ): RequestCartProduct {
 	// Allow setting meta (theme name or domain name) from products in the URL by
 	// using a colon between the product slug and the meta.
-	const [ , meta ] = productAlias.split( ':' );
+	const { meta, quantity } = getProductPartsFromAlias( productAlias );
+
 	// Some meta values contain slashes, so we decode them
 	const cartMeta = meta ? decodeProductFromUrl( meta ) : '';
 
-	debug( 'creating product with', productSlug, 'from alias', productAlias, 'with meta', cartMeta );
+	debug(
+		'creating product with',
+		productSlug,
+		'from alias',
+		productAlias,
+		'with meta',
+		cartMeta,
+		'and quantity',
+		quantity
+	);
 
 	return createRequestCartProduct( {
 		product_slug: productSlug,
+		quantity,
 		extra: {
 			isJetpackCheckout,
 			jetpackSiteSlug,

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY } from '@automattic/calypso-products';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
 import { render, fireEvent, screen, within, waitFor, act } from '@testing-library/react';
@@ -306,7 +307,7 @@ describe( 'CheckoutMain', () => {
 		expect( navigate ).not.toHaveBeenCalled();
 	} );
 
-	it( 'adds the domain mapping product to the cart when the url has a theme', async () => {
+	it( 'adds the theme product to the cart when the url has a theme', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		const additionalProps = { productAliasFromUrl: 'theme:ovation' };
 		render(
@@ -321,6 +322,33 @@ describe( 'CheckoutMain', () => {
 				.getAllByLabelText( 'Premium Theme: Ovation' )
 				.map( ( element ) => expect( element ).toHaveTextContent( 'R$69' ) );
 		} );
+	} );
+
+	it( 'adds the product quantity and domain to the cart when the url has a product with a quantity', async () => {
+		const domainName = 'example.com';
+		const quantity = 12;
+		const productSlug = GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY;
+		const additionalProps = {
+			productAliasFromUrl: `${ productSlug }:${ domainName }:-q-${ quantity }`,
+		};
+		render( <MyCheckout additionalProps={ additionalProps } />, container );
+		expect(
+			await screen.findByLabelText(
+				`Google Workspace for '${ domainName }' and quantity '${ quantity }'`
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'adds the product quantity to the cart when the url has a product with a quantity but no domain', async () => {
+		const quantity = 12;
+		const productSlug = GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY;
+		const additionalProps = {
+			productAliasFromUrl: `${ productSlug }:-q-${ quantity }`,
+		};
+		render( <MyCheckout additionalProps={ additionalProps } />, container );
+		expect(
+			await screen.findByLabelText( `Google Workspace for '' and quantity '${ quantity }'` )
+		).toBeInTheDocument();
 	} );
 
 	it( 'does not redirect if the cart is empty when it loads but the url has a domain map', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY } from '@automattic/calypso-products';
 import {
 	getEmptyResponseCart,
 	getEmptyResponseCartProduct,
@@ -441,6 +442,38 @@ function convertRequestProductToResponseProduct(
 					meta: product.meta,
 					volume: 1,
 					extra: {},
+				};
+			case GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY:
+				return {
+					...getEmptyResponseCartProduct(),
+					product_id: 690,
+					// Adding the quantity to the name is a hacky way to validate that it
+					// is passed to the endpoint correctly.
+					product_name: `Google Workspace for '${ product.meta ?? '' }' and quantity '${
+						product.quantity ?? ''
+					}'`,
+					product_slug: GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
+					currency: currency,
+					is_domain_registration: false,
+					item_original_cost_integer: 7000,
+					item_original_cost_display: 'R$70',
+					item_subtotal_integer: 7000,
+					bill_period: '365',
+					months_per_bill_period: 12,
+					item_tax: 0,
+					meta: product.meta,
+					quantity: product.quantity,
+					extra: {
+						google_apps_users: [
+							{
+								email: 'foo@bar.com',
+								firstname: 'Human',
+								lastname: 'Person',
+								recoveryEmail: 'foo@example.com',
+								hash: '1234567',
+							},
+						],
+					},
 				};
 			case 'premium_theme':
 				return {


### PR DESCRIPTION
#### Proposed Changes

When visiting the checkout URL in calypso, a series of product aliases can be included at the end of the URL that will be automatically added to the cart as it loads. For example, `/checkout/personal` will add a Personal plan. Some products require additional metadata, like `/checkout/domain_reg:example.com` which will add a Domain registration for the `example.com` domain.

This PR extends this behavior to allow setting the `quantity` of a product via the URL. If a URL's product alias includes a colon followed by the code `-q-` and a number, that number will be interpreted as a quantity (we know this is not a domain because domains cannot start with a hyphen). So a URL like `/checkout/some_product:-q-20` will add a product with a quantity of 20.

**Note:** few products can have a quantity set and even fewer products allow a user-supplied quantity, so although this PR will allow _requesting_ a quantity, the choice to actually _use_ that quantity lies within the shopping-cart API endpoint.

This implementation also creates a pattern for future reuse; if we need to encode additional metadata for a product into the URL, we can use a colon followed by a hyphen and a string to label that data. For example if we ever wanted to encode the `extra.signup` boolean flag, we could accept products like `some_product:-signup-1`.

This feature was requested in a p2 discussion here: p1HpG7-jya-p2#comment-60450

#### Testing Instructions

Automated tests are included. To test this manually:

- Open calypso with your browser's devtools open and recording network traffic to the `/me/shopping-cart` endpoint.
- Visit a checkout url with a quantity (it doesn't have to be real) like `/checkout/business:-q-23`.
- Verify that a network request is made to the shopping-cart endpoint with the quantity set to the number in the URL.

<img width="272" alt="Screenshot 2023-02-06 at 7 35 24 PM" src="https://user-images.githubusercontent.com/2036909/217118420-18bcfe2a-6a65-43d8-80bf-ba67d6dfa4ef.png">