### PR TITLE
Email stats: Add summary page route & skeleton

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -13,6 +13,7 @@ import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import StatsSite from './site';
 import StatsEmailDetail from './stats-email-detail';
+import StatsEmailSummary from './stats-email-summary';
 
 const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
@@ -550,6 +551,22 @@ export function emailStats( context, next ) {
 			isValidStartDate={ isValidStartDate }
 		/>
 	);
+
+	next();
+}
+
+export function emailSummary( context, next ) {
+	const givenSiteId = context.params.site;
+
+	const selectedSite = getSite( context.store.getState(), givenSiteId );
+	const siteId = selectedSite ? selectedSite.ID || 0 : 0;
+
+	if ( 0 === siteId ) {
+		window.location = '/stats';
+		return next();
+	}
+
+	context.primary = <StatsEmailSummary />;
 
 	next();
 }

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -15,6 +15,7 @@ import {
 	redirectToDefaultSitePage,
 	redirectToDefaultWordAdsPeriod,
 	emailStats,
+	emailSummary,
 } from './controller';
 
 import './style.scss';
@@ -85,6 +86,7 @@ export default function () {
 			`/stats/email/:statType/:period(${ validEmailPeriods })/:email_id/:site`,
 			emailStats
 		);
+		statsPage( `/stats/day/emails/:site`, emailSummary );
 	}
 
 	// Anything else should redirect to default stats page

--- a/client/my-sites/stats/stats-email-summary/index.js
+++ b/client/my-sites/stats/stats-email-summary/index.js
@@ -1,0 +1,16 @@
+import './style.scss';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+const StatsEmailSummary = () => {
+	return <p>Email summary placeholder</p>;
+};
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		siteId: getSelectedSiteId( state ),
+		siteSlug: getSelectedSiteSlug( state, siteId ),
+	};
+} )( localize( StatsEmailSummary ) );

--- a/client/my-sites/stats/stats-email-summary/style.scss
+++ b/client/my-sites/stats/stats-email-summary/style.scss
@@ -1,0 +1,1 @@
+@import "@wordpress/base-styles/breakpoints";


### PR DESCRIPTION
## Proposed Changes

This PR adds a route for the email summary page (the page you go to when you click `View more` on the card).

## Testing Instructions

* Apply this PR
* Visit `/stats/day/emails/<yoursite>?flags=newsletter/stats`
* You should be greeted with this placeholder:

<img width="682" alt="CleanShot 2023-02-09 at 11 39 39@2x" src="https://user-images.githubusercontent.com/528287/217789608-7de32aec-9c92-42e8-a575-80286fb08a1d.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
