### PR TITLE
reader: Restore focus when using back button from full post view to feed

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -190,6 +190,12 @@ class ReaderStream extends Component {
 			window.history.scrollRestoration = 'manual';
 		}
 
+		if ( this.props.selectedPostKey ) {
+			setTimeout( () => {
+				this.focusSelectedPost( this.props.selectedPostKey );
+			}, 100 );
+		}
+
 		document.addEventListener( 'keydown', this.handleKeydown, true );
 	}
 


### PR DESCRIPTION
Builds on https://github.com/Automattic/wp-calypso/pull/72940 to finish off https://github.com/Automattic/wp-calypso/issues/61318

> When you open a single post from the reader list view, then close that post again, the currently tabbed element is reset to the start of the page, but the current post stays as it was prior to it being opened.

This PR fixes this behavior by checking for a selected post and moving the focus to that post.

The timeout is necessary here because the DOM is not available to `focus()` similar to [this question on SO](https://stackoverflow.com/questions/35522220/react-ref-with-focus-doesnt-work-without-settimeout-my-example). I played with different values and found `100ms` works but `10ms` does not.


https://user-images.githubusercontent.com/22446385/217420161-8960ba59-3e4c-42b7-aa48-d396d81b02a9.mov

