### PR TITLE
i18N: Translate colors in the newsletter sign-up flow.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -60,31 +60,31 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 	const getColorOptions = useCallback(
 		(): ColorOption[] => [
 			{
-				label: 'Lettre',
+				label: __( 'Lettre' ),
 				value: COLORS.Lettre,
 				icon: <ColorSwatch color={ COLORS.Lettre } />,
 				isPremium: false,
 			},
 			{
-				label: 'Black',
+				label: __( 'Black' ),
 				value: COLORS.Black,
 				icon: <ColorSwatch color={ COLORS.Black } />,
 				isPremium: shouldLimitGlobalStyles,
 			},
 			{
-				label: 'Vivid red',
+				label: __( 'Vivid red' ),
 				value: COLORS.VividRed,
 				icon: <ColorSwatch color={ COLORS.VividRed } />,
 				isPremium: shouldLimitGlobalStyles,
 			},
 			{
-				label: 'Vivid purple',
+				label: __( 'Vivid purple' ),
 				value: COLORS.VividPurple,
 				icon: <ColorSwatch color={ COLORS.VividPurple } />,
 				isPremium: shouldLimitGlobalStyles,
 			},
 			{
-				label: 'Custom',
+				label: __( 'Custom' ),
 				value: 'custom',
 				icon: <Icon className="custom_color_icon" icon={ color } width={ 22 } height={ 22 } />,
 				isPremium: shouldLimitGlobalStyles,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

In the newsletter signup flow (https://wordpress.com/setup/newsletter/newsletterSetup). the color names aren't translated. This PR wraps the strings in the translation function. 

## Testing Instructions
- Set one of the Mag16 languages for your account
Visit `setup/newsletter/newsletterSetup` and confirm that the color names are now translated.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
