### PR TITLE
Used fixed history to navigate back at the new domain flow

### DIFF
--- a/client/my-sites/domains/components/domain-and-plan-package/navigation/index.jsx
+++ b/client/my-sites/domains/components/domain-and-plan-package/navigation/index.jsx
@@ -1,5 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 
 import './style.scss';
 
@@ -7,7 +8,11 @@ export default function DomainAndPlanPackageNavigation( props ) {
 	const translate = useTranslate();
 
 	const goBack = () => {
-		window.history.go( -1 );
+		if ( props.goBackLink ) {
+			page( props.goBackLink );
+		} else {
+			window.history.go( -1 );
+		}
 	};
 
 	const step = props.step ? props.step : 1;

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -277,7 +277,10 @@ class DomainSearch extends Component {
 						<div className="domains__header">
 							{ domainSidebarExperimentUser && (
 								<>
-									<DomainAndPlanPackageNavigation step={ 1 } />
+									<DomainAndPlanPackageNavigation
+										goBackLink={ domainManagementList( selectedSiteSlug ) }
+										step={ 1 }
+									/>
 									<FormattedHeader
 										brandFont
 										headerText={ translate( 'Claim your domain' ) }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -281,6 +281,9 @@ class Plans extends Component {
 		const yourDomainName = allDomains.length
 			? allDomains.slice( -1 )[ 0 ]?.meta
 			: translate( 'your domain name' );
+		const goBackLink = addQueryArgs( `/domains/add/${ selectedSite.slug }`, {
+			domainAndPlanPackage: true,
+		} );
 
 		return (
 			<div className={ is2023OnboardingPricingGrid ? 'is-2023-pricing-grid' : '' }>
@@ -309,7 +312,7 @@ class Plans extends Component {
 							{ domainSidebarExperimentUser && (
 								<>
 									<div className="plans__header">
-										<DomainAndPlanPackageNavigation step={ 2 } />
+										<DomainAndPlanPackageNavigation goBackLink={ goBackLink } step={ 2 } />
 
 										<FormattedHeader
 											brandFont


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* We're using fixed navigation history instead of relying at browser default back history.

Bug:

https://user-images.githubusercontent.com/1044309/217806028-0802a6af-4d3d-47dd-9590-0f844f8177de.mp4



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the video flow and make sure the problem doesn't happen anymore

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
