### PR TITLE
Copy update: addons -> plugins; yoursite.com -> yourgroovydomain.com

### DIFF
--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -575,7 +575,12 @@ export const FEATURES_LIST: FeatureList = {
 			}
 			if ( is2023OnboardingPricingGrid ) {
 				return i18n.translate(
-					'Get a custom domain – like yourgroovydomain.com – free for the first year.'
+					'Get a custom domain – like {{i}}yourgroovydomain.com{{/i}} – free for the first year.',
+					{
+						components: {
+							i: <i />,
+						},
+					}
 				);
 			}
 			return i18n.translate(

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -575,7 +575,7 @@ export const FEATURES_LIST: FeatureList = {
 			}
 			if ( is2023OnboardingPricingGrid ) {
 				return i18n.translate(
-					'Get a custom domain – like yoursite.com – free for the first year.'
+					'Get a custom domain – like yourgroovydomain.com – free for the first year.'
 				);
 			}
 			return i18n.translate(
@@ -1753,7 +1753,7 @@ export const FEATURES_LIST: FeatureList = {
 		getSlug: () => FEATURE_PLUGINS_THEMES,
 		getTitle: () => i18n.translate( 'Install plugins & themes' ),
 		getDescription: () =>
-			i18n.translate( 'Unlock access to 50,000+ add-ons, design templates, and integrations.' ),
+			i18n.translate( 'Unlock access to 50,000+ plugins, design templates, and integrations.' ),
 	},
 	[ FEATURE_BANDWIDTH ]: {
 		getSlug: () => FEATURE_BANDWIDTH,

--- a/client/my-sites/plan-features-2023-grid/plans-2023-tooltip.tsx
+++ b/client/my-sites/plan-features-2023-grid/plans-2023-tooltip.tsx
@@ -12,7 +12,6 @@ const StyledTooltip = styled( Tooltip )`
 		border-radius: 4px;
 		min-height: 32px;
 		width: 210px;
-		display: flex;
 		align-items: center;
 		font-style: normal;
 		font-weight: 400;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1485

## Proposed Changes

This PR is the calypso part of updating tooltip copies accoding to the proposed changes in the tracking issue:

Precisely:

* Tooltip of "install plugins & themes": updating "add-ons" to "plugins"
* Tooltip of "free domain for one year": updating "yoursite.com" to "yourgroovydomain.com", which we own.

Referential images:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/1842898/218614177-c839df24-691b-427f-8407-7e1b24cc2f36.png">
<img width="392" alt="image" src="https://user-images.githubusercontent.com/1842898/218614219-5cd8b382-9b12-4431-ae7b-0aa5f28bc85b.png">


## Testing Instructions

Go to the 2023 plan grid, e.g. at `/start/plans`, and make sure the referred two tooltips are updated accordingly.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
