### PR TITLE
Sensei Tailored Flow: Fix styling for the domain suggestion badges

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
@@ -220,6 +220,15 @@
 	}
 
 	.featured-domain-suggestions {
+		.domain-registration-suggestion__title-wrapper {
+			flex-wrap: wrap-reverse;
+		}
+
+		.domain-registration-suggestion__badges {
+			margin-bottom: 5px;
+			margin-left: 0;
+		}
+
 		.domain-suggestion__action {
 			border: none;
 			border-radius: 4px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
@@ -224,6 +224,10 @@
 			flex-wrap: wrap-reverse;
 		}
 
+		.domain-registration-suggestion__title {
+			align-self: unset;
+		}
+
 		.domain-registration-suggestion__badges {
 			margin-bottom: 5px;
 			margin-left: 0;


### PR DESCRIPTION
## Proposed Changes

* Move the domain suggestion badge above the domain to prevent overflow layout issues

## Testing Instructions

* Go to http://calypso.localhost:3000/setup/sensei/senseiDomain
* Enter a really really long domain
* See that the badge is above the domain and that there is no overlap


## Before
![Screenshot 2023-02-09 at 12 58 05 PM](https://user-images.githubusercontent.com/3220162/217961278-68b235ea-8150-4d01-a91f-f5b034be165b.png)

## After
![Screenshot 2023-02-09 at 12 57 06 PM](https://user-images.githubusercontent.com/3220162/217961289-0e46dfa5-8ddb-42f4-8afe-d7dcd42af4c7.png)


