### PR TITLE
Reading Settings: Replace Settings -> Reading menu item's title with calypso translation (temporary)

### DIFF
--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useLocale } from '@automattic/i18n-utils';
+import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import domainOnlyFallbackMenu from 'calypso/my-sites/sidebar/static-data/domain-only-fallback-menu';
@@ -16,6 +17,30 @@ import { requestAdminMenu } from '../../state/admin-menu/actions';
 import allSitesMenu from './static-data/all-sites-menu';
 import buildFallbackResponse from './static-data/fallback-menu';
 import jetpackMenu from './static-data/jetpack-fallback-menu';
+
+const withTranslatedReadingSettingsTitle = ( menuItems ) => {
+	return menuItems.map( ( item ) => {
+		if ( item.slug?.endsWith( 'options-general-php' ) ) {
+			// Settings menu item has children, one of which is Reading.
+			const childrenWithTranslation = item.children?.map( ( child ) => {
+				if ( child.slug?.endsWith( 'options-reading-php' ) ) {
+					return {
+						...child,
+						title: translate( 'Reading' ),
+					};
+				}
+				return child;
+			} );
+
+			return {
+				...item,
+				children: childrenWithTranslation,
+			};
+		}
+
+		return item;
+	} );
+};
 
 const useSiteMenuItems = () => {
 	const dispatch = useDispatch();
@@ -92,6 +117,10 @@ const useSiteMenuItems = () => {
 		shouldShowInbox,
 		shouldShowAddOns: shouldShowAddOnsInFallbackMenu,
 	};
+
+	if ( isEnabled( 'settings/modernize-reading-settings' ) && menuItems ) {
+		return withTranslatedReadingSettingsTitle( menuItems );
+	}
 
 	return menuItems ?? buildFallbackResponse( fallbackDataOverrides );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/72750
Related to  https://github.com/Automattic/jetpack/pull/28616#pullrequestreview-1272725427

## Proposed Changes

* Replace title of Settings --> Reading menu item with calypso translation.
  * The title is provided by Jetpack plugin. The "Reading" title is a newly added string and may be not translated in time for new Jetpack version release. Calypso on the other hand, already has translations for "Reading" string. Therefore we implement this temporary string replacement until the string is fully translated for Jetpack plugin use. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change your wpcom profile language to one that in Jetpack does not have the "Reading" string translated yet
* Go back to site management in calypso and switch to a Jetpack connected site
* Ensure the Settings -> Reading menu item is translated as expected in the admin sidebar menu

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
