### PR TITLE
Limited Image width on marketing tools page

### DIFF
--- a/client/my-sites/marketing/tools/style.scss
+++ b/client/my-sites/marketing/tools/style.scss
@@ -117,7 +117,8 @@
 
 .tools__feature-list-item-body-image {
 	margin: 10px 20px 0 0;
-	max-width: 150px;
+	max-width: 75px;
+	max-height: 75px;
 	width: 16%;
 
 	@include breakpoint-deprecated( ">1040px" ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Slack thread: p1675946484388459/1675944986.651119-slack-CKZHG0QCR

## Proposed Changes

* We want to have images with the same width/height on the marketing > tools page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access /marketing/tools and make sure the images have the same max size:

![image](https://user-images.githubusercontent.com/1044309/217888144-ae6b7411-d077-4dd3-9793-e8781c8de06e.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?