### PR TITLE
Make sure it's using AT site domain in the migration plugin flow

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -156,7 +156,7 @@ export class ImportEverything extends SectionMigrate {
 	}
 
 	renderMigrationProgress() {
-		const { translate, sourceSite, targetSiteSlug } = this.props;
+		const { translate, sourceSite, targetSite } = this.props;
 
 		return (
 			<>
@@ -168,7 +168,7 @@ export class ImportEverything extends SectionMigrate {
 							sprintf( translate( 'Backing up %(website)s' ), { website: sourceSite.slug } ) +
 								'...' }
 						{ MigrationStatus.RESTORING === this.state.migrationStatus &&
-							sprintf( translate( 'Restoring to %(website)s' ), { website: targetSiteSlug } ) +
+							sprintf( translate( 'Restoring to %(website)s' ), { website: targetSite.slug } ) +
 								'...' }
 					</Title>
 					<ProgressBar compact={ true } value={ this.state.percent ? this.state.percent : 0 } />
@@ -237,7 +237,7 @@ export class ImportEverything extends SectionMigrate {
 	}
 
 	renderHoorayScreenWithDomainInfo() {
-		const { translate, stepNavigator, targetSiteSlug } = this.props;
+		const { translate, stepNavigator, targetSite } = this.props;
 		return (
 			<>
 				<Title>{ translate( "Migration done! You're all set!" ) }</Title>
@@ -249,7 +249,7 @@ export class ImportEverything extends SectionMigrate {
 						{ br: createElement( 'br' ) }
 					) }
 				</SubTitle>
-				<DomainInfo domain={ targetSiteSlug } />
+				<DomainInfo domain={ targetSite.slug } />
 				<DoneButton
 					className="is-normal-width"
 					label={ translate( 'Update domain name' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves to #72760 

## Proposed Changes

* Using `targetSite.slug` to replace `targetSiteSlug` variable so it always gets the updated name in the screen.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a JN testing site.
* Navigate to `calypso.localhost:3000/setup/import-focused/siteCreationStep?from=${YOUR_JN_SITE_SLUG}`
* Purchase the plan and finish the migration process.
* See if you get the Atomic site slug name on the done screen.

![migration-screen](https://user-images.githubusercontent.com/4074459/218427121-03fff0d7-8f9f-4adf-9da6-49a006c6d8c3.png)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
