### PR TITLE
Stats: Split insights, wordads, post detail and comment follows from the first bundle

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -2,20 +2,31 @@ import i18n from 'i18n-calypso';
 import { find, pick } from 'lodash';
 import moment from 'moment';
 import page from 'page';
+import AsyncLoad from 'calypso/components/async-load';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import { getSiteFragment, getStatsDefaultSitePage } from 'calypso/lib/route';
 import { getSite, getSiteOption } from 'calypso/state/sites/selectors';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import StatsCommentFollows from './comment-follows';
 import StatsOverview from './overview';
 import StatsSite from './site';
 import StatsEmailDetail from './stats-email-detail';
-import StatsInsights from './stats-insights';
-import StatsPostDetail from './stats-post-detail';
 import StatsSummary from './summary';
-import WordAds from './wordads';
+
+const PageLoading = (
+	<div
+		style={ {
+			minHeight: 'calc( 100vh - 100px )',
+			width: '100%',
+			display: 'flex',
+			justifyContent: 'center',
+			alignItems: 'center',
+		} }
+	>
+		<img width="32" height="32" alt="Loading" src="//en.wordpress.com/i/loading/loading-64.gif" />
+	</div>
+);
 
 function rangeOfPeriod( period, date ) {
 	const periodRange = {
@@ -194,7 +205,9 @@ export function redirectToDefaultModulePage( context ) {
 }
 
 export function insights( context, next ) {
-	context.primary = <StatsInsights />;
+	context.primary = (
+		<AsyncLoad require="calypso/my-sites/stats/stats-insights" placeholder={ PageLoading } />
+	);
 	next();
 }
 
@@ -381,7 +394,15 @@ export function post( context, next ) {
 		return next();
 	}
 
-	context.primary = <StatsPostDetail path={ context.path } postId={ postId } context={ context } />;
+	context.primary = (
+		<AsyncLoad
+			require="calypso/my-sites/stats/stats-post-detail"
+			placeholder={ PageLoading }
+			path={ context.path }
+			postId={ postId }
+			context={ context }
+		/>
+	);
 
 	next();
 }
@@ -410,7 +431,9 @@ export function follows( context, next ) {
 	}
 
 	context.primary = (
-		<StatsCommentFollows
+		<AsyncLoad
+			require="calypso/my-sites/stats/comment-follows"
+			placeholder={ PageLoading }
 			path={ context.path }
 			page={ pageNum }
 			perPage="20"
@@ -453,7 +476,9 @@ export function wordAds( context, next ) {
 	bumpStat( 'calypso_wordads_stats_site_period', activeFilter.period + numPeriodAgo );
 
 	context.primary = (
-		<WordAds
+		<AsyncLoad
+			require="calypso/my-sites/stats/wordads"
+			placeholder={ PageLoading }
 			path={ context.pathname }
 			date={ date }
 			chartTab={ queryOptions.tab || 'impressions' }

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -11,10 +11,8 @@ import { getSite, getSiteOption } from 'calypso/state/sites/selectors';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import StatsOverview from './overview';
 import StatsSite from './site';
 import StatsEmailDetail from './stats-email-detail';
-import StatsSummary from './summary';
 
 const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
@@ -252,7 +250,14 @@ export function overview( context, next ) {
 
 	bumpStat( 'calypso_stats_overview_period', activeFilter.period );
 
-	context.primary = <StatsOverview period={ activeFilter.period } path={ context.pathname } />;
+	context.primary = (
+		<AsyncLoad
+			require="calypso/my-sites/stats/overview"
+			placeholder={ PageLoading }
+			period={ activeFilter.period }
+			path={ context.pathname }
+		/>
+	);
 	next();
 }
 
@@ -378,7 +383,9 @@ export function summary( context, next ) {
 	}
 
 	context.primary = (
-		<StatsSummary
+		<AsyncLoad
+			require="calypso/my-sites/stats/summary"
+			placeholder={ PageLoading }
 			path={ context.pathname }
 			statsQueryOptions={ statsQueryOptions }
 			date={ date }

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -1,3 +1,5 @@
+import config from '@automattic/calypso-config';
+import { Spinner } from '@automattic/components';
 import i18n from 'i18n-calypso';
 import { find, pick } from 'lodash';
 import moment from 'moment';
@@ -14,6 +16,8 @@ import StatsSite from './site';
 import StatsEmailDetail from './stats-email-detail';
 import StatsSummary from './summary';
 
+const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+
 const PageLoading = (
 	<div
 		style={ {
@@ -24,7 +28,11 @@ const PageLoading = (
 			alignItems: 'center',
 		} }
 	>
-		<img width="32" height="32" alt="Loading" src="//en.wordpress.com/i/loading/loading-64.gif" />
+		{ isOdysseyStats ? (
+			<img width="32" height="32" alt="Loading" src="//en.wordpress.com/i/loading/loading-64.gif" />
+		) : (
+			<Spinner />
+		) }
 	</div>
 );
 


### PR DESCRIPTION
## Proposed Changes
The PR proposes to load the not-always-used insights, wordads, post detail and comment follows pages asynchronously on demand, so that we could reduce the size of the first bundle `build.min.js` and accelerate the page loading. Traffic page is not split because it's the default page for Stats. It also adds a PageLoading placeholder for smoother page switching. 

I tried refactor `client/my-sites/stats/controller.jsx` to separate files to limit the imports, which has very little effect on the final bundle size and is not included in the PR. 

I also tried to lazy load with Reactjs [code splitting methods](https://reactjs.org/docs/code-splitting.html), but which has almost the same effect with AsynLoad in Calypso, so didn't use it.

Another thing is that it might be more natural to only load the difference between pages, however the current pages are structured without shared  layout, which would require some serious refactoring in the future. 

The PR reduces the first bundle size by `~17%`, from about `~1.1M` to `~930K`.

## Testing Instructions

* Open `/wp-admin/admin.php?page=stats` on a JP site with new Stats enabled
* Ensure the mentioned pages still works as before, only with a loading spinner on switching
* Ensure Jetpack Stats on WP.com works the same way only with a different loading spinner

Note: you could throttle networking with `Slow 3G`  to see the effects.

<img width="516" alt="image" src="https://user-images.githubusercontent.com/1425433/217662118-ace010c0-a91d-41b0-825c-e268b6f70ab2.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
