### PR TITLE
Update post purchase upsell width

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
@@ -46,7 +46,12 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 
 	image() {
 		return (
-			<img className="business-plan-upgrade-upsell-new-design__image" src={ upsellImage } alt="" />
+			<img
+				className="business-plan-upgrade-upsell-new-design__image"
+				src={ upsellImage }
+				alt=""
+				width="255"
+			/>
 		);
 	}
 
@@ -140,7 +145,7 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 	footer() {
 		const { translate, handleClickAccept, handleClickDecline } = this.props;
 		return (
-			<footer className="business-plan-upgrade-upsell-new-design__footer">
+			<footer>
 				<Button
 					data-e2e-button="decline"
 					className="business-plan-upgrade-upsell-new-design__decline-offer-button"

--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/style.scss
@@ -61,7 +61,9 @@ main.business-plan-upgrade-upsell-new-design.main {
 		}
 
 		img {
-			margin: 0 0 0 30px;
+			@include breakpoint-deprecated( ">660px" ) {
+				margin: 0 0 0 30px;
+			}
 		}
 	}
 

--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/style.scss
@@ -54,7 +54,6 @@ main.business-plan-upgrade-upsell-new-design.main {
 	}
 
 	&__image-container {
-		min-width: 200px;
 		grid-area: images;
 		text-align: center;
 		@include breakpoint-deprecated( "<660px" ) {
@@ -62,7 +61,7 @@ main.business-plan-upgrade-upsell-new-design.main {
 		}
 
 		img {
-			max-width: 60%;
+			margin: 0 0 0 30px;
 		}
 	}
 
@@ -77,21 +76,19 @@ main.business-plan-upgrade-upsell-new-design.main {
 	}
 
 	&__container {
-		max-width: 746px;
+		max-width: 830px;
 		margin: 0 auto;
 		display: grid;
-		grid-auto-rows: auto 1fr;
-		grid-template-columns: minmax(0, 1fr) 50%;
+		grid-auto-rows: auto;
+		grid-template-columns: 1fr 2fr auto;
 		grid-template-areas:
 			"body body images"
-			"countdown countdown images"
 			"buttons buttons images";
 		@include breakpoint-deprecated( "<660px" ) {
 			grid-auto-rows: auto;
 			grid-template-columns: 1fr;
 			grid-template-areas:
 				"body body body"
-				"countdown countdown countdown"
 				"buttons buttons buttons"
 				"images images images";
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1596
## Proposed Changes

* This PR updates the style of the post purchase upsell so the height of the copy + buttons is the same as the image.

Before | After
--|--
![post-purchase-before](https://user-images.githubusercontent.com/140841/217966248-28ef88b2-c45a-44ac-beea-bc886290cf13.png)  | ![post-purchase-after](https://user-images.githubusercontent.com/140841/217966255-6dd5d068-72ee-42f7-99a7-38f88b84df1e.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Using a free site, purchase a Premium plan. After checking out, you'll see this upsell page.
* How does it look?
* Does it look in different browsers, resolutions, and on mobile?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
