### PR TITLE
Use the link-in-bio-tld vendor string for the w.link flow

### DIFF
--- a/packages/domain-picker/src/utils/index.ts
+++ b/packages/domain-picker/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
+import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import type { DomainSuggestions } from '@automattic/data-stores';
 
 export function mockDomainSuggestion(
@@ -35,13 +35,14 @@ interface DomainSuggestionsVendorOptions {
 	isSignup?: boolean;
 	isDomainOnly?: boolean;
 	isPremium?: boolean;
-	flowName?: typeof NEWSLETTER_FLOW | typeof LINK_IN_BIO_FLOW;
+	flowName?: typeof NEWSLETTER_FLOW | typeof LINK_IN_BIO_FLOW | typeof LINK_IN_BIO_TLD_FLOW;
 }
 type DomainSuggestionsVendor =
 	| 'variation2_front'
 	| 'variation4_front'
 	| 'variation8_front'
 	| 'link-in-bio'
+	| 'link-in-bio-tld'
 	| 'newsletter';
 
 export function getDomainSuggestionsVendor(
@@ -49,6 +50,9 @@ export function getDomainSuggestionsVendor(
 ): DomainSuggestionsVendor {
 	if ( options.flowName === LINK_IN_BIO_FLOW ) {
 		return 'link-in-bio';
+	}
+	if ( options.flowName === LINK_IN_BIO_TLD_FLOW ) {
+		return 'link-in-bio-tld';
 	}
 	if ( options.flowName === NEWSLETTER_FLOW ) {
 		return 'newsletter';


### PR DESCRIPTION
We launched .link premiums for the link-in-bio-tld flow.  We need to make sure we use the correct vendor string to allow premium domains in the suggestions for this flow.

## Testing Instructions

Apply back-end patch D100901-code

Visit http://calypso.localhost:3000/setup/link-in-bio-tld/domains?new=010101.link

Make sure that the call to the /suggestions endpoint includes the `vendor=link-in-bio-tld` query string.

Make sure that the suggestions include the exact match for the requested premium .link domain.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?