### PR TITLE
Add better pricing messaging on trial plans

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -1,6 +1,6 @@
 import { TranslateResult } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
-import PlanPrice from 'calypso/my-sites/plan-price';
+import PlanPrice, { PriceAsString } from 'calypso/my-sites/plan-price';
 import PriceAriaLabel from './price-aria-label';
 import TimeFrame from './time-frame';
 import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';
@@ -129,6 +129,7 @@ const Paid: React.FC< OwnProps > = ( props ) => {
 				<TimeFrame
 					billingTerm={ billingTerm }
 					discountedPriceDuration={ discountedPriceDuration }
+					formattedOriginalPrice={ PriceAsString( originalPrice, currencyCode ) }
 				/>
 			</span>
 		</>

--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -1,6 +1,6 @@
 import { TranslateResult } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
-import PlanPrice, { PriceAsString } from 'calypso/my-sites/plan-price';
+import PlanPrice, { priceAsString } from 'calypso/my-sites/plan-price';
 import PriceAriaLabel from './price-aria-label';
 import TimeFrame from './time-frame';
 import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';
@@ -104,7 +104,7 @@ const Paid: React.FC< OwnProps > = ( props ) => {
 		return <Placeholder { ...props } />;
 	}
 
-	const formattedOriginalPrice = PriceAsString( originalPrice, currencyCode );
+	const formattedOriginalPrice = priceAsString( originalPrice, currencyCode );
 
 	let priceComponent = isDiscounted ? (
 		<DiscountedPrice { ...props } finalPrice={ finalPrice } />

--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -104,6 +104,24 @@ const Paid: React.FC< OwnProps > = ( props ) => {
 		return <Placeholder { ...props } />;
 	}
 
+	const formattedOriginalPrice = PriceAsString( originalPrice, currencyCode );
+
+	let priceComponent = isDiscounted ? (
+		<DiscountedPrice { ...props } finalPrice={ finalPrice } />
+	) : (
+		<OriginalPrice { ...props } finalPrice={ finalPrice } />
+	);
+
+	// If the pricing has a limited discount duration, the original price is handled in the duration string
+	// In this case, we'll just show the final price and not the crossed-out price.
+	if ( discountedPriceDuration ) {
+		priceComponent = (
+			<span className="display-price__standalone-card-price">
+				<PlanPrice rawPrice={ finalPrice } currencyCode={ currencyCode } />
+			</span>
+		);
+	}
+
 	return (
 		<>
 			<PriceAriaLabel
@@ -111,14 +129,11 @@ const Paid: React.FC< OwnProps > = ( props ) => {
 				currencyCode={ currencyCode }
 				finalPrice={ finalPrice }
 				isDiscounted={ isDiscounted }
+				formattedOriginalPrice={ formattedOriginalPrice }
 			/>
 			<span className="display-price__prices" aria-hidden="true">
 				{ displayFrom && <span className="display-price__from">from</span> }
-				{ isDiscounted ? (
-					<DiscountedPrice { ...props } finalPrice={ finalPrice } />
-				) : (
-					<OriginalPrice { ...props } finalPrice={ finalPrice } />
-				) }
+				{ priceComponent }
 			</span>
 			{ tooltipText && (
 				<InfoPopover position="top" className="display-price__price-tooltip">
@@ -129,7 +144,7 @@ const Paid: React.FC< OwnProps > = ( props ) => {
 				<TimeFrame
 					billingTerm={ billingTerm }
 					discountedPriceDuration={ discountedPriceDuration }
-					formattedOriginalPrice={ PriceAsString( originalPrice, currencyCode ) }
+					formattedOriginalPrice={ formattedOriginalPrice }
 				/>
 			</span>
 		</>

--- a/client/components/jetpack/card/jetpack-product-card/display-price/price-aria-label.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/price-aria-label.tsx
@@ -9,6 +9,7 @@ interface Props {
 	isDiscounted: boolean;
 	finalPrice: number;
 	originalPrice?: number;
+	formattedOriginalPrice?: string;
 	discountedPriceDuration?: number;
 }
 

--- a/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/style.scss
@@ -207,6 +207,12 @@
 		color: var(--studio-pink-50);
 	}
 
+	&__standalone-card-price {
+		.plan-price {
+			margin: 0 0.2rem 0 0;
+		}
+	}
+
 	&.is-placeholder {
 		.plan-price {
 			@include placeholder( --color-neutral-10 );
@@ -258,6 +264,17 @@
 	&.is-disabled {
 		.display-price {
 			opacity: 0.4;
+		}
+	}
+}
+
+// TODO: This was originally a hotfix and needs cleanup
+.item-price .display-price {
+	&.is-jetpack-cloud:not(.is-placeholder) {
+		max-height: none;
+
+		.display-price__billing-time-frame {
+			line-height: 1.2;
 		}
 	}
 }

--- a/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
@@ -1,5 +1,5 @@
 import { TERM_MONTHLY } from '@automattic/calypso-products';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';
@@ -96,6 +96,7 @@ const PartialDiscountTimeFrame: React.FC< PartialDiscountTimeFrameProps & A11yPr
 	forScreenReader,
 } ) => {
 	const translate = useTranslate();
+	let text;
 
 	const opts = {
 		count: discountedPriceDuration,
@@ -106,20 +107,44 @@ const PartialDiscountTimeFrame: React.FC< PartialDiscountTimeFrameProps & A11yPr
 	};
 
 	/* eslint-disable wpcalypso/i18n-mismatched-placeholders */
-	let text = translate(
-		'for the first month, then %(original_price)s /month billed yearly',
-		'for the first %(months)d months, then %(original_price) /month billed yearly',
-		opts
-	);
-
 	if ( billingTerm === TERM_MONTHLY ) {
-		text = translate(
-			'for the first month, then %(original_price)s /month billed monthly',
-			'for the first %(months)d months, then %(original_price) /month billed monthly',
-			opts
-		);
+		if (
+			getLocaleSlug() === 'en' ||
+			getLocaleSlug() === 'en-gb' ||
+			i18n.hasTranslation( 'for the first month, then %(original_price)s /month billed monthly' )
+		) {
+			text = translate(
+				'for the first month, then %(original_price)s /month billed monthly',
+				'for the first %(months)d months, then %(original_price) /month billed monthly',
+				opts
+			);
+		} else {
+			text = translate(
+				'for the first month, billed monthly',
+				'for the first %(months)d months, billed monthly',
+				opts
+			);
+		}
+	} else {
+		// eslint-disable-next-line no-lonely-if
+		if (
+			getLocaleSlug() === 'en' ||
+			getLocaleSlug() === 'en-gb' ||
+			i18n.hasTranslation( 'for the first month, then %(original_price)s /month billed yearly' )
+		) {
+			text = translate(
+				'for the first month, then %(original_price)s /month billed yearly',
+				'for the first %(months)d months, then %(original_price) /month billed yearly',
+				opts
+			);
+		} else {
+			text = translate(
+				'for the first month, billed yearly',
+				'for the first %(months)d months, billed yearly',
+				opts
+			);
+		}
 	}
-	/* eslint-enable wpcalypso/i18n-mismatched-placeholders */
 
 	if ( forScreenReader ) {
 		return <>{ text }</>;

--- a/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
@@ -9,6 +9,7 @@ interface TimeFrameProps {
 	expiryDate?: Moment;
 	billingTerm: Duration;
 	discountedPriceDuration?: number;
+	formattedOriginalPrice?: string;
 }
 
 interface RegularTimeFrameProps {
@@ -22,6 +23,7 @@ interface ExpiringDateTimeFrameProps {
 interface PartialDiscountTimeFrameProps {
 	billingTerm: Duration;
 	discountedPriceDuration: number;
+	formattedOriginalPrice: string;
 }
 
 interface A11yProps {
@@ -90,6 +92,7 @@ const ExpiringDateTimeFrame: React.FC< ExpiringDateTimeFrameProps > = ( { produc
 const PartialDiscountTimeFrame: React.FC< PartialDiscountTimeFrameProps & A11yProps > = ( {
 	billingTerm,
 	discountedPriceDuration,
+	formattedOriginalPrice,
 	forScreenReader,
 } ) => {
 	const translate = useTranslate();
@@ -98,20 +101,21 @@ const PartialDiscountTimeFrame: React.FC< PartialDiscountTimeFrameProps & A11yPr
 		count: discountedPriceDuration,
 		args: {
 			months: discountedPriceDuration,
+			original_price: formattedOriginalPrice,
 		},
 	};
 
 	/* eslint-disable wpcalypso/i18n-mismatched-placeholders */
 	let text = translate(
-		'for the first month, billed yearly',
-		'for the first %(months)d months, billed yearly',
+		'for the first month, then %(original_price)s /month billed yearly',
+		'for the first %(months)d months, then %(original_price) /month billed yearly',
 		opts
 	);
 
 	if ( billingTerm === TERM_MONTHLY ) {
 		text = translate(
-			'for the first month, billed monthly',
-			'for the first %(months)d months, billed monthly',
+			'for the first month, then %(original_price)s /month billed monthly',
+			'for the first %(months)d months, then %(original_price) /month billed monthly',
 			opts
 		);
 	}
@@ -128,6 +132,7 @@ const TimeFrame: React.FC< TimeFrameProps & A11yProps > = ( {
 	expiryDate,
 	billingTerm,
 	discountedPriceDuration,
+	formattedOriginalPrice,
 	forScreenReader,
 } ) => {
 	const moment = useLocalizedMoment();
@@ -138,12 +143,13 @@ const TimeFrame: React.FC< TimeFrameProps & A11yProps > = ( {
 		return <ExpiringDateTimeFrame productExpiryDate={ productExpiryDate } />;
 	}
 
-	if ( discountedPriceDuration ) {
+	if ( discountedPriceDuration && formattedOriginalPrice ) {
 		return (
 			<PartialDiscountTimeFrame
 				billingTerm={ billingTerm }
 				discountedPriceDuration={ discountedPriceDuration }
 				forScreenReader={ forScreenReader }
+				formattedOriginalPrice={ formattedOriginalPrice }
 			/>
 		);
 	}

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -218,6 +218,16 @@ function PriceWithoutHtml( {
 	return <>{ priceObj.integer }</>;
 }
 
+export function PriceAsString( price: number, currencyCode: string, isSmallestUnit = false ) {
+	const priceObj = getCurrencyObject( price, currencyCode, { isSmallestUnit } );
+	return (
+		priceObj.symbol +
+		( priceObj.hasNonZeroFraction
+			? `${ priceObj.integer }${ priceObj.fraction }`
+			: priceObj.integer )
+	);
+}
+
 function FlatPriceDisplay( {
 	smallerPrice,
 	higherPrice,

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -218,7 +218,7 @@ function PriceWithoutHtml( {
 	return <>{ priceObj.integer }</>;
 }
 
-export function PriceAsString( price: number, currencyCode: string, isSmallestUnit = false ) {
+export function priceAsString( price: number, currencyCode: string, isSmallestUnit = false ) {
 	const priceObj = getCurrencyObject( price, currencyCode, { isSmallestUnit } );
 	return (
 		priceObj.symbol +

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import TimeFrame from 'calypso/components/jetpack/card/jetpack-product-card/display-price/time-frame';
-import PlanPrice from 'calypso/my-sites/plan-price';
+import PlanPrice, { PriceAsString } from 'calypso/my-sites/plan-price';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { useItemPriceCompact } from '../product-store/hooks/use-item-price-compact';
 import ItemPriceMessage from '../product-store/item-price/item-price-message';
@@ -85,6 +85,7 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 								<TimeFrame
 									billingTerm={ billingTerm }
 									discountedPriceDuration={ discountedPriceDuration }
+									formattedOriginalPrice={ PriceAsString( originalPrice, currencyCode ) }
 								/>
 							</div>
 						</div>

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import TimeFrame from 'calypso/components/jetpack/card/jetpack-product-card/display-price/time-frame';
-import PlanPrice, { PriceAsString } from 'calypso/my-sites/plan-price';
+import PlanPrice, { priceAsString } from 'calypso/my-sites/plan-price';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { useItemPriceCompact } from '../product-store/hooks/use-item-price-compact';
 import ItemPriceMessage from '../product-store/item-price/item-price-message';
@@ -85,7 +85,7 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 								<TimeFrame
 									billingTerm={ billingTerm }
 									discountedPriceDuration={ discountedPriceDuration }
-									formattedOriginalPrice={ PriceAsString( originalPrice, currencyCode ) }
+									formattedOriginalPrice={ priceAsString( originalPrice, currencyCode ) }
 								/>
 							</div>
 						</div>


### PR DESCRIPTION
## Proposed Changes

* This diff updates the language on the the Jetpack pricing page to better indicate how the $1 for the first month offers work.

## Testing Instructions

* Apply this patch to your testing environment or use the Calypso live link
* Check the `/pricing` page for the Jetpack Cloud environment
* Check the language next to the pricing for the VaultPress Backup and Social Basic, it should read something like "for the first month, then $10 /month billed yearly"
* Click the "More about" link for both these products to view the lightbox - the same language should be used within the lightbox

![Screen Shot 2023-02-07 at 4 27 12 PM](https://user-images.githubusercontent.com/18016357/217372118-ab253278-4037-4363-a622-2297e545c42e.png)
![Screen Shot 2023-02-07 at 4 26 58 PM](https://user-images.githubusercontent.com/18016357/217372121-9f806570-2b9e-456f-880f-891e0f3cc08c.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203923622825716