### PR TITLE
E2E: Enable CoBlocks tests against Atomic env

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/pricing-table-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/pricing-table-block.ts
@@ -1,10 +1,5 @@
 import { Frame, Page, ElementHandle } from 'playwright';
 
-// Workaround to get a type from predefined array.
-// See https://stackoverflow.com/a/59857409.
-const gutterValuesArray = [ 'None', 'Small', 'Medium', 'Large', 'Huge' ] as const;
-export type gutterValues = typeof gutterValuesArray[ number ];
-
 const selectors = {
 	block: '.wp-block-coblocks-pricing-table',
 	pricing: '.wp-block-coblocks-pricing-table-item__amount',
@@ -18,7 +13,7 @@ export class PricingTableBlock {
 	// Static properties.
 	static blockName = 'Pricing Table';
 	static blockEditorSelector = '[aria-label="Block: Pricing Table"]';
-	static gutterValues = gutterValuesArray;
+
 	block: ElementHandle;
 
 	/**
@@ -47,21 +42,21 @@ export class PricingTableBlock {
 	/**
 	 * Given an appropriate value, select the gutter value on the settings sidebar for Pricing Table block.
 	 *
-	 * @param {string} value Value to set the gutter to.
+	 * @param {string} name Name of the gutter preset.
+	 * @param {number} value Value of the gutter for the "Custom" preset (Atomic).
 	 * @returns {Promise<void>} No return value.
 	 */
-	async setGutter( value: gutterValues ): Promise< void > {
+	async setGutter( name: string, value?: number ): Promise< void > {
 		const frame = ( await this.block.ownerFrame() ) as Frame;
+		const buttonSelector = `${ selectors.gutterControl } button[aria-label="${ name }"]`;
 
-		const selector = `${ selectors.gutterControl } button[aria-label="${ value }"]`;
-		await frame.click( selector );
-		const elementHandle = await frame.waitForSelector( selector );
-		// waitForFunction will do its own validation, so no need to return the value
-		// to caller for a check.
-		await frame.waitForFunction(
-			( element: SVGElement | HTMLElement ) => element.ariaPressed === 'true',
-			elementHandle
-		);
+		await frame.locator( buttonSelector ).click();
+		await frame.locator( `${ buttonSelector }[aria-pressed="true"]` ).waitFor();
+
+		if ( name === 'Custom' && value !== undefined ) {
+			const valueInput = frame.locator( 'input[type="number"]:below(button[aria-label="Custom"])' );
+			await valueInput.fill( String( value ) );
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
+++ b/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
@@ -23,6 +23,7 @@ const defaultCriteria: FeatureCriteria[] = [
 		accountName: 'coBlocksSimpleSiteEdgeUser',
 	},
 	{
+		// CoBlocks on Atomic: https://github.com/Automattic/wp-calypso/pull/73052
 		coblocks: 'edge',
 		gutenberg: 'stable',
 		siteType: 'atomic',

--- a/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
+++ b/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
@@ -24,13 +24,13 @@ const defaultCriteria: FeatureCriteria[] = [
 	},
 	{
 		coblocks: 'edge',
-		gutenberg: 'edge',
+		gutenberg: 'stable',
 		siteType: 'atomic',
 		accountName: 'coBlocksAtomicSiteEdgeUser',
 	},
 	{
 		coblocks: 'edge',
-		gutenberg: 'stable',
+		gutenberg: 'edge',
 		siteType: 'atomic',
 		accountName: 'coBlocksAtomicSiteEdgeUser',
 	},

--- a/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
+++ b/packages/calypso-e2e/src/lib/utils/criteria-for-test-accounts.ts
@@ -23,6 +23,18 @@ const defaultCriteria: FeatureCriteria[] = [
 		accountName: 'coBlocksSimpleSiteEdgeUser',
 	},
 	{
+		coblocks: 'edge',
+		gutenberg: 'edge',
+		siteType: 'atomic',
+		accountName: 'coBlocksAtomicSiteEdgeUser',
+	},
+	{
+		coblocks: 'edge',
+		gutenberg: 'stable',
+		siteType: 'atomic',
+		accountName: 'coBlocksAtomicSiteEdgeUser',
+	},
+	{
 		gutenberg: 'stable',
 		siteType: 'simple',
 		variant: 'siteEditor',

--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
@@ -21,7 +21,10 @@ import { TEST_IMAGE_PATH } from '../constants';
 
 declare const browser: Browser;
 
-const features = envToFeatureKey( envVariables );
+const features = envToFeatureKey( {
+	...envVariables,
+	COBLOCKS_EDGE: envVariables.TEST_ON_ATOMIC || envVariables.COBLOCKS_EDGE,
+} );
 
 describe( DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ), () => {
 	const accountName = getTestAccountByFeature( features );

--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
@@ -17,107 +17,103 @@ import {
 	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { skipDescribeIf } from '../../jest-helpers';
 import { TEST_IMAGE_PATH } from '../constants';
 
 declare const browser: Browser;
 
 const features = envToFeatureKey( envVariables );
 
-skipDescribeIf( features.siteType === 'atomic' )(
-	DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ),
-	() => {
-		const accountName = getTestAccountByFeature( features );
+describe( DataHelper.createSuiteTitle( 'CoBlocks: Blocks' ), () => {
+	const accountName = getTestAccountByFeature( features );
 
-		let page: Page;
-		let testAccount: TestAccount;
-		let editorPage: EditorPage;
-		let pricingTableBlock: PricingTableBlock;
-		let logoImage: TestFile;
+	let page: Page;
+	let testAccount: TestAccount;
+	let editorPage: EditorPage;
+	let pricingTableBlock: PricingTableBlock;
+	let logoImage: TestFile;
 
-		// Test data
-		const pricingTableBlockPrices = [ 4.99, 9.99 ];
-		const heroBlockHeading = 'Hero heading';
-		const clicktoTweetBlockTweet = 'Tweet text';
+	// Test data
+	const pricingTableBlockPrices = [ 4.99, 9.99 ];
+	const heroBlockHeading = 'Hero heading';
+	const clicktoTweetBlockTweet = 'Tweet text';
 
-		beforeAll( async () => {
-			page = await browser.newPage();
-			logoImage = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
-			testAccount = new TestAccount( accountName );
-			editorPage = new EditorPage( page, { target: features.siteType } );
+	beforeAll( async () => {
+		page = await browser.newPage();
+		logoImage = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
+		testAccount = new TestAccount( accountName );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
-			await testAccount.authenticate( page );
-		} );
+		await testAccount.authenticate( page );
+	} );
 
-		it( 'Go to the new post page', async () => {
-			await editorPage.visit( 'post' );
-		} );
+	it( 'Go to the new post page', async () => {
+		await editorPage.visit( 'post' );
+	} );
 
-		it( `Insert ${ PricingTableBlock.blockName } block and enter prices`, async function () {
-			const blockHandle = await editorPage.addBlockFromSidebar(
-				PricingTableBlock.blockName,
-				PricingTableBlock.blockEditorSelector
-			);
-			pricingTableBlock = new PricingTableBlock( blockHandle );
-			await pricingTableBlock.enterPrice( 1, pricingTableBlockPrices[ 0 ] );
-			await pricingTableBlock.enterPrice( 2, pricingTableBlockPrices[ 1 ] );
-		} );
-
-		it( `Insert ${ DynamicHRBlock.blockName } block`, async function () {
-			await editorPage.addBlockFromSidebar(
-				DynamicHRBlock.blockName,
-				DynamicHRBlock.blockEditorSelector
-			);
-		} );
-
-		it( `Insert ${ HeroBlock.blockName } block and enter heading`, async function () {
-			const blockHandle = await editorPage.addBlockFromSidebar(
-				HeroBlock.blockName,
-				HeroBlock.blockEditorSelector
-			);
-			const heroBlock = new HeroBlock( blockHandle );
-			await heroBlock.enterHeading( heroBlockHeading );
-		} );
-
-		it( `Insert ${ ClicktoTweetBlock.blockName } block and enter tweet content`, async function () {
-			const blockHandle = await editorPage.addBlockFromSidebar(
-				ClicktoTweetBlock.blockName,
-				ClicktoTweetBlock.blockEditorSelector
-			);
-			const clickToTweetBlock = new ClicktoTweetBlock( blockHandle );
-			await clickToTweetBlock.enterTweetContent( clicktoTweetBlockTweet );
-		} );
-
-		it( `Insert ${ LogosBlock.blockName } block and set image`, async function () {
-			const blockHandle = await editorPage.addBlockFromSidebar(
-				LogosBlock.blockName,
-				LogosBlock.blockEditorSelector
-			);
-			const logosBlock = new LogosBlock( blockHandle );
-			await logosBlock.upload( logoImage.fullpath );
-		} );
-
-		it( 'Publish and visit the post', async function () {
-			await editorPage.publish( { visit: true } );
-		} );
-
-		// Pass in a 1D array of values or text strings to validate each block.
-		it.each`
-			block                  | content
-			${ PricingTableBlock } | ${ pricingTableBlockPrices }
-			${ DynamicHRBlock }    | ${ null }
-			${ HeroBlock }         | ${ [ heroBlockHeading ] }
-			${ ClicktoTweetBlock } | ${ [ clicktoTweetBlockTweet ] }
-		`(
-			`Confirm $block.blockName block is visible in published post`,
-			async ( { block, content } ) => {
-				// Pass the Block object class here then call the static method to validate.
-				await block.validatePublishedContent( page, content );
-			}
+	it( `Insert ${ PricingTableBlock.blockName } block and enter prices`, async function () {
+		const blockHandle = await editorPage.addBlockFromSidebar(
+			PricingTableBlock.blockName,
+			PricingTableBlock.blockEditorSelector
 		);
+		pricingTableBlock = new PricingTableBlock( blockHandle );
+		await pricingTableBlock.enterPrice( 1, pricingTableBlockPrices[ 0 ] );
+		await pricingTableBlock.enterPrice( 2, pricingTableBlockPrices[ 1 ] );
+	} );
 
-		it( `Confirm Logos block is visible in published post`, async () => {
-			await LogosBlock.validatePublishedContent( page, [ logoImage.filename ] );
-		} );
-	}
-);
+	it( `Insert ${ DynamicHRBlock.blockName } block`, async function () {
+		await editorPage.addBlockFromSidebar(
+			DynamicHRBlock.blockName,
+			DynamicHRBlock.blockEditorSelector
+		);
+	} );
+
+	it( `Insert ${ HeroBlock.blockName } block and enter heading`, async function () {
+		const blockHandle = await editorPage.addBlockFromSidebar(
+			HeroBlock.blockName,
+			HeroBlock.blockEditorSelector
+		);
+		const heroBlock = new HeroBlock( blockHandle );
+		await heroBlock.enterHeading( heroBlockHeading );
+	} );
+
+	it( `Insert ${ ClicktoTweetBlock.blockName } block and enter tweet content`, async function () {
+		const blockHandle = await editorPage.addBlockFromSidebar(
+			ClicktoTweetBlock.blockName,
+			ClicktoTweetBlock.blockEditorSelector
+		);
+		const clickToTweetBlock = new ClicktoTweetBlock( blockHandle );
+		await clickToTweetBlock.enterTweetContent( clicktoTweetBlockTweet );
+	} );
+
+	it( `Insert ${ LogosBlock.blockName } block and set image`, async function () {
+		const blockHandle = await editorPage.addBlockFromSidebar(
+			LogosBlock.blockName,
+			LogosBlock.blockEditorSelector
+		);
+		const logosBlock = new LogosBlock( blockHandle );
+		await logosBlock.upload( logoImage.fullpath );
+	} );
+
+	it( 'Publish and visit the post', async function () {
+		await editorPage.publish( { visit: true } );
+	} );
+
+	// Pass in a 1D array of values or text strings to validate each block.
+	it.each`
+		block                  | content
+		${ PricingTableBlock } | ${ pricingTableBlockPrices }
+		${ DynamicHRBlock }    | ${ null }
+		${ HeroBlock }         | ${ [ heroBlockHeading ] }
+		${ ClicktoTweetBlock } | ${ [ clicktoTweetBlockTweet ] }
+	`(
+		`Confirm $block.blockName block is visible in published post`,
+		async ( { block, content } ) => {
+			// Pass the Block object class here then call the static method to validate.
+			await block.validatePublishedContent( page, content );
+		}
+	);
+
+	it( `Confirm Logos block is visible in published post`, async () => {
+		await LogosBlock.validatePublishedContent( page, [ logoImage.filename ] );
+	} );
+} );

--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
@@ -23,6 +23,7 @@ declare const browser: Browser;
 
 const features = envToFeatureKey( {
 	...envVariables,
+	// See https://github.com/Automattic/wp-calypso/pull/73052
 	COBLOCKS_EDGE: envVariables.TEST_ON_ATOMIC || envVariables.COBLOCKS_EDGE,
 } );
 

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -19,6 +19,7 @@ declare const browser: Browser;
 
 const features = envToFeatureKey( {
 	...envVariables,
+	// CoBlocks on Atomic: https://github.com/Automattic/wp-calypso/pull/73052
 	COBLOCKS_EDGE: envVariables.TEST_ON_ATOMIC || envVariables.COBLOCKS_EDGE,
 } );
 

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -17,7 +17,10 @@ import { TEST_IMAGE_PATH } from '../constants';
 
 declare const browser: Browser;
 
-const features = envToFeatureKey( envVariables );
+const features = envToFeatureKey( {
+	...envVariables,
+	COBLOCKS_EDGE: envVariables.TEST_ON_ATOMIC || envVariables.COBLOCKS_EDGE,
+} );
 
 describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ), () => {
 	const accountName = getTestAccountByFeature( features );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -13,76 +13,72 @@ import {
 	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Page, Browser, Locator } from 'playwright';
-import { skipDescribeIf } from '../../jest-helpers';
 import { TEST_IMAGE_PATH } from '../constants';
 
 declare const browser: Browser;
 
 const features = envToFeatureKey( envVariables );
 
-skipDescribeIf( features.siteType === 'atomic' )(
-	DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ),
-	() => {
-		const accountName = getTestAccountByFeature( features );
+describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ), () => {
+	const accountName = getTestAccountByFeature( features );
 
-		let page: Page;
-		let testAccount: TestAccount;
-		let editorPage: EditorPage;
-		let imageFile: TestFile;
-		let coverBlock: CoverBlock;
-		let editorWindowLocator: Locator;
+	let page: Page;
+	let testAccount: TestAccount;
+	let editorPage: EditorPage;
+	let imageFile: TestFile;
+	let coverBlock: CoverBlock;
+	let editorWindowLocator: Locator;
 
-		beforeAll( async () => {
-			page = await browser.newPage();
-			imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
-			testAccount = new TestAccount( accountName );
-			editorPage = new EditorPage( page, { target: features.siteType } );
+	beforeAll( async () => {
+		page = await browser.newPage();
+		imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
+		testAccount = new TestAccount( accountName );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
-			await testAccount.authenticate( page );
-		} );
+		await testAccount.authenticate( page );
+	} );
 
-		it( 'Go to the new post page', async () => {
-			await editorPage.visit( 'post' );
-		} );
+	it( 'Go to the new post page', async () => {
+		await editorPage.visit( 'post' );
+	} );
 
-		it( 'Insert Cover block', async () => {
-			const blockHandle = await editorPage.addBlockFromSidebar(
-				CoverBlock.blockName,
-				CoverBlock.blockEditorSelector
-			);
-			coverBlock = new CoverBlock( blockHandle );
-		} );
+	it( 'Insert Cover block', async () => {
+		const blockHandle = await editorPage.addBlockFromSidebar(
+			CoverBlock.blockName,
+			CoverBlock.blockEditorSelector
+		);
+		coverBlock = new CoverBlock( blockHandle );
+	} );
 
-		it( 'Upload image', async () => {
-			await coverBlock.upload( imageFile.fullpath );
-			// After uploading the image the focus is switched to the inner
-			// paragraph block (Cover title), so we need to switch it back outside.
-			editorWindowLocator = editorPage.getEditorWindowLocator();
-			await editorWindowLocator.locator( '.wp-block-cover' ).click( { position: { x: 1, y: 1 } } );
-		} );
+	it( 'Upload image', async () => {
+		await coverBlock.upload( imageFile.fullpath );
+		// After uploading the image the focus is switched to the inner
+		// paragraph block (Cover title), so we need to switch it back outside.
+		editorWindowLocator = editorPage.getEditorWindowLocator();
+		await editorWindowLocator.locator( '.wp-block-cover' ).click( { position: { x: 1, y: 1 } } );
+	} );
 
-		it( 'Open settings sidebar', async function () {
-			await editorPage.openSettings();
-		} );
+	it( 'Open settings sidebar', async function () {
+		await editorPage.openSettings();
+	} );
 
-		it.each( CoverBlock.coverStyles )( 'Verify "%s" style is available', async ( style ) => {
-			await editorWindowLocator.locator( `button[aria-label="${ style }"]` ).waitFor();
-		} );
+	it.each( CoverBlock.coverStyles )( 'Verify "%s" style is available', async ( style ) => {
+		await editorWindowLocator.locator( `button[aria-label="${ style }"]` ).waitFor();
+	} );
 
-		it( 'Set "Bottom Wave" style', async () => {
-			await coverBlock.setCoverStyle( 'Bottom Wave' );
-		} );
+	it( 'Set "Bottom Wave" style', async () => {
+		await coverBlock.setCoverStyle( 'Bottom Wave' );
+	} );
 
-		it( 'Close settings sidebar', async () => {
-			await editorPage.closeSettings();
-		} );
+	it( 'Close settings sidebar', async () => {
+		await editorPage.closeSettings();
+	} );
 
-		it( 'Publish and visit the post', async () => {
-			await editorPage.publish( { visit: true } );
-		} );
+	it( 'Publish and visit the post', async () => {
+		await editorPage.publish( { visit: true } );
+	} );
 
-		it( 'Verify the class for "Bottom Wave" style is present', async () => {
-			await page.waitForSelector( '.wp-block-cover.is-style-bottom-wave' );
-		} );
-	}
-);
+	it( 'Verify the class for "Bottom Wave" style is present', async () => {
+		await page.waitForSelector( '.wp-block-cover.is-style-bottom-wave' );
+	} );
+} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
@@ -15,9 +15,12 @@ import { skipItIf } from '../../jest-helpers';
 
 declare const browser: Browser;
 
-const features = envToFeatureKey( envVariables );
 const isAtomic = envVariables.TEST_ON_ATOMIC;
 const isSimple = ! envVariables.TEST_ON_ATOMIC;
+const features = envToFeatureKey( {
+	...envVariables,
+	COBLOCKS_EDGE: isAtomic || envVariables.COBLOCKS_EDGE,
+} );
 
 describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Gutter Control' ), () => {
 	const accountName = getTestAccountByFeature( features );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
@@ -11,73 +11,90 @@ import {
 	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { skipDescribeIf } from '../../jest-helpers';
+import { skipItIf } from '../../jest-helpers';
 
 declare const browser: Browser;
 
 const features = envToFeatureKey( envVariables );
+const isAtomic = envVariables.TEST_ON_ATOMIC;
+const isSimple = ! envVariables.TEST_ON_ATOMIC;
 
-skipDescribeIf( features.siteType === 'atomic' )(
-	DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Gutter Control' ),
-	() => {
-		const accountName = getTestAccountByFeature( features );
+describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Gutter Control' ), () => {
+	const accountName = getTestAccountByFeature( features );
 
-		let page: Page;
-		let testAccount: TestAccount;
-		let editorPage: EditorPage;
-		let pricingTableBlock: PricingTableBlock;
+	let page: Page;
+	let testAccount: TestAccount;
+	let editorPage: EditorPage;
+	let pricingTableBlock: PricingTableBlock;
 
-		beforeAll( async () => {
-			page = await browser.newPage();
-			testAccount = new TestAccount( accountName );
-			editorPage = new EditorPage( page, { target: features.siteType } );
+	beforeAll( async () => {
+		page = await browser.newPage();
+		testAccount = new TestAccount( accountName );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
-			await testAccount.authenticate( page );
-		} );
+		await testAccount.authenticate( page );
+	} );
 
-		it( 'Go to the new post page', async () => {
-			await editorPage.visit( 'post' );
-		} );
+	it( 'Go to the new post page', async () => {
+		await editorPage.visit( 'post' );
+	} );
 
-		it( 'Insert Pricing Table block', async () => {
-			const blockHandle = await editorPage.addBlockFromSidebar(
-				PricingTableBlock.blockName,
-				PricingTableBlock.blockEditorSelector
-			);
-			pricingTableBlock = new PricingTableBlock( blockHandle );
-		} );
-
-		it( 'Open settings sidebar', async () => {
-			await editorPage.openSettings();
-		} );
-
-		it.each( PricingTableBlock.gutterValues )(
-			'Verify "%s" gutter button is present',
-			async ( value ) => {
-				const editorWindowLocator = editorPage.getEditorWindowLocator();
-				await editorWindowLocator.locator( `button[aria-label="${ value }"]` ).waitFor();
-			}
+	it( 'Insert Pricing Table block', async () => {
+		const blockHandle = await editorPage.addBlockFromSidebar(
+			PricingTableBlock.blockName,
+			PricingTableBlock.blockEditorSelector
 		);
+		pricingTableBlock = new PricingTableBlock( blockHandle );
+	} );
 
-		it( 'Set gutter to "Huge"', async () => {
-			await pricingTableBlock.setGutter( 'Huge' );
-		} );
+	it( 'Open settings sidebar', async () => {
+		await editorPage.openSettings();
+	} );
 
-		it( 'Close settings sidebar', async () => {
-			await editorPage.closeSettings();
-		} );
+	skipItIf( isAtomic )( 'Verify "None" gutter is available', async () => {
+		await pricingTableBlock.setGutter( 'None' );
+	} );
 
-		it( 'Fill the price fields so the block is visible', async () => {
-			await pricingTableBlock.enterPrice( 1, 4.99 );
-			await pricingTableBlock.enterPrice( 2, 9.99 );
-		} );
+	it( 'Verify "Small" gutter is available', async () => {
+		await pricingTableBlock.setGutter( 'Small' );
+	} );
 
-		it( 'Publish and visit the post', async () => {
-			await editorPage.publish( { visit: true } );
-		} );
+	it( 'Verify "Medium" gutter is available', async () => {
+		await pricingTableBlock.setGutter( 'Medium' );
+	} );
 
-		it( 'Verify the class for "Huge" gutter is present', async () => {
-			await page.waitForSelector( '.wp-block-coblocks-pricing-table .has-huge-gutter' );
-		} );
-	}
-);
+	it( 'Verify "Large" gutter is available', async () => {
+		await pricingTableBlock.setGutter( 'Large' );
+	} );
+
+	skipItIf( isAtomic )( 'Verify "Huge" gutter is available', async () => {
+		await pricingTableBlock.setGutter( 'Huge' );
+	} );
+
+	skipItIf( isSimple )( 'Verify "Custom" gutter is available', async () => {
+		await pricingTableBlock.setGutter( 'Custom', 2.7 );
+	} );
+
+	it( 'Close settings sidebar', async () => {
+		await editorPage.closeSettings();
+	} );
+
+	it( 'Fill the price fields so the block is visible', async () => {
+		await pricingTableBlock.enterPrice( 1, 4.99 );
+		await pricingTableBlock.enterPrice( 2, 9.99 );
+	} );
+
+	it( 'Publish and visit the post', async () => {
+		await editorPage.publish( { visit: true } );
+	} );
+
+	skipItIf( isAtomic )( 'Verify the class for "Huge" gutter is present', async () => {
+		await page.locator( '.wp-block-coblocks-pricing-table .has-huge-gutter' ).waitFor();
+	} );
+
+	skipItIf( isSimple )( 'Verify the proper value for "Custom" gutter is set', async () => {
+		await page
+			.locator( '.wp-block-coblocks-pricing-table [style="--coblocks-custom-gutter:2.7em"]' )
+			.waitFor();
+	} );
+} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
@@ -19,6 +19,7 @@ const isAtomic = envVariables.TEST_ON_ATOMIC;
 const isSimple = ! envVariables.TEST_ON_ATOMIC;
 const features = envToFeatureKey( {
 	...envVariables,
+	// CoBlocks on Atomic: https://github.com/Automattic/wp-calypso/pull/73052
 	COBLOCKS_EDGE: isAtomic || envVariables.COBLOCKS_EDGE,
 } );
 

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
@@ -14,78 +14,74 @@ import {
 	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { skipDescribeIf } from '../../jest-helpers';
 import { TEST_IMAGE_PATH } from '../constants';
 
 declare const browser: Browser;
 
 const features = envToFeatureKey( envVariables );
 
-skipDescribeIf( features.siteType === 'atomic' )(
-	DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Replace Image' ),
-	() => {
-		const accountName = getTestAccountByFeature( features );
+describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Replace Image' ), () => {
+	const accountName = getTestAccountByFeature( features );
 
-		let page: Page;
-		let editorPage: EditorPage;
-		let imageBlock: ImageBlock;
-		let imageFile: TestFile;
-		let uploadedImageURL: string;
-		let newImageURL: string;
+	let page: Page;
+	let editorPage: EditorPage;
+	let imageBlock: ImageBlock;
+	let imageFile: TestFile;
+	let uploadedImageURL: string;
+	let newImageURL: string;
 
-		beforeAll( async () => {
-			page = await browser.newPage();
-			imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
-			editorPage = new EditorPage( page, { target: features.siteType } );
+	beforeAll( async () => {
+		page = await browser.newPage();
+		imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
+		editorPage = new EditorPage( page, { target: features.siteType } );
 
-			const testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
+		const testAccount = new TestAccount( accountName );
+		await testAccount.authenticate( page );
+	} );
+
+	it( 'Go to the new post page', async () => {
+		await editorPage.visit( 'post' );
+	} );
+
+	it( `Insert ${ ImageBlock.blockName } block and upload image`, async () => {
+		const blockHandle = await editorPage.addBlockFromSidebar(
+			ImageBlock.blockName,
+			ImageBlock.blockEditorSelector
+		);
+		imageBlock = new ImageBlock( blockHandle );
+		const uploadedImage = await imageBlock.upload( imageFile.fullpath );
+		uploadedImageURL = ( await uploadedImage.getAttribute( 'src' ) ) as string;
+		uploadedImageURL = uploadedImageURL.split( '?' )[ 0 ];
+	} );
+
+	it( `Replace uploaded image`, async () => {
+		const editorWindowLocator = editorPage.getEditorWindowLocator();
+		await editorWindowLocator.locator( 'button:text("Replace")' ).click();
+		await editorWindowLocator
+			.locator( '.components-form-file-upload input[type="file"]' )
+			.setInputFiles( imageFile.fullpath );
+
+		await imageBlock.waitUntilUploaded();
+
+		const newImage = await imageBlock.getImage();
+		newImageURL = ( await newImage.getAttribute( 'src' ) ) as string;
+		newImageURL = newImageURL.split( '?' )[ 0 ];
+
+		expect( newImageURL ).not.toEqual( uploadedImageURL );
+	} );
+
+	it( 'Publish the post', async () => {
+		await editorPage.publish( { visit: true } );
+	} );
+
+	it( 'Verify the new image was published', async () => {
+		// Image is not always immediately available on a published site, so we need
+		// to refresh and check again.
+		await ElementHelper.reloadAndRetry( page, async function () {
+			const publishedImage = await page.waitForSelector( '.wp-block-image img' );
+			const publishedImageURL = ( await publishedImage.getAttribute( 'src' ) ) as string;
+
+			expect( publishedImageURL.split( '?' )[ 0 ] ).toEqual( newImageURL );
 		} );
-
-		it( 'Go to the new post page', async () => {
-			await editorPage.visit( 'post' );
-		} );
-
-		it( `Insert ${ ImageBlock.blockName } block and upload image`, async () => {
-			const blockHandle = await editorPage.addBlockFromSidebar(
-				ImageBlock.blockName,
-				ImageBlock.blockEditorSelector
-			);
-			imageBlock = new ImageBlock( blockHandle );
-			const uploadedImage = await imageBlock.upload( imageFile.fullpath );
-			uploadedImageURL = ( await uploadedImage.getAttribute( 'src' ) ) as string;
-			uploadedImageURL = uploadedImageURL.split( '?' )[ 0 ];
-		} );
-
-		it( `Replace uploaded image`, async () => {
-			const editorWindowLocator = editorPage.getEditorWindowLocator();
-			await editorWindowLocator.locator( 'button:text("Replace")' ).click();
-			await editorWindowLocator
-				.locator( '.components-form-file-upload input[type="file"]' )
-				.setInputFiles( imageFile.fullpath );
-
-			await imageBlock.waitUntilUploaded();
-
-			const newImage = await imageBlock.getImage();
-			newImageURL = ( await newImage.getAttribute( 'src' ) ) as string;
-			newImageURL = newImageURL.split( '?' )[ 0 ];
-
-			expect( newImageURL ).not.toEqual( uploadedImageURL );
-		} );
-
-		it( 'Publish the post', async () => {
-			await editorPage.publish( { visit: true } );
-		} );
-
-		it( 'Verify the new image was published', async () => {
-			// Image is not always immediately available on a published site, so we need
-			// to refresh and check again.
-			await ElementHelper.reloadAndRetry( page, async function () {
-				const publishedImage = await page.waitForSelector( '.wp-block-image img' );
-				const publishedImageURL = ( await publishedImage.getAttribute( 'src' ) ) as string;
-
-				expect( publishedImageURL.split( '?' )[ 0 ] ).toEqual( newImageURL );
-			} );
-		} );
-	}
-);
+	} );
+} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
@@ -18,7 +18,10 @@ import { TEST_IMAGE_PATH } from '../constants';
 
 declare const browser: Browser;
 
-const features = envToFeatureKey( envVariables );
+const features = envToFeatureKey( {
+	...envVariables,
+	COBLOCKS_EDGE: envVariables.TEST_ON_ATOMIC || envVariables.COBLOCKS_EDGE,
+} );
 
 describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Replace Image' ), () => {
 	const accountName = getTestAccountByFeature( features );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
@@ -20,6 +20,7 @@ declare const browser: Browser;
 
 const features = envToFeatureKey( {
 	...envVariables,
+	// CoBlocks on Atomic: https://github.com/Automattic/wp-calypso/pull/73052
 	COBLOCKS_EDGE: envVariables.TEST_ON_ATOMIC || envVariables.COBLOCKS_EDGE,
 } );
 


### PR DESCRIPTION
Related to p4TIVU-apL-p2

## Proposed Changes

Update and enable CoBlocks tests against the Atomic environment.

## How?

For now, let's go with the scenario where run (Atomic) CoBlocks tests within our regular Gutenberg upgrade test suite. The whole suite should run against the no-CoBlocks account (after the cutoff date), and only the CoBlocks tests would run against the account with the plugin enabled (before the cutoff date).

## Testing Instructions

As a part of the Gutenberg group, all CoBlocks tests should run against both Simple and Atomic sites (CI).

To verify locally, run the following and make sure correct accounts are being used (tip: exporting `DEBUG=1` will log out currently used accounts):
   
- `coBlocksAtomicSiteEdgeUser` (new, used only for CoBlocks tests, switched on via the atomic flag)
   
   ```
   TEST_ON_ATOMIC=true yarn test specs/blocks/blocks__coblocks__blocks.ts
   ```

- `gutenbergAtomicSiteUser` (as it was, used for tests other than CoBlocks)


   ```
   TEST_ON_ATOMIC=true yarn test specs/blocks/blocks__core.ts
   ```

- `coBlocksSimpleSiteEdgeUser` (as it was)

   ```
   COBLOCKS_EDGE=true yarn test specs/blocks/blocks__coblocks__blocks.ts
   ```

- `gutenbergSimpleSiteEdgeUser` (as it was)

   ```
   GUTENBERG_EDGE=true yarn test specs/blocks/blocks__coblocks__blocks.ts
   ```

- `simpleSitePersonalPlanUser` (as it was)

   ```
   yarn test specs/blocks/blocks__coblocks__blocks.ts
   ```