### PR TITLE
Launchpad: Say 'Skip to dashboard' instead of 'Go to Admin'

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -78,7 +78,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 				stepName="launchpad"
 				goNext={ navigation.goNext }
 				isWideLayout={ true }
-				skipLabelText={ translate( 'Go to Admin' ) }
+				skipLabelText={ translate( 'Skip to dashboard' ) }
 				skipButtonAlign="bottom"
 				hideBack={ true }
 				stepContent={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -168,7 +168,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 						recordTracksEvent( 'calypso_launchpad_go_to_admin_clicked', { flow: flow } );
 						goNext?.();
 					} }
-					label={ translate( 'Go to Admin' ) }
+					label={ translate( 'Skip to dashboard' ) }
 					borderless={ true }
 				/>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -69,7 +69,7 @@ describe( 'Sidebar', () => {
 	it( 'displays an escape hatch from Launchpad that will take the user to Calypso my Home', () => {
 		renderSidebar( props );
 
-		const escapeHatchButton = screen.getByRole( 'button', { name: /go to admin/i } );
+		const escapeHatchButton = screen.getByRole( 'button', { name: /Skip to dashboard/i } );
 		expect( escapeHatchButton ).toBeVisible();
 	} );
 


### PR DESCRIPTION
From p1675686594543799-slack-C9EJ7KSGH

## Proposed Changes

Switches a couple of strings to say 'Skip to dashboard' instead of 'Go to Admin'.

## Testing Instructions

1. Go through the flow and make sure the strings appear as expected.