### PR TITLE
Stats: Updating Comments module

### DIFF
--- a/client/my-sites/stats/stats-comments/style.scss
+++ b/client/my-sites/stats/stats-comments/style.scss
@@ -1,3 +1,8 @@
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+
+$common-border-radius: 4px;
+
 .tab-content,
 .stats-comments__tab-content {
 	display: none;
@@ -12,4 +17,54 @@
 .tab-top-authors .tab-content.top-authors,
 .tab-top-content .tab-content.top-content {
 	display: block;
+}
+
+.stats__modernised-comments {
+	.segmented-control {
+		.segmented-control__link {
+			padding: 6px 8px;
+			font-weight: 500;
+			line-height: 20px;
+			color: var(--studio-black);
+
+			&:focus {
+				outline: none;
+			}
+		}
+
+		.segmented-control__item {
+			&:not(:first-of-type) {
+				margin-left: -1px;
+			}
+
+			&.is-selected {
+				.segmented-control__link {
+					background-color: var(--color-primary);
+					border-color: var(--color-primary);
+					color: var(--studio-white);
+					position: relative;
+					z-index: 1;
+				}
+			}
+
+			&:first-of-type .segmented-control__link {
+				border-top-left-radius: $common-border-radius;
+				border-bottom-left-radius: $common-border-radius;
+				border-right: 0;
+			}
+
+			&:last-of-type .segmented-control__link {
+				border-top-right-radius: $common-border-radius;
+				border-bottom-right-radius: $common-border-radius;
+			}
+		}
+
+		@media ( max-width: 660px ) {
+			margin-top: 16px;
+
+			.segmented-control__link {
+				padding: 6px 26px;
+			}
+		}
+	}
 }

--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -4,6 +4,7 @@ import {
 	StatsCard,
 	StatsCardAvatar,
 } from '@automattic/components';
+import classNames from 'classnames';
 import debugFactory from 'debug';
 import page from 'page';
 import React, { useState, useCallback } from 'react';
@@ -28,6 +29,8 @@ const StatsListCard = ( {
 	splitHeader,
 	mainItemLabel,
 	additionalColumns,
+	toggleControl,
+	className,
 } ) => {
 	const moduleNameTitle = titlecase( moduleType );
 	const debug = debugFactory( `calypso:stats:list:${ moduleType }` );
@@ -101,12 +104,13 @@ const StatsListCard = ( {
 			}
 			emptyMessage={ emptyMessage }
 			isEmpty={ ! loader && ( ! data || ! data?.length ) }
-			className={ `list-${ moduleType }` }
+			className={ classNames( `list-${ moduleType }`, className ) }
 			metricLabel={ metricLabel }
 			heroElement={ heroElement }
 			splitHeader={ splitHeader }
 			mainItemLabel={ mainItemLabel }
 			additionalHeaderColumns={ additionalColumns?.header }
+			toggleControl={ toggleControl }
 		>
 			{ !! loader && loader }
 			{ !! error && error }
@@ -120,7 +124,7 @@ const StatsListCard = ( {
 						// left icon visible only for Author avatars and Contry flags.
 						if ( item?.countryCode ) {
 							leftSideItem = <StatsListCountryFlag countryCode={ item.countryCode } />;
-						} else if ( moduleType === 'authors' && item?.icon ) {
+						} else if ( ( moduleType === 'authors' || moduleType === 'comments' ) && item?.icon ) {
 							leftSideItem = <StatsCardAvatar url={ item?.icon } altName={ item?.label } />;
 						}
 

--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -62,6 +62,12 @@
 		}
 	}
 
+	.stats-card-header--main {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
 	.stats-card-header__additional {
 		@include additional-columns-wrapper;
 	}

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -19,6 +19,7 @@ const StatsCard = ( {
 	metricLabel,
 	mainItemLabel,
 	additionalHeaderColumns,
+	toggleControl,
 }: StatsCardProps ) => {
 	const translate = useTranslate();
 
@@ -42,7 +43,10 @@ const StatsCard = ( {
 	// (main item, optional additional columns and value)
 	const splitHeaderNode = (
 		<div className={ `${ BASE_CLASS_NAME }-header ${ BASE_CLASS_NAME }-header--split` }>
-			{ titleNode }
+			<div className={ `${ BASE_CLASS_NAME }-header--main` }>
+				{ titleNode }
+				{ toggleControl }
+			</div>
 			{ ! isEmpty && (
 				<div className={ `${ BASE_CLASS_NAME }--column-header` }>
 					<div className={ `${ BASE_CLASS_NAME }--column-header__left` }>

--- a/packages/components/src/horizontal-bar-list/types.ts
+++ b/packages/components/src/horizontal-bar-list/types.ts
@@ -59,6 +59,7 @@ export type StatsCardProps = {
 	splitHeader?: boolean;
 	mainItemLabel?: React.ReactNode;
 	additionalHeaderColumns?: React.ReactNode;
+	toggleControl?: React.ReactNode;
 };
 
 export type StatsCardAvatarProps = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72134
## Proposed Changes

* converting existing `Comments` component to new design adding horizontal bars, and swapping select to a toggle control
* extending horizontal bar card to accept custom CSS class and additional header item (toggle component in this case)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch and the `Insights` page
* verify that the current `Comments` renders correctly and select switching data sets works correctly
* apply feature flag to the URL `?flags=stats/insights-page-grid`
* verify that the new module with horizontal bars loads and toggle switches between data sets

| Before | After |
| --- | --- |
| ![SCR-20230210-x4o](https://user-images.githubusercontent.com/112354940/218074532-90096437-43cb-4f7c-b9bb-cb6744360f03.png) | ![SCR-20230210-x59](https://user-images.githubusercontent.com/112354940/218074579-062ad0a1-15ab-4d85-8faf-f6697a955bce.png) |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
