### PR TITLE
Revert "Copy Site: add products to site cart to resume the flow (#73130)"

### DIFF
--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -82,9 +82,16 @@ const copySite: Flow = {
 			recordFullStoryEvent( 'calypso_signup_start_copy_site', { flow: this.name } );
 		}, [ resetOnboardStore ] );
 
+		const urlQueryParams = useQuery();
+		const siteSlug = urlQueryParams.get( 'siteSlug' );
+
 		return [
-			{ slug: 'domains', component: DomainsStep },
-			{ slug: 'site-creation-step', component: SiteCreationStep },
+			...( ! siteSlug
+				? [
+						{ slug: 'domains', component: DomainsStep },
+						{ slug: 'site-creation-step', component: SiteCreationStep },
+				  ]
+				: [] ),
 			{ slug: 'processing', component: ProcessingStep },
 			{ slug: 'automated-copy', component: AutomatedCopySite },
 			{
@@ -99,7 +106,6 @@ const copySite: Flow = {
 					/>
 				),
 			},
-			{ slug: 'resuming', component: ProcessingStep }, // Needs siteSlug param
 		];
 	},
 
@@ -126,7 +132,6 @@ const copySite: Flow = {
 					return navigate( 'processing' );
 				}
 
-				case 'resuming':
 				case 'processing': {
 					const siteSlug = providedDependencies?.siteSlug || urlQueryParams.get( 'siteSlug' );
 					const destination = addQueryArgs( `/setup/${ this.name }/automated-copy`, {

--- a/client/my-sites/customer-home/cards/tasks/site-resume-copy/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-resume-copy/index.jsx
@@ -1,11 +1,9 @@
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import { connect } from 'react-redux';
 import siteCopyIllustration from 'calypso/assets/images/customer-home/illustration--import-complete.svg';
 import { useSiteCopy } from 'calypso/landing/stepper/hooks/use-site-copy';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
-import { navigate } from 'calypso/lib/navigate';
 import { TASK_SITE_RESUME_COPY } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 import { getSite, getSiteOption } from 'calypso/state/sites/selectors';
@@ -13,12 +11,10 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 
 const SiteResumeCopy = ( { siteSlug, sourceSite, sourceSiteSlug } ) => {
 	const translate = useTranslate();
-	const [ isAddingProducts, setIsAddingProducts ] = useState( false );
-	const { resumeSiteCopy } = useSiteCopy( sourceSite );
+	const { startSiteCopy } = useSiteCopy( sourceSite );
 
 	return (
 		<Task
-			actionBusy={ isAddingProducts }
 			isUrgent
 			title={ translate( 'Ready to finish copying your site?' ) }
 			description={ preventWidows(
@@ -27,13 +23,10 @@ const SiteResumeCopy = ( { siteSlug, sourceSite, sourceSiteSlug } ) => {
 				)
 			) }
 			actionText={ translate( 'Finish setting it up' ) }
-			actionOnClick={ async () => {
+			actionUrl={ `/setup/copy-site?sourceSlug=${ sourceSiteSlug }&siteSlug=${ siteSlug }` }
+			actionOnClick={ () => {
 				recordTracksEvent( 'calypso_resume_copy_site_click' );
-				setIsAddingProducts( true );
-				await resumeSiteCopy( siteSlug );
-				navigate(
-					`/setup/copy-site/resuming?sourceSlug=${ sourceSiteSlug }&siteSlug=${ siteSlug }`
-				);
+				startSiteCopy();
 			} }
 			illustration={ siteCopyIllustration }
 			taskId={ TASK_SITE_RESUME_COPY }

--- a/client/my-sites/customer-home/cards/tasks/task.tsx
+++ b/client/my-sites/customer-home/cards/tasks/task.tsx
@@ -19,7 +19,6 @@ import './style.scss';
 
 const Task = ( {
 	actionButton,
-	actionBusy = false,
 	actionOnClick,
 	actionTarget,
 	actionText,
@@ -41,7 +40,6 @@ const Task = ( {
 	title,
 }: {
 	actionOnClick?: () => void;
-	actionBusy?: boolean;
 	badgeText?: ReactNode;
 	completeOnStart?: boolean;
 	description: ReactNode;
@@ -144,7 +142,6 @@ const Task = ( {
 				onClick={ startTask }
 				href={ actionUrl }
 				target={ actionTarget }
-				busy={ actionBusy }
 			>
 				{ actionText }
 			</Button>


### PR DESCRIPTION
This reverts commit b12043ff4f980ee5140e066643ee8ff8f69c65e5.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/dotcom-forge/issues/1593

## Proposed Changes

* Revert the resume copy site since it seems it breaks the normal copy site flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check copy site flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
