### PR TITLE
Logged-out TS: Fix the BCPA CTA not show when looking for a WP.org theme

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -27,6 +27,9 @@ const noop = () => {};
 export const ThemesList = ( props ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
+	const isPatternAssemblerCTAEnabled =
+		isEnabled( 'pattern-assembler/logged-out-showcase' ) && ! isLoggedIn;
+
 	const fetchNextPage = useCallback(
 		( options ) => {
 			props.fetchNextPage( options );
@@ -58,7 +61,14 @@ export const ThemesList = ( props ) => {
 
 	if ( ! props.loading && props.themes.length === 0 ) {
 		if ( matchingWpOrgThemes.length ) {
-			return <WPOrgMatchingThemes matchingThemes={ matchingWpOrgThemes } { ...props } />;
+			return (
+				<>
+					<WPOrgMatchingThemes matchingThemes={ matchingWpOrgThemes } { ...props } />
+					{ isPatternAssemblerCTAEnabled && (
+						<PatternAssemblerCta onButtonClick={ goToSiteAssemblerFlow } />
+					) }
+				</>
+			);
 		}
 
 		return (
@@ -78,9 +88,9 @@ export const ThemesList = ( props ) => {
 				<ThemeBlock key={ 'theme-block' + index } theme={ theme } index={ index } { ...props } />
 			) ) }
 			{ /* The Pattern Assembler CTA will display on the 9th row and the behavior is controlled by CSS */ }
-			{ isEnabled( 'pattern-assembler/logged-out-showcase' ) &&
-				props.themes.length > 0 &&
-				! isLoggedIn && <PatternAssemblerCta onButtonClick={ goToSiteAssemblerFlow } /> }
+			{ isPatternAssemblerCTAEnabled && props.themes.length > 0 && (
+				<PatternAssemblerCta onButtonClick={ goToSiteAssemblerFlow } />
+			) }
 			{ props.loading && <LoadingPlaceholders placeholderCount={ props.placeholderCount } /> }
 			<InfiniteScroll nextPageMethod={ fetchNextPage } />
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-13U-p2#comment-1888

## Proposed Changes

* Show the Blank Canvas Pattern Assembler CTA even if you're looking for a WP.org theme

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the browser in Incognito mode
* Go to /themes
* Search a WP.org theme, e.g. `astra`
* Verify the Blank Canvas Pattern Assembler CTA is showing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?