### PR TITLE
Call migration store option API on siteCreationStep

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -8,6 +8,7 @@ import {
 	getWpOrgImporterUrl,
 } from 'calypso/blocks/import/util';
 import { WPImportOption } from 'calypso/blocks/importer/wordpress/types';
+import wpcom from 'calypso/lib/wp';
 import { BASE_ROUTE } from './config';
 
 export function getFinalImporterUrl(
@@ -61,4 +62,19 @@ export function generateStepPath( stepName: string, stepSectionName?: string ) {
 	const path = routes.join( '_' );
 
 	return camelCase( path ) as string;
+}
+
+export async function addTempSiteToSourceOption( targetBlogId: number, sourceSiteSlug: string ) {
+	return wpcom.req
+		.post( {
+			path: `/migrations/from-source/${ sourceSiteSlug }`,
+			apiNamespace: 'wpcom/v2',
+			body: {
+				target_blog_id: targetBlogId,
+			},
+		} )
+		.catch( ( error: Error ) => {
+			// eslint-disable-next-line no-console
+			console.error( 'Unable to store option in source site', error );
+		} );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -28,6 +28,7 @@ import {
 	getSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
+import { addTempSiteToSourceOption } from '../import/helper';
 import type { Step } from '../../types';
 
 import './styles.scss';
@@ -120,6 +121,13 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 
 		if ( productCartItems?.length ) {
 			await addProductsToCart( site?.siteSlug as string, flow as string, productCartItems );
+		}
+
+		if ( isMigrationFlow( flow ) ) {
+			const search = window.location.search;
+			const sourceSiteSlug = new URLSearchParams( search ).get( 'from' );
+			// Store temporary target blog id to source site option
+			await addTempSiteToSourceOption( site?.siteId as number, sourceSiteSlug as string );
 		}
 
 		return {


### PR DESCRIPTION
Related to #73076 
## Proposed Changes

* In this PR we added an API call to store a temporary blog id to the source site option on siteCreationStep when a user comes from the migration flow so later on users can get this target site information on the source site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jurassic Ninja testing site.
* Connect to your WP.com account.
* Navigate to `http://calypso.localhost:3000/setup/import-focused/siteCreationStep?from=${YOUR_JN_SITE_SLUG}`
* See if `POST | https://public-api.wordpress.com/wpcom/v2/migrations/from-source/${YOUR_JN_SITE_SLUG}` get called
* Check on your sandbox and see if option `migration_target_site_id` exists in the source site option table and if the value matches the temporary site just created.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
