### PR TITLE
Copy Site: `resetOnboardStore()` when initializing Stepper, v2

### DIFF
--- a/client/landing/stepper/hooks/use-site-copy.tsx
+++ b/client/landing/stepper/hooks/use-site-copy.tsx
@@ -66,7 +66,7 @@ export const useSiteCopy = (
 
 	const purchases = useSelector( ( state ) => getUserPurchases( state ) );
 
-	const { setPlanCartItem, setProductCartItems } = useDispatch( ONBOARD_STORE );
+	const { setPlanCartItem, setProductCartItems, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
 	const shouldShowSiteCopyItem = useMemo( () => {
 		return hasCopySiteFeature && isSiteOwner && plan && isAtomic && ! isLoadingPurchases;
@@ -77,6 +77,7 @@ export const useSiteCopy = (
 			return;
 		}
 		clearSignupDestinationCookie();
+		resetOnboardStore();
 		setPlanCartItem( { product_slug: plan?.product_slug as string } );
 
 		const marketplacePluginProducts = ( purchases || [] )
@@ -88,7 +89,15 @@ export const useSiteCopy = (
 			.map( ( purchase ) => ( { product_slug: purchase.productSlug } ) );
 
 		setProductCartItems( marketplacePluginProducts );
-	}, [ plan, setPlanCartItem, purchases, shouldShowSiteCopyItem, setProductCartItems, site?.ID ] );
+	}, [
+		plan,
+		setPlanCartItem,
+		purchases,
+		resetOnboardStore,
+		shouldShowSiteCopyItem,
+		setProductCartItems,
+		site?.ID,
+	] );
 
 	return useMemo(
 		() => ( {


### PR DESCRIPTION
## Proposed Changes

Ensure the domain search form starts out as empty by calling `resetOnboardStore()` when initializing Stepper

Originally https://github.com/Automattic/wp-calypso/pull/73166#issuecomment-1425757910
Discussion in p1676031433499719-slack-C04GESRBWKW

## Testing Instructions

1. Initiate Copy Site flow for a Business site and enter a domain search term.
2. Navigate back to Sites.
3. Initiate Copy Site flow for a different Business site.
4. Verify the original domain search term doesn't appear in the form.
5. Enter a new domain and **complete the entire checkout process** to verify Copy Site still works.