### PR TITLE
Jetpack Backup: Add Backup retention management setting

### DIFF
--- a/client/components/backup-retention-management/constants.ts
+++ b/client/components/backup-retention-management/constants.ts
@@ -1,0 +1,11 @@
+export const RETENTION_OPTIONS = {
+	RETENTION_DAYS_7: 7,
+	RETENTION_DAYS_30: 30,
+	RETENTION_DAYS_120: 120,
+	RETENTION_DAYS_365: 365,
+} as const;
+
+export const STORAGE_ESTIMATION_ADDITIONAL_BUFFER = 0.25;
+
+export const STORAGE_RETENTION_LEARN_MORE_LINK =
+	'https://jetpack.com/support/backup/#how-is-storage-usage-calculated';

--- a/client/components/backup-retention-management/consts.tsx
+++ b/client/components/backup-retention-management/consts.tsx
@@ -1,0 +1,15 @@
+export const RetentionOptions = {
+	RETENTION_DAYS_7: 7,
+	RETENTION_DAYS_30: 30,
+	RETENTION_DAYS_120: 120,
+	RETENTION_DAYS_365: 365,
+} as const;
+
+export interface RetentionRadioOptionType {
+	label: string; // 7 days
+	spaceNeeded: any; // 700MB
+	upgradeRequired: boolean;
+	isCurrentPlan: boolean;
+	value: number; // 7
+	checked: boolean;
+}

--- a/client/components/backup-retention-management/consts.tsx
+++ b/client/components/backup-retention-management/consts.tsx
@@ -1,6 +1,0 @@
-export const RetentionOptions = {
-	RETENTION_DAYS_7: 7,
-	RETENTION_DAYS_30: 30,
-	RETENTION_DAYS_120: 120,
-	RETENTION_DAYS_365: 365,
-} as const;

--- a/client/components/backup-retention-management/consts.tsx
+++ b/client/components/backup-retention-management/consts.tsx
@@ -1,3 +1,5 @@
+import type { TranslateResult } from 'i18n-calypso';
+
 export const RetentionOptions = {
 	RETENTION_DAYS_7: 7,
 	RETENTION_DAYS_30: 30,
@@ -7,7 +9,7 @@ export const RetentionOptions = {
 
 export interface RetentionRadioOptionType {
 	label: string; // 7 days
-	spaceNeeded: any; // 700MB
+	spaceNeeded: TranslateResult | string; // 700MB
 	upgradeRequired: boolean;
 	isCurrentPlan: boolean;
 	value: number; // 7

--- a/client/components/backup-retention-management/consts.tsx
+++ b/client/components/backup-retention-management/consts.tsx
@@ -1,17 +1,6 @@
-import type { TranslateResult } from 'i18n-calypso';
-
 export const RetentionOptions = {
 	RETENTION_DAYS_7: 7,
 	RETENTION_DAYS_30: 30,
 	RETENTION_DAYS_120: 120,
 	RETENTION_DAYS_365: 365,
 } as const;
-
-export interface RetentionRadioOptionType {
-	label: string; // 7 days
-	spaceNeeded: TranslateResult | string; // 700MB
-	upgradeRequired: boolean;
-	isCurrentPlan: boolean;
-	value: number; // 7
-	checked: boolean;
-}

--- a/client/components/backup-retention-management/hooks.tsx
+++ b/client/components/backup-retention-management/hooks.tsx
@@ -2,6 +2,7 @@ import { useMemo } from '@wordpress/element';
 import { useSelector } from 'react-redux';
 import { useStorageText } from 'calypso/components/backup-storage-space/hooks';
 import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
+import getBackupCurrentSiteSize from 'calypso/state/rewind/selectors/get-backup-current-site-size';
 import getRewindBytesAvailable from 'calypso/state/rewind/selectors/get-rewind-bytes-available';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { RetentionRadioOptionType } from './consts';
@@ -10,7 +11,10 @@ import { RetentionRadioOptionType } from './consts';
  * Estimate the current site size based on the last backup size, adding a 25% buffer
  */
 export function useEstimatedCurrentSiteSize(): number {
-	const lastBackupSize = 2 ** 30; // @TODO: Fetch this from #73031 when it's ready. We will need to call getBackupCurrentSiteSize() from the state.
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const lastBackupSize = useSelector(
+		( state ) => getBackupCurrentSiteSize( state, siteId ) as number
+	);
 	return useMemo( () => lastBackupSize + lastBackupSize * 0.25, [ lastBackupSize ] );
 }
 

--- a/client/components/backup-retention-management/hooks.tsx
+++ b/client/components/backup-retention-management/hooks.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from '@wordpress/element';
+import { useSelector } from 'react-redux';
+import { useStorageText } from 'calypso/components/backup-storage-space/hooks';
+import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
+import getRewindBytesAvailable from 'calypso/state/rewind/selectors/get-rewind-bytes-available';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { RetentionRadioOptionType } from './consts';
+
+/**
+ * Estimate the current site size based on the last backup size, adding a 25% buffer
+ */
+export function useEstimatedCurrentSiteSize(): number {
+	const lastBackupSize = 2 ** 30; // @TODO: Fetch this from #73031 when it's ready. We will need to call getBackupCurrentSiteSize() from the state.
+	return useMemo( () => lastBackupSize + lastBackupSize * 0.25, [ lastBackupSize ] );
+}
+
+/**
+ * Estimate the space needed based on the current site size and the retention days
+ *
+ * @param currentSiteSizeInBytes Current site size in bytes
+ * @param desiredRetentionDays   Desired backup retention days
+ * @returns Space needed in bytes
+ */
+export function useEstimateSpaceNeeded(
+	currentSiteSizeInBytes: number,
+	desiredRetentionDays: number
+): number {
+	return useMemo( () => {
+		return currentSiteSizeInBytes * desiredRetentionDays;
+	}, [ currentSiteSizeInBytes, desiredRetentionDays ] );
+}
+
+/**
+ * Prepare the retention options for the RetentionOptionsControl component
+ */
+export function usePrepareRetentionOptions(
+	label: string,
+	desiredRetentionDays: number,
+	checked: boolean
+): RetentionRadioOptionType {
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const currentSiteSizeInBytes = useEstimatedCurrentSiteSize();
+
+	const storageLimitBytes = useSelector( ( state ) =>
+		getRewindBytesAvailable( state, siteId )
+	) as number;
+
+	const planRetentionPeriod = useSelector( ( state ) =>
+		getActivityLogVisibleDays( state, siteId )
+	);
+
+	const spaceNeeded = useEstimateSpaceNeeded( currentSiteSizeInBytes, desiredRetentionDays );
+	const spaceNeededText = useStorageText( spaceNeeded );
+
+	return useMemo( () => {
+		return {
+			label,
+			spaceNeeded: spaceNeededText,
+			upgradeRequired: spaceNeeded > storageLimitBytes,
+			isCurrentPlan: desiredRetentionDays === planRetentionPeriod,
+			value: desiredRetentionDays,
+			checked,
+		};
+	}, [
+		label,
+		spaceNeededText,
+		spaceNeeded,
+		storageLimitBytes,
+		desiredRetentionDays,
+		planRetentionPeriod,
+		checked,
+	] );
+}

--- a/client/components/backup-retention-management/hooks.tsx
+++ b/client/components/backup-retention-management/hooks.tsx
@@ -4,7 +4,7 @@ import { useStorageText } from 'calypso/components/backup-storage-space/hooks';
 import getBackupCurrentSiteSize from 'calypso/state/rewind/selectors/get-backup-current-site-size';
 import getRewindBytesAvailable from 'calypso/state/rewind/selectors/get-rewind-bytes-available';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { RetentionRadioOptionType } from './consts';
+import type { RetentionRadioOptionType } from './types';
 
 /**
  * Estimate the current site size based on the last backup size, adding a 25% buffer

--- a/client/components/backup-retention-management/hooks.tsx
+++ b/client/components/backup-retention-management/hooks.tsx
@@ -4,6 +4,7 @@ import { useStorageText } from 'calypso/components/backup-storage-space/hooks';
 import getBackupCurrentSiteSize from 'calypso/state/rewind/selectors/get-backup-current-site-size';
 import getRewindBytesAvailable from 'calypso/state/rewind/selectors/get-rewind-bytes-available';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { STORAGE_ESTIMATION_ADDITIONAL_BUFFER } from './constants';
 import type { RetentionRadioOptionType } from './types';
 
 /**
@@ -14,7 +15,10 @@ export function useEstimatedCurrentSiteSize(): number {
 	const lastBackupSize = useSelector(
 		( state ) => getBackupCurrentSiteSize( state, siteId ) as number
 	);
-	return useMemo( () => lastBackupSize + lastBackupSize * 0.25, [ lastBackupSize ] );
+	return useMemo(
+		() => lastBackupSize + lastBackupSize * STORAGE_ESTIMATION_ADDITIONAL_BUFFER,
+		[ lastBackupSize ]
+	);
 }
 
 /**

--- a/client/components/backup-retention-management/hooks.tsx
+++ b/client/components/backup-retention-management/hooks.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from '@wordpress/element';
 import { useSelector } from 'react-redux';
 import { useStorageText } from 'calypso/components/backup-storage-space/hooks';
-import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
 import getBackupCurrentSiteSize from 'calypso/state/rewind/selectors/get-backup-current-site-size';
 import getRewindBytesAvailable from 'calypso/state/rewind/selectors/get-rewind-bytes-available';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -40,6 +39,7 @@ export function useEstimateSpaceNeeded(
 export function usePrepareRetentionOptions(
 	label: string,
 	desiredRetentionDays: number,
+	currentRetentionPlan: number,
 	checked: boolean
 ): RetentionRadioOptionType {
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -49,10 +49,6 @@ export function usePrepareRetentionOptions(
 		getRewindBytesAvailable( state, siteId )
 	) as number;
 
-	const planRetentionPeriod = useSelector( ( state ) =>
-		getActivityLogVisibleDays( state, siteId )
-	);
-
 	const spaceNeeded = useEstimateSpaceNeeded( currentSiteSizeInBytes, desiredRetentionDays );
 	const spaceNeededText = useStorageText( spaceNeeded );
 
@@ -61,7 +57,7 @@ export function usePrepareRetentionOptions(
 			label,
 			spaceNeeded: spaceNeededText,
 			upgradeRequired: spaceNeeded > storageLimitBytes,
-			isCurrentPlan: desiredRetentionDays === planRetentionPeriod,
+			isCurrentPlan: desiredRetentionDays === currentRetentionPlan,
 			value: desiredRetentionDays,
 			checked,
 		};
@@ -71,7 +67,7 @@ export function usePrepareRetentionOptions(
 		spaceNeeded,
 		storageLimitBytes,
 		desiredRetentionDays,
-		planRetentionPeriod,
+		currentRetentionPlan,
 		checked,
 	] );
 }

--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -1,0 +1,128 @@
+import { Button, Card } from '@automattic/components';
+import { useEffect, useState, useCallback } from '@wordpress/element';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import { useSelector } from 'react-redux';
+import { useStorageText } from 'calypso/components/backup-storage-space/hooks';
+import QueryRewindPolicies from 'calypso/components/data/query-rewind-policies';
+import QueryRewindSize from 'calypso/components/data/query-rewind-size';
+import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
+import getRewindBytesAvailable from 'calypso/state/rewind/selectors/get-rewind-bytes-available';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { RetentionOptions, RetentionRadioOptionType } from './consts';
+import { useEstimatedCurrentSiteSize, usePrepareRetentionOptions } from './hooks';
+import RetentionOptionsControl from './retention-options/retention-options-control';
+import './style.scss';
+
+const BackupRetentionManagement: FunctionComponent = () => {
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const translate = useTranslate();
+
+	const disableForm = false;
+	const formHasErrors = false;
+
+	const [ retentionSelected, setRetentionSelected ] = useState( 0 );
+	const planRetentionPeriod = useSelector( ( state ) =>
+		getActivityLogVisibleDays( state, siteId )
+	);
+	const storageLimitBytes = useSelector( ( state ) =>
+		getRewindBytesAvailable( state, siteId )
+	) as number;
+	const estimatedCurrentSiteSize = useEstimatedCurrentSiteSize();
+
+	const currentSiteSizeText = useStorageText( estimatedCurrentSiteSize );
+	const storageLimitText = useStorageText( storageLimitBytes );
+
+	const retentionOptionsCards: Array< RetentionRadioOptionType > = [
+		usePrepareRetentionOptions(
+			translate( '7 days' ),
+			RetentionOptions.RETENTION_DAYS_7,
+			retentionSelected === RetentionOptions.RETENTION_DAYS_7
+		),
+		usePrepareRetentionOptions(
+			translate( '30 days' ),
+			RetentionOptions.RETENTION_DAYS_30,
+			retentionSelected === RetentionOptions.RETENTION_DAYS_30
+		),
+		usePrepareRetentionOptions(
+			translate( '120 days' ),
+			RetentionOptions.RETENTION_DAYS_120,
+			retentionSelected === RetentionOptions.RETENTION_DAYS_120
+		),
+		usePrepareRetentionOptions(
+			translate( '1 year' ),
+			RetentionOptions.RETENTION_DAYS_365,
+			retentionSelected === RetentionOptions.RETENTION_DAYS_365
+		),
+	];
+
+	useEffect( () => {
+		if ( planRetentionPeriod ) {
+			setRetentionSelected( planRetentionPeriod );
+		}
+	}, [ planRetentionPeriod ] );
+
+	const handleUpdateRetention = () => {
+		return;
+	};
+
+	const onRetentionSelectionChange = useCallback( ( value: number ) => {
+		setRetentionSelected( value );
+	}, [] );
+
+	return (
+		<div className="backup-retention-management">
+			<QueryRewindPolicies siteId={ siteId } />
+			<QueryRewindSize siteId={ siteId } />
+			<Card compact={ true }>
+				<h3>{ translate( 'Days of backups saved' ) }</h3>
+			</Card>
+			<Card>
+				<div className="storage-details">
+					<div className="storage-details__size">
+						<div className="size__label label">{ translate( 'Current site size*' ) }</div>
+						<div className="size__value value">{ currentSiteSizeText }</div>
+					</div>
+					<div className="storage-details__limit">
+						<div className="limit__label label">{ translate( 'Space included in plan' ) }</div>
+						<div className="limit__value value">{ storageLimitText }</div>
+					</div>
+				</div>
+				<div className="retention-form">
+					<div className="retention-form__instructions">
+						{ translate( 'Select the number of days you would like your backups to be saved.' ) }
+					</div>
+					<RetentionOptionsControl
+						onChange={ onRetentionSelectionChange }
+						retentionSelected={ retentionSelected }
+						retentionOptions={ retentionOptionsCards }
+					/>
+					<div className="retention-form__disclaimer">
+						{ translate(
+							'*We estimate the space you need based on your current site size and the selected number of days.'
+						) }
+					</div>
+					<div className="retention-form__additional-storage">
+						<div className="additional-storage__label">
+							{ translate( 'You need additional storage to choose this setting.' ) }
+						</div>
+						<div className="additional-storage__cta">
+							{ translate( 'Add XXGB additional storage for $X/month' ) }
+						</div>
+					</div>
+					<div className="retention-form__submit">
+						<Button
+							primary
+							onClick={ handleUpdateRetention }
+							disabled={ disableForm || formHasErrors }
+						>
+							{ translate( 'Update settings' ) }
+						</Button>
+					</div>
+				</div>
+			</Card>
+		</div>
+	);
+};
+
+export default BackupRetentionManagement;

--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -4,18 +4,26 @@ import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 import { useStorageText } from 'calypso/components/backup-storage-space/hooks';
-import QueryRewindPolicies from 'calypso/components/data/query-rewind-policies';
-import QueryRewindSize from 'calypso/components/data/query-rewind-size';
+import { useQueryRewindPolicies } from 'calypso/components/data/query-rewind-policies';
+import { useQueryRewindSize } from 'calypso/components/data/query-rewind-size';
 import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
 import getRewindBytesAvailable from 'calypso/state/rewind/selectors/get-rewind-bytes-available';
+import isRequestingRewindPolicies from 'calypso/state/rewind/selectors/is-requesting-rewind-policies';
+import isRequestingRewindSize from 'calypso/state/rewind/selectors/is-requesting-rewind-size';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { RetentionOptions, RetentionRadioOptionType } from './consts';
 import { useEstimatedCurrentSiteSize, usePrepareRetentionOptions } from './hooks';
+import LoadingPlaceholder from './loading';
 import RetentionOptionsControl from './retention-options/retention-options-control';
 import './style.scss';
 
 const BackupRetentionManagement: FunctionComponent = () => {
 	const siteId = useSelector( getSelectedSiteId ) as number;
+
+	// Query dependencies
+	useQueryRewindSize( siteId );
+	useQueryRewindPolicies( siteId );
+
 	const translate = useTranslate();
 
 	const disableForm = false;
@@ -33,95 +41,106 @@ const BackupRetentionManagement: FunctionComponent = () => {
 	const currentSiteSizeText = useStorageText( estimatedCurrentSiteSize );
 	const storageLimitText = useStorageText( storageLimitBytes );
 
-	const retentionOptionsCards: Array< RetentionRadioOptionType > = [
-		usePrepareRetentionOptions(
+	const requestingSize = useSelector( ( state ) => isRequestingRewindSize( state, siteId ) );
+	const requestingPolicies = useSelector( ( state ) =>
+		isRequestingRewindPolicies( state, siteId )
+	);
+
+	const isFetching = requestingSize || requestingPolicies;
+
+	const retentionOptionsCards: Record< number, RetentionRadioOptionType > = {
+		[ RetentionOptions.RETENTION_DAYS_7 ]: usePrepareRetentionOptions(
 			translate( '7 days' ),
 			RetentionOptions.RETENTION_DAYS_7,
 			retentionSelected === RetentionOptions.RETENTION_DAYS_7
 		),
-		usePrepareRetentionOptions(
+		[ RetentionOptions.RETENTION_DAYS_30 ]: usePrepareRetentionOptions(
 			translate( '30 days' ),
 			RetentionOptions.RETENTION_DAYS_30,
 			retentionSelected === RetentionOptions.RETENTION_DAYS_30
 		),
-		usePrepareRetentionOptions(
+		[ RetentionOptions.RETENTION_DAYS_120 ]: usePrepareRetentionOptions(
 			translate( '120 days' ),
 			RetentionOptions.RETENTION_DAYS_120,
 			retentionSelected === RetentionOptions.RETENTION_DAYS_120
 		),
-		usePrepareRetentionOptions(
+		[ RetentionOptions.RETENTION_DAYS_365 ]: usePrepareRetentionOptions(
 			translate( '1 year' ),
 			RetentionOptions.RETENTION_DAYS_365,
 			retentionSelected === RetentionOptions.RETENTION_DAYS_365
 		),
-	];
+	};
 
+	// Set the retention period selected when we fetch the current plan retention period
 	useEffect( () => {
-		if ( planRetentionPeriod ) {
+		if ( planRetentionPeriod && ! retentionSelected ) {
 			setRetentionSelected( planRetentionPeriod );
 		}
-	}, [ planRetentionPeriod ] );
+	}, [ planRetentionPeriod, retentionSelected ] );
 
 	const handleUpdateRetention = () => {
 		return;
 	};
 
+	// Set the retention period selected when the user selects a new option
 	const onRetentionSelectionChange = useCallback( ( value: number ) => {
-		setRetentionSelected( value );
+		if ( value ) {
+			setRetentionSelected( value );
+		}
 	}, [] );
 
 	return (
-		<div className="backup-retention-management">
-			<QueryRewindPolicies siteId={ siteId } />
-			<QueryRewindSize siteId={ siteId } />
-			<Card compact={ true }>
-				<h3>{ translate( 'Days of backups saved' ) }</h3>
-			</Card>
-			<Card>
-				<div className="storage-details">
-					<div className="storage-details__size">
-						<div className="size__label label">{ translate( 'Current site size*' ) }</div>
-						<div className="size__value value">{ currentSiteSizeText }</div>
-					</div>
-					<div className="storage-details__limit">
-						<div className="limit__label label">{ translate( 'Space included in plan' ) }</div>
-						<div className="limit__value value">{ storageLimitText }</div>
-					</div>
-				</div>
-				<div className="retention-form">
-					<div className="retention-form__instructions">
-						{ translate( 'Select the number of days you would like your backups to be saved.' ) }
-					</div>
-					<RetentionOptionsControl
-						onChange={ onRetentionSelectionChange }
-						retentionSelected={ retentionSelected }
-						retentionOptions={ retentionOptionsCards }
-					/>
-					<div className="retention-form__disclaimer">
-						{ translate(
-							'*We estimate the space you need based on your current site size and the selected number of days.'
-						) }
-					</div>
-					<div className="retention-form__additional-storage">
-						<div className="additional-storage__label">
-							{ translate( 'You need additional storage to choose this setting.' ) }
+		( isFetching && <LoadingPlaceholder /> ) || (
+			<div className="backup-retention-management">
+				<Card compact={ true }>
+					<h3>{ translate( 'Days of backups saved' ) }</h3>
+				</Card>
+				<Card>
+					<div className="storage-details">
+						<div className="storage-details__size">
+							<div className="size__label label">{ translate( 'Current site size*' ) }</div>
+							<div className="size__value value">{ currentSiteSizeText }</div>
 						</div>
-						<div className="additional-storage__cta">
-							{ translate( 'Add XXGB additional storage for $X/month' ) }
+						<div className="storage-details__limit">
+							<div className="limit__label label">{ translate( 'Space included in plan' ) }</div>
+							<div className="limit__value value">{ storageLimitText }</div>
 						</div>
 					</div>
-					<div className="retention-form__submit">
-						<Button
-							primary
-							onClick={ handleUpdateRetention }
-							disabled={ disableForm || formHasErrors }
-						>
-							{ translate( 'Update settings' ) }
-						</Button>
+					<div className="retention-form">
+						<div className="retention-form__instructions">
+							{ translate( 'Select the number of days you would like your backups to be saved.' ) }
+						</div>
+						<RetentionOptionsControl
+							onChange={ onRetentionSelectionChange }
+							retentionSelected={ retentionSelected }
+							retentionOptions={ retentionOptionsCards }
+						/>
+						<div className="retention-form__disclaimer">
+							{ translate(
+								'*We estimate the space you need based on your current site size and the selected number of days.'
+							) }
+						</div>
+						<div className="retention-form__additional-storage">
+							<div className="additional-storage__label">
+								{ translate( 'You need additional storage to choose this setting.' ) }
+							</div>
+							<div className="additional-storage__cta">
+								{ translate( 'Add XXGB additional storage for $X/month' ) }
+							</div>
+						</div>
+						<div className="retention-form__submit">
+							<Button
+								primary
+								onClick={ handleUpdateRetention }
+								disabled={ disableForm || formHasErrors }
+							>
+								{ translate( 'Update settings' ) }
+							</Button>
+						</div>
 					</div>
-				</div>
-			</Card>
-		</div>
+				</Card>
+			</div>
+		)
 	);
 };
 

--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -53,7 +53,7 @@ const BackupRetentionManagement: FunctionComponent = () => {
 
 	// The retention days that currently applies for this customer.
 	const [ currentRetentionPlan, setCurrentRetentionPlan ] = useState( 0 );
-	useMemo( () => {
+	useEffect( () => {
 		if ( isFetching ) {
 			return;
 		}
@@ -63,7 +63,8 @@ const BackupRetentionManagement: FunctionComponent = () => {
 		} else if ( planRetentionPeriod ) {
 			setCurrentRetentionPlan( planRetentionPeriod );
 		}
-	}, [ customerRetentionPeriod, isFetching, planRetentionPeriod ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ customerRetentionPeriod, planRetentionPeriod ] );
 
 	const storageLimitBytes = useSelector( ( state ) =>
 		getRewindBytesAvailable( state, siteId )

--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Card, Dialog } from '@automattic/components';
 import { Spinner } from '@wordpress/components';
-import { useEffect, useState, useCallback, useMemo } from '@wordpress/element';
+import { useEffect, useState, useCallback } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useDispatch, useSelector } from 'react-redux';

--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -15,11 +15,12 @@ import getRewindBytesAvailable from 'calypso/state/rewind/selectors/get-rewind-b
 import isRequestingRewindPolicies from 'calypso/state/rewind/selectors/is-requesting-rewind-policies';
 import isRequestingRewindSize from 'calypso/state/rewind/selectors/is-requesting-rewind-size';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { RetentionOptions, RetentionRadioOptionType } from './consts';
+import { RetentionOptions } from './consts';
 import { useEstimatedCurrentSiteSize, usePrepareRetentionOptions } from './hooks';
 import InfoTooltip from './info-tooltip';
 import LoadingPlaceholder from './loading';
 import RetentionOptionsControl from './retention-options/retention-options-control';
+import type { RetentionRadioOptionType } from './types';
 import type { RetentionPeriod } from 'calypso/state/rewind/retention/types';
 import './style.scss';
 

--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -17,6 +17,7 @@ import isRequestingRewindSize from 'calypso/state/rewind/selectors/is-requesting
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { RetentionOptions, RetentionRadioOptionType } from './consts';
 import { useEstimatedCurrentSiteSize, usePrepareRetentionOptions } from './hooks';
+import InfoTooltip from './info-tooltip';
 import LoadingPlaceholder from './loading';
 import RetentionOptionsControl from './retention-options/retention-options-control';
 import type { RetentionPeriod } from 'calypso/state/rewind/retention/types';
@@ -160,8 +161,9 @@ const BackupRetentionManagement: FunctionComponent = () => {
 	return (
 		( isFetching && <LoadingPlaceholder /> ) || (
 			<div className="backup-retention-management">
-				<Card compact={ true }>
-					<h3>{ translate( 'Days of backups saved' ) }</h3>
+				<Card compact={ true } className="setting-title">
+					<h3>{ translate( 'Days of backups saved' ) } </h3>
+					<InfoTooltip />
 				</Card>
 				<Card>
 					<div className="storage-details">

--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -166,7 +166,7 @@ const BackupRetentionManagement: FunctionComponent = () => {
 					<h3>{ translate( 'Days of backups saved' ) } </h3>
 					<InfoTooltip />
 				</Card>
-				<Card>
+				<Card className="setting-content">
 					<div className="storage-details">
 						<div className="storage-details__size">
 							<div className="size__label label">{ translate( 'Current site size*' ) }</div>

--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -15,7 +15,7 @@ import getRewindBytesAvailable from 'calypso/state/rewind/selectors/get-rewind-b
 import isRequestingRewindPolicies from 'calypso/state/rewind/selectors/is-requesting-rewind-policies';
 import isRequestingRewindSize from 'calypso/state/rewind/selectors/is-requesting-rewind-size';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { RetentionOptions } from './consts';
+import { RETENTION_OPTIONS } from './constants';
 import { useEstimatedCurrentSiteSize, usePrepareRetentionOptions } from './hooks';
 import InfoTooltip from './info-tooltip';
 import LoadingPlaceholder from './loading';
@@ -76,29 +76,29 @@ const BackupRetentionManagement: FunctionComponent = () => {
 	const storageLimitText = useStorageText( storageLimitBytes );
 
 	const retentionOptionsCards: Record< number, RetentionRadioOptionType > = {
-		[ RetentionOptions.RETENTION_DAYS_7 ]: usePrepareRetentionOptions(
+		[ RETENTION_OPTIONS.RETENTION_DAYS_7 ]: usePrepareRetentionOptions(
 			translate( '7 days' ),
-			RetentionOptions.RETENTION_DAYS_7,
+			RETENTION_OPTIONS.RETENTION_DAYS_7,
 			currentRetentionPlan,
-			retentionSelected === RetentionOptions.RETENTION_DAYS_7
+			retentionSelected === RETENTION_OPTIONS.RETENTION_DAYS_7
 		),
-		[ RetentionOptions.RETENTION_DAYS_30 ]: usePrepareRetentionOptions(
+		[ RETENTION_OPTIONS.RETENTION_DAYS_30 ]: usePrepareRetentionOptions(
 			translate( '30 days' ),
-			RetentionOptions.RETENTION_DAYS_30,
+			RETENTION_OPTIONS.RETENTION_DAYS_30,
 			currentRetentionPlan,
-			retentionSelected === RetentionOptions.RETENTION_DAYS_30
+			retentionSelected === RETENTION_OPTIONS.RETENTION_DAYS_30
 		),
-		[ RetentionOptions.RETENTION_DAYS_120 ]: usePrepareRetentionOptions(
+		[ RETENTION_OPTIONS.RETENTION_DAYS_120 ]: usePrepareRetentionOptions(
 			translate( '120 days' ),
-			RetentionOptions.RETENTION_DAYS_120,
+			RETENTION_OPTIONS.RETENTION_DAYS_120,
 			currentRetentionPlan,
-			retentionSelected === RetentionOptions.RETENTION_DAYS_120
+			retentionSelected === RETENTION_OPTIONS.RETENTION_DAYS_120
 		),
-		[ RetentionOptions.RETENTION_DAYS_365 ]: usePrepareRetentionOptions(
+		[ RETENTION_OPTIONS.RETENTION_DAYS_365 ]: usePrepareRetentionOptions(
 			translate( '1 year' ),
-			RetentionOptions.RETENTION_DAYS_365,
+			RETENTION_OPTIONS.RETENTION_DAYS_365,
 			currentRetentionPlan,
-			retentionSelected === RetentionOptions.RETENTION_DAYS_365
+			retentionSelected === RETENTION_OPTIONS.RETENTION_DAYS_365
 		),
 	};
 

--- a/client/components/backup-retention-management/info-tooltip/index.tsx
+++ b/client/components/backup-retention-management/info-tooltip/index.tsx
@@ -1,0 +1,68 @@
+import { Button, Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import * as React from 'react';
+import Tooltip from 'calypso/components/tooltip';
+import './style.scss';
+
+const InfoToolTip: React.FC = () => {
+	const translate = useTranslate();
+	const [ isTooltipVisible, setTooltipVisible ] = React.useState< boolean >( false );
+	const tooltip = React.useRef< SVGSVGElement >( null );
+
+	const toggleTooltip = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ): void => {
+		setTooltipVisible( ! isTooltipVisible );
+		// when the info tooltip inside a button, we don't want clicking it to propagate up
+		event.stopPropagation();
+	};
+
+	const closeTooltip = () => {
+		setTooltipVisible( false );
+	};
+
+	return (
+		<div className="retention-setting-info-tooltip">
+			<Button
+				borderless
+				className="retention-setting-info-tooltip__toggle-tooltip"
+				onClick={ toggleTooltip }
+			>
+				<Gridicon ref={ tooltip } icon="info-outline" />
+			</Button>
+			<Tooltip
+				className="retention-setting-info-tooltip__tooltip"
+				isVisible={ isTooltipVisible }
+				position="right"
+				context={ tooltip.current }
+				showOnMobile
+			>
+				<p>
+					{ translate(
+						'You can manage the storage used by changing how many days of backups will be saved.'
+					) }
+					<Button
+						borderless
+						compact
+						className="retention-setting-info-tooltip__close-tooltip"
+						onClick={ closeTooltip }
+					>
+						<Gridicon icon="cross" size={ 18 } />
+					</Button>
+				</p>
+				<hr />
+				{ translate( '{{a}}Learn more…{{/a}}', {
+					components: {
+						a: (
+							<a
+								href="https://jetpack.com/support/backup/#how-is-storage-usage-calculated"
+								target="_blank"
+								rel="external noreferrer noopener"
+							/>
+						),
+					},
+				} ) }
+			</Tooltip>
+		</div>
+	);
+};
+
+export default InfoToolTip;

--- a/client/components/backup-retention-management/info-tooltip/index.tsx
+++ b/client/components/backup-retention-management/info-tooltip/index.tsx
@@ -2,6 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import Tooltip from 'calypso/components/tooltip';
+import { STORAGE_RETENTION_LEARN_MORE_LINK } from '../constants';
 import './style.scss';
 
 const InfoToolTip: React.FC = () => {
@@ -53,7 +54,7 @@ const InfoToolTip: React.FC = () => {
 					components: {
 						a: (
 							<a
-								href="https://jetpack.com/support/backup/#how-is-storage-usage-calculated"
+								href={ STORAGE_RETENTION_LEARN_MORE_LINK }
 								target="_blank"
 								rel="external noreferrer noopener"
 							/>

--- a/client/components/backup-retention-management/info-tooltip/index.tsx
+++ b/client/components/backup-retention-management/info-tooltip/index.tsx
@@ -1,14 +1,15 @@
 import { Button, Gridicon } from '@automattic/components';
+import { useRef, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import * as React from 'react';
+import { FunctionComponent } from 'react';
 import Tooltip from 'calypso/components/tooltip';
 import { STORAGE_RETENTION_LEARN_MORE_LINK } from '../constants';
 import './style.scss';
 
-const InfoToolTip: React.FC = () => {
+const InfoToolTip: FunctionComponent = () => {
 	const translate = useTranslate();
-	const [ isTooltipVisible, setTooltipVisible ] = React.useState< boolean >( false );
-	const tooltip = React.useRef< SVGSVGElement >( null );
+	const [ isTooltipVisible, setTooltipVisible ] = useState< boolean >( false );
+	const tooltip = useRef< SVGSVGElement >( null );
 
 	const toggleTooltip = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ): void => {
 		setTooltipVisible( ! isTooltipVisible );

--- a/client/components/backup-retention-management/info-tooltip/style.scss
+++ b/client/components/backup-retention-management/info-tooltip/style.scss
@@ -1,0 +1,74 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.retention-setting-info-tooltip {
+	line-height: normal;
+
+	&__tooltip.popover {
+		&.is-right .popover__arrow {
+			border-right-color: #fff;
+		}
+
+		&.is-top-right .popover__arrow {
+			border-top-color: #fff;
+		}
+
+		&.is-bottom-right .popover__arrow {
+			border-bottom-color: #fff;
+		}
+
+		.popover__inner {
+			padding: 16px;
+			color: var(--studio-gray-70);
+			background: #fff;
+			border-radius: 2px;
+			box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+
+			p {
+				padding-right: 24px;
+				font-size: 0.875rem;
+				color: var(--studio-gray-60);
+				margin: 0;
+			}
+
+			hr {
+				margin-bottom: 0.25rem;
+			}
+
+			a {
+				font-size: 0.875rem;
+				text-decoration: underline;
+			}
+		}
+
+		@include break-mobile() {
+			max-width: 270px;
+		}
+	}
+
+	&__toggle-tooltip {
+		vertical-align: middle;
+
+		&.button.is-borderless {
+			padding: 0;
+			height: 20px;
+
+			.gridicon {
+				top: 0;
+				color: var(--studio-gray-60);
+			}
+		}
+	}
+
+	&__close-tooltip {
+		position: absolute;
+		right: 16px;
+		top: 16px;
+		color: var(--studio-gray-40);
+
+		&.button {
+			height: 18px;
+			padding: 0;
+		}
+	}
+}

--- a/client/components/backup-retention-management/loading/index.tsx
+++ b/client/components/backup-retention-management/loading/index.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import './style.scss';
+
+const LoadingPlaceholder: React.FC = () => (
+	<div className="backup-retention-management__loading loading">
+		<div className="loading__placeholder" />
+	</div>
+);
+
+export default LoadingPlaceholder;

--- a/client/components/backup-retention-management/loading/index.tsx
+++ b/client/components/backup-retention-management/loading/index.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import { FunctionComponent } from 'react';
 import './style.scss';
 
-const LoadingPlaceholder: React.FC = () => (
+const LoadingPlaceholder: FunctionComponent = () => (
 	<div className="backup-retention-management__loading loading">
 		<div className="loading__placeholder" />
 	</div>

--- a/client/components/backup-retention-management/loading/style.scss
+++ b/client/components/backup-retention-management/loading/style.scss
@@ -1,0 +1,16 @@
+.backup-retention-management__loading {
+	&.loading {
+		box-sizing: border-box;
+		max-width: 720px;
+		margin: 0 auto;
+		margin-bottom: 16px;
+		padding: 0 16px;
+
+		&__placeholder {
+			@include placeholder();
+
+			width: 100%;
+			height: 186px;
+		}
+	}
+}

--- a/client/components/backup-retention-management/retention-options/retention-option-card.tsx
+++ b/client/components/backup-retention-management/retention-options/retention-option-card.tsx
@@ -1,0 +1,74 @@
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+
+interface RetentionOptionCardProps {
+	label: string;
+	spaceNeeded: string;
+	upgradeRequired: boolean;
+	isCurrentPlan: boolean;
+	value: number;
+	checked?: boolean;
+	onChange: ( value: number ) => void;
+}
+
+const RetentionOptionCard: React.FC< RetentionOptionCardProps > = ( {
+	label,
+	spaceNeeded,
+	upgradeRequired,
+	isCurrentPlan,
+	value,
+	checked = false,
+	onChange,
+} ) => {
+	const translate = useTranslate();
+
+	const handleOptionClick = () => {
+		onChange( value );
+	};
+
+	return (
+		<div
+			className="retention-option"
+			role="radio"
+			aria-checked={ checked }
+			onClick={ handleOptionClick }
+			onKeyDown={ handleOptionClick }
+			tabIndex={ 0 }
+		>
+			<div className="retention-option__headline">
+				<div className="headline__label">{ label }</div>
+				<input
+					className="headline__input components-radio-control__input"
+					type="radio"
+					name="storage_option"
+					value={ value }
+					checked={ checked }
+					onChange={ ( event ) => {
+						onChange( Number( event.target.value ) );
+					} }
+				/>
+			</div>
+			<div className="retention-option__space-needed">
+				<div className="space-needed__label">{ translate( 'Space needed:' ) }</div>
+				<div className="space-needed__value">{ spaceNeeded }</div>
+			</div>
+			<div
+				className={ classnames( 'retention-option__upgrade-required', {
+					'is-visible': upgradeRequired,
+				} ) }
+			>
+				{ translate( 'Upgrade required' ) }
+			</div>
+			<div
+				className={ classnames( 'retention-option__current-plan', {
+					'is-visible': isCurrentPlan,
+				} ) }
+			>
+				{ translate( 'Current plan' ) }
+			</div>
+		</div>
+	);
+};
+
+export default RetentionOptionCard;

--- a/client/components/backup-retention-management/retention-options/retention-option-card.tsx
+++ b/client/components/backup-retention-management/retention-options/retention-option-card.tsx
@@ -1,10 +1,11 @@
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
+import type { TranslateResult } from 'i18n-calypso';
 
 interface RetentionOptionCardProps {
 	label: string;
-	spaceNeeded: string;
+	spaceNeeded: TranslateResult | string;
 	upgradeRequired: boolean;
 	isCurrentPlan: boolean;
 	value: number;

--- a/client/components/backup-retention-management/retention-options/retention-option-card.tsx
+++ b/client/components/backup-retention-management/retention-options/retention-option-card.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
+import { FunctionComponent } from 'react';
 import type { TranslateResult } from 'i18n-calypso';
 
 interface RetentionOptionCardProps {
@@ -13,7 +13,7 @@ interface RetentionOptionCardProps {
 	onChange: ( value: number ) => void;
 }
 
-const RetentionOptionCard: React.FC< RetentionOptionCardProps > = ( {
+const RetentionOptionCard: FunctionComponent< RetentionOptionCardProps > = ( {
 	label,
 	spaceNeeded,
 	upgradeRequired,

--- a/client/components/backup-retention-management/retention-options/retention-options-control.tsx
+++ b/client/components/backup-retention-management/retention-options/retention-options-control.tsx
@@ -28,7 +28,7 @@ const RetentionOptionsControl: React.FC< RetentionOptionsControlProps > = ( {
 
 	return (
 		<div className="retention-form__options">
-			{ retentionOptions.map( ( option ) => (
+			{ Object.values( retentionOptions ).map( ( option ) => (
 				<RetentionOptionCard
 					{ ...option }
 					key={ option.value }

--- a/client/components/backup-retention-management/retention-options/retention-options-control.tsx
+++ b/client/components/backup-retention-management/retention-options/retention-options-control.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState, useCallback } from '@wordpress/element';
+import React from 'react';
+import { RetentionRadioOptionType } from '../consts';
+import RetentionOptionCard from './retention-option-card';
+
+interface RetentionOptionsControlProps {
+	retentionOptions: Array< RetentionRadioOptionType >;
+	retentionSelected?: number;
+	onChange: ( value: number ) => void;
+}
+
+const RetentionOptionsControl: React.FC< RetentionOptionsControlProps > = ( {
+	retentionOptions,
+	retentionSelected,
+	onChange,
+} ) => {
+	const [ selectedOption, setSelectedOption ] = useState( retentionSelected );
+
+	useEffect( () => {
+		if ( typeof selectedOption === 'number' ) {
+			onChange( selectedOption );
+		}
+	}, [ selectedOption, onChange ] );
+
+	const handleRetentionOptionChange = useCallback( ( value: number ) => {
+		setSelectedOption( value );
+	}, [] );
+
+	return (
+		<div className="retention-form__options">
+			{ retentionOptions.map( ( option ) => (
+				<RetentionOptionCard
+					{ ...option }
+					key={ option.value }
+					onChange={ handleRetentionOptionChange }
+				/>
+			) ) }
+		</div>
+	);
+};
+
+export default RetentionOptionsControl;

--- a/client/components/backup-retention-management/retention-options/retention-options-control.tsx
+++ b/client/components/backup-retention-management/retention-options/retention-options-control.tsx
@@ -4,7 +4,7 @@ import { RetentionRadioOptionType } from '../consts';
 import RetentionOptionCard from './retention-option-card';
 
 interface RetentionOptionsControlProps {
-	retentionOptions: Array< RetentionRadioOptionType >;
+	retentionOptions: Record< number, RetentionRadioOptionType >;
 	retentionSelected?: number;
 	onChange: ( value: number ) => void;
 }

--- a/client/components/backup-retention-management/retention-options/retention-options-control.tsx
+++ b/client/components/backup-retention-management/retention-options/retention-options-control.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from '@wordpress/element';
 import React from 'react';
-import { RetentionRadioOptionType } from '../consts';
 import RetentionOptionCard from './retention-option-card';
+import type { RetentionRadioOptionType } from '../types';
 
 interface RetentionOptionsControlProps {
 	retentionOptions: Record< number, RetentionRadioOptionType >;

--- a/client/components/backup-retention-management/style.scss
+++ b/client/components/backup-retention-management/style.scss
@@ -1,0 +1,170 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.backup-retention-management {
+	--color-accent: var(--studio-green-50);
+	box-sizing: border-box;
+	margin: auto;
+	max-width: 720px;
+	padding-left: 16px;
+	padding-right: 16px;
+
+	h3 {
+		font-size: $font-body;
+	}
+
+	.storage-details {
+		display: flex;
+		flex-direction: row;
+		grid-column-gap: 48px;
+		margin-bottom: 26px;
+
+		.label {
+			font-size: 0.875rem;
+		}
+
+		.value {
+			font-size: 1.75rem;
+			font-weight: 600;
+			color: var(--studio-gray-60);
+		}
+	}
+
+	.retention-form {
+		.retention-form__instructions {
+			margin-bottom: 24px;
+			font-size: 1rem;
+			font-weight: 400;
+			line-height: 24px;
+			color: var(--studio-gray-50);
+		}
+
+		.retention-form__options {
+			display: flex;
+			flex-direction: row;
+			align-items: flex-start;
+			justify-content: space-between;
+			column-gap: 8px;
+			margin-bottom: 8px;
+
+			.retention-option {
+				box-shadow: 0 0 0 1px var(--color-border-subtle);
+				padding: 16px 12px;
+				border-radius: 4px;
+				width: 100%;
+				cursor: pointer;
+				align-self: stretch;
+
+				.retention-option__headline {
+					display: flex;
+					flex-direction: row;
+					align-items: center;
+					justify-content: space-between;
+					margin-bottom: 16px;
+
+					.headline__label {
+						font-size: 1.5rem;
+						line-height: 24px;
+						font-weight: 600;
+						color: var(--studio-gray-80);
+					}
+
+					.headline__input {
+						-webkit-appearance: none;
+						appearance: none;
+						margin: 0;
+						padding: 0;
+						width: 24px;
+						height: 24px;
+						border-width: 2px;
+						border-color: var(--studio-gray-40);
+
+						&:focus {
+							box-shadow: none;
+						}
+
+						&::after {
+							content: "";
+							display: block;
+							border-radius: 50%;
+							width: 10px;
+							height: 10px;
+							margin: 1px;
+						}
+
+						&:checked {
+							&::after {
+								border: 4px solid #fff;
+							}
+
+							border-color: var(--color-accent);
+						}
+					}
+				}
+
+				.retention-option__space-needed {
+					margin-bottom: 16px;
+
+					.space-needed__label {
+						font-size: 0.875rem;
+						font-weight: 400;
+						line-height: 28px;
+						color: var(--studio-gray-80);
+					}
+
+					.space-needed__value {
+						font-size: 1rem;
+						font-weight: 600;
+						color: var(--studio-gray-80);
+					}
+				}
+
+				&__upgrade-required {
+					font-size: 0.875rem;
+					font-weight: 400;
+					color: var(--studio-red-50);
+					margin-bottom: 8px;
+					visibility: hidden;
+					&.is-visible {
+						visibility: visible;
+					}
+				}
+
+				&__current-plan {
+					background: var(--studio-green-5);
+					border-radius: 2px;
+					color: var(--studio-green-60);
+					display: inline-block;
+					font-size: 0.75rem;
+					font-weight: 400;
+					line-height: 24px;
+					padding: 0 8px;
+					visibility: hidden;
+					&.is-visible {
+						visibility: visible;
+					}
+				}
+			}
+		}
+
+		.retention-form__disclaimer {
+			font-size: 0.75rem;
+			font-weight: 400;
+			line-height: 18px;
+			color: var(--studio-gray-50);
+			margin-bottom: 18px;
+		}
+
+		.retention-form__additional-storage {
+			margin-bottom: 8px;
+
+			.additional-storage__cta {
+				font-weight: 600;
+			}
+		}
+
+		.retention-form__submit {
+			text-align: right;
+		}
+	}
+}

--- a/client/components/backup-retention-management/style.scss
+++ b/client/components/backup-retention-management/style.scss
@@ -45,6 +45,7 @@
 			grid-template-rows: repeat(2, 1fr);
 			grid-column-gap: 8px;
 			grid-row-gap: 8px;
+			margin-bottom: 8px;
 
 			@include break-large {
 				grid-template-columns: repeat(4, 1fr);
@@ -168,5 +169,17 @@
 		.retention-form__submit {
 			text-align: right;
 		}
+	}
+}
+
+.backup-retention-management.retention-form__confirmation-dialog {
+	max-width: 465px;
+
+	h3 {
+		margin-bottom: 16px;
+	}
+
+	p {
+		font-size: 1rem;
 	}
 }

--- a/client/components/backup-retention-management/style.scss
+++ b/client/components/backup-retention-management/style.scss
@@ -173,7 +173,9 @@
 }
 
 .backup-retention-management.retention-form__confirmation-dialog {
-	max-width: 465px;
+	&.dialog.card {
+		max-width: 465px;
+	}
 
 	h3 {
 		margin-bottom: 16px;

--- a/client/components/backup-retention-management/style.scss
+++ b/client/components/backup-retention-management/style.scss
@@ -17,7 +17,7 @@
 		display: flex;
 		flex-direction: row;
 		grid-column-gap: 48px;
-		margin-bottom: 26px;
+		margin-bottom: 32px;
 
 		.label {
 			font-size: 0.875rem;
@@ -39,6 +39,10 @@
 	justify-content: flex-start;
 }
 
+.backup-retention-management .setting-content {
+	padding-top: 28px;
+}
+
 .backup-retention-management .retention-form {
 	&__instructions {
 		margin-bottom: 24px;
@@ -53,7 +57,7 @@
 		font-weight: 400;
 		line-height: 18px;
 		color: var(--studio-gray-50);
-		margin-bottom: 18px;
+		margin-bottom: 24px;
 	}
 
 	&__additional-storage {

--- a/client/components/backup-retention-management/style.scss
+++ b/client/components/backup-retention-management/style.scss
@@ -29,145 +29,145 @@
 			color: var(--studio-gray-60);
 		}
 	}
+}
 
-	.retention-form {
-		.retention-form__instructions {
-			margin-bottom: 24px;
-			font-size: 1rem;
-			font-weight: 400;
+.backup-retention-management .retention-form {
+	&__instructions {
+		margin-bottom: 24px;
+		font-size: 1rem;
+		font-weight: 400;
+		line-height: 24px;
+		color: var(--studio-gray-50);
+	}
+
+	&__disclaimer {
+		font-size: 0.75rem;
+		font-weight: 400;
+		line-height: 18px;
+		color: var(--studio-gray-50);
+		margin-bottom: 18px;
+	}
+
+	&__additional-storage {
+		margin-bottom: 8px;
+
+		.additional-storage__cta {
+			font-weight: 600;
+		}
+	}
+
+	&__submit {
+		text-align: right;
+	}
+}
+
+.backup-retention-management .retention-form .retention-form__options {
+	display: grid;
+	grid-template-columns: repeat(2, 1fr);
+	grid-template-rows: repeat(2, 1fr);
+	grid-column-gap: 8px;
+	grid-row-gap: 8px;
+	margin-bottom: 8px;
+
+	@include break-large {
+		grid-template-columns: repeat(4, 1fr);
+		grid-template-rows: repeat(1, 1fr);
+	}
+
+	.retention-option {
+		box-shadow: 0 0 0 1px var(--color-border-subtle);
+		padding: 16px 12px;
+		border-radius: 4px;
+		cursor: pointer;
+
+		&__headline {
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			justify-content: space-between;
+			margin-bottom: 16px;
+		}
+
+		&__headline .headline__label {
+			font-size: 1.25rem;
 			line-height: 24px;
-			color: var(--studio-gray-50);
+			font-weight: 600;
+			color: var(--studio-gray-80);
 		}
 
-		.retention-form__options {
-			display: grid;
-			grid-template-columns: repeat(2, 1fr);
-			grid-template-rows: repeat(2, 1fr);
-			grid-column-gap: 8px;
-			grid-row-gap: 8px;
+		&__headline	.headline__input {
+			-webkit-appearance: none;
+			appearance: none;
+			margin: 0;
+			padding: 0;
+			width: 20px;
+			height: 20px;
+			border-width: 1px;
+			border-color: var(--studio-gray-40);
+
+			&:focus {
+				box-shadow: none;
+			}
+
+			&::after {
+				content: "";
+				display: block;
+				border-radius: 50%;
+				width: 10px;
+				height: 10px;
+				margin: 1px;
+			}
+
+			&:checked {
+				&::after {
+					border: 3px solid #fff;
+				}
+
+				border-color: var(--color-accent);
+			}
+		}
+
+		&__space-needed {
+			margin-bottom: 16px;
+
+			.space-needed__label {
+				font-size: 0.875rem;
+				font-weight: 400;
+				line-height: 28px;
+				color: var(--studio-gray-80);
+			}
+
+			.space-needed__value {
+				font-size: 1rem;
+				font-weight: 600;
+				color: var(--studio-gray-80);
+			}
+		}
+
+		&__upgrade-required {
+			font-size: 0.875rem;
+			font-weight: 400;
+			color: var(--studio-red-50);
 			margin-bottom: 8px;
-
-			@include break-large {
-				grid-template-columns: repeat(4, 1fr);
-				grid-template-rows: repeat(1, 1fr);
-			}
-
-			.retention-option {
-				box-shadow: 0 0 0 1px var(--color-border-subtle);
-				padding: 16px 12px;
-				border-radius: 4px;
-				cursor: pointer;
-
-				.retention-option__headline {
-					display: flex;
-					flex-direction: row;
-					align-items: center;
-					justify-content: space-between;
-					margin-bottom: 16px;
-
-					.headline__label {
-						font-size: 1.25rem;
-						line-height: 24px;
-						font-weight: 600;
-						color: var(--studio-gray-80);
-					}
-
-					.headline__input {
-						-webkit-appearance: none;
-						appearance: none;
-						margin: 0;
-						padding: 0;
-						width: 20px;
-						height: 20px;
-						border-width: 1px;
-						border-color: var(--studio-gray-40);
-
-						&:focus {
-							box-shadow: none;
-						}
-
-						&::after {
-							content: "";
-							display: block;
-							border-radius: 50%;
-							width: 10px;
-							height: 10px;
-							margin: 1px;
-						}
-
-						&:checked {
-							&::after {
-								border: 3px solid #fff;
-							}
-
-							border-color: var(--color-accent);
-						}
-					}
-				}
-
-				.retention-option__space-needed {
-					margin-bottom: 16px;
-
-					.space-needed__label {
-						font-size: 0.875rem;
-						font-weight: 400;
-						line-height: 28px;
-						color: var(--studio-gray-80);
-					}
-
-					.space-needed__value {
-						font-size: 1rem;
-						font-weight: 600;
-						color: var(--studio-gray-80);
-					}
-				}
-
-				&__upgrade-required {
-					font-size: 0.875rem;
-					font-weight: 400;
-					color: var(--studio-red-50);
-					margin-bottom: 8px;
-					visibility: hidden;
-					&.is-visible {
-						visibility: visible;
-					}
-				}
-
-				&__current-plan {
-					background: var(--studio-green-5);
-					border-radius: 2px;
-					color: var(--studio-green-60);
-					display: inline-block;
-					font-size: 0.75rem;
-					font-weight: 400;
-					line-height: 24px;
-					padding: 0 8px;
-					visibility: hidden;
-					&.is-visible {
-						visibility: visible;
-					}
-				}
+			visibility: hidden;
+			&.is-visible {
+				visibility: visible;
 			}
 		}
 
-		.retention-form__disclaimer {
+		&__current-plan {
+			background: var(--studio-green-5);
+			border-radius: 2px;
+			color: var(--studio-green-60);
+			display: inline-block;
 			font-size: 0.75rem;
 			font-weight: 400;
-			line-height: 18px;
-			color: var(--studio-gray-50);
-			margin-bottom: 18px;
-		}
-
-		.retention-form__additional-storage {
-			margin-bottom: 8px;
-
-			.additional-storage__cta {
-				font-weight: 600;
+			line-height: 24px;
+			padding: 0 8px;
+			visibility: hidden;
+			&.is-visible {
+				visibility: visible;
 			}
-		}
-
-		.retention-form__submit {
-			text-align: right;
 		}
 	}
 }

--- a/client/components/backup-retention-management/style.scss
+++ b/client/components/backup-retention-management/style.scss
@@ -40,20 +40,22 @@
 		}
 
 		.retention-form__options {
-			display: flex;
-			flex-direction: row;
-			align-items: flex-start;
-			justify-content: space-between;
-			column-gap: 8px;
-			margin-bottom: 8px;
+			display: grid;
+			grid-template-columns: repeat(2, 1fr);
+			grid-template-rows: repeat(2, 1fr);
+			grid-column-gap: 8px;
+			grid-row-gap: 8px;
+
+			@include break-large {
+				grid-template-columns: repeat(4, 1fr);
+				grid-template-rows: repeat(1, 1fr);
+			}
 
 			.retention-option {
 				box-shadow: 0 0 0 1px var(--color-border-subtle);
 				padding: 16px 12px;
 				border-radius: 4px;
-				width: 100%;
 				cursor: pointer;
-				align-self: stretch;
 
 				.retention-option__headline {
 					display: flex;
@@ -63,7 +65,7 @@
 					margin-bottom: 16px;
 
 					.headline__label {
-						font-size: 1.5rem;
+						font-size: 1.25rem;
 						line-height: 24px;
 						font-weight: 600;
 						color: var(--studio-gray-80);
@@ -74,9 +76,9 @@
 						appearance: none;
 						margin: 0;
 						padding: 0;
-						width: 24px;
-						height: 24px;
-						border-width: 2px;
+						width: 20px;
+						height: 20px;
+						border-width: 1px;
 						border-color: var(--studio-gray-40);
 
 						&:focus {
@@ -94,7 +96,7 @@
 
 						&:checked {
 							&::after {
-								border: 4px solid #fff;
+								border: 3px solid #fff;
 							}
 
 							border-color: var(--color-accent);

--- a/client/components/backup-retention-management/style.scss
+++ b/client/components/backup-retention-management/style.scss
@@ -31,6 +31,15 @@
 	}
 }
 
+.backup-retention-management .setting-title {
+	align-items: center;
+	column-gap: 8px;
+	display: flex;
+	flex-direction: row;
+	justify-content: flex-start;
+	margin-bottom: 16px;
+}
+
 .backup-retention-management .retention-form {
 	&__instructions {
 		margin-bottom: 24px;

--- a/client/components/backup-retention-management/style.scss
+++ b/client/components/backup-retention-management/style.scss
@@ -37,7 +37,6 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: flex-start;
-	margin-bottom: 16px;
 }
 
 .backup-retention-management .retention-form {

--- a/client/components/backup-retention-management/test/hooks.tsx
+++ b/client/components/backup-retention-management/test/hooks.tsx
@@ -2,7 +2,6 @@ import { renderHook } from '@testing-library/react-hooks';
 import getBackupCurrentSiteSize from 'calypso/state/rewind/selectors/get-backup-current-site-size';
 import getRewindBytesAvailable from 'calypso/state/rewind/selectors/get-rewind-bytes-available';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
-import { useStorageText } from '../../backup-storage-space/hooks';
 import {
 	useEstimatedCurrentSiteSize,
 	useEstimateSpaceNeeded,
@@ -20,17 +19,10 @@ jest.mock( 'react-redux', () => ( {
 	useSelector: jest.fn( ( func ) => func() ),
 } ) );
 
-jest.mock( 'i18n-calypso', () => ( {
-	useTranslate: jest.fn( () => ( text ) => text ),
-} ) );
-
 // Mock selectors
 jest.mock( 'calypso/state/ui/selectors/get-selected-site-id', () => jest.fn( () => MOCK_SITE_ID ) );
 jest.mock( 'calypso/state/rewind/selectors/get-backup-current-site-size', () => jest.fn() );
 jest.mock( 'calypso/state/rewind/selectors/get-rewind-bytes-available', () => jest.fn() );
-jest.mock( 'calypso/components/backup-storage-space/hooks', () => ( {
-	useStorageText: jest.fn(),
-} ) );
 
 // Fixtures
 const RETENTION_OPTIONS_FIXTURES = {
@@ -101,10 +93,6 @@ describe( 'hooks', () => {
 	} );
 
 	describe( 'usePrepareRetentionOptions', () => {
-		beforeAll( () => {
-			( useStorageText as jest.Mock ).mockImplementation( () => '10GB' );
-		} );
-
 		it( 'should return a retention option that is the current plan and requires upgrade when spaceNeeded is higher than storage limit', () => {
 			( getBackupCurrentSiteSize as jest.Mock ).mockImplementation( () => GB_IN_BYTES * 20 );
 			( getRewindBytesAvailable as jest.Mock ).mockImplementation( () => GB_IN_BYTES * 10 );
@@ -120,7 +108,7 @@ describe( 'hooks', () => {
 
 			const expectedOutput = {
 				label: input.label,
-				spaceNeeded: '10GB',
+				spaceNeeded: '750GB',
 				upgradeRequired: true,
 				isCurrentPlan: true,
 				value: input.desiredRetentionDays,
@@ -145,7 +133,7 @@ describe( 'hooks', () => {
 
 			const expectedOutput = {
 				label: input.label,
-				spaceNeeded: '10GB',
+				spaceNeeded: '0.0GB',
 				upgradeRequired: false,
 				isCurrentPlan: true,
 				value: input.desiredRetentionDays,
@@ -170,7 +158,7 @@ describe( 'hooks', () => {
 
 			const expectedOutput = {
 				label: input.label,
-				spaceNeeded: '10GB',
+				spaceNeeded: '2.9TB',
 				upgradeRequired: true,
 				isCurrentPlan: false,
 				value: input.desiredRetentionDays,
@@ -195,7 +183,7 @@ describe( 'hooks', () => {
 
 			const expectedOutput = {
 				label: input.label,
-				spaceNeeded: '10GB',
+				spaceNeeded: '0.1GB',
 				upgradeRequired: false,
 				isCurrentPlan: false,
 				value: input.desiredRetentionDays,

--- a/client/components/backup-retention-management/test/hooks.tsx
+++ b/client/components/backup-retention-management/test/hooks.tsx
@@ -1,0 +1,208 @@
+import { renderHook } from '@testing-library/react-hooks';
+import getBackupCurrentSiteSize from 'calypso/state/rewind/selectors/get-backup-current-site-size';
+import getRewindBytesAvailable from 'calypso/state/rewind/selectors/get-rewind-bytes-available';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import { useStorageText } from '../../backup-storage-space/hooks';
+import {
+	useEstimatedCurrentSiteSize,
+	useEstimateSpaceNeeded,
+	usePrepareRetentionOptions,
+} from '../hooks';
+
+// Constants
+const MOCK_SITE_ID = 123456;
+const MB_IN_BYTES = 2 ** 20;
+const GB_IN_BYTES = 2 ** 30;
+const TB_IN_BYTES = 2 ** 40;
+
+// Mock useSelector
+jest.mock( 'react-redux', () => ( {
+	useSelector: jest.fn( ( func ) => func() ),
+} ) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: jest.fn( () => ( text ) => text ),
+} ) );
+
+// Mock selectors
+jest.mock( 'calypso/state/ui/selectors/get-selected-site-id', () => jest.fn( () => MOCK_SITE_ID ) );
+jest.mock( 'calypso/state/rewind/selectors/get-backup-current-site-size', () => jest.fn() );
+jest.mock( 'calypso/state/rewind/selectors/get-rewind-bytes-available', () => jest.fn() );
+jest.mock( 'calypso/components/backup-storage-space/hooks', () => ( {
+	useStorageText: jest.fn(),
+} ) );
+
+// Fixtures
+const RETENTION_OPTIONS_FIXTURES = {
+	CURRENT_PLAN: {
+		label: '30 days',
+		desiredRetentionDays: 30,
+		currentRetentionPlan: 30,
+		checked: false,
+	},
+	DIFFERENT_PLAN: {
+		label: '120 days',
+		desiredRetentionDays: 120,
+		currentRetentionPlan: 30,
+		checked: false,
+	},
+};
+
+// Helper functions
+function renderPrepareRetentionOptionsHook(
+	label: string,
+	desiredRetentionDays: number,
+	retentionPlan: number,
+	checked: boolean
+) {
+	const { result } = renderHook( () =>
+		usePrepareRetentionOptions( label, desiredRetentionDays, retentionPlan, checked )
+	);
+
+	return result.current;
+}
+
+describe( 'hooks', () => {
+	describe( 'useEstimatedCurrentSiteSize', () => {
+		beforeAll( () => {
+			( getSelectedSiteId as jest.Mock ).mockReturnValue( MOCK_SITE_ID );
+		} );
+
+		it.each( [
+			[ 0, 0 ],
+			[ GB_IN_BYTES * 1.25, GB_IN_BYTES ],
+			[ TB_IN_BYTES * 1.25, TB_IN_BYTES ],
+		] )(
+			'should return %d estimated size in bytes, given the last backup size of %d',
+			( expectedEstimation, lastBackupSize ) => {
+				( getBackupCurrentSiteSize as jest.Mock ).mockImplementation( () => lastBackupSize );
+				const { result } = renderHook( () => useEstimatedCurrentSiteSize() );
+				expect( result.current ).toBe( expectedEstimation );
+			}
+		);
+	} );
+
+	describe( 'useEstimateSpaceNeeded', () => {
+		it.each( [
+			[ 0, 0, 0 ],
+			[ 9395240960, 1342177280, 7 ],
+			[ 40265318400, 1342177280, 30 ],
+			[ 161061273600, 1342177280, 120 ],
+			[ 489894707200, 1342177280, 365 ],
+		] )(
+			'should return %d as space needed in bytes, given the %d current site size in bytes and %d retention days',
+			( expectedSpaceNeeded, currentSiteSizeInBytes, desiredRetentionDays ) => {
+				const { result } = renderHook( () =>
+					useEstimateSpaceNeeded( currentSiteSizeInBytes, desiredRetentionDays )
+				);
+				expect( result.current ).toBe( expectedSpaceNeeded );
+			}
+		);
+	} );
+
+	describe( 'usePrepareRetentionOptions', () => {
+		beforeAll( () => {
+			( useStorageText as jest.Mock ).mockImplementation( () => '10GB' );
+		} );
+
+		it( 'should return a retention option that is the current plan and requires upgrade when spaceNeeded is higher than storage limit', () => {
+			( getBackupCurrentSiteSize as jest.Mock ).mockImplementation( () => GB_IN_BYTES * 20 );
+			( getRewindBytesAvailable as jest.Mock ).mockImplementation( () => GB_IN_BYTES * 10 );
+
+			const input = RETENTION_OPTIONS_FIXTURES.CURRENT_PLAN;
+
+			const output = renderPrepareRetentionOptionsHook(
+				input.label,
+				input.desiredRetentionDays,
+				input.currentRetentionPlan,
+				input.checked
+			);
+
+			const expectedOutput = {
+				label: input.label,
+				spaceNeeded: '10GB',
+				upgradeRequired: true,
+				isCurrentPlan: true,
+				value: input.desiredRetentionDays,
+				checked: input.checked,
+			};
+
+			expect( output ).toStrictEqual( expectedOutput );
+		} );
+
+		it( 'should return a retention option that is the current plan and not requires upgrade when spaceNeeded is lower than storage limit', () => {
+			( getBackupCurrentSiteSize as jest.Mock ).mockImplementation( () => MB_IN_BYTES );
+			( getRewindBytesAvailable as jest.Mock ).mockImplementation( () => GB_IN_BYTES * 10 );
+
+			const input = RETENTION_OPTIONS_FIXTURES.CURRENT_PLAN;
+
+			const output = renderPrepareRetentionOptionsHook(
+				input.label,
+				input.desiredRetentionDays,
+				input.currentRetentionPlan,
+				input.checked
+			);
+
+			const expectedOutput = {
+				label: input.label,
+				spaceNeeded: '10GB',
+				upgradeRequired: false,
+				isCurrentPlan: true,
+				value: input.desiredRetentionDays,
+				checked: input.checked,
+			};
+
+			expect( output ).toStrictEqual( expectedOutput );
+		} );
+
+		it( 'should return a retention option that is not the current plan and requires upgrade when spaceNeeded is higher than storage limit', () => {
+			( getBackupCurrentSiteSize as jest.Mock ).mockImplementation( () => GB_IN_BYTES * 20 );
+			( getRewindBytesAvailable as jest.Mock ).mockImplementation( () => GB_IN_BYTES * 10 );
+
+			const input = RETENTION_OPTIONS_FIXTURES.DIFFERENT_PLAN;
+
+			const output = renderPrepareRetentionOptionsHook(
+				input.label,
+				input.desiredRetentionDays,
+				input.currentRetentionPlan,
+				input.checked
+			);
+
+			const expectedOutput = {
+				label: input.label,
+				spaceNeeded: '10GB',
+				upgradeRequired: true,
+				isCurrentPlan: false,
+				value: input.desiredRetentionDays,
+				checked: input.checked,
+			};
+
+			expect( output ).toStrictEqual( expectedOutput );
+		} );
+
+		it( 'should return a retention option that is not the current plan and not requires upgrade when spaceNeeded is lower than storage limit', () => {
+			( getBackupCurrentSiteSize as jest.Mock ).mockImplementation( () => MB_IN_BYTES );
+			( getRewindBytesAvailable as jest.Mock ).mockImplementation( () => GB_IN_BYTES * 10 );
+
+			const input = RETENTION_OPTIONS_FIXTURES.DIFFERENT_PLAN;
+
+			const output = renderPrepareRetentionOptionsHook(
+				input.label,
+				input.desiredRetentionDays,
+				input.currentRetentionPlan,
+				input.checked
+			);
+
+			const expectedOutput = {
+				label: input.label,
+				spaceNeeded: '10GB',
+				upgradeRequired: false,
+				isCurrentPlan: false,
+				value: input.desiredRetentionDays,
+				checked: input.checked,
+			};
+
+			expect( output ).toStrictEqual( expectedOutput );
+		} );
+	} );
+} );

--- a/client/components/backup-retention-management/types.ts
+++ b/client/components/backup-retention-management/types.ts
@@ -1,0 +1,10 @@
+import type { TranslateResult } from 'i18n-calypso';
+
+export interface RetentionRadioOptionType {
+	label: string; // 7 days
+	spaceNeeded: TranslateResult | string; // 700MB
+	upgradeRequired: boolean;
+	isCurrentPlan: boolean;
+	value: number; // 7
+	checked: boolean;
+}

--- a/client/components/backup-storage-space/hooks.tsx
+++ b/client/components/backup-storage-space/hooks.tsx
@@ -111,3 +111,49 @@ export const useDaysOfBackupsSavedText = (
 		);
 	}, [ translate, daysOfBackupsSaved, siteSlug ] );
 };
+
+/**
+ * The idea is to convert any storage amount in bytes to a human readable format.
+ *
+ * @param storageInBytes The storage amount in bytes
+ * @returns				 The storage amount in a human readable format
+ */
+export const useStorageText = ( storageInBytes: number ): TranslateResult | string => {
+	const translate = useTranslate();
+
+	return useMemo( () => {
+		if ( storageInBytes && storageInBytes >= 0 ) {
+			const { unitAmount, unit } = convertBytesToUnitAmount( storageInBytes );
+
+			switch ( unit ) {
+				case StorageUnits.Gigabyte:
+					if ( unitAmount % 1 === 0 ) {
+						return translate( '%(storageInBytes)dGB', {
+							args: { storageInBytes: unitAmount },
+							comment: 'Must use unit abbreviation; describes an storage amounts (e.g., 20GB)',
+						} );
+					}
+
+					return translate( '%(storageInBytes).1fGB', {
+						args: { storageInBytes: unitAmount },
+						comment:
+							'Must use unit abbreviation; describes an storage amounts with 1 decimal point (e.g., 20.0GB)',
+					} );
+				case StorageUnits.Terabyte:
+					if ( unitAmount % 1 === 0 ) {
+						return translate( '%(storageInBytes)dTB', {
+							args: { storageInBytes: unitAmount },
+							comment: 'Must use unit abbreviation; describes an storage amounts (e.g., 1TB)',
+						} );
+					}
+
+					return translate( '%(storageInBytes).1fTB', {
+						args: { storageInBytes: unitAmount },
+						comment: 'Must use unit abbreviation; describes an storage amounts (e.g., 1.5TB)',
+					} );
+			}
+		}
+
+		return '';
+	}, [ translate, storageInBytes ] );
+};

--- a/client/components/backup-storage-space/hooks.tsx
+++ b/client/components/backup-storage-space/hooks.tsx
@@ -149,7 +149,8 @@ export const useStorageText = ( storageInBytes: number ): TranslateResult | stri
 
 					return translate( '%(storageInBytes).1fTB', {
 						args: { storageInBytes: unitAmount },
-						comment: 'Must use unit abbreviation; describes an storage amounts (e.g., 1.5TB)',
+						comment:
+							'Must use unit abbreviation; describes an storage amounts with 1 decimal point (e.g., 1.5TB)',
 					} );
 			}
 		}

--- a/client/components/backup-storage-space/test/hooks.js
+++ b/client/components/backup-storage-space/test/hooks.js
@@ -21,6 +21,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import {
 	useDaysOfBackupsSavedText,
 	useStorageUsageText,
+	useStorageText,
 } from 'calypso/components/backup-storage-space/hooks';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
@@ -128,5 +129,21 @@ describe( 'useDaysOfBackupsSavedText', () => {
 		expect( text.childNodes[ 0 ] ).toContainHTML(
 			'<a href="/activity-log/site-slug?group=rewind">7 days of backups saved</a>'
 		);
+	} );
+} );
+
+describe( 'useStorageText', () => {
+	test.each( [
+		[ 2 ** 30 / 2, '0.5GB' ],
+		[ 2 ** 30, '1GB' ],
+		[ 2 ** 30 * 3, '3GB' ],
+		[ 2 ** 40 / 2, '512GB' ],
+		[ 2 ** 40 * 2, '2TB' ],
+		[ 2 ** 40 * 3.5, '3.5TB' ],
+		[ null, '' ],
+		[ -1, '' ],
+	] )( 'renders storage in human readable format for %s bytes', ( storageInBytes, expected ) => {
+		const { result } = renderHook( () => useStorageText( storageInBytes ) );
+		expect( result.current ).toBe( expected );
 	} );
 } );

--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -1,4 +1,5 @@
 import AdvancedCredentials from 'calypso/components/advanced-credentials';
+import BackupRetentionManagement from 'calypso/components/backup-retention-management';
 import HasSitePurchasesSwitch from 'calypso/components/has-site-purchases-switch';
 import IsCurrentUserAdminSwitch from 'calypso/components/jetpack/is-current-user-admin-switch';
 import NotAuthorizedPage from 'calypso/components/jetpack/not-authorized-page';
@@ -22,19 +23,22 @@ export const advancedCredentials: PageJS.Callback = ( context, next ) => {
 	const sectionElt = <AdvancedCredentials action={ action } host={ host } role="main" />;
 
 	context.primary = (
-		<HasSiteCredentialsSwitch
-			siteId={ siteId }
-			trueComponent={ sectionElt }
-			falseComponent={
-				<HasSitePurchasesSwitch
-					siteId={ siteId }
-					trueComponent={ sectionElt }
-					falseComponent={ <NoSitesPurchasesMessage /> }
-					loadingComponent={ <AdvancedCredentialsLoadingPlaceholder /> }
-				/>
-			}
-			loadingComponent={ <AdvancedCredentialsLoadingPlaceholder /> }
-		/>
+		<>
+			<BackupRetentionManagement />
+			<HasSiteCredentialsSwitch
+				siteId={ siteId }
+				trueComponent={ sectionElt }
+				falseComponent={
+					<HasSitePurchasesSwitch
+						siteId={ siteId }
+						trueComponent={ sectionElt }
+						falseComponent={ <NoSitesPurchasesMessage /> }
+						loadingComponent={ <AdvancedCredentialsLoadingPlaceholder /> }
+					/>
+				}
+				loadingComponent={ <AdvancedCredentialsLoadingPlaceholder /> }
+			/>
+		</>
 	);
 
 	next();

--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import AdvancedCredentials from 'calypso/components/advanced-credentials';
 import BackupRetentionManagement from 'calypso/components/backup-retention-management';
 import HasSitePurchasesSwitch from 'calypso/components/has-site-purchases-switch';
@@ -24,7 +25,9 @@ export const advancedCredentials: PageJS.Callback = ( context, next ) => {
 
 	context.primary = (
 		<>
-			<BackupRetentionManagement />
+			{ config.isEnabled( 'jetpack/backup-retention-settings' ) ? (
+				<BackupRetentionManagement />
+			) : null }
 			<HasSiteCredentialsSwitch
 				siteId={ siteId }
 				trueComponent={ sectionElt }

--- a/client/state/data-layer/wpcom/sites/rewind/retention/index.ts
+++ b/client/state/data-layer/wpcom/sites/rewind/retention/index.ts
@@ -1,3 +1,4 @@
+import { translate } from 'i18n-calypso';
 import {
 	JETPACK_BACKUP_RETENTION_UPDATE,
 	JETPACK_BACKUP_RETENTION_UPDATE_ERROR,
@@ -6,6 +7,7 @@ import {
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import type { UpdateRequestActionType } from 'calypso/state/rewind/retention/types';
 
 export const updateRetention = ( action: UpdateRequestActionType ) =>
@@ -19,16 +21,26 @@ export const updateRetention = ( action: UpdateRequestActionType ) =>
 		action
 	);
 
-const onSuccess = ( { siteId }: UpdateRequestActionType ) => ( {
-	type: JETPACK_BACKUP_RETENTION_UPDATE_SUCCESS,
-	siteId,
-} );
+const onSuccess = ( { siteId }: UpdateRequestActionType ) => [
+	{
+		type: JETPACK_BACKUP_RETENTION_UPDATE_SUCCESS,
+		siteId,
+	},
+	successNotice( translate( 'Your new days of saved backups has been saved successfully!' ), {
+		duration: 5000,
+	} ),
+];
 
-const onError = ( { siteId }: UpdateRequestActionType, error: string ) => ( {
-	type: JETPACK_BACKUP_RETENTION_UPDATE_ERROR,
-	siteId,
-	error,
-} );
+const onError = ( { siteId }: UpdateRequestActionType, error: string ) => [
+	{
+		type: JETPACK_BACKUP_RETENTION_UPDATE_ERROR,
+		siteId,
+		error,
+	},
+	errorNotice( translate( 'Update settings failed. Please, try again.' ), {
+		duration: 5000,
+	} ),
+];
 
 registerHandlers( 'state/data-layer/wpcom/sites/rewind/retention', {
 	[ JETPACK_BACKUP_RETENTION_UPDATE ]: [

--- a/client/state/data-layer/wpcom/sites/rewind/retention/index.ts
+++ b/client/state/data-layer/wpcom/sites/rewind/retention/index.ts
@@ -21,14 +21,21 @@ export const updateRetention = ( action: UpdateRequestActionType ) =>
 		action
 	);
 
-const onSuccess = ( { siteId }: UpdateRequestActionType ) => [
+const onSuccess = ( { siteId, retentionDays }: UpdateRequestActionType ) => [
 	{
 		type: JETPACK_BACKUP_RETENTION_UPDATE_SUCCESS,
 		siteId,
 	},
-	successNotice( translate( 'Your new days of saved backups has been saved successfully!' ), {
-		duration: 5000,
-	} ),
+	successNotice(
+		translate( 'You have successfully changed the time period of saved backups to %(days)d days', {
+			args: {
+				days: retentionDays,
+			},
+		} ),
+		{
+			duration: 5000,
+		}
+	),
 ];
 
 const onError = ( { siteId }: UpdateRequestActionType, error: string ) => [

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -42,6 +42,7 @@
 		"jetpack/activity-log-sharing": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
+		"jetpack/backup-retention-settings": true,
 		"jetpack/partner-portal-downtime-monitoring-updates": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -36,6 +36,7 @@
 		"jetpack-cloud": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
+		"jetpack/backup-retention-settings": true,
 		"jetpack/partner-portal-downtime-monitoring-updates": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -39,6 +39,7 @@
 		"jetpack/activity-log-sharing": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
+		"jetpack/backup-retention-settings": true,
 		"jetpack/partner-portal-downtime-monitoring-updates": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,


### PR DESCRIPTION
#### Proposed Changes

* Add a new `Days of backups saved` (backup retention period) setting in Jetpack Cloud, under Settings page. For this PR, it will be available only for A12s (dev & stage environment). The idea is to start the review process of this new functionality.
* This iteration includes:
  * Allow to update the setting only to a number of days that doesn't require a storage upgrade.
  * Fetch and update the customer-defined retention period to our backend.
  * Confirmation dialog when attempting to update to a lower retention period.

#### Demo

https://user-images.githubusercontent.com/1488641/218225112-ce96783e-d079-447b-8df2-24d9f54666fd.mov

↪ [Demo v1 (deprecated)](https://user-images.githubusercontent.com/1488641/217998763-cc89187c-9ce8-4536-a8fb-785c153ab76c.mov)


#### Screenshots

| Description | Screenshot |
|---|---|
| Setting page | ![image](https://user-images.githubusercontent.com/1488641/218224377-49cd64f7-bc66-4748-a0fa-999049c8e638.png) |
| Confirmation dialog | ![image](https://user-images.githubusercontent.com/1488641/218224478-25866771-8b23-49ee-9094-441fa6a1960a.png) |
| Tooltip | ![image](https://user-images.githubusercontent.com/1488641/218224599-6b25c3cb-d23b-46f2-a851-c97d086dfe33.png) |
| Success notice | ![image](https://user-images.githubusercontent.com/1488641/218224332-d387d0ab-e73e-4d3b-9377-54dba3f57fab.png) |
| Error notice | ![image](https://user-images.githubusercontent.com/1488641/218000224-10eb567e-2f3c-4e94-8613-c1f2947d8328.png) |




#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start a Jetpack Cloud live branch
* Navigate to Settings and wait for the new setting to load.
* The `Update settings` button will be disabled when the current plan or an option that requires an upgrade are selected.
* You could try to update the days of backups saved. The way to re-confirm it was properly saved is refreshing the page.

Notes:
* If you haven't configured this setting before, the current retention period associated to your plan will be preselected. Otherwise, your current configuration will be preselected.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->