### PR TITLE
Update backup features tests to use strings from function

### DIFF
--- a/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
@@ -12,9 +12,11 @@ import { checkoutTheme } from '@automattic/composite-checkout';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
 import { ThemeProvider } from '@emotion/react';
 import { render, screen, waitFor } from '@testing-library/react';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import WPCheckoutOrderSummary from '../components/wp-checkout-order-summary';
+import getJetpackProductFeatures from '../lib/get-jetpack-product-features';
 import {
 	mockSetCartEndpointWith,
 	mockGetCartEndpointWith,
@@ -32,13 +34,9 @@ jest.mock( '@automattic/calypso-config', () => {
 	return mock;
 } );
 
-const jetpackBackupFeatureList = [
-	'Real-time cloud backups',
-	'10GB of backup storage',
-	'30-day archive & activity log',
-	'One-click restores',
-	'Priority support',
-];
+const translate: ( original: string ) => string = ( original ) => {
+	return original;
+};
 
 describe( 'WPCheckoutOrderSummary', () => {
 	let container: HTMLDivElement | null;
@@ -91,6 +89,10 @@ describe( 'WPCheckoutOrderSummary', () => {
 			const backupT1Monthly = convertProductSlugToResponseProduct(
 				PRODUCT_JETPACK_BACKUP_T1_MONTHLY
 			);
+			const productFeatures = getJetpackProductFeatures(
+				backupT1Monthly,
+				translate as ReturnType< typeof useTranslate >
+			);
 			const cartChanges = {
 				products: [ backupT1Monthly ],
 			};
@@ -98,7 +100,7 @@ describe( 'WPCheckoutOrderSummary', () => {
 			render( <MyCheckoutSummary cartChanges={ cartChanges } /> );
 
 			await waitFor( async () => {
-				jetpackBackupFeatureList.map( ( feature ) => {
+				productFeatures.map( ( feature ) => {
 					expect( screen.queryByText( feature ) ).toBeInTheDocument();
 				} );
 			} );
@@ -108,6 +110,10 @@ describe( 'WPCheckoutOrderSummary', () => {
 			const backupT1Yearly = convertProductSlugToResponseProduct(
 				PRODUCT_JETPACK_BACKUP_T1_YEARLY
 			);
+			const productFeatures = getJetpackProductFeatures(
+				backupT1Yearly,
+				translate as ReturnType< typeof useTranslate >
+			);
 			const cartChanges = {
 				products: [ backupT1Yearly ],
 			};
@@ -115,7 +121,7 @@ describe( 'WPCheckoutOrderSummary', () => {
 			render( <MyCheckoutSummary cartChanges={ cartChanges } /> );
 
 			await waitFor( async () => {
-				jetpackBackupFeatureList.map( ( feature ) => {
+				productFeatures.map( ( feature ) => {
 					expect( screen.queryByText( feature ) ).toBeInTheDocument();
 				} );
 			} );
@@ -124,6 +130,10 @@ describe( 'WPCheckoutOrderSummary', () => {
 		test( 'VaultPress Backup T1 related feature list does not show up if there are multiple items in the cart', async () => {
 			const backupT1Yearly = convertProductSlugToResponseProduct(
 				PRODUCT_JETPACK_BACKUP_T1_YEARLY
+			);
+			const productFeatures = getJetpackProductFeatures(
+				backupT1Yearly,
+				translate as ReturnType< typeof useTranslate >
 			);
 			const scan = convertProductSlugToResponseProduct( PRODUCT_JETPACK_SCAN );
 
@@ -134,19 +144,26 @@ describe( 'WPCheckoutOrderSummary', () => {
 			render( <MyCheckoutSummary cartChanges={ cartChanges } /> );
 
 			await waitFor( async () => {
-				jetpackBackupFeatureList.map( ( feature ) => {
+				productFeatures.map( ( feature ) => {
 					expect( screen.queryByText( feature ) ).toBeNull();
 				} );
 			} );
 		} );
 
 		test( 'VaultPress Backup T1 related feature list does not show up if the cart is empty', async () => {
+			const backupT1Yearly = convertProductSlugToResponseProduct(
+				PRODUCT_JETPACK_BACKUP_T1_YEARLY
+			);
+			const productFeatures = getJetpackProductFeatures(
+				backupT1Yearly,
+				translate as ReturnType< typeof useTranslate >
+			);
 			const cartChanges = { products: [] };
 
 			render( <MyCheckoutSummary cartChanges={ cartChanges } /> );
 
 			await waitFor( async () => {
-				jetpackBackupFeatureList.map( ( feature ) => {
+				productFeatures.map( ( feature ) => {
 					expect( screen.queryByText( feature ) ).toBeNull();
 				} );
 			} );
@@ -154,12 +171,19 @@ describe( 'WPCheckoutOrderSummary', () => {
 
 		test( 'VaultPress Backup T1 related feature list does not show up if a different Jetpack product is in cart', async () => {
 			const scan = convertProductSlugToResponseProduct( PRODUCT_JETPACK_SCAN );
+			const backupT1Yearly = convertProductSlugToResponseProduct(
+				PRODUCT_JETPACK_BACKUP_T1_YEARLY
+			);
+			const productFeatures = getJetpackProductFeatures(
+				backupT1Yearly,
+				translate as ReturnType< typeof useTranslate >
+			);
 			const cartChanges = { products: [ scan ] };
 
 			render( <MyCheckoutSummary cartChanges={ cartChanges } /> );
 
 			await waitFor( async () => {
-				jetpackBackupFeatureList.map( ( feature ) => {
+				productFeatures.map( ( feature ) => {
 					expect( screen.queryByText( feature ) ).toBeNull();
 				} );
 			} );

--- a/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
@@ -34,9 +34,7 @@ jest.mock( '@automattic/calypso-config', () => {
 	return mock;
 } );
 
-const translate: ( original: string ) => string = ( original ) => {
-	return original;
-};
+const identity = ( x: string ) => x;
 
 describe( 'WPCheckoutOrderSummary', () => {
 	let container: HTMLDivElement | null;
@@ -91,7 +89,7 @@ describe( 'WPCheckoutOrderSummary', () => {
 			);
 			const productFeatures = getJetpackProductFeatures(
 				backupT1Monthly,
-				translate as ReturnType< typeof useTranslate >
+				identity as ReturnType< typeof useTranslate >
 			);
 			const cartChanges = {
 				products: [ backupT1Monthly ],
@@ -112,7 +110,7 @@ describe( 'WPCheckoutOrderSummary', () => {
 			);
 			const productFeatures = getJetpackProductFeatures(
 				backupT1Yearly,
-				translate as ReturnType< typeof useTranslate >
+				identity as ReturnType< typeof useTranslate >
 			);
 			const cartChanges = {
 				products: [ backupT1Yearly ],
@@ -133,7 +131,7 @@ describe( 'WPCheckoutOrderSummary', () => {
 			);
 			const productFeatures = getJetpackProductFeatures(
 				backupT1Yearly,
-				translate as ReturnType< typeof useTranslate >
+				identity as ReturnType< typeof useTranslate >
 			);
 			const scan = convertProductSlugToResponseProduct( PRODUCT_JETPACK_SCAN );
 
@@ -156,7 +154,7 @@ describe( 'WPCheckoutOrderSummary', () => {
 			);
 			const productFeatures = getJetpackProductFeatures(
 				backupT1Yearly,
-				translate as ReturnType< typeof useTranslate >
+				identity as ReturnType< typeof useTranslate >
 			);
 			const cartChanges = { products: [] };
 
@@ -176,7 +174,7 @@ describe( 'WPCheckoutOrderSummary', () => {
 			);
 			const productFeatures = getJetpackProductFeatures(
 				backupT1Yearly,
-				translate as ReturnType< typeof useTranslate >
+				identity as ReturnType< typeof useTranslate >
 			);
 			const cartChanges = { products: [ scan ] };
 


### PR DESCRIPTION
#### Proposed Changes

Updating tests to pull strings from function instead of redefining them in tests

This was at the request of @creativecoder [here](https://github.com/Automattic/wp-calypso/pull/72525#discussion_r1094902203)

#### Testing Instructions

1. From the root directory, run the following command
`yarn test-client -- client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx`
2. Make sure tests still pass

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
