### PR TITLE
Jetpack Pro Dashboard: update API to enable/disable the monitor

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
@@ -51,7 +51,7 @@ export function useToggleActivateMonitor(
 		onMutate: async ( { siteId } ) => {
 			dispatch( setSiteMonitorStatus( siteId, 'loading' ) );
 		},
-		onSuccess: async ( data, { siteId } ) => {
+		onSuccess: async ( _data, { siteId, params } ) => {
 			// Cancel any current refetches, so they don't overwrite our update
 			await queryClient.cancelQueries( queryKey );
 
@@ -65,7 +65,7 @@ export function useToggleActivateMonitor(
 								...site,
 								monitor_settings: {
 									...site.monitor_settings,
-									monitor_active: data.settings.monitor_active,
+									monitor_active: params.monitor_active,
 								},
 							};
 						}

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from 'react-query';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setSiteMonitorStatus } from 'calypso/state/jetpack-agency-dashboard/actions';
+import useToggleActivateMonitorMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-toggle-activate-monitor-mutation';
 import useUpdateMonitorSettingsMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-update-monitor-settings-mutation';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import SitesOverviewContext from './sites-overview/context';
@@ -46,7 +47,7 @@ export function useToggleActivateMonitor(
 	const { filter, search, currentPage } = useContext( SitesOverviewContext );
 	const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter ];
 
-	const toggleActivateMonitoring = useUpdateMonitorSettingsMutation( {
+	const toggleActivateMonitoring = useToggleActivateMonitorMutation( {
 		onMutate: async ( { siteId } ) => {
 			dispatch( setSiteMonitorStatus( siteId, 'loading' ) );
 		},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -170,7 +170,6 @@ export interface APIToggleFavorite {
 export interface UpdateMonitorSettingsAPIResponse {
 	success: boolean;
 	settings: {
-		monitor_active: boolean;
 		email_notifications: boolean;
 		wp_note_notifications: boolean;
 		jetmon_defer_status_down_minutes: number;
@@ -178,7 +177,6 @@ export interface UpdateMonitorSettingsAPIResponse {
 }
 
 export interface UpdateMonitorSettingsParams {
-	monitor_active?: boolean;
 	wp_note_notifications?: boolean;
 	email_notifications?: boolean;
 	jetmon_defer_status_down_minutes?: number;
@@ -191,3 +189,12 @@ export interface UpdateMonitorSettingsArgs {
 export type SiteMonitorStatus = {
 	[ siteId: number ]: 'loading' | 'completed';
 };
+
+export interface ToggleActivaateMonitorAPIResponse {
+	code: 'success' | 'error';
+	message: string;
+}
+export interface ToggleActivateMonitorArgs {
+	siteId: number;
+	params: { monitor_active: boolean };
+}

--- a/client/state/jetpack-agency-dashboard/hooks/use-toggle-activate-monitor-mutation.ts
+++ b/client/state/jetpack-agency-dashboard/hooks/use-toggle-activate-monitor-mutation.ts
@@ -1,0 +1,26 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+import type {
+	APIError,
+	ToggleActivaateMonitorAPIResponse as APIResponse,
+	ToggleActivateMonitorArgs,
+} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+function mutationToggleActivateMonitor( {
+	siteId,
+	params,
+}: ToggleActivateMonitorArgs ): Promise< APIResponse > {
+	return wpcom.req.post( `/jetpack-blogs/${ siteId }/rest-api`, {
+		path: '/jetpack/v4/module/monitor/active/',
+		body: JSON.stringify( { active: params.monitor_active } ),
+	} );
+}
+
+export default function useToggleActivateMonitorMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, ToggleActivateMonitorArgs, TContext >
+): UseMutationResult< APIResponse, APIError, ToggleActivateMonitorArgs, TContext > {
+	return useMutation< APIResponse, APIError, ToggleActivateMonitorArgs, TContext >(
+		mutationToggleActivateMonitor,
+		options
+	);
+}


### PR DESCRIPTION
#### Proposed Changes

This PR updates the API to enable/disable monitor in the Jetpack Pro Dashboard

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/toggle-activate-monitor-api-changes` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify clicking on the toggle switch(enable and disable) in the monitor column works as expected.

<img width="211" alt="Screenshot 2023-02-09 at 11 36 44 AM" src="https://user-images.githubusercontent.com/10586875/217731766-33e6c67a-aed4-4aac-b6b3-110494e9c1bc.png">

4. Click `Edit All` and perform bulk actions - `Pause Monitor` and `Resume Monitor` and verify everything works as expected.

<img width="261" alt="Screenshot 2023-02-09 at 11 36 54 AM" src="https://user-images.githubusercontent.com/10586875/217731893-bd7aad91-21f3-4f78-a434-ee82dc4b3b12.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related to 1202619025189113-as-1203804587729626