### PR TITLE
Stats: Add two post stats cards to the Insights page

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -168,7 +168,11 @@ export default function AllTimeHighlightsSection( {
 		<div className="stats__all-time-highlights-section">
 			{ siteId && (
 				<>
-					<QueryPosts siteId={ siteId } query={ { status: 'publish', number: 1 } } />
+					<QueryPosts
+						siteId={ siteId }
+						postId={ null }
+						query={ { status: 'publish', number: 1 } }
+					/>
 					<QuerySiteStats siteId={ siteId } statType="stats" query={ {} } />
 					<QuerySiteStats siteId={ siteId } statType="statsInsights" query={ insightsQuery } />
 				</>

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -37,7 +37,13 @@ type MostPopularData = {
 	hourPercent: number;
 };
 
-export default function AllTimeHighlightsSection( { siteId }: { siteId: number } ) {
+export default function AllTimeHighlightsSection( {
+	siteId,
+	siteSlug,
+}: {
+	siteId: number;
+	siteSlug: string;
+} ) {
 	const translate = useTranslate();
 
 	const insightsQuery = {};
@@ -270,8 +276,8 @@ export default function AllTimeHighlightsSection( { siteId }: { siteId: number }
 
 				{ isLatestPostReplaced && (
 					<div className="highlight-cards-list">
-						<LatestPostCard siteId={ siteId } />
-						<MostPopularPostCard siteId={ siteId } />
+						<LatestPostCard siteId={ siteId } siteSlug={ siteSlug } />
+						<MostPopularPostCard siteId={ siteId } siteSlug={ siteSlug } />
 					</div>
 				) }
 			</div>

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	Card,
 	PercentCalculator as percentCalculator,
@@ -8,12 +9,15 @@ import { Icon, people, postContent, starEmpty, commentContent } from '@wordpress
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import QueryPosts from 'calypso/components/data/query-posts';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import DotPager from 'calypso/components/dot-pager';
 import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData,
 } from 'calypso/state/stats/lists/selectors';
+import LatestPostCard from './latest-post-card';
+import MostPopularPostCard from './most-popular-card';
 
 import './style.scss';
 
@@ -36,12 +40,14 @@ type MostPopularData = {
 export default function AllTimeHighlightsSection( { siteId }: { siteId: number } ) {
 	const translate = useTranslate();
 
+	const insightsQuery = {};
+
 	const isStatsRequesting = useSelector( ( state ) =>
 		isRequestingSiteStatsForQuery( state, siteId, 'stats', {} )
 	);
 
 	const isInsightsRequesting = useSelector( ( state ) =>
-		isRequestingSiteStatsForQuery( state, siteId, 'statsInsights', {} )
+		isRequestingSiteStatsForQuery( state, siteId, 'statsInsights', insightsQuery )
 	);
 
 	const { comments, posts, views, visitors, viewsBestDay, viewsBestDayTotal } = useSelector(
@@ -49,7 +55,7 @@ export default function AllTimeHighlightsSection( { siteId }: { siteId: number }
 	) as AllTimeData;
 
 	const { day, percent, hour, hourPercent } = useSelector(
-		( state ) => getSiteStatsNormalizedData( state, siteId, 'statsInsights', {} ) || {}
+		( state ) => getSiteStatsNormalizedData( state, siteId, 'statsInsights', insightsQuery ) || {}
 	) as MostPopularData;
 
 	const isStatsLoading = isStatsRequesting && ! views;
@@ -150,12 +156,15 @@ export default function AllTimeHighlightsSection( { siteId }: { siteId: number }
 		};
 	}, [ isStatsLoading, translate, views, viewsBestDay, viewsBestDayTotal ] );
 
+	const isLatestPostReplaced = config.isEnabled( 'stats/latest-post-stats' );
+
 	return (
 		<div className="stats__all-time-highlights-section">
 			{ siteId && (
 				<>
+					<QueryPosts siteId={ siteId } query={ { status: 'publish', number: 1 } } />
 					<QuerySiteStats siteId={ siteId } statType="stats" query={ {} } />
-					<QuerySiteStats siteId={ siteId } statType="statsInsights" />
+					<QuerySiteStats siteId={ siteId } statType="statsInsights" query={ insightsQuery } />
 				</>
 			) }
 
@@ -258,6 +267,13 @@ export default function AllTimeHighlightsSection( { siteId }: { siteId: number }
 						);
 					} ) }
 				</div>
+
+				{ isLatestPostReplaced && (
+					<div className="highlight-cards-list">
+						<LatestPostCard siteId={ siteId } />
+						<MostPopularPostCard siteId={ siteId } />
+					</div>
+				) }
 			</div>
 		</div>
 	);

--- a/client/my-sites/stats/all-time-highlights-section/latest-post-card.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/latest-post-card.tsx
@@ -20,7 +20,13 @@ const textTruncator = ( text: string, limit = 48 ) => {
 	return `${ truncatedText }${ text.length > limit ? '...' : '' } `;
 };
 
-export default function LatestPostCard( { siteId }: { siteId: number } ) {
+export default function LatestPostCard( {
+	siteId,
+	siteSlug,
+}: {
+	siteId: number;
+	siteSlug: string;
+} ) {
 	const translate = useTranslate();
 
 	const posts = useSelector( ( state ) =>
@@ -57,6 +63,7 @@ export default function LatestPostCard( { siteId }: { siteId: number } ) {
 					post={ latestPostData }
 					viewCount={ latestPostData?.viewCount }
 					commentCount={ latestPostData?.commentCount }
+					titleLink={ `/stats/post/${ latestPost.ID }/${ siteSlug }` }
 				/>
 			) }
 		</>

--- a/client/my-sites/stats/all-time-highlights-section/latest-post-card.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/latest-post-card.tsx
@@ -1,0 +1,64 @@
+import { PostStatsCard } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import QueryPostStats from 'calypso/components/data/query-post-stats';
+import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
+import { getPostsForQuery } from 'calypso/state/posts/selectors';
+import { getPostStat } from 'calypso/state/stats/posts/selectors';
+
+const POST_STATS_CARD_TITLE_LIMIT = 48;
+
+// Use ellipsis when characters count over the limit.
+// TODO: Extract to shared utilities
+const textTruncator = ( text: string, limit = 48 ) => {
+	if ( ! text ) {
+		return '';
+	}
+
+	const truncatedText = text.substring( 0, limit );
+
+	return `${ truncatedText }${ text.length > limit ? '...' : '' } `;
+};
+
+export default function LatestPostCard( { siteId }: { siteId: number } ) {
+	const translate = useTranslate();
+
+	const posts = useSelector( ( state ) =>
+		getPostsForQuery( state, siteId, { status: 'publish', number: 1 } )
+	);
+
+	const latestPost = posts && posts.length ? posts[ 0 ] : null;
+
+	const lastesPostViewCount = useSelector( ( state ) =>
+		getPostStat( state, siteId, latestPost?.ID, 'views' )
+	);
+
+	const latestPostData = {
+		date: latestPost?.date,
+		post_thumbnail: latestPost?.post_thumbnail?.URL || null,
+		title: decodeEntities(
+			stripHTML( textTruncator( latestPost?.title, POST_STATS_CARD_TITLE_LIMIT ) )
+		),
+		likeCount: latestPost?.like_count,
+		viewCount: lastesPostViewCount,
+		commentCount: latestPost?.discussion?.comment_count,
+	};
+
+	return (
+		<>
+			{ siteId && latestPost && (
+				<QueryPostStats siteId={ siteId } postId={ latestPost.ID } fields={ [ 'views' ] } />
+			) }
+
+			{ latestPost && (
+				<PostStatsCard
+					heading={ translate( 'Latest post' ) }
+					likeCount={ latestPostData?.likeCount }
+					post={ latestPostData }
+					viewCount={ latestPostData?.viewCount }
+					commentCount={ latestPostData?.commentCount }
+				/>
+			) }
+		</>
+	);
+}

--- a/client/my-sites/stats/all-time-highlights-section/latest-post-card.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/latest-post-card.tsx
@@ -6,7 +6,7 @@ import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { getPostsForQuery } from 'calypso/state/posts/selectors';
 import { getPostStat } from 'calypso/state/stats/posts/selectors';
 
-const POST_STATS_CARD_TITLE_LIMIT = 48;
+const POST_STATS_CARD_TITLE_LIMIT = 40;
 
 // Use ellipsis when characters count over the limit.
 // TODO: Extract to shared utilities

--- a/client/my-sites/stats/all-time-highlights-section/most-popular-card.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/most-popular-card.tsx
@@ -1,0 +1,127 @@
+import { PostStatsCard } from '@automattic/components';
+import { createSelector } from '@automattic/state-utils';
+import { useTranslate } from 'i18n-calypso';
+import moment from 'moment';
+import { useSelector } from 'react-redux';
+import QueryPostStats from 'calypso/components/data/query-post-stats';
+import QueryPosts from 'calypso/components/data/query-posts';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
+import { getSitePost } from 'calypso/state/posts/selectors';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import {
+	getTopPostAndPage,
+	isRequestingSiteStatsForQuery,
+} from 'calypso/state/stats/lists/selectors';
+import { getPostStat } from 'calypso/state/stats/posts/selectors';
+
+const POST_STATS_CARD_TITLE_LIMIT = 48;
+
+// Use ellipsis when characters count over the limit.
+// TODO: Extract to shared utilities
+const textTruncator = ( text: string, limit = 48 ) => {
+	if ( ! text ) {
+		return '';
+	}
+
+	const truncatedText = text.substring( 0, limit );
+
+	return `${ truncatedText }${ text.length > limit ? '...' : '' } `;
+};
+
+const getStatsQueries = createSelector(
+	( state, siteId ) => {
+		const period = 'day';
+		const quantity = 7;
+
+		const gmtOffset = getSiteOption( state, siteId, 'gmt_offset' ) as string | number;
+		const date = moment()
+			.utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 )
+			.format( 'YYYY-MM-DD' );
+
+		const topPostsQuery = {
+			date,
+			num: quantity,
+			period,
+		};
+
+		return {
+			topPostsQuery,
+		};
+	},
+	( state, siteId ) => getSiteOption( state, siteId, 'gmt_offset' )
+);
+
+const getStatsData = createSelector(
+	( state, siteId, topPostsQuery ) => {
+		const { post: topPost, page: topPage } = getTopPostAndPage( state, siteId, topPostsQuery );
+
+		return {
+			topPost,
+			topPage,
+		};
+	},
+	( state, siteId, topPostsQuery ) => [ topPostsQuery ]
+);
+
+export default function MostPopularPostCard( { siteId }: { siteId: number } ) {
+	const translate = useTranslate();
+
+	const { topPostsQuery } = useSelector( ( state ) => getStatsQueries( state, siteId ) );
+
+	const isTopViewedPostRequesting = useSelector( ( state ) =>
+		isRequestingSiteStatsForQuery( state, siteId, 'statsTopPosts', topPostsQuery )
+	);
+
+	// Get the most `viewed` post from the past `seven` days defined in the `topPostsQuery`.
+	const { topPost: topViewedPost } = useSelector( ( state ) =>
+		getStatsData( state, siteId, topPostsQuery )
+	);
+
+	// The returned data period to sum the view count from API `stats/post` would differ by post.
+	const mostPopularPostViewCount = useSelector( ( state ) =>
+		getPostStat( state, siteId, topViewedPost?.id, 'views' )
+	);
+
+	const mostPopularPost = useSelector( ( state ) =>
+		getSitePost( state, siteId, topViewedPost?.id )
+	);
+
+	const mostPopularPostData = {
+		date: mostPopularPost?.date,
+		post_thumbnail: mostPopularPost?.post_thumbnail?.URL || null,
+		title: decodeEntities(
+			stripHTML( textTruncator( mostPopularPost?.title, POST_STATS_CARD_TITLE_LIMIT ) )
+		),
+		likeCount: mostPopularPost?.like_count,
+		viewCount: mostPopularPostViewCount, // or topViewedPost?.views
+		commentCount: mostPopularPost?.discussion?.comment_count,
+	};
+
+	return (
+		<>
+			{ siteId && (
+				<>
+					<QuerySiteStats siteId={ siteId } statType="statsTopPosts" query={ topPostsQuery } />
+				</>
+			) }
+
+			{ siteId && topViewedPost && (
+				<>
+					<QueryPosts siteId={ siteId } postId={ topViewedPost.id } query={ {} } />
+					<QueryPostStats siteId={ siteId } postId={ topViewedPost.id } fields={ [ 'views' ] } />
+				</>
+			) }
+
+			{ ! isTopViewedPostRequesting && mostPopularPost && (
+				<PostStatsCard
+					heading={ translate( 'Most popular post' ) }
+					likeCount={ mostPopularPostData?.likeCount }
+					post={ mostPopularPostData }
+					viewCount={ mostPopularPostData?.viewCount }
+					commentCount={ mostPopularPostData?.commentCount }
+				/>
+			) }
+		</>
+	);
+}

--- a/client/my-sites/stats/all-time-highlights-section/most-popular-card.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/most-popular-card.tsx
@@ -64,7 +64,13 @@ const getStatsData = createSelector(
 	( state, siteId, topPostsQuery ) => [ topPostsQuery ]
 );
 
-export default function MostPopularPostCard( { siteId }: { siteId: number } ) {
+export default function MostPopularPostCard( {
+	siteId,
+	siteSlug,
+}: {
+	siteId: number;
+	siteSlug: string;
+} ) {
 	const translate = useTranslate();
 
 	const { topPostsQuery } = useSelector( ( state ) => getStatsQueries( state, siteId ) );
@@ -120,6 +126,7 @@ export default function MostPopularPostCard( { siteId }: { siteId: number } ) {
 					post={ mostPopularPostData }
 					viewCount={ mostPopularPostData?.viewCount }
 					commentCount={ mostPopularPostData?.commentCount }
+					titleLink={ `/stats/post/${ mostPopularPost.ID }/${ siteSlug }` }
 				/>
 			) }
 		</>

--- a/client/my-sites/stats/all-time-highlights-section/most-popular-card.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/most-popular-card.tsx
@@ -15,7 +15,7 @@ import {
 } from 'calypso/state/stats/lists/selectors';
 import { getPostStat } from 'calypso/state/stats/posts/selectors';
 
-const POST_STATS_CARD_TITLE_LIMIT = 48;
+const POST_STATS_CARD_TITLE_LIMIT = 40;
 
 // Use ellipsis when characters count over the limit.
 // TODO: Extract to shared utilities

--- a/client/my-sites/stats/all-time-highlights-section/style.scss
+++ b/client/my-sites/stats/all-time-highlights-section/style.scss
@@ -38,9 +38,24 @@ $mobile-layout-breakpoint: $break-small;
 		}
 	}
 
-	.highlight-cards-list .highlight-card {
-		padding: 24px;
-		min-width: 320px;
+	.highlight-cards-list {
+		&:not(:first-child) {
+			margin-top: 24px;
+		}
+
+		.highlight-card {
+			padding: 24px;
+			min-width: 320px;
+		}
+
+		.post-stats-card {
+			flex: 1;
+			max-height: unset;
+
+			&:not(:first-child) {
+				margin-left: 24px;
+			}
+		}
 	}
 
 	.highlight-card-heading {

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -65,10 +65,6 @@
 		@media ( max-width: $break-small ) {
 			gap: 24px 12px;
 		}
-
-		&::after {
-			display: none;
-		}
 	}
 
 	.post-stats-card__thumbnail {

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -56,7 +56,7 @@ const StatsInsights = ( props ) => {
 				/>
 				<StatsNavigation selectedItem="insights" siteId={ siteId } slug={ siteSlug } />
 				<AnnualHighlightsSection siteId={ siteId } />
-				<AllTimelHighlightsSection siteId={ siteId } />
+				<AllTimelHighlightsSection siteId={ siteId } siteSlug={ siteSlug } />
 				<PostingActivity siteId={ siteId } />
 				<AllTimeViewsSection siteId={ siteId } slug={ siteSlug } />
 				{ siteId && (

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -28,7 +28,9 @@ import statsStrings from '../stats-strings';
 const StatsInsights = ( props ) => {
 	const { siteId, siteSlug, translate, isOdysseyStats } = props;
 	const moduleStrings = statsStrings();
+
 	const isInsightsPageGridEnabled = config.isEnabled( 'stats/insights-page-grid' );
+	const isLatestPostReplaced = config.isEnabled( 'stats/latest-post-stats' );
 
 	const statsModuleListClass = classNames( 'stats__module-list stats__module--unified', {
 		'is-insights-page-enabled': isInsightsPageGridEnabled,
@@ -87,7 +89,7 @@ const StatsInsights = ( props ) => {
 							hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
 						/>
 
-						<LatestPostSummary />
+						{ ! isLatestPostReplaced && <LatestPostSummary /> }
 						<Reach />
 					</div>
 				) : (

--- a/packages/components/src/post-stats-card/index.tsx
+++ b/packages/components/src/post-stats-card/index.tsx
@@ -15,6 +15,7 @@ type PostStatsCardProps = {
 		post_thumbnail: string | null;
 		title: string;
 	};
+	titleLink?: string | undefined;
 };
 
 export default function PostStatsCard( {
@@ -23,14 +24,18 @@ export default function PostStatsCard( {
 	likeCount,
 	post,
 	viewCount,
+	titleLink,
 }: PostStatsCardProps ) {
 	const translate = useTranslate();
 	const parsedDate = useMemo( () => new Date( post?.date ).toLocaleDateString(), [ post?.date ] );
+	const TitleTag = titleLink ? 'a' : 'div';
 	return (
 		<Card className="post-stats-card">
 			<div className="post-stats-card__heading">{ heading }</div>
 			<div className="post-stats-card__post-info">
-				<div className="post-stats-card__post-title">{ post?.title }</div>
+				<TitleTag className="post-stats-card__post-title" href={ titleLink }>
+					{ post?.title }
+				</TitleTag>
 				{ post?.date && (
 					<div className="post-stats-card__post-date">
 						{ translate( 'Published %(date)s', {

--- a/packages/components/src/post-stats-card/style.scss
+++ b/packages/components/src/post-stats-card/style.scss
@@ -23,6 +23,11 @@ $break-wpcom-smallest: 320px;
 	max-height: 255px;
 	padding: $card-padding;
 	gap: $card-padding;
+
+	// Eliminate the `::after` pseudo-element from frequently accompanied .card
+	&.card::after {
+		display: none;
+	}
 }
 
 .post-stats-card__heading {

--- a/packages/components/src/post-stats-card/style.scss
+++ b/packages/components/src/post-stats-card/style.scss
@@ -43,6 +43,10 @@ $break-wpcom-smallest: 320px;
 .post-stats-card__post-title {
 	@include stats-section-header;
 	margin-bottom: 4px;
+
+	&:visited {
+		color: var(--studio-gray-100);
+	}
 }
 
 .post-stats-card__post-info {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70854 
## Proposed Changes

* Introduce the `LatestPostCard` and `MostPopularPostCard` based on the `PostStatsCard` component.
* Gate the new post stats cards and `LatestPostSummary` replacement behind the feature flag `stats/latest-post-stats`.
* Support title link to post stats card component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the `Stats` > `Insights` page.
* Ensure the `All-time highlights` and `Latest post summary` work as previously.
* Append the feature flag `?flags=stats/latest-post-stats` to the URL.
* Ensure there are two new post-stats cards appended to the `All-time highlights` section and the `Latest post summary` is removed.
* Ensure the `title` of two new post-stats cards can be linked to the respective `post details page`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
