### PR TITLE
VideoPress Onboarding: Tweaks to "Learn more" styling

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -102,16 +102,22 @@
 		}
 
 		.button.is-primary {
-			background-color: #ffe61c;
+			background: #ffe61c;
 			color: #000;
-		}
-
-		.intro__button-more {
-			border-color: transparent;
+			transition: box-shadow 0.4s ease-in-out;
 
 			&:hover {
-				color: #fff !important;
-				border-color: #fff !important;
+				box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1) inset, 0 2px 24px rgba(255, 230, 28, 0.3), 0 0 8px rgba(255, 230, 28, 0.18), 0 0 4px rgba(255, 230, 28, 0.15), 0 0 2.5px rgba(255, 230, 28, 0.12), 0 0 4px rgba(255, 230, 28, 0.1), 0 0 2px rgba(0, 0, 0, 0.8);
+			}
+		}
+
+		.button.intro__button-more {
+			border-color: rgba(255, 255, 255, 0.5);
+			transition: border 0.2s ease-in-out;
+
+			&:hover {
+				color: #fff;
+				border-color: #fff;
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -106,8 +106,13 @@
 			color: #000;
 		}
 
-		.intro__button-more:hover {
-			color: var(--color-surface) !important;
+		.intro__button-more {
+			border-color: transparent;
+
+			&:hover {
+				color: #fff !important;
+				border-color: #fff !important;
+			}
 		}
 	}
 
@@ -233,7 +238,7 @@
 		justify-content: center;
 
 		.intro__button,
-		.intro_button-more {
+		.intro__button-more {
 			font-family: "SF Pro Text", $sans;
 			color: var(--color-surface);
 			font-weight: 500;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/videopress-intro-modal-styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/videopress-intro-modal-styles.scss
@@ -51,6 +51,8 @@
 			width: 100%;
 			max-width: 220px;
 			font-weight: 500;
+			padding-top: 10px;
+			padding-bottom: 10px;
 		}
 
 		.learn-more {


### PR DESCRIPTION
This PR fixes a non-obvious css selector typo, and adds some custom hover behaviour to the "Learn more" button on VideoPress Intro page.

| normal | hover |
| ---- | ----|
| <img width="555" alt="image" src="https://user-images.githubusercontent.com/4081020/217926827-9e6101ae-245d-4d8e-9e94-20adcb3891db.png"> | <img width="569" alt="image (1)" src="https://user-images.githubusercontent.com/4081020/217926825-21583721-7b85-4a06-a1b2-da91c25f1e7b.png"> |


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
## Proposed Changes

* fix a typo
* add custom styling to videopress "open modal" button

## Testing Instructions

<!--


Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* apply PR or use pre-built image
* visit `/setup/videopress/intro`
* hover over the Learn more button to see new behaviour, font weight should match the "Get started" button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
