### PR TITLE
Shopping Cart: Show persistent error messages in checkout only

### DIFF
--- a/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
+++ b/client/my-sites/checkout/calypso-shopping-cart-provider.tsx
@@ -7,7 +7,19 @@ import { cartManagerClient } from './cart-manager-client';
 // for calypso and to display error and success messages returned from calls to
 // the cart endpoint.
 // eslint-disable-next-line @typescript-eslint/ban-types
-export default function CalypsoShoppingCartProvider( { children }: PropsWithChildren< {} > ) {
+export default function CalypsoShoppingCartProvider( {
+	children,
+	shouldShowPersistentErrors,
+}: PropsWithChildren< {
+	/**
+	 * Persistent errors like "Purchases are disabled for this site" are returned
+	 * during cart fetch (regular cart errors are transient and only are returned
+	 * when changing the cart). We want to display these errors only in certain
+	 * contexts where they will make sense (like checkout), not in every place
+	 * that happens to render this component (like the plans page).
+	 */
+	shouldShowPersistentErrors?: boolean;
+} > ) {
 	const options = useMemo(
 		() => ( {
 			refetchOnWindowFocus: true,
@@ -17,7 +29,7 @@ export default function CalypsoShoppingCartProvider( { children }: PropsWithChil
 
 	return (
 		<ShoppingCartProvider managerClient={ cartManagerClient } options={ options }>
-			<CartMessages />
+			<CartMessages shouldShowPersistentErrors={ shouldShowPersistentErrors } />
 			{ children }
 		</ShoppingCartProvider>
 	);

--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -23,7 +23,18 @@ function CartMessage( { message }: { message: ResponseCartMessage } ) {
 	return <>{ getPrettyMessage( message ) }</>;
 }
 
-export default function CartMessages(): null {
+export default function CartMessages( {
+	shouldShowPersistentErrors,
+}: {
+	/**
+	 * Persistent errors like "Purchases are disabled for this site" are returned
+	 * during cart fetch (regular cart errors are transient and only are returned
+	 * when changing the cart). We want to display these errors only in certain
+	 * contexts where they will make sense (like checkout), not in every place
+	 * that happens to render this component (like the plans page).
+	 */
+	shouldShowPersistentErrors?: boolean;
+} ): null {
 	const cartKey = useCartKey();
 	const { responseCart: cart, isLoading: isLoadingCart } = useShoppingCart( cartKey );
 	const reduxDispatch = useDispatch();
@@ -47,6 +58,7 @@ export default function CartMessages(): null {
 		isLoadingCart,
 		showErrorMessages,
 		showSuccessMessages,
+		shouldShowPersistentErrors: shouldShowPersistentErrors ?? false,
 	} );
 
 	return null;

--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -102,7 +102,7 @@ export default function CheckoutMainWrapper( {
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
 				onError={ logCheckoutError }
 			>
-				<CalypsoShoppingCartProvider>
+				<CalypsoShoppingCartProvider shouldShowPersistentErrors>
 					<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ locale }>
 						<CheckoutOrderBanner />
 						<CheckoutMain

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -339,6 +339,7 @@ export type TempResponseCart = ResponseCart< RequestCartProduct >;
 export interface ResponseCartMessages {
 	errors?: ResponseCartMessage[];
 	success?: ResponseCartMessage[];
+	persistent_errors?: ResponseCartMessage[];
 }
 
 export interface ResponseCartMessage {


### PR DESCRIPTION
The shopping-cart endpoint returns an array of `errors` for the client to display. These messages are displayed on every page in calypso that has access to the shopping cart by the `CartMessages` component inside the `CalypsoShoppingCartProvider` (since the masterbar includes a shopping cart, this is pretty much every page). Typically these messages are related to the most recent cart action (for example: adding a product or a coupon). When we are just fetching an existing cart and not making any changes, errors might still occur (for example: if a product is no longer available) but they will not be returned by the endpoint.

However, some error messages are not related to the transaction. I'm calling these "persistent errors" as opposed to the more common "transient errors". Currently these include the "Your purchases are blocked" message and the "You have to pay a chargeback fee" message. Persistent errors have special rules about when they should be shown to a user:

- They should never be shown to the user when we are not in a checkout context (like transient errors).
- They should always be shown to the user in a checkout context (even if no changes are being made to the cart).

This is difficult because it's hard to differentiate between the two types of messages in calypso.

See https://github.com/Automattic/payments-shilling/issues/1384

## Proposed Changes

In D101050-code we separated out persistent messages from transient messages and returned them in a new property, `persistent_errors`. Because they are in a separate property, `CartMessages` won't display them by default on every page (meeting our first requirement above). In this PR we add a flag to enable displaying these messages and use that flag in checkout (meeting our second requirement).

<img width="638" alt="Screenshot 2023-02-10 at 6 34 22 PM" src="https://user-images.githubusercontent.com/2036909/218221905-85f3101c-ca4e-4308-acbc-10d4b3303056.png">

## Testing Instructions

- First, apply D101050-code to your sandbox and sandbox the API.
- Add a product to your cart and visit checkout.
- On your sandbox, cause a persistent error to be set on the shopping cart. One way to do this is to alter the code that adds the `'blocked'` error in the shopping cart validator so that it always runs. Another way to do this would be to set the `'block_purchases'` user attribute on your test user.
- Reload checkout and verify that you see the "Purchases are currently disabled" error displayed. Dismiss the error.
- Visit another page in calypso (like the Plans page) and verify that you do not see the error displayed. Reload and check again for good measure.
