### PR TITLE
Stats: Updating Reach module

### DIFF
--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -81,17 +81,10 @@ const StatsInsights = ( props ) => {
 						{ ! isOdysseyStats && <StatShares siteId={ siteId } /> }
 
 						<Followers path="followers" />
-						<StatsModule
-							path="publicize"
-							moduleStrings={ moduleStrings.publicize }
-							statType="statsPublicize"
-							hideSummaryLink
-							hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
-						/>
+						<Reach />
 
 						{ /* Replaced by new modules on top of the page */ }
 						{ ! isLatestPostReplaced && <LatestPostSummary /> }
-						{ /* <Reach /> */ }
 					</div>
 				) : (
 					// remove all this section when cleaning 'stats/insights-page-grid'

--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -11,6 +11,8 @@ import {
 	getSiteStatsNormalizedData,
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import StatsListCard from '../stats-list/stats-list-card';
+import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsTabs from '../stats-tabs';
 import StatsTab from '../stats-tabs/tab';
 
@@ -36,39 +38,108 @@ export const StatsReach = ( props ) => {
 		0
 	);
 
+	const isInsightsPageGridEnabled = config.isEnabled( 'stats/insights-page-grid' );
+
+	let data = [];
+
+	if ( isInsightsPageGridEnabled ) {
+		const wpData = {
+			value: wpcomFollowCount,
+			label: translate( 'WordPress.com' ),
+		};
+
+		const emailData = {
+			value: emailFollowCount,
+			label: translate( 'Email' ),
+		};
+
+		const socialData = {
+			value: publicizeFollowCount,
+			label: translate( 'Social' ),
+		};
+
+		if ( ! isOdysseyStats ) {
+			wpData.actions = [
+				{
+					type: 'link',
+					data: `/people/followers/${ siteSlug }`,
+				},
+			];
+
+			emailData.actions = [
+				{
+					type: 'link',
+					data: `/people/email-followers/${ siteSlug }`,
+				},
+			];
+		}
+
+		if ( publicizeFollowCount > 0 ) {
+			socialData.children = publicizeData;
+		}
+
+		data = [ wpData, emailData, socialData ];
+
+		// sort descending
+		data.sort( ( a, b ) => b.value - a.value );
+	}
+
 	return (
-		<div className="list-total-followers">
+		<>
 			{ siteId && <QuerySiteStats siteId={ siteId } statType="statsFollowers" /> }
 			{ siteId && <QuerySiteStats siteId={ siteId } statType="statsPublicize" /> }
-			<SectionHeader label={ translate( 'Subscriber totals' ) } />
-			<Card className="stats-module stats-reach__card">
-				<StatsTabs borderless>
-					<StatsTab
-						gridicon="my-sites"
-						label={ translate( 'WordPress.com' ) }
-						loading={ isLoadingFollowData }
-						href={ ! isOdysseyStats ? `/people/followers/${ siteSlug }` : null }
-						value={ wpcomFollowCount }
-						compact
-					/>
-					<StatsTab
-						gridicon="mail"
-						label={ translate( 'Email' ) }
-						loading={ isLoadingFollowData }
-						href={ ! isOdysseyStats ? `/people/email-followers/${ siteSlug }` : null }
-						value={ emailFollowCount }
-						compact
-					/>
-					<StatsTab
-						gridicon="share"
-						label={ translate( 'Social' ) }
-						loading={ isLoadingPublicize }
-						value={ publicizeFollowCount }
-						compact
-					/>
-				</StatsTabs>
-			</Card>
-		</div>
+			{ isInsightsPageGridEnabled && (
+				<StatsListCard
+					moduleType="publicize"
+					data={ data }
+					title={ translate( 'Social subscribers' ) }
+					emptyMessage={ translate( 'No subscribers recorded' ) }
+					mainItemLabel={ translate( 'Service' ) }
+					metricLabel={ translate( 'Total subscribers' ) }
+					splitHeader
+					useShortNumber
+					// Shares don't have a summary page yet.
+					// TODO: limit to 5 items after summary page is added.
+					// showMore={ ... }
+					// TODO: add error state once it's implemented
+					loader={
+						isLoadingFollowData && <StatsModulePlaceholder isLoading={ isLoadingFollowData } />
+					}
+				/>
+			) }
+			{ ! isInsightsPageGridEnabled && (
+				<div className="list-total-followers">
+					<SectionHeader label={ translate( 'Subscriber totals' ) } />
+					<Card className="stats-module stats-reach__card">
+						<StatsTabs borderless>
+							<StatsTab
+								gridicon="my-sites"
+								label={ translate( 'WordPress.com' ) }
+								loading={ isLoadingFollowData }
+								href={ ! isOdysseyStats ? `/people/followers/${ siteSlug }` : null }
+								value={ wpcomFollowCount }
+								compact
+							/>
+							<StatsTab
+								gridicon="mail"
+								label={ translate( 'Email' ) }
+								loading={ isLoadingFollowData }
+								href={ ! isOdysseyStats ? `/people/email-followers/${ siteSlug }` : null }
+								value={ emailFollowCount }
+								compact
+							/>
+							<StatsTab
+								gridicon="share"
+								label={ translate( 'Social' ) }
+								loading={ isLoadingPublicize }
+								value={ publicizeFollowCount }
+								compact
+							/>
+						</StatsTabs>
+					</Card>
+				</div>
+			) }
+		</>
 	);
 };
 

--- a/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
+++ b/packages/components/src/horizontal-bar-list/horizontal-bar-grid-item.tsx
@@ -132,6 +132,7 @@ const HorizontalBarListItem = ( {
 									data={ child }
 									maxValue={ maxValue }
 									useShortLabel={ useShortLabel }
+									useShortNumber={ useShortNumber }
 									renderRightSideItem={ renderRightSideItem }
 									onClick={ ( e ) => onClick?.( e, child ) }
 									hasIndicator={ hasIndicator }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72134
## Proposed Changes

* Update the existing `Reach` component that already combines `Publicize` and `Subscribers totals` data to display new `Social followers` with horizontal bars
* Fix horizontal bar groups to render shortened numbers for the child elements

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch and the `Insights` page
* verify that the current `Subscribers totals` renders correctly
* apply feature flag to the URL `?flags=stats/insights-page-grid`
* verify that the new module with horizontal bars loads correctly next to the `Subscribers` card on the second row of the grid

| Before | After |
| --- | --- |
| ![SCR-20230210-kpn](https://user-images.githubusercontent.com/112354940/217981393-f4d1e611-50b3-431f-9c1f-3dd9627b57b7.png) | ![SCR-20230210-kob](https://user-images.githubusercontent.com/112354940/217981427-7c0d57ac-7dc1-487d-a9cf-8d0f2661cfa9.png) |
| n/a |  ![SCR-20230210-kp2](https://user-images.githubusercontent.com/112354940/217981452-25a73a42-ec60-40a5-b5e4-1234c652ca3e.png) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
