### PR TITLE
Fix bug reintroduced in PR 73062

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -269,12 +269,12 @@ class Plans extends Component {
 			domainSidebarExperimentUser,
 		} = this.props;
 
-		const currentPlanSlug = selectedSite.plan.product_slug;
-		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
-
 		if ( ! selectedSite || this.isInvalidPlanInterval() || ! currentPlan ) {
 			return this.renderPlaceholder();
 		}
+
+		const currentPlanSlug = selectedSite?.plan?.product_slug;
+		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 
 		const allDomains = domainSidebarExperimentUser ? getDomainRegistrations( this.props.cart ) : [];
 		const yourDomainName = allDomains.length


### PR DESCRIPTION
Related to #73062, #72992, #72990

## Proposed Changes

* This PR is effectively identical to #72992, which was inadvertently overridden in #73062, most likely due to a merge conflict/rebase that went awry. I was working on the same few lines of code today and noticed the broken code was back. 🐛 

## Testing Instructions

* We can follow the testing instructions from #72990 again, but I think it's safe to get this merged again (especially seeing as it's a defensive change to start with).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [N/A] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?