### PR TITLE
Authorize button renders busy state while user is authorizing in popup

### DIFF
--- a/client/my-sites/hosting/github/github-authorize-card/index.tsx
+++ b/client/my-sites/hosting/github/github-authorize-card/index.tsx
@@ -1,6 +1,7 @@
 import { Button, Card } from '@automattic/components';
 import requestExternalAccess from '@automattic/request-external-access';
 import { translate } from 'i18n-calypso';
+import { useMutation } from 'react-query';
 import { useSelector, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
@@ -18,11 +19,13 @@ export const GithubAuthorizeCard = () => {
 	const github = useSelector( ( state ) =>
 		getKeyringServiceByName( state, 'github-deploy' )
 	) as Service;
-	const handleClick = () => {
-		requestExternalAccess( github.connect_URL, () => {
-			dispatch( requestKeyringConnections() );
-		} );
-	};
+
+	const { mutate: authorize, isLoading: isAuthorizing } = useMutation< void, unknown, string >(
+		async ( connectURL ) => {
+			await new Promise( ( resolve ) => requestExternalAccess( connectURL, resolve ) );
+			await dispatch( requestKeyringConnections() );
+		}
+	);
 
 	return (
 		<Card className="github-hosting-card">
@@ -33,7 +36,12 @@ export const GithubAuthorizeCard = () => {
 					'Connect this site to a GitHub repository, choose a branch, and deploy with each push.'
 				) }
 			</p>
-			<Button className="is-primary" disabled={ ! github } onClick={ handleClick }>
+			<Button
+				className="is-primary"
+				busy={ isAuthorizing }
+				disabled={ ! github || isAuthorizing }
+				onClick={ () => authorize( github.connect_URL ) }
+			>
 				{ translate( 'Authorize' ) }
 			</Button>
 		</Card>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Small UX improvement so that the "Authorize" button looks busy while the is popup window is open.



https://user-images.githubusercontent.com/1500769/217711573-25c32396-7360-4652-af05-0a85b2cee52e.mp4

Uses ReactQuery to manage the async state so we don't get the "state was updated after a component was unmounted" error.

A follow up improvement would be that the spinner doesn't immediately show after authorising and instead it continues to show the busy "Authorize" button until we're ready to show the repo/branch selector.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Authorise with the GitHub
* Notice the button is disabled and "spinning" while the user has the

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
