### PR TITLE
Plans 2023: Adjust media queries for collapsed sidebar

### DIFF
--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -10,7 +10,7 @@ $plans-2023-large-breakpoint: 1500px;
 /**
  * Media queries for the plans grid in onboarding/signup
  */
-@mixin onboarding-2023-pricing-grid-plans-breakpoints {
+@mixin pricing-grid-breakpoints {
 	max-width: 414px;
 
 	@media ( min-width: $plans-2023-small-breakpoint ) {
@@ -31,7 +31,7 @@ $plans-2023-large-breakpoint: 1500px;
  * Since there is a sidebar on internal pages,
  * we add the sidebar width to the default breakpoints.
  */
-@mixin pricing-grid-2023-plans-section-breakpoints {
+@mixin pricing-grid-breakpoints-with-sidebar {
 	max-width: 414px;
 
 	@media ( min-width: $plans-2023-small-breakpoint + $plan-features-sidebar-width ) {
@@ -53,7 +53,7 @@ $plans-2023-large-breakpoint: 1500px;
  * Tablet layout:  $plans-2023-small-breakpoint < width < $plans-2023-medium-breakpoint
  * Mobile layout:  width < $plans-2023-small-breakpoint
  */
-@mixin plan-features-layout-switcher-onboarding {
+@mixin plan-features-layout-switcher {
 	.plan-features-2023-grid__desktop-view {
 		display: none;
 
@@ -84,9 +84,9 @@ $plans-2023-large-breakpoint: 1500px;
 }
 
 /**
- * Same as `plan-features-layout-switcher-onboarding`, except that we add the sidebar width to the breakpoints.
+ * Same as `plan-features-layout-switcher`, except that we add the sidebar width to the breakpoints.
  */
-@mixin plan-features-layout-switcher-onboarding-plans-section {
+@mixin plan-features-layout-switcher-with-sidebar {
 	.plan-features-2023-grid__desktop-view {
 		display: none;
 
@@ -124,8 +124,14 @@ $plans-2023-large-breakpoint: 1500px;
 		}
 	}
 
-	.is-section-plans & {
+	.is-section-plans:not(.is-sidebar-collapsed) & {
 		@media ( min-width: $plans-2023-small-breakpoint + $plan-features-sidebar-width ) {
+			@content;
+		}
+	}
+
+	.is-section-plans.is-sidebar-collapsed & {
+		@media ( min-width: $plans-2023-small-breakpoint ) {
 			@content;
 		}
 	}
@@ -139,8 +145,14 @@ $plans-2023-large-breakpoint: 1500px;
 		}
 	}
 
-	.is-section-plans & {
+	.is-section-plans:not(.is-sidebar-collapsed) & {
 		@media ( min-width: $plans-2023-medium-breakpoint + $plan-features-sidebar-width ) {
+			@content;
+		}
+	}
+
+	.is-section-plans.is-sidebar-collapsed & {
+		@media ( min-width: $plans-2023-medium-breakpoint ) {
 			@content;
 		}
 	}

--- a/client/my-sites/plan-features-2023-grid/media-queries.tsx
+++ b/client/my-sites/plan-features-2023-grid/media-queries.tsx
@@ -2,12 +2,12 @@ import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
 
 const sidebarWidth = 272; //in px
-export const plans2023SmallBreakpoint = '880px';
-export const plans2023MediumBreakpoint = '1340px';
-export const plans2023LargeBreakpoint = '1500px';
-export const plans2023SmallWithSidebarBreakpoint = `${ 880 + sidebarWidth }px`;
-export const plans2023MediumWithSidebarBreakpoint = `${ 1340 + sidebarWidth }px`;
-export const plans2023LargeWithSidebarBreakpoint = `${ 1500 + sidebarWidth }px`;
+const plans2023SmallBreakpoint = '880px';
+const plans2023MediumBreakpoint = '1340px';
+const plans2023LargeBreakpoint = '1500px';
+const plans2023SmallWithSidebarBreakpoint = `${ 880 + sidebarWidth }px`;
+const plans2023MediumWithSidebarBreakpoint = `${ 1340 + sidebarWidth }px`;
+const plans2023LargeWithSidebarBreakpoint = `${ 1500 + sidebarWidth }px`;
 
 export const plansBreakSmall = ( styles: SerializedStyles ) => css`
 	body.is-section-signup.is-white-signup & {

--- a/client/my-sites/plan-features-2023-grid/media-queries.tsx
+++ b/client/my-sites/plan-features-2023-grid/media-queries.tsx
@@ -1,0 +1,70 @@
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+
+const sidebarWidth = 272; //in px
+export const plans2023SmallBreakpoint = '880px';
+export const plans2023MediumBreakpoint = '1340px';
+export const plans2023LargeBreakpoint = '1500px';
+export const plans2023SmallWithSidebarBreakpoint = `${ 880 + sidebarWidth }px`;
+export const plans2023MediumWithSidebarBreakpoint = `${ 1340 + sidebarWidth }px`;
+export const plans2023LargeWithSidebarBreakpoint = `${ 1500 + sidebarWidth }px`;
+
+export const plansBreakSmall = ( styles: SerializedStyles ) => css`
+	body.is-section-signup.is-white-signup & {
+		@media ( min-width: ${ plans2023SmallBreakpoint } ) {
+			${ styles }
+		}
+	}
+
+	.is-section-plans:not( .is-sidebar-collapsed ) & {
+		@media ( min-width: ${ plans2023SmallWithSidebarBreakpoint } ) {
+			${ styles }
+		}
+	}
+
+	.is-section-plans.is-sidebar-collapsed & {
+		@media ( min-width: ${ plans2023SmallBreakpoint } ) {
+			${ styles }
+		}
+	}
+`;
+
+export const plansBreakMedium = ( styles: SerializedStyles ) => css`
+	body.is-section-signup.is-white-signup & {
+		@media ( min-width: ${ plans2023MediumBreakpoint } ) {
+			${ styles }
+		}
+	}
+
+	.is-section-plans:not( .is-sidebar-collapsed ) & {
+		@media ( min-width: ${ plans2023MediumWithSidebarBreakpoint } ) {
+			${ styles }
+		}
+	}
+
+	.is-section-plans.is-sidebar-collapsed & {
+		@media ( min-width: ${ plans2023MediumBreakpoint } ) {
+			${ styles }
+		}
+	}
+`;
+
+export const plansBreakLarge = ( styles: SerializedStyles ) => css`
+	body.is-section-signup.is-white-signup & {
+		@media ( min-width: ${ plans2023LargeBreakpoint } ) {
+			${ styles }
+		}
+	}
+
+	.is-section-plans:not( .is-sidebar-collapsed ) & {
+		@media ( min-width: ${ plans2023LargeWithSidebarBreakpoint } ) {
+			${ styles }
+		}
+	}
+
+	.is-section-plans.is-sidebar-collapsed & {
+		@media ( min-width: ${ plans2023LargeBreakpoint } ) {
+			${ styles }
+		}
+	}
+`;

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -110,7 +110,7 @@ const PlanRow = styled( Row )`
 		&:last-of-type {
 			display: flex;
 			padding-top: 0;
-			padding-bottom: 24px;
+			padding-bottom: 0;
 		}
 	` ) }
 `;

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -99,6 +99,22 @@ const Row = styled.div< { isHiddenInMobile?: boolean } >`
 	` ) }
 `;
 
+const PlanRow = styled( Row )`
+	&:last-of-type {
+		display: none;
+	}
+
+	${ plansBreakSmall( css`
+		border-bottom: none;
+
+		&:last-of-type {
+			display: flex;
+			padding-top: 0;
+			padding-bottom: 24px;
+		}
+	` ) }
+`;
+
 const TitleRow = styled( Row )`
 	cursor: pointer;
 	display: flex;
@@ -286,7 +302,7 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const allVisible = visiblePlansProperties.length === displayedPlansProperties.length;
 	return (
-		<Row className="plan-comparison-grid__plan-row">
+		<PlanRow>
 			<RowHead
 				key="feature-name"
 				className="plan-comparison-grid__header plan-comparison-grid__interval-toggle"
@@ -390,7 +406,7 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 					</Cell>
 				);
 			} ) }
-		</Row>
+		</PlanRow>
 	);
 };
 

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -26,7 +26,7 @@ import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selector
 import PlanFeatures2023GridActions from './actions';
 import PlanFeatures2023GridBillingTimeframe from './billing-timeframe';
 import PlanFeatures2023GridHeaderPrice from './header-price';
-import { plansBreakSmall, plansBreakLarge, plans2023SmallBreakpoint } from './media-queries';
+import { plansBreakSmall, plansBreakLarge } from './media-queries';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import { usePricingBreakpoint } from './util';
 import type { PlanProperties } from './types';
@@ -119,6 +119,7 @@ const Cell = styled.div< { textAlign?: string; isInSignup: boolean } >`
 	flex-direction: column;
 	align-items: center;
 	padding: 33px 20px 0;
+	border-right: solid 1px #e0e0e0;
 
 	.gridicon {
 		fill: currentColor;
@@ -128,31 +129,37 @@ const Cell = styled.div< { textAlign?: string; isInSignup: boolean } >`
 		max-width: 100%;
 	}
 
-	@media ( max-width: ${ plans2023SmallBreakpoint } ) {
-		&.title-is-subtitle {
-			padding-top: 0;
-		}
+	&.title-is-subtitle {
+		padding-top: 0;
+	}
 
-		border-right: solid 1px #e0e0e0;
+	&:last-of-type {
+		border-right: none;
+	}
 
-		&:last-of-type {
-			border-right: none;
-		}
-
-		${ Row }:last-of-type & {
-			padding-bottom: 24px;
-		}
+	${ Row }:last-of-type & {
+		padding-bottom: 24px;
 	}
 
 	${ plansBreakSmall( css`
 		padding: 0 14px;
 		min-width: 180px;
+		border-right: none;
 
 		&:first-of-type {
 			padding-left: 0;
 		}
 		&:last-of-type {
 			padding-right: 0;
+			border-right: none;
+		}
+
+		&.title-is-subtitle {
+			padding-top: 33px;
+		}
+
+		${ Row }:last-of-type & {
+			padding-bottom: 0px;
 		}
 	` ) }
 

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -10,6 +10,7 @@ import {
 	PLAN_ENTERPRISE_GRID_WPCOM,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -25,16 +26,10 @@ import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selector
 import PlanFeatures2023GridActions from './actions';
 import PlanFeatures2023GridBillingTimeframe from './billing-timeframe';
 import PlanFeatures2023GridHeaderPrice from './header-price';
+import { plansBreakSmall, plansBreakLarge, plans2023SmallBreakpoint } from './media-queries';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
-import { PlanProperties } from './types';
 import { usePricingBreakpoint } from './util';
-
-function getMobileBreakpoint( { isInSignup }: { isInSignup: boolean } ) {
-	if ( isInSignup ) {
-		return '880px';
-	}
-	return '1152px'; // 880px + 272px (sidebar)
-}
+import type { PlanProperties } from './types';
 
 const JetpackIconContainer = styled.div`
 	padding-left: 6px;
@@ -52,7 +47,7 @@ const PlanComparisonHeader = styled.h1`
 	}
 `;
 
-const Title = styled.div< { isHiddenInMobile?: boolean; isInSignup: boolean } >`
+const Title = styled.div< { isHiddenInMobile?: boolean } >`
 	font-weight: 500;
 	font-size: 20px;
 	padding: 14px;
@@ -69,7 +64,7 @@ const Title = styled.div< { isHiddenInMobile?: boolean; isInSignup: boolean } >`
 			props.isHiddenInMobile ? 'rotateZ( 180deg )' : 'rotateZ( 0deg )' };
 	}
 
-	@media ( min-width: ${ getMobileBreakpoint } ) {
+	${ plansBreakSmall( css`
 		padding-left: 0;
 		border: none;
 		padding: 0;
@@ -77,7 +72,7 @@ const Title = styled.div< { isHiddenInMobile?: boolean; isInSignup: boolean } >`
 		.gridicon {
 			display: none;
 		}
-	}
+	` ) }
 `;
 
 const Grid = styled.div< { isInSignup: boolean } >`
@@ -90,30 +85,30 @@ const Grid = styled.div< { isInSignup: boolean } >`
 		border-radius: 5px;
 	}
 `;
-const Row = styled.div< { isHiddenInMobile?: boolean; isInSignup: boolean } >`
+const Row = styled.div< { isHiddenInMobile?: boolean } >`
 	justify-content: space-between;
 	margin-bottom: -1px;
 	align-items: stretch;
 	display: ${ ( props ) => ( props.isHiddenInMobile ? 'none' : 'flex' ) };
 
-	@media ( min-width: ${ getMobileBreakpoint } ) {
+	${ plansBreakSmall( css`
 		display: flex;
 		margin: 0 20px;
 		padding: 12px 0;
 		border-bottom: 1px solid #eee;
-	}
+	` ) }
 `;
 
-const TitleRow = styled( Row )< { isInSignup: boolean } >`
+const TitleRow = styled( Row )`
 	cursor: pointer;
 	display: flex;
 
-	@media ( min-width: ${ getMobileBreakpoint } ) {
+	${ plansBreakSmall( css`
 		cursor: default;
 		border-bottom: none;
 		padding: 20px 0 10px;
 		pointer-events: none;
-	}
+	` ) }
 `;
 
 const Cell = styled.div< { textAlign?: string; isInSignup: boolean } >`
@@ -133,7 +128,7 @@ const Cell = styled.div< { textAlign?: string; isInSignup: boolean } >`
 		max-width: 100%;
 	}
 
-	@media ( max-width: ${ getMobileBreakpoint } ) {
+	@media ( max-width: ${ plans2023SmallBreakpoint } ) {
 		&.title-is-subtitle {
 			padding-top: 0;
 		}
@@ -149,9 +144,9 @@ const Cell = styled.div< { textAlign?: string; isInSignup: boolean } >`
 		}
 	}
 
-	@media ( min-width: ${ getMobileBreakpoint } ) {
+	${ plansBreakSmall( css`
 		padding: 0 14px;
-		max-width: ${ ( { isInSignup } ) => ( isInSignup ? '180px' : '160px' ) };
+		min-width: 180px;
 
 		&:first-of-type {
 			padding-left: 0;
@@ -159,23 +154,33 @@ const Cell = styled.div< { textAlign?: string; isInSignup: boolean } >`
 		&:last-of-type {
 			padding-right: 0;
 		}
-	}
-	@media ( min-width: ${ getMobileBreakpoint } ) {
-		min-width: 180px;
-	}
+	` ) }
 
-	@media ( min-width: 1500px ) {
+	${ ( props ) =>
+		props.isInSignup
+			? plansBreakSmall(
+					css`
+						max-width: 180px;
+					`
+			  )
+			: plansBreakSmall(
+					css`
+						max-width: 160px;
+					`
+			  ) }
+
+	${ plansBreakLarge( css`
 		max-width: 200px;
-	}
+	` ) }
 `;
 
-const RowHead = styled.div< { isInSignup: boolean } >`
+const RowHead = styled.div`
 	display: none;
 	font-size: 14px;
-	@media ( min-width: ${ getMobileBreakpoint } ) {
+	${ plansBreakSmall( css`
 		display: block;
 		flex: 1;
-	}
+	` ) }
 `;
 
 const PlanSelector = styled.header`
@@ -210,7 +215,7 @@ const PlanSelector = styled.header`
 	}
 `;
 
-const StorageButton = styled.div< { isInSignup: boolean } >`
+const StorageButton = styled.div`
 	background: #f2f2f2;
 	border-radius: 5px;
 	padding: 4px 0;
@@ -224,9 +229,9 @@ const StorageButton = styled.div< { isInSignup: boolean } >`
 	min-width: 64px;
 	margin-top: 10px;
 
-	@media ( min-width: ${ getMobileBreakpoint } ) {
+	${ plansBreakSmall( css`
 		margin-top: 0;
-	}
+	` ) }
 `;
 type PlanComparisonGridProps = {
 	planProperties?: Array< PlanProperties >;
@@ -274,11 +279,10 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const allVisible = visiblePlansProperties.length === displayedPlansProperties.length;
 	return (
-		<Row className="plan-comparison-grid__plan-row" isInSignup={ isInSignup }>
+		<Row className="plan-comparison-grid__plan-row">
 			<RowHead
 				key="feature-name"
 				className="plan-comparison-grid__header plan-comparison-grid__interval-toggle"
-				isInSignup={ isInSignup }
 			/>
 			{ visiblePlansProperties.map( ( planProperties ) => {
 				const { planName, planConstantObj, availableForPurchase, current, ...planPropertiesObj } =
@@ -567,12 +571,10 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 						<div key={ featureGroupClass } className={ featureGroup.slug }>
 							<TitleRow
 								className="plan-comparison-grid__group-title-row"
-								isInSignup={ isInSignup }
 								onClick={ () => toggleFeatureGroup( featureGroup.slug ) }
 							>
 								<Title
 									isHiddenInMobile={ isHiddenInMobile }
-									isInSignup={ isInSignup }
 									className={ `plan-comparison-grid__group-${ featureGroup.slug }` }
 								>
 									<Gridicon icon="chevron-up" size={ 12 } color="#1E1E1E" />
@@ -585,13 +587,11 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 									<Row
 										key={ featureSlug }
 										isHiddenInMobile={ isHiddenInMobile }
-										isInSignup={ isInSignup }
 										className="plan-comparison-grid__feature-row"
 									>
 										<RowHead
 											key="feature-name"
 											className="plan-comparison-grid__feature-feature-name"
-											isInSignup={ isInSignup }
 										>
 											<Plans2023Tooltip text={ feature.getDescription?.() }>
 												{ feature.getTitle() }
@@ -650,13 +650,11 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 								<Row
 									key="feature-storage"
 									isHiddenInMobile={ isHiddenInMobile }
-									isInSignup={ isInSignup }
 									className="plan-comparison-grid__feature-storage"
 								>
 									<RowHead
 										key="feature-name"
 										className="plan-comparison-grid__feature-feature-name storage"
-										isInSignup={ isInSignup }
 									>
 										<Plans2023Tooltip
 											text={ translate( 'Space to store your photos, media, and more.' ) }
@@ -688,7 +686,6 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 												</span>
 												<StorageButton
 													className="plan-features-2023-grid__storage-button"
-													isInSignup={ isInSignup }
 													key={ planName }
 												>
 													{ featureObject.getCompareTitle?.() }

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -329,7 +329,6 @@
 		}
 
 		@include plans-2023-break-small {
-			border-right: solid 1px #e0e0e0;
 			border-left: solid 1px #e0e0e0;
 
 			&.is-bottom-aligned {

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -167,11 +167,15 @@
 
 	.is-section-stepper &,
 	.is-section-signup & {
-		@include plan-features-layout-switcher-onboarding;
+		@include plan-features-layout-switcher;
 	}
 
-	.is-section-plans & {
-		@include plan-features-layout-switcher-onboarding-plans-section;
+	.is-section-plans:not(.is-sidebar-collapsed) & {
+		@include plan-features-layout-switcher-with-sidebar;
+	}
+
+	.is-section-plans.is-sidebar-collapsed & {
+		@include plan-features-layout-switcher;
 	}
 
 	.plan-features-2023-grid__mobile-view {

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -778,6 +778,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 
 			&.plan-is-footer {
 				padding-top: 50px;
+				padding-bottom: 24px;
 			}
 		}
 

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -757,21 +757,6 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 	.plan-features-2023-gridrison__actions-buttons {
 		min-height: 40px;
 	}
-	.plan-comparison-grid__plan-row {
-		padding-top: 0;
-		padding-bottom: 0;
-		border-bottom: none;
-
-		&:last-of-type {
-			display: none;
-		}
-
-		@include plans-2023-break-small {
-			&:last-of-type {
-				display: flex;
-			}
-		}
-	}
 	.plan-comparison-grid__header {
 		display: flex;
 		flex-direction: column;

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -57,12 +57,16 @@
 
 	.is-section-stepper &,
 	.is-section-signup & {
-		@include onboarding-2023-pricing-grid-plans-breakpoints;
+		@include pricing-grid-breakpoints;
 	}
 
-	.is-section-plans & {
-		@include pricing-grid-2023-plans-section-breakpoints;
+	.is-section-plans:not(.is-sidebar-collapsed) & {
+		@include pricing-grid-breakpoints-with-sidebar;
 
+	}
+
+	.is-section-plans.is-sidebar-collapsed & {
+		@include pricing-grid-breakpoints;
 	}
 
 }

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -2,12 +2,15 @@
 
 .is-section-stepper .plans-features-main__group.is-2023-pricing-grid,
 .is-section-signup .plans-features-main__group.is-2023-pricing-grid {
-	@include onboarding-2023-pricing-grid-plans-breakpoints;
+	@include pricing-grid-breakpoints;
 }
 
-.is-section-plans .plans-features-main__group.is-2023-pricing-grid {
-	@include pricing-grid-2023-plans-section-breakpoints;
+.is-section-plans:not(.is-sidebar-collapsed) .plans-features-main__group.is-2023-pricing-grid {
+	@include pricing-grid-breakpoints-with-sidebar;
+}
 
+.is-section-plans.is-sidebar-collapsed .plans-features-main__group.is-2023-pricing-grid {
+	@include pricing-grid-breakpoints;
 }
 
 .plans-step {
@@ -29,7 +32,7 @@
 	}
 
 	.is-onboarding-2023-pricing-grid &.is-wide-layout {
-		@include onboarding-2023-pricing-grid-plans-breakpoints;
+		@include pricing-grid-breakpoints;
 	}
 
 	.formatted-header.is-without-subhead {
@@ -42,7 +45,7 @@
 		}
 
 		.is-onboarding-2023-pricing-grid .signup__step &.is-wide-layout {
-			@include onboarding-2023-pricing-grid-plans-breakpoints;
+			@include pricing-grid-breakpoints;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1470

## Proposed Changes

* If the sidebar is collapsed, for the sake of simplicity, we treat it as if there is no sidebar, and the media queries used for the signup step are used.
* Renamed these mixins to better convey their meaning:

|Old|New|
|---|---|
|`onboarding-2023-pricing-grid-plans-breakpoints`|`pricing-grid-breakpoints`|
|`pricing-grid-2023-plans-section-breakpoints`|`pricing-grid-breakpoints-with-sidebar`|
|`plan-features-layout-switcher-onboarding`|`plan-features-layout-switcher`|
|`plan-features-layout-switcher-onboarding-plans-section`|`plan-features-layout-switcher-with-sidebar`|

* Breakpoints to be tested:

|Screen width on Signup flow OR sidebar collapsed on /plans|Screen width with expanded sidebar on /plans|Result|
|---|---|---|
|1500px|1772px|Large, grid width 1480px|
|1340px|1612px|Medium, grid width 1320px|
|880px|1152px|Small, grid width 860px|

_**Note: This change does not correctly handle the plan comparison grid.**_

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans?flags=onboarding/2023-pricing-grid`
* For each of the screen widths in the table above, confirm that the grid's width matches the one in the table. Decrease the screen width by 1px and confirm that the width/layout changes.
* Adjust the screen width manually by dragging the browser window horizontally, and confirm that the layout does not break.
* Go to `/plans/{SITE_ID}?flags=onboarding/2023-pricing-grid` and repeat the above two steps.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
