### PR TITLE
Domains: Fix problem with domain-only signup flows

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -502,7 +502,7 @@ class Signup extends Component {
 			siteId,
 			isNewUser,
 			hasCartItems,
-			planProductSlug: hasCartItems ? cartItem.product_slug : undefined,
+			planProductSlug: hasCartItems && cartItem !== null ? cartItem.product_slug : undefined,
 			domainProductSlug:
 				undefined !== domainItem && domainItem.is_domain_registration
 					? domainItem.product_slug


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR fixes a problem where domain-only signup flows were broken due to a `cartItem` variable not being defined. When a domain was chosen in the signup flow and the "Just buy a domain" option was selected, the progress bar got stuck with the "Preparing your domain" message - the user was never redirected to the checkout page. After that, if I tried to access a signup flow again, I got a blank page, and the only way to access it again was by cleaning the site data.

This issue was introduced in #72970 and reported to Nomado in p1675883481551099-slack-C0BNMNMNG.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to `/start/domain/domain-only` (or any other domain-only flow)
- Choose a domain and select the "Just buy a domain" option
- Ensure that you arrive at the checkout page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
