### PR TITLE
Email stats: add email stats summary page

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -13,6 +13,7 @@ import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import StatsSite from './site';
 import StatsEmailDetail from './stats-email-detail';
+import StatsEmailSummary from './stats-email-summary';
 
 const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
@@ -550,6 +551,22 @@ export function emailStats( context, next ) {
 			isValidStartDate={ isValidStartDate }
 		/>
 	);
+
+	next();
+}
+
+export function emailSummary( context, next ) {
+	const givenSiteId = context.params.site;
+
+	const selectedSite = getSite( context.store.getState(), givenSiteId );
+	const siteId = selectedSite ? selectedSite.ID || 0 : 0;
+
+	if ( 0 === siteId ) {
+		window.location = '/stats';
+		return next();
+	}
+
+	context.primary = <StatsEmailSummary />;
 
 	next();
 }

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -142,6 +142,12 @@ function getSiteFilters( siteId ) {
 			id: 'stats-email-clicks-day',
 			period: 'day',
 		},
+		{
+			title: i18n.translate( 'Days' ),
+			path: `/stats/day/emails`,
+			id: 'stats-email-summary',
+			period: 'day',
+		},
 	];
 }
 
@@ -566,7 +572,17 @@ export function emailSummary( context, next ) {
 		return next();
 	}
 
-	context.primary = <StatsEmailSummary />;
+	const filters = getSiteFilters( givenSiteId );
+	const activeFilter = find( filters, ( filter ) => {
+		return (
+			context.path.indexOf( filter.path ) >= 0 ||
+			( filter.altPaths && context.path.indexOf( filter.altPaths ) >= 0 )
+		);
+	} );
+
+	const date = moment().locale( 'en' );
+
+	context.primary = <StatsEmailSummary period={ rangeOfPeriod( activeFilter.period, date ) } />;
 
 	next();
 }

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -15,6 +15,7 @@ import {
 	redirectToDefaultSitePage,
 	redirectToDefaultWordAdsPeriod,
 	emailStats,
+	emailSummary,
 } from './controller';
 
 import './style.scss';
@@ -85,6 +86,7 @@ export default function () {
 			`/stats/email/:statType/:period(${ validEmailPeriods })/:email_id/:site`,
 			emailStats
 		);
+		statsPage( `/stats/day/emails/:site`, emailSummary );
 	}
 
 	// Anything else should redirect to default stats page

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -379,8 +379,8 @@ class StatsSite extends Component {
 									query={ query }
 									statType="statsEmailsSummary"
 									mainItemLabel={ translate( 'Latest Emails' ) }
-									hideSummaryLink
 									metricLabel={ translate( 'Clicks' ) }
+									showSummaryLink
 								/>
 							</>
 						) }

--- a/client/my-sites/stats/stats-email-summary/index.js
+++ b/client/my-sites/stats/stats-email-summary/index.js
@@ -79,7 +79,7 @@ const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
 					moduleStrings={ { ...StatsStrings.emails, title: '' } }
 					period={ period }
 					query={ query }
-					statType="statsEmailsSummary"
+					statType="statsEmailsSummaryByOpens"
 					mainItemLabel={ translate( 'Latest Emails' ) }
 					hideSummaryLink
 					metricLabel={ translate( 'Clicks' ) }

--- a/client/my-sites/stats/stats-email-summary/index.js
+++ b/client/my-sites/stats/stats-email-summary/index.js
@@ -1,0 +1,16 @@
+import './style.scss';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+const StatsEmailSummary = () => {
+	return <p>Email summary placeholder</p>;
+};
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		siteId: getSelectedSiteId( state ),
+		siteSlug: getSelectedSiteSlug( state, siteId ),
+	};
+} )( localize( StatsEmailSummary ) );

--- a/client/my-sites/stats/stats-email-summary/index.js
+++ b/client/my-sites/stats/stats-email-summary/index.js
@@ -1,10 +1,93 @@
-import './style.scss';
+import config from '@automattic/calypso-config';
+import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import titlecase from 'to-title-case';
+import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+import JetpackColophon from 'calypso/components/jetpack-colophon';
+import Main from 'calypso/components/main';
+import { PageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import StatsModule from '../stats-module';
+import statsStringsFactory from '../stats-strings';
 
-const StatsEmailSummary = () => {
-	return <p>Email summary placeholder</p>;
+const StatsStrings = statsStringsFactory();
+
+const StatsEmailSummary = ( { translate, period, siteSlug } ) => {
+	// Navigation settings. One of the following, depending on the summary view.
+	// Traffic => /stats/day/
+	// Insights => /stats/insights/
+	const localizedTabNames = {
+		traffic: translate( 'Traffic' ),
+		insights: translate( 'Insights' ),
+	};
+	const backLabel = localizedTabNames.traffic;
+	let backLink = `/stats/day/`;
+
+	const query = {
+		period: period,
+		quantity: 30,
+	};
+	const module = 'emails';
+	const title = translate( 'Emails' );
+
+	// Set up for FixedNavigationHeader.
+	const domain = siteSlug;
+	if ( domain?.length > 0 ) {
+		backLink += domain;
+	}
+	const navigationItems = [ { label: backLabel, href: backLink }, { label: title } ];
+
+	const isHorizontalBarComponentEnabledEverywhere = config.isEnabled(
+		'stats/horizontal-bars-everywhere'
+	);
+
+	const cardParentClassName = classNames( 'stats-summary-view', {
+		'stats-summary__positioned': isHorizontalBarComponentEnabledEverywhere,
+	} );
+	return (
+		<Main className="has-fixed-nav" wideLayout>
+			<PageViewTracker
+				path={ `/stats/${ module }/:site` }
+				title={ `Stats > ${ titlecase( module ) }` }
+			/>
+			<FixedNavigationHeader navigationItems={ navigationItems } />
+
+			<div id="my-stats-content" className={ cardParentClassName }>
+				<div className="stats-summary-nav__header">
+					<div>
+						<div className="stats-section-title">
+							<h3>{ translate( 'Stats for Emails' ) }</h3>
+						</div>
+					</div>
+				</div>
+
+				<StatsModule
+					additionalColumns={ {
+						header: (
+							<>
+								<span>{ translate( 'Opens' ) }</span>
+							</>
+						),
+						body: ( item ) => (
+							<>
+								<span>{ item.opens }</span>
+							</>
+						),
+					} }
+					path="emails"
+					moduleStrings={ { ...StatsStrings.emails, title: '' } }
+					period={ period }
+					query={ query }
+					statType="statsEmailsSummary"
+					mainItemLabel={ translate( 'Latest Emails' ) }
+					hideSummaryLink
+					metricLabel={ translate( 'Clicks' ) }
+				/>
+				<JetpackColophon />
+			</div>
+		</Main>
+	);
 };
 
 export default connect( ( state ) => {

--- a/client/my-sites/stats/stats-email-summary/style.scss
+++ b/client/my-sites/stats/stats-email-summary/style.scss
@@ -1,0 +1,1 @@
+@import "@wordpress/base-styles/breakpoints";

--- a/client/my-sites/stats/stats-email-summary/style.scss
+++ b/client/my-sites/stats/stats-email-summary/style.scss
@@ -1,1 +1,5 @@
-@import "@wordpress/base-styles/breakpoints";
+.stats-section-title {
+	color: var(--color-neutral-50);
+	font-size: 1.25rem;
+	margin: 1em 0;
+}

--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -34,6 +34,7 @@ const wpcomV1Endpoints = {
 	statsFileDownloads: 'stats/file-downloads',
 	statsAds: 'wordads/stats',
 	statsEmailsSummary: 'stats/emails/summary',
+	statsEmailsSummaryByOpens: 'stats/emails/summary',
 };
 
 const wpcomV2Endpoints = {
@@ -76,12 +77,23 @@ export function requestSiteStats( siteId, statType, query ) {
 				case 'statsVideo':
 					return query.postId;
 				case 'statsEmailsSummary':
-					return { period: PERIOD_ALL_TIME, quantity: query.quantity ?? 10 };
+					return {
+						period: PERIOD_ALL_TIME,
+						quantity: query.quantity ?? 10,
+						sort_field: query.sort_field ?? 'post_id',
+						sort_order: query.sort_order ?? 'desc',
+					};
+				case 'statsEmailsSummaryByOpens':
+					return {
+						period: PERIOD_ALL_TIME,
+						quantity: query.quantity ?? 10,
+						sort_field: 'opens',
+						sort_order: 'desc',
+					};
 				default:
 					return query;
 			}
 		} )();
-
 		const requestStats = subpath
 			? wpcom.req.get(
 					{

--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -76,7 +76,7 @@ export function requestSiteStats( siteId, statType, query ) {
 				case 'statsVideo':
 					return query.postId;
 				case 'statsEmailsSummary':
-					return { period: PERIOD_ALL_TIME, quantity: 10 };
+					return { period: PERIOD_ALL_TIME, quantity: query.quantity ?? 10 };
 				default:
 					return query;
 			}

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -973,4 +973,16 @@ export const normalizers = {
 			};
 		} );
 	},
+	/**
+	 * Returns a normalized statsEmailsSummaryByOpens array, ready for use in stats-module
+	 *
+	 * @param   {Object} data   Stats data
+	 * @param   {Object} query  Stats query
+	 * @param   {number} siteId  Site ID
+	 * @param   {Object} site    Site object
+	 * @returns {Array}       Normalized stats data
+	 */
+	statsEmailsSummaryByOpens: ( data, query, siteId, site ) => {
+		return normalizers.statsEmailsSummary( data, query, siteId, site );
+	},
 };


### PR DESCRIPTION
Closes #72433

## Proposed Changes

This PR adds a very basic email stats summary page. This page is accesible by clicking the `View Details` link at the bottom of the Email card on the stats overview.

![CleanShot 2023-02-10 at 10 39 17@2x](https://user-images.githubusercontent.com/528287/218057743-ee34e0cd-4c10-4542-9094-3cba21c6b13f.png)

The list shown is sorted by Opens descending.

![CleanShot 2023-02-10 at 10 41 59@2x](https://user-images.githubusercontent.com/528287/218058342-c947dd0e-d96f-4990-a11c-81dc7dd6a133.png)


## Testing Instructions

* Apply this patch to your sandbox: D100869-code (make sure to sandbox `public-api.wordpress.com`)
* Apply this PR
* Visit your stats, and add the feature flag: `/stats/day/<yoursite>?flags=newsletter/stats`
* At the bottom you should see the Email card, with a `View Details` link$
* Click this link
* You should be transported to the new list
* This list will show 30 items (at most), and is sorted by opens descending. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?