### PR TITLE
Copy Site: `resetOnboardStore()` when initializing Stepper

### DIFF
--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -75,10 +75,12 @@ const copySite: Flow = {
 	},
 
 	useSteps() {
+		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
 		useEffect( () => {
+			resetOnboardStore();
 			recordTracksEvent( 'calypso_signup_start', { flow: this.name } );
 			recordFullStoryEvent( 'calypso_signup_start_copy_site', { flow: this.name } );
-		}, [] );
+		}, [ resetOnboardStore ] );
 
 		const urlQueryParams = useQuery();
 		const siteSlug = urlQueryParams.get( 'siteSlug' );

--- a/client/landing/stepper/hooks/use-site-copy.tsx
+++ b/client/landing/stepper/hooks/use-site-copy.tsx
@@ -66,7 +66,7 @@ export const useSiteCopy = (
 
 	const purchases = useSelector( ( state ) => getUserPurchases( state ) );
 
-	const { setPlanCartItem, setProductCartItems, resetOnboardStore } = useDispatch( ONBOARD_STORE );
+	const { setPlanCartItem, setProductCartItems } = useDispatch( ONBOARD_STORE );
 
 	const shouldShowSiteCopyItem = useMemo( () => {
 		return hasCopySiteFeature && isSiteOwner && plan && isAtomic && ! isLoadingPurchases;
@@ -76,7 +76,6 @@ export const useSiteCopy = (
 		if ( ! shouldShowSiteCopyItem ) {
 			return;
 		}
-		resetOnboardStore();
 		clearSignupDestinationCookie();
 		setPlanCartItem( { product_slug: plan?.product_slug as string } );
 
@@ -89,15 +88,7 @@ export const useSiteCopy = (
 			.map( ( purchase ) => ( { product_slug: purchase.productSlug } ) );
 
 		setProductCartItems( marketplacePluginProducts );
-	}, [
-		plan,
-		setPlanCartItem,
-		purchases,
-		shouldShowSiteCopyItem,
-		setProductCartItems,
-		resetOnboardStore,
-		site?.ID,
-	] );
+	}, [ plan, setPlanCartItem, purchases, shouldShowSiteCopyItem, setProductCartItems, site?.ID ] );
 
 	return useMemo(
 		() => ( {

--- a/client/landing/stepper/hooks/use-site-copy.tsx
+++ b/client/landing/stepper/hooks/use-site-copy.tsx
@@ -66,7 +66,7 @@ export const useSiteCopy = (
 
 	const purchases = useSelector( ( state ) => getUserPurchases( state ) );
 
-	const { setPlanCartItem, setProductCartItems } = useDispatch( ONBOARD_STORE );
+	const { setPlanCartItem, setProductCartItems, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
 	const shouldShowSiteCopyItem = useMemo( () => {
 		return hasCopySiteFeature && isSiteOwner && plan && isAtomic && ! isLoadingPurchases;
@@ -76,6 +76,7 @@ export const useSiteCopy = (
 		if ( ! shouldShowSiteCopyItem ) {
 			return;
 		}
+		resetOnboardStore();
 		clearSignupDestinationCookie();
 		setPlanCartItem( { product_slug: plan?.product_slug as string } );
 
@@ -88,7 +89,15 @@ export const useSiteCopy = (
 			.map( ( purchase ) => ( { product_slug: purchase.productSlug } ) );
 
 		setProductCartItems( marketplacePluginProducts );
-	}, [ plan, setPlanCartItem, purchases, shouldShowSiteCopyItem, setProductCartItems, site?.ID ] );
+	}, [
+		plan,
+		setPlanCartItem,
+		purchases,
+		shouldShowSiteCopyItem,
+		setProductCartItems,
+		resetOnboardStore,
+		site?.ID,
+	] );
 
 	return useMemo(
 		() => ( {


### PR DESCRIPTION
## Proposed Changes

Ensure the domain search form starts out as empty by calling `resetOnboardStore()` when initializing Stepper

See p1675772784687109-slack-C04GESRBWKW

## Testing Instructions

1. Initiate Copy Site flow for a Business site and enter a domain search term.
2. Navigate back to Sites.
3. Initiate Copy Site flow for a different Business site.
4. Verify the original domain search term doesn't appear in the form.