### PR TITLE
Filter out duplicate pending comments

### DIFF
--- a/client/state/comments/selectors/get-post-comments-tree.js
+++ b/client/state/comments/selectors/get-post-comments-tree.js
@@ -28,17 +28,6 @@ export const getPostCommentsTree = treeSelect(
 			) {
 				return false;
 			}
-
-			// Filter out pending comments that are duplicates of approved comments
-			if ( item.status === 'pending' ) {
-				const duplicate = allItems.find(
-					( comment ) => comment.content === item.content && comment.ID !== item.ID
-				);
-				if ( duplicate ) {
-					return false;
-				}
-			}
-
 			if ( status !== 'all' ) {
 				return item.isPlaceholder || item.status === status;
 			}

--- a/client/state/comments/selectors/get-post-comments-tree.js
+++ b/client/state/comments/selectors/get-post-comments-tree.js
@@ -28,6 +28,17 @@ export const getPostCommentsTree = treeSelect(
 			) {
 				return false;
 			}
+
+			// Filter out pending comments that are duplicates of approved comments
+			if ( item.status === 'pending' ) {
+				const duplicate = allItems.find(
+					( comment ) => comment.content === item.content && comment.ID !== item.ID
+				);
+				if ( duplicate ) {
+					return false;
+				}
+			}
+
 			if ( status !== 'all' ) {
 				return item.isPlaceholder || item.status === status;
 			}

--- a/client/state/lasagna/post-channel/middleware.js
+++ b/client/state/lasagna/post-channel/middleware.js
@@ -57,14 +57,19 @@ const joinChannel = async ( store, joinParams ) => {
 			return;
 		}
 
-		store.dispatch(
-			receiveComments( {
-				siteId: comment.post.site_ID,
-				postId: comment.post.ID,
-				comments: [ comment ],
-				commentById: true,
-			} )
-		);
+		// If the comment's author is 0, that means it was authored by the current user.
+		// In that case do not dispatch the event as it may arrive before the pending comment has been deleted,
+		// causing a duplicate comment. See https://github.com/Automattic/wp-calypso/issues/61812
+		if ( comment.author && comment.author.ID !== 0 ) {
+			store.dispatch(
+				receiveComments( {
+					siteId: comment.post.site_ID,
+					postId: comment.post.ID,
+					comments: [ comment ],
+					commentById: true,
+				} )
+			);
+		}
 	} );
 
 	lasagna.joinChannel( topic, () => debug( topic + ' channel join ok' ) );


### PR DESCRIPTION
#### Proposed Changes
Fixes https://github.com/Automattic/wp-calypso/issues/61812

I found on inspecting the commentTree object, that in some instances it can contain duplicates where there is a pending comment, and an approved comment that briefly exist at the same time. This causes the issue described in https://github.com/Automattic/wp-calypso/issues/61812.

This is a somewhat "quick and dirty" patch as I haven't dug right down to the cause of why there can sometimes be duplicates, but it fixes the issue and I don't think it adds too much complexity.

#### Testing Instructions
see https://github.com/Automattic/wp-calypso/issues/61812#issuecomment-1419023924
I personally found that I could only reproduce the issue when
* I wasn't sandboxed
* I was replying to a post that already had many (10+) comments.