### PR TITLE
Jetpack Pro Dashboard: add feature flag for site expandable block

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
@@ -100,6 +101,7 @@ export default function SitesOverview() {
 	}, [ refetch, jetpackSiteDisconnected ] );
 
 	const pageTitle = translate( 'Dashboard' );
+	const expandableBlockEnabled = 'Dashboard - Expandable block for sites enabled';
 
 	const basePath = '/dashboard';
 
@@ -231,7 +233,11 @@ export default function SitesOverview() {
 								} ) }
 							>
 								<div className="sites-overview__page-heading">
-									<h2 className="sites-overview__page-title">{ pageTitle }</h2>
+									{ isEnabled( 'jetpack/pro-dashboard-expandable-block' ) ? (
+										<h2 className="sites-overview__page-title">{ expandableBlockEnabled }</h2>
+									) : (
+										<h2 className="sites-overview__page-title">{ pageTitle }</h2>
+									) }
 									<div className="sites-overview__page-subtitle">
 										{ translate( 'Manage all your Jetpack sites from one location' ) }
 									</div>

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -43,6 +43,7 @@
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
+		"jetpack/pro-dashboard-expandable-block": true,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -37,6 +37,7 @@
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
+		"jetpack/pro-dashboard-expandable-block": false,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -39,6 +39,7 @@
 		"jetpack-cloud": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
+		"jetpack/pro-dashboard-expandable-block": false,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -40,6 +40,7 @@
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
+		"jetpack/pro-dashboard-expandable-block": false,
 		"jetpack/partner-portal-payment": true,
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,


### PR DESCRIPTION
#### Proposed Changes

This PR adds the feature flag for the expandable block for the sites in the Jetpack Pro Dashboard

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/feature-flag-for-site-expandable-block` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that the feature flag `jetpack/pro-dashboard-expandable-block` is enabled in dev.
4. Verify that you can now see the page title below

<img width="916" alt="Screenshot 2023-02-10 at 1 10 12 PM" src="https://user-images.githubusercontent.com/10586875/218031458-839174b8-a417-408d-8bb0-bdc32033d347.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related to 1203940061556608-as-1203942568423001