### PR TITLE
Persist advertising opt-out status to user options (backend)

### DIFF
--- a/client/blocks/cookie-banner/index.tsx
+++ b/client/blocks/cookie-banner/index.tsx
@@ -1,14 +1,17 @@
 import { CookieBanner } from '@automattic/privacy-toolset';
 import cookie from 'cookie';
 import { useCallback, useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import {
 	refreshCountryCodeCookieGdpr,
 	setTrackingPrefs,
 	shouldSeeCookieBanner,
 	getTrackingPrefs,
+	useDoNotSell,
 } from 'calypso/lib/analytics/utils';
 import { useDispatch } from 'calypso/state';
 import { bumpStat } from 'calypso/state/analytics/actions';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { useCookieBannerContent } from './use-cookie-banner-content';
 import type { CookieBannerProps } from '@automattic/privacy-toolset';
 
@@ -18,10 +21,16 @@ const noop = () => undefined;
 const CookieBannerInner = ( { onClose }: { onClose: () => void } ) => {
 	const content = useCookieBannerContent();
 	const dispatch = useDispatch();
+	const isLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
+	const { setUserAdvertisingOptOut } = useDoNotSell();
 
 	const handleAccept = useCallback< CookieBannerProps[ 'onAccept' ] >(
 		( buckets ) => {
 			setTrackingPrefs( { ok: true, buckets } );
+			// If the user is logged in, update their advertising opt-out setting
+			if ( isLoggedIn ) {
+				setUserAdvertisingOptOut( ! buckets.advertising );
+			}
 			onClose();
 		},
 		[ onClose ]

--- a/client/blocks/cookie-banner/index.tsx
+++ b/client/blocks/cookie-banner/index.tsx
@@ -1,7 +1,7 @@
 import { CookieBanner } from '@automattic/privacy-toolset';
 import cookie from 'cookie';
 import { useCallback, useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import {
 	refreshCountryCodeCookieGdpr,
 	setTrackingPrefs,

--- a/client/lib/analytics/test/mocks/config/index.js
+++ b/client/lib/analytics/test/mocks/config/index.js
@@ -14,6 +14,9 @@ config.isEnabled = ( feature ) => {
 	if ( 'google-analytics' === feature ) {
 		return false;
 	}
+	if ( 'safari-idb-mitigation' === feature ) {
+		return false;
+	}
 	if ( 'ad-tracking' === feature ) {
 		return true;
 	}

--- a/client/lib/analytics/utils/use-do-not-sell.ts
+++ b/client/lib/analytics/utils/use-do-not-sell.ts
@@ -1,12 +1,24 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import cookie from 'cookie';
 import { useCallback, useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import { saveUserSettings } from 'calypso/state/user-settings/actions';
 import isRegionInCcpaZone from './is-region-in-ccpa-zone';
 import { getTrackingPrefs, refreshCountryCodeCookieGdpr, setTrackingPrefs } from '.';
+
+const ADVERTISING_OPT_OUT_USER_SETTINGS_KEY = 'advertising_targeting_opt_out';
 
 export default () => {
 	const [ shouldSeeDoNotSell, setShouldSeeDoNotSell ] = useState( false );
 	const [ isDoNotSell, setIsDoNotSell ] = useState( false );
+	const dispatch = useDispatch();
+
+	// TODO: this assumes this hook being used in a state where user settings have already been loaded
+	// We could potentially add a conditional query to load settings here for good measure
+	const userHasOptedOutOfAdvertising = useSelector( ( state ) => {
+		return getUserSetting( state, ADVERTISING_OPT_OUT_USER_SETTINGS_KEY ) ?? false;
+	} );
 
 	useEffect( () => {
 		const controller = new AbortController();
@@ -26,12 +38,24 @@ export default () => {
 	}, [ setShouldSeeDoNotSell ] );
 
 	useEffect( () => {
+		if ( userHasOptedOutOfAdvertising !== null ) {
+			// If the user settings show that the user has opted out of advertising, set the advertising bucket to false
+			setTrackingPrefs( { ok: true, buckets: { advertising: ! userHasOptedOutOfAdvertising } } );
+		}
 		// We set initial `isDoNotSell` via hook to make sure it run only on client side (when SSR)
 		setIsDoNotSell( ! getTrackingPrefs().buckets.advertising );
-	}, [] );
+	}, [ userHasOptedOutOfAdvertising ] );
+
+	const setUserAdvertisingOptOut = useCallback(
+		( isOptedOut: boolean ) => {
+			dispatch( saveUserSettings( { advertising_targeting_opt_out: isOptedOut } ) );
+		},
+		[ saveUserSettings ]
+	);
 
 	const onSetDoNotSell = useCallback(
 		( isActive: boolean ) => {
+			// Update the preferences in the cookie
 			// isActive = true means user has opted out of "advertising" tracking
 			const prefs = setTrackingPrefs( { ok: true, buckets: { advertising: ! isActive } } );
 
@@ -43,10 +67,11 @@ export default () => {
 				} );
 			}
 
+			setUserAdvertisingOptOut( isActive );
 			setIsDoNotSell( ! prefs.buckets.advertising );
 		},
 		[ setIsDoNotSell ]
 	);
 
-	return { shouldSeeDoNotSell, onSetDoNotSell, isDoNotSell };
+	return { shouldSeeDoNotSell, onSetDoNotSell, setUserAdvertisingOptOut, isDoNotSell };
 };

--- a/client/me/privacy/do-not-sell.tsx
+++ b/client/me/privacy/do-not-sell.tsx
@@ -1,12 +1,20 @@
 import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
+import { useDispatch } from 'react-redux';
 import { useDoNotSellContent } from 'calypso/blocks/do-not-sell-dialog/use-do-not-sell-content';
 import SectionHeader from 'calypso/components/section-header';
 import { useDoNotSell } from 'calypso/lib/analytics/utils';
+import { saveUserSettings } from 'calypso/state/user-settings/actions';
 
 export const DoNotSellSetting = () => {
 	const { shouldSeeDoNotSell, isDoNotSell, onSetDoNotSell } = useDoNotSell();
 	const { title, toggleLabel, longDescription } = useDoNotSellContent();
+	const dispatch = useDispatch();
+
+	const handleDoNotSellToggle = ( isChecked: boolean ) => {
+		onSetDoNotSell( isChecked );
+		dispatch( saveUserSettings( { advertising_targeting_opt_out: isChecked } ) );
+	};
 
 	if ( ! shouldSeeDoNotSell ) {
 		return null;
@@ -18,7 +26,11 @@ export const DoNotSellSetting = () => {
 			<Card className="privacy__settings">
 				{ longDescription }
 				<hr />
-				<ToggleControl checked={ isDoNotSell } onChange={ onSetDoNotSell } label={ toggleLabel } />
+				<ToggleControl
+					checked={ isDoNotSell }
+					onChange={ handleDoNotSellToggle }
+					label={ toggleLabel }
+				/>
 			</Card>
 		</>
 	);

--- a/client/me/privacy/do-not-sell.tsx
+++ b/client/me/privacy/do-not-sell.tsx
@@ -1,20 +1,12 @@
 import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
-import { useDispatch } from 'react-redux';
 import { useDoNotSellContent } from 'calypso/blocks/do-not-sell-dialog/use-do-not-sell-content';
 import SectionHeader from 'calypso/components/section-header';
 import { useDoNotSell } from 'calypso/lib/analytics/utils';
-import { saveUserSettings } from 'calypso/state/user-settings/actions';
 
 export const DoNotSellSetting = () => {
 	const { shouldSeeDoNotSell, isDoNotSell, onSetDoNotSell } = useDoNotSell();
 	const { title, toggleLabel, longDescription } = useDoNotSellContent();
-	const dispatch = useDispatch();
-
-	const handleDoNotSellToggle = ( isChecked: boolean ) => {
-		onSetDoNotSell( isChecked );
-		dispatch( saveUserSettings( { advertising_targeting_opt_out: isChecked } ) );
-	};
 
 	if ( ! shouldSeeDoNotSell ) {
 		return null;
@@ -26,11 +18,7 @@ export const DoNotSellSetting = () => {
 			<Card className="privacy__settings">
 				{ longDescription }
 				<hr />
-				<ToggleControl
-					checked={ isDoNotSell }
-					onChange={ handleDoNotSellToggle }
-					label={ toggleLabel }
-				/>
+				<ToggleControl checked={ isDoNotSell } onChange={ onSetDoNotSell } label={ toggleLabel } />
 			</Card>
 		</>
 	);


### PR DESCRIPTION
This diff makes some changes to save and load a persistent user setting when "Do not sell or share my personal data" toggle is toggled. 

This can be tested with the corresponding backend differential, which will add the expected functionality to store it.

To test, you need to patch this diff D100729-code, and sandbox public-api.wordpress.com.

## Testing Instructions

* Please follow the test plan on D100729-code which has instructions to test both PRs together

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?