### PR TITLE
Plugins: Add getFilteredAndSortedPlugins to selectors-ts

### DIFF
--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -135,7 +135,7 @@ export const getFilteredAndSortedPlugins = createSelector(
 		const allPluginsIndexedBySiteId = getAllPluginsIndexedBySiteId( state );
 
 		// Properties on the objects in allPluginsIndexedBySiteId will be modified and the
-		// selector memoization always returns the same object, so use cloneDeep to avoid
+		// selector memoization always returns the same object, so use `structuredClone` to avoid
 		// altering it for everyone.
 		const allPluginsForSites: { [ pluginSlug: string ]: Plugin } = structuredClone(
 			siteIds

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -160,28 +160,27 @@ export const getFilteredAndSortedPlugins = createSelector(
 		// Filter the plugins using the pluginFilter if it is set
 		const pluginList =
 			pluginFilter && _filters[ pluginFilter ]
-				? Object.entries( allPluginsForSites )
-						.filter( ( [ , plugin ] ) => _filters[ pluginFilter ]( plugin ) )
-						.reduce( ( obj, [ pluginSlug, plugin ] ) => {
-							obj[ pluginSlug ] = plugin;
+				? Object.values( allPluginsForSites )
+						.filter( ( plugin ) => _filters[ pluginFilter ]( plugin ) )
+						.reduce( ( obj, plugin ) => {
+							obj[ plugin.slug ] = plugin;
 							return obj;
 						}, {} as { [ pluginSlug: string ]: Plugin } )
 				: allPluginsForSites;
 
 		// Sort the plugins alphabetically by slug
-		const sortedPluginListEntries = Object.entries( pluginList ).sort(
-			( [ pluginSlugA ], [ pluginSlugB ] ) => {
-				const pluginSlugALower = pluginSlugA.toLowerCase();
-				const pluginSlugBLower = pluginSlugB.toLowerCase();
-				if ( pluginSlugALower < pluginSlugBLower ) {
-					return -1;
-				} else if ( pluginSlugALower > pluginSlugBLower ) {
-					return 1;
-				}
-				return 0;
+		const sortedPluginListEntries = Object.values( pluginList ).sort( ( pluginA, pluginB ) => {
+			const pluginSlugALower = pluginA.slug.toLowerCase();
+			const pluginSlugBLower = pluginB.slug.toLowerCase();
+			if ( pluginSlugALower < pluginSlugBLower ) {
+				return -1;
+			} else if ( pluginSlugALower > pluginSlugBLower ) {
+				return 1;
 			}
-		);
-		return sortedPluginListEntries.map( ( [ , plugin ] ) => plugin );
+			return 0;
+		} );
+
+		return sortedPluginListEntries;
 	},
 	( state: AppState ) => [ getAllPluginsIndexedBySiteId( state ) ],
 	( state: AppState, siteIds: number[], pluginFilter?: PluginFilter ) => {

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -157,6 +157,7 @@ export const getFilteredAndSortedPlugins = createSelector(
 				}, {} as PluginSites );
 		}
 
+		// Filter the plugins using the pluginFilter if it is set
 		const pluginList =
 			pluginFilter && _filters[ pluginFilter ]
 				? Object.entries( allPluginsForSites )
@@ -167,6 +168,7 @@ export const getFilteredAndSortedPlugins = createSelector(
 						}, {} as { [ pluginSlug: string ]: Plugin } )
 				: allPluginsForSites;
 
+		// Sort the plugins alphabetically by slug
 		const sortedPluginListEntries = Object.entries( pluginList ).sort(
 			( [ pluginSlugA ], [ pluginSlugB ] ) => {
 				const pluginSlugALower = pluginSlugA.toLowerCase();

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -1,5 +1,4 @@
 import { createSelector } from '@automattic/state-utils';
-import { cloneDeep } from 'lodash';
 import { isRequesting, isRequestingForAllSites } from './selectors';
 import type {
 	InstalledPlugins,
@@ -138,7 +137,7 @@ export const getFilteredAndSortedPlugins = createSelector(
 		// Properties on the objects in allPluginsIndexedBySiteId will be modified and the
 		// selector memoization always returns the same object, so use cloneDeep to avoid
 		// altering it for everyone.
-		const allPluginsForSites: { [ pluginSlug: string ]: Plugin } = cloneDeep(
+		const allPluginsForSites: { [ pluginSlug: string ]: Plugin } = structuredClone(
 			siteIds
 				.map( ( siteId: number ) => allPluginsIndexedBySiteId[ siteId ] )
 				.filter( Boolean )

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -9,6 +9,9 @@ import {
 
 import 'calypso/state/plugins/init';
 
+// TODO: Much of the functionality in this file is duplicated with selectors.js
+// which needs to be removed when this file is complete.
+
 const _filters = {
 	none: function () {
 		return false;

--- a/client/state/plugins/installed/test/selectors-ts.ts
+++ b/client/state/plugins/installed/test/selectors-ts.ts
@@ -5,7 +5,11 @@ import {
 	INSTALL_PLUGIN,
 } from 'calypso/lib/plugins/constants';
 import { userState } from 'calypso/state/selectors/test/fixtures/user-state';
-import { getAllPluginsIndexedByPluginSlug, getAllPluginsIndexedBySiteId } from '../selectors-ts';
+import {
+	getAllPluginsIndexedByPluginSlug,
+	getAllPluginsIndexedBySiteId,
+	getFilteredAndSortedPlugins,
+} from '../selectors-ts';
 import { akismet, helloDolly, jetpack } from './fixtures/plugins';
 
 const siteOneId = 12345;
@@ -211,5 +215,53 @@ describe( 'getAllPluginsIndexedBySiteId', () => {
 		const pluginsTwo = getAllPluginsIndexedBySiteId( state );
 
 		expect( pluginsOne ).toBe( pluginsTwo );
+	} );
+} );
+
+describe( 'getFilteredAndSortedPlugins', () => {
+	test( 'Should get an empty array if the requested site is not in the current state', () => {
+		const plugins = getFilteredAndSortedPlugins( state, [ nonExistingSiteId ], undefined );
+		expect( plugins ).toHaveLength( 0 );
+	} );
+
+	test( 'Should get an empty array if the plugins for this site are still being requested', () => {
+		const plugins = getFilteredAndSortedPlugins( state, [ siteThreeId ], undefined );
+		expect( plugins ).toHaveLength( 0 );
+	} );
+
+	test( 'Should get a plugin list of length 3 if both sites are requested', () => {
+		const plugins = getFilteredAndSortedPlugins( state, [ siteOneId, siteTwoId ], undefined );
+		expect( plugins ).toHaveLength( 3 );
+	} );
+
+	test( 'Should get a plugin list containing jetpack if both sites are requested', () => {
+		const plugins = getFilteredAndSortedPlugins( state, [ siteOneId, siteTwoId ], undefined );
+		const siteWithPlugin = {
+			[ siteTwoId ]: {
+				active: jetpack.active,
+				autoupdate: jetpack.autoupdate,
+				update: jetpack.update,
+				version: jetpack.version,
+			},
+		};
+		const { active, autoupdate, update, version, ...pluginProperties } = jetpack;
+		expect( plugins ).toEqual(
+			expect.arrayContaining( [ { ...pluginProperties, sites: siteWithPlugin } ] )
+		);
+	} );
+
+	test( 'Should get a plugin list of length 2 if only site 1 is requested', () => {
+		const plugins = getFilteredAndSortedPlugins( state, [ siteOneId ], undefined );
+		expect( plugins ).toHaveLength( 2 );
+	} );
+
+	test( 'Should get a plugin list of length 2 if active plugins on both sites are requested', () => {
+		const plugins = getFilteredAndSortedPlugins( state, [ siteOneId, siteTwoId ], 'active' );
+		expect( plugins ).toHaveLength( 2 );
+	} );
+
+	test( 'Should get a plugin list of length 1 if inactive plugins on site 1 is requested', () => {
+		const plugins = getFilteredAndSortedPlugins( state, [ siteOneId ], 'inactive' );
+		expect( plugins ).toHaveLength( 1 );
 	} );
 } );

--- a/client/state/plugins/installed/test/selectors-ts.ts
+++ b/client/state/plugins/installed/test/selectors-ts.ts
@@ -234,20 +234,9 @@ describe( 'getFilteredAndSortedPlugins', () => {
 		expect( plugins ).toHaveLength( 3 );
 	} );
 
-	test( 'Should get a plugin list containing jetpack if both sites are requested', () => {
+	test( 'Should get a plugin list containing all plugins in sorted order if both sites are requested', () => {
 		const plugins = getFilteredAndSortedPlugins( state, [ siteOneId, siteTwoId ], undefined );
-		const siteWithPlugin = {
-			[ siteTwoId ]: {
-				active: jetpack.active,
-				autoupdate: jetpack.autoupdate,
-				update: jetpack.update,
-				version: jetpack.version,
-			},
-		};
-		const { active, autoupdate, update, version, ...pluginProperties } = jetpack;
-		expect( plugins ).toEqual(
-			expect.arrayContaining( [ { ...pluginProperties, sites: siteWithPlugin } ] )
-		);
+		expect( plugins ).toEqual( [ akismetWithSites, helloDollyWithSites, jetpackWithSites ] );
 	} );
 
 	test( 'Should get a plugin list of length 2 if only site 1 is requested', () => {

--- a/client/state/plugins/installed/types.ts
+++ b/client/state/plugins/installed/types.ts
@@ -37,7 +37,7 @@ export type Plugin = {
 };
 
 export type PluginSites = {
-	[ key: string ]: {
+	[ siteId: string ]: {
 		active: boolean;
 		autoupdate: boolean;
 		update?: PluginUpdate;

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -30,7 +30,7 @@ jest.mock( 'wpcom-proxy-request', () => ( {
 	__esModule: true,
 } ) );
 
-// structuredClone wasn't available in Jest before verson 28 so this creates
+// TODO: structuredClone wasn't available in Jest before verson 28 so this creates
 // a version to be used for the tests. Once Jest is upgraded to 28 this should
 // be removed.
 global.structuredClone = jest.fn( ( value ) => {

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -29,3 +29,10 @@ global.CSS = {
 jest.mock( 'wpcom-proxy-request', () => ( {
 	__esModule: true,
 } ) );
+
+// structuredClone wasn't available in Jest before verson 28 so this creates
+// a version to be used for the tests. Once Jest is upgraded to 28 this should
+// be removed.
+global.structuredClone = jest.fn( ( value ) => {
+	return JSON.parse( JSON.stringify( value ) );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR adds the `getFilteredAndSortedPlugins` to `selectors-ts`. It will be a replacement for the existing `getPlugins` function in `selectors.js`, with the name being updated to better reflect what it does.

It is the same as the version found in https://github.com/Automattic/wp-calypso/pull/72363, except that I have removed all usages of `lodash` from it as I decided to remove `lodash` from `selectors-ts` in accordance with the plans to remove `lodash` from Calypso.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Review the code and run the tests.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
