### PR TITLE
Stats: Updating new grid items take max height

### DIFF
--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -61,6 +61,27 @@ $grid-vertical-gutters: 32px;
 		padding: 0 16px;
 	}
 
+	// Temporary change until all cards are replaced with new components. Remove when cleaning 'stats/insights-page-grid' FF.
+	@media (min-width: 661px) {
+		& > div {
+			display: flex;
+			flex-direction: column;
+			align-items: stretch;
+
+			& > * {
+				margin: 0;
+
+				& + div {
+					flex: 1 0 auto;
+				}
+			}
+
+			.card.stats-module {
+				margin-bottom: 0;
+			}
+		}
+	}
+
 	.stats__module-wrapper--tags-categories,
 	.list-tags-categories {
 		grid-area: tags-categories;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72134
## Proposed Changes

* Use CSS class controlled by a feature flag and apply styles stretching each of the cards on the grid on the modernised Insights page

This change is behind a feature flag and is temporary until all of the cards are replaced with new horizontal bar cards (which stretch automatically)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* use live branch to verify that the `Insights` page loads correctly and when the bottom of the page doesn't have a CSS grid applied (similar to the Traffic page) the modules are not stretched
* apply feature flag to the URL `?flags=stats/insights-page-grid`
* verify that all modules are stretched and aligned to the grid

Grid after the changes:
![SCR-20230210-qr7](https://user-images.githubusercontent.com/112354940/218017233-d49e819d-e82e-4546-8b75-3176a8526a84.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
