### PR TITLE
Domain sidebar upsell experiment: Add back to my home in navigation

### DIFF
--- a/client/my-sites/domains/components/domain-and-plan-package/navigation/index.jsx
+++ b/client/my-sites/domains/components/domain-and-plan-package/navigation/index.jsx
@@ -29,7 +29,7 @@ export default function DomainAndPlanPackageNavigation( props ) {
 					{ props.step !== 1 ? (
 						<span>{ translate( 'Back' ) }</span>
 					) : (
-						<span>{ translate( 'Back to My Home' ) }</span>
+						<span>{ translate( 'Home' ) }</span>
 					) }
 				</Button>
 			</div>

--- a/client/my-sites/domains/components/domain-and-plan-package/navigation/index.jsx
+++ b/client/my-sites/domains/components/domain-and-plan-package/navigation/index.jsx
@@ -26,7 +26,11 @@ export default function DomainAndPlanPackageNavigation( props ) {
 			<div className="domain-and-plan-package-navigation__back">
 				<Button borderless="true" onClick={ goBack }>
 					<Gridicon icon="chevron-left" />
-					<span>{ translate( 'Back' ) }</span>
+					{ props.step !== 1 ? (
+						<span>{ translate( 'Back' ) }</span>
+					) : (
+						<span>{ translate( 'Back to My Home' ) }</span>
+					) }
 				</Button>
 			</div>
 			<ol className="domain-and-plan-package-navigation__steps">

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -275,7 +275,7 @@ class DomainSearch extends Component {
 							{ domainSidebarExperimentUser && (
 								<>
 									<DomainAndPlanPackageNavigation
-										goBackLink={ domainManagementList( selectedSiteSlug ) }
+										goBackLink={ `/home/${ selectedSiteSlug }` }
 										step={ 1 }
 									/>
 									<FormattedHeader


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72892 
## Proposed Changes
![back to my home](https://user-images.githubusercontent.com/6586048/218061317-d8cb2b9a-9b84-4c22-98f2-491639a361ff.png)

* Added Back to Home to the first page of the domain sidebar upsell experiment for clarity

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set yourself to treatment in the experiment
* Click on the sidebar domain upsell (free user)
* Test around the back buttons for each step to be sure
* Looks good on mobile and desktop

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
