### PR TITLE
Copy Site: add products to site cart to resume the flow

### DIFF
--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -80,16 +80,9 @@ const copySite: Flow = {
 			recordFullStoryEvent( 'calypso_signup_start_copy_site', { flow: this.name } );
 		}, [] );
 
-		const urlQueryParams = useQuery();
-		const siteSlug = urlQueryParams.get( 'siteSlug' );
-
 		return [
-			...( ! siteSlug
-				? [
-						{ slug: 'domains', component: DomainsStep },
-						{ slug: 'site-creation-step', component: SiteCreationStep },
-				  ]
-				: [] ),
+			{ slug: 'domains', component: DomainsStep },
+			{ slug: 'site-creation-step', component: SiteCreationStep },
 			{ slug: 'processing', component: ProcessingStep },
 			{ slug: 'automated-copy', component: AutomatedCopySite },
 			{
@@ -104,6 +97,7 @@ const copySite: Flow = {
 					/>
 				),
 			},
+			{ slug: 'resuming', component: ProcessingStep }, // Needs siteSlug param
 		];
 	},
 
@@ -130,6 +124,7 @@ const copySite: Flow = {
 					return navigate( 'processing' );
 				}
 
+				case 'resuming':
 				case 'processing': {
 					const siteSlug = providedDependencies?.siteSlug || urlQueryParams.get( 'siteSlug' );
 					const destination = addQueryArgs( `/setup/${ this.name }/automated-copy`, {

--- a/client/landing/stepper/hooks/use-site-copy.tsx
+++ b/client/landing/stepper/hooks/use-site-copy.tsx
@@ -1,4 +1,5 @@
 import { WPCOM_FEATURES_COPY_SITE } from '@automattic/calypso-products';
+import { COPY_SITE_FLOW, addProductsToCart } from '@automattic/onboarding';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useMemo, useCallback } from 'react';
@@ -16,6 +17,7 @@ import getSiteFeatures from 'calypso/state/selectors/get-site-features';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+import type { Purchase } from 'calypso/lib/purchases/types';
 
 interface SiteCopyOptions {
 	enabled: boolean;
@@ -36,6 +38,20 @@ function useSafeSiteHasFeature( siteId: number | undefined, feature: string, ena
 		}
 		return siteHasFeature( state, siteId, feature );
 	} );
+}
+
+function getMarketplaceProducts( purchases: Purchase[] | null, siteId: number ) {
+	return ( purchases || [] )
+		.filter(
+			( purchase ) =>
+				[ 'marketplace_plugin', 'marketplace_theme' ].includes( purchase.productType ) &&
+				purchase.siteId === siteId
+		)
+		.map( ( purchase ) => ( { product_slug: purchase.productSlug } ) );
+}
+
+function getPlanProduct( plan: SiteExcerptData[ 'plan' ] ) {
+	return { product_slug: plan?.product_slug as string };
 }
 
 export const useSiteCopy = (
@@ -73,30 +89,43 @@ export const useSiteCopy = (
 	}, [ hasCopySiteFeature, isSiteOwner, plan, isLoadingPurchases, isAtomic ] );
 
 	const startSiteCopy = useCallback( () => {
-		if ( ! shouldShowSiteCopyItem ) {
+		if ( ! shouldShowSiteCopyItem || ! site?.ID ) {
 			return;
 		}
 		clearSignupDestinationCookie();
-		setPlanCartItem( { product_slug: plan?.product_slug as string } );
-
-		const marketplacePluginProducts = ( purchases || [] )
-			.filter(
-				( purchase ) =>
-					[ 'marketplace_plugin', 'marketplace_theme' ].includes( purchase.productType ) &&
-					purchase.siteId === site?.ID
-			)
-			.map( ( purchase ) => ( { product_slug: purchase.productSlug } ) );
-
-		setProductCartItems( marketplacePluginProducts );
+		const planProduct = getPlanProduct( plan );
+		setPlanCartItem( planProduct );
+		const marketplaceProducts = getMarketplaceProducts( purchases, site?.ID );
+		setProductCartItems( marketplaceProducts );
 	}, [ plan, setPlanCartItem, purchases, shouldShowSiteCopyItem, setProductCartItems, site?.ID ] );
+
+	const resumeSiteCopy = useCallback(
+		async ( destinationSiteSlug: string ) => {
+			if ( ! shouldShowSiteCopyItem || ! site?.ID ) {
+				return;
+			}
+			await addProductsToCart( destinationSiteSlug, COPY_SITE_FLOW, [
+				getPlanProduct( plan ),
+				...getMarketplaceProducts( purchases, site.ID ),
+			] );
+		},
+		[ plan, purchases, shouldShowSiteCopyItem, site?.ID ]
+	);
 
 	return useMemo(
 		() => ( {
 			shouldShowSiteCopyItem,
 			startSiteCopy,
+			resumeSiteCopy,
 			isFetching: isLoadingPurchases || isRequestingSiteFeatures,
 		} ),
-		[ isLoadingPurchases, isRequestingSiteFeatures, shouldShowSiteCopyItem, startSiteCopy ]
+		[
+			isLoadingPurchases,
+			isRequestingSiteFeatures,
+			resumeSiteCopy,
+			shouldShowSiteCopyItem,
+			startSiteCopy,
+		]
 	);
 };
 

--- a/client/my-sites/customer-home/cards/tasks/site-resume-copy/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-resume-copy/index.jsx
@@ -1,9 +1,11 @@
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import { connect } from 'react-redux';
 import siteCopyIllustration from 'calypso/assets/images/customer-home/illustration--import-complete.svg';
 import { useSiteCopy } from 'calypso/landing/stepper/hooks/use-site-copy';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
+import { navigate } from 'calypso/lib/navigate';
 import { TASK_SITE_RESUME_COPY } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 import { getSite, getSiteOption } from 'calypso/state/sites/selectors';
@@ -11,10 +13,12 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 
 const SiteResumeCopy = ( { siteSlug, sourceSite, sourceSiteSlug } ) => {
 	const translate = useTranslate();
-	const { startSiteCopy } = useSiteCopy( sourceSite );
+	const [ isAddingProducts, setIsAddingProducts ] = useState( false );
+	const { resumeSiteCopy } = useSiteCopy( sourceSite );
 
 	return (
 		<Task
+			actionBusy={ isAddingProducts }
 			isUrgent
 			title={ translate( 'Ready to finish copying your site?' ) }
 			description={ preventWidows(
@@ -23,10 +27,13 @@ const SiteResumeCopy = ( { siteSlug, sourceSite, sourceSiteSlug } ) => {
 				)
 			) }
 			actionText={ translate( 'Finish setting it up' ) }
-			actionUrl={ `/setup/copy-site?sourceSlug=${ sourceSiteSlug }&siteSlug=${ siteSlug }` }
-			actionOnClick={ () => {
+			actionOnClick={ async () => {
 				recordTracksEvent( 'calypso_resume_copy_site_click' );
-				startSiteCopy();
+				setIsAddingProducts( true );
+				await resumeSiteCopy( siteSlug );
+				navigate(
+					`/setup/copy-site/resuming?sourceSlug=${ sourceSiteSlug }&siteSlug=${ siteSlug }`
+				);
 			} }
 			illustration={ siteCopyIllustration }
 			taskId={ TASK_SITE_RESUME_COPY }

--- a/client/my-sites/customer-home/cards/tasks/task.tsx
+++ b/client/my-sites/customer-home/cards/tasks/task.tsx
@@ -19,6 +19,7 @@ import './style.scss';
 
 const Task = ( {
 	actionButton,
+	actionBusy = false,
 	actionOnClick,
 	actionTarget,
 	actionText,
@@ -40,6 +41,7 @@ const Task = ( {
 	title,
 }: {
 	actionOnClick?: () => void;
+	actionBusy?: boolean;
 	badgeText?: ReactNode;
 	completeOnStart?: boolean;
 	description: ReactNode;
@@ -142,6 +144,7 @@ const Task = ( {
 				onClick={ startTask }
 				href={ actionUrl }
 				target={ actionTarget }
+				busy={ actionBusy }
 			>
 				{ actionText }
 			</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/1593

## Proposed Changes

* Add products to the site cart async to resume the payment and copy site flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site`
* Start `Copy Site` on a business site by clicking on the action menu > `Copy Site`
* Select a domain and continue the flow
* When you are landed on the checkout, click on the `X` and `Empty the cart`
* Go to `My Home`
* Click on `Finish setting it up` to resume the flow
* Observe you landed to the checkout and you have the plan and market plugins in your cart
* Pay with credits
* Observe the copy site process resumes and finishes as expected.

## Screencast


https://user-images.githubusercontent.com/779993/217679290-2ddb3604-2b39-458e-9b14-f28d76c56ca6.mp4

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
