### PR TITLE
GH Integration: Disconnect button which deletes the keyring connection

### DIFF
--- a/client/my-sites/hosting/github/disconnect-github-expander/index.tsx
+++ b/client/my-sites/hosting/github/disconnect-github-expander/index.tsx
@@ -2,6 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
+import { useMutation } from 'react-query';
 import { useDispatch } from 'react-redux';
 import { deleteStoredKeyringConnection } from 'calypso/state/sharing/keyring/actions';
 import './style.scss';
@@ -17,13 +18,12 @@ export function DisconnectGitHubExpander( { connection }: DisconnectGitHubExpand
 	const panelId = useInstanceId( DisconnectGitHubExpander, 'disconnect-github' ) + '-panel';
 	const dispatch = useDispatch();
 	const [ isExpanded, setIsExpanded ] = useState( false );
-	const [ isDisconnecting, setIsDisconnecting ] = useState( false );
 
-	const handleClick = async () => {
-		setIsDisconnecting( true );
-		await dispatch( deleteStoredKeyringConnection( connection ) );
-		setIsDisconnecting( false );
-	};
+	// Using ReactQuery to manage `isDisconnecting` state because it's not exposed from the Redux store.
+	const mutation = useMutation< unknown, unknown, Connection >(
+		async ( c ) => await dispatch( deleteStoredKeyringConnection( c ) )
+	);
+	const { mutate: disconnect, isLoading: isDisconnecting } = mutation;
 
 	return (
 		<>
@@ -42,7 +42,7 @@ export function DisconnectGitHubExpander( { connection }: DisconnectGitHubExpand
 			>
 				<Button
 					scary
-					onClick={ handleClick }
+					onClick={ () => disconnect( connection ) }
 					busy={ isDisconnecting }
 					disabled={ isDisconnecting } // `busy` doesn't actually disable the button
 				>

--- a/client/my-sites/hosting/github/disconnect-github-expander/index.tsx
+++ b/client/my-sites/hosting/github/disconnect-github-expander/index.tsx
@@ -1,0 +1,54 @@
+import { Button, Gridicon } from '@automattic/components';
+import { useInstanceId } from '@wordpress/compose';
+import { useI18n } from '@wordpress/react-i18n';
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { deleteStoredKeyringConnection } from 'calypso/state/sharing/keyring/actions';
+import './style.scss';
+
+type Connection = Parameters< typeof deleteStoredKeyringConnection >[ 0 ];
+
+interface DisconnectGitHubExpanderProps {
+	connection: Connection;
+}
+
+export function DisconnectGitHubExpander( { connection }: DisconnectGitHubExpanderProps ) {
+	const { __ } = useI18n();
+	const panelId = useInstanceId( DisconnectGitHubExpander, 'disconnect-github' ) + '-panel';
+	const dispatch = useDispatch();
+	const [ isExpanded, setIsExpanded ] = useState( false );
+	const [ isDisconnecting, setIsDisconnecting ] = useState( false );
+
+	const handleClick = async () => {
+		setIsDisconnecting( true );
+		await dispatch( deleteStoredKeyringConnection( connection ) );
+		setIsDisconnecting( false );
+	};
+
+	return (
+		<>
+			<button
+				className="disconnect-github-expander__button"
+				aria-controls={ panelId }
+				aria-expanded={ isExpanded }
+				onClick={ () => setIsExpanded( ( expanded ) => ! expanded ) }
+			>
+				<Gridicon icon="chevron-right" size={ 16 } /> { __( 'Disconnect from GitHub' ) }
+			</button>
+			<div
+				id={ panelId }
+				className="disconnect-github-expander__panel"
+				style={ { display: isExpanded ? 'block' : 'none' } }
+			>
+				<Button
+					scary
+					onClick={ handleClick }
+					busy={ isDisconnecting }
+					disabled={ isDisconnecting } // `busy` doesn't actually disable the button
+				>
+					{ __( 'Disconnect' ) }
+				</Button>
+			</div>
+		</>
+	);
+}

--- a/client/my-sites/hosting/github/disconnect-github-expander/style.scss
+++ b/client/my-sites/hosting/github/disconnect-github-expander/style.scss
@@ -10,11 +10,19 @@
 
 	.gridicon {
 		transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
-		padding-right: 0.3em;
+		margin-inline-end: 0.3em;
 	}
 
 	&[aria-expanded="true"] .gridicon {
 		transform: rotate(90deg);
+	}
+
+	[dir="rtl"] &[aria-expanded="true"] .gridicon {
+		// Auto-rtl flips the rotate() direction. We specific 90deg so that
+		// ultimately it will end up as -90deg, which is what we want. The
+		// processing also a scaleX() to flip the icon. We add it too so the
+		// transition doesn't break.
+		transform: rotate(90deg) scaleX(-1);
 	}
 }
 

--- a/client/my-sites/hosting/github/disconnect-github-expander/style.scss
+++ b/client/my-sites/hosting/github/disconnect-github-expander/style.scss
@@ -1,0 +1,23 @@
+.disconnect-github-expander__button {
+	display: flex;
+	align-items: center;
+	cursor: pointer;
+
+	&:focus-visible {
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 2px var(--color-primary-light);
+	}
+
+	.gridicon {
+		transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
+		padding-right: 0.3em;
+	}
+
+	&[aria-expanded="true"] .gridicon {
+		transform: rotate(90deg);
+	}
+}
+
+.disconnect-github-expander__panel {
+	padding-top: 1rem;
+}

--- a/client/my-sites/hosting/github/github-connect-card/index.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/index.tsx
@@ -1,16 +1,23 @@
 import { Card } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
 import CardHeading from 'calypso/components/card-heading';
+import { DisconnectGitHubExpander } from '../disconnect-github-expander';
 import iconGitHub from '../github.svg';
+import type { ComponentProps } from 'react';
+
+interface GithubConnectCardProps {
+	connection: ComponentProps< typeof DisconnectGitHubExpander >[ 'connection' ];
+}
 
 // todo - just a placeholder for now as the implementation of this
 // component falls under another PR.
-export const GithubConnectCard = () => {
+export const GithubConnectCard = ( { connection }: GithubConnectCardProps ) => {
 	const { __ } = useI18n();
 	return (
 		<Card className="github-hosting-card">
 			<img className="github-hosting-icon" src={ iconGitHub } alt="" />
 			<CardHeading>{ __( 'Connect Branch' ) }</CardHeading>
+			<DisconnectGitHubExpander connection={ connection } />
 		</Card>
 	);
 };

--- a/client/my-sites/hosting/github/index.tsx
+++ b/client/my-sites/hosting/github/index.tsx
@@ -18,7 +18,7 @@ export const GitHubCard = () => {
 	const gitHub = connections.find( ( connection ) => connection.service === 'github-deploy' );
 
 	if ( gitHub ) {
-		return <GithubConnectCard />;
+		return <GithubConnectCard connection={ gitHub } />;
 	}
 
 	return <GithubAuthorizeCard />;

--- a/client/my-sites/hosting/github/test/disconnect-github-expander.test.tsx
+++ b/client/my-sites/hosting/github/test/disconnect-github-expander.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, render, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClientProvider } from 'react-query';
+import { Provider as ReduxProvider } from 'react-redux';
+import wpcom from 'calypso/lib/wp';
+import { createReduxStore } from 'calypso/state';
+import { createQueryClient } from 'calypso/state/query-client';
+import initialReducer from 'calypso/state/reducer';
+import { DisconnectGitHubExpander } from '../disconnect-github-expander';
+
+jest.mock( 'calypso/lib/wp' );
+
+function renderWithProviders( connection ) {
+	return render(
+		<QueryClientProvider client={ createQueryClient() }>
+			<ReduxProvider store={ createReduxStore( undefined, initialReducer ) }>
+				<DisconnectGitHubExpander connection={ connection } />
+			</ReduxProvider>
+		</QueryClientProvider>
+	);
+}
+
+test( 'toggles visibility of disconnect button', () => {
+	renderWithProviders( { ID: 1, label: '' } );
+	const toggleButton = screen.getByRole( 'button', { name: 'Disconnect from GitHub' } );
+
+	expect( toggleButton ).toHaveAttribute( 'aria-expanded', 'false' );
+	expect( screen.queryByRole( 'button', { name: 'Disconnect' } ) ).toBeNull();
+
+	fireEvent.click( toggleButton );
+
+	expect( toggleButton ).toHaveAttribute( 'aria-expanded', 'true' );
+	expect( screen.getByRole( 'button', { name: 'Disconnect' } ) ).toBeVisible();
+
+	fireEvent.click( toggleButton );
+
+	expect( toggleButton ).toHaveAttribute( 'aria-expanded', 'false' );
+	expect( screen.queryByRole( 'button', { name: 'Disconnect' } ) ).toBeNull();
+} );
+
+test( 'disconnect button is disabled during request', async () => {
+	renderWithProviders( { ID: 1, label: '' } );
+
+	fireEvent.click( screen.getByRole( 'button', { name: 'Disconnect from GitHub' } ) );
+	const disconnectButton = screen.getByRole( 'button', { name: 'Disconnect' } );
+
+	expect( disconnectButton ).not.toBeDisabled();
+
+	let resolve;
+	( wpcom.req.get as jest.Mock ).mockReturnValue( new Promise( ( r ) => ( resolve = r ) ) );
+
+	fireEvent.click( disconnectButton );
+	await waitFor( () => expect( disconnectButton ).toBeDisabled() );
+
+	expect( wpcom.req.get ).toHaveBeenCalledWith(
+		expect.objectContaining( {
+			path: expect.stringMatching( '/1' ),
+			method: 'DELETE',
+		} )
+	);
+
+	resolve( { ID: 28807201, deleted: true } );
+
+	await waitFor( () => expect( disconnectButton ).not.toBeDisabled() );
+} );
+
+test( 'disconnect button is re-enabled after error', async () => {
+	renderWithProviders( { ID: 1, label: '' } );
+
+	fireEvent.click( screen.getByRole( 'button', { name: 'Disconnect from GitHub' } ) );
+	const disconnectButton = screen.getByRole( 'button', { name: 'Disconnect' } );
+
+	expect( disconnectButton ).not.toBeDisabled();
+
+	let reject;
+	( wpcom.req.get as jest.Mock ).mockReturnValue( new Promise( ( _, r ) => ( reject = r ) ) );
+
+	fireEvent.click( disconnectButton );
+	await waitFor( () => expect( disconnectButton ).toBeDisabled() );
+
+	expect( wpcom.req.get ).toHaveBeenCalledWith(
+		expect.objectContaining( {
+			path: expect.stringMatching( '/1' ),
+			method: 'DELETE',
+		} )
+	);
+
+	reject( { statusCode: 500 } );
+
+	await waitFor( () => expect( disconnectButton ).not.toBeDisabled() );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70382
_Note it doesn't yet uninstall the app on the GitHub side yet, that's coming in another PR_

## Proposed Changes

* New `<DisconnectGitHubExpander>` component that can be added to the bottom of any of the GitHub cards
* "Disconnect" button is hidden by default since users shouldn't want to press it too often
* Button deletes the keyring connection

https://user-images.githubusercontent.com/1500769/217470266-1d5021be-552a-49f1-9305-bef456f68eb6.mov

The "Disconnect" button is disabled while the request is being processed. The "is deleting" state isn't exposed by Redux so I'm using ReactQuery, which doesn't have to be for network requests, it's an abstraction that works for managing any sort of async state. In the first commit you can see I kept track of the processing state myself using `useState`, however this can lead to "state was changed after component unmounted" errors.

## Screenshot

<img width="753" alt="CleanShot 2023-02-09 at 13 41 05@2x" src="https://user-images.githubusercontent.com/1500769/217684933-0c9941ad-12b7-4fae-bbb0-bc187cd51ad7.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Connect to the GitHub app
* Use the "Disconnect" button to disconnect
* Confirm the keyring connection is no longer stored in the database
* In between each round of testing you'll need to go to GitHub and manually uninstall the app integration.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
