### PR TITLE
Stats: Fix retrieve the startDate from a nullable object inside the StatsPostSummary page

### DIFF
--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -152,7 +152,7 @@ class StatsPostSummary extends Component {
 				{ isFeatured ? (
 					<StatsPeriodHeader>
 						<StatsPeriodNavigation showArrows={ false }>
-							<DatePicker period={ this.state.period } date={ selectedRecord.startDate } isShort />
+							<DatePicker period={ this.state.period } date={ selectedRecord?.startDate } isShort />
 						</StatsPeriodNavigation>
 						<SegmentedControl primary>
 							{ periods.map( ( { id, label } ) => (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Use optional parameter syntax to fix the retrieve from a nullable object.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to certain post details page: `/stats/post/${post-id}/${site}`.
* Ensure the console error does not occur anymore.

<img width="664" alt="image" src="https://user-images.githubusercontent.com/6869813/217639731-d390b7f5-5c11-4be7-9bc8-a2154922873f.png">

<img width="1100" alt="截圖 2023-02-09 上午3 54 27" src="https://user-images.githubusercontent.com/6869813/217639150-0e359f9e-4a26-4a75-80ca-587f3a1703bc.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
