### PR TITLE
Marketplace: Remove hook and use a Query component instead

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -172,6 +172,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	if ( selectedSite && isPreinstalledPremiumPlugin ) {
 		return (
 			<div className="plugin-details-cta__container">
+				<QuerySitePurchases siteId={ selectedSite?.ID } />
 				<PluginDetailsCTAPreinstalledPremiumPlugins
 					isPluginInstalledOnsite={ isPluginInstalledOnsiteWithSubscription }
 					plugin={ plugin }

--- a/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
+++ b/client/my-sites/plugins/use-preinstalled-premium-plugin/index.js
@@ -1,6 +1,5 @@
 import { isJetpackSearchFree, isJetpackSearch } from '@automattic/calypso-products';
 import { useSelector } from 'react-redux';
-import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import { getSitesWithPlugin } from 'calypso/state/plugins/installed/selectors';
@@ -19,8 +18,6 @@ export default function usePreinstalledPremiumPlugin( pluginSlug ) {
 
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const billingPeriod = useSelector( getBillingInterval );
-
-	useQuerySitePurchases( selectedSiteId );
 
 	const isPreinstalledPremiumPluginUpgraded = useSelector(
 		( state ) =>


### PR DESCRIPTION
This PR fixes a performance issue that triggers multiple network calls to `/purchases` endpoint. The `usePreinstalledPremiumPlugin` hook [here](https://github.com/Automattic/wp-calypso/pull/73179/files#diff-6a51f69e677bc46ecd250fd1cb66d5646eaf976c51638d649c09555e52ab8d11L23) was being called from multiple places while the `PluginDetailsCTAPreinstalledPremiumPlugins` [here](https://github.com/Automattic/wp-calypso/pull/73179/files#diff-84ecb17a0e2202226688ef5fdee0a57a431fc680dc4d9494783cc51ff84898baR175) is only called when a site is selected and the plugin opened is `Jetpack Search`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Remove the call to the purchases endpoint from inside a hook
* Use a Query component instead

## Testing Instructions

* Select a site that contains some purchases or with a Business site, purchase a plugin
* Navigate to `/plugins/:siteId` and open the Developer Tools
* In the Network Tab, clear the network calls and make sure there are no more network calls. **Note:** There could be network calls if scrolling

![CleanShot 2023-02-09 at 19 55 22@2x](https://user-images.githubusercontent.com/3519124/217912637-1b4a42b9-78e2-46f6-8439-48187cd9e9cf.png)

### Additional testing
Make sure the testing on this related PR still works as expected. Testing only with an Atomic site should be enough:

- https://github.com/Automattic/wp-calypso/pull/73006

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
