### PR TITLE
Marketplace: Fix install Jetpack Search when no site is selected

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -92,7 +92,6 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	const sitesWithPlugin = useSelector( ( state ) =>
 		getSiteObjectsWithPlugin( state, siteIds, softwareSlug )
 	);
-
 	const installedOnSitesQuantity = sitesWithPlugin.length;
 
 	const [ displayManageSitePluginsModal, setDisplayManageSitePluginsModal ] = useState( false );

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -92,6 +92,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	const sitesWithPlugin = useSelector( ( state ) =>
 		getSiteObjectsWithPlugin( state, siteIds, softwareSlug )
 	);
+
 	const installedOnSitesQuantity = sitesWithPlugin.length;
 
 	const [ displayManageSitePluginsModal, setDisplayManageSitePluginsModal ] = useState( false );
@@ -169,7 +170,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 
 	// Some plugins can be preinstalled on WPCOM and available as standalone on WPORG,
 	// but require a paid upgrade to function.
-	if ( isPreinstalledPremiumPlugin ) {
+	if ( selectedSite && isPreinstalledPremiumPlugin ) {
 		return (
 			<div className="plugin-details-cta__container">
 				<PluginDetailsCTAPreinstalledPremiumPlugins


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #73009
## Proposed Changes

* Fixes an issue with the CTA button of the Jetpack Search plugin that was failing. 
* The button will read `Manage sites` as other plugins and it will trigger the same modal than other plugins
* The classic `jetpack-search` plugin will be installed from that modal on the selected sites

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/plugins/jetpack-search` (without any site selected)
* Click on `Manage sites` button
* Install `Jetpack Search` on any site
* Ensure the plugin is installed using `wp-admin`. Navigate to `https://:siteId/wp-admin/plugins.php`
* Check that `Jetpack Search` is listed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
