### PR TITLE
Import content only: Remove themes and plugins from the details modal

### DIFF
--- a/client/blocks/import/ready/platform-details.tsx
+++ b/client/blocks/import/ready/platform-details.tsx
@@ -30,8 +30,8 @@ const platformFeatureList: { [ key: string ]: { [ key: string ]: FeatureName[] }
 		unsupported: [ 'styles', 'themes', 'colors', 'fonts' ],
 	},
 	wordpress: {
-		supported: [ 'posts', 'pages', 'themes', 'plugins' ],
-		unsupported: [ 'styles', 'fonts', 'colors' ],
+		supported: [ 'posts', 'pages' ],
+		unsupported: [ 'themes', 'plugins', 'styles', 'fonts', 'colors' ],
 	},
 	medium: {
 		supported: [ 'posts', 'tags' ],


### PR DESCRIPTION
Closes #72759

## Proposed Changes

* Import content only: Remove themes and plugins from the details modal

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/site-setup/importReadyPreview?siteSlug={SITE_SLUG}&from={JN_SITE_SLUG}`
* Click on `What can be imported?` link
* Chech if there are no "Themes" and "Plugins" items for the content only option

## Screenshot
<img width="757" alt="Screenshot 2023-02-08 at 14 24 01" src="https://user-images.githubusercontent.com/1241413/217543726-4ac1d220-3868-47f7-9a28-9ee60dc50158.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
