### PR TITLE
HelpCenter: style new blocks appearing in content

### DIFF
--- a/packages/help-center/src/components/help-center-article-content.scss
+++ b/packages/help-center/src/components/help-center-article-content.scss
@@ -213,4 +213,28 @@
 	img:first-child {
 		margin-top: 0;
 	}
+
+	.a8c-table-of-contents {
+		& > p,
+		& > button {
+			display: none;
+		}
+	}
+
+	.wp-block-wpsupport3-update-plan-cta {
+		.container .card {
+			margin-top: 16px;
+			.small {
+				font-size: $font-body-extra-small;
+			}
+
+			.title {
+				font-size: $font-title-small;
+			}
+		}
+
+		.plan-options {
+			display: none;
+		}
+	}
 }


### PR DESCRIPTION
Since the help center retrieves the content via api calls, custom blocks that are included in the content can have missing styling. This PR fixes styling issues for the `a8c-table-of-contents` and `wp-block-wpsupport3-update-plan-cta` block.

| Before  | After |
| ------------- | ------------- |
| <img width="377" alt="Screenshot 2023-02-09 at 10 03 32" src="https://user-images.githubusercontent.com/7000684/217765974-ae5c9a07-ce10-42db-8b11-523f270fb4f7.png">  |  <img width="384" alt="Screenshot 2023-02-09 at 09 55 31" src="https://user-images.githubusercontent.com/7000684/217766012-acc0fadf-8390-4a5d-a226-cd9694b7482a.png"> |
| <img width="381" alt="Screenshot 2023-02-09 at 10 03 38" src="https://user-images.githubusercontent.com/7000684/217766085-a8e529e7-ed1f-4f8e-ac1d-cd9f5f2b5031.png"> | <img width="378" alt="Screenshot 2023-02-09 at 09 55 40" src="https://user-images.githubusercontent.com/7000684/217766109-fbd163b8-ef9c-4413-9fb2-c1c30a64d790.png"> |


## Testing Instructions
- Sandbox [supportcft.wordpress.com](http://supportcft.wordpress.com/) 
- Ensure that the help center articles are retrieved from there as well as described here p1675681890860379-slack-C02T4NVL4JJ 
- Run calypso
- Open the help center and search for "domain alternative" and open the article 'Connect a Domain (Alternative Method)'
- Ensure that the two blocks are rendered correctly
- Test the ToC block on other articles as well