### PR TITLE
Updating sharing button mockup styles in marketing section

### DIFF
--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -832,7 +832,7 @@
 	background: #fff;
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(0, 0, 0, 0.12);
 	line-height: 23px;
-	padding: 5px 11px 4px 9px;
+	padding: 4px 11px 3px 9px;
 
 	&:hover {
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22), 0 0 0 1px rgba(0, 0, 0, 0.22);

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -612,7 +612,8 @@
 }
 
 .sharing-buttons-preview__reblog-like .sharing-buttons-preview-button {
-	margin: 0 0 3px;
+	margin-bottom: 3px;
+	margin-top: 0;
 }
 
 .sharing-buttons-preview__reblog,

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -975,6 +975,7 @@
 			box-shadow: none;
 			box-sizing: border-box;
 			line-height: 1;
+			border-style: solid;
 			border-radius: 2px;
 			padding: 7px;
 			float: left;

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -612,8 +612,7 @@
 }
 
 .sharing-buttons-preview__reblog-like .sharing-buttons-preview-button {
-	margin-bottom: 3px;
-	margin-top: 0;
+	margin: 0 0 3px;
 }
 
 .sharing-buttons-preview__reblog,

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -643,6 +643,8 @@
 	width: 32px;
 	line-height: 1;
 	vertical-align: top;
+	position: relative;
+	top: -1px;
 }
 
 .sharing-buttons-preview__fake-like {

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -833,6 +833,10 @@
 	line-height: 23px;
 	padding: 5px 11px 4px 9px;
 
+	&:hover {
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22), 0 0 0 1px rgba(0, 0, 0, 0.22);
+	}
+
 	&.style-icon {
 		border-radius: 50%;
 		border: 0;

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -612,7 +612,8 @@
 }
 
 .sharing-buttons-preview__reblog-like .sharing-buttons-preview-button {
-	margin: 0 1em 3px 0;
+	margin-bottom: 3px;
+	margin-top: 0;
 }
 
 .sharing-buttons-preview__reblog,
@@ -637,10 +638,9 @@
 }
 
 .sharing-buttons-preview__fake-user {
-	border: 1px solid var(--color-neutral-10);
 	display: inline-block;
-	height: 24px;
-	width: 24px;
+	height: 32px;
+	width: 32px;
 	line-height: 1;
 	vertical-align: top;
 }
@@ -825,14 +825,13 @@
 	display: inline-block;
 	margin: 8px 8px 0 0;
 	cursor: default;
-	font-size: $font-body-extra-small;
-	border-radius: 2px;
-	color: #777;
-	background: #f8f8f8;
-	border: 1px solid #ccc;
-	box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
+	font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	border-radius: 4px;
+	color: var(--color-neutral-80);
+	background: #fff;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(0, 0, 0, 0.12);
 	line-height: 23px;
-	padding: 1px 8px 0 5px;
+	padding: 5px 11px 4px 9px;
 
 	&.style-icon {
 		border-radius: 50%;
@@ -869,7 +868,7 @@
 
 .sharing-buttons-preview-button__service {
 	line-height: 23px;
-	margin-left: 3px;
+	margin-left: 5px;
 }
 
 .sharing-buttons-preview-button.style-icon .sharing-buttons-preview-button__service {

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -826,6 +826,7 @@
 	margin: 8px 8px 0 0;
 	cursor: default;
 	font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	font-weight: 500;
 	border-radius: 4px;
 	color: var(--color-neutral-80);
 	background: #fff;


### PR DESCRIPTION
## Description

As outlined in [this JP issue](https://github.com/Automattic/jetpack/issues/27817), we plan to update the sharing button styles that are seen at the bottom of each post. This is one of a couple of PRs that need to be updated. 

## Testing

- Visit https://wordpress.com/marketing/sharing-buttons/{site-url}

## Before

<img width="1006" alt="before" src="https://user-images.githubusercontent.com/5634774/217664404-00d0d637-055c-4197-8b71-22cf3eced11e.png">

## After

<img width="1004" alt="after" src="https://user-images.githubusercontent.com/5634774/217664391-331c6900-7d35-4d66-8dc6-afa7a88d1259.png">

## Related
- https://github.com/Automattic/jetpack/issues/27817
- https://github.com/Automattic/jetpack/pull/28874
- https://github.com/Automattic/jetpack/pull/28876