### PR TITLE
Email stats: summary card

### DIFF
--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -103,7 +103,7 @@ $grid-vertical-gutters: 32px;
 		"country country country country country country country country country country country country"
 		"authors authors authors authors search search search search clicks clicks clicks clicks"
 		"videos videos videos videos videos videos downloads downloads downloads downloads downloads downloads"
-		"emails-open emails-open emails-open emails-open emails-open emails-open emails-click emails-click emails-click emails-click emails-click emails-click",
+		"emails emails emails emails emails emails emails emails emails emails emails emails",
 		6
 	);
 
@@ -113,7 +113,7 @@ $grid-vertical-gutters: 32px;
 		"authors authors authors authors search search search search"
 		"clicks clicks clicks clicks videos videos videos videos"
 		"downloads downloads downloads downloads downloads downloads downloads downloads"
-		"emails-open emails-open emails-open emails-open emails-click emails-click emails-click emails-click",
+		"emails emails emails emails emails emails emails emails",
 		7
 	);
 
@@ -126,8 +126,7 @@ $grid-vertical-gutters: 32px;
 		"clicks clicks clicks clicks"
 		"videos videos videos videos"
 		"downloads downloads downloads downloads"
-		"emails-open emails-open emails-open emails-open"
-		"emails-click emails-click emails-click emails-click",
+		"emails emails emails emails",
 		10
 	);
 
@@ -204,12 +203,7 @@ $grid-vertical-gutters: 32px;
 	}
 
 	.stats__module-wrapper--emails,
-	.list-emails-open {
-		grid-area: emails-open;
-	}
-
-	.stats__module-wrapper--emails,
-	.list-emails-click {
-		grid-area: emails-click;
+	.list-emails {
+		grid-area: emails;
 	}
 }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -111,6 +111,7 @@ Object.defineProperty( CHART_COMMENTS, 'label', {
 } );
 
 const getActiveTab = ( chartTab ) => find( CHARTS, { attr: chartTab } ) || CHARTS[ 0 ];
+
 class StatsSite extends Component {
 	static defaultProps = {
 		chartTab: 'views',
@@ -360,22 +361,26 @@ class StatsSite extends Component {
 						{ config.isEnabled( 'newsletter/stats' ) && (
 							<>
 								<StatsModule
-									path="emails-open"
-									moduleStrings={ moduleStrings.emailsOpenStats }
+									additionalColumns={ {
+										header: (
+											<>
+												<span>{ translate( 'Clicks' ) }</span>
+											</>
+										),
+										body: ( item ) => (
+											<>
+												<span>{ item.clicks }</span>
+											</>
+										),
+									} }
+									path="emails"
+									moduleStrings={ moduleStrings.emails }
 									period={ this.props.period }
 									query={ query }
-									statType="statsEmailsOpen"
+									statType="statsEmailsSummary"
+									mainItemLabel={ <span>{ translate( 'Post' ) }</span> }
 									hideSummaryLink
 									metricLabel={ translate( 'Opens' ) }
-								/>
-								<StatsModule
-									path="emails-click"
-									moduleStrings={ moduleStrings.emailsClickStats }
-									period={ this.props.period }
-									query={ query }
-									statType="statsEmailsClick"
-									hideSummaryLink
-									metricLabel={ translate( 'Clicks' ) }
 								/>
 							</>
 						) }
@@ -451,6 +456,7 @@ class StatsSite extends Component {
 		);
 	}
 }
+
 const enableJetpackStatsModule = ( siteId, path ) =>
 	withAnalytics(
 		recordTracksEvent( 'calypso_jetpack_module_toggle', {

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -44,6 +44,8 @@ class StatsModule extends Component {
 		showSummaryLink: PropTypes.bool,
 		translate: PropTypes.func,
 		metricLabel: PropTypes.string,
+		mainItemLabel: PropTypes.string,
+		additionalColumns: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -133,6 +135,8 @@ class StatsModule extends Component {
 			useShortLabel,
 			hideNewModule, // remove when cleaning 'stats/horizontal-bars-everywhere' FF
 			metricLabel,
+			additionalColumns,
+			mainItemLabel,
 		} = this.props;
 
 		const noData = data && this.state.loaded && ! data.length;
@@ -220,6 +224,9 @@ class StatsModule extends Component {
 							error={ hasError && <ErrorPanel /> }
 							loader={ isLoading && <StatsModulePlaceholder isLoading={ isLoading } /> }
 							heroElement={ path === 'countryviews' && <Geochart query={ query } /> }
+							additionalColumns={ additionalColumns }
+							splitHeader={ !! additionalColumns }
+							mainItemLabel={ mainItemLabel }
 						/>
 						{ isAllTime && (
 							<div className={ footerClass }>

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -113,8 +113,8 @@ export default function () {
 		} ),
 	};
 
-	statsStrings.emailsOpenStats = {
-		title: translate( 'Email opens', { context: 'Stats: title of module' } ),
+	statsStrings.emails = {
+		title: translate( 'Emails', { context: 'Stats: title of module' } ),
 		item: translate( 'Title', { context: 'Stats: module row header for post title.' } ),
 		value: translate( 'Opens', { context: 'Stats: module row header for number of email opens.' } ),
 		empty: translate( 'No email opens', {

--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -33,8 +33,7 @@ const wpcomV1Endpoints = {
 	statsInsights: 'stats/insights',
 	statsFileDownloads: 'stats/file-downloads',
 	statsAds: 'wordads/stats',
-	statsEmailsOpen: 'stats/opens/emails/summary',
-	statsEmailsClick: 'stats/clicks/emails/summary',
+	statsEmailsSummary: 'stats/emails/summary',
 };
 
 const wpcomV2Endpoints = {
@@ -76,8 +75,7 @@ export function requestSiteStats( siteId, statType, query ) {
 			switch ( statType ) {
 				case 'statsVideo':
 					return query.postId;
-				case 'statsEmailsOpen':
-				case 'statsEmailsClick':
+				case 'statsEmailsSummary':
 					return { period: PERIOD_ALL_TIME, quantity: 10 };
 				default:
 					return query;

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -937,7 +937,7 @@ export const normalizers = {
 	},
 
 	/**
-	 * Returns a normalized statsEmailsOpen array, ready for use in stats-module
+	 * Returns a normalized statsEmailsSummary array, ready for use in stats-module
 	 *
 	 * @param   {Object} data   Stats data
 	 * @param   {Object} query  Stats query
@@ -945,14 +945,14 @@ export const normalizers = {
 	 * @param   {Object} site    Site object
 	 * @returns {Array}       Normalized stats data
 	 */
-	statsEmailsOpen( data, query = {}, siteId, site ) {
-		if ( ! data || ! query.period || ! query.date ) {
+	statsEmailsSummary( data, query, siteId, site ) {
+		if ( ! data ) {
 			return [];
 		}
 
 		const emailsData = get( data, [ 'posts' ], [] );
 
-		return emailsData.map( ( { id, href, date, title, type, opens } ) => {
+		return emailsData.map( ( { id, href, date, title, type, opens, clicks } ) => {
 			const detailPage = site ? `/stats/email/opens/day/${ id }/${ site.slug }` : null;
 			return {
 				id,
@@ -961,42 +961,7 @@ export const normalizers = {
 				label: title,
 				type,
 				value: opens || '0',
-				page: detailPage,
-				actions: [
-					{
-						type: 'link',
-						data: href,
-					},
-				],
-			};
-		} );
-	},
-
-	/**
-	 * Returns a normalized statsEmailsClick array, ready for use in stats-module
-	 *
-	 * @param   {Object} data   Stats data
-	 * @param   {Object} query  Stats query
-	 * @param   {number} siteId  Site ID
-	 * @param   {Object} site    Site object
-	 * @returns {Array}       Normalized stats data
-	 */
-	statsEmailsClick( data, query = {}, siteId, site ) {
-		if ( ! data || ! query.period || ! query.date ) {
-			return [];
-		}
-
-		const emailsData = get( data, [ 'posts' ], [] );
-
-		return emailsData.map( ( { id, href, date, title, type, clicks } ) => {
-			const detailPage = site ? `/stats/email/clicks/day/${ id }/${ site.slug }` : null;
-			return {
-				id,
-				href,
-				date,
-				label: title,
-				type,
-				value: clicks || '0',
+				clicks: clicks || '0',
 				page: detailPage,
 				actions: [
 					{


### PR DESCRIPTION
## Proposed Changes

This PR merges the email cards on the stats page. 

![CleanShot 2023-02-08 at 11 45 09@2x](https://user-images.githubusercontent.com/528287/217508041-3a1c1d72-e044-4e3e-89e7-60f4a8b1a39d.png)


## Testing Instructions

- Apply this PR
- Visit `http://calypso.localhost:3000/stats/day/<yoursite>?flags=newsletter/stats`
- The combined card should be in the bottom.

(This patch should also be applied to your sandbox: D100665-code )
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?