### PR TITLE
Move email stats to Post stats page

### DIFF
--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -49,7 +49,8 @@ const Container = styled.div`
 		margin: auto;
 	}
 
-	.stats & {
+	.stats &,
+	.stats__email-detail & {
 		max-width: 1224px;
 		margin: auto;
 	}

--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Card, PostStatsCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
@@ -75,7 +76,9 @@ export default function PostDetailHighlightsSection( {
 			<div className="highlight-cards">
 				<h1 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h1>
 
-				<StatsDetailsNavigation postId={ postId } givenSiteId={ siteId } />
+				{ config.isEnabled( 'newsletter/stats' ) && (
+					<StatsDetailsNavigation postId={ postId } givenSiteId={ siteId } />
+				) }
 
 				<div className="highlight-cards-list">
 					<PostStatsCard

--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { getPostStat } from 'calypso/state/stats/posts/selectors';
+import StatsDetailsNavigation from '../stats-details-navigation';
 import PostLikes from '../stats-post-likes';
 
 import './style.scss';
@@ -73,6 +74,8 @@ export default function PostDetailHighlightsSection( {
 
 			<div className="highlight-cards">
 				<h1 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h1>
+
+				<StatsDetailsNavigation postId={ postId } givenSiteId={ siteId } />
 
 				<div className="highlight-cards-list">
 					<PostStatsCard

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -25,6 +25,10 @@
 		}
 	}
 
+	.section-nav {
+		box-shadow: inset 0 -1px 0 #0000000d;
+	}
+
 	.highlight-cards-list {
 		display: grid;
 		grid-template-columns: 3fr 2fr;

--- a/client/my-sites/stats/stats-details-navigation/index.jsx
+++ b/client/my-sites/stats/stats-details-navigation/index.jsx
@@ -4,25 +4,29 @@ import NavTabs from 'calypso/components/section-nav/tabs';
 
 const navItems = ( postId, period, statType, givenSiteId ) =>
 	[ 'highlights', 'opens', 'clicks' ].map( ( item ) => {
+		const selected = statType ? statType === item : 'highlights' === item;
 		const pathParam = [ 'opens', 'clicks' ].includes( item )
 			? `email/${ item }/${ period }`
 			: `post`;
 		const attr = {
 			key: item,
 			path: `/stats/${ pathParam }/${ postId }/${ givenSiteId }`,
-			selected: statType === item,
+			selected,
 		};
 
 		// uppercase first character of item
 		return <NavItem { ...attr }>{ item.charAt( 0 ).toUpperCase() + item.slice( 1 ) }</NavItem>;
 	} );
 
-export default function StatsDetailsNavigation( { postId, period, statType, givenSiteId } ) {
+export default function StatsDetailsNavigation( {
+	postId,
+	period = 'day',
+	statType,
+	givenSiteId,
+} ) {
 	return (
 		<SectionNav>
-			<NavTabs label="Stats" selectedText="Opens">
-				{ navItems( postId, period, statType, givenSiteId ) }
-			</NavTabs>
+			<NavTabs label="Stats">{ navItems( postId, period, statType, givenSiteId ) }</NavTabs>
 		</SectionNav>
 	);
 }

--- a/client/my-sites/stats/stats-details-navigation/index.jsx
+++ b/client/my-sites/stats/stats-details-navigation/index.jsx
@@ -1,0 +1,28 @@
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+
+const navItems = ( postId, period, statType, givenSiteId ) =>
+	[ 'highlights', 'opens', 'clicks' ].map( ( item ) => {
+		const pathParam = [ 'opens', 'clicks' ].includes( item )
+			? `email/${ item }/${ period }`
+			: `post`;
+		const attr = {
+			key: item,
+			path: `/stats/${ pathParam }/${ postId }/${ givenSiteId }`,
+			selected: statType === item,
+		};
+
+		// uppercase first character of item
+		return <NavItem { ...attr }>{ item.charAt( 0 ).toUpperCase() + item.slice( 1 ) }</NavItem>;
+	} );
+
+export default function StatsDetailsNavigation( { postId, period, statType, givenSiteId } ) {
+	return (
+		<SectionNav>
+			<NavTabs label="Stats" selectedText="Opens">
+				{ navItems( postId, period, statType, givenSiteId ) }
+			</NavTabs>
+		</SectionNav>
+	);
+}

--- a/client/my-sites/stats/stats-details-navigation/index.tsx
+++ b/client/my-sites/stats/stats-details-navigation/index.tsx
@@ -7,15 +7,18 @@ interface propTypes {
 	postId: number;
 	period?: string;
 	statType?: string;
-	givenSiteId: number;
+	givenSiteId: string;
 }
+
+const tabs = { highlights: 'Highlights', opens: 'Email opens', clicks: 'Email clicks' };
+
 const navItems = (
 	postId: number,
 	period: string | undefined = 'day',
 	statType: string | undefined,
-	givenSiteId: number
-) =>
-	[ 'highlights', 'opens', 'clicks' ].map( ( item ) => {
+	givenSiteId: string
+) => {
+	return Object.keys( tabs ).map( ( item ) => {
 		const selected = statType ? statType === item : 'highlights' === item;
 		const pathParam = [ 'opens', 'clicks' ].includes( item )
 			? `email/${ item }/${ period }`
@@ -25,10 +28,12 @@ const navItems = (
 			path: `/stats/${ pathParam }/${ postId }/${ givenSiteId }`,
 			selected,
 		};
+		const label = tabs[ item as keyof typeof tabs ];
 
 		// uppercase first character of item
-		return <NavItem { ...attr }>{ item.charAt( 0 ).toUpperCase() + item.slice( 1 ) }</NavItem>;
+		return <NavItem { ...attr }>{ label }</NavItem>;
 	} );
+};
 
 function StatsDetailsNavigation( { postId, period, statType, givenSiteId }: propTypes ) {
 	return (
@@ -42,7 +47,7 @@ StatsDetailsNavigation.propTypes = {
 	postId: PropTypes.number.isRequired,
 	period: PropTypes.string,
 	statType: PropTypes.string,
-	givenSiteId: PropTypes.number.isRequired,
+	givenSiteId: PropTypes.string.isRequired,
 };
 
 export default StatsDetailsNavigation;

--- a/client/my-sites/stats/stats-details-navigation/index.tsx
+++ b/client/my-sites/stats/stats-details-navigation/index.tsx
@@ -3,7 +3,18 @@ import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 
-const navItems = ( postId: number, period: string, statType: string, givenSiteId: number ) =>
+interface propTypes {
+	postId: number;
+	period?: string;
+	statType?: string;
+	givenSiteId: number;
+}
+const navItems = (
+	postId: number,
+	period: string | undefined = 'day',
+	statType: string | undefined,
+	givenSiteId: number
+) =>
 	[ 'highlights', 'opens', 'clicks' ].map( ( item ) => {
 		const selected = statType ? statType === item : 'highlights' === item;
 		const pathParam = [ 'opens', 'clicks' ].includes( item )
@@ -19,22 +30,19 @@ const navItems = ( postId: number, period: string, statType: string, givenSiteId
 		return <NavItem { ...attr }>{ item.charAt( 0 ).toUpperCase() + item.slice( 1 ) }</NavItem>;
 	} );
 
-const propTypes = {
-	postId: PropTypes.number.isRequired,
-	period: PropTypes.string,
-	statType: PropTypes.string,
-	givenSiteId: PropTypes.number.isRequired
-}
-
-export default function StatsDetailsNavigation( {
-	postId,
-	period = 'day',
-	statType,
-	givenSiteId,
-}: propTypes ) {
+function StatsDetailsNavigation( { postId, period, statType, givenSiteId }: propTypes ) {
 	return (
 		<SectionNav>
 			<NavTabs label="Stats">{ navItems( postId, period, statType, givenSiteId ) }</NavTabs>
 		</SectionNav>
 	);
 }
+
+StatsDetailsNavigation.propTypes = {
+	postId: PropTypes.number.isRequired,
+	period: PropTypes.string,
+	statType: PropTypes.string,
+	givenSiteId: PropTypes.number.isRequired,
+};
+
+export default StatsDetailsNavigation;

--- a/client/my-sites/stats/stats-details-navigation/index.tsx
+++ b/client/my-sites/stats/stats-details-navigation/index.tsx
@@ -1,8 +1,9 @@
+import PropTypes from 'prop-types';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 
-const navItems = ( postId, period, statType, givenSiteId ) =>
+const navItems = ( postId: number, period: string, statType: string, givenSiteId: number ) =>
 	[ 'highlights', 'opens', 'clicks' ].map( ( item ) => {
 		const selected = statType ? statType === item : 'highlights' === item;
 		const pathParam = [ 'opens', 'clicks' ].includes( item )
@@ -18,12 +19,19 @@ const navItems = ( postId, period, statType, givenSiteId ) =>
 		return <NavItem { ...attr }>{ item.charAt( 0 ).toUpperCase() + item.slice( 1 ) }</NavItem>;
 	} );
 
+const propTypes = {
+	postId: PropTypes.number.isRequired,
+	period: PropTypes.string,
+	statType: PropTypes.string,
+	givenSiteId: PropTypes.number.isRequired
+}
+
 export default function StatsDetailsNavigation( {
 	postId,
 	period = 'day',
 	statType,
 	givenSiteId,
-} ) {
+}: propTypes ) {
 	return (
 		<SectionNav>
 			<NavTabs label="Stats">{ navItems( postId, period, statType, givenSiteId ) }</NavTabs>

--- a/client/my-sites/stats/stats-details-navigation/index.tsx
+++ b/client/my-sites/stats/stats-details-navigation/index.tsx
@@ -7,7 +7,7 @@ interface propTypes {
 	postId: number;
 	period?: string;
 	statType?: string;
-	givenSiteId: string;
+	givenSiteId: string | number;
 }
 
 const tabs = { highlights: 'Highlights', opens: 'Email opens', clicks: 'Email clicks' };
@@ -16,7 +16,7 @@ const navItems = (
 	postId: number,
 	period: string | undefined = 'day',
 	statType: string | undefined,
-	givenSiteId: string
+	givenSiteId: string | number
 ) => {
 	return Object.keys( tabs ).map( ( item ) => {
 		const selected = statType ? statType === item : 'highlights' === item;
@@ -47,7 +47,7 @@ StatsDetailsNavigation.propTypes = {
 	postId: PropTypes.number.isRequired,
 	period: PropTypes.string,
 	statType: PropTypes.string,
-	givenSiteId: PropTypes.string.isRequired,
+	givenSiteId: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ).isRequired,
 };
 
 export default StatsDetailsNavigation;

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -195,7 +195,7 @@ class StatsEmailDetail extends Component {
 		const pathTemplate = `${ traffic.path }/{{ interval }}/${ postId }${ slugPath }`;
 		return (
 			<>
-				<Main className="has-fixed-nav stats__email-detail" wideLayout>
+				<Main className="has-fixed-nav stats__email-detail">
 					<QueryEmailStats
 						siteId={ siteId }
 						postId={ postId }

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -192,10 +192,13 @@ class StatsEmailDetail extends Component {
 			path: `/stats/email/${ statType }`,
 		};
 
-		const navItems = [ 'opens', 'clicks' ].map( ( item ) => {
+		const navItems = [ 'highlights', 'opens', 'clicks' ].map( ( item ) => {
+			const pathParam = [ 'opens', 'clicks' ].includes( item )
+				? `email/${ item }/${ period }`
+				: `post`;
 			const attr = {
 				key: item,
-				path: `/stats/email/${ item }/${ period }/${ postId }/${ givenSiteId }`,
+				path: `/stats/${ pathParam }/${ postId }/${ givenSiteId }`,
 				selected: statType === item,
 			};
 

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -17,7 +17,6 @@ import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import memoizeLast from 'calypso/lib/memoize-last';
 import StatsEmailModule from 'calypso/my-sites/stats/stats-email-module';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
@@ -36,6 +35,11 @@ import { StatsNoContentBanner } from '../stats-no-content-banner';
 import StatsPeriodHeader from '../stats-period-header';
 import StatsPeriodNavigation from '../stats-period-navigation';
 import './style.scss';
+
+const pageTitles = {
+	opens: translate( 'Email opens' ),
+	clicks: translate( 'Email clicks' ),
+};
 
 function getPageUrl() {
 	return getUrlParts( page.current );
@@ -137,15 +141,7 @@ class StatsEmailDetail extends Component {
 		window.scrollTo( 0, 0 );
 	}
 
-	getTitle() {
-		const { post } = this.props;
-
-		if ( typeof post?.title === 'string' && post.title.length ) {
-			return decodeEntities( stripHTML( post.title ) );
-		}
-
-		return null;
-	}
+	getTitle = ( statType ) => pageTitles[ statType ];
 
 	onChangeLegend = ( activeLegend ) => this.setState( { activeLegend } );
 
@@ -215,7 +211,7 @@ class StatsEmailDetail extends Component {
 					/>
 
 					<FixedNavigationHeader
-						navigationItems={ this.getNavigationItemsWithTitle( this.getTitle() ) }
+						navigationItems={ this.getNavigationItemsWithTitle( this.getTitle( statType ) ) }
 					></FixedNavigationHeader>
 
 					{ ! isRequestingStats && ! countViews && post && (
@@ -232,7 +228,7 @@ class StatsEmailDetail extends Component {
 					{ post ? (
 						<>
 							<div className="main-container">
-								<h1>{ this.getTitle() }</h1>
+								<h1>{ this.getTitle( statType ) }</h1>
 
 								<StatsDetailsNavigation
 									postId={ postId }

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -16,9 +16,6 @@ import QueryEmailStats from 'calypso/components/data/query-email-stats';
 import EmptyContent from 'calypso/components/empty-content';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import Main from 'calypso/components/main';
-import SectionNav from 'calypso/components/section-nav';
-import NavItem from 'calypso/components/section-nav/item';
-import NavTabs from 'calypso/components/section-nav/tabs';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import memoizeLast from 'calypso/lib/memoize-last';
@@ -32,6 +29,7 @@ import { getEmailStat, isRequestingEmailStats } from 'calypso/state/stats/emails
 import { getPeriodWithFallback, getCharts } from 'calypso/state/stats/emails/utils';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import DatePicker from '../stats-date-picker';
+import StatsDetailsNavigation from '../stats-details-navigation';
 import ChartTabs from '../stats-email-chart-tabs';
 import StatsEmailTopRow from '../stats-email-top-row';
 import { StatsNoContentBanner } from '../stats-no-content-banner';
@@ -192,21 +190,6 @@ class StatsEmailDetail extends Component {
 			path: `/stats/email/${ statType }`,
 		};
 
-		const navItems = [ 'highlights', 'opens', 'clicks' ].map( ( item ) => {
-			const pathParam = [ 'opens', 'clicks' ].includes( item )
-				? `email/${ item }/${ period }`
-				: `post`;
-			const attr = {
-				key: item,
-				path: `/stats/${ pathParam }/${ postId }/${ givenSiteId }`,
-				selected: statType === item,
-			};
-
-			// uppercase first character of item
-
-			return <NavItem { ...attr }>{ item.charAt( 0 ).toUpperCase() + item.slice( 1 ) }</NavItem>;
-		} );
-
 		const query = memoizedQuery( period, endOf );
 		const slugPath = slug ? `/${ slug }` : '';
 		const pathTemplate = `${ traffic.path }/{{ interval }}/${ postId }${ slugPath }`;
@@ -251,11 +234,12 @@ class StatsEmailDetail extends Component {
 							<div>
 								<h1>{ this.getTitle() }</h1>
 
-								<SectionNav>
-									<NavTabs label="Stats" selectedText="Opens">
-										{ navItems }
-									</NavTabs>
-								</SectionNav>
+								<StatsDetailsNavigation
+									postId={ postId }
+									period={ period }
+									statType={ statType }
+									givenSiteId={ givenSiteId }
+								/>
 
 								<StatsEmailTopRow siteId={ siteId } postId={ postId } statType={ statType } />
 

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -231,7 +231,7 @@ class StatsEmailDetail extends Component {
 					) }
 					{ post ? (
 						<>
-							<div>
+							<div className="main-container">
 								<h1>{ this.getTitle() }</h1>
 
 								<StatsDetailsNavigation

--- a/client/my-sites/stats/stats-email-detail/style.scss
+++ b/client/my-sites/stats/stats-email-detail/style.scss
@@ -4,6 +4,10 @@ $break-large-stats-countries: 1280px;
 
 // Countries
 .stats__email-detail {
+	.main-container {
+		padding: 32px 12px;
+	}
+
 	.no-data {
 		text-align: center;
 	}

--- a/client/my-sites/stats/stats-email-detail/style.scss
+++ b/client/my-sites/stats/stats-email-detail/style.scss
@@ -1,11 +1,16 @@
 @import "@wordpress/base-styles/breakpoints";
+@import "calypso/my-sites/stats/modernized-layout-styles.scss";
 
 $break-large-stats-countries: 1280px;
 
 // Countries
 .stats__email-detail {
+	&.main {
+		max-width: $stats-sections-max-width;
+	}
+
 	.main-container {
-		padding: 32px 12px;
+		padding: 32px 0;
 	}
 
 	.no-data {

--- a/client/state/stats/email-chart-tabs/selectors.js
+++ b/client/state/stats/email-chart-tabs/selectors.js
@@ -50,10 +50,11 @@ export function isLoadingTabs(
 	barNumber
 ) {
 	const stats = get( state.stats.emails.items, [ siteId, postId, period, statType, date ], null );
-	// if we have redux stats ready return false
-	if ( dataLength < barNumber ) {
+	// If we have data for 30 columns, that's the maximum the endpoint can return
+	if ( dataLength < barNumber && dataLength < 30 ) {
 		return true;
 	}
+	// if we have redux stats ready return false
 	if ( stats ) {
 		return false;
 	}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/73093

## Proposed Changes

The changes in this PR move the new Email Opens and Email Clicks stat pages into the already established Post stats page. In order to do that, a tab navigation menu was introduced, like this:

<img width="696" alt="Screenshot 2023-02-09 at 14 39 43" src="https://user-images.githubusercontent.com/3832570/217828329-69740b1e-9f66-4eda-916b-3a69ab300726.png">

Also, some style differences between the three pages has been polished.

## Testing Instructions

- Apply this PR to your local calypso code and start the application.
- Go to the stats main page (`http://calypso.localhost:3000/stats/day/[your-site-domain]`).
- Click on one of the post or pages in the corresponding card:
<img width="574" alt="Screenshot 2023-02-08 at 14 43 14" src="https://user-images.githubusercontent.com/3832570/217546875-2cfd1d8f-43c4-45b1-96dc-09daeeb09bdf.png">
- Check that the new tabbed navigation is there:
<img width="474" alt="Screenshot 2023-02-08 at 14 43 25" src="https://user-images.githubusercontent.com/3832570/217547056-932954fc-6c57-4383-b416-0428d6b96bad.png">
- Click on both `Opens` and `Clicks` and check that the corresponding page shows.
- Click back and forth the three items in the menu and see that nobody breaks.

Thanks in advance for the help! ❤️


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
