### PR TITLE
Hosting redesign: Add hosting onboarding flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -16,12 +16,13 @@ export function generateFlows( {
 	getDestinationFromIntent = noop,
 	getDIFMSignupDestination = noop,
 	getDIFMSiteContentCollectionDestination = noop,
+	getHomeDestination = noop,
 } = {} ) {
 	const flows = [
 		{
 			name: HOSTING_LP_FLOW,
 			steps: [ 'plans', 'user', 'domains' ],
-			destination: getSignupDestination,
+			destination: getHomeDestination,
 			description:
 				'Create an account and a blog and give the user the option of adding a domain and plan to the cart.',
 			lastModified: '2023-02-09',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -22,7 +22,8 @@ export function generateFlows( {
 			name: HOSTING_LP_FLOW,
 			steps: [ 'plans', 'user', 'domains' ],
 			destination: getSignupDestination,
-			description: 'Create an account and a blog and then add the starter plan to the users cart.',
+			description:
+				'Create an account and a blog and give the user the option of adding a domain and plan to the cart.',
 			lastModified: '2023-02-09',
 			showRecaptcha: true,
 		},

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { setupSiteAfterCreation } from '@automattic/onboarding';
+import { HOSTING_LP_FLOW, setupSiteAfterCreation } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
 
 const noop = () => {};
@@ -18,6 +18,14 @@ export function generateFlows( {
 	getDIFMSiteContentCollectionDestination = noop,
 } = {} ) {
 	const flows = [
+		{
+			name: HOSTING_LP_FLOW,
+			steps: [ 'plans', 'user', 'domains' ],
+			destination: getSignupDestination,
+			description: 'Create an account and a blog and then add the starter plan to the users cart.',
+			lastModified: '2023-02-09',
+			showRecaptcha: true,
+		},
 		{
 			name: 'account',
 			steps: [ 'user' ],

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -169,6 +169,10 @@ function getDIFMSiteContentCollectionDestination( { siteSlug } ) {
 	return `/home/${ siteSlug }`;
 }
 
+function getHomeDestination( { siteSlug } ) {
+	return `/home/${ siteSlug }`;
+}
+
 const flows = generateFlows( {
 	getSiteDestination,
 	getRedirectDestination,
@@ -182,6 +186,7 @@ const flows = generateFlows( {
 	getDestinationFromIntent,
 	getDIFMSignupDestination,
 	getDIFMSiteContentCollectionDestination,
+	getHomeDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -10,6 +10,7 @@ import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
 import {
 	isLinkInBioFlow,
+	isHostingLPFlow,
 	isNewsletterOrLinkInBioFlow,
 	isSiteAssemblerFlow,
 	isTailoredSignupFlow,
@@ -422,7 +423,7 @@ export class PlansStep extends Component {
 					stepName={ stepName }
 					positionInFlow={ positionInFlow }
 					headerText={ headerText }
-					shouldHideNavButtons={ this.isTailoredFlow() }
+					shouldHideNavButtons={ this.isTailoredFlow() || isHostingLPFlow( this.props.flowName ) }
 					fallbackHeaderText={ fallbackHeaderText }
 					subHeaderText={ subHeaderText }
 					fallbackSubHeaderText={ fallbackSubHeaderText }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -191,6 +191,7 @@
 		"developer",
 		"site-content-collection",
 		"importer",
+		"hosting",
 		"import",
 		"import-light",
 		"from",

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -683,6 +683,13 @@ export const getPopularPlanSpec = ( {
 
 	const group = GROUP_WPCOM;
 
+	if ( flowName === 'hosting' ) {
+		return {
+			type: TYPE_BUSINESS,
+			group,
+		};
+	}
+
 	if ( flowName === 'link-in-bio' || flowName === 'link-in-bio-tld' ) {
 		return {
 			type: TYPE_PERSONAL,

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -1,5 +1,6 @@
 export const NEWSLETTER_FLOW = 'newsletter';
 export const NEWSLETTER_POST_SETUP_FLOW = 'newsletter-post-setup';
+export const HOSTING_LP_FLOW = 'hosting';
 export const LINK_IN_BIO_FLOW = 'link-in-bio';
 export const LINK_IN_BIO_TLD_FLOW = 'link-in-bio-tld';
 export const LINK_IN_BIO_POST_SETUP_FLOW = 'link-in-bio-post-setup';
@@ -27,6 +28,10 @@ export const isLinkInBioFlow = ( flowName: string | null ) => {
 
 export const isFreeFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ FREE_FLOW, FREE_POST_SETUP_FLOW ].includes( flowName ) );
+};
+
+export const isHostingLPFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && HOSTING_LP_FLOW === flowName );
 };
 
 export const isNewsletterOrLinkInBioFlow = ( flowName: string | null ) => {


### PR DESCRIPTION
Part of https://github.com/Automattic/dotcom-forge/issues/1620.

## Proposed Changes

We want to show the plans grid as the first step for users coming from [wordpress.com/hosting](https://wordpress.com/hosting) because as the CTA is on top, they won't see anything they're getting.

This is a temporary fix until we add more CTAs to the page, then we can revert to using the normal onboarding flow steps (plans after domain).

Reasons we're adding this new flow:

- show the plans grid first so the user knows what they're buying (features are shown below the price tag)
- highlight the Business plan instead of the Personal one since that's the one we're selling on wordpress.com/hosting

## Testing Instructions

- Check out this branch and browse to `/start/hosting`
- You should see the plans grid first. Check that `Business` is highlighted and choose that plan
- Sign up and choose a domain name

You should be presented with the checkout page. Enter the payment information and the flow should be completed with a `/home` redirection.

## Additional information

We tried skipping the domain part but it looks like it's actually necessary to have a domain (I think the plan is tied to the domain). Apparently, it's possible to add a stub one (email or username) but you cannot buy a plan without a domain, and you also need to be signed in. That makes it impossible to go to the cart without signing up, so we need the `user` step too.

At the end of the day, we're just shuffling the steps to make `plans` appear first and with the Business plan highlighted.