### PR TITLE
Plans 2023: New 2023 plans break plans inside link-in-bio flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { StepContainer } from '@automattic/onboarding';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import PlansWrapper from './plans-wrapper';
@@ -9,13 +10,14 @@ const plans: Step = function plans( { navigation, flow } ) {
 	const handleSubmit = () => {
 		submit?.();
 	};
-
+	const is2023OnboardingPricingGrid = isEnabled( 'onboarding/2023-pricing-grid' );
 	return (
 		<StepContainer
 			stepName="plans"
 			goBack={ goBack }
 			isHorizontalLayout={ false }
-			isWideLayout={ true }
+			isWideLayout={ ! is2023OnboardingPricingGrid }
+			isFullLayout={ is2023OnboardingPricingGrid }
 			hideFormattedHeader={ true }
 			isLargeSkipLayout={ false }
 			hideBack={ true }

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -117,6 +117,7 @@ $plans-2023-large-breakpoint: 1500px;
 }
 
 @mixin plans-2023-break-small() {
+	body.is-section-stepper &,
 	body.is-section-signup.is-white-signup & {
 		@media ( min-width: $plans-2023-small-breakpoint ) {
 			@content;
@@ -131,6 +132,7 @@ $plans-2023-large-breakpoint: 1500px;
 }
 
 @mixin plans-2023-break-medium() {
+	body.is-section-stepper &,
 	body.is-section-signup.is-white-signup & {
 		@media ( min-width: $plans-2023-medium-breakpoint ) {
 			@content;

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -44,9 +44,12 @@ const JetpackIconContainer = styled.div`
 `;
 
 const PlanComparisonHeader = styled.h1`
-	font-size: 2rem;
-	text-align: center;
-	margin: 48px 0;
+	.plans .step-container .step-container__content &&,
+	&& {
+		font-size: 2rem;
+		text-align: center;
+		margin: 48px 0;
+	}
 `;
 
 const Title = styled.div< { isHiddenInMobile?: boolean; isInSignup: boolean } >`
@@ -121,6 +124,14 @@ const Cell = styled.div< { textAlign?: string; isInSignup: boolean } >`
 	flex-direction: column;
 	align-items: center;
 	padding: 33px 20px 0;
+
+	.gridicon {
+		fill: currentColor;
+	}
+
+	img {
+		max-width: 100%;
+	}
 
 	@media ( max-width: ${ getMobileBreakpoint } ) {
 		&.title-is-subtitle {
@@ -579,7 +590,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 									>
 										<RowHead
 											key="feature-name"
-											className={ `plan-comparison-grid__feature-feature-name ${ feature.getTitle() }` }
+											className="plan-comparison-grid__feature-feature-name"
 											isInSignup={ isInSignup }
 										>
 											<Plans2023Tooltip text={ feature.getDescription?.() }>

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -162,6 +162,7 @@
 		width: auto;
 	}
 
+	.is-section-stepper &,
 	.is-section-signup & {
 		@include plan-features-layout-switcher-onboarding;
 	}
@@ -266,6 +267,8 @@
 		border-radius: 5px; /* stylelint-disable-line */
 		background-color: #fff;
 		margin: 0;
+		border-spacing: 0;
+		width: 100%;
 	}
 
 	.plan-features-2023-grid__table-bottom .plan-features-2023-grid__table {
@@ -273,6 +276,7 @@
 	}
 
 	.plan-features-2023-grid__header-title {
+		margin-top: 0;
 		margin-bottom: 5px;
 		font-size: $font-title-large;
 		line-height: 0.7;
@@ -307,6 +311,7 @@
 		border: none;
 		background-color: var(--color-surface);
 		position: relative;
+		vertical-align: baseline;
 
 		.is-bold {
 			font-weight: 600;
@@ -512,6 +517,7 @@
 	border-radius: 4px;
 }
 
+body.is-section-stepper,
 body.is-section-signup.is-white-signup,
 .is-2023-pricing-grid {
 
@@ -684,6 +690,7 @@ body.is-section-signup.is-white-signup,
 	}
 }
 
+.plans-features-main.is-pricing-grid-2023-plans-features-main  ul.segmented-control.price-toggle,
 body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup__step .segmented-control.price-toggle,
 #primary .is-pricing-grid-2023-plans-features-main .segmented-control.price-toggle {
 	background-color: #f2f2f2;
@@ -699,18 +706,18 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 		padding: 6px 11px;
 	}
 
-	.segmented-control__item {
+	li.segmented-control__item:not(.is-selected) {
 		border: 6px;
 		padding: 2px;
 		font-weight: 500;
 
-		& .segmented-control__link {
+		& a.segmented-control__link {
 			border: 1px solid #f2f2f2;
 			border-radius: 5px; /* stylelint-disable-line scales/radii */
 
 			&:hover {
 				border-color: rgba(0, 0, 0, 0.04);
-				background: rgba(255, 255, 255, 0.3);
+				background: rgba(255, 255, 255, 0.3) !important;
 			}
 			&:focus {
 				box-shadow: 0 0 0 1px var(--studio-gray-90);
@@ -912,6 +919,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 
 
 	.plan-comparison-grid__title {
+		margin-top: 0;
 		margin-bottom: 12px;
 		font-size: $font-title-small;
 		line-height: 1.2;
@@ -1001,6 +1009,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 		&:not([disabled]):focus {
 			border-color: var(--studio-gray-100);
 			box-shadow: none;
+			color: inherit;
 		}
 	}
 }
@@ -1012,4 +1021,8 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
  */
 .is-section-plans .plan-features-2023-grid__plan-comparison-grid-container {
 	scroll-margin-top: $plan-features-header-banner-height + 24px;
+}
+
+.formatted-header {
+	margin-bottom: 0;
 }

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -95,6 +95,9 @@
 		}
 	}
 }
+.plan-features-2023-grid__table-item {
+	padding: 0;
+}
 .plan-features-2023-grid__table-item.is-top-buttons {
 	padding: 0 20px;
 	vertical-align: bottom;
@@ -302,6 +305,7 @@
 			font-size: 0.813rem; /* stylelint-disable-line */
 			line-height: 16px;
 			padding-bottom: 8px;
+			min-height: 50px;
 		}
 	}
 
@@ -718,6 +722,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 			&:hover {
 				border-color: rgba(0, 0, 0, 0.04);
 				background: rgba(255, 255, 255, 0.3) !important;
+				background: rgba(255, 255, 255, 0.3);
 			}
 			&:focus {
 				box-shadow: 0 0 0 1px var(--studio-gray-90);

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -722,7 +722,6 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 			&:hover {
 				border-color: rgba(0, 0, 0, 0.04);
 				background: rgba(255, 255, 255, 0.3) !important;
-				background: rgba(255, 255, 255, 0.3);
 			}
 			&:focus {
 				box-shadow: 0 0 0 1px var(--studio-gray-90);

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -55,6 +55,7 @@
 	margin: auto;
 	max-width: 335px;
 
+	.is-section-stepper &,
 	.is-section-signup & {
 		@include onboarding-2023-pricing-grid-plans-breakpoints;
 	}

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -1,5 +1,6 @@
 @import "calypso/my-sites/plan-features-2023-grid/media-queries";
 
+.is-section-stepper .plans-features-main__group.is-2023-pricing-grid,
 .is-section-signup .plans-features-main__group.is-2023-pricing-grid {
 	@include onboarding-2023-pricing-grid-plans-breakpoints;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
## Proposed Changes

This fixes the styling of the new Plans and Comparison grids on the `/setup/link-in-bio` flow. The issues are caused by the fact there's a different layout being used in this flow, which wasn't covered by the new Pricing Grid changes.


<img width="320" alt="216987751-2e2cc517-c31b-4ff7-a01a-934fd1c6b529" src="https://user-images.githubusercontent.com/2749938/217515868-ed9e5f8b-ccee-41ee-8362-110060418d26.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/link-in-bio/plans`
* The design should match the one on `/start/newsletter/plans-newsletter` on different viewport widths.

<img width="320" src="https://user-images.githubusercontent.com/2749938/217516643-437f190f-1c92-4321-9457-eaf8d7b1047f.png" />
<img width="240" src="https://user-images.githubusercontent.com/2749938/217516637-10142d07-82f4-4867-a0e0-da4123b2e7d0.png" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Addresses https://github.com/Automattic/martech/issues/1478