### PR TITLE
Translate and extract features for eCommerce trial plans page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/ecommerce-features.ts
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-features.ts
@@ -1,0 +1,238 @@
+import { translate as i18nTranslate } from 'i18n-calypso';
+import customization from 'calypso/assets/images/plans/wpcom/ecommerce-trial/customization.png';
+import generalFeatures from 'calypso/assets/images/plans/wpcom/ecommerce-trial/general-features.png';
+import growth from 'calypso/assets/images/plans/wpcom/ecommerce-trial/growth.png';
+import payments from 'calypso/assets/images/plans/wpcom/ecommerce-trial/payments.png';
+import productManagement from 'calypso/assets/images/plans/wpcom/ecommerce-trial/product-management.png';
+import shipping from 'calypso/assets/images/plans/wpcom/ecommerce-trial/shipping.png';
+import type { ECommercePlanFeatureSet } from './trial-feature-card';
+
+type ECommerceFeatureSetProps = {
+	translate: typeof i18nTranslate;
+};
+
+export const getECommerceFeatureSets = ( {
+	translate,
+}: ECommerceFeatureSetProps ): ECommercePlanFeatureSet[] => {
+	return [
+		{
+			expanded: true,
+			illustration: generalFeatures,
+			title: translate( 'General features', { textOnly: true } ),
+			subtitle: translate( 'Everything you need to grow your business.' ),
+			items: [
+				{
+					title: translate( 'Sell the simple way', { textOnly: true } ),
+					subtitle: translate(
+						'Your store includes everything you need to launch quickly and grow over time – all in one turnkey package.'
+					),
+				},
+				{
+					title: translate( 'Manage on the go', { textOnly: true } ),
+					subtitle: translate(
+						'Process orders and manage your store anywhere with the WooCommerce Mobile App.'
+					),
+				},
+				{
+					title: translate( 'Get support 24/7', { textOnly: true } ),
+					subtitle: translate( 'Need help? Reach out anytime via email or chat.' ),
+				},
+				{
+					title: translate( 'Have unlimited admin accounts', { textOnly: true } ),
+					subtitle: translate(
+						'Add as many staff accounts as you need to help run your business.'
+					),
+				},
+			],
+		},
+		{
+			illustration: payments,
+			title: translate( 'Payments', { textOnly: true } ),
+			subtitle: translate( 'Quickly and easily accept payments.' ),
+			items: [
+				{
+					title: translate( 'Give your customers more ways to pay.', { textOnly: true } ),
+					subtitle: translate(
+						'Accept all major credit and debit cards, plus popular options like Apple Pay and Google Pay.'
+					),
+				},
+				{
+					title: translate( 'Sell in over 60 countries', { textOnly: true } ),
+					subtitle: translate( 'Get paid in more than 100 currencies from all over the world.' ),
+				},
+				{
+					title: translate( 'Offer subscriptions', { textOnly: true } ),
+					subtitle: translate(
+						'Add a subscription for any product or service, including the ability to set subscription discounts, signup fees, free trials, or expiration periods.'
+					),
+				},
+				{
+					title: translate( 'Automate tax collection', { textOnly: true } ),
+					subtitle: translate(
+						'Automatically calculate how much sales tax should be collected at checkout.'
+					),
+				},
+				{
+					title: translate( 'Sell in person', { textOnly: true } ),
+					subtitle: translate(
+						'Use a mobile card reader to take payments in a store, at a popup, or wherever your business takes you.'
+					),
+				},
+			],
+		},
+		{
+			illustration: productManagement,
+			title: translate( 'Product management', { textOnly: true } ),
+			subtitle: translate( 'Simplify the way you manage, sell and promote your products.' ),
+			items: [
+				{
+					title: translate( 'Unlimited products', { textOnly: true } ),
+					subtitle: translate( 'Add unlimited products to your store.' ),
+				},
+				{
+					title: translate( 'Offer gift cards', { textOnly: true } ),
+					subtitle: translate( 'Sell and accept pre-paid, multi-purpose e-gift vouchers.' ),
+				},
+				{
+					title: translate( 'Send back in stock notifications', { textOnly: true } ),
+					subtitle: translate( 'Notify customers when your products are restocked.' ),
+				},
+				{
+					title: translate( 'Set order limits', { textOnly: true } ),
+					subtitle: translate( 'Specify min and max allowed product quantities for orders.' ),
+				},
+				{
+					title: translate( 'Sell product bundles', { textOnly: true } ),
+					subtitle: translate( 'Offer personalized product packages and bulk discounts.' ),
+				},
+				{
+					title: translate( 'Offer customizable product kits', { textOnly: true } ),
+					subtitle: translate(
+						'Use Composite Products to add product kit building functionality with inventory management.'
+					),
+				},
+				{
+					title: translate( 'Import your products via CSV', { textOnly: true } ),
+					subtitle: translate( 'Import, merge, and export products using a CSV file.' ),
+				},
+				{
+					title: translate( 'Sell product add-ons', { textOnly: true } ),
+					subtitle: translate( 'Enable gift wrapping/messages or custom pricing.' ),
+				},
+				{
+					title: translate( 'Unlimited images', { textOnly: true } ),
+					subtitle: translate( 'Add any number of images to your product variations.' ),
+				},
+				{
+					title: translate( 'Product recommendations', { textOnly: true } ),
+					subtitle: translate(
+						'Earn more revenue with automated upsell and cross-sell product recommendations.'
+					),
+				},
+				{
+					title: translate( 'Take pre-orders', { textOnly: true } ),
+					subtitle: translate( 'Let customers order products before they’re available.' ),
+				},
+			],
+		},
+		{
+			illustration: customization,
+			title: translate( 'Themes and customization', { textOnly: true } ),
+			subtitle: translate( 'Bring your brand to life with a fully customizable storefront.' ),
+			items: [
+				{
+					title: translate( 'Premium themes', { textOnly: true } ),
+					subtitle: translate(
+						'Tap into a diverse selection of beautifully designed premium themes.'
+					),
+				},
+				{
+					title: translate( 'Block-based templates', { textOnly: true } ),
+					subtitle: translate(
+						"Take control over your store's layout without touching a line of code."
+					),
+				},
+				{
+					title: translate( 'Cart and checkout optimization', { textOnly: true } ),
+					subtitle: translate(
+						'Streamline your checkout and boost conversions with the Cart and Checkout blocks.'
+					),
+				},
+			],
+		},
+		{
+			illustration: growth,
+			title: translate( 'Marketing and growth', { textOnly: true } ),
+			subtitle: translate(
+				'Optimize your store for sales by adding in email and social integrations.'
+			),
+			items: [
+				{
+					title: translate( 'Sell everywhere', { textOnly: true } ),
+					subtitle: translate(
+						'Promote and sell your products on popular social media platforms and marketplaces.'
+					),
+				},
+				{
+					title: translate( 'Automate your marketing', { textOnly: true } ),
+					subtitle: translate(
+						'Build custom email automations to keep customers and prospects engaged.'
+					),
+				},
+				{
+					title: translate( 'Recover abandoned carts', { textOnly: true } ),
+					subtitle: translate(
+						'Drive more sales by automatically emailing customers who leave your store without checking out.'
+					),
+				},
+				{
+					title: translate( 'Encourage referrals', { textOnly: true } ),
+					subtitle: translate(
+						'Offer free gifts or coupons when your customers refer new shoppers.'
+					),
+				},
+				{
+					title: translate( 'Send birthday coupons', { textOnly: true } ),
+					subtitle: translate(
+						'Automatically email your customers a birthday discount to keep them coming back.'
+					),
+				},
+				{
+					title: translate( 'Drive loyalty', { textOnly: true } ),
+					subtitle: translate( 'Keep your loyal customers loyal with a rewards program.' ),
+				},
+			],
+		},
+		{
+			illustration: shipping,
+			title: translate( 'Shipping', { textOnly: true } ),
+			subtitle: translate( 'Streamline your fulfillment with integrated shipping.' ),
+			items: [
+				{
+					title: translate( 'Print shipping labels', { textOnly: true } ),
+					subtitle: translate( 'Print shipping labels from your store to save time and money.' ),
+				},
+				{
+					title: translate( 'Offer shipment tracking', { textOnly: true } ),
+					subtitle: translate( 'Provide customers with an easy way to track their shipment.' ),
+				},
+				{
+					title: translate( 'Customize shipping rates', { textOnly: true } ),
+					subtitle: translate(
+						'Define multiple shipping rates based on location, price, weight, or other criteria.'
+					),
+				},
+				{
+					title: translate( 'Set conditional shipping', { textOnly: true } ),
+					subtitle: translate( 'Restrict shipping and payment options using conditional logic.' ),
+				},
+				{
+					title: translate( 'Simplify returns and exchanges', { textOnly: true } ),
+					subtitle: translate(
+						'Manage the RMA process, add warranties to products and let customers request/manage returns from their account.'
+					),
+				},
+			],
+		},
+	];
+};

--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -54,7 +54,7 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 
 		page.redirect( checkoutUrl );
 	}, [ siteSlug, targetECommercePlan ] );
-	
+
 	const eCommercePlanFeatureSets = useMemo( () => {
 		return getECommerceFeatureSets( { translate } );
 	}, [ translate ] );

--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -8,17 +8,12 @@ import { Button, Card } from '@automattic/components';
 import { getCurrencyObject } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import customization from 'calypso/assets/images/plans/wpcom/ecommerce-trial/customization.png';
-import generalFeatures from 'calypso/assets/images/plans/wpcom/ecommerce-trial/general-features.png';
-import growth from 'calypso/assets/images/plans/wpcom/ecommerce-trial/growth.png';
-import payments from 'calypso/assets/images/plans/wpcom/ecommerce-trial/payments.png';
-import productManagement from 'calypso/assets/images/plans/wpcom/ecommerce-trial/product-management.png';
-import shipping from 'calypso/assets/images/plans/wpcom/ecommerce-trial/shipping.png';
 import SegmentedControl from 'calypso/components/segmented-control';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getPlanRawPrice, getPlan } from 'calypso/state/plans/selectors';
+import { getECommerceFeatureSets } from './ecommerce-features';
 import ECommerceTrialBanner from './ecommerce-trial-banner';
 import TrialFeatureCard from './trial-feature-card';
 
@@ -59,201 +54,10 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 
 		page.redirect( checkoutUrl );
 	}, [ siteSlug, targetECommercePlan ] );
-
-	const features = [
-		{
-			expanded: true,
-			illustration: generalFeatures,
-			title: 'General features',
-			subtitle: 'Everything you need to grow your business.',
-			items: [
-				{
-					title: 'Sell the simple way',
-					subtitle:
-						'Your store includes everything you need to launch quickly and grow over time – all in one turnkey package.',
-				},
-				{
-					title: 'Manage on the go',
-					subtitle:
-						'Process orders and manage your store anywhere with the WooCommerce Mobile App.',
-				},
-				{
-					title: 'Get support 24/7',
-					subtitle: 'Need help? Reach out anytime via email or chat.',
-				},
-				{
-					title: 'Have unlimited admin accounts',
-					subtitle: 'Add as many staff accounts as you need to help run your business.',
-				},
-			],
-		},
-		{
-			illustration: payments,
-			title: 'Payments',
-			subtitle: 'Quickly and easily accept payments.',
-			items: [
-				{
-					title: 'Give your customers more ways to pay.',
-					subtitle:
-						'Accept all major credit and debit cards, plus popular options like Apple Pay and Google Pay.',
-				},
-				{
-					title: 'Sell in over 60 countries',
-					subtitle: 'Get paid in more than 100 currencies from all over the world.',
-				},
-				{
-					title: 'Offer subscriptions',
-					subtitle:
-						'Add a subscription for any product or service, including the ability to set subscription discounts, signup fees, free trials, or expiration periods.',
-				},
-				{
-					title: 'Automate tax collection',
-					subtitle: 'Automatically calculate how much sales tax should be collected at checkout.',
-				},
-				{
-					title: 'Sell in person',
-					subtitle:
-						'Use a mobile card reader to take payments in a store, at a popup, or wherever your business takes you.',
-				},
-			],
-		},
-		{
-			illustration: productManagement,
-			title: 'Product management',
-			subtitle: 'Simplify the way you manage, sell and promote your products.',
-			items: [
-				{
-					title: 'Unlimited products',
-					subtitle: 'Add unlimited products to your store.',
-				},
-				{
-					title: 'Offer gift cards',
-					subtitle: 'Sell and accept pre-paid, multi-purpose e-gift vouchers.',
-				},
-				{
-					title: 'Send back in stock notifications',
-					subtitle: 'Notify customers when your products are restocked.',
-				},
-				{
-					title: 'Set order limits',
-					subtitle: 'Specify min and max allowed product quantities for orders.',
-				},
-				{
-					title: 'Sell product bundles',
-					subtitle: 'Offer personalized product packages and bulk discounts.',
-				},
-				{
-					title: 'Offer customizable product kits',
-					subtitle:
-						'Use Composite Products to add product kit building functionality with inventory management.',
-				},
-				{
-					title: 'Import your products via CSV',
-					subtitle: 'Import, merge, and export products using a CSV file.',
-				},
-				{
-					title: 'Sell product add-ons',
-					subtitle: 'Enable gift wrapping/messages or custom pricing.',
-				},
-				{
-					title: 'Unlimited images',
-					subtitle: 'Add any number of images to your product variations.',
-				},
-				{
-					title: 'Product recommendations',
-					subtitle:
-						'Earn more revenue with automated upsell and cross-sell product recommendations.',
-				},
-				{
-					title: 'Take pre-orders',
-					subtitle: 'Let customers order products before they’re available.',
-				},
-			],
-		},
-		{
-			illustration: customization,
-			title: 'Themes and customization',
-			subtitle: 'Bring your brand to life with a fully customizable storefront.',
-			items: [
-				{
-					title: 'Premium themes',
-					subtitle: 'Tap into a diverse selection of beautifully designed premium themes.',
-				},
-				{
-					title: 'Block-based templates',
-					subtitle: "Take control over your store's layout without touching a line of code.",
-				},
-				{
-					title: 'Cart and checkout optimization',
-					subtitle:
-						'Streamline your checkout and boost conversions with the Cart and Checkout blocks.',
-				},
-			],
-		},
-		{
-			illustration: growth,
-			title: 'Marketing and growth',
-			subtitle: 'Optimize your store for sales by adding in email and social integrations.',
-			items: [
-				{
-					title: 'Sell everywhere',
-					subtitle:
-						'Promote and sell your products on popular social media platforms and marketplaces.',
-				},
-				{
-					title: 'Automate your marketing',
-					subtitle: 'Build custom email automations to keep customers and prospects engaged.',
-				},
-				{
-					title: 'Recover abandoned carts',
-					subtitle:
-						'Drive more sales by automatically emailing customers who leave your store without checking out.',
-				},
-				{
-					title: 'Encourage referrals',
-					subtitle: 'Offer free gifts or coupons when your customers refer new shoppers.',
-				},
-				{
-					title: 'Send birthday coupons',
-					subtitle:
-						'Automatically email your customers a birthday discount to keep them coming back.',
-				},
-				{
-					title: 'Drive loyalty',
-					subtitle: 'Keep your loyal customers loyal with a rewards program.',
-				},
-			],
-		},
-		{
-			illustration: shipping,
-			title: 'Shipping',
-			subtitle: 'Streamline your fulfillment with integrated shipping.',
-			items: [
-				{
-					title: 'Print shipping labels',
-					subtitle: 'Print shipping labels from your store to save time and money.',
-				},
-				{
-					title: 'Offer shipment tracking',
-					subtitle: 'Provide customers with an easy way to track their shipment.',
-				},
-				{
-					title: 'Customize shipping rates',
-					subtitle:
-						'Define multiple shipping rates based on location, price, weight, or other criteria.',
-				},
-				{
-					title: 'Set conditional shipping',
-					subtitle: 'Restrict shipping and payment options using conditional logic.',
-				},
-				{
-					title: 'Simplify returns and exchanges',
-					subtitle:
-						'Manage the RMA process, add warranties to products and let customers request/manage returns from their account.',
-				},
-			],
-		},
-	];
+	
+	const eCommercePlanFeatureSets = useMemo( () => {
+		return getECommerceFeatureSets( { translate } );
+	}, [ translate ] );
 
 	const monthlyPriceWrapper = <span className="e-commerce-trial-plans__price-card-value" />;
 	const priceDescription = <span className="e-commerce-trial-plans__price-card-interval" />;
@@ -349,8 +153,8 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 			</Card>
 
 			<div className="e-commerce-trial-plans__features-wrapper">
-				{ features.map( ( feature ) => (
-					<TrialFeatureCard key={ feature.title } { ...feature } />
+				{ eCommercePlanFeatureSets.map( ( featureSet ) => (
+					<TrialFeatureCard key={ featureSet.title } { ...featureSet } />
 				) ) }
 			</div>
 			<div className="e-commerce-trial-plans__cta-wrapper">

--- a/client/my-sites/plans/ecommerce-trial/trial-feature-card/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/trial-feature-card/index.tsx
@@ -1,20 +1,21 @@
 import { Card, Gridicon } from '@automattic/components';
 import { useState } from 'react';
+import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
 
-interface TrialFeatureCardProps {
+export interface ECommercePlanFeatureSet {
 	illustration: string;
 	title: string;
-	subtitle: string;
+	subtitle: TranslateResult;
 	items: {
 		title: string;
-		subtitle: string;
+		subtitle: TranslateResult;
 	}[];
 	expanded?: boolean;
 }
 
-export default function TrialFeatureCard( props: TrialFeatureCardProps ) {
+export default function TrialFeatureCard( props: ECommercePlanFeatureSet ) {
 	const { illustration, title, subtitle, items } = props;
 
 	const [ expanded, setExpanded ] = useState( !! props.expanded );


### PR DESCRIPTION
Related to #72797

## Proposed Changes

This PR involves two core changes:
* The list of eCommerce plan features has been refactored into a new `getECommerceFeatureSets()` function in `client/my-sites/plans/ecommerce-trial/ecommerce-features.ts`, which also involved renaming the existing `TrialFeatureCardProps` type to `ECommercePlanFeatureSet`, and wrapping retrieval of the features list in `useMemo()`
* Translating all the strings in the feature list so we can get this queued up for next week's translation bundle, which will go out super-early on Monday morning (see p1676020817196269/1676019525.391739-slack-C02AED43D)
  - This also involved updating some of the types in `ECommercePlanFeatureSet`

## Testing Instructions

* Run this branch locally or via the Calypso.live branch
* For a site with the eCommerce Trial plan, navigate to _Upgrades_ -> _Plans_
* Verify that all the plan features are visible and can be looked at directly
* Verify that there are no console errors

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? -- _We'll queue these up either by adding the label later today, or by merging as this feature hasn't launched yet._
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

## Screenshots

<img width="810" alt="Screenshot 2023-02-10 at 12 23 39" src="https://user-images.githubusercontent.com/3376401/218070362-c0aef905-2fb9-4ad4-b9e2-fc3d5812b316.png">
<img width="813" alt="Screenshot 2023-02-10 at 12 24 19" src="https://user-images.githubusercontent.com/3376401/218070389-18085c99-4b7e-499e-82c5-33ca078b988f.png">
<img width="813" alt="Screenshot 2023-02-10 at 12 24 01" src="https://user-images.githubusercontent.com/3376401/218070398-b5f7b345-f0c2-4d66-9d66-c1ebfffdaf26.png">
