### PR TITLE
Add commas in timeframe strings

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
@@ -111,11 +111,11 @@ const PartialDiscountTimeFrame: React.FC< PartialDiscountTimeFrameProps & A11yPr
 		if (
 			getLocaleSlug() === 'en' ||
 			getLocaleSlug() === 'en-gb' ||
-			i18n.hasTranslation( 'for the first month, then %(original_price)s /month billed monthly' )
+			i18n.hasTranslation( 'for the first month, then %(original_price)s /month, billed monthly' )
 		) {
 			text = translate(
-				'for the first month, then %(original_price)s /month billed monthly',
-				'for the first %(months)d months, then %(original_price)s /month billed monthly',
+				'for the first month, then %(original_price)s /month, billed monthly',
+				'for the first %(months)d months, then %(original_price)s /month, billed monthly',
 				opts
 			);
 		} else {
@@ -130,11 +130,11 @@ const PartialDiscountTimeFrame: React.FC< PartialDiscountTimeFrameProps & A11yPr
 		if (
 			getLocaleSlug() === 'en' ||
 			getLocaleSlug() === 'en-gb' ||
-			i18n.hasTranslation( 'for the first month, then %(original_price)s /month billed yearly' )
+			i18n.hasTranslation( 'for the first month, then %(original_price)s /month, billed yearly' )
 		) {
 			text = translate(
-				'for the first month, then %(original_price)s /month billed yearly',
-				'for the first %(months)d months, then %(original_price)s /month billed yearly',
+				'for the first month, then %(original_price)s /month, billed yearly',
+				'for the first %(months)d months, then %(original_price)s /month, billed yearly',
 				opts
 			);
 		} else {


### PR DESCRIPTION
## Proposed Changes

* This diff adds some missing commas in strings

Current: $1 for the first month, then $10 /month billed yearly
Should be: $1 for the first month, then $10 /month, billed yearly

## Testing Instructions

* You can view these strings on `cloud.jetpack.com/pricing` on the VaultPress and Social products.
