### PR TITLE
Virtual themes: Show Premium badge

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -92,6 +92,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				site && select( SITE_STORE ).siteHasFeature( site.ID, WPCOM_FEATURES_PREMIUM_THEMES )
 		)
 	);
+	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 
 	// ********** Logic for vertical
 	const { data: siteVertical, isLoading: isLoadingSiteVertical } =
@@ -129,6 +130,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		{
 			enabled: true,
 			select: selectStarterDesigns,
+			shouldLimitGlobalStyles,
 		}
 	);
 
@@ -358,8 +360,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	}
 
 	// ********** Logic for Premium Global Styles
-
-	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 	const [ showPremiumGlobalStylesModal, setShowPremiumGlobalStylesModal ] = useState( false );
 
 	function unlockPremiumGlobalStyles() {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -92,7 +92,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				site && select( SITE_STORE ).siteHasFeature( site.ID, WPCOM_FEATURES_PREMIUM_THEMES )
 		)
 	);
-	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 
 	// ********** Logic for vertical
 	const { data: siteVertical, isLoading: isLoadingSiteVertical } =
@@ -130,7 +129,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		{
 			enabled: true,
 			select: selectStarterDesigns,
-			shouldLimitGlobalStyles,
 		}
 	);
 
@@ -360,6 +358,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	}
 
 	// ********** Logic for Premium Global Styles
+
+	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 	const [ showPremiumGlobalStylesModal, setShowPremiumGlobalStylesModal ] = useState( false );
 
 	function unlockPremiumGlobalStyles() {
@@ -707,6 +707,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			isPremiumThemeAvailable={ isPremiumThemeAvailable }
 			purchasedThemes={ purchasedThemes }
 			currentPlanFeatures={ currentPlanFeatures }
+			shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 		/>
 	);
 

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -21,7 +21,6 @@ interface StarterDesignsQueryParams {
 interface Options extends QueryOptions< StarterDesignsResponse, unknown > {
 	enabled?: boolean;
 	select?: ( response: StarterDesigns ) => StarterDesigns;
-	shouldLimitGlobalStyles?: boolean;
 }
 
 interface StarterDesignsResponse {
@@ -52,7 +51,7 @@ interface GeneratedDesign {
 
 export function useStarterDesignsQuery(
 	queryParams: StarterDesignsQueryParams,
-	{ select, shouldLimitGlobalStyles, ...queryOptions }: Options = {}
+	{ select, ...queryOptions }: Options = {}
 ): UseQueryResult< StarterDesigns > {
 	return useQuery( [ 'starter-designs', queryParams ], () => fetchStarterDesigns( queryParams ), {
 		select: ( response: StarterDesignsResponse ) => {
@@ -61,9 +60,7 @@ export function useStarterDesignsQuery(
 					designs: response.generated?.designs?.map( apiStarterDesignsGeneratedToDesign ),
 				},
 				static: {
-					designs: response.static?.designs?.map( ( design ) =>
-						apiStarterDesignsStaticToDesign( design, shouldLimitGlobalStyles )
-					),
+					designs: response.static?.designs?.map( apiStarterDesignsStaticToDesign ),
 				},
 			};
 
@@ -85,10 +82,7 @@ function fetchStarterDesigns(
 	} );
 }
 
-function apiStarterDesignsStaticToDesign(
-	design: StaticDesign,
-	shouldLimitGlobalStyles?: boolean
-): Design {
+function apiStarterDesignsStaticToDesign( design: StaticDesign ): Design {
 	const {
 		slug,
 		title,
@@ -103,9 +97,7 @@ function apiStarterDesignsStaticToDesign(
 		style_variation_slug,
 	} = design;
 	const is_premium =
-		( design.recipe.stylesheet && design.recipe.stylesheet.startsWith( 'premium/' ) ) ||
-		( is_virtual && style_variation_slug && shouldLimitGlobalStyles ) ||
-		false;
+		( design.recipe.stylesheet && design.recipe.stylesheet.startsWith( 'premium/' ) ) || false;
 
 	const is_bundled_with_woo_commerce = ( design.software_sets || [] ).some(
 		( { slug } ) => slug === 'woo-on-plans'

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -150,6 +150,7 @@ interface DesignButtonProps {
 	onCheckout?: any;
 	verticalId?: string;
 	currentPlanFeatures?: string[];
+	shouldLimitGlobalStyles?: boolean;
 }
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
@@ -160,9 +161,11 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	hasPurchasedTheme = false,
 	verticalId,
 	currentPlanFeatures,
+	shouldLimitGlobalStyles,
 } ) => {
 	const { __ } = useI18n();
-	const { style_variations = [], is_premium: isPremium = false } = design;
+	const { is_premium = false, is_virtual, style_variation, style_variations = [] } = design;
+	const isPremium = is_premium || ( shouldLimitGlobalStyles && is_virtual && style_variation );
 	const shouldUpgrade = isPremium && ! isPremiumThemeAvailable && ! hasPurchasedTheme;
 	const currentSiteCanInstallWoo = currentPlanFeatures?.includes( FEATURE_WOOP ) ?? false;
 
@@ -384,6 +387,7 @@ interface DesignPickerProps {
 	onCheckout?: any;
 	purchasedThemes?: string[];
 	currentPlanFeatures?: string[];
+	shouldLimitGlobalStyles?: boolean;
 }
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -399,6 +403,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	verticalId,
 	purchasedThemes,
 	currentPlanFeatures,
+	shouldLimitGlobalStyles,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 	const filteredStaticDesigns = useMemo( () => {
@@ -433,6 +438,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						verticalId={ verticalId }
 						hasPurchasedTheme={ wasThemePurchased( purchasedThemes, design ) }
 						currentPlanFeatures={ currentPlanFeatures }
+						shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 					/>
 				) ) }
 				{ categorization?.selection === SHOW_GENERATED_DESIGNS_SLUG &&
@@ -466,6 +472,7 @@ export interface UnifiedDesignPickerProps {
 	onCheckout?: any;
 	purchasedThemes?: string[];
 	currentPlanFeatures?: string[];
+	shouldLimitGlobalStyles?: boolean;
 }
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
@@ -483,6 +490,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	onCheckout,
 	purchasedThemes,
 	currentPlanFeatures,
+	shouldLimitGlobalStyles,
 } ) => {
 	const translate = useTranslate();
 	const hasCategories = !! categorization?.categories.length;
@@ -519,6 +527,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					onCheckout={ onCheckout }
 					purchasedThemes={ purchasedThemes }
 					currentPlanFeatures={ currentPlanFeatures }
+					shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 				/>
 				{ ( ! isShowAll || ! hasGeneratedDesigns ) && bottomAnchorContent }
 			</div>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1611.
Requires https://github.com/Automattic/wp-calypso/pull/73109.

## Proposed Changes

Virtual themes are now labeled as Premium since they require the Premium plan to unlock the style variation.

<img width="1229" alt="Screenshot 2023-02-10 at 14 30 12" src="https://user-images.githubusercontent.com/1233880/218106235-df1e52f4-e6c6-4507-aad1-c708051cadce.png">

## Testing Instructions

- Use the Calypso live link below
- Grab the domain of a site with Limited Global Styles
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>&flags=virtual-themes/onboarding`.
- Make sure the virtual themes show the Premium badge.
- Select a virtual theme
- Make sure the CTA in the preview says "Unlock this style"
- In the same preview screen, pick the default variation
- Make sure the CTA changes to "Continue"
- Switch to a site without Limited Global Styles
- Make sure the virtual themes are labeled as Free