### PR TITLE
Reader: Visually fix file download link in reader full post page

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -623,6 +623,14 @@
 	display: none;
 }
 
+.wp-block-file {
+	margin-bottom: 24px;
+
+	.wp-block-file__button {
+		display: none;
+	}
+}
+
 .reader-post-actions__item {
 	&:hover,
 	button.is-active,


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/43595

Currently the "File" block looks slightly broken, this tiny PR gives it a little tidy up and hides the unnecessary "Download" button

### Before 
<img width="773" alt="Screen Shot 2023-02-10 at 2 55 43 pm" src="https://user-images.githubusercontent.com/22446385/218004570-1d923eba-1c3f-4671-a311-53d2199e2ea5.png">

### After 
<img width="794" alt="Screen Shot 2023-02-10 at 2 55 38 pm" src="https://user-images.githubusercontent.com/22446385/218004597-ab1adc5c-e09d-4652-82dc-b6b93747909d.png">

### Testing instructions 
Example site https://wordpress.com/read/blogs/159889361/posts/1219
