### PR TITLE
Reader: Tidy up "latest posts" block from reader full post page

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -647,6 +647,6 @@
 	}
 }
 
-.wp-block-latest-posts {
-	display: none;
+.wp-block-latest-posts__post-date::before {
+	content: " - ";
 }

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -646,3 +646,7 @@
 		}
 	}
 }
+
+.wp-block-latest-posts {
+	display: none;
+}


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/43595

Given the purpose of reader and the full post page is to read one blog post at a time, I don't think that displaying a nested list of posts is in alignment with that goal.

Currently the "latest posts" block looks somewhat broken in reader.

This PR simply hides the block.

### Before
<img width="789" alt="Screen Shot 2023-02-10 at 2 49 32 pm" src="https://user-images.githubusercontent.com/22446385/218003581-775f8586-588b-4881-9409-7e47a73bce63.png">

### After 
<img width="776" alt="Screen Shot 2023-02-10 at 2 49 39 pm" src="https://user-images.githubusercontent.com/22446385/218003588-24bbad92-85c4-484a-80b9-9c00b63a60b1.png">


### Testing instructions 

Example post: https://wordpress.com/read/blogs/159889361/posts/1003
