### PR TITLE
i18n: Fix plural placeholder in Jetpack partial discount

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
@@ -115,7 +115,7 @@ const PartialDiscountTimeFrame: React.FC< PartialDiscountTimeFrameProps & A11yPr
 		) {
 			text = translate(
 				'for the first month, then %(original_price)s /month billed monthly',
-				'for the first %(months)d months, then %(original_price) /month billed monthly',
+				'for the first %(months)d months, then %(original_price)s /month billed monthly',
 				opts
 			);
 		} else {
@@ -134,7 +134,7 @@ const PartialDiscountTimeFrame: React.FC< PartialDiscountTimeFrameProps & A11yPr
 		) {
 			text = translate(
 				'for the first month, then %(original_price)s /month billed yearly',
-				'for the first %(months)d months, then %(original_price) /month billed yearly',
+				'for the first %(months)d months, then %(original_price)s /month billed yearly',
 				opts
 			);
 		} else {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up for https://github.com/Automattic/wp-calypso/pull/73063.
## Proposed Changes

* Fixes the syntax for the `original_price` placeholder in the plural strings in `PartialDiscountTimeFrame`.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/75777864/217484129-d53ce9de-f639-46b6-afd9-8ffd7e93298f.png) | ![image](https://user-images.githubusercontent.com/75777864/217483847-d0c88c3b-17dd-4272-b5f4-82d77047ad44.png) |



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To trigger the plural version of the string, open `time-frame.tsx` and in the `opts` on line 101, change `count` and `months` to `discountedPriceDuration+1`. 
* Run `yarn start-jetpack-cloud` and go to http://jetpack.cloud.localhost:3000/en/pricing.
* Verify that the discount strings match the "After" screenshot above.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
