### PR TITLE
Rename jetpack-migration to wpcom-migration

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -352,9 +352,9 @@ export class LoginForm extends Component {
 
 	showJetpackConnectSiteOnly = () => {
 		const { currentQuery } = this.props;
-		const isFromJetpackMigration = currentQuery?.redirect_to?.includes( 'jetpack-migration' );
+		const isFromMigrationPlugin = currentQuery?.redirect_to?.includes( 'wpcom-migration' );
 		return (
-			( currentQuery?.skip_user || currentQuery?.allow_site_connection ) && ! isFromJetpackMigration
+			( currentQuery?.skip_user || currentQuery?.allow_site_connection ) && ! isFromMigrationPlugin
 		);
 	};
 

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -291,7 +291,7 @@ export class JetpackAuthorize extends Component {
 		} else if ( this.isFromJetpackBackupPlugin() && ! siteHasBackups ) {
 			debug( `Redirecting directly to cart with ${ PRODUCT_JETPACK_BACKUP_T1_YEARLY } in cart.` );
 			navigate( `/checkout/${ urlToSlug( homeUrl ) }/${ PRODUCT_JETPACK_BACKUP_T1_YEARLY }` );
-		} else if ( this.isFromJetpackMigration() ) {
+		} else if ( this.isFromMigrationPlugin() ) {
 			navigate( `/setup/import-focused/migrationHandler?from=${ urlToSlug( homeUrl ) }` );
 		} else {
 			const redirectionTarget = this.getRedirectionTarget();

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -418,9 +418,9 @@ export class JetpackAuthorize extends Component {
 		return startsWith( from, 'jetpack-partner-coupon' );
 	}
 
-	isFromJetpackMigration( props = this.props ) {
+	isFromMigrationPlugin( props = this.props ) {
 		const { from } = props.authQuery;
-		return startsWith( from, 'jetpack-migration' );
+		return startsWith( from, 'wpcom-migration' );
 	}
 
 	shouldRedirectJetpackStart( props = this.props ) {

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -389,7 +389,7 @@ export function signupForm( context, next ) {
 	const isLoggedIn = isUserLoggedIn( context.store.getState() );
 	const { query } = context;
 	const from = query.from;
-	if ( from && startsWith( from, 'jetpack-migration' ) ) {
+	if ( from && startsWith( from, 'wpcom-migration' ) ) {
 		const signupUrl = config( 'signup_url' );
 		const urlQueryArgs = {
 			redirect_to: context.path,

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -203,7 +203,7 @@ export function redirectJetpack( context, next ) {
 	const isUserComingFromPricingPage =
 		redirect_to?.includes( 'source=jetpack-plans' ) ||
 		redirect_to?.includes( 'source=jetpack-connect-plans' );
-	const isUserComingFromMigrationPlugin = redirect_to?.includes( 'jetpack-migration' );
+	const isUserComingFromMigrationPlugin = redirect_to?.includes( 'wpcom-migration' );
 
 	/**
 	 * Send arrivals from the jetpack connect process or jetpack's pricing page


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72946 
## Proposed Changes

* Replace plugin slug from `jetpack-migration` to `wpcom-migration`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a JN testing site with [Migration plugin](https://jurassic.ninja/create/?jetpack-beta&branches.wpcom-migration=master&wp-debug-log)
* Navigate to `Move to WordPress.com` and click `Get Started`
* Continue on user approval, see if it takes you to the migrationHandler page

Note: The authorization might having some glitch on calypso at the moment, it works fine in production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
