### PR TITLE
Adding migrationHandler step to the importer-flow to handle redirects

### DIFF
--- a/client/data/site-migration/use-add-temp-site-mutation.ts
+++ b/client/data/site-migration/use-add-temp-site-mutation.ts
@@ -1,0 +1,37 @@
+import { useCallback } from 'react';
+import { useMutation, useQueryClient } from 'react-query';
+import wp from 'calypso/lib/wp';
+
+interface TempSiteToSourceOption {
+	targetBlogId: number;
+	sourceBlogId: number;
+}
+
+function useAddTempSiteToSourceOptionMutation() {
+	const queryClient = useQueryClient();
+	const mutation = useMutation(
+		( { targetBlogId, sourceBlogId }: TempSiteToSourceOption ) =>
+			wp.req.post(
+				`/migrations/from-source/${ sourceBlogId }`,
+				{
+					apiNamespace: 'wpcom/v2',
+				},
+				{ target_blog_id: targetBlogId }
+			),
+		{
+			onSuccess( data, { sourceBlogId } ) {
+				queryClient.setQueryData( [ 'temp-target-site', sourceBlogId ], data );
+			},
+		}
+	);
+
+	const { mutate } = mutation;
+	const addTempSiteToSourceOption = useCallback(
+		( targetBlogId: number, sourceBlogId: number ) => mutate( { targetBlogId, sourceBlogId } ),
+		[ mutate ]
+	);
+
+	return { addTempSiteToSourceOption, ...mutation };
+}
+
+export default useAddTempSiteToSourceOptionMutation;

--- a/client/data/site-migration/use-source-migration-status-query.ts
+++ b/client/data/site-migration/use-source-migration-status-query.ts
@@ -1,0 +1,21 @@
+import { SourceSiteMigrationDetails } from '@automattic/data-stores/src/site';
+import { useQuery } from 'react-query';
+import wp from 'calypso/lib/wp';
+import type { SiteId } from 'calypso/types';
+
+export const useSourceMigrationStatusQuery = ( sourceId: SiteId | undefined ) => {
+	return useQuery(
+		[ 'source-migration-status', sourceId ],
+		(): Promise< SourceSiteMigrationDetails > =>
+			wp.req.get( {
+				path: '/migrations/from-source/' + encodeURIComponent( sourceId as number ),
+				apiNamespace: 'wpcom/v2',
+			} ),
+		{
+			meta: {
+				persist: false,
+			},
+			enabled: !! sourceId,
+		}
+	);
+};

--- a/client/data/sites/use-site-query.ts
+++ b/client/data/sites/use-site-query.ts
@@ -1,0 +1,19 @@
+import { SiteDetails } from '@automattic/data-stores/src/site';
+import { useQuery } from 'react-query';
+import wp from 'calypso/lib/wp';
+
+export const useSiteQuery = ( sourceSiteSlug: string, enabled = true ) => {
+	return useQuery(
+		[ 'site-details', sourceSiteSlug ],
+		(): Promise< SiteDetails > =>
+			wp.req.get( {
+				path: '/sites/' + encodeURIComponent( sourceSiteSlug as string ),
+			} ),
+		{
+			meta: {
+				persist: false,
+			},
+			enabled,
+		}
+	);
+};

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -181,6 +181,8 @@ export class JetpackAuthorize extends Component {
 			return this.redirect();
 		} else if ( nextProps.isAlreadyOnSitesList && alreadyAuthorized ) {
 			return this.redirect();
+		} else if ( this.isFromJetpackMigration() && nextProps.isAlreadyOnSitesList ) {
+			return this.redirect();
 		}
 		if (
 			authorizeError &&
@@ -292,7 +294,7 @@ export class JetpackAuthorize extends Component {
 			debug( `Redirecting directly to cart with ${ PRODUCT_JETPACK_BACKUP_T1_YEARLY } in cart.` );
 			navigate( `/checkout/${ urlToSlug( homeUrl ) }/${ PRODUCT_JETPACK_BACKUP_T1_YEARLY }` );
 		} else if ( this.isFromJetpackMigration() ) {
-			navigate( `/setup/import-focused/siteCreationStep?from=${ urlToSlug( homeUrl ) }` );
+			navigate( `/setup/import-focused/migrationHandler?from=${ urlToSlug( homeUrl ) }` );
 		} else {
 			const redirectionTarget = this.getRedirectionTarget();
 			debug( `Redirecting to: ${ redirectionTarget }` );

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -18,6 +18,7 @@ import ImporterMedium from './internals/steps-repository/importer-medium';
 import ImporterSquarespace from './internals/steps-repository/importer-squarespace';
 import ImporterWix from './internals/steps-repository/importer-wix';
 import ImporterWordpress from './internals/steps-repository/importer-wordpress';
+import MigrationHandler from './internals/steps-repository/migration-handler';
 import PatternAssembler from './internals/steps-repository/pattern-assembler';
 import ProcessingStep from './internals/steps-repository/processing-step';
 import SiteCreationStep from './internals/steps-repository/site-creation-step';
@@ -43,6 +44,7 @@ const importFlow: Flow = {
 			{ slug: 'patternAssembler', component: PatternAssembler },
 			{ slug: 'processing', component: ProcessingStep },
 			{ slug: 'siteCreationStep', component: SiteCreationStep },
+			{ slug: 'migrationHandler', component: MigrationHandler },
 		];
 	},
 
@@ -70,6 +72,28 @@ const importFlow: Flow = {
 			} );
 
 			return navigate( 'processing' );
+		};
+
+		const handleMigrationRedirects = ( providedDependencies: ProvidedDependencies = {} ) => {
+			const from = urlQueryParams.get( 'from' );
+			// If there's any errors, we redirct them to the siteCreationStep for a clean start
+			if ( providedDependencies?.hasError ) {
+				return navigate( 'siteCreationStep' );
+			}
+			if ( providedDependencies?.status === 'inactive' ) {
+				// This means they haven't kick off the migration before, so we send them to create a new site
+				if ( ! providedDependencies?.targetBlogId ) {
+					return navigate( 'siteCreationStep' );
+				}
+				// For some reason, the admin role is mismatch, we want to create a new site for them as well
+				if ( providedDependencies?.isAdminOnTarget === false ) {
+					return navigate( 'siteCreationStep' );
+				}
+			}
+			// For those who hasn't paid or in the middle of the migration process, we sent them to the importerWordPress step
+			return navigate(
+				`importerWordpress?siteSlug=${ providedDependencies?.targetBlogSlug }&from=${ from }&option=everything`
+			);
 		};
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
@@ -120,6 +144,9 @@ const importFlow: Flow = {
 					return navigate( 'processing' );
 
 				case 'processing': {
+					if ( providedDependencies?.isFromMigrationPlugin ) {
+						return handleMigrationRedirects( providedDependencies );
+					}
 					if ( providedDependencies?.siteSlug ) {
 						const from = urlQueryParams.get( 'from' );
 						return navigate( `import?siteSlug=${ providedDependencies?.siteSlug }&from=${ from }` );
@@ -130,6 +157,9 @@ const importFlow: Flow = {
 					}
 
 					return exitFlow( `/home/${ siteSlugParam }` );
+				}
+				case 'migrationHandler': {
+					return navigate( 'processing' );
 				}
 			}
 		};

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -144,9 +144,6 @@ const importFlow: Flow = {
 					return navigate( 'processing' );
 
 				case 'processing': {
-					if ( providedDependencies?.isFromMigrationPlugin ) {
-						return handleMigrationRedirects( providedDependencies );
-					}
 					if ( providedDependencies?.siteSlug ) {
 						const from = urlQueryParams.get( 'from' );
 						return navigate( `import?siteSlug=${ providedDependencies?.siteSlug }&from=${ from }` );
@@ -159,7 +156,7 @@ const importFlow: Flow = {
 					return exitFlow( `/home/${ siteSlugParam }` );
 				}
 				case 'migrationHandler': {
-					return navigate( 'processing' );
+					return handleMigrationRedirects( providedDependencies );
 				}
 			}
 		};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -1,8 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { SiteDetails, SourceSiteMigrationDetails } from '@automattic/data-stores/src/site';
 import { addQueryArgs } from '@wordpress/url';
 import { camelCase } from 'lodash';
-import wpcomRequest from 'wpcom-proxy-request';
 import { ImporterPlatform } from 'calypso/blocks/import/types';
 import {
 	getImporterUrl,
@@ -10,7 +8,6 @@ import {
 	getWpOrgImporterUrl,
 } from 'calypso/blocks/import/util';
 import { WPImportOption } from 'calypso/blocks/importer/wordpress/types';
-import wpcom from 'calypso/lib/wp';
 import { BASE_ROUTE } from './config';
 
 export function getFinalImporterUrl(
@@ -64,37 +61,4 @@ export function generateStepPath( stepName: string, stepSectionName?: string ) {
 	const path = routes.join( '_' );
 
 	return camelCase( path ) as string;
-}
-
-export async function addTempSiteToSourceOption( targetBlogId: number, sourceSiteSlug: string ) {
-	try {
-		const sourceSite = await getSite( sourceSiteSlug );
-		const result = await wpcom.req.post( {
-			path: `/migrations/from-source/${ sourceSite.ID }`,
-			apiNamespace: 'wpcom/v2',
-			body: {
-				target_blog_id: targetBlogId,
-			},
-		} );
-		return result;
-	} catch ( error ) {
-		// eslint-disable-next-line no-console
-		console.error( 'Unable to store option in source site', error );
-	}
-}
-
-export function getSite( sourceSiteSlug: string ) {
-	return wpcomRequest< SiteDetails >( {
-		path: '/sites/' + encodeURIComponent( sourceSiteSlug as string ),
-		apiVersion: '1.1',
-	} );
-}
-
-export function getSourceSiteMigrationData(
-	sourceId: number
-): Promise< SourceSiteMigrationDetails > {
-	return wpcom.req.get( {
-		path: '/migrations/from-source/' + encodeURIComponent( sourceId as number ),
-		apiNamespace: 'wpcom/v2',
-	} );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -1,6 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { SiteDetails, SourceSiteMigrationDetails } from '@automattic/data-stores/src/site';
 import { addQueryArgs } from '@wordpress/url';
 import { camelCase } from 'lodash';
+import wpcomRequest from 'wpcom-proxy-request';
 import { ImporterPlatform } from 'calypso/blocks/import/types';
 import {
 	getImporterUrl,
@@ -77,4 +79,20 @@ export async function addTempSiteToSourceOption( targetBlogId: number, sourceSit
 			// eslint-disable-next-line no-console
 			console.error( 'Unable to store option in source site', error );
 		} );
+}
+
+export function getSite( sourceSiteSlug: string ) {
+	return wpcomRequest< SiteDetails >( {
+		path: '/sites/' + encodeURIComponent( sourceSiteSlug as string ),
+		apiVersion: '1.1',
+	} );
+}
+
+export function getSourceSiteMigrationData(
+	sourceId: number
+): Promise< SourceSiteMigrationDetails > {
+	return wpcom.req.get( {
+		path: '/migrations/from-source/' + encodeURIComponent( sourceId as number ),
+		apiNamespace: 'wpcom/v2',
+	} );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -67,18 +67,20 @@ export function generateStepPath( stepName: string, stepSectionName?: string ) {
 }
 
 export async function addTempSiteToSourceOption( targetBlogId: number, sourceSiteSlug: string ) {
-	return wpcom.req
-		.post( {
-			path: `/migrations/from-source/${ sourceSiteSlug }`,
+	try {
+		const sourceSite = await getSite( sourceSiteSlug );
+		const result = await wpcom.req.post( {
+			path: `/migrations/from-source/${ sourceSite.ID }`,
 			apiNamespace: 'wpcom/v2',
 			body: {
 				target_blog_id: targetBlogId,
 			},
-		} )
-		.catch( ( error: Error ) => {
-			// eslint-disable-next-line no-console
-			console.error( 'Unable to store option in source site', error );
 		} );
+		return result;
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Unable to store option in source site', error );
+	}
 }
 
 export function getSite( sourceSiteSlug: string ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -1,14 +1,12 @@
-import { SiteDetails, SourceSiteMigrationDetails } from '@automattic/data-stores/src/site';
 import { StepContainer, Title } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
-import wpcomRequest from 'wpcom-proxy-request';
 import DocumentHead from 'calypso/components/data/document-head';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import wpcom from 'calypso/lib/wp';
+import { getSite, getSourceSiteMigrationData } from '../import/helper';
 import type { Step } from '../../types';
 import './styles.scss';
 
@@ -18,26 +16,12 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
 	const { setPendingAction, setIsMigrateFromWp } = useDispatch( ONBOARD_STORE );
 
-	function getSite( sourceSiteSlug: string ) {
-		return wpcomRequest< SiteDetails >( {
-			path: '/sites/' + encodeURIComponent( sourceSiteSlug as string ),
-			apiVersion: '1.1',
-		} );
-	}
-
-	function getSourceSiteData( sourceId: number ): Promise< SourceSiteMigrationDetails > {
-		return wpcom.req.get( {
-			path: '/migrations/from-source/' + encodeURIComponent( sourceId as number ),
-			apiNamespace: 'wpcom/v2',
-		} );
-	}
-
 	async function fetchSourceMigrationStatus() {
 		const search = window.location.search;
 		const sourceSiteSlug = new URLSearchParams( search ).get( 'from' ) || '';
 		try {
 			const sourceSiteInfo = await getSite( sourceSiteSlug );
-			const sourceSiteMigrationStatus = await getSourceSiteData( sourceSiteInfo?.ID );
+			const sourceSiteMigrationStatus = await getSourceSiteMigrationData( sourceSiteInfo?.ID );
 
 			return {
 				isFromMigrationPlugin: true,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -1,0 +1,92 @@
+import { SiteDetails, SourceSiteMigrationDetails } from '@automattic/data-stores/src/site';
+import { StepContainer, Title } from '@automattic/onboarding';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import { useEffect } from 'react';
+import wpcomRequest from 'wpcom-proxy-request';
+import DocumentHead from 'calypso/components/data/document-head';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import wpcom from 'calypso/lib/wp';
+import type { Step } from '../../types';
+import './styles.scss';
+
+const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
+	const { submit } = navigation;
+	const { __ } = useI18n();
+	const stepProgress = useSelect( ( select ) => select( ONBOARD_STORE ).getStepProgress() );
+	const { setPendingAction, setIsMigrateFromWp } = useDispatch( ONBOARD_STORE );
+
+	function getSite( sourceSiteSlug: string ) {
+		return wpcomRequest< SiteDetails >( {
+			path: '/sites/' + encodeURIComponent( sourceSiteSlug as string ),
+			apiVersion: '1.1',
+		} );
+	}
+
+	function getSourceSiteData( sourceId: number ): Promise< SourceSiteMigrationDetails > {
+		return wpcom.req.get( {
+			path: '/migrations/from-source/' + encodeURIComponent( sourceId as number ),
+			apiNamespace: 'wpcom/v2',
+		} );
+	}
+
+	async function fetchSourceMigrationStatus() {
+		const search = window.location.search;
+		const sourceSiteSlug = new URLSearchParams( search ).get( 'from' ) || '';
+		try {
+			const sourceSiteInfo = await getSite( sourceSiteSlug );
+			const sourceSiteMigrationStatus = await getSourceSiteData( sourceSiteInfo?.ID );
+
+			return {
+				isFromMigrationPlugin: true,
+				status: sourceSiteMigrationStatus?.status,
+				targetBlogId: sourceSiteMigrationStatus?.target_blog_id,
+				isAdminOnTarget: sourceSiteMigrationStatus?.is_target_blog_admin,
+				isTargetBlogUpgraded: sourceSiteMigrationStatus?.is_target_blog_upgraded,
+				targetBlogSlug: sourceSiteMigrationStatus?.target_blog_slug,
+			};
+		} catch ( error ) {
+			return {
+				isFromMigrationPlugin: true,
+				hasError: true,
+			};
+		}
+	}
+	useEffect( () => {
+		setIsMigrateFromWp( true );
+		if ( submit ) {
+			setPendingAction( fetchSourceMigrationStatus );
+			submit();
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	const getCurrentMessage = () => {
+		return __( 'Scanning your site' );
+	};
+
+	return (
+		<>
+			<DocumentHead title={ getCurrentMessage() } />
+			<StepContainer
+				shouldHideNavButtons={ true }
+				hideFormattedHeader={ true }
+				stepName="migration-handler"
+				isHorizontalLayout={ true }
+				recordTracksEvent={ recordTracksEvent }
+				stepContent={
+					<>
+						<Title>{ getCurrentMessage() }</Title>
+						<LoadingEllipsis />
+					</>
+				}
+				stepProgress={ stepProgress }
+				showFooterWooCommercePowered={ false }
+			/>
+		</>
+	);
+};
+
+export default MigrationHandler;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/styles.scss
@@ -1,0 +1,16 @@
+@import "../style";
+
+.migration-handler {
+	max-width: 540px;
+	text-align: center;
+	margin: 16vh auto 0;
+
+	.step-container__content {
+		.onboarding-title {
+			font-size: 1.625rem; /* stylelint-disable-line scales/font-sizes */
+			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+			line-height: 1em;
+			margin-bottom: 1.5rem;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -19,6 +19,8 @@ import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import useAddTempSiteToSourceOptionMutation from 'calypso/data/site-migration/use-add-temp-site-mutation';
+import { useSiteQuery } from 'calypso/data/sites/use-site-query';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
@@ -28,7 +30,6 @@ import {
 	getSignupCompleteSlug,
 } from 'calypso/signup/storageUtils';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
-import { addTempSiteToSourceOption } from '../import/helper';
 import type { Step } from '../../types';
 
 import './styles.scss';
@@ -92,6 +93,10 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 		wasSignupCheckoutPageUnloaded() && signupDestinationCookieExists && isReEnteringFlow
 	);
 	const blogTitle = isFreeFlow( 'free' ) ? getSelectedSiteTitle : '';
+	const { addTempSiteToSourceOption } = useAddTempSiteToSourceOptionMutation();
+	const search = window.location.search;
+	const sourceSiteSlug = new URLSearchParams( search ).get( 'from' ) || '';
+	const { data: siteData } = useSiteQuery( sourceSiteSlug, isCopySiteFlow( flow ) );
 
 	async function createSite() {
 		if ( isManageSiteFlow ) {
@@ -124,10 +129,8 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 		}
 
 		if ( isMigrationFlow( flow ) ) {
-			const search = window.location.search;
-			const sourceSiteSlug = new URLSearchParams( search ).get( 'from' );
 			// Store temporary target blog id to source site option
-			await addTempSiteToSourceOption( site?.siteId as number, sourceSiteSlug as string );
+			addTempSiteToSourceOption( site?.siteId as number, siteData?.ID as number );
 		}
 
 		return {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -54,7 +54,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 
 	const username = useSelector( ( state ) => getCurrentUserName( state ) );
 
-	const { setPendingAction, setIsMigrateFromWp } = useDispatch( ONBOARD_STORE );
+	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
 	let theme: string;
 	if ( isMigrationFlow( flow ) || isCopySiteFlow( flow ) ) {
@@ -138,11 +138,6 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 
 	useEffect( () => {
 		setProgress( 0.1 );
-
-		if ( isMigrationFlow( flow ) ) {
-			setIsMigrateFromWp( true );
-		}
-
 		if ( submit ) {
 			setPendingAction( createSite );
 			submit();

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -481,3 +481,11 @@ export interface ActiveTheme {
 		'wp:user-global-styles': { href: string }[];
 	};
 }
+
+export interface SourceSiteMigrationDetails {
+	status: string;
+	target_blog_id?: number;
+	is_target_blog_admin?: boolean;
+	is_target_blog_upgraded?: boolean;
+	target_blog_slug?: string;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73146
Related to [dotcom-forge #1644](https://github.com/Automattic/dotcom-forge/issues/1644)

## Proposed Changes

* Adding a step here to handle all the redirection logic for the migration plugin. In this way if we changes the URL again, we can change it in the repo directly.
* Update `addTempSiteToSourceOption` function to use blog id.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a JN site and connect to your WordPress.com account
* Navigate to `calypso.localhost:3000/setup/import-focused/migrationHandler?from=${YOUR_JN_TESTING_SITE}`

From here it depends on the migration status and decide which page to bring you to:

To mock up the rest of the scenario, you can do the same thing as this diff -> D100538-code. Try to update_blog_option with a site you own, a site you don't own, a site that's in the middle of migration, etc. Then navigate to `calypso.localhost:3000/setup/import-focused/migrationHandler?from=${YOUR_JN_TESTING_SITE}` and see where it takes you.

- **Use case 1:** If you haven't started a migration before, it should redirect to -> siteCreationStep and creates a temporary new site for you. This PR also changes the store option API from using site slug to site id. You can follow the instruction in D101107-code to see if the temporary target site id stores in the source site option table correctly.
- **Use case 2:** If you're not an admin on the target site it should redirect you to the siteCreationStep and creates a new site for you.
- **Use case 3:** If you don't have a paid plan yet, in the middle of migration, or didn't finish a migration before it will redirect you to ``importerWordpress?siteSlug=${TARGET_SITE_SLUG}&from=${YOUR_JN_SITE}&option=everything``


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?