### PR TITLE
Checkout: Do not allow unchecking VAT checkbox if the VAT details are pre-filled

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -204,6 +204,7 @@ export function VatForm( {
 					checked={ isFormActive }
 					onChange={ toggleVatForm }
 					label={ translate( 'Add VAT details' ) }
+					disabled={ isDisabled || Boolean( vatDetailsFromServer.id ) }
 				/>
 				{ countryCode === 'GB' && (
 					<CheckboxControl

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/style.css
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/style.css
@@ -13,6 +13,6 @@
 	display: block;
 }
 
-.vat-form__row input:disabled {
+.vat-form__row input[type=checkbox]:disabled {
 	opacity: 0.5;
 }

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/style.css
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/style.css
@@ -12,3 +12,7 @@
 .vat-form__row--full-width {
 	display: block;
 }
+
+.vat-form__row input:disabled {
+	opacity: 0.5;
+}

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/style.css
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/style.css
@@ -13,6 +13,6 @@
 	display: block;
 }
 
-.vat-form__row input[type=checkbox]:disabled {
+.vat-form__row input[type="checkbox"]:disabled {
 	opacity: 0.5;
 }


### PR DESCRIPTION
## Proposed Changes

Currently when a user is eligible for VAT details, checkout will display a checkbox that reads "Add VAT details". Checking the box will show the VAT ID, organization, and address fields; essentially the same form as the one available at `/me/purchases/vat-details`. If the VAT details have already been set, the checkbox will start pre-checked and the fields will be pre-filled.

If the checkbox is unchecked, even if the database contains VAT details (ie: they are set on `/me/purchases/vat-details`), the VAT ID, organization, and address will not be sent to the shopping-cart endpoint as part of its tax information. This was by design to allow users to chose to opt-out of using their VAT number. See https://github.com/Automattic/wp-calypso/pull/71285 for this implementation.

However, this choice presents some problems detailed in https://github.com/Automattic/wp-calypso/issues/73058.

In this PR we modify the form such that the "Add VAT details" checkbox cannot be unchecked if the form is pre-filled.

Fixes https://github.com/Automattic/wp-calypso/issues/73058

<img width="567" alt="Screenshot 2023-02-07 at 6 01 39 PM" src="https://user-images.githubusercontent.com/2036909/217386575-26d47ade-0ec2-4db7-96d5-220750fc277c.png">

## Testing Instructions

Automated tests are included. To test manually:

- Visit `/me/purchases/vat-details` and pre-fill VAT details. Set the country to 'GB' and the VAT Number to a valid one like 553557881. (Note: this is a test number that will only work when the API is sandboxed).
- Add a product to your cart and visit checkout.
- Click "Edit" to edit the contact/billing step if it is not already visible.
- Verify that the "Add VAT details" checkbox is pre-checked, the VAT fields are pre-filled, and that you cannot uncheck the checkbox.