### PR TITLE
Copy Site: Remove `shouldStickyNavButtons` to show back button on the left

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -221,7 +221,6 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		<StepContainer
 			stepName="domains"
 			isWideLayout={ true }
-			shouldStickyNavButtons={ isCopySiteFlow( flow ) }
 			hideBack={ ! isCopySiteFlow( flow ) }
 			backLabelText={ __( 'Back to Sites' ) }
 			hideSkip={ true }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/dotcom-forge/issues/1519

## Proposed Changes

* Show the back button on the left. Making it more consistent with other flows such as https://wordpress.com/start/domains

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites`
* Open the actions menu and click on `Copy site` on any business site
* In the first step, the Domains step, Observe that the `< Back to sites` button is on the left.

## Screenshot

| **Before** | **After** |
|---|---|
| <img width="1832" alt="back-before" src="https://user-images.githubusercontent.com/779993/218084492-7a6ad6de-b75e-45e5-a7a0-0a1acdf65f1a.png"> | <img width="1832" alt="back-after" src="https://user-images.githubusercontent.com/779993/218084504-3ecf2ce4-171a-4cc9-9af2-a9ae484ff47c.png"> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
