### PR TITLE
Jetpack Connection: exclude Boost plugin from the Checkout connection redirect

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -541,6 +541,8 @@ export function siteSelection( context, next ) {
 					freshSiteId = getSiteId( getState(), wpcomStagingFragment );
 				}
 
+				// If the user is presumably not connected to WPCOM, we ignore the site ID we found.
+				// Details: p9dueE-6Hf-p2
 				if ( freshSiteId && ! isUnlinkedCheckout ) {
 					// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
 					// to wp-admin. In that case, don't continue handling the route.

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -506,7 +506,7 @@ export function siteSelection( context, next ) {
 	const isUnlinkedCheckout =
 		'1' === context.query?.unlinked &&
 		context.pathname.match( /^\/checkout\/[^/]+\/jetpack_/i ) &&
-		context.pathname.includes( 'jetpack_boost' );
+		! context.pathname.includes( 'jetpack_boost' );
 
 	if ( siteId && ! isUnlinkedCheckout ) {
 		// onSelectedSiteAvailable might render an error page about domain-only sites or redirect


### PR DESCRIPTION
## Proposed Changes
This PR excludes the changes introduced in #72985 from Jetpack Boost.

## Testing Instructions
Same instructions as in #72985.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
