### PR TITLE
Copy Site: Enable for all environments

### DIFF
--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -8,6 +8,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 	'anchor-fm-flow': () =>
 		import( /* webpackChunkName: "anchor-fm-flow" */ '../declarative-flow/anchor-fm-flow' ),
 
+	'copy-site': () =>
+		import( /* webpackChunkName: "copy-site-flow" */ '../declarative-flow/copy-site' ),
+
 	newsletter: () =>
 		import( /* webpackChunkName: "newsletter-flow" */ '../declarative-flow/newsletter' ),
 
@@ -63,11 +66,6 @@ availableFlows[ 'plugin-bundle' ] = () =>
 if ( config.isEnabled( 'sensei/onboarding' ) ) {
 	availableFlows[ 'sensei' ] = () =>
 		import( /* webpackChunkName: "sensei-flow" */ '../declarative-flow/sensei' );
-}
-
-if ( config.isEnabled( 'sites/copy-site' ) ) {
-	availableFlows[ 'copy-site' ] = () =>
-		import( /* webpackChunkName: "copy-site" */ '../declarative-flow/copy-site' );
 }
 
 export default availableFlows;

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { compose } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
@@ -98,7 +97,7 @@ class SiteTools extends Component {
 						description={ translate( "Register a new domain or change your site's address." ) }
 					/>
 				) }
-				{ isEnabled( 'sites/copy-site' ) && shouldShowSiteCopyItem && (
+				{ shouldShowSiteCopyItem && (
 					<SiteToolsLink
 						href={ copySiteUrl }
 						onClick={ () => {

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	WPCOM_FEATURES_MANAGE_PLUGINS,
 	WPCOM_FEATURES_SITE_PREVIEW_LINKS,
@@ -274,7 +273,7 @@ export const SitesEllipsisMenu = ( {
 					<ManagePluginsItem { ...props } />
 					{ showHosting && <HostingConfigItem { ...props } /> }
 					{ site.is_coming_soon && <PreviewSiteModalItem { ...props } /> }
-					{ isEnabled( 'sites/copy-site' ) && <CopySiteItem { ...props } /> }
+					<CopySiteItem { ...props } />
 					<WpAdminItem { ...props } />
 				</SiteMenuGroup>
 			) }

--- a/config/development.json
+++ b/config/development.json
@@ -168,7 +168,6 @@
 		"signup/social": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
-		"sites/copy-site": true,
 		"ssr/prefetch-timebox": false,
 		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -138,7 +138,6 @@
 		"signup/social": true,
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
-		"sites/copy-site": true,
 		"ssr/prefetch-timebox": true,
 		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,


### PR DESCRIPTION
See p1675769200535599/1675720603.259269-slack-C034AL34Q3W

## Proposed Changes

Enables Copy Site for all environments to soft-launch feature.

## Testing Instructions

1. Verify 'Copy site' appears in the dropdown menu.
2. Verify 'Copy site' flow works as expected