### PR TITLE
Remove limited time offer copy from premium-business upsell

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
@@ -41,15 +41,7 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 	}
 
 	header() {
-		const { translate } = this.props;
-
-		return (
-			<header className="business-plan-upgrade-upsell-new-design__small-header">
-				<h1 className="business-plan-upgrade-upsell-new-design__small-header-title">
-					{ translate( 'Limited time offer' ) }
-				</h1>
-			</header>
-		);
+		return null;
 	}
 
 	image() {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1606
## Proposed Changes

* Remove "Limited Time Offer" copy from the premium - business upsell.


Before | After
--|--
![limited-before](https://user-images.githubusercontent.com/140841/217674804-5808f2eb-ef5c-454e-8971-3ef09c85ba87.png)  | ![limited-after](https://user-images.githubusercontent.com/140841/217674813-bc944d03-f034-4198-9df9-e1270216804c.png) 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the PR
* Upgrade a free site to a Premium site.
* You should see the upsell pictured above. It should not mention a "limited time offer"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
