### PR TITLE
Wire in purchases from eCommerce trial Plans page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -7,6 +7,8 @@ import {
 import { Button, Card } from '@automattic/components';
 import { getCurrencyObject } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import customization from 'calypso/assets/images/plans/wpcom/ecommerce-trial/customization.png';
 import generalFeatures from 'calypso/assets/images/plans/wpcom/ecommerce-trial/general-features.png';
@@ -46,10 +48,17 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 	const { symbol: currencySymbol } = getCurrencyObject( 0, eCommercePlanPrices.currencyCode );
 
 	const isAnnualSubscription = interval === 'yearly';
+	const targetECommercePlan = isAnnualSubscription ? eCommercePlanAnnual : eCommercePlanMonthly;
 
 	const percentageSavings = Math.floor(
 		( 1 - eCommercePlanPrices.annualPlanMonthlyPrice / eCommercePlanPrices.monthlyPlanPrice ) * 100
 	);
+
+	const redirectToCheckoutForPlan = useCallback( () => {
+		const checkoutUrl = `/checkout/${ siteSlug }/${ targetECommercePlan.getStoreSlug() }`;
+
+		page.redirect( checkoutUrl );
+	}, [ siteSlug, targetECommercePlan ] );
 
 	const features = [
 		{
@@ -314,10 +323,7 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 			<Card className="e-commerce-trial-plans__price-card">
 				<div className="e-commerce-trial-plans__price-card-text">
 					<span className="e-commerce-trial-plans__price-card-title">
-						{
-							// TODO: translate when final copy is available
-							'Commerce'
-						}
+						{ targetECommercePlan.getTitle() }
 					</span>
 					<span className="e-commerce-trial-plans__price-card-subtitle">
 						{ translate( 'Accelerate your growth with advanced features.' ) }
@@ -332,7 +338,11 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 					</span>
 				</div>
 				<div className="e-commerce-trial-plans__price-card-cta-wrapper">
-					<Button className="e-commerce-trial-plans__price-card-cta" primary>
+					<Button
+						className="e-commerce-trial-plans__price-card-cta"
+						primary
+						onClick={ redirectToCheckoutForPlan }
+					>
 						{ translate( 'Upgrade now' ) }
 					</Button>
 				</div>
@@ -344,7 +354,10 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 				) ) }
 			</div>
 			<div className="e-commerce-trial-plans__cta-wrapper">
-				<Button className="e-commerce-trial-plans__cta is-primary">
+				<Button
+					className="e-commerce-trial-plans__cta is-primary"
+					onClick={ redirectToCheckoutForPlan }
+				>
 					{ translate( 'Upgrade now' ) }
 				</Button>
 			</div>


### PR DESCRIPTION
Related to #72797, #73184

## Proposed Changes

* This PR wires in redirects to checkout for eCommerce plan purchases from the eCommerce trial Plans page
* I have also updated the title for the main card to be pulled from the `Plan` object we are upgrading to, which means we will stay aligned with WordPress.com's naming for the plan.

## Testing Instructions

* Run this branch locally or via Calypso.live
* Navigate to _Upgrades_ -> _Plans_ for a site on the eCommerce Trial plan
* For both the "Pay Monthly" and "Pay Annually" states in the toggle, test the following:
  - Click on the _Upgrade now_ button in the main title card above the feature list
  - Verify that you're taken to checkout for the site with the appropriate plan term in your cart
  - Remove the product from your cart -- this should take you back to the Plans page, but if it doesn't navigate back to _Upgrades_ -> _Plans_
  - Click on the _Upgrade now_ button below the feature list
  - Verify that you're taken to checkout for the site with the appropriate plan term in your cart
  - Remove the product from your cart -- this should take you back to the Plans page, but if it doesn't navigate back to _Upgrades_ -> _Plans_

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Fixes #72772