### PR TITLE
Stats: Format numbers in 7-day highlight

### DIFF
--- a/packages/components/src/highlight-cards/highlight-card.tsx
+++ b/packages/components/src/highlight-cards/highlight-card.tsx
@@ -38,6 +38,7 @@ export default function HighlightCard( {
 	showValueTooltip,
 }: HighlightCardProps ) {
 	const difference = subtract( count, previousCount );
+	const differenceMagnitude = Math.abs( difference as number );
 	const percentage = Number.isFinite( difference )
 		? percentCalculator( Math.abs( difference as number ), previousCount )
 		: null;
@@ -74,8 +75,8 @@ export default function HighlightCard( {
 							{ difference > 0 && <Icon size={ 18 } icon={ arrowUp } /> }
 						</span>
 						<span className="highlight-card-difference-absolute-value">
-							{ difference <= 9999 && formattedNumber( Math.abs( difference ) ) }
-							{ difference > 9999 && <ShortenedNumber value={ Math.abs( difference ) } /> }
+							{ differenceMagnitude <= 9999 && formattedNumber( differenceMagnitude ) }
+							{ differenceMagnitude > 9999 && <ShortenedNumber value={ differenceMagnitude } /> }
 						</span>
 						{ percentage !== null && (
 							<span className="highlight-card-difference-absolute-percentage">

--- a/packages/components/src/highlight-cards/highlight-card.tsx
+++ b/packages/components/src/highlight-cards/highlight-card.tsx
@@ -74,7 +74,7 @@ export default function HighlightCard( {
 							{ difference > 0 && <Icon size={ 18 } icon={ arrowUp } /> }
 						</span>
 						<span className="highlight-card-difference-absolute-value">
-							{ Math.abs( difference ) }
+							{ formattedNumber( Math.abs( difference ) ) }
 						</span>
 						{ percentage !== null && (
 							<span className="highlight-card-difference-absolute-percentage">

--- a/packages/components/src/highlight-cards/highlight-card.tsx
+++ b/packages/components/src/highlight-cards/highlight-card.tsx
@@ -74,7 +74,8 @@ export default function HighlightCard( {
 							{ difference > 0 && <Icon size={ 18 } icon={ arrowUp } /> }
 						</span>
 						<span className="highlight-card-difference-absolute-value">
-							{ formattedNumber( Math.abs( difference ) ) }
+							{ difference <= 9999 && formattedNumber( Math.abs( difference ) ) }
+							{ difference > 9999 && <ShortenedNumber value={ Math.abs( difference ) } /> }
 						</span>
 						{ percentage !== null && (
 							<span className="highlight-card-difference-absolute-percentage">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #73065 
## Proposed Changes

* Formats the number of the difference. 
* `formattedNumber()` aka 9,999 for 4-digit numbers.
* `ShortenedNumber` aka 10.1k for 5-digit and higher. 

## Testing Instructions
View a site stats with big numbers in http://calypso.localhost:3000/stats/day/SITEURL.com

Large number should be formatted.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
