### PR TITLE
Plans section: Modernised header and navbar

### DIFF
--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -64,6 +64,7 @@ FormattedHeader.propTypes = {
 	isSecondary: PropTypes.bool,
 	align: PropTypes.oneOf( [ 'center', 'left', 'right' ] ),
 	hasScreenOptions: PropTypes.bool,
+	children: PropTypes.node,
 };
 
 FormattedHeader.defaultProps = {

--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -16,6 +16,7 @@ function FormattedHeader( {
 	align,
 	isSecondary,
 	hasScreenOptions,
+	children,
 } ) {
 	const classes = classNames( 'formatted-header', className, {
 		'is-without-subhead': ! subHeaderText,
@@ -34,6 +35,7 @@ function FormattedHeader( {
 
 	return (
 		<header id={ id } className={ classes }>
+			{ children }
 			{ ! isSecondary && (
 				<h1 className={ headerClasses }>
 					{ preventWidows( headerText, 2 ) } { tooltip }

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -15,6 +15,7 @@ import {
 	isFreeJetpackPlan,
 	isFreePlanProduct,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	isFreePlan,
 } from '@automattic/calypso-products';
 import { Dialog } from '@automattic/components';
 import classNames from 'classnames';
@@ -44,6 +45,7 @@ import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import JetpackChecklist from 'calypso/my-sites/plans/current-plan/jetpack-checklist';
 import PlanRenewalMessage from 'calypso/my-sites/plans/jetpack-plans/plan-renewal-message';
 import legacyPlanNotice from 'calypso/my-sites/plans/legacy-plan-notice';
+import ModernizedLayout from 'calypso/my-sites/plans/modernized-layout';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
@@ -209,11 +211,11 @@ class CurrentPlan extends Component {
 			showThankYou,
 			translate,
 			eligibleForProPlan,
+			isJetpackNotAtomic,
 		} = this.props;
 
 		const currentPlanSlug = selectedSite.plan.product_slug;
 		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
-
 		const shouldQuerySiteDomains = selectedSiteId && shouldShowDomainWarnings;
 		const showDomainWarnings = hasDomainsLoaded && shouldShowDomainWarnings;
 
@@ -233,71 +235,76 @@ class CurrentPlan extends Component {
 		}
 
 		return (
-			<Main className="current-plan" wideLayout>
+			<div>
+				{ ! isJetpackNotAtomic && (
+					<ModernizedLayout dropShadowOnHeader={ isFreePlan( currentPlanSlug ) } />
+				) }
 				<DocumentHead title={ translate( 'My Plan' ) } />
-				<FormattedHeader
-					brandFont
-					className="current-plan__page-heading"
-					headerText={ translate( 'Plans' ) }
-					subHeaderText={ translate(
-						'Learn about the features included in your WordPress.com plan.'
-					) }
-					align="left"
-				/>
-				<div className="current-plan__content">
-					{ selectedSiteId && (
-						// key={ selectedSiteId } ensures data is refetched for changing selectedSiteId
-						<QueryConciergeInitial key={ selectedSiteId } siteId={ selectedSiteId } />
-					) }
-					<QuerySites siteId={ selectedSiteId } />
-					<QuerySitePlans siteId={ selectedSiteId } />
-					<QuerySitePurchases siteId={ selectedSiteId } />
-					<QuerySiteProducts siteId={ selectedSiteId } />
-					{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
+				{ selectedSiteId && (
+					<QueryConciergeInitial key={ selectedSiteId } siteId={ selectedSiteId } />
+				) }
+				<QuerySites siteId={ selectedSiteId } />
+				<QuerySitePlans siteId={ selectedSiteId } />
+				<QuerySitePurchases siteId={ selectedSiteId } />
+				<QuerySiteProducts siteId={ selectedSiteId } />
+				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
+				<div>
+					<FormattedHeader
+						brandFont
+						className="current-plan__section-header modernized-header"
+						headerText={ translate( 'Plans' ) }
+						subHeaderText={ translate(
+							'Learn about the features included in your WordPress.com plan.'
+						) }
+						align="left"
+					/>
+					<div className="current-plan current-plan__content">
+						{ showThankYou && ! this.state.hideThankYouModal && (
+							<Dialog
+								baseClassName="current-plan__dialog dialog__content dialog__backdrop"
+								isVisible={ showThankYou }
+								onClose={ this.hideThankYouModalOnClose }
+							>
+								{ this.renderThankYou() }
+							</Dialog>
+						) }
 
-					{ showThankYou && ! this.state.hideThankYouModal && (
-						<Dialog
-							baseClassName="current-plan__dialog dialog__content dialog__backdrop"
-							isVisible={ showThankYou }
-							onClose={ this.hideThankYouModalOnClose }
-						>
-							{ this.renderThankYou() }
-						</Dialog>
-					) }
+						<PlansNavigation path={ path } />
 
-					<PlansNavigation path={ path } />
+						<Main wideLayout>
+							{ showDomainWarnings && (
+								<DomainWarnings
+									domains={ domains }
+									position="current-plan"
+									selectedSite={ selectedSite }
+									allowedRules={ [
+										'newDomainsWithPrimary',
+										'newDomains',
+										'unverifiedDomainsCanManage',
+										'unverifiedDomainsCannotManage',
+										'wrongNSMappedDomains',
+										'newTransfersWrongNS',
+									] }
+								/>
+							) }
 
-					{ showDomainWarnings && (
-						<DomainWarnings
-							domains={ domains }
-							position="current-plan"
-							selectedSite={ selectedSite }
-							allowedRules={ [
-								'newDomainsWithPrimary',
-								'newDomains',
-								'unverifiedDomainsCanManage',
-								'unverifiedDomainsCannotManage',
-								'wrongNSMappedDomains',
-								'newTransfersWrongNS',
-							] }
-						/>
-					) }
+							{ showExpiryNotice && (
+								<Notice status="is-info" text={ <PlanRenewalMessage /> } showDismiss={ false }>
+									<NoticeAction href={ `/plans/${ selectedSite.slug || '' }` }>
+										{ translate( 'View plans' ) }
+									</NoticeAction>
+								</Notice>
+							) }
 
-					{ showExpiryNotice && (
-						<Notice status="is-info" text={ <PlanRenewalMessage /> } showDismiss={ false }>
-							<NoticeAction href={ `/plans/${ selectedSite.slug || '' }` }>
-								{ translate( 'View plans' ) }
-							</NoticeAction>
-						</Notice>
-					) }
+							{ legacyPlanNotice( eligibleForProPlan, selectedSite ) }
 
-					{ legacyPlanNotice( eligibleForProPlan, selectedSite ) }
+							{ isEcommerceTrial ? this.renderEcommerceTrialPage() : this.renderMain() }
 
-					{ isEcommerceTrial ? this.renderEcommerceTrialPage() : this.renderMain() }
-
-					<TrackComponentView eventName="calypso_plans_my_plan_view" />
+							<TrackComponentView eventName="calypso_plans_my_plan_view" />
+						</Main>
+					</div>
 				</div>
-			</Main>
+			</div>
 		);
 	}
 }
@@ -330,5 +337,6 @@ export default connect( ( state, { requestThankYou } ) => {
 		showThankYou: requestThankYou && isJetpackNotAtomic,
 		scheduleId: getConciergeScheduleId( state ),
 		eligibleForProPlan,
+		isJetpackNotAtomic,
 	};
 } )( localize( CurrentPlan ) );

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -1,3 +1,7 @@
+.current-plan main {
+	padding-top: 17px;
+}
+
 .current-plan__dialog.dialog__backdrop {
 	background-color: rgba(var(--color-neutral-dark-rgb), 0.85);
 	box-shadow: none;

--- a/client/my-sites/plans/header.jsx
+++ b/client/my-sites/plans/header.jsx
@@ -110,6 +110,7 @@ export default function PlansHeader() {
 	if ( null === domainFromHomeUpsellFlow ) {
 		return (
 			<FormattedHeader
+				className="plans__section-header modernized-header"
 				brandFont
 				headerText={ translate( 'Plans' ) }
 				subHeaderText={ plansDescription }
@@ -121,25 +122,27 @@ export default function PlansHeader() {
 	return (
 		<>
 			{ renderDeleteDialog() }
-			<header className="formatted-header navigation">
-				<Button onClick={ onBackClick } className="inline-help__cancel-button" borderless>
-					<Gridicon icon="arrow-left" size={ 18 } />
-					{ translate( 'Back' ) }
-				</Button>
-
-				<Button onClick={ onSkipClick } borderless href="/">
-					{ translate( 'Skip' ) }
-					<Gridicon icon="arrow-right" size={ 18 } />
-				</Button>
-			</header>
-
 			<FormattedHeader
-				className="header-text"
+				className="header-text plans__section-header modernized-header"
 				brandFont
 				headerText={ translate( 'Free for the first year!' ) }
 				subHeaderText={ domainUpsellDescription }
 				align="left"
-			/>
+			>
+				<div>
+					<div className="plans__section-header-navigation">
+						<Button onClick={ onBackClick } className="inline-help__cancel-button" borderless>
+							<Gridicon icon="arrow-left" size={ 18 } />
+							{ translate( 'Back' ) }
+						</Button>
+
+						<Button onClick={ onSkipClick } borderless href="/">
+							{ translate( 'Skip' ) }
+							<Gridicon icon="arrow-right" size={ 18 } />
+						</Button>
+					</div>
+				</div>
+			</FormattedHeader>
 		</>
 	);
 }

--- a/client/my-sites/plans/header.scss
+++ b/client/my-sites/plans/header.scss
@@ -1,6 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 
-.is-section-plans .formatted-header.navigation {
+.is-section-plans .plans__section-header-navigation {
 	display: flex;
 	justify-content: space-between;
 	margin: 0;
@@ -11,8 +11,11 @@
 	}
 }
 
-.is-section-plans .formatted-header.header-text {
-	max-width: $break-medium;
+.is-section-plans .plans__section-header {
+	.formatted-header__title,
+	.formatted-header__subtitle {
+		max-width: $break-medium;
+	}
 }
 
 .dialog.planspage__domain-upsell {
@@ -50,22 +53,5 @@
 		color: var(--color-text-subtle);
 		font-size: 1rem;
 		margin: 0 24px;
-	}
-}
-
-
-.is-2023-pricing-grid {
-	.formatted-header.formatted-header,
-	.notice.notice,
-	.section-nav.section-nav {
-		max-width: 1040px;
-		margin-left: auto;
-		margin-right: auto;
-	}
-
-	@media (max-width: 660px) {
-		.formatted-header.formatted-header {
-			margin: 16px;
-		}
 	}
 }

--- a/client/my-sites/plans/modernized-layout.scss
+++ b/client/my-sites/plans/modernized-layout.scss
@@ -1,0 +1,5 @@
+@import "@wordpress/base-styles/variables";
+
+:root {
+	--scss-font-body-small: #{$font-body-small};
+}

--- a/client/my-sites/plans/modernized-layout.tsx
+++ b/client/my-sites/plans/modernized-layout.tsx
@@ -1,0 +1,154 @@
+/**
+ * - section styles borrowed from /my-sites/stats, adapted to modernize the header and navbar.
+ * - .navigation styles borrowed from /blocks/stats-navigation, adapted to modernize the plans navigation component.
+ *  This is a temporary solution until we can use a Layout component.
+ */
+
+import { css, Global } from '@emotion/react';
+import { memo } from '@wordpress/element';
+import './modernized-layout.scss';
+
+const ModernizedLayout: React.FunctionComponent< { dropShadowOnHeader?: boolean } > = ( {
+	dropShadowOnHeader = true,
+} ) => {
+	const backgroundColor = '#fdfdfd';
+	const sectionMaxWidth = '1224px';
+	const layoutContentPaddingTop = '79px';
+	const sidebarAppearanceBreakPoint = '783px';
+	const breakMedium = '782px';
+	const breakMobile = '480px';
+	// ----------------------------------------------
+	// from @automattic/components/src/highlight-cards/variables.scss:
+	// ----------------------------------------------
+	const customBreakpointSmall = '660px';
+	const verticalMargin = '32px';
+	// ----------------------------------------------
+
+	const globalOverrides = css`
+		.plans__section-header,
+		.current-plan__section-header {
+			background-color: var( --studio-white );
+			${ dropShadowOnHeader && 'box-shadow: inset 0 -1px 0 #0000000d;' }
+
+			@media ( min-width: ${ customBreakpointSmall } ) {
+				padding: 0 max( calc( 50% - ( ${ sectionMaxWidth } / 2 ) ), 32px );
+			}
+		}
+
+		// Main layout content
+		.plans,
+		.current-plan {
+			// Ensures horizontal padding for all sections.
+			@media ( min-width: ${ customBreakpointSmall } ) {
+				> * {
+					padding: 0 max( calc( 50% - ( ${ sectionMaxWidth } / 2 ) ), 32px );
+				}
+			}
+
+			&.has-fixed-nav {
+				padding-top: 44px;
+			}
+
+			.navigation {
+				box-shadow: inset 0 -1px 0 #0000000d;
+				background-color: var( --studio-white );
+
+				.segmented-control {
+					margin-left: 0;
+
+					@media ( min-width: ${ breakMedium } ) {
+						margin-left: 16px;
+					}
+				}
+
+				.section-nav {
+					margin: 0;
+					box-shadow: inset 0 -1px 0 #0000000d;
+				}
+
+				.section-nav-group__label {
+					padding: 0;
+				}
+
+				.section-nav__panel {
+					padding: 0;
+
+					@media ( max-width: ${ breakMedium } ) {
+						padding: 0 16px;
+					}
+				}
+
+				.section-nav-tab {
+					&:not( :first-of-type ) {
+						margin-left: 16px;
+
+						@media ( max-width: ${ breakMobile } ) {
+							margin-left: 0;
+						}
+					}
+
+					.section-nav-tab__link {
+						padding: 8px 12px;
+						font-size: var( --scss-font-body-small );
+						line-height: 20px;
+
+						&:hover {
+							color: var( --color-neutral-60 );
+							background-color: var( --color-surface );
+						}
+
+						@media ( max-width: ${ breakMedium } ) {
+							padding: 8px 0;
+						}
+
+						@media ( max-width: ${ breakMobile } ) {
+							padding: 8px;
+						}
+					}
+
+					@media ( min-width: ${ breakMobile } ) {
+						.section-nav-tab__link {
+							color: var( --color-neutral-60 );
+						}
+						&.is-selected {
+							border-bottom-color: var( --color-neutral-100 );
+
+							.section-nav-tab__link {
+								color: var( --color-neutral-100 );
+							}
+						}
+					}
+				}
+			}
+		}
+
+		.is-section-plans {
+			background-color: var( --studio-white );
+
+			.plans,
+			.current-plan {
+				background-color: ${ backgroundColor };
+			}
+
+			// this overrides the default .layout__content that adds unwanted padding
+			& .layout__content,
+			&.theme-default .focus-content .layout__content {
+				padding: ${ layoutContentPaddingTop } 0 0 0;
+
+				@media ( min-width: ${ sidebarAppearanceBreakPoint } ) {
+					padding: ${ layoutContentPaddingTop } 0 0 calc( var( --sidebar-width-max ) + 1px );
+				}
+
+				.jetpack-colophon {
+					padding-top: ${ verticalMargin };
+					padding-bottom: ${ verticalMargin };
+					margin-top: 0;
+				}
+			}
+		}
+	`;
+
+	return <Global styles={ globalOverrides } />;
+};
+
+export default memo( ModernizedLayout );

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -44,24 +44,26 @@ class PlansNavigation extends Component {
 		return (
 			site &&
 			shouldShowNavigation && (
-				<SectionNav hasPinnedItems={ hasPinnedItems } selectedText={ sectionTitle }>
-					<NavTabs label="Section" selectedText={ sectionTitle }>
-						<NavItem
-							path={ `/plans/my-plan/${ site.slug }` }
-							selected={ path === '/plans/my-plan' }
-						>
-							{ translate( 'My Plan' ) }
-						</NavItem>
-						<NavItem
-							path={ `/plans/${ site.slug }` }
-							selected={
-								path === '/plans' || path === '/plans/monthly' || path === '/plans/yearly'
-							}
-						>
-							{ translate( 'Plans' ) }
-						</NavItem>
-					</NavTabs>
-				</SectionNav>
+				<div className="navigation">
+					<SectionNav hasPinnedItems={ hasPinnedItems } selectedText={ sectionTitle }>
+						<NavTabs label="Section" selectedText={ sectionTitle }>
+							<NavItem
+								path={ `/plans/my-plan/${ site.slug }` }
+								selected={ path === '/plans/my-plan' }
+							>
+								{ translate( 'My Plan' ) }
+							</NavItem>
+							<NavItem
+								path={ `/plans/${ site.slug }` }
+								selected={
+									path === '/plans' || path === '/plans/monthly' || path === '/plans/yearly'
+								}
+							>
+								{ translate( 'Plans' ) }
+							</NavItem>
+						</NavTabs>
+					</SectionNav>
+				</div>
 			)
 		);
 	}

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -19,7 +19,8 @@ body.is-section-plans.is-domain-sidebar-experiment-user {
 	}
 
 	.plans__header {
-		// display: block;
+		display: block;
+		overflow: auto;
 
 		.formatted-header__title,
 		.formatted-header__subtitle {
@@ -49,10 +50,6 @@ body.is-section-plans.is-domain-sidebar-experiment-user {
 			}
 		}
 	}
-
-	// .main.is-wide-layout {
-	// 	max-width: $break-medium;
-	// }
 
 	// plans comparison grid
 	.plan-features-comparison__table-item {

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -8,9 +8,9 @@
 body.is-section-plans.is-domain-sidebar-experiment-user {
 	background: var(--color-body-background);
 
-	.layout__content {
-		padding-left: 0 !important;
-	}
+	// .layout__content {
+	// 	padding-left: 0 !important;
+	// }
 
 	.plans__has-sidebar {
 		.section-nav {
@@ -19,7 +19,12 @@ body.is-section-plans.is-domain-sidebar-experiment-user {
 	}
 
 	.plans__header {
-		display: block;
+		// display: block;
+
+		.formatted-header__title,
+		.formatted-header__subtitle {
+			max-width: unset;
+		}
 
 		h1 {
 			font-family: $brand-serif;
@@ -45,9 +50,9 @@ body.is-section-plans.is-domain-sidebar-experiment-user {
 		}
 	}
 
-	.main.is-wide-layout {
-		max-width: $break-medium;
-	}
+	// .main.is-wide-layout {
+	// 	max-width: $break-medium;
+	// }
 
 	// plans comparison grid
 	.plan-features-comparison__table-item {


### PR DESCRIPTION
### Proposed Changes

Partially addresses https://github.com/Automattic/martech/issues/1463

This brings the "modernized" header & navbar by default to `/plans/my-plan` & `/plan` (not behind a feature flag). This is another temp solution with follow-ups in TODO list below.

_Notes:_ Plans header & navigation are used for [jetpack-plans](https://github.com/Automattic/wp-calypso/tree/trunk/client/my-sites/plans/jetpack-plans) code, but the changes should not affect these (something for a follow-up)

#### Media

with some of the states I notice for the plans pages (info & upsell notices):

_Old `/plans`_

<img width="700" alt="Screenshot 2023-02-06 at 4 25 02 PM" src="https://user-images.githubusercontent.com/1705499/216997389-4ab1c688-857d-4958-81a4-cbd73af1b934.png">

_New `/plans`_

<img width="700" alt="Screenshot 2023-02-06 at 4 23 42 PM" src="https://user-images.githubusercontent.com/1705499/216997457-c062689e-2417-4522-9ced-c2bfcef61345.png">

_New `/plans` free site_

<img width="700" alt="Screenshot 2023-02-06 at 5 12 03 PM" src="https://user-images.githubusercontent.com/1705499/217009326-c5995696-26ae-4186-a241-3fad2e70fc5f.png">


_`/plans/my-plan`_

<img width="700" alt="Screenshot 2023-02-06 at 4 24 30 PM" src="https://user-images.githubusercontent.com/1705499/216997597-9fc7b1b1-f348-4e16-94e5-b8010dc39895.png">

_`/plans` domain-only flow_

<img width="700" alt="Screenshot 2023-02-09 at 12 34 08 PM" src="https://user-images.githubusercontent.com/1705499/217788550-92b573e1-1b6e-4340-9dad-2720b57812f7.png">


### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate to `/plans/[site_slug]?flags=onboarding/2023-pricing-grid`
- Confirm the changes
- Do the same without the flag `/plans/[site_slug]?flags=-onboarding/2023-pricing-grid`
- Do the same for domain-only flow (e.g. `plans/yearly/[freeplan.no.domain]?get_domain=freeplan.blog`)
- Confirm no changes in `jetpack-plans` (instructions [here](https://github.com/Automattic/wp-calypso/pull/72960#issuecomment-1420258817))

### TODO

- [x] Extract into a layout component to allow reuse | [issue](https://github.com/Automattic/wp-calypso/issues/73102)
- [x] Extract navigation into a component to allow reuse | [issue](https://github.com/Automattic/wp-calypso/issues/73102)
- [x] Consider navbar inside header to reduce some of the complexity | [issue](https://github.com/Automattic/wp-calypso/issues/73102)

### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1463
