### PR TITLE
Add steps style to mobile view and add steps to domain search page

### DIFF
--- a/client/my-sites/domains/components/domain-and-plan-package/navigation/index.jsx
+++ b/client/my-sites/domains/components/domain-and-plan-package/navigation/index.jsx
@@ -12,6 +12,10 @@ export default function DomainAndPlanPackageNavigation( props ) {
 
 	const step = props.step ? props.step : 1;
 
+	const stepIndication = translate( 'Step %(currentStep)s of %(stepCount)s', {
+		args: { currentStep: step, stepCount: 3 },
+	} );
+
 	return (
 		<div className="domain-and-plan-package-navigation">
 			<div className="domain-and-plan-package-navigation__back">
@@ -32,6 +36,7 @@ export default function DomainAndPlanPackageNavigation( props ) {
 				</li>
 				<li>{ translate( 'Complete your purchase' ) }</li>
 			</ol>
+			<div className="domain-and-plan-package-navigation__step-indication">{ stepIndication }</div>
 		</div>
 	);
 }

--- a/client/my-sites/domains/components/domain-and-plan-package/navigation/style.scss
+++ b/client/my-sites/domains/components/domain-and-plan-package/navigation/style.scss
@@ -5,7 +5,8 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	margin: 24px 0;
+	margin: 24px 0 48px;
+	color: var(--studio-gray-40);
 
 	&__back {
 		height: 24px;
@@ -36,7 +37,16 @@
 		display: none;
 	}
 
+	&__step-indication {
+		position: absolute;
+		right: 24px;
+	}
+
 	@include break-xlarge {
+		&__step-indication {
+			display: none;
+		}
+
 		&__steps {
 			display: block;
 			counter-reset: step-counter;
@@ -46,12 +56,10 @@
 			.gridicons-chevron-right {
 				float: right;
 				margin: 0 30px;
-				color: var(--studio-gray-40);
 			}
 		}
 
 		&__steps > li {
-			color: var(--studio-gray-40);
 			display: inline-block;
 			counter-increment: step-counter;
 			padding: 0 0 0 30px;

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -25,6 +25,7 @@ import {
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { addQueryArgs } from 'calypso/lib/url';
 import withCartKey from 'calypso/my-sites/checkout/with-cart-key';
+import DomainAndPlanPackageNavigation from 'calypso/my-sites/domains/components/domain-and-plan-package/navigation';
 import NewDomainsRedirectionNoticeUpsell from 'calypso/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
 import {
 	domainAddEmailUpsell,
@@ -48,7 +49,6 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-import DomainAndPlanPackageNavigation from '../components/domain-and-plan-package/navigation';
 
 import './style.scss';
 import 'calypso/my-sites/domains/style.scss';

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -48,6 +48,7 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+import DomainAndPlanPackageNavigation from '../components/domain-and-plan-package/navigation';
 
 import './style.scss';
 import 'calypso/my-sites/domains/style.scss';
@@ -276,6 +277,7 @@ class DomainSearch extends Component {
 						<div className="domains__header">
 							{ domainSidebarExperimentUser && (
 								<>
+									<DomainAndPlanPackageNavigation step={ 1 } />
 									<FormattedHeader
 										brandFont
 										headerText={ translate( 'Claim your domain' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72892
## Proposed Changes

* This PR adds the domain upsell steps component to the "domain search" page (step 1).
* This PR also creates a "Step X of 3" mobile view. See video below.


https://user-images.githubusercontent.com/140841/217657855-dd73e70a-e0d0-4de7-a19f-d823c8cb455d.mp4



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR and make sure you're part of the treatment for the experiment. You can do this by following the instructions on [this PR](https://github.com/Automattic/wp-calypso/pull/73017). 
* Verify the steps navigation appears on the "domain search" page after you click the masterbar domain upsell.
* Verify that it shows "Step X of 3" on mobile views.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
