### PR TITLE
Developer UX: Add support for anchors to Hosting Configuration

### DIFF
--- a/client/components/card-heading/README.md
+++ b/client/components/card-heading/README.md
@@ -22,3 +22,4 @@ function render() {
 - `size` (`int`) - The font size of the heading
 - `isBold` (`bool`) - Sets the heading to bold
 - `className` (`string`) - Adds additional class names to the component
+- `id` (`string`) - Adds id attribute to the component

--- a/client/components/card-heading/index.jsx
+++ b/client/components/card-heading/index.jsx
@@ -26,6 +26,7 @@ CardHeading.propTypes = {
 	size: PropTypes.number,
 	isBold: PropTypes.bool,
 	className: PropTypes.string,
+	id: PropTypes.string,
 };
 
 export default CardHeading;

--- a/client/components/card-heading/index.jsx
+++ b/client/components/card-heading/index.jsx
@@ -9,7 +9,7 @@ import './style.scss';
 //Sizes 47, 21, and 11 are deprecated; use the nearest equivalent
 const validTypeSizes = [ 54, 48, 47, 36, 32, 24, 21, 20, 16, 14, 12, 11 ];
 
-function CardHeading( { tagName = 'h1', size = 20, isBold = false, className, children } ) {
+function CardHeading( { tagName = 'h1', size = 20, isBold = false, className, id, children } ) {
 	const classNameObject = {};
 	classNameObject[ 'card-heading-' + size ] = includes( validTypeSizes, size );
 	const classes = classNames(
@@ -18,7 +18,7 @@ function CardHeading( { tagName = 'h1', size = 20, isBold = false, className, ch
 		className && className,
 		classNameObject
 	);
-	return createElement( tagName, { className: classes }, preventWidows( children, 2 ) );
+	return createElement( tagName, { className: classes, id }, preventWidows( children, 2 ) );
 }
 
 CardHeading.propTypes = {

--- a/client/lib/scroll-to-anchor/README.md
+++ b/client/lib/scroll-to-anchor/README.md
@@ -9,7 +9,7 @@ import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 
 class MyComponent extends Component {
 	componentDidMount() {
-		setTimeout(() => scrollToAnchor({offset: 15}));
+		setTimeout( () => scrollToAnchor( { offset: 15 } ) );
 	}
 }
 ```

--- a/client/lib/scroll-to-anchor/README.md
+++ b/client/lib/scroll-to-anchor/README.md
@@ -7,7 +7,9 @@ A utility module to smoothly scroll to a URL anchor position.
 ```js
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 
-componentDidMount() {
-	setTimeout( () => scrollToAnchor( { offset: 15 } ) );
+class MyComponent extends Component {
+	componentDidMount() {
+		setTimeout(() => scrollToAnchor({offset: 15}));
+	}
 }
 ```

--- a/client/lib/scroll-to-anchor/README.md
+++ b/client/lib/scroll-to-anchor/README.md
@@ -1,0 +1,13 @@
+# scroll-to-anchor
+
+A utility module to smoothly scroll to a URL anchor position.
+
+## Usage
+
+```js
+import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
+
+componentDidMount() {
+	setTimeout( () => scrollToAnchor( { offset: 15 } ) );
+}
+```

--- a/client/lib/scroll-to-anchor/index.js
+++ b/client/lib/scroll-to-anchor/index.js
@@ -1,0 +1,36 @@
+import scrollTo from 'calypso/lib/scroll-to';
+
+// Danger! Recursive
+// (relatively safe since the DOM tree is only so deep)
+function getOffsetTop( element ) {
+	const offset = element.offsetTop;
+
+	return element.offsetParent ? offset + getOffsetTop( element.offsetParent ) : offset;
+}
+
+/**
+ * Scrolls to the anchor location
+ *
+ * Wait for page.js to update the URL, then see if we are linking
+ * directly to a section of this page.
+ *
+ * @param {Object} options - options object (see below)
+ * @param {number} [options.offset] - desired offset
+ */
+export default function scrollToAnchor( options ) {
+	const offset = options.offset;
+
+	if ( ! window || ! window.location ) {
+		// This code breaks everything in the tests (they hang with no
+		// error message).
+		return;
+	}
+
+	const hash = window.location.hash;
+	const el = hash && document.getElementById( hash.substring( 1 ) );
+
+	if ( hash && el ) {
+		const y = getOffsetTop( el ) - document.getElementById( 'header' ).offsetHeight - offset;
+		scrollTo( { y } );
+	}
+}

--- a/client/lib/scroll-to-anchor/index.ts
+++ b/client/lib/scroll-to-anchor/index.ts
@@ -2,10 +2,12 @@ import scrollTo from 'calypso/lib/scroll-to';
 
 // Danger! Recursive
 // (relatively safe since the DOM tree is only so deep)
-function getOffsetTop( element ) {
+function getOffsetTop( element: HTMLElement ): number {
 	const offset = element.offsetTop;
 
-	return element.offsetParent ? offset + getOffsetTop( element.offsetParent ) : offset;
+	return element.offsetParent
+		? offset + getOffsetTop( element.offsetParent as HTMLElement )
+		: offset;
 }
 
 /**
@@ -13,11 +15,8 @@ function getOffsetTop( element ) {
  *
  * Wait for page.js to update the URL, then see if we are linking
  * directly to a section of this page.
- *
- * @param {Object} options - options object (see below)
- * @param {number} [options.offset] - desired offset
  */
-export default function scrollToAnchor( options ) {
+export default function scrollToAnchor( options: { offset: number } ) {
 	const offset = options.offset;
 
 	if ( ! window || ! window.location ) {
@@ -30,7 +29,8 @@ export default function scrollToAnchor( options ) {
 	const el = hash && document.getElementById( hash.substring( 1 ) );
 
 	if ( hash && el ) {
-		const y = getOffsetTop( el ) - document.getElementById( 'header' ).offsetHeight - offset;
+		const offsetHeight = document.getElementById( 'header' )?.offsetHeight || 0;
+		const y = getOffsetTop( el ) - offsetHeight - offset;
 		scrollTo( { y } );
 	}
 }

--- a/client/my-sites/hosting/github/github-authorize-card/index.tsx
+++ b/client/my-sites/hosting/github/github-authorize-card/index.tsx
@@ -30,7 +30,7 @@ export const GithubAuthorizeCard = () => {
 	return (
 		<Card className="github-hosting-card">
 			<img className="github-hosting-icon" src={ iconGitHub } alt="" />
-			<CardHeading>{ translate( 'Connect GitHub' ) }</CardHeading>
+			<CardHeading id="connect-github">{ translate( 'Connect GitHub' ) }</CardHeading>
 			<p>
 				{ translate(
 					'Connect this site to a GitHub repository, choose a branch, and deploy with each push.'

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -17,6 +17,7 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import { GitHubCard } from 'calypso/my-sites/hosting/github';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
@@ -65,6 +66,7 @@ class Hosting extends Component {
 			// Try to refresh the transfer state
 			this.props.fetchAutomatedTransferStatus( this.props.siteId );
 		}
+		setTimeout( () => scrollToAnchor( { offset: 30 } ), 2000 );
 	}
 
 	render() {

--- a/client/my-sites/hosting/phpmyadmin-card/index.js
+++ b/client/my-sites/hosting/phpmyadmin-card/index.js
@@ -59,7 +59,7 @@ export default function PhpMyAdminCard( { disabled } ) {
 	return (
 		<Card className="phpmyadmin-card">
 			<MaterialIcon icon="dns" size={ 32 } />
-			<CardHeading>{ translate( 'Database Access' ) }</CardHeading>
+			<CardHeading id="database-access">{ translate( 'Database Access' ) }</CardHeading>
 			<p>
 				{ translate(
 					'For the tech-savvy, manage your database with phpMyAdmin and run a wide range of operations with MySQL.'

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -217,7 +217,7 @@ export const SftpCard = ( {
 	return (
 		<Card className="sftp-card">
 			<MaterialIcon icon="key" size={ 32 } />
-			<CardHeading>
+			<CardHeading id="sftp-credentials">
 				{ siteHasSshFeature
 					? translate( 'SFTP/SSH credentials' )
 					: translate( 'SFTP credentials' ) }

--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -267,7 +267,7 @@ const WebServerSettingsCard = ( {
 			<QuerySitePhpVersion siteId={ siteId } />
 			<QuerySiteStaticFile404 siteId={ siteId } />
 			<MaterialIcon icon="build" size={ 32 } />
-			<CardHeading>{ translate( 'Web Server Settings' ) }</CardHeading>
+			<CardHeading id="web-server-settings">{ translate( 'Web Server Settings' ) }</CardHeading>
 			<p>
 				{ translate(
 					'For sites with specialized needs, fine-tune how the web server runs your website.'

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -33,7 +33,7 @@ import NoticeAction from 'calypso/components/notice/notice-action';
 import SitePreviewLink from 'calypso/components/site-preview-link';
 import Timezone from 'calypso/components/timezone';
 import { preventWidows } from 'calypso/lib/formatting';
-import scrollTo from 'calypso/lib/scroll-to';
+import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -63,21 +63,7 @@ import wrapSettingsForm from './wrap-settings-form';
 
 export class SiteSettingsFormGeneral extends Component {
 	componentDidMount() {
-		// Wait for page.js to update the URL, then see if we are linking
-		// directly to a section of this page.
-		setTimeout( () => {
-			if ( ! window || ! window.location ) {
-				// This code breaks everything in the tests (they hang with no
-				// error message).
-				return;
-			}
-			const hash = window.location.hash;
-			const el = hash && document.getElementById( hash.substring( 1 ) );
-			if ( hash && el ) {
-				const y = el.offsetTop - document.getElementById( 'header' ).offsetHeight - 15;
-				scrollTo( { y } );
-			}
-		} );
+		setTimeout( () => scrollToAnchor( { offset: 15 } ) );
 	}
 
 	getIncompleteLocaleNoticeMessage = ( language ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1628-gh-Automattic/dotcom-forge

## Proposed Changes

In this PR, I propose to make each section in Hosting Configuration linkable by adding `id` attributes.

I reuse a `scrollTo` logic from General Settings, and I extract it to a separate library to avoid repetition.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Open the following URLs and confirm that view is scrolled to the proper block:

```
/settings/general/SITE_URL#site-privacy-settings
/hosting-config/SITE_URL#database-access
/hosting-config/SITE_URL#sftp-credentials
/hosting-config/SITE_URL#web-server-settings
/hosting-config/SITE_URL#connect-github
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?