### PR TITLE
Extend comparison breakpoints to include stepper flows

### DIFF
--- a/client/my-sites/plan-features-2023-grid/media-queries.tsx
+++ b/client/my-sites/plan-features-2023-grid/media-queries.tsx
@@ -10,7 +10,8 @@ const plans2023MediumWithSidebarBreakpoint = `${ 1340 + sidebarWidth }px`;
 const plans2023LargeWithSidebarBreakpoint = `${ 1500 + sidebarWidth }px`;
 
 export const plansBreakSmall = ( styles: SerializedStyles ) => css`
-	body.is-section-signup.is-white-signup & {
+	body.is-section-signup.is-white-signup &,
+	body.is-section-stepper & {
 		@media ( min-width: ${ plans2023SmallBreakpoint } ) {
 			${ styles }
 		}
@@ -30,7 +31,8 @@ export const plansBreakSmall = ( styles: SerializedStyles ) => css`
 `;
 
 export const plansBreakMedium = ( styles: SerializedStyles ) => css`
-	body.is-section-signup.is-white-signup & {
+	body.is-section-signup.is-white-signup &,
+	body.is-section-stepper & {
 		@media ( min-width: ${ plans2023MediumBreakpoint } ) {
 			${ styles }
 		}
@@ -50,7 +52,8 @@ export const plansBreakMedium = ( styles: SerializedStyles ) => css`
 `;
 
 export const plansBreakLarge = ( styles: SerializedStyles ) => css`
-	body.is-section-signup.is-white-signup & {
+	body.is-section-signup.is-white-signup &,
+	body.is-section-stepper & {
 		@media ( min-width: ${ plans2023LargeBreakpoint } ) {
 			${ styles }
 		}

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -155,6 +155,10 @@ const Cell = styled.div< { textAlign?: string; isInSignup: boolean } >`
 
 	${ Row }:last-of-type & {
 		padding-bottom: 24px;
+
+		${ plansBreakSmall( css`
+			padding-bottom: 0px;
+		` ) }
 	}
 
 	${ plansBreakSmall( css`
@@ -168,14 +172,6 @@ const Cell = styled.div< { textAlign?: string; isInSignup: boolean } >`
 		&:last-of-type {
 			padding-right: 0;
 			border-right: none;
-		}
-
-		&.title-is-subtitle {
-			padding-top: 33px;
-		}
-
-		${ Row }:last-of-type & {
-			padding-bottom: 0px;
 		}
 	` ) }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1478

## Proposed Changes

This fixes the styling of the new Comparison grids on the `/setup/link-in-bio` flow by extending the relevant CSS selectors to cover stepper flows too.

<img width="420" alt="Screenshot 2023-02-13 at 12 09 23" src="https://user-images.githubusercontent.com/2749938/218429937-5a20a497-749a-4fe1-a33e-4d94315ae932.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/link-in-bio/plans`
* The Plan Comparison design should match the one on `/start/newsletter/plans-newsletter` on different viewport widths.
<img width="420" alt="Screenshot 2023-02-13 at 12 06 13" src="https://user-images.githubusercontent.com/2749938/218429975-63700cd8-1492-4054-bffe-7e0361a4c18a.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
