### PR TITLE
Virtual themes: Show previews

### DIFF
--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -35,7 +35,7 @@ export const getDesignPreviewUrl = (
 		source_site: 'patternboilerplates.wordpress.com',
 		use_screenshot_overrides: options.use_screenshot_overrides,
 		remove_assets: options.remove_assets,
-		...( is_virtual && style_variation && { style_variation: style_variation.slug } ),
+		...( is_virtual && style_variation && { style_variation: style_variation.title } ),
 	} );
 
 	// The preview url is sometimes used in a `background-image: url()` CSS rule and unescaped

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -10,7 +10,7 @@ export const getDesignPreviewUrl = (
 	design: Design,
 	options: DesignPreviewOptions = {}
 ): string => {
-	const { recipe, slug } = design;
+	const { recipe, slug, is_virtual, style_variation } = design;
 
 	//Anchor.fm themes get previews from their starter sites, ${slug}starter.wordpress.com
 	if ( [ 'hannah', 'riley', 'gilbert' ].indexOf( slug ) >= 0 ) {
@@ -35,6 +35,7 @@ export const getDesignPreviewUrl = (
 		source_site: 'patternboilerplates.wordpress.com',
 		use_screenshot_overrides: options.use_screenshot_overrides,
 		remove_assets: options.remove_assets,
+		...( is_virtual && style_variation && { style_variation: style_variation.slug } ),
 	} );
 
 	// The preview url is sometimes used in a `background-image: url()` CSS rule and unescaped


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1603.
Requires https://github.com/Automattic/wp-calypso/pull/73109.

## Proposed Changes

The designs grid displays now actual previews of virtual themes. They are generated by the `block-previews` endpoint which has been updated to support specific style variations (see D100749-code and D100858-code).

<img width="1237" alt="Screenshot 2023-02-09 at 15 54 01" src="https://user-images.githubusercontent.com/1233880/217850188-92c124e6-162e-4ab1-adb7-09ecda8ee46b.png">


## Testing Instructions

- Use the Calypso live link below.
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>&flags=virtual-themes/onboarding`.
- Make sure the designs grid displays actual previews of virtual themes.

If you don't see the correct previews, note that the API caches the images pretty aggressively, so you might need to a query param to bypass it:

```
diff --git a/packages/design-picker/src/utils/designs.ts b/packages/design-picker/src/utils/designs.ts
index cc98ee89d8..7bf9b9ae58 100644
--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -36,6 +36,7 @@ export const getDesignPreviewUrl = (
                use_screenshot_overrides: options.use_screenshot_overrides,
                remove_assets: options.remove_assets,
                ...( is_virtual && style_variation && { style_variation: style_variation.title } ),
+               temp: 1,
        } );
 
        // The preview url is sometimes used in a `background-image: url()` CSS rule and unescaped
```