### PR TITLE
Jetpack Backup: Fetch last backup size

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/size/from-api.ts
+++ b/client/state/data-layer/wpcom/sites/rewind/size/from-api.ts
@@ -7,6 +7,7 @@ type ApiResponse = {
 	days_of_backups_saved: number;
 	min_days_of_backups_allowed: number;
 	days_of_backups_allowed: number;
+	last_backup_size: number;
 };
 
 const fromApi = ( {
@@ -14,11 +15,13 @@ const fromApi = ( {
 	min_days_of_backups_allowed,
 	days_of_backups_allowed,
 	days_of_backups_saved,
+	last_backup_size,
 }: ApiResponse ): RewindSizeInfo => ( {
 	bytesUsed: size,
 	minDaysOfBackupsAllowed: min_days_of_backups_allowed,
 	daysOfBackupsAllowed: days_of_backups_allowed,
 	daysOfBackupsSaved: days_of_backups_saved,
+	lastBackupSize: last_backup_size,
 } );
 
 export default fromApi;

--- a/client/state/rewind/selectors/get-backup-current-site-size.ts
+++ b/client/state/rewind/selectors/get-backup-current-site-size.ts
@@ -8,6 +8,6 @@ import type { AppState } from 'calypso/types';
  * @returns The current site size number in bytes.
  */
 const getBackupCurrentSiteSize = ( state: AppState, siteId: number ): number | undefined =>
-	state.rewind[ siteId ]?.size?.lastBackupSize ?? null;
+	state.rewind[ siteId ]?.size?.lastBackupSize ?? undefined;
 
 export default getBackupCurrentSiteSize;

--- a/client/state/rewind/selectors/get-backup-current-site-size.ts
+++ b/client/state/rewind/selectors/get-backup-current-site-size.ts
@@ -1,0 +1,13 @@
+import type { AppState } from 'calypso/types';
+
+/**
+ * Retrieves current site size in bytes.
+ *
+ * @param state The application state.
+ * @param siteId The site ID for which to retrieve days of backups saved.
+ * @returns The current site size number in bytes.
+ */
+const getBackupCurrentSiteSize = ( state: AppState, siteId: number ): number | undefined =>
+	state.rewind[ siteId ]?.size?.lastBackupSize ?? null;
+
+export default getBackupCurrentSiteSize;

--- a/client/state/rewind/selectors/index.ts
+++ b/client/state/rewind/selectors/index.ts
@@ -11,3 +11,4 @@ export { default as getRewindDaysOfBackupsAllowed } from './get-rewind-days-of-b
 export { default as getRewindDaysOfBackupsSaved } from './get-rewind-days-of-backups-saved';
 export { default as getActivityLogVisibleDays } from './get-activity-log-visible-days';
 export { default as getRewindStorageUsageLevel } from './get-rewind-storage-usage-level';
+export { default as getBackupCurrentSiteSize } from './get-backup-current-site-size';

--- a/client/state/rewind/size/reducer.ts
+++ b/client/state/rewind/size/reducer.ts
@@ -65,10 +65,22 @@ const daysOfBackupsSaved = (
 	return size.daysOfBackupsSaved ?? null;
 };
 
+const lastBackupSize = (
+	state: AppState = null,
+	{ type, size }: AnyAction
+): AppState | number | null => {
+	if ( type !== REWIND_SIZE_SET ) {
+		return state;
+	}
+
+	return size.lastBackupSize ?? null;
+};
+
 export default combineReducers( {
 	requestStatus,
 	bytesUsed,
 	minDaysOfBackupsAllowed,
 	daysOfBackupsAllowed,
 	daysOfBackupsSaved,
+	lastBackupSize,
 } );

--- a/client/state/rewind/size/test/reducer.js
+++ b/client/state/rewind/size/test/reducer.js
@@ -1,0 +1,35 @@
+import { REWIND_SIZE_GET, REWIND_SIZE_SET } from 'calypso/state/action-types';
+import sizeReducer from '../reducer';
+
+// @TODO: Add tests for the other reducers
+describe( 'rewind.size reducers', () => {
+	describe( 'lastBackupSize', () => {
+		it.each( [
+			{
+				state: undefined,
+				action: {},
+				expected: null,
+			},
+			{
+				state: undefined,
+				action: { type: REWIND_SIZE_GET },
+				expected: null,
+			},
+			{
+				state: { lastBackupSize: 100 },
+				action: { type: REWIND_SIZE_GET },
+				expected: 100,
+			},
+			{
+				state: { lastBackupSize: 100 },
+				action: { type: REWIND_SIZE_SET, size: { lastBackupSize: 200 } },
+				expected: 200,
+			},
+		] )(
+			'should return a value different than null only when the state has a value or the action is REWIND_SIZE_SET',
+			( { state, action, expected } ) => {
+				expect( sizeReducer( state, action ).lastBackupSize ).toEqual( expected );
+			}
+		);
+	} );
+} );

--- a/client/state/rewind/size/types.ts
+++ b/client/state/rewind/size/types.ts
@@ -3,4 +3,5 @@ export type RewindSizeInfo = {
 	minDaysOfBackupsAllowed: number;
 	daysOfBackupsAllowed: number;
 	daysOfBackupsSaved: number;
+	lastBackupSize: number;
 };

--- a/client/state/rewind/test/selectors.js
+++ b/client/state/rewind/test/selectors.js
@@ -45,7 +45,7 @@ describe( 'getBackupCurrentSiteSize()', () => {
 				},
 			},
 			siteId: 123,
-			expected: null,
+			expected: undefined,
 		},
 		{
 			state: {
@@ -61,7 +61,7 @@ describe( 'getBackupCurrentSiteSize()', () => {
 			expected: 1024,
 		},
 	] )(
-		'should return the lastBackupSize if passed, null otherwise',
+		'should return the lastBackupSize if passed, undefined otherwise',
 		( { state, siteId, expected } ) => {
 			const output = getBackupCurrentSiteSize( state, siteId );
 			expect( output ).toBe( expected );

--- a/client/state/rewind/test/selectors.js
+++ b/client/state/rewind/test/selectors.js
@@ -1,4 +1,4 @@
-import { getRewindStorageUsageLevel } from '../selectors';
+import { getRewindStorageUsageLevel, getBackupCurrentSiteSize } from '../selectors';
 import { StorageUsageLevels } from '../storage/types';
 
 describe( 'getRewindStorageUsageLevel()', () => {
@@ -29,6 +29,41 @@ describe( 'getRewindStorageUsageLevel()', () => {
 		'should return values from StorageUsageLevels if passed, StorageUsageLevels.Normal otherwise',
 		( { state, siteId, expected } ) => {
 			const output = getRewindStorageUsageLevel( state, siteId );
+			expect( output ).toBe( expected );
+		}
+	);
+} );
+
+describe( 'getBackupCurrentSiteSize()', () => {
+	it.each( [
+		{
+			state: {
+				rewind: {
+					123: {
+						size: {},
+					},
+				},
+			},
+			siteId: 123,
+			expected: null,
+		},
+		{
+			state: {
+				rewind: {
+					123: {
+						size: {
+							lastBackupSize: 1024,
+						},
+					},
+				},
+			},
+			siteId: 123,
+			expected: 1024,
+		},
+	] )(
+		'should return the lastBackupSize if passed, null otherwise',
+		( { state, siteId, expected } ) => {
+			const output = getBackupCurrentSiteSize( state, siteId );
 			expect( output ).toBe( expected );
 		}
 	);


### PR DESCRIPTION
#### Proposed Changes

* Add the necessary logic to fetch the last backup size as part of the `rewind/size` API call. It includes reducer, selector and tests.

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure running testing passes by executing `yarn run test-client client/state/rewind`
* You can validate that the new `state.rewind[site_id].size.lastBackupSize` has been added to the state using Redux DevTools or developer console by running: `state.rewind[YOUR_BLOG_ID].size.lastBackupSize`

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
