### PR TITLE
Copy Site: Remove the uneccessary filtering that causing marketplace themes to filtered out

### DIFF
--- a/client/landing/stepper/hooks/use-site-copy.tsx
+++ b/client/landing/stepper/hooks/use-site-copy.tsx
@@ -85,10 +85,6 @@ export const useSiteCopy = (
 					[ 'marketplace_plugin', 'marketplace_theme' ].includes( purchase.productType ) &&
 					purchase.siteId === site?.ID
 			)
-			.filter(
-				( purchase ) =>
-					purchase.productType === 'marketplace_plugin' && purchase.siteId === site?.ID
-			)
 			.map( ( purchase ) => ( { product_slug: purchase.productSlug } ) );
 
 		setProductCartItems( marketplacePluginProducts );


### PR DESCRIPTION
Accidentally we filtered out the marketplace themes in `use-site-copy` hook. This pr solves that. It was due to merge leftovers: https://github.com/Automattic/wp-calypso/pull/72868#discussion_r1101327701

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
