### PR TITLE
Stats: Change wording 'Followers' to 'Subscribers'

### DIFF
--- a/client/blocks/followers-count/index.jsx
+++ b/client/blocks/followers-count/index.jsx
@@ -20,9 +20,9 @@ class FollowersCount extends Component {
 					<Button
 						borderless
 						href={ '/people/followers/' + slug }
-						title={ translate( 'Total of WordPress and Email Followers' ) }
+						title={ translate( 'Total of WordPress and Email Subscribers' ) }
 					>
-						{ translate( 'Followers' ) } <Count count={ followers } />
+						{ translate( 'Subscribers' ) } <Count count={ followers } />
 					</Button>
 				) }
 			</div>

--- a/client/my-sites/stats/comment-follows/index.jsx
+++ b/client/my-sites/stats/comment-follows/index.jsx
@@ -49,7 +49,7 @@ class StatsCommentFollows extends Component {
 				/>
 
 				<div id="my-stats-content">
-					<HeaderCake onClick={ this.goBack }>{ translate( 'Comments Followers' ) }</HeaderCake>
+					<HeaderCake onClick={ this.goBack }>{ translate( 'Comments Subscribers' ) }</HeaderCake>
 					<Followers
 						path="comment-follow-summary"
 						page={ this.props.page }

--- a/client/my-sites/stats/stats-comment-followers-page/index.jsx
+++ b/client/my-sites/stats/stats-comment-followers-page/index.jsx
@@ -56,11 +56,11 @@ class StatModuleFollowersPage extends Component {
 			}
 
 			paginationSummary = translate(
-				'Showing %(startIndex)s - %(endIndex)s of %(total)s %(itemType)s followers',
+				'Showing %(startIndex)s - %(endIndex)s of %(total)s %(itemType)s subscribers',
 				{
 					context: 'pagination',
 					comment:
-						'"Showing [start index] - [end index] of [total] [item]" Example: Showing 21 - 40 of 300 WordPress.com followers',
+						'"Showing [start index] - [end index] of [total] [item]" Example: Showing 21 - 40 of 300 WordPress.com subscribers',
 					args: {
 						startIndex: numberFormat( startIndex ),
 						endIndex: numberFormat( endIndex ),
@@ -89,20 +89,20 @@ class StatModuleFollowersPage extends Component {
 			labelLegend = translate( 'Post', {
 				context: 'noun',
 			} );
-			valueLegend = translate( 'Followers' );
+			valueLegend = translate( 'Subscribers' );
 		} else if ( data && data.subscribers ) {
 			followers = <StatsList data={ data.subscribers } moduleName="Followers" />;
-			labelLegend = translate( 'Follower' );
+			labelLegend = translate( 'Subscriber' );
 			valueLegend = translate( 'Since' );
 		}
 		return (
 			<div className="followers">
 				<QuerySiteStats statType="statsCommentFollowers" siteId={ siteId } query={ query } />
-				<SectionHeader label={ translate( 'Comments Followers' ) } />
+				<SectionHeader label={ translate( 'Comments Subscribers' ) } />
 				<Card className={ classNames( classes ) }>
 					<div className="module-content">
 						{ noData && ! hasError && ! isLoading && (
-							<ErrorPanel className="is-empty-message" message={ translate( 'No followers' ) } />
+							<ErrorPanel className="is-empty-message" message={ translate( 'No subscribers' ) } />
 						) }
 
 						{ paginationSummary }

--- a/client/my-sites/stats/stats-comments/index.jsx
+++ b/client/my-sites/stats/stats-comments/index.jsx
@@ -75,7 +75,7 @@ class StatsComments extends Component {
 		return (
 			<StatsModuleContent className="module-content-text-stat">
 				<p>
-					{ translate( 'Total posts with comment followers:' ) }{ ' ' }
+					{ translate( 'Total posts with comment subscribers:' ) }{ ' ' }
 					<a href={ commentFollowURL }>{ numberFormat( commentFollowersTotal ) }</a>
 				</p>
 			</StatsModuleContent>

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -59,11 +59,11 @@ class StatModuleFollowers extends Component {
 		const options = [
 			{
 				value: 'wpcom-followers',
-				label: this.props.translate( 'WordPress.com followers' ),
+				label: this.props.translate( 'WordPress.com subscribers' ),
 			},
 			{
 				value: 'email-followers',
-				label: this.props.translate( 'Email followers' ),
+				label: this.props.translate( 'Email subscribers' ),
 			},
 		];
 

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -121,12 +121,15 @@ class StatModuleFollowers extends Component {
 				{ siteId && (
 					<QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ emailQuery } />
 				) }
-				<SectionHeader label={ translate( 'Followers' ) } href={ summaryPageLink } />
+				<SectionHeader label={ translate( 'Subscribers' ) } href={ summaryPageLink } />
 				<Card className={ classNames( ...classes ) }>
 					<div className="followers">
 						<div className="module-content">
 							{ noData && ! hasError && ! isLoading && (
-								<ErrorPanel className="is-empty-message" message={ translate( 'No followers' ) } />
+								<ErrorPanel
+									className="is-empty-message"
+									message={ translate( 'No subscribers' ) }
+								/>
 							) }
 
 							{ this.filterSelect() }
@@ -135,12 +138,15 @@ class StatModuleFollowers extends Component {
 								<div className="module-content-text module-content-text-stat">
 									{ wpcomData && !! wpcomData.total_wpcom && (
 										<p>
-											{ translate( 'Total WordPress.com followers' ) }:{ ' ' }
+											{ translate( 'Total WordPress.com subscribers' ) }:{ ' ' }
 											{ numberFormat( wpcomData.total_wpcom ) }
 										</p>
 									) }
 								</div>
-								<StatsListLegend value={ translate( 'Since' ) } label={ translate( 'Follower' ) } />
+								<StatsListLegend
+									value={ translate( 'Since' ) }
+									label={ translate( 'Subscriber' ) }
+								/>
 								{ hasWpcomFollowers && (
 									<StatsList moduleName="wpcomFollowers" data={ wpcomData.subscribers } />
 								) }
@@ -151,13 +157,16 @@ class StatModuleFollowers extends Component {
 								<div className="module-content-text module-content-text-stat">
 									{ emailData && !! emailData.total_email && (
 										<p>
-											{ translate( 'Total Email Followers' ) }:{ ' ' }
+											{ translate( 'Total Email Subscribers' ) }:{ ' ' }
 											{ numberFormat( emailData.total_email ) }
 										</p>
 									) }
 								</div>
 
-								<StatsListLegend value={ translate( 'Since' ) } label={ translate( 'Follower' ) } />
+								<StatsListLegend
+									value={ translate( 'Since' ) }
+									label={ translate( 'Subscriber' ) }
+								/>
 								{ hasEmailFollowers && (
 									<StatsList moduleName="EmailFollowers" data={ emailData.subscribers } />
 								) }

--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -40,7 +40,7 @@ export const StatsReach = ( props ) => {
 		<div className="list-total-followers">
 			{ siteId && <QuerySiteStats siteId={ siteId } statType="statsFollowers" /> }
 			{ siteId && <QuerySiteStats siteId={ siteId } statType="statsPublicize" /> }
-			<SectionHeader label={ translate( 'Follower totals' ) } />
+			<SectionHeader label={ translate( 'Subscriber totals' ) } />
 			<Card className="stats-module stats-reach__card">
 				<StatsTabs borderless>
 					<StatsTab

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -105,10 +105,10 @@ export default function () {
 	statsStrings.publicize = {
 		title: translate( 'Publicize', { context: 'Stats: title of module' } ),
 		item: translate( 'Service', { context: 'Stats: module row header for publicize service.' } ),
-		value: translate( 'Followers', {
-			context: 'Stats: module row header for number of followers on the service.',
+		value: translate( 'Subscribers', {
+			context: 'Stats: module row header for number of subscribers on the service.',
 		} ),
-		empty: translate( 'No publicize followers recorded', {
+		empty: translate( 'No publicize subscribers recorded', {
 			context: 'Stats: Info box label when the publicize module is empty',
 		} ),
 	};

--- a/packages/components/src/highlight-cards/annual-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/annual-highlight-cards.tsx
@@ -75,7 +75,7 @@ export default function AnnualHighlightCards( {
 					showValueTooltip
 				/>
 				<HighlightCard
-					heading={ translate( 'Followers' ) }
+					heading={ translate( 'Subscribers' ) }
 					icon={ <Icon icon={ people } /> }
 					count={ counts?.followers ?? null }
 					showValueTooltip


### PR DESCRIPTION
Related to #73026 

## Proposed Changes

Changes wording 'Followers' to 'Subscribers' for the following places in Jetpack Stats:

![image](https://user-images.githubusercontent.com/1425433/217375811-ea02404b-46c3-462c-ab43-315c493f17cc.png)

![image](https://user-images.githubusercontent.com/1425433/217375971-dd202dba-da85-4544-92c2-a45869da0904.png)


![image](https://user-images.githubusercontent.com/1425433/217377631-a843a7e3-1041-46c9-80d9-fb26672f3f47.png)


![image](https://user-images.githubusercontent.com/1425433/217377203-535a356f-1114-454d-ae04-983108b9c996.png)

![image](https://user-images.githubusercontent.com/1425433/217376877-831cc6af-4cbc-48ce-93ca-73002a7ed13a.png)

## Testing Instructions

- Visit live Calypso link
- Ensure Followers is changed to Subscribers in all the places mentioned above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
