### PR TITLE
Add cookie consent scaffolding

### DIFF
--- a/packages/cookie-consent/.storybook/main.js
+++ b/packages/cookie-consent/.storybook/main.js
@@ -1,0 +1,3 @@
+const storybookDefaultConfig = require( '@automattic/calypso-storybook' );
+
+module.exports = storybookDefaultConfig();

--- a/packages/cookie-consent/.storybook/preview.js
+++ b/packages/cookie-consent/.storybook/preview.js
@@ -1,0 +1,14 @@
+import '@automattic/calypso-color-schemes';
+import '@wordpress/components/build-style/style.css';
+
+export const parameters = {
+	backgrounds: {
+		default: 'default',
+		values: [
+			{
+				name: 'default',
+				value: 'silver',
+			},
+		],
+	},
+};

--- a/packages/cookie-consent/README.md
+++ b/packages/cookie-consent/README.md
@@ -1,0 +1,12 @@
+# Cookie Consent Component
+
+This package includes a React component that implements an API-connected cookie consent banner. It takes care of geo locating and remembering user preference.
+
+## Context
+Please see this P2 for more details: pdDR7T-Ax-p2
+
+## Development
+For quick iteration, this component has a storybook implementation. Please cd into this package's directory, then run `yarn storybook`. This will give you a React environment with hot-reloading.
+
+## Need help?
+Please contact team Vertex.

--- a/packages/cookie-consent/jest.config.js
+++ b/packages/cookie-consent/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+	setupFiles: [ '<rootDir>/jestSetup.ts' ],
+	testEnvironment: 'jsdom',
+	moduleFileExtensions: [ 'ts', 'tsx', 'js', 'json' ],
+	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
+};

--- a/packages/cookie-consent/jestSetup.ts
+++ b/packages/cookie-consent/jestSetup.ts
@@ -1,0 +1,7 @@
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: () => false,
+	__esModule: true,
+	default: function config( key: string ) {
+		return key;
+	},
+} ) );

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -32,7 +32,8 @@
 	"dependencies": {
 		"classnames": "^2.3.1",
 		"react": "^17.0.2",
-		"react-dom": "^17.0.2"
+		"react-dom": "^17.0.2",
+		"@automattic/calypso-storybook": "workspace:^"
 	},
 	"devDependencies": {
 		"@storybook/addon-backgrounds": "^6.4.19",

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -1,0 +1,50 @@
+{
+	"name": "@automattic/cookie-consent",
+	"version": "1.0.0",
+	"description": "Help Center.",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.ts",
+	"sideEffects": [
+		"*.css",
+		"*.scss"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/help-center"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": "https://github.com/Automattic/wp-calypso/issues",
+	"types": "dist/types",
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch",
+		"storybook": "start-storybook"
+	},
+	"dependencies": {
+		"classnames": "^2.3.1",
+		"react": "^17.0.2",
+		"react-dom": "^17.0.2"
+	},
+	"devDependencies": {
+		"@storybook/addon-backgrounds": "^6.4.19",
+		"@storybook/react": "^6.4.19",
+		"typescript": "^4.7.4"
+	},
+	"peerDependencies": {
+		"@wordpress/data": "^6.1.5",
+		"@wordpress/element": "^4.5.0",
+		"react": "^17.0.2",
+		"react-dom": "^17.0.2",
+		"reakit-utils": "^0.15.1",
+		"redux": "^4.1.2"
+	}
+}

--- a/packages/cookie-consent/package.json
+++ b/packages/cookie-consent/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@automattic/cookie-consent",
 	"version": "1.0.0",
-	"description": "Help Center.",
+	"description": "The Ultimate Cookie Consent Handling Toolkit.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic Inc.",
@@ -15,7 +15,7 @@
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Automattic/wp-calypso.git",
-		"directory": "packages/help-center"
+		"directory": "packages/cookie-consent"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/cookie-consent/src/index.stories.tsx
+++ b/packages/cookie-consent/src/index.stories.tsx
@@ -1,0 +1,7 @@
+import { CookieConsent } from './index';
+
+export default {
+	title: 'CookieConsent',
+};
+
+export const Main = () => <CookieConsent />;

--- a/packages/cookie-consent/src/index.tsx
+++ b/packages/cookie-consent/src/index.tsx
@@ -1,0 +1,3 @@
+export function CookieConsent() {
+	return <div>Hi</div>;
+}

--- a/packages/cookie-consent/tsconfig-cjs.json
+++ b/packages/cookie-consent/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/cookie-consent/tsconfig.json
+++ b/packages/cookie-consent/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src"
+	},
+	"include": [ "src" ],
+	"exclude": [ "**/test/*" ],
+	"references": []
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -520,6 +520,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/cookie-consent@workspace:packages/cookie-consent":
+  version: 0.0.0-use.local
+  resolution: "@automattic/cookie-consent@workspace:packages/cookie-consent"
+  dependencies:
+    "@storybook/addon-backgrounds": ^6.4.19
+    "@storybook/react": ^6.4.19
+    classnames: ^2.3.1
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    typescript: ^4.7.4
+  peerDependencies:
+    "@wordpress/data": ^6.1.5
+    "@wordpress/element": ^4.5.0
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    reakit-utils: ^0.15.1
+    redux: ^4.1.2
+  languageName: unknown
+  linkType: soft
+
 "@automattic/create-calypso-config@workspace:^, @automattic/create-calypso-config@workspace:packages/create-calypso-config":
   version: 0.0.0-use.local
   resolution: "@automattic/create-calypso-config@workspace:packages/create-calypso-config"


### PR DESCRIPTION
#### Proposed Changes

* This adds the base shell for cookie consent and enables Storybook for quick iteration.

#### Testing Instructions

1. `cd packages/cookie-consent`. 
2. `yarn`.
3. `yarn storybook`.

You should see Story book rendering `Hi!`.