### PR TITLE
Checkout: add page load performance tracking

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -34,6 +34,7 @@ import {
 } from 'calypso/lib/cart-values/cart-items';
 import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
+import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url';
 import { leaveCheckout } from 'calypso/my-sites/checkout/composite-checkout/lib/leave-checkout';
@@ -266,6 +267,7 @@ export default function WPCheckout( {
 			<MainContentWrapper>
 				<NonCheckoutContentWrapper>
 					<NonCheckoutContentInnerWrapper>
+						<PerformanceTrackerStop />
 						<CheckoutCompleteRedirecting />
 						<SubmitButtonWrapper>
 							<Button buttonType="primary" fullWidth isBusy disabled>
@@ -292,6 +294,7 @@ export default function WPCheckout( {
 			<MainContentWrapper>
 				<NonCheckoutContentWrapper>
 					<NonCheckoutContentInnerWrapper>
+						<PerformanceTrackerStop />
 						<EmptyCart />
 						<SubmitButtonWrapper>
 							<Button buttonType="primary" fullWidth onClick={ goToPreviousPage }>
@@ -343,6 +346,7 @@ export default function WPCheckout( {
 				</CheckoutSummaryArea>
 			}
 		>
+			<PerformanceTrackerStop />
 			{ infoMessage }
 			<CheckoutStepBody
 				onError={ onReviewError }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-record-checkout-loaded.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-record-checkout-loaded.ts
@@ -2,6 +2,7 @@ import debugFactory from 'debug';
 import { useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { hasRenewalItem } from 'calypso/lib/cart-values/cart-items';
+import { usePerformanceTrackerStop } from 'calypso/lib/performance-tracking/use-performance-tracker-stop';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { StoredCard } from '../types/stored-cards';
 import type { ResponseCart } from '@automattic/shopping-cart';
@@ -25,6 +26,7 @@ export default function useRecordCheckoutLoaded( {
 } ): void {
 	const reduxDispatch = useDispatch();
 	const hasRecordedCheckoutLoad = useRef( false );
+	usePerformanceTrackerStop();
 	if ( ! isLoading && ! hasRecordedCheckoutLoad.current ) {
 		debug( 'composite checkout has loaded' );
 		reduxDispatch(

--- a/client/my-sites/checkout/composite-checkout/hooks/use-record-checkout-loaded.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-record-checkout-loaded.ts
@@ -2,7 +2,6 @@ import debugFactory from 'debug';
 import { useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { hasRenewalItem } from 'calypso/lib/cart-values/cart-items';
-import { usePerformanceTrackerStop } from 'calypso/lib/performance-tracking/use-performance-tracker-stop';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { StoredCard } from '../types/stored-cards';
 import type { ResponseCart } from '@automattic/shopping-cart';
@@ -26,7 +25,6 @@ export default function useRecordCheckoutLoaded( {
 } ): void {
 	const reduxDispatch = useDispatch();
 	const hasRecordedCheckoutLoad = useRef( false );
-	usePerformanceTrackerStop();
 	if ( ! isLoading && ! hasRecordedCheckoutLoad.current ) {
 		debug( 'composite checkout has loaded' );
 		reduxDispatch(

--- a/client/sections.js
+++ b/client/sections.js
@@ -262,6 +262,7 @@ const sections = [
 		module: 'calypso/my-sites/checkout',
 		group: 'sites',
 		enableLoggedOut: true,
+		trackLoadPerformance: true,
 	},
 	{
 		name: 'plans',


### PR DESCRIPTION
This adds page load performance tracking for the Checkout section.

#### Testing instructions

* Navigate to `Checkout`. You should see a request to `/logstash` in the network inspector. The call to `/logstash` should happen as close to the render of useful UI as possible (not just Calypso loading or the cart loading). Verify the payload contains data.
* Go to logstash and query for `message:"perf.nav"` and `properties.id:checkout` and check the data is there.