### PR TITLE
Copy Site: Remove page title from Stepper because it looks odd

### DIFF
--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -71,7 +71,7 @@ const copySite: Flow = {
 	name: COPY_SITE_FLOW,
 
 	get title() {
-		return translate( 'Copy Site' );
+		return '';
 	},
 
 	useSteps() {


### PR DESCRIPTION
See p1674661756737999-slack-C04GESRBWKW

## Proposed Changes

Removes the 'Copy Site' page title from Stepper because it looked odd. Now it looks much better:

<img width="1220" alt="CleanShot 2023-02-09 at 13 03 30@2x" src="https://user-images.githubusercontent.com/36432/217938894-7ea81590-33e5-4937-9468-330be9ac5aa2.png">

## Testing Instructions

1. Copy a site and verify everything looks as expected.