### PR TITLE
Clearer CTA after switching to a block theme

### DIFF
--- a/client/my-sites/themes/test/thanks-modal.jsx
+++ b/client/my-sites/themes/test/thanks-modal.jsx
@@ -64,7 +64,7 @@ const setupStore = ( { site = defaultSite, theme = defaultTheme } = {} ) => {
 
 describe( 'thanks-modal', () => {
 	describe( 'when activating an FSE theme', () => {
-		test( 'displays the "Edit site" call to action and links it to the site editor', async () => {
+		test( 'displays the "Customize site" call to action and links it to the site editor', async () => {
 			const store = setupStore( {
 				theme: {
 					...defaultTheme,
@@ -77,7 +77,7 @@ describe( 'thanks-modal', () => {
 			render( <TestComponent store={ store } /> );
 
 			await waitFor( () => {
-				const editSiteCallToAction = screen.getByText( 'Edit site' );
+				const editSiteCallToAction = screen.getByText( 'Customize site' );
 
 				expect( editSiteCallToAction ).toBeInTheDocument();
 				expect( editSiteCallToAction.closest( 'a' ) ).toHaveAttribute(

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -237,7 +237,7 @@ class ThanksModal extends Component {
 		if ( isFSEActive ) {
 			return (
 				<span className="thanks-modal__button-customize">
-					{ this.props.translate( 'Edit site' ) }
+					{ this.props.translate( 'Customize site' ) }
 				</span>
 			);
 		}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/68953

## Proposed Changes

After switching to a block theme, we display a modal encouraging users to edit every aspect of their site. The CTA button currently says "Edit site" but this can give users the wrong expectation that they should only edit the content, not the appearance or design of the site (see pc4f5j-2wc-p2#theme-activation). So this PR updates the CTA to "Customize site" to better reflect what users can achieve when they click on that button.

Before | After
--- | ---
<img width="375" alt="Screenshot 2023-02-13 at 10 41 02" src="https://user-images.githubusercontent.com/1233880/218425427-1a238903-14c0-42d7-a181-5ce9097ac19c.png"> | <img width="366" alt="Screenshot 2023-02-13 at 10 42 12" src="https://user-images.githubusercontent.com/1233880/218425843-2dde12c4-387e-40aa-ad79-e204879ca8d4.png">

## Testing Instructions

- Use the Calypso live link below
- Go to Appearance > Themes
- Activate a block theme
- Make sure the CTA in the post-activation modal says "Customize site"