### PR TITLE
Plans 2023: Add tooltip to logos

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -483,7 +483,7 @@ export class PlanFeatures2023Grid extends Component<
 								) }
 							>
 								<div className="plan-features-2023-grid__plan-logo">
-									<img src={ cloudLogo } alt="Cloud logo" />{ ' ' }
+									<img src={ cloudLogo } alt="WP Cloud logo" />{ ' ' }
 								</div>
 							</Plans2023Tooltip>
 						) }

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -88,6 +88,7 @@ import PlanFeatures2023GridFeatures from './features';
 import PlanFeatures2023GridHeaderPrice from './header-price';
 import { PlanFeaturesItem } from './item';
 import { PlanComparisonGrid } from './plan-comparison-grid';
+import { Plans2023Tooltip } from './plans-2023-tooltip';
 import { PlanProperties, TransformedFeatureObject } from './types';
 import { getStorageStringFromFeature } from './util';
 
@@ -476,19 +477,35 @@ export class PlanFeatures2023Grid extends Component<
 					) }
 					<header className={ headerClasses }>
 						{ isBusinessPlan( planName ) && (
-							<div className="plan-features-2023-grid__plan-logo">
-								<img src={ cloudLogo } alt="Cloud logo" />{ ' ' }
-							</div>
+							<Plans2023Tooltip
+								text={ translate(
+									'WP Cloud gives you the tools you need to add scalable, highly available, extremely fast WordPress hosting.'
+								) }
+							>
+								<div className="plan-features-2023-grid__plan-logo">
+									<img src={ cloudLogo } alt="Cloud logo" />{ ' ' }
+								</div>
+							</Plans2023Tooltip>
 						) }
 						{ isEcommercePlan( planName ) && (
-							<div className="plan-features-2023-grid__plan-logo">
-								<img src={ wooLogo } alt="WooCommerce logo" />{ ' ' }
-							</div>
+							<Plans2023Tooltip
+								text={ translate(
+									'Make your online store a reality with the power of WooCommerce.'
+								) }
+							>
+								<div className="plan-features-2023-grid__plan-logo">
+									<img src={ wooLogo } alt="WooCommerce logo" />{ ' ' }
+								</div>
+							</Plans2023Tooltip>
 						) }
 						{ isWpcomEnterpriseGridPlan( planName ) && (
-							<div className="plan-features-2023-grid__plan-logo">
-								<img src={ vipLogo } alt="WPVIP logo" />{ ' ' }
-							</div>
+							<Plans2023Tooltip
+								text={ translate( 'The trusted choice for enterprise WordPress hosting.' ) }
+							>
+								<div className="plan-features-2023-grid__plan-logo">
+									<img src={ vipLogo } alt="WPVIP logo" />{ ' ' }
+								</div>
+							</Plans2023Tooltip>
 						) }
 					</header>
 				</Container>
@@ -650,7 +667,7 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderPlanFeaturesList( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
-		const { domainName } = this.props;
+		const { domainName, translate } = this.props;
 		const planProperties = planPropertiesObj.filter(
 			( properties ) => ! isWpcomEnterpriseGridPlan( properties.planName )
 		);
@@ -670,7 +687,13 @@ export class PlanFeatures2023Grid extends Component<
 					/>
 					{ jpFeatures.length !== 0 && (
 						<div className="plan-features-2023-grid__jp-logo" key="jp-logo">
-							<JetpackLogo size={ 16 } />
+							<Plans2023Tooltip
+								text={ translate(
+									'Security, performance and growth tools made by the WordPress experts.'
+								) }
+							>
+								<JetpackLogo size={ 16 } />
+							</Plans2023Tooltip>
 						</div>
 					) }
 					<PlanFeatures2023GridFeatures


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1480

## Proposed Changes

Adds hover tooltips for plan logos. The tooltips have been added for the following logos:

* WP Cloud
<img width="642" alt="image" src="https://user-images.githubusercontent.com/5436027/217462312-d2e6b88a-1e26-45a4-a325-f0fd0c509121.png">

* WooCommerce
<img width="401" alt="image" src="https://user-images.githubusercontent.com/5436027/217462380-cd568a1a-82ff-4a44-9260-e5544aee915c.png">

* WP VIP
<img width="386" alt="image" src="https://user-images.githubusercontent.com/5436027/217462421-138aa18d-9982-47da-b76f-c13ecc239354.png">

* Jetpack
<img width="367" alt="image" src="https://user-images.githubusercontent.com/5436027/217462481-4bf3c695-f0cb-4d61-b186-d5f7802f402e.png">


Design: Automattic/martech#1480

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/{SITE_ID}?flags=onboarding/2023-pricing-grid` and confirm that the tooltips are displayed when hovering over the above mentioned logos.
* Go to `/start/plans?flags=onboarding/2023-pricing-grid` and confirm that the tooltips are displayed when hovering over the above mentioned logos.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
