### PR TITLE
[WordAds] Update ad dashboard for free sites removed from wordads

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -239,6 +239,11 @@ class ManagePurchase extends Component {
 		return hasNonPrimaryDomainsFlag && isPlan( purchase ) && hasCustomPrimaryDomain;
 	}
 
+	shouldShowWordAdsEligibilityWarning() {
+		const { hasSetupAds, purchase } = this.props;
+		return hasSetupAds && isPlan( purchase );
+	}
+
 	renderRenewButton() {
 		const { purchase, translate } = this.props;
 
@@ -480,6 +485,7 @@ class ManagePurchase extends Component {
 				hasLoadedSites={ hasLoadedSites }
 				hasLoadedUserPurchasesFromServer={ this.props.hasLoadedPurchasesFromServer }
 				hasNonPrimaryDomainsFlag={ hasNonPrimaryDomainsFlag }
+				hasSetupAds={ this.props.hasSetupAds }
 				hasCustomPrimaryDomain={ hasCustomPrimaryDomain }
 				activeSubscriptions={ this.getActiveMarketplaceSubscriptions() }
 				site={ site }
@@ -706,7 +712,7 @@ class ManagePurchase extends Component {
 				link_text: text,
 			} );
 
-			if ( this.props.hasSetupAds ) {
+			if ( this.shouldShowWordAdsEligibilityWarning() ) {
 				event.preventDefault();
 				this.showWordAdsEligibilityWarningDialog( link );
 			}

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -111,6 +111,7 @@ import { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors';
 import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isRequestingWordAdsApprovalForSite } from 'calypso/state/wordads/approve/selectors';
 import { cancelPurchase, managePurchase, purchasesRoot } from '../paths';
 import PurchaseSiteHeader from '../purchases-site/header';
 import RemovePurchase from '../remove-purchase';
@@ -546,6 +547,7 @@ class ManagePurchase extends Component {
 					planName={ getName( purchase ) }
 					oldDomainName={ site.domain }
 					newDomainName={ site.wpcom_url }
+					hasSetupAds={ this.props.hasSetupAds }
 				/>
 			);
 		}
@@ -1210,6 +1212,7 @@ export default connect(
 		const relatedMonthlyPlanSlug = getMonthlyPlanByYearly( purchase?.productSlug );
 		const relatedMonthlyPlanPrice = getSitePlanRawPrice( state, siteId, relatedMonthlyPlanSlug );
 		const primaryDomain = getPrimaryDomainBySiteId( state, siteId );
+
 		return {
 			hasLoadedDomains,
 			hasLoadedSites,
@@ -1220,6 +1223,9 @@ export default connect(
 				? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
 				: false,
 			hasCustomPrimaryDomain: hasCustomDomain( site ),
+			hasSetupAds: Boolean(
+				site?.options?.wordads || isRequestingWordAdsApprovalForSite( state, site )
+			),
 			productsList,
 			purchase,
 			purchases,

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -86,6 +86,7 @@ import { PreCancellationDialog } from 'calypso/me/purchases/pre-cancellation-dia
 import ProductLink from 'calypso/me/purchases/product-link';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
+import WordAdsEligibilityWarningDialog from 'calypso/me/purchases/wordads-eligibility-warning-dialog';
 import PlanPrice from 'calypso/my-sites/plan-price';
 import PlanRenewalMessage from 'calypso/my-sites/plans/jetpack-plans/plan-renewal-message';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
@@ -168,6 +169,7 @@ class ManagePurchase extends Component {
 	state = {
 		showNonPrimaryDomainWarningDialog: false,
 		showRemoveSubscriptionWarningDialog: false,
+		showWordAdsEligibilityWarningDialog: false,
 		cancelLink: null,
 		isRemoving: false,
 		isCancelSurveyVisible: false,
@@ -505,6 +507,18 @@ class ManagePurchase extends Component {
 		this.setState( {
 			showNonPrimaryDomainWarningDialog: false,
 			showRemoveSubscriptionWarningDialog: true,
+			showWordAdsEligibilityWarningDialog: false,
+			isRemoving: false,
+			isCancelSurveyVisible: false,
+			cancelLink,
+		} );
+	}
+
+	showWordAdsEligibilityWarningDialog( cancelLink ) {
+		this.setState( {
+			showNonPrimaryDomainWarningDialog: false,
+			showRemoveSubscriptionWarningDialog: false,
+			showWordAdsEligibilityWarningDialog: true,
 			isRemoving: false,
 			isCancelSurveyVisible: false,
 			cancelLink,
@@ -515,6 +529,7 @@ class ManagePurchase extends Component {
 		this.setState( {
 			showNonPrimaryDomainWarningDialog: false,
 			showRemoveSubscriptionWarningDialog: false,
+			showWordAdsEligibilityWarningDialog: false,
 			isRemoving: false,
 			isCancelSurveyVisible: true,
 			cancelLink,
@@ -525,6 +540,7 @@ class ManagePurchase extends Component {
 		this.setState( {
 			showNonPrimaryDomainWarningDialog: false,
 			showRemoveSubscriptionWarningDialog: false,
+			showWordAdsEligibilityWarningDialog: false,
 			isRemoving: false,
 			isCancelSurveyVisible: false,
 			cancelLink: null,
@@ -548,6 +564,21 @@ class ManagePurchase extends Component {
 					oldDomainName={ site.domain }
 					newDomainName={ site.wpcom_url }
 					hasSetupAds={ this.props.hasSetupAds }
+				/>
+			);
+		}
+
+		return null;
+	}
+
+	renderWordAdsEligibilityWarningDialog( purchase ) {
+		if ( this.state.showWordAdsEligibilityWarningDialog ) {
+			return (
+				<WordAdsEligibilityWarningDialog
+					isDialogVisible={ this.state.showWordAdsEligibilityWarningDialog }
+					closeDialog={ this.closeDialog }
+					removePlan={ this.goToCancelLink }
+					planName={ getName( purchase ) }
 				/>
 			);
 		}
@@ -677,6 +708,11 @@ class ManagePurchase extends Component {
 			if ( this.shouldShowNonPrimaryDomainWarning() ) {
 				event.preventDefault();
 				this.showNonPrimaryDomainWarningDialog( link );
+			}
+
+			if ( this.props.hasSetupAds ) {
+				event.preventDefault();
+				this.showWordAdsEligibilityWarningDialog( link );
 			}
 
 			if ( isSubscription( purchase ) ) {
@@ -1127,6 +1163,7 @@ class ManagePurchase extends Component {
 					purchase={ this.props.purchase }
 				/>
 				{ this.renderPurchaseDetail( preventRenewal ) }
+				{ this.renderWordAdsEligibilityWarningDialog( purchase ) }
 				{ site && this.renderNonPrimaryDomainWarningDialog( site, purchase ) }
 				{ site && this.renderRemoveSubscriptionWarningDialog( site, purchase ) }
 			</Fragment>

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -497,6 +497,7 @@ class ManagePurchase extends Component {
 		this.setState( {
 			showNonPrimaryDomainWarningDialog: true,
 			showRemoveSubscriptionWarningDialog: false,
+			showWordAdsEligibilityWarningDialog: false,
 			isRemoving: false,
 			isCancelSurveyVisible: false,
 			cancelLink,
@@ -705,14 +706,14 @@ class ManagePurchase extends Component {
 				link_text: text,
 			} );
 
-			if ( this.shouldShowNonPrimaryDomainWarning() ) {
-				event.preventDefault();
-				this.showNonPrimaryDomainWarningDialog( link );
-			}
-
 			if ( this.props.hasSetupAds ) {
 				event.preventDefault();
 				this.showWordAdsEligibilityWarningDialog( link );
+			}
+
+			if ( this.shouldShowNonPrimaryDomainWarning() ) {
+				event.preventDefault();
+				this.showNonPrimaryDomainWarningDialog( link );
 			}
 
 			if ( isSubscription( purchase ) ) {

--- a/client/me/purchases/non-primary-domain-dialog/index.jsx
+++ b/client/me/purchases/non-primary-domain-dialog/index.jsx
@@ -76,24 +76,30 @@ class NonPrimaryDomainDialog extends Component {
 									strong: <strong />,
 								},
 							}
+						) }{ ' ' }
+						{ hasSetupAds && (
+							<>
+								<br />
+								<br />
+								{ translate(
+									'You will also be ineligible for the WordAds program. Visit {{a}}our FAQ{{/a}} to learn more.',
+									{
+										components: {
+											a: (
+												<a
+													href="https://wordads.co/faq/#eligibility-for-wordads"
+													target="_blank"
+													rel="noopener noreferrer"
+												/>
+											),
+										},
+									}
+								) }
+								<br />
+								<br />
+							</>
 						) }
-						{ hasSetupAds &&
-							translate(
-								'{{br/}}{{br/}}You will also be ineligible for the WordAds program. Visit {{a}}our FAQ{{/a}} to learn more.{{br/}}{{br/}}',
-								{
-									components: {
-										a: (
-											<a
-												href="https://wordads.co/faq/#eligibility-for-wordads"
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-										br: <br />,
-									},
-								}
-							) }
-						{ translate( ' Would you still like to downgrade your plan?' ) }
+						{ translate( 'Would you still like to downgrade your plan?' ) }
 					</p>
 				</Fragment>
 			</Dialog>

--- a/client/me/purchases/non-primary-domain-dialog/index.jsx
+++ b/client/me/purchases/non-primary-domain-dialog/index.jsx
@@ -11,6 +11,7 @@ class NonPrimaryDomainDialog extends Component {
 		planName: PropTypes.string.isRequired,
 		oldDomainName: PropTypes.string.isRequired,
 		newDomainName: PropTypes.string.isRequired,
+		hasSetupAds: PropTypes.bool,
 	};
 
 	close = () => {
@@ -22,7 +23,7 @@ class NonPrimaryDomainDialog extends Component {
 	};
 
 	render() {
-		const { planName, oldDomainName, newDomainName, translate } = this.props;
+		const { planName, oldDomainName, newDomainName, translate, hasSetupAds } = this.props;
 		const buttons = [
 			{
 				action: 'cancel',
@@ -66,8 +67,7 @@ class NonPrimaryDomainDialog extends Component {
 						) }
 						<br />
 						{ translate(
-							'{{strong}}%(newDomain)s{{/strong}} will be the address that people see when they visit ' +
-								'your site. Would you still like to downgrade your plan?',
+							'{{strong}}%(newDomain)s{{/strong}} will be the address that people see when they visit your site.',
 							{
 								args: {
 									newDomain: newDomainName,
@@ -77,6 +77,23 @@ class NonPrimaryDomainDialog extends Component {
 								},
 							}
 						) }
+						{ hasSetupAds &&
+							translate(
+								'{{br/}}{{br/}}You will also be ineligible for the WordAds program. Visit {{a}}our FAQ{{/a}} to learn more.{{br/}}{{br/}}',
+								{
+									components: {
+										a: (
+											<a
+												href="https://wordads.co/faq/#eligibility-for-wordads"
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+										br: <br />,
+									},
+								}
+							) }
+						{ translate( ' Would you still like to downgrade your plan?' ) }
 					</p>
 				</Fragment>
 			</Dialog>

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -451,7 +451,6 @@ class RemovePurchase extends Component {
 				return this.renderMarketplaceSubscriptionsDialog();
 			}
 
-			// consider putting this last so that it doesn't block the other dialogs
 			if ( this.shouldShowWordAdsEligibilityWarning() ) {
 				return this.renderWordAdsEligibilityWarningDialog();
 			}

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -25,6 +25,7 @@ import GSuiteCancellationPurchaseDialog from 'calypso/components/marketing-surve
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { getName, isRemovable } from 'calypso/lib/purchases';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
+import WordAdsEligibilityWarningDialog from 'calypso/me/purchases/wordads-eligibility-warning-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
@@ -48,6 +49,7 @@ class RemovePurchase extends Component {
 	static propTypes = {
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
 		hasNonPrimaryDomainsFlag: PropTypes.bool,
+		hasSetupAds: PropTypes.bool,
 		isDomainOnlySite: PropTypes.bool,
 		hasCustomPrimaryDomain: PropTypes.bool,
 		receiveDeletedSite: PropTypes.func.isRequired,
@@ -74,6 +76,7 @@ class RemovePurchase extends Component {
 		isShowingNonPrimaryDomainWarning: false,
 		isShowingMarketplaceSubscriptionsDialog: false,
 		isShowingPreCancellationDialog: false,
+		isShowingWordAdsEligibilityWarningDialog: false,
 	};
 
 	closeDialog = () => {
@@ -82,6 +85,7 @@ class RemovePurchase extends Component {
 			isShowingNonPrimaryDomainWarning: false,
 			isShowingMarketplaceSubscriptionsDialog: false,
 			isShowingPreCancellationDialog: false,
+			isShowingWordAdsEligibilityWarningDialog: false,
 		} );
 	};
 
@@ -90,6 +94,7 @@ class RemovePurchase extends Component {
 			isShowingMarketplaceSubscriptionsDialog: false,
 			isShowingNonPrimaryDomainWarning: false,
 			isShowingPreCancellationDialog: false,
+			isShowingWordAdsEligibilityWarningDialog: false,
 			isDialogVisible: true,
 		} );
 	};
@@ -105,6 +110,7 @@ class RemovePurchase extends Component {
 				isShowingNonPrimaryDomainWarning: false,
 				isShowingMarketplaceSubscriptionsDialog: false,
 				isShowingPreCancellationDialog: true,
+				isShowingWordAdsEligibilityWarningDialog: false,
 				isDialogVisible: false,
 			} );
 		} else if (
@@ -115,6 +121,7 @@ class RemovePurchase extends Component {
 				isShowingNonPrimaryDomainWarning: true,
 				isShowingMarketplaceSubscriptionsDialog: false,
 				isShowingPreCancellationDialog: false,
+				isShowingWordAdsEligibilityWarningDialog: false,
 				isDialogVisible: false,
 			} );
 		} else if (
@@ -125,6 +132,18 @@ class RemovePurchase extends Component {
 				isShowingNonPrimaryDomainWarning: false,
 				isShowingMarketplaceSubscriptionsDialog: true,
 				isShowingPreCancellationDialog: false,
+				isShowingWordAdsEligibilityWarningDialog: false,
+				isDialogVisible: false,
+			} );
+		} else if (
+			this.shouldShowWordAdsEligibilityWarning() &&
+			! this.state.isShowingWordAdsEligibilityWarningDialog
+		) {
+			this.setState( {
+				isShowingNonPrimaryDomainWarning: false,
+				isShowingMarketplaceSubscriptionsDialog: false,
+				isShowingPreCancellationDialog: false,
+				isShowingWordAdsEligibilityWarningDialog: true,
 				isDialogVisible: false,
 			} );
 		} else {
@@ -132,6 +151,7 @@ class RemovePurchase extends Component {
 				isShowingNonPrimaryDomainWarning: false,
 				isShowingMarketplaceSubscriptionsDialog: false,
 				isShowingPreCancellationDialog: false,
+				isShowingWordAdsEligibilityWarningDialog: false,
 				isDialogVisible: true,
 			} );
 		}
@@ -216,8 +236,13 @@ class RemovePurchase extends Component {
 		);
 	}
 
+	shouldShowWordAdsEligibilityWarning() {
+		const { hasSetupAds, purchase } = this.props;
+		return hasSetupAds && isPlan( purchase );
+	}
+
 	renderNonPrimaryDomainWarningDialog() {
-		const { purchase, site } = this.props;
+		const { hasSetupAds, purchase, site } = this.props;
 		return (
 			<NonPrimaryDomainDialog
 				isDialogVisible={ this.state.isShowingNonPrimaryDomainWarning }
@@ -226,6 +251,19 @@ class RemovePurchase extends Component {
 				planName={ getName( purchase ) }
 				oldDomainName={ site.domain }
 				newDomainName={ site.wpcom_url }
+				hasSetupAds={ hasSetupAds }
+			/>
+		);
+	}
+
+	renderWordAdsEligibilityWarningDialog() {
+		const { purchase } = this.props;
+		return (
+			<WordAdsEligibilityWarningDialog
+				isDialogVisible={ this.state.isShowingWordAdsEligibilityWarningDialog }
+				closeDialog={ this.closeDialog }
+				removePlan={ this.showRemovePlanDialog }
+				planName={ getName( purchase ) }
 			/>
 		);
 	}
@@ -411,6 +449,11 @@ class RemovePurchase extends Component {
 
 			if ( this.shouldHandleMarketplaceSubscriptions() ) {
 				return this.renderMarketplaceSubscriptionsDialog();
+			}
+
+			// consider putting this last so that it doesn't block the other dialogs
+			if ( this.shouldShowWordAdsEligibilityWarning() ) {
+				return this.renderWordAdsEligibilityWarningDialog();
 			}
 
 			return null;

--- a/client/me/purchases/wordads-eligibility-warning-dialog/index.jsx
+++ b/client/me/purchases/wordads-eligibility-warning-dialog/index.jsx
@@ -1,0 +1,64 @@
+import { Dialog } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+
+import './style.scss';
+
+const WordAdsEligibilityWarningDialog = ( {
+	closeDialog,
+	isDialogVisible,
+	planName,
+	removePlan,
+} ) => {
+	const translate = useTranslate();
+
+	const buttons = [
+		{
+			action: 'cancel',
+			label: translate( 'Cancel' ),
+		},
+		{
+			action: 'remove',
+			isPrimary: true,
+			label: translate( 'Remove Plan' ),
+			onClick: removePlan,
+		},
+	];
+
+	return (
+		<Dialog
+			buttons={ buttons }
+			className="wordads-eligibility-warning-dialog"
+			isVisible={ isDialogVisible }
+			onClose={ closeDialog }
+		>
+			<>
+				<FormSectionHeading>
+					{ translate( 'Remove %(plan)s', {
+						args: { plan: planName },
+					} ) }
+				</FormSectionHeading>
+				<p>
+					{ translate(
+						'When you downgrade your plan, you will become ineligible for the WordAds program. Visit {{a}}our FAQ{{/a}} to learn more.{{br/}}{{br/}}',
+						{
+							components: {
+								a: (
+									<a
+										href="https://wordads.co/faq/#eligibility-for-wordads"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+								br: <br />,
+							},
+						}
+					) }
+					{ translate( ' Would you still like to downgrade your plan?' ) }
+				</p>
+			</>
+		</Dialog>
+	);
+};
+
+export default WordAdsEligibilityWarningDialog;

--- a/client/me/purchases/wordads-eligibility-warning-dialog/index.jsx
+++ b/client/me/purchases/wordads-eligibility-warning-dialog/index.jsx
@@ -40,7 +40,7 @@ const WordAdsEligibilityWarningDialog = ( {
 				</FormSectionHeading>
 				<p>
 					{ translate(
-						'When you downgrade your plan, you will become ineligible for the WordAds program. Visit {{a}}our FAQ{{/a}} to learn more.{{br/}}{{br/}}',
+						'When you downgrade your plan, you will become ineligible for the WordAds program. Visit {{a}}our FAQ{{/a}} to learn more.',
 						{
 							components: {
 								a: (
@@ -54,7 +54,9 @@ const WordAdsEligibilityWarningDialog = ( {
 							},
 						}
 					) }
-					{ translate( ' Would you still like to downgrade your plan?' ) }
+					<br />
+					<br />
+					{ translate( 'Would you still like to downgrade your plan?' ) }
 				</p>
 			</>
 		</Dialog>

--- a/client/me/purchases/wordads-eligibility-warning-dialog/style.scss
+++ b/client/me/purchases/wordads-eligibility-warning-dialog/style.scss
@@ -1,0 +1,3 @@
+.wordads-eligibility-warning-dialog {
+	max-width: 500px;
+}

--- a/client/my-sites/earn/ads/form-settings.jsx
+++ b/client/my-sites/earn/ads/form-settings.jsx
@@ -404,7 +404,7 @@ class AdsFormSettings extends Component {
 							/>
 							<FormSettingExplanation>
 								{ translate(
-									'Adds a link to your privacy policy to the bottom of the sale opt-out notice popup (optional).'
+									'Adds a link to your privacy policy to the notice popup triggered by the do not sell link (optional).'
 								) }
 							</FormSettingExplanation>
 						</FormFieldset>

--- a/client/my-sites/earn/ads/types.tsx
+++ b/client/my-sites/earn/ads/types.tsx
@@ -1,0 +1,8 @@
+export enum WordAdsStatus {
+	approved = 'approved',
+	rejected = 'rejected',
+	active = 'active',
+	paused = 'paused',
+	withdrawn = 'withdrawn',
+	ineligible = 'ineligible',
+}

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -2,6 +2,7 @@ import {
 	PLAN_PREMIUM,
 	PLAN_JETPACK_SECURITY_DAILY,
 	WPCOM_FEATURES_WORDADS,
+	FEATURE_WORDADS_INSTANT,
 } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
@@ -189,9 +190,9 @@ class AdsWrapper extends Component {
 	}
 
 	renderUpsell( options = {} ) {
-		const { forceDisplay = false } = options;
+		const { forceDisplay = false, url } = options;
 		const { siteSlug, translate } = this.props;
-		const bannerURL = `/checkout/${ siteSlug }/premium`;
+		const bannerURL = url || `/checkout/${ siteSlug }/premium`;
 		return (
 			<UpsellNudge
 				forceDisplay={ forceDisplay }
@@ -255,13 +256,14 @@ class AdsWrapper extends Component {
 		);
 	}
 
-	renderContenWithUpsell( component ) {
-		const { section } = this.props;
+	renderContentWithUpsell( component ) {
+		const { section, siteSlug } = this.props;
 		const allowedSections = [ 'ads-earnings', 'ads-payments' ];
 		const isAllowedSection = allowedSections.includes( section );
+		const url = `/plans/${ siteSlug }?feature=${ FEATURE_WORDADS_INSTANT }&plan=${ PLAN_PREMIUM }`;
 		return (
 			<>
-				{ this.renderUpsell( { forceDisplay: true } ) }
+				{ this.renderUpsell( { forceDisplay: true, url } ) }
 				{ isAllowedSection ? component : <FeatureExample>{ component }</FeatureExample> }
 			</>
 		);
@@ -303,7 +305,7 @@ class AdsWrapper extends Component {
 		} else if ( site.options.wordads && site.is_private ) {
 			notice = this.renderNoticeSiteIsPrivate();
 		} else if ( hasIneligiblePlanforWordAds ) {
-			component = this.renderContenWithUpsell( component );
+			component = this.renderContentWithUpsell( component );
 		}
 
 		return (

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import wordAdsImage from 'calypso/assets/images/illustrations/dotcom-wordads.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import ActionCard from 'calypso/components/action-card';
+import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySites from 'calypso/components/data/query-sites';
 import QueryWordadsStatus from 'calypso/components/data/query-wordads-status';
 import EmptyContent from 'calypso/components/empty-content';
@@ -327,6 +328,7 @@ class AdsWrapper extends Component {
 		return (
 			<div>
 				<QuerySites siteId={ siteId } />
+				<QuerySiteFeatures siteIds={ [ siteId ] } />
 				<QueryWordadsStatus siteId={ siteId } />
 				{ notice }
 				{ component }

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -19,7 +19,7 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSiteWordadsStatus from 'calypso/state/selectors/get-site-wordads-status';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import siteHasWordAds from 'calypso/state/selectors/site-has-wordads';
 import { canAccessWordAds, isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
@@ -319,7 +319,7 @@ class AdsWrapper extends Component {
 const mapStateToProps = ( state ) => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
-	const hasWordAdsFeature = siteHasFeature( state, siteId, WPCOM_FEATURES_WORDADS );
+	const hasWordAdsFeature = siteHasWordAds( state, siteId );
 	const canActivateWordAds = canCurrentUser( state, siteId, 'activate_wordads' );
 
 	return {

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import wordAdsImage from 'calypso/assets/images/illustrations/dotcom-wordads.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import ActionCard from 'calypso/components/action-card';
+import QuerySites from 'calypso/components/data/query-sites';
 import QueryWordadsStatus from 'calypso/components/data/query-wordads-status';
 import EmptyContent from 'calypso/components/empty-content';
 import FeatureExample from 'calypso/components/feature-example';
@@ -325,6 +326,7 @@ class AdsWrapper extends Component {
 
 		return (
 			<div>
+				<QuerySites siteId={ siteId } />
 				<QueryWordadsStatus siteId={ siteId } />
 				{ notice }
 				{ component }

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -18,6 +18,7 @@ import FeatureExample from 'calypso/components/feature-example';
 import FormButton from 'calypso/components/forms/form-button';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
+import { WordAdsStatus } from 'calypso/my-sites/earn/ads/types';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSiteWordadsStatus from 'calypso/state/selectors/get-site-wordads-status';
 import siteHasWordAds from 'calypso/state/selectors/site-has-wordads';
@@ -334,7 +335,7 @@ const mapStateToProps = ( state ) => {
 		canUpgradeToUseWordAds: ! site.options.wordads && ! hasWordAdsFeature,
 		hasWordAdsFeature,
 		hasIneligiblePlanforWordAds:
-			! hasWordAdsFeature && getSiteWordadsStatus( state, siteId ) === 'ineligible',
+			! hasWordAdsFeature && getSiteWordadsStatus( state, siteId ) === WordAdsStatus.ineligible,
 		requestingWordAdsApproval: isRequestingWordAdsApprovalForSite( state, site ),
 		wordAdsError: getWordAdsErrorForSite( state, site ),
 		wordAdsSuccess: getWordAdsSuccessForSite( state, site ),

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -58,12 +58,10 @@ class AdsWrapper extends Component {
 	};
 
 	renderInstantActivationToggle( component ) {
-		const { siteId, translate, adsProgramName } = this.props;
+		const { translate, adsProgramName } = this.props;
 
 		return (
 			<div>
-				<QueryWordadsStatus siteId={ siteId } />
-
 				{ this.props.wordAdsError && (
 					<Notice
 						classname="ads__activate-notice"
@@ -294,6 +292,7 @@ class AdsWrapper extends Component {
 			isEnrolledWithIneligiblePlan,
 			isWordadsInstantEligibleButNotOwner,
 			site,
+			siteId,
 			translate,
 		} = this.props;
 
@@ -326,6 +325,7 @@ class AdsWrapper extends Component {
 
 		return (
 			<div>
+				<QueryWordadsStatus siteId={ siteId } />
 				{ notice }
 				{ component }
 			</div>

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -45,7 +45,7 @@ interface ConnectedProps {
 	isNonAtomicJetpack: boolean;
 	isLoading: boolean;
 	hasSimplePayments: boolean;
-	hasWordAds: boolean;
+	hasWordAdsFeature: boolean;
 	hasConnectedAccount: boolean | null;
 	hasSetupAds: boolean;
 	trackUpgrade: ( plan: string, feature: string ) => void;
@@ -66,7 +66,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	isUserAdmin,
 	isLoading,
 	hasSimplePayments,
-	hasWordAds,
+	hasWordAdsFeature,
 	hasConnectedAccount,
 	hasSetupAds,
 	eligibleForProPlan,
@@ -466,7 +466,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 */
 	const getAdsCard = () => {
 		const cta =
-			hasWordAds || hasSetupAds
+			hasWordAdsFeature || hasSetupAds
 				? {
 						text: hasSetupAds ? translate( 'View ad dashboard' ) : translate( 'Earn ad revenue' ),
 						action: () => {
@@ -500,11 +500,11 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 					{ translate(
 						'Make money each time someone visits your site by displaying advertisements on all your posts and pages.'
 					) }
-					{ ! hasWordAds && <em>{ getPremiumPlanNames() }</em> }
+					{ ! hasWordAdsFeature && <em>{ getPremiumPlanNames() }</em> }
 				</>
 			);
 
-		const learnMoreLink = ! ( hasWordAds || hasSetupAds )
+		const learnMoreLink = ! ( hasWordAdsFeature || hasSetupAds )
 			? { url: 'https://wordads.co/', onClick: () => trackLearnLink( 'ads' ) }
 			: null;
 		return {
@@ -568,7 +568,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 
 	return (
 		<Fragment>
-			{ ! hasWordAds && <QueryWordadsStatus siteId={ siteId } /> }
+			{ ! hasWordAdsFeature && <QueryWordadsStatus siteId={ siteId } /> }
 			<QueryMembershipsSettings siteId={ siteId } />
 			{ isLoading && (
 				<div className="earn__placeholder-promo-card">
@@ -594,7 +594,7 @@ export default connect(
 			state?.memberships?.settings?.[ siteId ]?.connectedAccountId ?? null;
 		const sitePlanSlug = getSitePlanSlug( state, siteId );
 		const hasPaidPlan = isCurrentPlanPaid( state, siteId );
-		const hasWordAds = siteHasWordAds( state, siteId );
+		const hasWordAdsFeature = siteHasWordAds( state, siteId );
 		const isLoading = ( hasConnectedAccount === null && hasPaidPlan ) || sitePlanSlug === null;
 
 		return {
@@ -604,9 +604,9 @@ export default connect(
 				isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
 			),
 			isUserAdmin: canCurrentUser( state, siteId, 'manage_options' ),
-			hasWordAds,
+			hasWordAdsFeature,
 			hasIneligiblePlanforWordAds:
-				! hasWordAds && getSiteWordadsStatus( state, siteId ) === 'ineligible',
+				! hasWordAdsFeature && getSiteWordadsStatus( state, siteId ) === 'ineligible',
 			hasSimplePayments: siteHasFeature( state, siteId, FEATURE_SIMPLE_PAYMENTS ),
 			hasConnectedAccount,
 			eligibleForProPlan: isEligibleForProPlan( state, siteId ),

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -17,16 +17,13 @@ import { connect } from 'react-redux';
 import earnSectionImage from 'calypso/assets/images/earn/earn-section.svg';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
-import QueryWordadsStatus from 'calypso/components/data/query-wordads-status';
 import EmptyContent from 'calypso/components/empty-content';
 import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
 import { CtaButton } from 'calypso/components/promo-section/promo-card/cta';
 import wp from 'calypso/lib/wp';
-import { WordAdsStatus } from 'calypso/my-sites/earn/ads/types';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import getSiteWordadsStatus from 'calypso/state/selectors/get-site-wordads-status';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import siteHasWordAds from 'calypso/state/selectors/site-has-wordads';
@@ -57,7 +54,6 @@ interface ConnectedProps {
 	hasDonations: boolean;
 	hasPremiumContent: boolean;
 	hasRecurringPayments: boolean;
-	hasIneligiblePlanforWordAds: boolean;
 }
 
 const Home: FunctionComponent< ConnectedProps > = ( {
@@ -74,7 +70,6 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	hasDonations,
 	hasPremiumContent,
 	hasRecurringPayments,
-	hasIneligiblePlanforWordAds,
 	trackUpgrade,
 	trackLearnLink,
 	trackCtaButton,
@@ -486,24 +481,21 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 							);
 						},
 				  };
-		const title =
-			hasSetupAds && ! hasIneligiblePlanforWordAds
-				? translate( 'View ad dashboard' )
-				: translate( 'Earn ad revenue' );
 
-		const body =
-			hasSetupAds && ! hasIneligiblePlanforWordAds ? (
-				translate(
-					"Check out your ad earnings history, including total earnings, total paid to date, and the amount that you've still yet to be paid."
-				)
-			) : (
-				<>
-					{ translate(
-						'Make money each time someone visits your site by displaying advertisements on all your posts and pages.'
-					) }
-					{ ! hasWordAdsFeature && <em>{ getPremiumPlanNames() }</em> }
-				</>
-			);
+		const title = hasSetupAds ? translate( 'View ad dashboard' ) : translate( 'Earn ad revenue' );
+
+		const body = hasSetupAds ? (
+			translate(
+				"Check out your ad earnings history, including total earnings, total paid to date, and the amount that you've still yet to be paid."
+			)
+		) : (
+			<>
+				{ translate(
+					'Make money each time someone visits your site by displaying advertisements on all your posts and pages.'
+				) }
+				{ ! hasWordAdsFeature && <em>{ getPremiumPlanNames() }</em> }
+			</>
+		);
 
 		const learnMoreLink = ! ( hasWordAdsFeature || hasSetupAds )
 			? { url: 'https://wordads.co/', onClick: () => trackLearnLink( 'ads' ) }
@@ -569,7 +561,6 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 
 	return (
 		<Fragment>
-			{ ! hasWordAdsFeature && <QueryWordadsStatus siteId={ siteId } /> }
 			<QueryMembershipsSettings siteId={ siteId } />
 			{ isLoading && (
 				<div className="earn__placeholder-promo-card">
@@ -606,8 +597,6 @@ export default connect(
 			),
 			isUserAdmin: canCurrentUser( state, siteId, 'manage_options' ),
 			hasWordAdsFeature,
-			hasIneligiblePlanforWordAds:
-				! hasWordAdsFeature && getSiteWordadsStatus( state, siteId ) === WordAdsStatus.ineligible,
 			hasSimplePayments: siteHasFeature( state, siteId, FEATURE_SIMPLE_PAYMENTS ),
 			hasConnectedAccount,
 			eligibleForProPlan: isEligibleForProPlan( state, siteId ),

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -22,6 +22,7 @@ import EmptyContent from 'calypso/components/empty-content';
 import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
 import { CtaButton } from 'calypso/components/promo-section/promo-card/cta';
 import wp from 'calypso/lib/wp';
+import { WordAdsStatus } from 'calypso/my-sites/earn/ads/types';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -606,7 +607,7 @@ export default connect(
 			isUserAdmin: canCurrentUser( state, siteId, 'manage_options' ),
 			hasWordAdsFeature,
 			hasIneligiblePlanforWordAds:
-				! hasWordAdsFeature && getSiteWordadsStatus( state, siteId ) === 'ineligible',
+				! hasWordAdsFeature && getSiteWordadsStatus( state, siteId ) === WordAdsStatus.ineligible,
 			hasSimplePayments: siteHasFeature( state, siteId, FEATURE_SIMPLE_PAYMENTS ),
 			hasConnectedAccount,
 			eligibleForProPlan: isEligibleForProPlan( state, siteId ),

--- a/client/state/selectors/get-site-wordads-status.ts
+++ b/client/state/selectors/get-site-wordads-status.ts
@@ -1,0 +1,15 @@
+import { get } from 'lodash';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns the wordads status for a site
+ */
+export default function getSiteWordadsStatus(
+	state: AppState,
+	siteId: number | undefined | null
+): string | null {
+	if ( ! siteId ) {
+		return null;
+	}
+	return get( state, [ 'wordads', 'status', siteId, 'status' ], null );
+}

--- a/client/state/selectors/get-site-wordads-status.ts
+++ b/client/state/selectors/get-site-wordads-status.ts
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import type { AppState } from 'calypso/types';
 
 /**
@@ -11,5 +10,5 @@ export default function getSiteWordadsStatus(
 	if ( ! siteId ) {
 		return null;
 	}
-	return get( state, [ 'wordads', 'status', siteId, 'status' ], null );
+	return state.wordads?.status?.[ siteId ]?.status ?? null;
 }

--- a/client/state/selectors/site-has-wordads.ts
+++ b/client/state/selectors/site-has-wordads.ts
@@ -10,6 +10,5 @@ import type { AppState } from 'calypso/types';
  * @returns {boolean} True if the site has WPCOM_FEATURES_WORDADS feature. Otherwise, False.
  */
 export default function siteHasWordAds( state: AppState, siteId: number | null ): boolean {
-	//siteHasWordAdsFeature
 	return siteHasFeature( state, siteId, WPCOM_FEATURES_WORDADS );
 }

--- a/client/state/selectors/site-has-wordads.ts
+++ b/client/state/selectors/site-has-wordads.ts
@@ -1,0 +1,15 @@
+import { WPCOM_FEATURES_WORDADS } from '@automattic/calypso-products';
+import siteHasFeature from './site-has-feature';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Whether site has wordads feature.
+ *
+ * @param  {Object}  state       Global state tree
+ * @param  {number}  siteId      The ID of the site we're querying
+ * @returns {boolean} True if the site has WPCOM_FEATURES_WORDADS feature. Otherwise, False.
+ */
+export default function siteHasWordAds( state: AppState, siteId: number | null ): boolean {
+	//siteHasWordAdsFeature
+	return siteHasFeature( state, siteId, WPCOM_FEATURES_WORDADS );
+}

--- a/client/state/selectors/test/get-site-wordads-status.js
+++ b/client/state/selectors/test/get-site-wordads-status.js
@@ -1,0 +1,31 @@
+import getSiteWordadsStatus from 'calypso/state/selectors/get-site-wordads-status';
+
+const siteId = '123001';
+
+describe( 'selectors', () => {
+	describe( '#getSiteWordadsStatus()', () => {
+		test( 'should return current status for a site if status exists', () => {
+			const state = {
+				wordads: {
+					status: {
+						123001: {
+							status: 'ineligible',
+						},
+					},
+				},
+			};
+
+			const status = getSiteWordadsStatus( state, siteId );
+			expect( status ).toEqual( 'ineligible' );
+		} );
+
+		test( 'should return null when wordads status does not exist for site', () => {
+			const state = {
+				wordads: {},
+			};
+
+			const status = getSiteWordadsStatus( state, siteId );
+			expect( status ).toEqual( null );
+		} );
+	} );
+} );

--- a/client/state/selectors/test/site-has-wordads.js
+++ b/client/state/selectors/test/site-has-wordads.js
@@ -1,6 +1,6 @@
 import siteHasWordAds from 'calypso/state/selectors/site-has-wordads';
 
-const siteId = '123002';
+const siteId = '123001';
 
 describe( 'selectors', () => {
 	describe( '#siteHasWordAds()', () => {
@@ -9,7 +9,7 @@ describe( 'selectors', () => {
 			const state = {
 				sites: {
 					features: {
-						123002: {
+						123001: {
 							data: {
 								active: activeFeatures,
 							},
@@ -27,7 +27,7 @@ describe( 'selectors', () => {
 			const state = {
 				sites: {
 					features: {
-						123002: {
+						123001: {
 							data: {
 								active: activeFeatures,
 							},

--- a/client/state/selectors/test/site-has-wordads.js
+++ b/client/state/selectors/test/site-has-wordads.js
@@ -1,0 +1,43 @@
+import siteHasWordAds from 'calypso/state/selectors/site-has-wordads';
+
+const siteId = '123001';
+
+describe( 'selectors', () => {
+	describe( '#siteHasWordAds()', () => {
+		test( "should return TRUE when site's active features include wordads", () => {
+			const activeFeatures = [ 'feature_active_01', 'wordads', 'feature_active_03' ];
+			const state = {
+				sites: {
+					features: {
+						123001: {
+							data: {
+								active: activeFeatures,
+							},
+						},
+					},
+				},
+			};
+
+			const hasWordAdsFeature = siteHasWordAds( state, siteId );
+			expect( hasWordAdsFeature ).toEqual( true );
+		} );
+
+		test( "should return False when site's features does not include wordads", () => {
+			const activeFeatures = [ 'feature_active_01', 'feature_active_02' ];
+			const state = {
+				sites: {
+					features: {
+						123001: {
+							data: {
+								active: activeFeatures,
+							},
+						},
+					},
+				},
+			};
+
+			const hasWordAdsFeature = siteHasWordAds( state, siteId );
+			expect( hasWordAdsFeature ).toEqual( false );
+		} );
+	} );
+} );

--- a/client/state/selectors/test/site-has-wordads.js
+++ b/client/state/selectors/test/site-has-wordads.js
@@ -1,6 +1,6 @@
 import siteHasWordAds from 'calypso/state/selectors/site-has-wordads';
 
-const siteId = '123001';
+const siteId = '123002';
 
 describe( 'selectors', () => {
 	describe( '#siteHasWordAds()', () => {
@@ -9,7 +9,7 @@ describe( 'selectors', () => {
 			const state = {
 				sites: {
 					features: {
-						123001: {
+						123002: {
 							data: {
 								active: activeFeatures,
 							},
@@ -27,7 +27,7 @@ describe( 'selectors', () => {
 			const state = {
 				sites: {
 					features: {
-						123001: {
+						123002: {
 							data: {
 								active: activeFeatures,
 							},

--- a/client/state/sites/selectors/can-access-wordads.js
+++ b/client/state/sites/selectors/can-access-wordads.js
@@ -1,6 +1,5 @@
-import { WPCOM_FEATURES_WORDADS } from '@automattic/calypso-products';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import siteHasWordAds from 'calypso/state/selectors/site-has-wordads';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import getSiteOption from './get-site-option';
 
@@ -16,7 +15,7 @@ export default function canAccessWordAds( state, siteId = 0 ) {
 		siteId = getSelectedSiteId( state );
 	}
 
-	const hasWordAdsFeature = siteHasFeature( state, siteId, WPCOM_FEATURES_WORDADS );
+	const hasWordAdsFeature = siteHasWordAds( state, siteId );
 
 	if ( hasWordAdsFeature && canCurrentUser( state, siteId, 'activate_wordads' ) ) {
 		return true;

--- a/client/state/wordads/approve/selectors.js
+++ b/client/state/wordads/approve/selectors.js
@@ -8,7 +8,7 @@ import 'calypso/state/wordads/init';
  * @returns {boolean}       requesting state
  */
 export function isRequestingWordAdsApproval( state, siteId ) {
-	return !! state.wordads.approve.requesting[ siteId ];
+	return !! state?.wordads?.approve?.requesting[ siteId ];
 }
 
 /**

--- a/client/state/wordads/approve/selectors.js
+++ b/client/state/wordads/approve/selectors.js
@@ -8,7 +8,7 @@ import 'calypso/state/wordads/init';
  * @returns {boolean}       requesting state
  */
 export function isRequestingWordAdsApproval( state, siteId ) {
-	return !! state?.wordads?.approve?.requesting[ siteId ];
+	return !! state.wordads?.approve?.requesting?.[ siteId ];
 }
 
 /**

--- a/client/state/wordads/payments/selectors.js
+++ b/client/state/wordads/payments/selectors.js
@@ -10,5 +10,5 @@ import 'calypso/state/wordads/init';
  * @returns {Object}        WordAds Error
  */
 export function getWordAdsPayments( state, siteId ) {
-	return get( state, [ 'wordads', 'payments', siteId ], null );
+	return get( state, [ 'wordads', 'payments', siteId ], [] );
 }

--- a/client/state/wordads/payments/selectors.js
+++ b/client/state/wordads/payments/selectors.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 import 'calypso/state/wordads/init';
 
 /**
@@ -10,5 +8,5 @@ import 'calypso/state/wordads/init';
  * @returns {Object}        WordAds Error
  */
 export function getWordAdsPayments( state, siteId ) {
-	return get( state, [ 'wordads', 'payments', siteId ], [] );
+	return state.wordads?.payments?.[ siteId ] ?? [];
 }

--- a/client/state/wordads/status/actions.js
+++ b/client/state/wordads/status/actions.js
@@ -12,5 +12,5 @@ export const requestWordadsStatus = ( siteId ) => ( {
 export const receiveStatus = ( siteId, status ) => ( {
 	type: WORDADS_STATUS_RECEIVE,
 	siteId,
-	status: pick( status, [ 'approved', 'unsafe', 'active' ] ),
+	status: pick( status, [ 'approved', 'unsafe', 'active', 'status' ] ),
 } );


### PR DESCRIPTION
## Proposed Changes

Going forward sites enrolled in WordAds would be temporarily removed once they no longer have a valid WordPress.com plan. This PR updates the UX for those sites to:
- Inform them they would be removed from WordAds in the process of canceling their plan.
- Allow them to view their earning and payment history on the Earnings dashboard but prevent updates to Settings
- Provide them an option to rejoin WordAds by upgrading.

## Testing Instructions

* Create a new WordPress.com site and apply to join WordAds under, `My site -> Tools -> Earn -> Earn ad revenue`
* You would subscribe to a premium plan or higher (as part of Step 1)
* Navigate to `My site -> Upgrades -> Manage plan -> Cancel plan`, by clicking on the cancel plan button you should see a modal informing you of the consequences of canceling a plan.

 _In a scenario where the site has a primary domain the message will be combined_
<img width="1728" alt="notice" src="https://user-images.githubusercontent.com/9039613/219135431-b457e183-e96a-4d79-9a2c-151671a98fd2.png">

_In case the site has no primary domain at the time the message will be independent_
<img width="1728" alt="no primary domain" src="https://user-images.githubusercontent.com/9039613/219447859-c7fbbf12-3b30-4303-a3d9-d60348389d00.png">

* Now we need to simulate a subscription plan expiry by manually removing the subscription via the StoreAdmin. Before removing the subscription, make sure you are running the D100709-code revision in your sandbox
* Once you remove the subscription your WordAds site should now have an ineligible status
* Navigate to `My site  -> Tools -> Earn -> View ad dashboard`
<img width="1726" alt="1" src="https://user-images.githubusercontent.com/9039613/219136885-b3256f08-e8cb-4323-b6b3-df62430adf41.png">

* You should be able to view your Earnings and payment history, but the Settings tab should only have a preview with options disabled
*  You should also see an upgrade banner on top of the page
<img width="1720" alt="settings" src="https://user-images.githubusercontent.com/9039613/219137032-f0ef1161-6329-4820-8865-64f8b14a35a9.png">

* Upgrade your plan by clicking the "Upgrade" button
* After upgrading, navigate back to `My site -> Tools -> Earn -> View ad dashboard`, you should no longer see the upgrade banner and you should be able to make changes to the site Settings


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?