### PR TITLE
Site Assembler: Display color variations

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -323,6 +323,11 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 		} else if ( name === 'homepage' ) {
 			trackEventPatternAdd( 'section' );
 		}
+
+		recordTracksEvent( 'calypso_signup_pattern_assembler_main_item_select', {
+			...commonEventProps,
+			name,
+		} );
 	};
 
 	const onAddSection = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -409,6 +409,17 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 					/>
 				</NavigatorScreen>
 
+				{ isEnabled( 'pattern-assembler/color-and-fonts' ) && (
+					<NavigatorScreen path="/color-palettes">
+						<AsyncLoad
+							require="./screen-color-palettes"
+							placeholder={ null }
+							siteId={ site?.ID }
+							stylesheet={ selectedDesign?.recipe?.stylesheet }
+						/>
+					</NavigatorScreen>
+				) }
+
 				<NavigatorListener
 					onLocationChange={ ( navigatorLocation ) => {
 						setNavigatorPath( navigatorLocation.path );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
@@ -1,4 +1,5 @@
 import { BlockRendererProvider, PatternsRendererProvider } from '@automattic/block-renderer';
+import { GlobalStylesProvider } from '@automattic/global-styles';
 import { PLACEHOLDER_SITE_ID } from './constants';
 import type { SiteInfo } from '@automattic/block-renderer';
 
@@ -16,20 +17,30 @@ const PatternAssemblerContainer = ( {
 	patternIds,
 	children,
 	siteInfo,
-}: Props ) => (
-	<BlockRendererProvider siteId={ siteId } stylesheet={ stylesheet }>
-		<PatternsRendererProvider
-			// Site used to render site-related things on the previews,
-			// such as the logo, title, and tagline.
-			siteId={ PLACEHOLDER_SITE_ID }
-			stylesheet={ stylesheet }
-			patternIds={ patternIds }
-			// Use siteInfo to overwrite site-related things such as title, and tagline.
-			siteInfo={ siteInfo }
-		>
-			{ children }
-		</PatternsRendererProvider>
-	</BlockRendererProvider>
-);
+}: Props ) => {
+	const commonProps = {
+		siteId,
+		stylesheet,
+	};
+
+	// TODO: We might need to lazy load the GlobalStylesProvider
+	return (
+		<GlobalStylesProvider { ...commonProps }>
+			<BlockRendererProvider { ...commonProps }>
+				<PatternsRendererProvider
+					{ ...commonProps }
+					// Site used to render site-related things on the previews,
+					// such as the logo, title, and tagline.
+					siteId={ PLACEHOLDER_SITE_ID }
+					patternIds={ patternIds }
+					// Use siteInfo to overwrite site-related things such as title, and tagline.
+					siteInfo={ siteInfo }
+				>
+					{ children }
+				</PatternsRendererProvider>
+			</BlockRendererProvider>
+		</GlobalStylesProvider>
+	);
+};
 
 export default PatternAssemblerContainer;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
@@ -1,0 +1,39 @@
+import { Button } from '@automattic/components';
+import { ColorPaletteVariations } from '@automattic/global-styles';
+import { __experimentalNavigatorBackButton as NavigatorBackButton } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import NavigatorHeader from './navigator-header';
+
+interface Props {
+	siteId: number | string;
+	stylesheet: string;
+	onDoneClick: () => void;
+}
+
+const ScreenColorPalettes = ( { siteId, stylesheet, onDoneClick }: Props ) => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			<NavigatorHeader
+				title={ translate( 'Colours' ) }
+				description={ translate( 'Foreground and background colours used throughout your site.' ) }
+			/>
+			<div className="screen-container__body">
+				<ColorPaletteVariations siteId={ siteId } stylesheet={ stylesheet } />
+			</div>
+			<div className="screen-container__footer">
+				<NavigatorBackButton
+					as={ Button }
+					className="pattern-assembler__button"
+					onClick={ onDoneClick }
+					primary
+				>
+					{ translate( 'Done' ) }
+				</NavigatorBackButton>
+			</div>
+		</>
+	);
+};
+
+export default ScreenColorPalettes;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import {
 	__experimentalItemGroup as ItemGroup,
@@ -58,6 +59,21 @@ const ScreenMain = ( { onSelect, onContinueClick }: Props ) => {
 							{ translate( 'Create your homepage' ) }
 						</span>
 					</NavigationButtonAsItem>
+					{ isEnabled( 'pattern-assembler/color-and-fonts' ) && (
+						<>
+							<Divider />
+							<NavigationButtonAsItem
+								path="/color-palettes"
+								icon={ layout }
+								aria-label={ translate( 'Change colours' ) }
+								onClick={ () => onSelect( 'homepage' ) }
+							>
+								<span className="pattern-layout__list-item-text">
+									{ translate( 'Change colours' ) }
+								</span>
+							</NavigationButtonAsItem>
+						</>
+					) }
 				</ItemGroup>
 			</div>
 			<div className="screen-container__footer">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -4,7 +4,7 @@ import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalDivider as Divider,
 } from '@wordpress/components';
-import { header, footer, layout } from '@wordpress/icons';
+import { header, footer, layout, styles } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { NavigationButtonAsItem } from './navigator-buttons';
 import NavigatorHeader from './navigator-header';
@@ -64,7 +64,7 @@ const ScreenMain = ( { onSelect, onContinueClick }: Props ) => {
 							<Divider />
 							<NavigationButtonAsItem
 								path="/color-palettes"
-								icon={ layout }
+								icon={ styles }
 								aria-label={ translate( 'Change colours' ) }
 								onClick={ () => onSelect( 'homepage' ) }
 							>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -66,7 +66,7 @@ const ScreenMain = ( { onSelect, onContinueClick }: Props ) => {
 								path="/color-palettes"
 								icon={ styles }
 								aria-label={ translate( 'Change colours' ) }
-								onClick={ () => onSelect( 'homepage' ) }
+								onClick={ () => onSelect( 'color-palettes' ) }
 							>
 								<span className="pattern-layout__list-item-text">
 									{ translate( 'Change colours' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -170,7 +170,6 @@ $font-family: "SF Pro Text", $sans;
 		.pattern-layout__add-button-container {
 			position: relative;
 			margin-right: auto;
-			margin-bottom: 32px;
 		}
 
 		.pattern-layout__icon {
@@ -312,7 +311,8 @@ $font-family: "SF Pro Text", $sans;
 		display: flex;
 		flex-direction: column;
 		padding: 2px;
-		overflow: hidden;
+		margin-bottom: 32px;
+		overflow-y: auto;
 	}
 
 	.screen-container__footer {

--- a/config/development.json
+++ b/config/development.json
@@ -131,6 +131,7 @@
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/client-side-render": true,
+		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/sidebar-revamp": true,
 		"pattern-assembler/write-flow": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -82,6 +82,7 @@
 		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/client-side-render": true,
+		"pattern-assembler/color-and-fonts": false,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/sidebar-revamp": false,
 		"pattern-assembler/write-flow": true,

--- a/config/production.json
+++ b/config/production.json
@@ -96,6 +96,7 @@
 		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/client-side-render": true,
+		"pattern-assembler/color-and-fonts": false,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/sidebar-revamp": false,
 		"pattern-assembler/write-flow": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -94,6 +94,7 @@
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/client-side-render": true,
+		"pattern-assembler/color-and-fonts": false,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/sidebar-revamp": false,
 		"pattern-assembler/write-flow": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -105,6 +105,7 @@
 		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/client-side-render": true,
+		"pattern-assembler/color-and-fonts": false,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/sidebar-revamp": false,
 		"pattern-assembler/write-flow": true,

--- a/packages/block-renderer/src/global.d.ts
+++ b/packages/block-renderer/src/global.d.ts
@@ -8,3 +8,5 @@ declare module '@wordpress/block-editor' {
 	export const __unstableEditorStyles: React.ComponentType< Props >;
 	export const __unstablePresetDuotoneFilter: React.ComponentType< Props >;
 }
+
+declare module '@wordpress/edit-site/build-module/components/global-styles/use-global-styles-output';

--- a/packages/block-renderer/src/hooks/use-block-renderer-settings.ts
+++ b/packages/block-renderer/src/hooks/use-block-renderer-settings.ts
@@ -12,7 +12,7 @@ const useBlockRendererSettings = (
 	} );
 
 	return useQuery< any, unknown, BlockRendererSettings >(
-		[ siteId, 'block-renderer' ],
+		[ siteId, 'block-renderer', stylesheet ],
 		() =>
 			wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId ) }/block-renderer/settings`,

--- a/packages/global-styles/package.json
+++ b/packages/global-styles/package.json
@@ -35,6 +35,7 @@
 		"@wordpress/edit-site": "^4.6.0",
 		"@wordpress/keycodes": "^3.9.0",
 		"classnames": "^2.3.1",
+		"i18n-calypso": "workspace:^",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
 		"react-query": "^3.32.1",

--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -1,0 +1,99 @@
+import { GlobalStylesContext } from '@wordpress/edit-site/build-module/components/global-styles/context';
+import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/components/global-styles/global-styles-provider';
+import { ENTER } from '@wordpress/keycodes';
+import classnames from 'classnames';
+import { useState, useMemo, useContext } from 'react';
+import { useColorPaletteVariations } from '../../hooks';
+import ColorPaletteVariationPreview from './preview';
+import type { GlobalStylesObject } from '../../types';
+import './style.scss';
+
+interface ColorPaletteVariationProps {
+	colorPaletteVariation: GlobalStylesObject;
+	isActive: boolean;
+	selectColorPaletteVariation: () => void;
+}
+
+interface ColorPaletteVariationsProps {
+	siteId: number | string;
+	stylesheet: string;
+}
+
+const INITIAL_INDEX = -1;
+
+const ColorPaletteVariation = ( {
+	colorPaletteVariation,
+	isActive,
+	selectColorPaletteVariation,
+}: ColorPaletteVariationProps ) => {
+	const { base } = useContext( GlobalStylesContext );
+	const context = useMemo( () => {
+		return {
+			user: colorPaletteVariation,
+			base,
+			merged: mergeBaseAndUserConfigs( base, colorPaletteVariation ),
+		};
+	}, [ colorPaletteVariation, base ] );
+
+	const selectOnEnter = ( event: React.KeyboardEvent ) => {
+		if ( event.keyCode === ENTER ) {
+			event.preventDefault();
+			selectColorPaletteVariation();
+		}
+	};
+
+	return (
+		<GlobalStylesContext.Provider value={ context }>
+			<div
+				className={ classnames( 'global-styles-variation__item', {
+					'is-active': isActive,
+				} ) }
+				role="button"
+				onClick={ selectColorPaletteVariation }
+				onKeyDown={ selectOnEnter }
+				tabIndex={ 0 }
+				aria-current={ isActive }
+			>
+				<div className="global-styles-variation__item-preview">
+					<ColorPaletteVariationPreview />
+				</div>
+			</div>
+		</GlobalStylesContext.Provider>
+	);
+};
+
+const ColorPaletteVariations = ( { siteId, stylesheet }: ColorPaletteVariationsProps ) => {
+	const [ selectedIndex, setSelectedIndex ] = useState( INITIAL_INDEX );
+	const { base } = useContext( GlobalStylesContext );
+	const colorPaletteVariations = useColorPaletteVariations( siteId, stylesheet ) ?? [];
+
+	const selectColorPaletteVariation = (
+		colorPaletteVariation: GlobalStylesObject,
+		index: number
+	) => {
+		setSelectedIndex( index );
+	};
+
+	return (
+		<div className="color-palette-variations">
+			<ColorPaletteVariation
+				key="base"
+				colorPaletteVariation={ base }
+				isActive={ selectedIndex === INITIAL_INDEX }
+				selectColorPaletteVariation={ () => selectColorPaletteVariation( base, INITIAL_INDEX ) }
+			/>
+			{ colorPaletteVariations.map( ( colorPaletteVariation, index ) => (
+				<ColorPaletteVariation
+					key={ index }
+					colorPaletteVariation={ colorPaletteVariation }
+					isActive={ selectedIndex === index }
+					selectColorPaletteVariation={ () =>
+						selectColorPaletteVariation( colorPaletteVariation, index )
+					}
+				/>
+			) ) }
+		</div>
+	);
+};
+
+export default ColorPaletteVariations;

--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -2,6 +2,7 @@ import { GlobalStylesContext } from '@wordpress/edit-site/build-module/component
 import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/components/global-styles/global-styles-provider';
 import { ENTER } from '@wordpress/keycodes';
 import classnames from 'classnames';
+import { translate } from 'i18n-calypso';
 import { useState, useMemo, useContext } from 'react';
 import { useColorPaletteVariations } from '../../hooks';
 import ColorPaletteVariationPreview from './preview';
@@ -43,22 +44,28 @@ const ColorPaletteVariation = ( {
 	};
 
 	return (
-		<GlobalStylesContext.Provider value={ context }>
-			<div
-				className={ classnames( 'global-styles-variation__item', {
-					'is-active': isActive,
-				} ) }
-				role="button"
-				onClick={ selectColorPaletteVariation }
-				onKeyDown={ selectOnEnter }
-				tabIndex={ 0 }
-				aria-current={ isActive }
-			>
-				<div className="global-styles-variation__item-preview">
+		<div
+			className={ classnames( 'global-styles-variation__item', {
+				'is-active': isActive,
+			} ) }
+			role="button"
+			onClick={ selectColorPaletteVariation }
+			onKeyDown={ selectOnEnter }
+			tabIndex={ 0 }
+			aria-current={ isActive }
+			aria-label={
+				translate( 'Color: %s', {
+					comment: 'Aria label for color preview buttons',
+					args: colorPaletteVariation.title,
+				} ) as string
+			}
+		>
+			<div className="global-styles-variation__item-preview">
+				<GlobalStylesContext.Provider value={ context }>
 					<ColorPaletteVariationPreview />
-				</div>
+				</GlobalStylesContext.Provider>
 			</div>
-		</GlobalStylesContext.Provider>
+		</div>
 	);
 };
 

--- a/packages/global-styles/src/components/color-palette-variations/preview.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/preview.tsx
@@ -12,7 +12,7 @@ import {
 	STYLE_PREVIEW_HEIGHT,
 	STYLE_PREVIEW_COLOR_SWATCH_SIZE,
 } from '../../constants';
-import VariationPreviewContainer from '../variation-preview-container';
+import GlobalStylesVariationContainer from '../global-styles-variation-container';
 import type { Color } from '../../types';
 
 const ColorPaletteVariationPreview = () => {
@@ -30,7 +30,7 @@ const ColorPaletteVariationPreview = () => {
 		.slice( 0, 2 );
 
 	return (
-		<VariationPreviewContainer
+		<GlobalStylesVariationContainer
 			width={ width }
 			ratio={ ratio }
 			containerResizeListener={ containerResizeListener }
@@ -73,7 +73,7 @@ const ColorPaletteVariationPreview = () => {
 					</HStack>
 				</div>
 			</div>
-		</VariationPreviewContainer>
+		</GlobalStylesVariationContainer>
 	);
 };
 

--- a/packages/global-styles/src/components/color-palette-variations/preview.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/preview.tsx
@@ -1,0 +1,80 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useResizeObserver } from '@wordpress/compose';
+import {
+	useSetting,
+	useStyle,
+} from '@wordpress/edit-site/build-module/components/global-styles/hooks';
+import {
+	STYLE_PREVIEW_WIDTH,
+	STYLE_PREVIEW_HEIGHT,
+	STYLE_PREVIEW_COLOR_SWATCH_SIZE,
+} from '../../constants';
+import VariationPreviewContainer from '../variation-preview-container';
+import type { Color } from '../../types';
+
+const ColorPaletteVariationPreview = () => {
+	const [ backgroundColor = 'white' ] = useStyle( 'color.background' );
+	const [ gradientValue ] = useStyle( 'color.gradient' );
+	const [ themeColors ] = useSetting( 'color.palette.theme' );
+	const [ containerResizeListener, { width } ] = useResizeObserver();
+	const ratio = width ? width / STYLE_PREVIEW_WIDTH : 1;
+
+	const highlightedColors: Color[] = themeColors
+		.filter(
+			// we exclude background color because it is already visible in the preview.
+			( { color }: Color ) => color !== backgroundColor
+		)
+		.slice( 0, 2 );
+
+	return (
+		<VariationPreviewContainer
+			width={ width }
+			ratio={ ratio }
+			containerResizeListener={ containerResizeListener }
+		>
+			<div
+				style={ {
+					height: STYLE_PREVIEW_HEIGHT * ratio,
+					width: '100%',
+					background: gradientValue ?? backgroundColor,
+					cursor: 'pointer',
+				} }
+			>
+				<div
+					style={ {
+						height: '100%',
+						overflow: 'hidden',
+					} }
+				>
+					<HStack
+						spacing={ 10 * ratio }
+						justify="center"
+						style={ {
+							height: '100%',
+							overflow: 'hidden',
+						} }
+					>
+						<VStack spacing={ 4 * ratio }>
+							{ highlightedColors.map( ( { color }, index ) => (
+								<div
+									key={ index }
+									style={ {
+										height: STYLE_PREVIEW_COLOR_SWATCH_SIZE * ratio,
+										width: STYLE_PREVIEW_COLOR_SWATCH_SIZE * ratio,
+										background: color,
+										borderRadius: ( STYLE_PREVIEW_COLOR_SWATCH_SIZE * ratio ) / 2,
+									} }
+								/>
+							) ) }
+						</VStack>
+					</HStack>
+				</div>
+			</div>
+		</VariationPreviewContainer>
+	);
+};
+
+export default ColorPaletteVariationPreview;

--- a/packages/global-styles/src/components/color-palette-variations/style.scss
+++ b/packages/global-styles/src/components/color-palette-variations/style.scss
@@ -8,6 +8,7 @@
 
 .global-styles-variation__item {
 	position: relative;
+	margin: 3px;
 	cursor: pointer;
 
 	&:hover,
@@ -38,13 +39,4 @@
 			box-shadow: 0 0 0 2px var(--studio-gray);
 		}
 	}
-}
-
-.global-styles-variation-preview__iframe {
-	border-radius: 3px; /* stylelint-disable-line scales/radii */
-	box-shadow: 0 0 0 1px rgb(0 0 0 / 10%);
-	border: 0;
-	display: block;
-	max-width: 100%;
-	overflow: hidden;
 }

--- a/packages/global-styles/src/components/color-palette-variations/style.scss
+++ b/packages/global-styles/src/components/color-palette-variations/style.scss
@@ -1,0 +1,50 @@
+.color-palette-variations {
+	display: grid;
+	gap: 12px;
+	grid-template-columns: repeat(2, 1fr);
+	width: 100%;
+	box-sizing: border-box;
+}
+
+.global-styles-variation__item {
+	position: relative;
+	cursor: pointer;
+
+	&:hover,
+	&:focus-visible,
+	&.is-active {
+		&::after {
+			border-radius: 3px; /* stylelint-disable-line scales/radii */
+			bottom: -3px;
+			content: "";
+			display: block;
+			left: -3px;
+			pointer-events: none;
+			position: absolute;
+			right: -3px;
+			top: -3px;
+		}
+	}
+
+	&:hover,
+	&:focus-visible {
+		&::after {
+			box-shadow: 0 0 0 2px var(--studio-blue-50);
+		}
+	}
+
+	&.is-active {
+		&::after {
+			box-shadow: 0 0 0 2px var(--studio-gray);
+		}
+	}
+}
+
+.global-styles-variation-preview__iframe {
+	border-radius: 3px; /* stylelint-disable-line scales/radii */
+	box-shadow: 0 0 0 1px rgb(0 0 0 / 10%);
+	border: 0;
+	display: block;
+	max-width: 100%;
+	overflow: hidden;
+}

--- a/packages/global-styles/src/components/global-styles-provider/index.tsx
+++ b/packages/global-styles/src/components/global-styles-provider/index.tsx
@@ -1,0 +1,98 @@
+import { GlobalStylesContext } from '@wordpress/edit-site/build-module/components/global-styles/context';
+import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/components/global-styles/global-styles-provider';
+import { isEmpty, mapValues } from 'lodash';
+import { useState, useMemo, useCallback } from 'react';
+import { useGetGlobalStylesBaseConfig } from '../../hooks';
+import type { GlobalStylesObject } from '../../types';
+
+const cleanEmptyObject = ( object: any ) => {
+	if ( object === null || typeof object !== 'object' || Array.isArray( object ) ) {
+		return object;
+	}
+	const cleanedNestedObjects: any = Object.fromEntries(
+		Object.entries( mapValues( object, cleanEmptyObject ) ).filter( ( [ , value ] ) =>
+			Boolean( value )
+		)
+	);
+	return isEmpty( cleanedNestedObjects ) ? undefined : cleanedNestedObjects;
+};
+
+const useGlobalStylesUserConfig = () => {
+	const [ userConfig, setUserConfig ] = useState< GlobalStylesObject >( {
+		settings: {},
+		styles: {},
+	} );
+
+	const setConfig = useCallback(
+		( callback ) => {
+			setUserConfig( ( currentConfig ) => {
+				const updatedConfig = callback( currentConfig );
+				return {
+					styles: cleanEmptyObject( updatedConfig.styles ) || {},
+					settings: cleanEmptyObject( updatedConfig.settings ) || {},
+				};
+			} );
+		},
+		[ setUserConfig ]
+	);
+
+	return [ !! true, userConfig, setConfig ];
+};
+
+const useGlobalStylesBaseConfig = ( siteId: number | string, stylesheet: string ) => {
+	const { data } = useGetGlobalStylesBaseConfig( siteId, stylesheet );
+
+	return [ !! data, data ];
+};
+
+const useGlobalStylesContext = ( siteId: number | string, stylesheet: string ) => {
+	const [ isUserConfigReady, userConfig, setUserConfig ] = useGlobalStylesUserConfig();
+
+	const [ isBaseConfigReady, baseConfig ] = useGlobalStylesBaseConfig( siteId, stylesheet );
+
+	const mergedConfig = useMemo( () => {
+		if ( ! baseConfig || ! userConfig ) {
+			return {};
+		}
+		return mergeBaseAndUserConfigs( baseConfig, userConfig );
+	}, [ userConfig, baseConfig ] );
+
+	const context = useMemo( () => {
+		return {
+			isReady: isUserConfigReady && isBaseConfigReady,
+			user: userConfig,
+			base: baseConfig,
+			merged: mergedConfig,
+			setUserConfig,
+		};
+	}, [
+		mergedConfig,
+		userConfig,
+		baseConfig,
+		setUserConfig,
+		isUserConfigReady,
+		isBaseConfigReady,
+	] );
+
+	return context;
+};
+
+interface Props {
+	siteId: number | string;
+	stylesheet: string;
+	children: JSX.Element;
+}
+
+const GlobalStylesProvider = ( { siteId, stylesheet, children }: Props ) => {
+	const context = useGlobalStylesContext( siteId, stylesheet );
+
+	if ( ! context.isReady ) {
+		return null;
+	}
+
+	return (
+		<GlobalStylesContext.Provider value={ context }>{ children }</GlobalStylesContext.Provider>
+	);
+};
+
+export default GlobalStylesProvider;

--- a/packages/global-styles/src/components/global-styles-variation-container/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variation-container/index.tsx
@@ -5,6 +5,7 @@ import {
 import { useGlobalStylesOutput } from '@wordpress/edit-site/build-module/components/global-styles/use-global-styles-output';
 import { useMemo } from 'react';
 import { STYLE_PREVIEW_HEIGHT } from '../../constants';
+import './style.scss';
 
 interface Props {
 	width: number | null;
@@ -13,7 +14,7 @@ interface Props {
 	children: JSX.Element;
 }
 
-const VariationPreviewContainer = ( {
+const GlobalStylesVariationContainer = ( {
 	width,
 	ratio,
 	containerResizeListener,
@@ -39,7 +40,7 @@ const VariationPreviewContainer = ( {
 
 	return (
 		<Iframe
-			className="global-styles-variation-preview__iframe"
+			className="global-styles-variation-container__iframe"
 			head={ <EditorStyles styles={ editorStyles } /> }
 			style={ {
 				height: Math.ceil( STYLE_PREVIEW_HEIGHT * ratio ),
@@ -54,4 +55,4 @@ const VariationPreviewContainer = ( {
 	);
 };
 
-export default VariationPreviewContainer;
+export default GlobalStylesVariationContainer;

--- a/packages/global-styles/src/components/global-styles-variation-container/style.scss
+++ b/packages/global-styles/src/components/global-styles-variation-container/style.scss
@@ -1,0 +1,16 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.global-styles-variation-container__iframe {
+	border-radius: 3px; /* stylelint-disable-line scales/radii */
+	box-shadow: 0 0 0 1px rgb(0 0 0 / 10%);
+	border: 0;
+	display: block;
+	max-height: 61.2903px;
+	max-width: 100%;
+	overflow: hidden;
+
+	@include break-large {
+		max-height: 77.2258px;
+	}
+}

--- a/packages/global-styles/src/components/global-styles-variation-container/style.scss
+++ b/packages/global-styles/src/components/global-styles-variation-container/style.scss
@@ -6,11 +6,7 @@
 	box-shadow: 0 0 0 1px rgb(0 0 0 / 10%);
 	border: 0;
 	display: block;
-	max-height: 61.2903px;
+	max-height: 77.2258px;
 	max-width: 100%;
 	overflow: hidden;
-
-	@include break-large {
-		max-height: 77.2258px;
-	}
 }

--- a/packages/global-styles/src/components/index.ts
+++ b/packages/global-styles/src/components/index.ts
@@ -1,0 +1,2 @@
+export { default as ColorPaletteVariations } from './color-palette-variations';
+export { default as GlobalStylesProvider } from './global-styles-provider';

--- a/packages/global-styles/src/components/variation-preview-container/index.tsx
+++ b/packages/global-styles/src/components/variation-preview-container/index.tsx
@@ -1,0 +1,57 @@
+import {
+	__unstableIframe as Iframe,
+	__unstableEditorStyles as EditorStyles,
+} from '@wordpress/block-editor';
+import { useGlobalStylesOutput } from '@wordpress/edit-site/build-module/components/global-styles/use-global-styles-output';
+import { useMemo } from 'react';
+import { STYLE_PREVIEW_HEIGHT } from '../../constants';
+
+interface Props {
+	width: number | null;
+	ratio: number;
+	containerResizeListener: JSX.Element;
+	children: JSX.Element;
+}
+
+const VariationPreviewContainer = ( {
+	width,
+	ratio,
+	containerResizeListener,
+	children,
+	...props
+}: Props ) => {
+	const [ styles ] = useGlobalStylesOutput();
+
+	// Reset leaked styles from WP common.css and remove main content layout padding and border.
+	const editorStyles = useMemo( () => {
+		if ( styles ) {
+			return [
+				...styles,
+				{
+					css: 'html{overflow:hidden}body{min-width: 0;padding: 0;border: none;}',
+					isGlobalStyles: true,
+				},
+			];
+		}
+
+		return styles;
+	}, [ styles ] );
+
+	return (
+		<Iframe
+			className="global-styles-variation-preview__iframe"
+			head={ <EditorStyles styles={ editorStyles } /> }
+			style={ {
+				height: Math.ceil( STYLE_PREVIEW_HEIGHT * ratio ),
+				visibility: ! width ? 'hidden' : 'visible',
+			} }
+			tabIndex={ -1 }
+			{ ...props }
+		>
+			{ containerResizeListener }
+			{ children }
+		</Iframe>
+	);
+};
+
+export default VariationPreviewContainer;

--- a/packages/global-styles/src/constants.ts
+++ b/packages/global-styles/src/constants.ts
@@ -1,0 +1,3 @@
+export const STYLE_PREVIEW_WIDTH = 248;
+export const STYLE_PREVIEW_HEIGHT = 152;
+export const STYLE_PREVIEW_COLOR_SWATCH_SIZE = 32;

--- a/packages/global-styles/src/hooks/index.ts
+++ b/packages/global-styles/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { default as useColorPaletteVariations } from './use-color-palette-variations';
+export { default as useGetGlobalStylesBaseConfig } from './use-get-global-styles-base-config';

--- a/packages/global-styles/src/hooks/use-color-palette-variations.ts
+++ b/packages/global-styles/src/hooks/use-color-palette-variations.ts
@@ -1,0 +1,25 @@
+import { useQuery } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { GlobalStylesObject } from '../types';
+
+const useColorPaletteVariations = ( siteId: number | string, stylesheet: string ) => {
+	const { data } = useQuery< any, unknown, GlobalStylesObject[] >(
+		[ 'global-styles-color-palette', siteId, stylesheet ],
+		async () =>
+			wpcomRequest< GlobalStylesObject[] >( {
+				path: `/sites/${ encodeURIComponent( siteId ) }/global-styles-variation/color-palettes`,
+				method: 'GET',
+				apiNamespace: 'wpcom/v2',
+				query: new URLSearchParams( { stylesheet } ).toString(),
+			} ),
+		{
+			refetchOnMount: 'always',
+			staleTime: Infinity,
+			enabled: !! ( siteId && stylesheet ),
+		}
+	);
+
+	return data;
+};
+
+export default useColorPaletteVariations;

--- a/packages/global-styles/src/hooks/use-get-global-styles-base-config.ts
+++ b/packages/global-styles/src/hooks/use-get-global-styles-base-config.ts
@@ -1,0 +1,25 @@
+import { useQuery } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { GlobalStylesObject } from '../types';
+
+const useGetGlobalStylesBaseConfig = ( siteId: number | string, stylesheet: string ) => {
+	return useQuery< any, unknown, unknown >(
+		[ 'global-styles-base-config', siteId, stylesheet ],
+		async () =>
+			wpcomRequest< GlobalStylesObject >( {
+				// We have to fetch the base config from wpcom as the core endpoint only supports
+				// active theme
+				path: `/sites/${ encodeURIComponent( siteId ) }/global-styles-variation/theme`,
+				method: 'GET',
+				apiNamespace: 'wpcom/v2',
+				query: new URLSearchParams( { stylesheet } ).toString(),
+			} ),
+		{
+			refetchOnMount: 'always',
+			staleTime: Infinity,
+			enabled: !! ( siteId && stylesheet ),
+		}
+	);
+};
+
+export default useGetGlobalStylesBaseConfig;

--- a/packages/global-styles/src/index.tsx
+++ b/packages/global-styles/src/index.tsx
@@ -1,5 +1,2 @@
-const GlobalStyles = () => {
-	return null;
-};
-
-export default GlobalStyles;
+export * from './components';
+export * from './types';

--- a/packages/global-styles/src/types.ts
+++ b/packages/global-styles/src/types.ts
@@ -1,0 +1,29 @@
+export interface Color {
+	color: string;
+	name: string;
+	slug: string;
+}
+
+export interface GlobalStylesObject {
+	id?: number;
+	title?: string;
+	settings: {
+		color?: {
+			palette: {
+				theme: Color[];
+			};
+		};
+	};
+	styles: {
+		elements?: {
+			heading: {
+				typography: {
+					fontFamily: string;
+				};
+			};
+		};
+		typography?: {
+			fontFamily: string;
+		};
+	};
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -801,6 +801,7 @@ __metadata:
     "@wordpress/edit-site": ^4.6.0
     "@wordpress/keycodes": ^3.9.0
     classnames: ^2.3.1
+    i18n-calypso: "workspace:^"
     react: ^17.0.2
     react-dom: ^17.0.2
     react-query: ^3.32.1


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71978

## Proposed Changes

This PR is focusing on bringing up the color screen into the Pattern Assembler screen, so users are able to change the colors and see the different variations
* Introduce a feature flag, `pattern-assembler/color-and-fonts`, to control whether to display the color variation
* Implement `GlobalStylesProvider` to provide the context of the global styles as follows
  * base: The default styles of the theme
  * user: The selected styles of the user. For the newly created site, it should be an empty object.
  * merged: The value combined `base` and `user` config
  * setUserConfig: Provide the ability to update the locale user config
* Implement `ColorPaletteVariations` to display the color variations
* Implement `ScreenColorPalettes` to bring up `ColorPaletteVariations` to the Pattern Assembler

| Change colors | Color Screen |
| - | - |
| ![Screenshot 2023-02-22 at 3 24 12 PM](https://user-images.githubusercontent.com/13596067/220551657-7ac5b42b-9b92-4d8b-a2fc-d038af89a464.png) | ![image](https://user-images.githubusercontent.com/13596067/220551412-d9292a4c-c699-4893-bc73-8e32beee65eb.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/sidebar-revamp,pattern-assembler/color-and-fonts`
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Verify the "Change colours" is shown on the main screen
  * Select the "Change colours"
  * Verify the color variations are shown
  * Click on the "Done" button and verify you're able to go back to the main screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?