### PR TITLE
Change to triggering base images twice a day

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -205,7 +205,7 @@ object BuildBaseImages : BuildType({
 	triggers {
 		schedule {
 			schedulingPolicy = cron {
-				hours = "*/4"
+				hours = "*/12"
 			}
 			branchFilter = """
 				+:trunk


### PR DESCRIPTION
### Proposed Changes
Trigger base images twice a day instead of 6 times a day. The reason to have the base image build at this point is to essentially reset the image since we're updating it (pushing new layers to it) dynamically from trunk. I think twice a day is pretty fair.