### PR TITLE
Plans 2023: Restrict new pricing grid to English and Spanish locales only

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -1,4 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
+import { is2023PricingGridEnabled } from '@automattic/calypso-products';
 import { StepContainer } from '@automattic/onboarding';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import PlansWrapper from './plans-wrapper';
@@ -10,7 +10,7 @@ const plans: Step = function plans( { navigation, flow } ) {
 	const handleSubmit = () => {
 		submit?.();
 	};
-	const is2023OnboardingPricingGrid = isEnabled( 'onboarding/2023-pricing-grid' );
+	const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
 	return (
 		<StepContainer
 			stepName="plans"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -1,6 +1,5 @@
 // import { subscribeIsDesktop } from '@automattic/viewport';
-import { isEnabled } from '@automattic/calypso-config';
-import { getPlan, PLAN_FREE } from '@automattic/calypso-products';
+import { getPlan, PLAN_FREE, is2023PricingGridEnabled } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
 import { NEWSLETTER_FLOW } from '@automattic/onboarding';
@@ -160,7 +159,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					{ components: { link: freePlanButton } }
 			  );
 	};
-	const is2023OnboardingPricingGrid = isEnabled( 'onboarding/2023-pricing-grid' );
+	const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
 
 	const plansFeaturesSelection = () => {
 		const { flowName } = props;

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -218,6 +218,7 @@ import {
 	FEATURE_PREMIUM_CONTENT_JP,
 	FEATURE_SITE_ACTIVITY_LOG_JP,
 	FEATURE_GLOBAL_EDGE_CACHING,
+	is2023PricingGridEnabled,
 } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
 import i18n, { TranslateResult } from 'i18n-calypso';
@@ -229,7 +230,7 @@ import ExternalLinkWithTracking from 'calypso/components/external-link/with-trac
 import MaterialIcon from 'calypso/components/material-icon';
 import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from 'calypso/lib/url/support';
 
-const is2023OnboardingPricingGrid = isEnabled( 'onboarding/2023-pricing-grid' );
+const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
 
 export type FeatureObject = {
 	getSlug: () => string;

--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -1,5 +1,5 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
+	is2023PricingGridEnabled,
 	getPlanClass,
 	isMonthly,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
@@ -204,7 +204,7 @@ const LoggedInPlansFeatureActionButton = ( {
 		);
 	}
 
-	const is2023OnboardingPricingGrid = isEnabled( 'onboarding/2023-pricing-grid' );
+	const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
 	if ( ! availableForPurchase ) {
 		if ( is2023OnboardingPricingGrid ) {
 			return (

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -28,6 +28,7 @@ import {
 	PLAN_PERSONAL,
 	TITAN_MAIL_MONTHLY_SLUG,
 	PLAN_FREE,
+	is2023PricingGridEnabled,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
@@ -713,7 +714,7 @@ export default connect(
 		) {
 			customerType = 'business';
 		}
-		const is2023OnboardingPricingGrid = isEnabled( 'onboarding/2023-pricing-grid' );
+		const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
 		const planTypeSelectorProps = {
 			basePlansPath: props.basePlansPath,
 			isInSignup: props.isInSignup,

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -5,6 +5,7 @@ import {
 	PLAN_FREE,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	isFreePlan,
+	is2023PricingGridEnabled,
 } from '@automattic/calypso-products';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
@@ -227,7 +228,7 @@ class Plans extends Component {
 			);
 		}
 
-		const hideFreePlan = ! isEnabled( 'onboarding/2023-pricing-grid' );
+		const hideFreePlan = ! is2023PricingGridEnabled();
 		if ( this.props.domainSidebarExperimentUser && this.props.domainAndPlanPackage ) {
 			return (
 				<CalypsoShoppingCartProvider>
@@ -372,7 +373,7 @@ const ConnectedPlans = connect( ( state ) => {
 	const currentPlanIntervalType = getIntervalTypeForTerm(
 		getPlan( currentPlan?.productSlug )?.term
 	);
-	const is2023OnboardingPricingGrid = isEnabled( 'onboarding/2023-pricing-grid' );
+	const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
 
 	return {
 		currentPlan,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -3,6 +3,7 @@ import {
 	isDomainRegistration,
 	isDomainTransfer,
 	isDomainMapping,
+	is2023PricingGridEnabled,
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { isNewsletterOrLinkInBioFlow, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
@@ -774,7 +775,7 @@ class Signup extends Component {
 		// If there is any condition upon which the free plan should be hidden these issues need to be resolved.
 		// For now we always show the free plan for the 2023-pricing-grid
 		// More Context : Automattic/martech#1464
-		const hideFreePlan = config.isEnabled( 'onboarding/2023-pricing-grid' )
+		const hideFreePlan = is2023PricingGridEnabled()
 			? false
 			: planWithDomain || this.props.isDomainOnlySite || selectedHideFreePlan;
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -1,5 +1,5 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
+	is2023PricingGridEnabled,
 	planHasFeature,
 	FEATURE_UPLOAD_THEMES_PLUGINS,
 	getPlan,
@@ -439,7 +439,7 @@ export class PlansStep extends Component {
 	}
 
 	render() {
-		const is2023OnboardingPricingGrid = isEnabled( 'onboarding/2023-pricing-grid' );
+		const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
 
 		const classes = classNames( 'plans plans-step', {
 			'in-vertically-scrolled-plans-experiment':
@@ -514,7 +514,7 @@ export default connect(
 		isInVerticalScrollingPlansExperiment: true,
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
 		eligibleForProPlan: isEligibleForProPlan( state, getSiteBySlug( state, siteSlug )?.ID ),
-		isOnboarding2023PricingGrid: isEnabled( 'onboarding/2023-pricing-grid' ),
+		isOnboarding2023PricingGrid: is2023PricingGridEnabled(),
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep, errorNotice }
 )( localize( PlansStep ) );

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -320,6 +320,7 @@ import {
 	FEATURE_CLOUD_CRITICAL_CSS,
 	FEATURE_GLOBAL_EDGE_CACHING,
 } from './constants';
+import { is2023PricingGridEnabled } from './plans-utilities';
 import type {
 	BillingTerm,
 	Plan,
@@ -692,7 +693,8 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		},
 	} ),
 } );
-const is2023OnboardingPricingGrid = isEnabled( 'onboarding/2023-pricing-grid' );
+
+const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
 
 const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 	...getDotcomPlanDetails(),

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -1,3 +1,5 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { getLocaleSlug } from 'i18n-calypso';
 import {
 	JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN,
 	BEST_VALUE_PLANS,
@@ -38,3 +40,11 @@ export function getTermDuration( term: string ): number | undefined {
 }
 
 export const redirectCheckoutToWpAdmin = (): boolean => !! JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN;
+
+export const is2023PricingGridEnabled = () => {
+	const supportedLocales = [ 'en', 'en-gb', 'es' ];
+	return (
+		isEnabled( 'onboarding/2023-pricing-grid' ) &&
+		supportedLocales.includes( getLocaleSlug() || '' )
+	);
+};

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -45,6 +45,6 @@ export const is2023PricingGridEnabled = () => {
 	const supportedLocales = [ 'en', 'en-gb', 'es' ];
 	return (
 		isEnabled( 'onboarding/2023-pricing-grid' ) &&
-		supportedLocales.includes( getLocaleSlug() || '' )
+		supportedLocales.includes( getLocaleSlug() ?? '' )
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1495
## Proposed Changes

This uses a function that considers the feature flag and it will render the new pricing grid if the locale is English or Spanish.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a non-whitelisted locale, ex: German
* Go to `/start/plans` and `/plans/{SITE_DOMAIN}`
* You should see the old Pricing Grid

<img width="320" alt="Screenshot 2023-02-10 at 15 20 54" src="https://user-images.githubusercontent.com/2749938/218106136-b3d2bbe8-8bbe-4f55-806b-2928fe17c2cc.png">
<img width="320" alt="Screenshot 2023-02-10 at 15 20 42" src="https://user-images.githubusercontent.com/2749938/218106147-0e00fdbd-4176-4769-8e6c-3802bc95e400.png">

* Switch to a whitelisted locale, ex: English(UK)
* Go to `/start/plans` and `/plans/{SITE_DOMAIN}`
* You should see the new Pricing Grid
<img width="320" alt="Screenshot 2023-02-10 at 15 21 40" src="https://user-images.githubusercontent.com/2749938/218106052-0ff558c8-adad-4f0a-a01f-630c4b2bc55f.png">
<img width="320" alt="Screenshot 2023-02-10 at 15 21 22" src="https://user-images.githubusercontent.com/2749938/218106075-07592f8d-b7be-4982-9cc7-ad6346b575d3.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related Automattic/martech#1495