### PR TITLE
Fix relative theme feature links

### DIFF
--- a/client/my-sites/theme/theme-features-card.js
+++ b/client/my-sites/theme/theme-features-card.js
@@ -34,7 +34,7 @@ const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate } ) =>
 
 export default connect( ( state, { taxonomies } ) => {
 	const features = get( taxonomies, 'theme_feature', [] ).map( ( { name, slug } ) => {
-		const term = isValidThemeFilterTerm( state, slug ) ? slug : `feature:${ slug }`;
+		const term = isValidThemeFilterTerm( state, slug ) ? slug : `${ slug }`;
 		return { name, slug, term };
 	} );
 	return { features };


### PR DESCRIPTION
## Proposed Changes

There is an issue where links to the filter page for each feature contain relative links. These links somehow get rendered with a `:`. Those links that contain the `:` get redirected back to the main themes page. They look ugly and they are causing some confusion for search engines. Let's fix these. 
<img width="733" alt="Screenshot 2023-02-09 at 10 17 32 PM" src="https://user-images.githubusercontent.com/48809176/218009672-33d5ec45-5d4c-479f-8a96-0d5968ed5181.png">
<img width="440" alt="Screenshot 2023-02-09 at 10 18 03 PM" src="https://user-images.githubusercontent.com/48809176/218009671-9ee8019d-5ab4-48ec-b499-909ced97ac5b.png">
<img width="886" alt="Screenshot 2023-02-09 at 10 18 57 PM" src="https://user-images.githubusercontent.com/48809176/218009666-adffc2e2-b408-4328-af01-2c82fcb0df4f.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**The flow when logged-out, not running calypso locally:**
- Visit https://wordpress.com/themes
- Select a theme. I chose blank canvas
- Scroll down to the bottom to the features section and inspect a feature
- Inspected element shows `<a href="/themes/filter/custom-colors/">Custom Colors</a>`
- View page source to search for `theme__sheet-features-list`
`<li>` for Custom Colors should show `<li><a href="[/themes/filter/feature:custom-colors/](https://wordpress.com/themes/filter/feature:custom-colors/)">Custom Colors</a></li>`
- Crawlers follow that link, which redirects to wordpress.com/themes

**The flow when logged-in, running calypso locally with changes applied:**

- Visit https://wordpress.com/themes
- Site selector pops up. Select any site
- Sends you to `https://wordpress.com/themes/[site]`
- Select a theme. I chose blank canvas
- Scroll down to the bottom to the features section and inspect a feature
- Inspected element shows `<a href="/themes/filter/custom-colors/[site]">Custom Colors</a>`
- Trying to view page source won’t work in this scenario

**The flow when logged-in, not running calypso locally:**

- Visit https://wordpress.com/themes
- Site selector pops up. Select any site
- Sends you to `https://wordpress.com/themes/[site]`
- Select a theme. I chose blank canvas
- Scroll down to the bottom to the features section and inspect a feature
- Inspected element shows `<a href="/themes/filter/custom-colors/[site]">Custom Colors</a>`
- Trying to view page source won’t work in this scenario

**The flow when logged-out, running calypso locally with changes applied:**

- Visit https://wordpress.com/themes
- Select a theme. I chose blank canvas
- Scroll down to the bottom to the features section and inspect a feature
- Inspected element shows `<a href="/themes/filter/custom-colors/">Custom Colors</a>`
- View page source to search for `theme__sheet-features-list`
- `<li>` for Custom Colors should show `<li><a href="[/themes/filter/custom-colors/](http://calypso.localhost:3000/themes/filter/custom-colors/)">Custom Colors</a></li>`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
