### PR TITLE
Media Library: Add notice to Atomic private sites since Jetpack Image CDN is disabled

### DIFF
--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -10,7 +10,6 @@ import QueryMedia from 'calypso/components/data/query-media';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Notice from 'calypso/components/notice';
-import NoticeAction from 'calypso/components/notice/notice-action';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import { withEditMedia } from 'calypso/data/media/use-edit-media-mutation';
 import { withDeleteMedia } from 'calypso/data/media/with-delete-media';
@@ -365,13 +364,14 @@ class Media extends Component {
 						showDismiss={ false }
 						status="is-info"
 						text={ translate(
-							'Your site is Private and the image CDN is disabled. If image thumbnails do not display, switch to Coming Soon mode.'
+							'Your site is Private and the image CDN is disabled. If image thumbnails do not display, switch to Coming Soon mode. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+							{
+								components: {
+									learnMoreLink: <InlineSupportLink supportContext="privacy" showIcon={ false } />,
+								},
+							}
 						) }
-					>
-						<NoticeAction href="/support/settings/privacy-settings/#private" external>
-							{ translate( 'Learn more' ) }
-						</NoticeAction>
-					</Notice>
+					/>
 				) }
 				<FormattedHeader
 					brandFont

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -379,7 +379,7 @@ class Media extends Component {
 						showDismiss={ false }
 						status="is-info"
 						text={ translate(
-							'Your site is Private and the image CDN is disabled. If image thumbnails do not display, switch to Coming Soon mode. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+							'The image CDN is disabled because your site is marked Private. If image thumbnails do not display in your Media Library, you can switch to Coming Soon mode. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 							{
 								components: {
 									learnMoreLink: <InlineSupportLink supportContext="privacy" showIcon={ false } />,

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -359,20 +359,6 @@ class Media extends Component {
 				{ mediaId && site && site.ID && <QueryMedia siteId={ site.ID } mediaId={ mediaId } /> }
 				<PageViewTracker path={ this.getAnalyticsPath() } title="Media" />
 				<DocumentHead title={ translate( 'Media' ) } />
-				{ this.props.selectedSite.is_private && this.props.selectedSite.is_wpcom_atomic && (
-					<Notice
-						showDismiss={ false }
-						status="is-info"
-						text={ translate(
-							'Your site is Private and the image CDN is disabled. If image thumbnails do not display, switch to Coming Soon mode. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-							{
-								components: {
-									learnMoreLink: <InlineSupportLink supportContext="privacy" showIcon={ false } />,
-								},
-							}
-						) }
-					/>
-				) }
 				<FormattedHeader
 					brandFont
 					className="media__page-heading"
@@ -388,6 +374,20 @@ class Media extends Component {
 					align="left"
 					hasScreenOptions
 				/>
+				{ this.props.selectedSite.is_private && this.props.selectedSite.is_wpcom_atomic && (
+					<Notice
+						showDismiss={ false }
+						status="is-info"
+						text={ translate(
+							'Your site is Private and the image CDN is disabled. If image thumbnails do not display, switch to Coming Soon mode. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+							{
+								components: {
+									learnMoreLink: <InlineSupportLink supportContext="privacy" showIcon={ false } />,
+								},
+							}
+						) }
+					/>
+				) }
 				{ this.showDialog() && (
 					<EditorMediaModalDialog
 						isVisible

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -9,6 +9,8 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryMedia from 'calypso/components/data/query-media';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import { withEditMedia } from 'calypso/data/media/use-edit-media-mutation';
 import { withDeleteMedia } from 'calypso/data/media/with-delete-media';
@@ -358,6 +360,19 @@ class Media extends Component {
 				{ mediaId && site && site.ID && <QueryMedia siteId={ site.ID } mediaId={ mediaId } /> }
 				<PageViewTracker path={ this.getAnalyticsPath() } title="Media" />
 				<DocumentHead title={ translate( 'Media' ) } />
+				{ this.props.selectedSite.is_private && this.props.selectedSite.is_wpcom_atomic && (
+					<Notice
+						showDismiss={ false }
+						status="is-info"
+						text={ translate(
+							'Your site is Private and the image CDN is disabled. If image thumbnails do not display, switch to Coming Soon mode.'
+						) }
+					>
+						<NoticeAction href="/support/settings/privacy-settings/#private" external>
+							{ translate( 'Learn more' ) }
+						</NoticeAction>
+					</Notice>
+				) }
 				<FormattedHeader
 					brandFont
 					className="media__page-heading"


### PR DESCRIPTION
Related to [Atomic: Image thumbnails not loading when an AT site is Private #52520](https://github.com/Automattic/wp-calypso/issues/52520)
Internal Discussion: pdtR3Z-1Aa-p2

## Proposed Changes

This PR adds a notice to a Private Atomic site's media library that explains the Image CDN is disabled and links to public documentation about privacy settings on an Atomic site.

<img width="1013" alt="image" src="https://user-images.githubusercontent.com/36432/218839777-c453f684-bf08-45af-880e-db0d354985f1.png">


> The image CDN is disabled because your site is marked Private. If image thumbnails do not display in your Media Library, you can switch to Coming Soon mode.
[Learn more](http://wordpress.com/support/settings/privacy-settings/#private) 

### Problem this solves:

When an Atomic site is Private, `wpcomsh` (.com's mu-plugin) disables the `photon-cdn` Jetpack module to make the site truly private (source: P9HQHe-yS-p2). 

As a result, if an Atomic site is Public or Coming Soon and a user uploads photos while `photon-cdn` is enabled and then later sets the site to Private, the thumbnails in the user's Media Library result in grayboxes since `photon-cdn` is disabled and the thumbnails can't be loaded from the CDN links. Issue: https://github.com/Automattic/wp-calypso/issues/52520 

It was proposed that we regenerate media thumbnails every time an Atomic site is set to Private, but that could potentially mean regenerating thousands and sometimes tens of thousands of thumbnails per site, which is not an ideal use of site and system resources. 

After discussion with @ Automattic/reactor  and @ jdodd we decided a front-end notice in the media library via Calypso and wp-admin, along with documentation, is the best option at this time to reduce user confusion and direct support requests about https://github.com/Automattic/wp-calypso/issues/52520  ( pdtR3Z-1jX-p2#comment-983 )

### Testing instructions:

**On an Atomic site:** 

1. Start by creating a brand new site > Upgrade to Business > Go to Hosting Configuration > Activate to make the site Atomic. The site's Privacy setting by default will be **Coming Soon/Unlaunched**; The media library notice should **NOT display**. 
3. Change the Privacy Settings to **Public** and **Coming Soon** and refresh the Media Libray: The notice should **NOT display**. 
5. Set an Atomic site's Privacy Settings to **Private** and open its media library: The notice **SHOULD display**. 

**On a Simple site:** 

1. Create a new **Unlaunched/Coming Soon** site and load the media library. The notice should **NOT** display.  
2. Toggle the Privacy Settings to **Public, Private, or Coming Soon** and open its media library: The notice should **NOT display on simple sites** at all. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?