### PR TITLE
Plans 2023: Updates breakpoints

### DIFF
--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -7,7 +7,6 @@ $plans-2023-small-breakpoint: 780px;
 $plans-2023-medium-breakpoint: 1200px;
 
 $minWidthToGridWidthMap: (
-	650px: "570px",
 	780px: "668px",
 	1024px: "860px",
 	1200px: "1134px",
@@ -32,7 +31,6 @@ $minWidthToGridWidthMap: (
  * This should stretch to fill it's container.
  */
 @mixin pricing-grid-breakpoints-with-sidebar {
-
 	width: 100%;
 }
 

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -3,7 +3,7 @@ $plan-features-sidebar-width: 272px;
 $plan-features-header-banner-height: 20px;
 
 // Breakpoints
-$plans-2023-small-breakpoint: 650px;
+$plans-2023-small-breakpoint: 780px;
 $plans-2023-medium-breakpoint: 1200px;
 
 $minWidthToGridWidthMap: (

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -3,48 +3,37 @@ $plan-features-sidebar-width: 272px;
 $plan-features-header-banner-height: 20px;
 
 // Breakpoints
-$plans-2023-small-breakpoint: 880px;
-$plans-2023-medium-breakpoint: 1340px;
-$plans-2023-large-breakpoint: 1500px;
+$plans-2023-small-breakpoint: 650px;
+$plans-2023-medium-breakpoint: 1200px;
 
-/**
- * Media queries for the plans grid in onboarding/signup
- */
+$minWidthToGridWidthMap: (
+	650px: "570px",
+	780px: "668px",
+	1024px: "860px",
+	1200px: "1134px",
+	1440px: "1320px",
+	1600px: "1480px",
+);
+
+
 @mixin pricing-grid-breakpoints {
-	max-width: 414px;
+	width: 414px;
 
-	@media ( min-width: $plans-2023-small-breakpoint ) {
-		max-width: 860px;
+	@each $screenMinWidth, $gridWidth in $minWidthToGridWidthMap {
+		@media ( min-width: #{$screenMinWidth} ) {
+			width: #{$gridWidth};
+		}
 	}
 
-	@media ( min-width: $plans-2023-medium-breakpoint ) {
-		max-width: 1320px;
-	}
-
-	@media ( min-width: $plans-2023-large-breakpoint ) {
-		max-width: 1480px;
-	}
 }
 
 /**
  * Media queries for the plans grid on the /plans page.
- * Since there is a sidebar on internal pages,
- * we add the sidebar width to the default breakpoints.
+ * This should stretch to fill it's container.
  */
 @mixin pricing-grid-breakpoints-with-sidebar {
-	max-width: 414px;
 
-	@media ( min-width: $plans-2023-small-breakpoint + $plan-features-sidebar-width ) {
-		max-width: 860px;
-	}
-
-	@media ( min-width: $plans-2023-medium-breakpoint + $plan-features-sidebar-width ) {
-		max-width: 1320px;
-	}
-
-	@media ( min-width: $plans-2023-large-breakpoint + $plan-features-sidebar-width ) {
-		max-width: 1480px;
-	}
+	width: 100%;
 }
 
 /**

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -17,7 +17,7 @@ $minWidthToGridWidthMap: (
 
 
 @mixin pricing-grid-breakpoints {
-	width: 414px;
+	width: 100%;
 
 	@each $screenMinWidth, $gridWidth in $minWidthToGridWidthMap {
 		@media ( min-width: #{$screenMinWidth} ) {

--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -1,4 +1,5 @@
-// Variables
+@import "@automattic/components/src/highlight-cards/variables.scss";
+
 $plan-features-sidebar-width: 272px;
 $plan-features-header-banner-height: 20px;
 
@@ -140,6 +141,21 @@ $minWidthToGridWidthMap: (
 
 	.is-section-plans.is-sidebar-collapsed & {
 		@media ( min-width: $plans-2023-medium-breakpoint ) {
+			@content;
+		}
+	}
+}
+
+/**
+ * @see client/my-sites/plans/modernized-layout.tsx
+ * This file introduces padding for the header on the plans page
+ * at a custom mobile breakpoint.
+ *
+ * This mixin can be use to target that particular breakpoint.
+ */
+@mixin plans-section-custom-mobile-breakpoint() {
+	.is-section-plans & {
+		@media ( min-width: $custom-mobile-breakpoint ) {
 			@content;
 		}
 	}

--- a/client/my-sites/plan-features-2023-grid/media-queries.tsx
+++ b/client/my-sites/plan-features-2023-grid/media-queries.tsx
@@ -2,12 +2,12 @@ import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
 
 const sidebarWidth = 272; //in px
-const plans2023SmallBreakpoint = '880px';
-const plans2023MediumBreakpoint = '1340px';
-const plans2023LargeBreakpoint = '1500px';
-const plans2023SmallWithSidebarBreakpoint = `${ 880 + sidebarWidth }px`;
-const plans2023MediumWithSidebarBreakpoint = `${ 1340 + sidebarWidth }px`;
-const plans2023LargeWithSidebarBreakpoint = `${ 1500 + sidebarWidth }px`;
+const plans2023SmallBreakpoint = '650px';
+const plans2023MediumBreakpoint = '1200px';
+const plans2023LargeBreakpoint = '1600px';
+const plans2023SmallWithSidebarBreakpoint = `${ 650 + sidebarWidth }px`;
+const plans2023MediumWithSidebarBreakpoint = `${ 1200 + sidebarWidth }px`;
+const plans2023LargeWithSidebarBreakpoint = `${ 1600 + sidebarWidth }px`;
 
 export const plansBreakSmall = ( styles: SerializedStyles ) => css`
 	body.is-section-signup.is-white-signup &,

--- a/client/my-sites/plan-features-2023-grid/media-queries.tsx
+++ b/client/my-sites/plan-features-2023-grid/media-queries.tsx
@@ -2,10 +2,10 @@ import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
 
 const sidebarWidth = 272; //in px
-const plans2023SmallBreakpoint = '650px';
+const plans2023SmallBreakpoint = '780px';
 const plans2023MediumBreakpoint = '1200px';
 const plans2023LargeBreakpoint = '1600px';
-const plans2023SmallWithSidebarBreakpoint = `${ 650 + sidebarWidth }px`;
+const plans2023SmallWithSidebarBreakpoint = `${ 780 + sidebarWidth }px`;
 const plans2023MediumWithSidebarBreakpoint = `${ 1200 + sidebarWidth }px`;
 const plans2023LargeWithSidebarBreakpoint = `${ 1600 + sidebarWidth }px`;
 

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -140,7 +140,7 @@ const TitleRow = styled( Row )`
 	` ) }
 `;
 
-const Cell = styled.div< { textAlign?: string; isInSignup: boolean } >`
+const Cell = styled.div< { textAlign?: string } >`
 	text-align: ${ ( props ) => props.textAlign ?? 'left' };
 	display: flex;
 	flex: 1;
@@ -176,7 +176,7 @@ const Cell = styled.div< { textAlign?: string; isInSignup: boolean } >`
 
 	${ plansBreakSmall( css`
 		padding: 0 14px;
-		min-width: 180px;
+		min-width: 156px;
 		border-right: none;
 
 		&:first-of-type {
@@ -187,19 +187,6 @@ const Cell = styled.div< { textAlign?: string; isInSignup: boolean } >`
 			border-right: none;
 		}
 	` ) }
-
-	${ ( props ) =>
-		props.isInSignup
-			? plansBreakSmall(
-					css`
-						max-width: 180px;
-					`
-			  )
-			: plansBreakSmall(
-					css`
-						max-width: 160px;
-					`
-			  ) }
 
 	${ plansBreakLarge( css`
 		max-width: 200px;
@@ -334,12 +321,7 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 				const showPlanSelect = ! allVisible && ! current;
 
 				return (
-					<Cell
-						key={ planName }
-						isInSignup={ isInSignup }
-						className={ headerClasses }
-						textAlign="left"
-					>
+					<Cell key={ planName } className={ headerClasses } textAlign="left">
 						{ isBusinessPlan( planName ) && (
 							<div className="plan-features-2023-grid__popular-badge">
 								<PlanPill isInSignup={ isInSignup }>{ translate( 'Popular' ) }</PlanPill>
@@ -647,12 +629,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 											);
 
 											return (
-												<Cell
-													key={ planName }
-													isInSignup={ isInSignup }
-													className={ cellClasses }
-													textAlign="center"
-												>
+												<Cell key={ planName } className={ cellClasses } textAlign="center">
 													{ feature.getIcon && (
 														<span className="plan-comparison-grid__plan-image">
 															{ feature.getIcon() }
@@ -706,12 +683,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 										);
 
 										return (
-											<Cell
-												key={ planName }
-												isInSignup={ isInSignup }
-												className={ cellClasses }
-												textAlign="center"
-											>
+											<Cell key={ planName } className={ cellClasses } textAlign="center">
 												<span className="plan-comparison-grid__plan-title">
 													{ translate( 'Storage' ) }
 												</span>

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -94,9 +94,9 @@ const Grid = styled.div< { isInSignup: boolean } >`
 	background: #fff;
 	border: solid 1px #e0e0e0;
 
-	@media ( min-width: 385px ) {
+	${ plansBreakSmall( css`
 		border-radius: 5px;
-	}
+	` ) }
 `;
 const Row = styled.div< { isHiddenInMobile?: boolean } >`
 	justify-content: space-between;

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -976,6 +976,8 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 	display: flex;
 	justify-content: center;
 	margin-top: 32px;
+	margin-left: 20px;
+	margin-right: 20px;
 
 	button {
 		background: var(--studio-white);

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -182,7 +182,7 @@
 			padding: 38px 0 20px 0;
 			margin: 20px;
 
-			.is-section-plans & {
+			@include plans-section-custom-mobile-breakpoint {
 				margin-left: 0;
 				margin-right: 0;
 			}
@@ -984,7 +984,7 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 	margin-left: 20px;
 	margin-right: 20px;
 
-	.is-section-plans & {
+	@include plans-section-custom-mobile-breakpoint {
 		margin-left: 0;
 		margin-right: 0;
 	}

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -179,8 +179,13 @@
 			border: 1px solid #e0e0e0;
 			/* stylelint-disable-next-line */
 			border-radius: 5px;
-			margin: 20px;
 			padding: 38px 0 20px 0;
+			margin: 20px;
+
+			.is-section-plans & {
+				margin-left: 0;
+				margin-right: 0;
+			}
 
 			&:first-of-type {
 				margin-top: 0;
@@ -978,6 +983,11 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 	margin-top: 32px;
 	margin-left: 20px;
 	margin-right: 20px;
+
+	.is-section-plans & {
+		margin-left: 0;
+		margin-right: 0;
+	}
 
 	button {
 		background: var(--studio-white);

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -289,6 +289,8 @@ const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSig
 	display: ${ ( { isInSignup } ) => ( isInSignup ? 'flex' : 'block' ) };
 	align-content: space-between;
 	justify-content: center;
+	margin-left: 20px;
+	margin-right: 20px;
 
 	> .segmented-control.is-compact:not( .is-signup ) {
 		margin: 8px auto 16px;

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -289,8 +289,6 @@ const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSig
 	display: ${ ( { isInSignup } ) => ( isInSignup ? 'flex' : 'block' ) };
 	align-content: space-between;
 	justify-content: center;
-	margin-left: 20px;
-	margin-right: 20px;
 
 	> .segmented-control.is-compact:not( .is-signup ) {
 		margin: 8px auto 16px;

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -53,7 +53,6 @@
 .plans-features-main__group.is-2023-pricing-grid {
 	position: relative;
 	margin: auto;
-	max-width: 335px;
 
 	.is-section-stepper &,
 	.is-section-signup & {

--- a/client/my-sites/plans/modernized-layout.tsx
+++ b/client/my-sites/plans/modernized-layout.tsx
@@ -20,6 +20,7 @@ const ModernizedLayout: React.FunctionComponent< { dropShadowOnHeader?: boolean 
 	// ----------------------------------------------
 	// from @automattic/components/src/highlight-cards/variables.scss:
 	// ----------------------------------------------
+	// If changed, also change @plans-section-custom-mobile-breakpoint in client/my-sites/plan-features-2023-grid/_media-queries.scss
 	const customBreakpointSmall = '660px';
 	const verticalMargin = '32px';
 	// ----------------------------------------------


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1484
Fixes Automattic/martech#1483
## Proposed Changes

* Adjusts breakpoints according to the new design.
* On /start/plans or in any of the signup flows, the breakpoints are following:

|Min Screen Width|Grid Width|
|---|---|
|650px|570px|
|780px|668px|
|1024px|860px|
|1200px|1134px|
|1440px|1320px|
|1600px|1480px|

* On `/plans`, the grid's width should be 100% of the available width and should change fluidly according to the screen width. 

* We switch between mobile/tablet/desktop layouts at the following breakpoints:

**On `/start/plans`, or if the sidebar is collapsed**:
|Screen Width|Layout|
|---|---|
|0-~650px~780px|Mobile|
| > ~650px~780px| Tablet|
| > 1200px| Desktop|

**On `/plans` (272px is the sidebar width)**:
|Screen Width|Layout|
|---|---|
|0-~922px~1052px|Mobile|
| > ~922px~1052px (780px + 272px)| Tablet|
| > 1472px (1200px + 272px)| Desktop|

* Removes margin for the plans comparison grid in mobile view. The grid will have 100% width. (Automattic/martech#1483)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans?flags=onboarding/2023-pricing-grid` and confirm that the width of the plans grid is according to the above table. Also, confirm that the layout switches between desktop/tablet/mobile at the given widths.
* Go to `/plans/{SITE_ID}?flags=onboarding/2023-pricing-grid`. Confirm that the width of the grid is same as the header width at different screen widths. Also, confirm that the layout switches between desktop/tablet/mobile at the given widths.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
