### PR TITLE
Fix typos in scss comments added in #73071

### DIFF
--- a/client/my-sites/hosting/github/disconnect-github-expander/style.scss
+++ b/client/my-sites/hosting/github/disconnect-github-expander/style.scss
@@ -18,10 +18,10 @@
 	}
 
 	[dir="rtl"] &[aria-expanded="true"] .gridicon {
-		// Auto-rtl flips the rotate() direction. We specific 90deg so that
-		// ultimately it will end up as -90deg, which is what we want. The
-		// processing also a scaleX() to flip the icon. We add it too so the
-		// transition doesn't break.
+		// Auto-rtl flips the rotate() direction. We specify 90deg so that
+		// ultimately it ends up as -90deg, which is what we actually want. The
+		// processing also adds a scaleX() to flip the icon. We add it so the
+		// transition effect doesn't break.
 		transform: rotate(90deg) scaleX(-1);
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
