### PR TITLE
WooExpress: Plans page bottom margin

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/style.scss
@@ -119,7 +119,7 @@ body.is-section-plans.is-ecommerce-trial-plan {
 
 	.e-commerce-trial-plans__cta-wrapper {
 		text-align: center;
-		margin-top: 45px;
+		margin: 45px 0;
 
 		@media (max-width: $break-mobile) {
 			padding: 0 20px;


### PR DESCRIPTION
## Proposed Changes

* In desktop mode, the trial's Plans page has no space between the last button and the end of the page.
![image](https://user-images.githubusercontent.com/3801502/218107435-7449405b-7b51-4250-8580-4cb8e758cb7d.png)

* This PR adds the margin
![image](https://user-images.githubusercontent.com/3801502/218107649-66e3d944-5684-40cd-b3a1-cace95fe20dd.png)


## Testing Instructions

* Open the Plans page of a trial site and check margin at the bottom of the page