### PR TITLE
Update: Remove Blaze widget header for the mobile app

### DIFF
--- a/client/components/blazepress-widget/style.scss
+++ b/client/components/blazepress-widget/style.scss
@@ -81,4 +81,7 @@ $headerHeight: 72px;
 		height: 100%;
 		margin-top: 0;
 	}
+	.blazepress-widget .wpcom__loading-ellipsis {
+		margin-top: 50%;
+	}
 }

--- a/client/components/blazepress-widget/style.scss
+++ b/client/components/blazepress-widget/style.scss
@@ -72,3 +72,13 @@ $headerHeight: 72px;
 .blazepress-widget.dialog__backdrop {
 	background-color: rgba(var(--color-neutral-100-rgb), 0.6);
 }
+
+.is-mobile-app-view {
+	.blazepress-widget__header-bar {
+		display: none;
+	}
+	.blazepress-widget__content {
+		height: 100%;
+		margin-top: 0;
+	}
+}


### PR DESCRIPTION
Related to pe7hp4-aM-p2

## Proposed Changes

* Remove the Blaze Branding header from the widget for when the widget is displayed in the mobile app. 

## Testing Instructions

* Load this PR. 
* Using the `Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 wp-android` UA header. You can change it in the developer tools preview
<img width="791" alt="Screenshot 2023-02-10 at 6 02 01 AM" src="https://user-images.githubusercontent.com/115071/218110642-11e38427-64ab-4983-9bc9-c067c4495b2a.png">

Notice that the header is not there any more. 

Notice that the header is there when using a regular iPhone or Android browser headers. 

## Pre-merge Checklist


- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
