### PR TITLE
i18n: Localize Reading Settings

### DIFF
--- a/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/EmailsTextSetting.tsx
@@ -44,7 +44,7 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 			<FormFieldset>
 				{ /* @ts-expect-error FormLegend is not typed and is causing errors */ }
 				<FormLegend>
-					These settings change the emails sent from your site to your readers
+					{ translate( 'These settings change the emails sent from your site to your readers' ) }
 				</FormLegend>
 				<FormLabel htmlFor="confirmation_email_message">
 					{ hasTranslation( 'Confirmation email message' ) || locale.startsWith( 'en' )

--- a/client/my-sites/site-settings/reading-newsletter-settings/ExcerptSetting.tsx
+++ b/client/my-sites/site-settings/reading-newsletter-settings/ExcerptSetting.tsx
@@ -19,7 +19,7 @@ export const ExcerptSetting = ( {
 	const translate = useTranslate();
 	return (
 		<FormFieldset>
-			<FormLabel>For each new post email, include</FormLabel>
+			<FormLabel>{ translate( 'For each new post email, include' ) }</FormLabel>
 			<FormLabel>
 				{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
 				<FormRadio

--- a/client/my-sites/site-settings/reading-rss-feed-settings/ExcerptSetting.tsx
+++ b/client/my-sites/site-settings/reading-rss-feed-settings/ExcerptSetting.tsx
@@ -19,7 +19,7 @@ export const ExcerptSetting = ( {
 	const translate = useTranslate();
 	return (
 		<FormFieldset>
-			<FormLabel>For each post in a feed, include</FormLabel>
+			<FormLabel>{ translate( 'For each post in a feed, include' ) }</FormLabel>
 			<FormLabel>
 				{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
 				<FormRadio


### PR DESCRIPTION
## Proposed Changes

* This PR localizes 3 strings on the Reading Settings page:
- "For each post in a feed, include"
- "These settings change the emails sent from your site to your readers"
- "For each new post email, include"

![image](https://user-images.githubusercontent.com/23708351/218119854-20a3e28b-2f75-4ce9-a27d-05befad6fa63.png)


## Testing Instructions
1. Code review as the strings are not yet translated (they were not wrapped in translation calls).


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
