### PR TITLE
Reader: fix media inside comments

### DIFF
--- a/client/blocks/comments/post-comment-content.scss
+++ b/client/blocks/comments/post-comment-content.scss
@@ -4,6 +4,7 @@
 // Post comments line-clamping
 .comments__comment-content-wrapper {
 	position: relative;
+	@include clear-fix;
 
 	&.is-single-line,
 	&.is-single-line .comments__comment-content {


### PR DESCRIPTION
fixes: https://github.com/Automattic/wp-calypso/issues/52021

Exactly as described in the issue, when media is posted in a comment it can be `float: left`, but the parent element doesn't have any kind of clear fix, causing the other comment to come up alongside it and appear broken.

### Before:
![115054959-288b9a80-9ee1-11eb-9323-74fae45e9ee9](https://user-images.githubusercontent.com/22446385/218352657-1aeb876b-3f8f-4c63-8739-86d7ddfa3454.png)

### After:
<img width="1728" alt="Screen Shot 2023-02-13 at 11 47 23 am" src="https://user-images.githubusercontent.com/22446385/218352797-265c35fa-ebe0-4108-bf63-f8ea1911e5c3.png">

### Testing instructions:

see https://wordpress.com/read/blogs/11326809/posts/33863
