### PR TITLE
Integrate stats navbar with breadcrumb bar

### DIFF
--- a/client/components/fixed-navigation-header/index.tsx
+++ b/client/components/fixed-navigation-header/index.tsx
@@ -32,6 +32,11 @@ const Header = styled.header`
 			padding: 0 16px;
 		}
 	}
+
+	&.stats__post-detail-header,
+	&.stats__email-detail-header {
+		border-bottom: 0;
+	}
 `;
 
 const Container = styled.div`

--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -74,11 +74,11 @@ export default function PostDetailHighlightsSection( {
 			) }
 
 			<div className="highlight-cards">
-				<h1 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h1>
-
 				{ config.isEnabled( 'newsletter/stats' ) && (
 					<StatsDetailsNavigation postId={ postId } givenSiteId={ siteId } />
 				) }
+
+				<h1 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h1>
 
 				<div className="highlight-cards-list">
 					<PostStatsCard

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -228,15 +228,15 @@ class StatsEmailDetail extends Component {
 					) }
 					{ post ? (
 						<>
+							<StatsDetailsNavigation
+								postId={ postId }
+								period={ period }
+								statType={ statType }
+								givenSiteId={ givenSiteId }
+							/>
+
 							<div className="main-container">
 								<h1>{ this.getTitle( statType ) }</h1>
-
-								<StatsDetailsNavigation
-									postId={ postId }
-									period={ period }
-									statType={ statType }
-									givenSiteId={ givenSiteId }
-								/>
 
 								<StatsEmailTopRow siteId={ siteId } postId={ postId } statType={ statType } />
 

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -211,6 +211,7 @@ class StatsEmailDetail extends Component {
 					/>
 
 					<FixedNavigationHeader
+						className="stats__email-detail-header"
 						navigationItems={ this.getNavigationItemsWithTitle( this.getTitle( statType ) ) }
 					></FixedNavigationHeader>
 

--- a/client/my-sites/stats/stats-email-detail/style.scss
+++ b/client/my-sites/stats/stats-email-detail/style.scss
@@ -10,7 +10,17 @@ $break-large-stats-countries: 1280px;
 	}
 
 	.main-container {
-		padding: 32px 0;
+		padding: 0;
+
+		@media ( max-width: $break-medium ) {
+			padding: 0 0.875rem;
+
+			.stats-email-open-top-row {
+				.highlight-cards-list {
+					padding: 4px;
+				}
+			}
+		}
 	}
 
 	.no-data {

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -152,6 +152,7 @@ class StatsPostDetail extends Component {
 
 				<div className="stats has-fixed-nav">
 					<FixedNavigationHeader
+						className="stats__post-detail-header"
 						navigationItems={ this.getNavigationItemsWithTitle( this.getTitle() ) }
 					>
 						{ showViewLink && (

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -39,18 +39,26 @@
 
 // Compensate for the fixed header.
 .is-section-stats .has-fixed-nav {
-	padding-top: 44px;
+	padding-top: 0;
 
 	&.stats__email-detail {
-		padding: 44px 20px;
+		padding: 32px;
 	}
 
 	@media ( max-width: 782px ) {
-		padding-top: 65px;
+		padding: 0;
+
+		&.stats__email-detail {
+			padding: 32px 0;
+		}
 	}
 
 	@media ( max-width: 660px ) {
-		padding-top: 60px;
+		padding: 0;
+
+		&.stats__email-detail {
+			padding-left: 32px 0;
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/73167

## Proposed Changes

The changes proposed in this PR integrates the tabbed navigation bar in the Post Stats Details screen with the breadcrumbs in the top of that screen.

The old version is this:
<img width="474" alt="Screenshot 2023-02-08 at 14 43 25" src="https://user-images.githubusercontent.com/3832570/218141606-5bb104e9-0877-4889-be1a-317a434b2d1f.png">

The new one is this:
<img width="546" alt="Screenshot 2023-02-10 at 17 17 57" src="https://user-images.githubusercontent.com/3832570/218141862-11e6f4ee-dced-4d08-a9a2-73936fbd8afb.png">

## Testing Instructions

* Apply this PR into your local calypso
* Go to the stats details page of one of your posts (url like `http://calypso.localhost:3000/stats/email/opens/day/[post-id]/[site-id]`
* Check the navigation bar is right after the breadcrumbs.
* Change the resolution to emulate it in different mobile and tablet screens and check all keeps being ok.

Thanks for your time reviewing this PR! ❤️ 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
