### PR TITLE
Reading Settings: Update the label/description on the "Welcome email text" and "Comment follow email text" settings

### DIFF
--- a/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
@@ -60,9 +60,15 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 					autoCapitalize="none"
 				/>
 				<FormSettingExplanation>
-					{ translate(
-						'The welcome message sent out to new readers when they subscribe to your blog.'
-					) }
+					{ hasTranslation(
+						'The confirmation message sent out to new readers when they subscribe to your blog.'
+					) || locale.startsWith( 'en' )
+						? translate(
+								'The confirmation message sent out to new readers when they subscribe to your blog.'
+						  )
+						: translate(
+								'The welcome message sent out to new readers when they subscribe to your blog.'
+						  ) }
 				</FormSettingExplanation>
 				<FormLabel htmlFor="comment_follow_email_text">
 					{ translate( 'Comment follow email text' ) }

--- a/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
@@ -36,7 +36,7 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 		};
 
 	return (
-		<div className="site-settings__emails-test-settings-container">
+		<div className="site-settings__emails-text-settings-container">
 			<FormFieldset>
 				{ /* @ts-expect-error FormLegend is not typed and is causing errors */ }
 				<FormLegend>

--- a/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
@@ -70,12 +70,14 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 								'The welcome message sent out to new readers when they subscribe to your blog.'
 						  ) }
 				</FormSettingExplanation>
-				<FormLabel htmlFor="comment_follow_email_text">
-					{ translate( 'Comment follow email text' ) }
+				<FormLabel htmlFor="comment_follow_email_message">
+					{ hasTranslation( 'Comment follow email message' ) || locale.startsWith( 'en' )
+						? translate( 'Comment follow email message' )
+						: translate( 'Comment follow email text' ) }
 				</FormLabel>
 				<FormTextarea
-					name="comment_follow_email_text"
-					id="comment_follow_email_text"
+					name="comment_follow_email_message"
+					id="comment_follow_email_message"
 					value={ value?.comment_follow }
 					onChange={ updateSubscriptionOptions( 'comment_follow' ) }
 					disabled={ disabled }

--- a/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
@@ -1,3 +1,5 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -18,6 +20,8 @@ type SubscriptionOption = {
 
 export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsTextSettingProps ) => {
 	const translate = useTranslate();
+	const locale = useLocale();
+	const { hasTranslation } = useI18n();
 
 	const updateSubscriptionOptions =
 		( option: string ) => ( event: React.ChangeEvent< HTMLInputElement > ) => {
@@ -42,10 +46,14 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 				<FormLegend>
 					These settings change the emails sent from your site to your readers
 				</FormLegend>
-				<FormLabel htmlFor="welcome_email_text">{ translate( 'Welcome email text' ) }</FormLabel>
+				<FormLabel htmlFor="confirmation_email_message">
+					{ hasTranslation( 'Confirmation email message' ) || locale.startsWith( 'en' )
+						? translate( 'Confirmation email message' )
+						: translate( 'Welcome email text' ) }
+				</FormLabel>
 				<FormTextarea
-					name="welcome_email_text"
-					id="welcome_email_text"
+					name="confirmation_email_message"
+					id="confirmation_email_message"
 					value={ value?.invitation }
 					onChange={ updateSubscriptionOptions( 'invitation' ) }
 					disabled={ disabled }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -677,7 +677,7 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	}
 }
 
-.site-settings__emails-test-settings-container {
+.site-settings__emails-text-settings-container {
 	legend {
 		font-weight: 400;
 		margin-bottom: 0;


### PR DESCRIPTION
This PR updates labels and description on several form fields on the new Reading settings page.
 
#### Proposed Changes

* Change `Welcome email text` form field label to `Confirmation email message`.
* Change `The welcome message sent out to new readers when they subscribe to your blog.` form field explanation to `The confirmation message sent out to new readers when they subscribe to your blog.`.
* Change `Comment follow email text` form field label to `Comment follow email message`.
* Fix a minor typo in the CSS class name: `site-settings__emails-test-settings-container` → `site-settings__emails-text-settings-container`.

| Before | After |
| ------------- | ------------- |
| ![Markup on 2023-02-06 at 10:28:47](https://user-images.githubusercontent.com/25105483/216936886-de785b79-3b0c-48cb-ba9d-28d890812774.png) | ![Markup on 2023-02-06 at 10:26:22](https://user-images.githubusercontent.com/25105483/216936939-9bb3b960-b19a-4705-add8-364c2e0778bf.png) |

Fixes https://github.com/Automattic/wp-calypso/issues/72485.

Related discussion: pdtkmj-Vc-p2#comment-1886

#### Testing Instructions

1. Check out the PR and build it locally.
2. Make sure the WPCOM locale is set to English at http://calypso.localhost:3000/me/account.
3. Navigate to the new Reading settings page at `http://calypso.localhost:3000/settings/reading/[site-address]`.
4. Review the updated labels and field description - they should match the "After" screenshot.
5. Change your WPCOM locale to non-English language.
6. Review the updated labels and field description again - this time, the old already-translated strings should be used.

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->