### PR TITLE
Settings: Adjust setting section title's padding

### DIFF
--- a/client/my-sites/site-settings/reading-rss-feed-settings/ExcerptSetting.tsx
+++ b/client/my-sites/site-settings/reading-rss-feed-settings/ExcerptSetting.tsx
@@ -19,7 +19,9 @@ export const ExcerptSetting = ( {
 	const translate = useTranslate();
 	return (
 		<FormFieldset>
-			<FormLabel>{ translate( 'For each post in a feed, include' ) }</FormLabel>
+			<FormLabel className="increase-margin-bottom-fix">
+				{ translate( 'For each post in a feed, include' ) }
+			</FormLabel>
 			<FormLabel>
 				{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
 				<FormRadio

--- a/client/my-sites/site-settings/reading-rss-feed-settings/SyndicationFeedsSetting.tsx
+++ b/client/my-sites/site-settings/reading-rss-feed-settings/SyndicationFeedsSetting.tsx
@@ -23,7 +23,11 @@ export const SyndicationFeedsSetting = ( {
 	const siteFeedUrl = siteUrl ? `${ siteUrl }/feed/` : '';
 	return (
 		<FormFieldset>
-			<FormLabel id={ `${ SYNDICATION_FEEDS_OPTION }-label` } htmlFor={ SYNDICATION_FEEDS_OPTION }>
+			<FormLabel
+				id={ `${ SYNDICATION_FEEDS_OPTION }-label` }
+				className="reduce-margin-bottom-fix"
+				htmlFor={ SYNDICATION_FEEDS_OPTION }
+			>
 				{ translate( 'Syndication feeds' ) }
 			</FormLabel>
 			<div>

--- a/client/my-sites/site-settings/reading-site-settings/BlogPagesSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/BlogPagesSetting.tsx
@@ -16,7 +16,11 @@ export const BlogPagesSetting = ( { value = 10, onChange, disabled }: BlogPagesS
 	const translate = useTranslate();
 	return (
 		<FormFieldset>
-			<FormLabel id={ `${ BLOG_PAGES_OPTION }-label` } htmlFor={ BLOG_PAGES_OPTION }>
+			<FormLabel
+				id={ `${ BLOG_PAGES_OPTION }-label` }
+				htmlFor={ BLOG_PAGES_OPTION }
+				className="reduce-margin-bottom-fix"
+			>
 				{ translate( 'Blog pages' ) }
 			</FormLabel>
 			<div>

--- a/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
@@ -28,7 +28,9 @@ export const RelatedPostsSetting = ( {
 	const translate = useTranslate();
 	return (
 		<>
-			<FormLabel id="related-posts-settings">{ translate( 'Related Posts' ) }</FormLabel>
+			<FormLabel id="related-posts-settings" className="increase-margin-bottom-fix">
+				{ translate( 'Related Posts' ) }
+			</FormLabel>
 			<RelatedPostsFormFieldset
 				fields={ fields }
 				handleToggle={ handleToggle }

--- a/client/my-sites/site-settings/settings-newsletter/ExcerptSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/ExcerptSetting.tsx
@@ -19,7 +19,9 @@ export const ExcerptSetting = ( {
 	const translate = useTranslate();
 	return (
 		<FormFieldset>
-			<FormLabel>{ translate( 'For each new post email, include' ) }</FormLabel>
+			<FormLabel className="increase-margin-bottom-fix">
+				{ translate( 'For each new post email, include' ) }
+			</FormLabel>
 			<FormLabel>
 				{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
 				<FormRadio

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -15,11 +15,6 @@
 
 	label {
 		display: block;
-		margin-bottom: 12px;
-	}
-
-	legend {
-		margin-bottom: 5px;
 	}
 
 	input {
@@ -47,8 +42,17 @@
 
 	legend,
 	label {
+		margin-bottom: 5px;
 		font-size: $font-body-small;
 		font-weight: 700;
+	}
+
+	label.reduce-margin-bottom-fix {
+		margin-bottom: 2px;
+	}
+
+	label.increase-margin-bottom-fix {
+		margin-bottom: 7px;
 	}
 
 	.components-toggle-control__label {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -15,6 +15,11 @@
 
 	label {
 		display: block;
+		margin-bottom: 12px;
+	}
+
+	legend {
+		margin-bottom: 5px;
 	}
 
 	input {
@@ -42,7 +47,6 @@
 
 	legend,
 	label {
-		margin-bottom: 5px;
 		font-size: $font-body-small;
 		font-weight: 700;
 	}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -2,6 +2,8 @@
 @import "@wordpress/base-styles/mixins";
 
 .site-settings {
+	$margin-bottom-setting-label: 5px;
+
 	font-size: $font-body-small;
 
 	fieldset.form-fieldset {
@@ -42,17 +44,19 @@
 
 	legend,
 	label {
-		margin-bottom: 5px;
+		margin-bottom: $margin-bottom-setting-label;
 		font-size: $font-body-small;
 		font-weight: 700;
 	}
 
+	// Addressing an issue of inconsistent spacing bettwen setting label's and the following block: https://github.com/Automattic/wp-calypso/issues/72721
 	label.reduce-margin-bottom-fix {
-		margin-bottom: 2px;
+		margin-bottom: $margin-bottom-setting-label - 3px;
 	}
 
+	// Addressing an issue of inconsistent spacing bettwen setting label's and the following block: https://github.com/Automattic/wp-calypso/issues/72721
 	label.increase-margin-bottom-fix {
-		margin-bottom: 7px;
+		margin-bottom: $margin-bottom-setting-label + 2px;
 	}
 
 	.components-toggle-control__label {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/72721

## Proposed Changes

* change the title's bottom margin to 12px as suggested by @saygunnyc in https://github.com/Automattic/wp-calypso/issues/72721
* note that this change affects the bottom title margin on all caylpso's settings pages

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/settings/reading/your-test-site-here

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

#### With the margin adjusted
![calypso localhost_3000_settings_reading_simple-site blog (1)](https://user-images.githubusercontent.com/2019970/218729986-5608ffa1-2ab3-40c7-9abc-30d974ffb972.png)

