### PR TITLE
deprecated custom breakpoint is removed and new breakpoint is added #…

### DIFF
--- a/client/components/theme-preview-modal/style.scss
+++ b/client/components/theme-preview-modal/style.scss
@@ -2,10 +2,10 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
-$break-design-preview: 1024px;
+$break-xlarge: 1080px;
 
 @mixin break-design-preview() {
-	@media (min-width: #{ ($break-design-preview) }) {
+	@media (min-width: #{ ($break-xlarge) }) {
 		@content;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -6,10 +6,10 @@
 $gray-100: #101517;
 $gray-60: #50575e;
 $design-button-primary-color: rgb(17, 122, 201);
-$break-design-preview: 1024px;
+$break-xlarge: 1080px;
 
 @mixin break-design-preview() {
-	@media (min-width: #{ ($break-design-preview) }) {
+	@media (min-width: #{ ($break-xlarge) }) {
 		@content;
 	}
 }

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -2,10 +2,10 @@
 @import "@wordpress/base-styles/mixins";
 @import "@automattic/typography/styles/fonts";
 
-$break-design-preview: 1024px;
+$break-xlarge: 1080px;
 
 @mixin break-design-preview() {
-	@media (min-width: #{ ($break-design-preview) }) {
+	@media (min-width: #{ ($break-xlarge) }) {
 		@content;
 	}
 }


### PR DESCRIPTION
…71655

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
