### PR TITLE
Improve happy-blocks assets loading

### DIFF
--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -35,34 +35,12 @@
  *      ```
  */
 
-/**
- * Load editor assets.
- */
-function a8c_happyblocks_assets() {
-	$assets = require_once plugin_dir_path( __FILE__ ) . 'dist/editor.min.asset.php';
-
-	wp_enqueue_script(
-		'a8c-happyblocks-edit-js',
-		plugins_url( 'dist/editor.min.js', __FILE__ ),
-		array_merge( array( 'a8c-happyblocks-pricing-plans' ), $assets['dependencies'] ),
-		$assets['version'],
-		true
-	);
-
-	$style_file = 'dist/editor' . ( is_rtl() ? '.rtl.css' : '.css' );
-	wp_enqueue_style(
-		'a8c-happyblocks-edit-css',
-		plugins_url( $style_file, __FILE__ ),
-		array( 'wp-edit-blocks' ),
-		$assets['version']
-	);
-}
-
-/**
- * Load front-end view assets.
- */
-function a8c_happyblocks_view_assets() {
-	$assets = require plugin_dir_path( __FILE__ ) . 'dist/view.min.asset.php';
+ /**
+	* Load the shared assets for the custom block (view and editor).
+	* @return void
+	*/
+ function a8c_happyblocks_shared_assets() {
+	$assets = require plugin_dir_path( __FILE__ ) . 'dist/editor.min.asset.php';
 
 	wp_register_script( 'a8c-happyblocks-pricing-plans', '', array(), '20221212', true );
 	wp_enqueue_script( 'a8c-happyblocks-pricing-plans' );
@@ -83,6 +61,32 @@ function a8c_happyblocks_view_assets() {
 		array(),
 		$assets['version']
 	);
+}
+
+/**
+ * Load editor assets.
+ */
+function a8c_happyblocks_edit_assets() {
+	a8c_happyblocks_shared_assets();
+
+	$assets = require plugin_dir_path( __FILE__ ) . 'dist/editor.min.asset.php';
+
+	wp_enqueue_script(
+		'a8c-happyblocks-edit-js',
+		plugins_url( 'dist/editor.min.js', __FILE__ ),
+		array_merge( array( 'a8c-happyblocks-pricing-plans' ), $assets['dependencies'] ),
+		$assets['version'],
+		true
+	);
+}
+
+/**
+ * Load view assets.
+ */
+function a8c_happyblocks_view_assets() {
+	a8c_happyblocks_shared_assets();
+
+	$assets = require plugin_dir_path( __FILE__ ) . 'dist/view.min.asset.php';
 
 	$script_file = 'dist/view.js';
 	wp_enqueue_script(
@@ -93,7 +97,7 @@ function a8c_happyblocks_view_assets() {
 		true
 	);
 }
-add_action( 'enqueue_block_editor_assets', 'a8c_happyblocks_assets' );
+add_action( 'enqueue_block_editor_assets', 'a8c_happyblocks_edit_assets' );
 add_action( 'wp_enqueue_scripts', 'a8c_happyblocks_view_assets' );
 
 /**
@@ -161,4 +165,5 @@ function a8c_happyblocks_register() {
 	);
 
 }
+
 add_action( 'init', 'a8c_happyblocks_register' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

fixes 266-gh-Automattic/lighthouse-forums

## Proposed Changes

This PR refactors the assets loading structure so that the assets that are shared both, in the view and in the edit part of the block are always included.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync these changes with `yarn dev --sync`
* Ensure the related issue is fixed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
