### PR TITLE
Fix padding on paragraph in group block

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -168,6 +168,9 @@
 	.has-text-align-right {
 		text-align: right;
 	}
+	.wp-block-group p:last-child {
+		margin-bottom: 24px;
+	}
 }
 
 .reader-full-post__story-content img {


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/43595

I don't think we want to support the `group` block with any special display CSS, but currently it can cause the whitespace to be a little broken in the full post page.

This ensures that paragraphs within group blocks do not have their padding stripped

### Before:
<img width="754" alt="Screen Shot 2023-02-10 at 2 27 55 pm" src="https://user-images.githubusercontent.com/22446385/218000762-01d684f3-38f9-482a-bbab-bdeade338690.png">

### After
<img width="781" alt="Screen Shot 2023-02-10 at 2 34 58 pm" src="https://user-images.githubusercontent.com/22446385/218001660-da7fda16-e761-404c-815a-a107c42c4d73.png">

### Testing instructions 
see https://github.com/Automattic/wp-calypso/issues/43595

example post: https://wordpress.com/read/blogs/159889361/posts/1037
