### PR TITLE
Add interval toggles to eCommerce trial Plans page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -1,4 +1,9 @@
-import { getPlans, PLAN_ECOMMERCE, PLAN_ECOMMERCE_MONTHLY } from '@automattic/calypso-products';
+import {
+	getPlans,
+	plansLink,
+	PLAN_ECOMMERCE,
+	PLAN_ECOMMERCE_MONTHLY,
+} from '@automattic/calypso-products';
 import { Button, Card } from '@automattic/components';
 import { getCurrencyObject } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
@@ -9,6 +14,7 @@ import growth from 'calypso/assets/images/plans/wpcom/ecommerce-trial/growth.png
 import payments from 'calypso/assets/images/plans/wpcom/ecommerce-trial/payments.png';
 import productManagement from 'calypso/assets/images/plans/wpcom/ecommerce-trial/product-management.png';
 import shipping from 'calypso/assets/images/plans/wpcom/ecommerce-trial/shipping.png';
+import SegmentedControl from 'calypso/components/segmented-control';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getPlanRawPrice, getPlan } from 'calypso/state/plans/selectors';
 import ECommerceTrialBanner from './ecommerce-trial-banner';
@@ -16,7 +22,15 @@ import TrialFeatureCard from './trial-feature-card';
 
 import './style.scss';
 
-const ECommerceTrialPlansPage = () => {
+interface ECommerceTrialPlansPageProps {
+	interval?: 'monthly' | 'yearly';
+	siteSlug: string;
+}
+
+const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
+	const interval = props.interval ?? 'monthly';
+	const siteSlug = props.siteSlug;
+
 	const translate = useTranslate();
 
 	const eCommercePlanAnnual = getPlans()[ PLAN_ECOMMERCE ];
@@ -31,8 +45,7 @@ const ECommerceTrialPlansPage = () => {
 
 	const { symbol: currencySymbol } = getCurrencyObject( 0, eCommercePlanPrices.currencyCode );
 
-	// Defaulting to annual while we don't add the toggle
-	const isAnnualSubscription = true;
+	const isAnnualSubscription = interval === 'yearly';
 
 	const percentageSavings = Math.floor(
 		( 1 - eCommercePlanPrices.annualPlanMonthlyPrice / eCommercePlanPrices.monthlyPlanPrice ) * 100
@@ -268,20 +281,34 @@ const ECommerceTrialPlansPage = () => {
 				}
 		  );
 
-	const annualUpsellContent = isAnnualSubscription && (
-		<span className="e-commerce-trial-plans__price-card-savings">
-			{ translate( 'Save %(percentageSavings)s%% by paying annually', {
-				args: { percentageSavings },
-			} ) }
-		</span>
-	);
-
 	return (
 		<>
 			<BodySectionCssClass bodyClass={ [ 'is-ecommerce-trial-plan' ] } />
 
 			<div className="e-commerce-trial-plans__banner-wrapper">
 				<ECommerceTrialBanner />
+			</div>
+
+			<div className="e-commerce-trial-plans__interval-toggle-wrapper">
+				<SegmentedControl
+					compact
+					primary={ true }
+					className="e-commerce-trial-plans__interval-toggle price-toggle"
+				>
+					<SegmentedControl.Item
+						selected={ interval === 'monthly' }
+						path={ plansLink( '/plans', siteSlug, 'monthly', true ) }
+					>
+						<span>{ translate( 'Pay Monthly' ) }</span>
+					</SegmentedControl.Item>
+
+					<SegmentedControl.Item
+						selected={ interval === 'yearly' }
+						path={ plansLink( '/plans', siteSlug, 'yearly', true ) }
+					>
+						<span>{ translate( 'Pay Annually' ) }</span>
+					</SegmentedControl.Item>
+				</SegmentedControl>
 			</div>
 
 			<Card className="e-commerce-trial-plans__price-card">
@@ -298,7 +325,11 @@ const ECommerceTrialPlansPage = () => {
 				</div>
 				<div className="e-commerce-trial-plans__price-card-conditions">
 					{ priceContent }
-					{ annualUpsellContent }
+					<span className="e-commerce-trial-plans__price-card-savings">
+						{ translate( 'Save %(percentageSavings)s%% by paying annually', {
+							args: { percentageSavings },
+						} ) }
+					</span>
 				</div>
 				<div className="e-commerce-trial-plans__price-card-cta-wrapper">
 					<Button className="e-commerce-trial-plans__price-card-cta" primary>

--- a/client/my-sites/plans/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/style.scss
@@ -9,6 +9,25 @@ body.is-section-plans.is-ecommerce-trial-plan {
 		box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.05);
 	}
 
+	.e-commerce-trial-plans__interval-toggle-wrapper {
+		display: flex;
+		justify-content: center;
+		margin: 48px 0 32px 0;
+		padding: 0 20px;
+
+		.e-commerce-trial-plans__interval-toggle {
+			font-weight: 500;
+			max-width: -moz-fit-content;
+			max-width: fit-content;
+			width: auto;
+
+			@media (max-width: $break-mobile) {
+				max-width: 100%;
+				width: 100%;
+			}
+		}
+	}
+
 	.e-commerce-trial-plans__banner-wrapper {
 		margin: 20px 0;
 	}

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -255,7 +255,16 @@ class Plans extends Component {
 	}
 
 	renderEcommerceTrialPage() {
-		return <ECommerceTrialPlansPage />;
+		const { intervalType, selectedSite } = this.props;
+
+		if ( ! selectedSite ) {
+			return this.renderPlaceholder();
+		}
+
+		// Only accept monthly or yearly for the interval; otherwise let the component provide a default.
+		const interval =
+			intervalType === 'monthly' || intervalType === 'yearly' ? intervalType : undefined;
+		return <ECommerceTrialPlansPage interval={ interval } siteSlug={ selectedSite.slug } />;
 	}
 
 	render() {


### PR DESCRIPTION
Related to #72797

## Proposed Changes

* This PR builds on #72797 and implements the billing interval toggle for the eCommerce trial Plans page
* In addition to wiring in the interval toggle, this PR also shows the "Save X%" message for annual pricing on both monthly and annual tabs -- it shows the user an offer if they're on the monthly tab, and it reinforces their choice if they're on the annual tab

## Testing Instructions

Before testing, ensure you have a site with an active eCommerce trial plan.

* Run this branch locally or via Calypso.live
* For the site with an eCommerce trial, navigate to _Upgrades_ -> _Plans_
* Verify that the URL is `/plans/:siteSlug` and that the billing interval defaults to monthly billing ("Pay Monthly")
* Verify that we show the "Save 35% ..." in the pricing section
* Click on the "Pay Annually" option
* Verify that the URL changes to `/plans/yearly/:siteSlug` and the toggle updates
* Also verify that you see the annual pricing, and still see the "Save 35% ..." message
* Click on the "Pay Monthly" option
* Verify that the URL changes to `/plans/monthly/:siteSlug` and the toggle updates
* Verify that we see the monthly pricing details
* Switch to a mobile screen size and verify the toggles work and display well as per the steps above.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

## Screenshot

<img width="736" alt="Screenshot 2023-02-10 at 13 27 14" src="https://user-images.githubusercontent.com/3376401/218081697-1c392ebc-4b69-4acc-8e97-ffa7c291487e.png">
