### PR TITLE
Show virtual themes in onboarding design picker

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -124,6 +124,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			intent,
 			seed: siteSlugOrId || undefined,
 			_locale: locale,
+			include_virtual_designs: isEnabled( 'virtual-themes/onboarding' ),
 		},
 		{
 			enabled: true,

--- a/config/development.json
+++ b/config/development.json
@@ -191,6 +191,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"user-management-revamp": true,
+		"virtual-themes/onboarding": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -39,7 +39,7 @@ interface StaticDesign {
 	style_variations?: StyleVariation[];
 	software_sets?: SoftwareSet[];
 	is_virtual: boolean;
-	style_variation: StyleVariation | null;
+	style_variation_slug: string | null;
 }
 
 interface GeneratedDesign {
@@ -94,7 +94,7 @@ function apiStarterDesignsStaticToDesign( design: StaticDesign ): Design {
 		style_variations,
 		software_sets,
 		is_virtual,
-		style_variation,
+		style_variation_slug,
 	} = design;
 	const is_premium =
 		( design.recipe.stylesheet && design.recipe.stylesheet.startsWith( 'premium/' ) ) || false;
@@ -102,6 +102,9 @@ function apiStarterDesignsStaticToDesign( design: StaticDesign ): Design {
 	const is_bundled_with_woo_commerce = ( design.software_sets || [] ).some(
 		( { slug } ) => slug === 'woo-on-plans'
 	);
+
+	const style_variation =
+		style_variations?.find( ( { slug } ) => slug === style_variation_slug ) ?? null;
 
 	return {
 		slug,

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -15,6 +15,7 @@ interface StarterDesignsQueryParams {
 	intent: string;
 	seed?: string;
 	_locale: string;
+	include_virtual_designs?: boolean;
 }
 
 interface Options extends QueryOptions< StarterDesignsResponse, unknown > {
@@ -37,6 +38,8 @@ interface StaticDesign {
 	price?: string;
 	style_variations?: StyleVariation[];
 	software_sets?: SoftwareSet[];
+	is_virtual: boolean;
+	style_variation: StyleVariation | null;
 }
 
 interface GeneratedDesign {
@@ -90,6 +93,8 @@ function apiStarterDesignsStaticToDesign( design: StaticDesign ): Design {
 		price,
 		style_variations,
 		software_sets,
+		is_virtual,
+		style_variation,
 	} = design;
 	const is_premium =
 		( design.recipe.stylesheet && design.recipe.stylesheet.startsWith( 'premium/' ) ) || false;
@@ -111,6 +116,8 @@ function apiStarterDesignsStaticToDesign( design: StaticDesign ): Design {
 		software_sets,
 		design_type: is_premium ? 'premium' : 'standard',
 		style_variations,
+		is_virtual,
+		style_variation,
 		// Deprecated; used for /start flow
 		features: [],
 		template: '',

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -214,7 +214,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 
 	const getTitle = () => {
 		if ( design.is_virtual && design.style_variation ) {
-			return `${ design.title } – ${ design.style_variation?.title }`;
+			return `${ design.title } – ${ design.style_variation.title }`;
 		}
 
 		return design.title;

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -205,12 +205,24 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 		);
 	}
 
+	const previewDesign = () => {
+		if ( design.is_virtual && design.style_variation ) {
+			return onPreview( design, design.style_variation );
+		}
+		return onPreview( design );
+	};
+
+	const getTitle = () => {
+		if ( design.is_virtual && design.style_variation ) {
+			return `${ design.title } – ${ design.style_variation?.title }`;
+		}
+
+		return design.title;
+	};
+
 	return (
 		<div className="design-picker__design-option">
-			<button
-				data-e2e-button={ isPremium ? 'paidOption' : 'freeOption' }
-				onClick={ () => onPreview( design ) }
-			>
+			<button data-e2e-button={ isPremium ? 'paidOption' : 'freeOption' } onClick={ previewDesign }>
 				<span
 					className={ classnames(
 						'design-picker__image-frame',
@@ -225,7 +237,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 				</span>
 				<span className="design-picker__option-overlay">
 					<span id={ makeOptionId( design ) } className="design-picker__option-meta">
-						<span className="design-picker__option-name">{ design.title }</span>
+						<span className="design-picker__option-name">{ getTitle() }</span>
 						{ style_variations.length > 0 && (
 							<div className="design-picker__options-style-variations">
 								<StyleVariationBadges
@@ -407,10 +419,10 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 				/>
 			) }
 			<div className="design-picker__grid">
-				{ filteredStaticDesigns.map( ( design ) => (
+				{ filteredStaticDesigns.map( ( design, index ) => (
 					<DesignButtonContainer
 						category={ categorization?.selection }
-						key={ design.slug }
+						key={ index }
 						design={ design }
 						locale={ locale }
 						onSelect={ onSelect }

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -96,6 +96,8 @@ export interface Design {
 	price?: string;
 	software_sets?: SoftwareSet[];
 	is_bundled_with_woo_commerce?: boolean;
+	is_virtual?: boolean;
+	style_variation?: StyleVariation | null; // Style variation used by virtual themes.
 
 	/** @deprecated used for Gutenboarding (/new flow) */
 	stylesheet?: string;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1598
Fixes https://github.com/Automattic/dotcom-forge/issues/1599

## Proposed Changes

- Introduces a new `virtual-themes/onboarding` feature flag so we can ship small iterations of the Virtual Themes work without exposing the feature in production.
- Displays the style variations as separate themes in the design picker step of the onboarding (*).

(*) Thumbnails don't show an actual preview of the virtual theme yet – that will be handled separately in https://github.com/Automattic/dotcom-forge/issues/1603.

<img width="1007" alt="Screenshot 2023-02-08 at 17 28 07" src="https://user-images.githubusercontent.com/2070010/217606523-7a7315c4-243c-4552-84a9-512c182d4d7e.png">

## Testing Instructions

- Use the Calypso live link below.
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>`.
- Make sure the virtual themes don't show up.
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>&flags=virtual-themes/onboarding`.
- Make sure the virtual themes show up.
- Make sure their title follow the "Theme - Style variation" format.
- Select a virtual theme.
- Make sure the "actual" theme is selected, and the relevant style variation has been chosen automatically.