### PR TITLE
Implementing plans page for domain upsell

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { getLanguageSlugs } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import page from 'page';
+import { useEffect } from 'react';
 import { QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
@@ -10,6 +11,7 @@ import MomentProvider from 'calypso/components/localized-moment/provider';
 import { RouteProvider } from 'calypso/components/route';
 import Layout from 'calypso/layout';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { login } from 'calypso/lib/paths';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import { getSiteFragment } from 'calypso/lib/route';
@@ -39,6 +41,18 @@ export const ProviderWrappedLayout = ( {
 } ) => {
 	const state = store.getState();
 	const userLoggedIn = isUserLoggedIn( state );
+
+	useEffect( () => {
+		async function loadExperiment() {
+			const experimentAssignment = await loadExperimentAssignment(
+				'calypso_sidebar_upsell_dedicated_upgrade_flow_202301'
+			);
+			const variationName2 = experimentAssignment?.variationName;
+			sessionStorage.setItem( 'calypso_sidebar_upsell_experiment', variationName2 );
+		}
+
+		loadExperiment();
+	}, [] );
 
 	const layout = userLoggedIn ? (
 		<Layout primary={ primary } secondary={ secondary } />

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -47,8 +47,8 @@ export const ProviderWrappedLayout = ( {
 			const experimentAssignment = await loadExperimentAssignment(
 				'calypso_sidebar_upsell_dedicated_upgrade_flow_202301'
 			);
-			const variationName2 = experimentAssignment?.variationName;
-			sessionStorage.setItem( 'calypso_sidebar_upsell_experiment', variationName2 );
+			const variationName = experimentAssignment?.variationName;
+			sessionStorage.setItem( 'calypso_sidebar_upsell_experiment', variationName );
 		}
 
 		loadExperiment();

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { getLanguageSlugs } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import page from 'page';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
@@ -53,18 +53,20 @@ export const ProviderWrappedLayout = ( {
 		setIsExperimentLoaded( true );
 	}
 
-	function shouldLoadDomainExperiment() {
-		return (
+	const shouldLoadDomainExperiment = useCallback( () => {
+		const domainAndPackage = currentQuery && 'true' === currentQuery.domainAndPlanPackage;
+		const experimentPages =
 			window.location.pathname.startsWith( '/domains/add' ) ||
-			window.location.pathname.startsWith( '/plans/yearly' )
-		);
-	}
+			window.location.pathname.startsWith( '/plans/yearly' );
+
+		return domainAndPackage && experimentPages;
+	}, [ currentQuery ] );
 
 	useEffect( () => {
 		if ( shouldLoadDomainExperiment() ) {
 			loadDomainExperiment();
 		}
-	}, [ currentRoute ] );
+	}, [ currentRoute, currentQuery, shouldLoadDomainExperiment ] );
 
 	if ( shouldLoadDomainExperiment() && ! isExperimentLoaded ) {
 		return null;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -384,8 +384,15 @@ export default withCurrentRoute(
 		const isJetpack =
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );
-		const noMasterbarForRoute = isJetpackLogin || currentRoute === '/me/account/closed';
-		const noMasterbarForSection = [ 'signup', 'jetpack-connect' ].includes( sectionName );
+		const userBelongsToExperiment =
+			'treatment' === sessionStorage.getItem( 'calypso_sidebar_upsell_experiment' );
+		const isStartDomainExperiment =
+			( currentRoute.startsWith( '/domains/add' ) || currentRoute.startsWith( '/plans/yearly' ) ) &&
+			userBelongsToExperiment;
+		const noMasterbarForRoute =
+			isStartDomainExperiment || isJetpackLogin || currentRoute === '/me/account/closed';
+		const noMasterbarForSection =
+			isStartDomainExperiment || [ 'signup', 'jetpack-connect' ].includes( sectionName );
 		const masterbarIsHidden =
 			! masterbarIsVisible( state ) ||
 			noMasterbarForSection ||
@@ -409,7 +416,7 @@ export default withCurrentRoute(
 			'plugins',
 			'comments',
 		].includes( sectionName );
-		const sidebarIsHidden = ! secondary || isWcMobileApp();
+		const sidebarIsHidden = isStartDomainExperiment || ! secondary || isWcMobileApp();
 		const chatIsDocked = ! [ 'reader', 'theme' ].includes( sectionName ) && ! sidebarIsHidden;
 
 		const userAllowedToHelpCenter =

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -28,6 +28,7 @@ import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
+import { isDomainSidebarExperimentUser } from 'calypso/my-sites/controller';
 import { isOffline } from 'calypso/state/application/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import hasActiveHappychatSession from 'calypso/state/happychat/selectors/has-active-happychat-session';
@@ -384,11 +385,9 @@ export default withCurrentRoute(
 		const isJetpack =
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );
-		const userBelongsToExperiment =
-			'treatment' === sessionStorage.getItem( 'calypso_sidebar_upsell_experiment' );
 		const isStartDomainExperiment =
 			( currentRoute.startsWith( '/domains/add' ) || currentRoute.startsWith( '/plans/yearly' ) ) &&
-			userBelongsToExperiment;
+			isDomainSidebarExperimentUser();
 		const noMasterbarForRoute =
 			isStartDomainExperiment || isJetpackLogin || currentRoute === '/me/account/closed';
 		const noMasterbarForSection =

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -13,6 +13,7 @@ import { cloudSiteSelection } from 'calypso/jetpack-cloud/controller';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { navigate } from 'calypso/lib/navigate';
 import { onboardingUrl } from 'calypso/lib/paths';
@@ -425,6 +426,17 @@ export function noSite( context, next ) {
 
 	context.store.dispatch( setSelectedSiteId( null ) );
 	return next();
+}
+
+export async function setExperimentVariation( context, next ) {
+	const experimentAssignment = await loadExperimentAssignment(
+		'calypso_sidebar_upsell_dedicated_upgrade_flow_202301'
+	);
+
+	const variationName = experimentAssignment?.variationName;
+	sessionStorage.setItem( 'calypso_sidebar_upsell_experiment', variationName );
+
+	next();
 }
 
 /*

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -13,7 +13,6 @@ import { cloudSiteSelection } from 'calypso/jetpack-cloud/controller';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { navigate } from 'calypso/lib/navigate';
 import { onboardingUrl } from 'calypso/lib/paths';
@@ -426,17 +425,6 @@ export function noSite( context, next ) {
 
 	context.store.dispatch( setSelectedSiteId( null ) );
 	return next();
-}
-
-export async function setExperimentVariation( context, next ) {
-	const experimentAssignment = await loadExperimentAssignment(
-		'calypso_sidebar_upsell_dedicated_upgrade_flow_202301'
-	);
-
-	const variationName = experimentAssignment?.variationName;
-	sessionStorage.setItem( 'calypso_sidebar_upsell_experiment', variationName );
-
-	next();
 }
 
 /*

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -718,7 +718,11 @@ export function shouldRedirectToJetpackAuthorize( context, site ) {
  * @returns {boolean} Whether the user is in the Domain sidebar upsell experiment.
  */
 export const isDomainSidebarExperimentUser = () => {
-	return 'treatment' === sessionStorage.getItem( 'calypso_sidebar_upsell_experiment' );
+	const domainAndPackage = new URL( document.location ).searchParams.has( 'domainAndPlanPackage' );
+	return (
+		domainAndPackage &&
+		'treatment' === sessionStorage.getItem( 'calypso_sidebar_upsell_experiment' )
+	);
 };
 
 /**

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -725,6 +725,15 @@ export function shouldRedirectToJetpackAuthorize( context, site ) {
 }
 
 /**
+ * Whether the user is in the Domain sidebar upsell experiment.
+ *
+ * @returns {boolean} Whether the user is in the Domain sidebar upsell experiment.
+ */
+export const isDomainSidebarExperimentUser = () => {
+	return 'treatment' === sessionStorage.getItem( 'calypso_sidebar_upsell_experiment' );
+};
+
+/**
  * Get redirect URL to the Jetpack site for authorization.
  *
  * @param {Object} context -- The context object.

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -24,6 +24,7 @@ import {
 } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
+import { isDomainSidebarExperimentUser } from 'calypso/my-sites/controller';
 import NewDomainsRedirectionNoticeUpsell from 'calypso/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
 import {
 	domainAddEmailUpsell,
@@ -101,6 +102,9 @@ class DomainSearch extends Component {
 	};
 
 	componentDidMount() {
+		if ( isDomainSidebarExperimentUser() ) {
+			document.body.classList.add( 'is-experiment-user' );
+		}
 		this.checkSiteIsUpgradeable();
 
 		this.isMounted = true;
@@ -113,6 +117,10 @@ class DomainSearch extends Component {
 	}
 
 	componentWillUnmount() {
+		if ( isDomainSidebarExperimentUser() ) {
+			document.body.classList.remove( 'is-experiment-user' );
+		}
+
 		this.isMounted = false;
 	}
 
@@ -236,24 +244,46 @@ class DomainSearch extends Component {
 			content = (
 				<span>
 					<div className="domain-search__content">
-						<BackButton
-							className="domain-search__go-back"
-							href={ domainManagementList( selectedSiteSlug ) }
-						>
-							<Gridicon icon="arrow-left" size={ 18 } />
-							{ translate( 'Back' ) }
-						</BackButton>
+						{ false === isDomainSidebarExperimentUser() && (
+							<BackButton
+								className="domain-search__go-back"
+								href={ domainManagementList( selectedSiteSlug ) }
+							>
+								<Gridicon icon="arrow-left" size={ 18 } />
+								{ translate( 'Back' ) }
+							</BackButton>
+						) }
+
 						{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 						<div className="domains__header">
-							<FormattedHeader
-								brandFont
-								headerText={
-									isManagingAllDomains
-										? translate( 'All Domains' )
-										: translate( 'Search for a domain' )
-								}
-								align="left"
-							/>
+							{ isDomainSidebarExperimentUser() && (
+								<>
+									<FormattedHeader
+										brandFont
+										headerText={ translate( 'Claim your domain' ) }
+										align="center"
+									/>
+
+									<p>
+										{ translate(
+											'Stake your claim on your corner of the web with a custom domain name that’s easy to find, share, and follow. Not sure yet?'
+										) }
+										<a href="/support/domains/">{ translate( 'Decide later.' ) }</a>
+									</p>
+								</>
+							) }
+
+							{ false === isDomainSidebarExperimentUser() && (
+								<FormattedHeader
+									brandFont
+									headerText={
+										isManagingAllDomains
+											? translate( 'All Domains' )
+											: translate( 'Search for a domain' )
+									}
+									align="left"
+								/>
+							) }
 						</div>
 
 						<EmailVerificationGate

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -6,7 +6,6 @@ import {
 	siteSelection,
 	sites,
 	wpForTeamsGeneralNotSupportedRedirect,
-	setExperimentVariation,
 } from 'calypso/my-sites/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
@@ -205,7 +204,6 @@ export default function () {
 	page(
 		'/domains/add/:domain',
 		siteSelection,
-		setExperimentVariation,
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/add' ),
 		domainsController.redirectToUseYourDomainIfVipSite(),

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -6,6 +6,7 @@ import {
 	siteSelection,
 	sites,
 	wpForTeamsGeneralNotSupportedRedirect,
+	setExperimentVariation,
 } from 'calypso/my-sites/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
@@ -204,6 +205,7 @@ export default function () {
 	page(
 		'/domains/add/:domain',
 		siteSelection,
+		setExperimentVariation,
 		navigation,
 		domainsController.redirectIfNoSite( '/domains/add' ),
 		domainsController.redirectToUseYourDomainIfVipSite(),

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@automattic/typography/styles/variables";
 
 .domains__header {
 	display: flex;
@@ -8,5 +9,47 @@
 
 	@include breakpoint-deprecated( "<660px" ) {
 		align-items: center;
+	}
+}
+
+body.is-section-domains.is-experiment-user {
+	background: #fdfdfd;
+
+	.domains__header {
+		display: block;
+
+		h1 {
+			font-family: $brand-serif;
+			font-size: $font-headline-small;
+		}
+
+		p {
+			font-size: $font-body;
+			color: var(--color-text-subtle);
+			text-align: center;
+			padding: 0 10px;
+		}
+
+		a {
+			color: var(--studio-gray-90);
+			font-weight: 500;
+			padding-left: 5px;
+			text-decoration: underline;
+		}
+	}
+
+	@include break-small {
+		.domains__header {
+			h1 {
+				font-size: $font-headline-medium;
+			}
+			p {
+				padding: 0 80px;
+			}
+		}
+	}
+
+	.main.is-wide-layout {
+		max-width: $break-medium;
 	}
 }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -272,8 +272,13 @@ class Plans extends Component {
 			return this.renderPlaceholder();
 		}
 
-		const allDomains = getDomainRegistrations( this.props.cart );
+		const allDomains = isDomainSidebarExperimentUser()
+			? getDomainRegistrations( this.props.cart )
+			: [];
 		const currentDomain = allDomains.length ? allDomains[ 0 ]?.meta : null;
+		if ( isDomainSidebarExperimentUser() && ! currentDomain ) {
+			page.redirect( `/domains/add/${ selectedSite.slug }?domainAndPlanPackage=true` );
+		}
 
 		return (
 			<div>
@@ -337,7 +342,7 @@ class Plans extends Component {
 	}
 }
 
-export default connect( ( state ) => {
+const ConnectedPlans = connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 
 	const currentPlan = getCurrentPlan( state, selectedSiteId );
@@ -358,4 +363,12 @@ export default connect( ( state ) => {
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
 		is2023OnboardingPricingGrid,
 	};
-} )( localize( withTrackingTool( 'HotJar' )( Plans ) ) );
+} )( withCartKey( withShoppingCart( localize( withTrackingTool( 'HotJar' )( Plans ) ) ) ) );
+
+export default function PlansWrapper( props ) {
+	return (
+		<CalypsoShoppingCartProvider>
+			<ConnectedPlans { ...props } />
+		</CalypsoShoppingCartProvider>
+	);
+}

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -1,0 +1,55 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "@automattic/typography/styles/variables";
+
+.domains__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+
+	@include breakpoint-deprecated( "<660px" ) {
+		align-items: center;
+	}
+}
+
+body.is-section-plans.is-experiment-user {
+	background: #fdfdfd;
+
+	.plans__header {
+		display: block;
+
+		h1 {
+			font-family: $brand-serif;
+			font-size: $font-headline-small;
+		}
+
+		p {
+			font-size: $font-body;
+			color: var(--color-text-subtle);
+			text-align: center;
+			padding: 0 10px;
+		}
+
+		a {
+			color: var(--studio-gray-90);
+			font-weight: 500;
+			padding-left: 5px;
+			text-decoration: underline;
+		}
+	}
+
+	@include break-small {
+		.plans__header {
+			h1 {
+				font-size: $font-headline-medium;
+			}
+			p {
+				padding: 0 80px;
+			}
+		}
+	}
+
+	.main.is-wide-layout {
+		max-width: $break-medium;
+	}
+}

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -52,4 +52,71 @@ body.is-section-plans.is-experiment-user {
 	.main.is-wide-layout {
 		max-width: $break-medium;
 	}
+
+	// plans comparison grid
+	.plan-features-comparison__table-item {
+		border-left: none;
+		background-color: transparent;
+
+		&:last-of-type {
+			border-right: none;
+		}
+
+		.plan-pill.is-in-signup {
+			font-size: 0.75rem;
+			font-weight: 500;
+			letter-spacing: 0.2px;
+			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+			line-height: 1.25rem;
+			padding: 0 8px;
+			right: 52%;
+			transform: translate(50%);
+			border-radius: 4px;
+			background-color: var(--studio-green-5);
+			color: var(--studio-gray-80);
+		}
+	}
+
+	.plan-features-comparison__header {
+		background-color: transparent;
+	}
+
+	.plan-features-comparison__row:last-of-type .plan-features-comparison__table-item {
+		border-bottom: none;
+	}
+
+	.plan-features--signup .is-premium-plan .plan-features-comparison__header-title {
+		font-weight: 500;
+	}
+
+	.plan-features--signup .plan-features-comparison__pricing {
+		.plan-price {
+			font-weight: 500;
+
+			.plan-price__integer {
+				font-weight: 500;
+			}
+		}
+
+		.plan-features-comparison__header-billing-info {
+			font-weight: 500;
+		}
+	}
+
+	.plan-features-comparison__item-title {
+		color: var(--studio-gray-60);
+	}
+
+	.plan-features-comparison__item.plan-features-comparison__item-available {
+		.plan-features-comparison__item-annual-plan-container
+		.plan-features-comparison__item-annual-plan {
+			color: var(--studio-orange-40);
+		}
+	}
+
+	.plans-features-main__group.is-scrollable {
+		@media ( min-width: 1800px ) {
+			margin-left: -360px;
+		}
+	}
 }


### PR DESCRIPTION
#### Proposed Changes


https://user-images.githubusercontent.com/6586048/217244666-a1b7f6a0-44b8-4d28-b075-2c403244bc3e.mp4

Known issues: the time to wait is long after clicking (Issue TBD)

* Copied checkout logic for plans from [here](https://github.com/Automattic/wp-calypso/blob/ec6e6a42d63d6ff669eb8acb0cb99442204a2993/client/my-sites/plan-features/index.jsx#L606-L662)
* Header changes from @lupus2k 
* Load page accordingly to experiment

#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/yearly/:site?domainAndPlanPackage=true&flags=-onboarding/2023-pricing-grid`
* Choose a plan
* Wait a bit
* Gets to checkout
* Please test around this issue
* Same for mobile

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #72890
