### PR TITLE
Pattern Assembler - The link "Open the editor" in the CTA should redirect to the Site Editor

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -125,9 +125,7 @@ const importFlow: Flow = {
 						return navigate( `import?siteSlug=${ providedDependencies?.siteSlug }&from=${ from }` );
 					}
 					// End of Pattern Assembler flow
-					if ( selectedDesign?.design_type === 'assembler' ) {
-						return exitFlow( `/site-editor/${ siteSlugParam }` );
-					} else if ( isBlankCanvasDesign( selectedDesign ) ) {
+					if ( isBlankCanvasDesign( selectedDesign ) ) {
 						return exitFlow( `/site-editor/${ siteSlugParam }` );
 					}
 

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -1,4 +1,4 @@
-import { Design } from '@automattic/design-picker';
+import { Design, isBlankCanvasDesign } from '@automattic/design-picker';
 import { IMPORT_FOCUSED_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
@@ -126,6 +126,8 @@ const importFlow: Flow = {
 					}
 					// End of Pattern Assembler flow
 					if ( selectedDesign?.design_type === 'assembler' ) {
+						return exitFlow( `/site-editor/${ siteSlugParam }` );
+					} else if ( isBlankCanvasDesign( selectedDesign ) ) {
 						return exitFlow( `/site-editor/${ siteSlugParam }` );
 					}
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -237,10 +237,8 @@ const siteSetupFlow: Flow = {
 					}
 
 					// End of Pattern Assembler flow
-					if ( selectedDesign?.design_type === 'assembler' ) {
+					if ( isBlankCanvasDesign( selectedDesign ) ) {
 						window.sessionStorage.setItem( 'wpcom_signup_completed_flow', 'pattern_assembler' );
-						return exitFlow( `/site-editor/${ siteSlug }` );
-					} else if ( isBlankCanvasDesign( selectedDesign ) ) {
 						return exitFlow( `/site-editor/${ siteSlug }` );
 					}
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
-import { Design } from '@automattic/design-picker';
+import { Design, isBlankCanvasDesign } from '@automattic/design-picker';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
@@ -239,6 +239,8 @@ const siteSetupFlow: Flow = {
 					// End of Pattern Assembler flow
 					if ( selectedDesign?.design_type === 'assembler' ) {
 						window.sessionStorage.setItem( 'wpcom_signup_completed_flow', 'pattern_assembler' );
+						return exitFlow( `/site-editor/${ siteSlug }` );
+					} else if ( isBlankCanvasDesign( selectedDesign ) ) {
 						return exitFlow( `/site-editor/${ siteSlug }` );
 					}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/71514
Closes https://github.com/Automattic/wp-calypso/issues/73276

## Proposed Changes

* Redirect to site editor when Blank Canvas theme is selected from the design picker
* Show the welcome tour in the editor when users click "Open the editor"

This PR doesn't introduce any changes to the tracks events.

## Screenshots
The "Open the editor" link is shown in the CTA when the screen width is lower than `960px`.

<img width="709" alt="Screenshot 2566-02-13 at 15 49 00" src="https://user-images.githubusercontent.com/1881481/218433594-80a63d24-f67c-41e1-ab2b-f7bb16205f1d.png">

## Notes for reviewers
Note that the property `design_type: assembler` is used to identify when Blank Canvas is selected in Desktop (`vw > 960px`) because that path uses the Assembler. When the screen is smaller, Blank Canvas is selected as any other theme.

See how we call `pickDesign` [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx#L483).

Note that there are only two ways to select Blank Canvas from the Design Picker:
- `vw > 960px` 
  - "Start designing" using the Assembler flow 
- `vw < 960px`  
  - "Open the editor" skips the Assembler flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access `/setup?siteSlug=[ your site ]`.
- Resize the window width to a value smaller than `960px`.
- On the goals screen, test two scenarios:
  - **Build flow**: Don't select any goal, continue until the design picker
  - **Write flow**: Select the goal "Write and publish" and continue until the design picker
- Scroll down to find the section "Design your own"
- Verify the CTA button says "Open the editor"
- Click and you should be redirected to the Site Editor 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
