### PR TITLE
VAT Info Page: Add logging for errors while fetching VAT details

### DIFF
--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -285,7 +285,10 @@ function useRecordVatEvents( {
 	useEffect( () => {
 		if ( fetchError && lastFetchError.current !== fetchError ) {
 			reduxDispatch(
-				recordTracksEvent( 'calypso_vat_details_fetch_failure', { error: fetchError.error } )
+				recordTracksEvent( 'calypso_vat_details_fetch_failure', {
+					error: fetchError.error,
+					message: fetchError.message,
+				} )
 			);
 			lastFetchError.current = fetchError;
 			return;

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -1,7 +1,6 @@
 import { CompactCard, Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
-import * as React from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -280,19 +279,23 @@ function useRecordVatEvents( {
 	isUpdateSuccessful?: boolean;
 } ) {
 	const reduxDispatch = useDispatch();
+	const lastFetchError = useRef< FetchError >();
+	const lastUpdateError = useRef< UpdateError >();
 
 	useEffect( () => {
-		if ( fetchError ) {
+		if ( fetchError && lastFetchError.current !== fetchError ) {
 			reduxDispatch(
 				recordTracksEvent( 'calypso_vat_details_fetch_failure', { error: fetchError.error } )
 			);
+			lastFetchError.current = fetchError;
 			return;
 		}
 
-		if ( updateError ) {
+		if ( updateError && lastUpdateError.current !== updateError ) {
 			reduxDispatch(
 				recordTracksEvent( 'calypso_vat_details_validation_failure', { error: updateError.error } )
 			);
+			lastUpdateError.current = updateError;
 			return;
 		}
 

--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -10,12 +10,17 @@ export interface UpdateError {
 	error: string;
 }
 
+export interface FetchError {
+	message: string;
+	error: string;
+}
+
 export interface VatDetailsManager {
 	vatDetails: VatDetails;
 	isLoading: boolean;
 	isUpdating: boolean;
 	isUpdateSuccessful: boolean;
-	fetchError: Error | null;
+	fetchError: FetchError | null;
 	updateError: UpdateError | null;
 	setVatDetails: SetVatDetails;
 }
@@ -35,7 +40,7 @@ const emptyVatDetails = {};
 
 export default function useVatDetails(): VatDetailsManager {
 	const queryClient = useQueryClient();
-	const query = useQuery< VatDetails, Error >( 'vat-details', fetchVatDetails );
+	const query = useQuery< VatDetails, FetchError >( 'vat-details', fetchVatDetails );
 	const mutation = useMutation< VatDetails, UpdateError, VatDetails >( setVatDetails, {
 		onSuccess: ( data ) => {
 			queryClient.setQueryData( 'vat-details', data );


### PR DESCRIPTION
When we load the `/me/purchases/vat-details` page, an API request is made to the `/me/vat-info` API endpoint. If that request fails, we do not log it anywhere. If the form on that page is used to change the VAT details, and the update fails, we do log that error.

Recently we've gotten several reports of the GET request failing without an obvious cause. See pNPgK-6n6-p2

Here's what the user sees:

<img width="614" alt="Screenshot 2023-02-09 at 1 06 13 PM" src="https://user-images.githubusercontent.com/2036909/217904182-64654a50-2c32-4835-800a-9a8a6ea2f446.png">

## Proposed Changes

In this PR we add logging for the fetch error as well. (While not required, D100880-code will improve the error message that we get.)

## Testing Instructions

- Sandbox the API and add a fatal error the the `/me/vat-info` GET endpoint.
- Visit `/me/purchases/vat-details`.
- In the JS console, run `localStorage.setItem('debug', 'calypso:analytics')` and reload the page to activate the additional logging.
- Verify that you see the `calypso_vat_details_fetch_failure` error logged. (It will include the error message you added if D100880-code is also applied but it should log regardless.)

<img width="592" alt="Screenshot 2023-02-09 at 1 24 43 PM" src="https://user-images.githubusercontent.com/2036909/217904087-e2823576-e44f-4cbe-a7a3-2c81768a5d75.png">
