### PR TITLE
Stats: Adjust the latest post card layout and hide the most popular post

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -227,6 +227,10 @@ export default function AllTimeHighlightsSection( {
 						);
 					} ) }
 				</DotPager>
+
+				<div className="highlight-cards-list">
+					<LatestPostCard siteId={ siteId } siteSlug={ siteSlug } />
+				</div>
 			</div>
 
 			<div className="highlight-cards">

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -163,6 +163,7 @@ export default function AllTimeHighlightsSection( {
 	}, [ isStatsLoading, translate, views, viewsBestDay, viewsBestDayTotal ] );
 
 	const isLatestPostReplaced = config.isEnabled( 'stats/latest-post-stats' );
+	const isMostPopularPostShow = config.isEnabled( 'stats/most-popular-post' );
 
 	return (
 		<div className="stats__all-time-highlights-section">
@@ -281,7 +282,9 @@ export default function AllTimeHighlightsSection( {
 				{ isLatestPostReplaced && (
 					<div className="highlight-cards-list">
 						<LatestPostCard siteId={ siteId } siteSlug={ siteSlug } />
-						<MostPopularPostCard siteId={ siteId } siteSlug={ siteSlug } />
+						{ isMostPopularPostShow && (
+							<MostPopularPostCard siteId={ siteId } siteSlug={ siteSlug } />
+						) }
 					</div>
 				) }
 			</div>

--- a/client/my-sites/stats/all-time-highlights-section/latest-post-card.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/latest-post-card.tsx
@@ -6,7 +6,7 @@ import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { getPostsForQuery } from 'calypso/state/posts/selectors';
 import { getPostStat } from 'calypso/state/stats/posts/selectors';
 
-const POST_STATS_CARD_TITLE_LIMIT = 40;
+const POST_STATS_CARD_TITLE_LIMIT = 60;
 
 // Use ellipsis when characters count over the limit.
 // TODO: Extract to shared utilities

--- a/client/my-sites/stats/all-time-highlights-section/style.scss
+++ b/client/my-sites/stats/all-time-highlights-section/style.scss
@@ -49,19 +49,24 @@ $mobile-layout-breakpoint: $break-small;
 		&:not(:first-child) {
 			margin-top: 24px;
 		}
+	}
 
-		.highlight-card {
-			padding: 24px;
-			min-width: 320px;
+	.highlight-card {
+		padding: 24px;
+		min-width: 320px;
+	}
+
+	.post-stats-card {
+		flex: 1;
+		max-height: unset;
+		grid-template-columns: minmax(10px, 550px) minmax(0, auto);
+
+		&:not(:first-child) {
+			margin-left: 24px;
 		}
 
-		.post-stats-card {
-			flex: 1;
-			max-height: unset;
-
-			&:not(:first-child) {
-				margin-left: 24px;
-			}
+		.post-stats-card__thumbnail {
+			margin-left: auto;
 		}
 	}
 

--- a/client/my-sites/stats/all-time-highlights-section/style.scss
+++ b/client/my-sites/stats/all-time-highlights-section/style.scss
@@ -31,6 +31,7 @@ $mobile-layout-breakpoint: $break-small;
 			padding: 24px;
 			border: 1px var(--color-border-subtle);
 			border-style: solid none;
+			background-color: var(--color-surface);
 		}
 
 		.card {

--- a/client/my-sites/stats/all-time-highlights-section/style.scss
+++ b/client/my-sites/stats/all-time-highlights-section/style.scss
@@ -13,6 +13,7 @@ $mobile-layout-breakpoint: $break-small;
 		}
 	}
 
+	// Mobile layout
 	.stats__all-time-highlights-mobile {
 		display: none;
 		margin: 16px 0;
@@ -25,16 +26,21 @@ $mobile-layout-breakpoint: $break-small;
 			margin: 16px 16px 24px;
 		}
 
-		.dot-pager {
+		.dot-pager,
+		.highlight-cards-list {
 			padding: 24px;
 			border: 1px var(--color-border-subtle);
 			border-style: solid none;
 		}
 
-		.card.highlight-card {
-			padding: 0;
-			margin: 0;
-			box-shadow: none;
+		.card {
+			&.highlight-card,
+			&.post-stats-card {
+				padding: 0;
+				margin: 0;
+				box-shadow: none;
+				border: 0;
+			}
 		}
 	}
 

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -97,7 +97,7 @@ const StatsInsights = ( props ) => {
 					<div className="stats-insights__nonperiodic has-recent">
 						<div className={ statsModuleListClass }>
 							<div className="stats__module-column">
-								<LatestPostSummary />
+								{ ! isLatestPostReplaced && <LatestPostSummary /> }
 
 								<StatsModule
 									path="tags-categories"

--- a/config/client.json
+++ b/config/client.json
@@ -28,6 +28,8 @@
 	"stats/enhance-post-detail",
 	"stats/horizontal-bars-everywhere",
 	"stats/insights-page-grid",
+	"stats/latest-post-stats",
+	"stats/most-popular-post",
 	"stats/new-video-summary",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",

--- a/config/development.json
+++ b/config/development.json
@@ -173,6 +173,8 @@
 		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": true,
+		"stats/latest-post-stats": true,
+		"stats/most-popular-post": false,
 		"stats/new-video-summary": true,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -117,6 +117,8 @@
 		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
+		"stats/latest-post-stats": false,
+		"stats/most-popular-post": false,
 		"stats/new-video-summary": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/production.json
+++ b/config/production.json
@@ -137,6 +137,8 @@
 		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
+		"stats/latest-post-stats": false,
+		"stats/most-popular-post": false,
 		"stats/new-video-summary": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -134,6 +134,8 @@
 		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
+		"stats/latest-post-stats": false,
+		"stats/most-popular-post": false,
 		"stats/new-video-summary": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/config/test.json
+++ b/config/test.json
@@ -97,6 +97,8 @@
 		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
+		"stats/latest-post-stats": false,
+		"stats/most-popular-post": false,
 		"stats/new-video-summary": false,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -143,6 +143,8 @@
 		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
+		"stats/latest-post-stats": false,
+		"stats/most-popular-post": false,
 		"stats/new-video-summary": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,

--- a/packages/components/src/post-stats-card/style.scss
+++ b/packages/components/src/post-stats-card/style.scss
@@ -63,7 +63,7 @@ $break-wpcom-smallest: 320px;
 	display: flex;
 	flex-flow: row;
 	grid-area: counts;
-	justify-content: space-between;
+	gap: 64px;
 }
 
 .post-stats-card__count {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70854 
## Proposed Changes

* Introduce the feature flag `stats/most-popular-post` to gate the intentionally hidden most popular post card.
* Complete the mobile layout for the latest post card appended to the all-time highlights.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the `Stats` > `Insights` page.
* Ensure the `All-time highlights` and `Latest post summary` work as previously.
* Append the feature flag `?flags=stats/latest-post-stats` to the URL.
* Ensure there is the latest post card appended to the `All-time highlights` section and the `Latest post summary` is removed.
* Change the viewport to mobile.
* Ensure there is the mobile latest post card appended to the `All-time highlights` section.

##### PC
<img width="1271" alt="截圖 2023-02-09 下午5 11 34" src="https://user-images.githubusercontent.com/6869813/217768333-9c0ed039-bf21-4e4b-9e15-12945b3ee8ec.png">

##### Mobile
<img width="487" alt="截圖 2023-02-09 下午5 12 05" src="https://user-images.githubusercontent.com/6869813/217768386-becf7b3b-064a-4a85-944e-bcccc00899c6.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
