### PR TITLE
Site Assembler:  Support font variations

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -70,10 +70,15 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 
 	const [ selectedColorPaletteVariation, setSelectedColorPaletteVariation ] =
 		useState< GlobalStylesObject | null >( null );
+	const [ selectedFontPairingVariation, setSelectedFontPairingVariation ] =
+		useState< GlobalStylesObject | null >( null );
 
 	const selectedVariations = useMemo(
-		() => [ selectedColorPaletteVariation ].filter( Boolean ) as GlobalStylesObject[],
-		[ selectedColorPaletteVariation ]
+		() =>
+			[ selectedColorPaletteVariation, selectedFontPairingVariation ].filter(
+				Boolean
+			) as GlobalStylesObject[],
+		[ selectedColorPaletteVariation, selectedFontPairingVariation ]
 	);
 
 	const syncedGlobalStylesUserConfig = useSyncGlobalStylesUserConfig(
@@ -440,6 +445,19 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 							stylesheet={ selectedDesign?.recipe?.stylesheet }
 							selectedColorPaletteVariation={ selectedColorPaletteVariation }
 							onSelect={ setSelectedColorPaletteVariation }
+						/>
+					</NavigatorScreen>
+				) }
+
+				{ isEnabledColorAndFonts && (
+					<NavigatorScreen path="/font-pairings">
+						<AsyncLoad
+							require="./screen-font-pairings"
+							placeholder={ null }
+							siteId={ site?.ID }
+							stylesheet={ selectedDesign?.recipe?.stylesheet }
+							selectedFontPairingVariation={ selectedFontPairingVariation }
+							onSelect={ setSelectedFontPairingVariation }
 						/>
 					</NavigatorScreen>
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
@@ -9,7 +9,7 @@ interface Props {
 	siteId: number | string;
 	stylesheet: string;
 	selectedFontPairingVariation: GlobalStylesObject | null;
-	onSelect: ( fontPairingVariation: GlobalStylesObject ) => void;
+	onSelect: ( fontPairingVariation: GlobalStylesObject | null ) => void;
 	onDoneClick: () => void;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
@@ -1,0 +1,55 @@
+import { Button } from '@automattic/components';
+import { FontPairingVariations } from '@automattic/global-styles';
+import { __experimentalNavigatorBackButton as NavigatorBackButton } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import NavigatorHeader from './navigator-header';
+import type { GlobalStylesObject } from '@automattic/global-styles';
+
+interface Props {
+	siteId: number | string;
+	stylesheet: string;
+	selectedFontPairingVariation: GlobalStylesObject | null;
+	onSelect: ( fontPairingVariation: GlobalStylesObject ) => void;
+	onDoneClick: () => void;
+}
+
+const ScreenFontPairings = ( {
+	siteId,
+	stylesheet,
+	selectedFontPairingVariation,
+	onSelect,
+	onDoneClick,
+}: Props ) => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			<NavigatorHeader
+				title={ translate( 'Fonts' ) }
+				description={ translate(
+					'We’ve hand picked a selection of font pairings that you can customise later.'
+				) }
+			/>
+			<div className="screen-container__body">
+				<FontPairingVariations
+					siteId={ siteId }
+					stylesheet={ stylesheet }
+					selectedFontPairingVariation={ selectedFontPairingVariation }
+					onSelect={ onSelect }
+				/>
+			</div>
+			<div className="screen-container__footer">
+				<NavigatorBackButton
+					as={ Button }
+					className="pattern-assembler__button"
+					onClick={ onDoneClick }
+					primary
+				>
+					{ translate( 'Done' ) }
+				</NavigatorBackButton>
+			</div>
+		</>
+	);
+};
+
+export default ScreenFontPairings;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -4,7 +4,7 @@ import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalDivider as Divider,
 } from '@wordpress/components';
-import { header, footer, layout, styles } from '@wordpress/icons';
+import { header, footer, layout, styles, typography } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { NavigationButtonAsItem } from './navigator-buttons';
 import NavigatorHeader from './navigator-header';
@@ -70,6 +70,17 @@ const ScreenMain = ( { onSelect, onContinueClick }: Props ) => {
 							>
 								<span className="pattern-layout__list-item-text">
 									{ translate( 'Change colours' ) }
+								</span>
+							</NavigationButtonAsItem>
+							<Divider />
+							<NavigationButtonAsItem
+								path="/font-pairings"
+								icon={ typography }
+								aria-label={ translate( 'Change fonts' ) }
+								onClick={ () => onSelect( 'font-pairings' ) }
+							>
+								<span className="pattern-layout__list-item-text">
+									{ translate( 'Change fonts' ) }
 								</span>
 							</NavigationButtonAsItem>
 						</>

--- a/packages/global-styles/src/components/font-pairing-variations/font-families-loader.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/font-families-loader.tsx
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+import type { FontFamily } from '../../types';
+
+interface Props {
+	fontFamilies: FontFamily[];
+}
+
+// See https://developers.google.com/fonts/docs/css2
+const FONT_API_BASE = 'https://fonts-api.wp.com/css2';
+
+const FONT_AXIS = 'ital,wght@0,400;0,700;1,400;1,700';
+
+const SYSTEM_FONT_SLUG = 'system-font';
+
+const FontFamiliesLoader = ( { fontFamilies }: Props ) => {
+	const params = useMemo(
+		() =>
+			new URLSearchParams( [
+				...fontFamilies
+					.filter( ( { slug } ) => slug !== SYSTEM_FONT_SLUG )
+					.map( ( { fontFamily } ) => [ 'family', `${ fontFamily }:${ FONT_AXIS }` ] ),
+				[ 'display', 'swap' ],
+			] ),
+		fontFamilies
+	);
+
+	if ( ! params.getAll( 'family' ).length ) {
+		return null;
+	}
+
+	return <link rel="stylesheet" type="text/css" href={ `${ FONT_API_BASE }?${ params }` } />;
+};
+
+export default FontFamiliesLoader;

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -1,0 +1,94 @@
+import { GlobalStylesContext } from '@wordpress/edit-site/build-module/components/global-styles/context';
+import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/components/global-styles/global-styles-provider';
+import { ENTER } from '@wordpress/keycodes';
+import classnames from 'classnames';
+import { useMemo, useContext } from 'react';
+import { useFontPairingVariations } from '../../hooks';
+import FontPairingVariationPreview from './preview';
+import type { GlobalStylesObject } from '../../types';
+import './style.scss';
+
+interface FontPairingVariationProps {
+	fontPairingVariation: GlobalStylesObject;
+	isActive: boolean;
+	onSelect: () => void;
+}
+
+interface FontPairingVariationsProps {
+	siteId: number | string;
+	stylesheet: string;
+	selectedFontPairingVariation: GlobalStylesObject | null;
+	onSelect: ( fontPairingVariation: GlobalStylesObject | null ) => void;
+}
+
+const FontPairingVariation = ( {
+	fontPairingVariation,
+	isActive,
+	onSelect,
+}: FontPairingVariationProps ) => {
+	const { base } = useContext( GlobalStylesContext );
+	const context = useMemo( () => {
+		return {
+			user: fontPairingVariation,
+			base,
+			merged: mergeBaseAndUserConfigs( base, fontPairingVariation ),
+		};
+	}, [ fontPairingVariation, base ] );
+
+	const selectOnEnter = ( event: React.KeyboardEvent ) => {
+		if ( event.keyCode === ENTER ) {
+			event.preventDefault();
+			onSelect();
+		}
+	};
+
+	return (
+		<GlobalStylesContext.Provider value={ context }>
+			<div
+				className={ classnames( 'global-styles-variation__item', {
+					'is-active': isActive,
+				} ) }
+				role="button"
+				onClick={ onSelect }
+				onKeyDown={ selectOnEnter }
+				tabIndex={ 0 }
+				aria-current={ isActive }
+			>
+				<div className="global-styles-variation__item-preview">
+					<FontPairingVariationPreview />
+				</div>
+			</div>
+		</GlobalStylesContext.Provider>
+	);
+};
+
+const FontPairingVariations = ( {
+	siteId,
+	stylesheet,
+	selectedFontPairingVariation,
+	onSelect,
+}: FontPairingVariationsProps ) => {
+	const { base } = useContext( GlobalStylesContext );
+	const fontPairingVariations = useFontPairingVariations( siteId, stylesheet ) ?? [];
+
+	return (
+		<div className="font-pairing-variations">
+			<FontPairingVariation
+				key="base"
+				fontPairingVariation={ base }
+				isActive={ ! selectedFontPairingVariation }
+				onSelect={ () => onSelect( null ) }
+			/>
+			{ fontPairingVariations.map( ( fontPairingVariation, index ) => (
+				<FontPairingVariation
+					key={ index }
+					fontPairingVariation={ fontPairingVariation }
+					isActive={ fontPairingVariation.title === selectedFontPairingVariation?.title }
+					onSelect={ () => onSelect( fontPairingVariation ) }
+				/>
+			) ) }
+		</div>
+	);
+};
+
+export default FontPairingVariations;

--- a/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/preview.tsx
@@ -10,7 +10,14 @@ import {
 import { useMemo } from 'react';
 import { STYLE_PREVIEW_WIDTH, STYLE_PREVIEW_HEIGHT } from '../../constants';
 import GlobalStylesVariationContainer from '../global-styles-variation-container';
+import FontFamiliesLoader from './font-families-loader';
 import type { FontFamily } from '../../types';
+
+const DEFAULT_FONT_STYLES: React.CSSProperties = {
+	whiteSpace: 'nowrap',
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+};
 
 const FontPairingVariationPreview = () => {
 	const [ fontFamilies ] = useSetting( 'typography.fontFamilies' );
@@ -45,55 +52,62 @@ const FontPairingVariationPreview = () => {
 			ratio={ ratio }
 			containerResizeListener={ containerResizeListener }
 		>
-			<div
-				style={ {
-					height: STYLE_PREVIEW_HEIGHT * ratio,
-					width: '100%',
-					background: 'white',
-					cursor: 'pointer',
-				} }
-			>
+			<>
 				<div
 					style={ {
-						height: '100%',
-						overflow: 'hidden',
+						height: STYLE_PREVIEW_HEIGHT * ratio,
+						width: '100%',
+						background: 'white',
+						cursor: 'pointer',
 					} }
 				>
-					<HStack
-						spacing={ 10 * ratio }
-						justify="flex-start"
+					<div
 						style={ {
 							height: '100%',
 							overflow: 'hidden',
 						} }
 					>
-						<VStack spacing={ 4 * ratio } style={ { margin: '16px' } }>
-							<div
-								style={ {
-									color: '#000000',
-									fontSize: '16px',
-									fontWeight: 400,
-									fontFamily: headingFontFamily,
-									whiteSpace: 'nowrap',
-								} }
-							>
-								{ headingFontFamilyName }
-							</div>
-							<div
-								style={ {
-									color: '#444444',
-									fontSize: '12px',
-									fontWeight: 400,
-									fontFamily: textFontFamily,
-									whiteSpace: 'nowrap',
-								} }
-							>
-								{ textFontFamilyName }
-							</div>
-						</VStack>
-					</HStack>
+						<HStack
+							spacing={ 10 * ratio }
+							justify="flex-start"
+							style={ {
+								height: '100%',
+								overflow: 'hidden',
+							} }
+						>
+							<VStack spacing={ 4 * ratio } style={ { margin: '16px' } }>
+								<div
+									title={ headingFontFamilyName }
+									aria-label={ headingFontFamilyName }
+									style={ {
+										...DEFAULT_FONT_STYLES,
+										color: '#000000',
+										fontSize: '16px',
+										fontWeight: 400,
+										fontFamily: headingFontFamily,
+									} }
+								>
+									{ headingFontFamilyName }
+								</div>
+								<div
+									title={ textFontFamilyName }
+									aria-label={ textFontFamilyName }
+									style={ {
+										...DEFAULT_FONT_STYLES,
+										color: '#444444',
+										fontSize: '12px',
+										fontWeight: 400,
+										fontFamily: textFontFamily,
+									} }
+								>
+									{ textFontFamilyName }
+								</div>
+							</VStack>
+						</HStack>
+					</div>
 				</div>
-			</div>
+				<FontFamiliesLoader fontFamilies={ fontFamilies } />
+			</>
 		</GlobalStylesVariationContainer>
 	);
 };

--- a/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/preview.tsx
@@ -1,0 +1,101 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useResizeObserver } from '@wordpress/compose';
+import {
+	useSetting,
+	useStyle,
+} from '@wordpress/edit-site/build-module/components/global-styles/hooks';
+import { useMemo } from 'react';
+import { STYLE_PREVIEW_WIDTH, STYLE_PREVIEW_HEIGHT } from '../../constants';
+import GlobalStylesVariationContainer from '../global-styles-variation-container';
+import type { FontFamily } from '../../types';
+
+const FontPairingVariationPreview = () => {
+	const [ fontFamilies ] = useSetting( 'typography.fontFamilies' );
+	const [ textFontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
+	const [ headingFontFamily = textFontFamily ] = useStyle(
+		'elements.heading.typography.fontFamily'
+	);
+	const [ containerResizeListener, { width } ] = useResizeObserver();
+	const ratio = width ? width / STYLE_PREVIEW_WIDTH : 1;
+
+	const getFontFamilyName = ( targetFontFamily: string ) => {
+		const fontFamily = fontFamilies.find(
+			( { fontFamily }: FontFamily ) => fontFamily === targetFontFamily
+		);
+
+		return fontFamily ? fontFamily.name : targetFontFamily;
+	};
+
+	const textFontFamilyName = useMemo(
+		() => getFontFamilyName( textFontFamily ),
+		[ textFontFamily, fontFamilies ]
+	);
+
+	const headingFontFamilyName = useMemo(
+		() => getFontFamilyName( headingFontFamily ),
+		[ headingFontFamily, fontFamilies ]
+	);
+
+	return (
+		<GlobalStylesVariationContainer
+			width={ width }
+			ratio={ ratio }
+			containerResizeListener={ containerResizeListener }
+		>
+			<div
+				style={ {
+					height: STYLE_PREVIEW_HEIGHT * ratio,
+					width: '100%',
+					background: 'white',
+					cursor: 'pointer',
+				} }
+			>
+				<div
+					style={ {
+						height: '100%',
+						overflow: 'hidden',
+					} }
+				>
+					<HStack
+						spacing={ 10 * ratio }
+						justify="flex-start"
+						style={ {
+							height: '100%',
+							overflow: 'hidden',
+						} }
+					>
+						<VStack spacing={ 4 * ratio } style={ { margin: '16px' } }>
+							<div
+								style={ {
+									color: '#000000',
+									fontSize: '16px',
+									fontWeight: 400,
+									fontFamily: headingFontFamily,
+									whiteSpace: 'nowrap',
+								} }
+							>
+								{ headingFontFamilyName }
+							</div>
+							<div
+								style={ {
+									color: '#444444',
+									fontSize: '12px',
+									fontWeight: 400,
+									fontFamily: textFontFamily,
+									whiteSpace: 'nowrap',
+								} }
+							>
+								{ textFontFamilyName }
+							</div>
+						</VStack>
+					</HStack>
+				</div>
+			</div>
+		</GlobalStylesVariationContainer>
+	);
+};
+
+export default FontPairingVariationPreview;

--- a/packages/global-styles/src/components/font-pairing-variations/style.scss
+++ b/packages/global-styles/src/components/font-pairing-variations/style.scss
@@ -1,0 +1,42 @@
+.font-pairing-variations {
+	display: grid;
+	gap: 12px;
+	grid-template-columns: repeat(2, 1fr);
+	width: 100%;
+	box-sizing: border-box;
+}
+
+.global-styles-variation__item {
+	position: relative;
+	margin: 3px;
+	cursor: pointer;
+
+	&:hover,
+	&:focus-visible,
+	&.is-active {
+		&::after {
+			border-radius: 3px; /* stylelint-disable-line scales/radii */
+			bottom: -3px;
+			content: "";
+			display: block;
+			left: -3px;
+			pointer-events: none;
+			position: absolute;
+			right: -3px;
+			top: -3px;
+		}
+	}
+
+	&:hover,
+	&:focus-visible {
+		&::after {
+			box-shadow: 0 0 0 2px var(--studio-blue-50);
+		}
+	}
+
+	&.is-active {
+		&::after {
+			box-shadow: 0 0 0 2px var(--studio-gray);
+		}
+	}
+}

--- a/packages/global-styles/src/components/index.ts
+++ b/packages/global-styles/src/components/index.ts
@@ -1,2 +1,3 @@
 export { default as ColorPaletteVariations } from './color-palette-variations';
+export { default as FontPairingVariations } from './font-pairing-variations';
 export { default as GlobalStylesProvider } from './global-styles-provider';

--- a/packages/global-styles/src/hooks/index.ts
+++ b/packages/global-styles/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useColorPaletteVariations } from './use-color-palette-variations';
+export { default as useFontPairingVariations } from './use-font-pairing-variations';
 export { default as useGetGlobalStylesBaseConfig } from './use-get-global-styles-base-config';
 export { default as useSyncGlobalStylesUserConfig } from './use-sync-global-styles-user-config';

--- a/packages/global-styles/src/hooks/use-font-pairing-variations.ts
+++ b/packages/global-styles/src/hooks/use-font-pairing-variations.ts
@@ -1,0 +1,25 @@
+import { useQuery } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { GlobalStylesObject } from '../types';
+
+const useFontPairingVariations = ( siteId: number | string, stylesheet: string ) => {
+	const { data } = useQuery< any, unknown, GlobalStylesObject[] >(
+		[ 'global-styles-font-pairings', siteId, stylesheet ],
+		async () =>
+			wpcomRequest< GlobalStylesObject[] >( {
+				path: `/sites/${ encodeURIComponent( siteId ) }/global-styles-variation/font-pairings`,
+				method: 'GET',
+				apiNamespace: 'wpcom/v2',
+				query: new URLSearchParams( { stylesheet } ).toString(),
+			} ),
+		{
+			refetchOnMount: 'always',
+			staleTime: Infinity,
+			enabled: !! ( siteId && stylesheet ),
+		}
+	);
+
+	return data;
+};
+
+export default useFontPairingVariations;

--- a/packages/global-styles/src/types.ts
+++ b/packages/global-styles/src/types.ts
@@ -4,6 +4,20 @@ export interface Color {
 	slug: string;
 }
 
+export interface FontFamily {
+	fontFamily: string;
+	name: string;
+	slug: string;
+}
+
+export interface Typography {
+	fontFamily?: string;
+	fontSize?: string;
+	fontStyle?: string;
+	fontWeight?: string;
+	lineHeight?: string;
+}
+
 export interface GlobalStylesObject {
 	id?: number;
 	title?: string;
@@ -17,13 +31,9 @@ export interface GlobalStylesObject {
 	styles: {
 		elements?: {
 			heading: {
-				typography: {
-					fontFamily: string;
-				};
+				typography: Typography;
 			};
 		};
-		typography?: {
-			fontFamily: string;
-		};
+		typography?: Typography;
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71977

## Proposed Changes

This PR is focusing on bringing up font variations to the Pattern Assembler
* Implement `FontPairingVariations` to display the font variations
* Implmenet `ScreenFontPairings` to display `FontPairingVariations` and allow users to select the font variation
* Apply the selected font variation to the patterns
* Apply the selected font variation when users finish the Pattern Assembler step
* Load the fonts from the google API

https://user-images.githubusercontent.com/13596067/218705272-0241f6ec-4ddc-4b9e-a526-c26dac187d9c.mov

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/sidebar-revamp,pattern-assembler/color-and-fonts`
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Pick any patterns
  * Select any font and verify the font of selected patterns is changed
  * Submit the selected patterns and font
* On the site editor, verify the colors still works there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?