### PR TITLE
Writing Prompts: Pass index of prompts to card

### DIFF
--- a/client/components/blogging-prompt-card/index.jsx
+++ b/client/components/blogging-prompt-card/index.jsx
@@ -15,11 +15,7 @@ import PromptsNavigation from './prompts-navigation';
 
 import './style.scss';
 
-<<<<<<< HEAD:client/components/blogging-prompt-card/index.jsx
-const BloggingPromptCard = ( { siteId, viewContext, showMenu } ) => {
-=======
-const BloggingPromptCard = ( { index } ) => {
->>>>>>> 93c3eca481 (Pass index of prompts to card):client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
+const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
@@ -82,15 +78,12 @@ const BloggingPromptCard = ( { index } ) => {
 					</span>
 					{ showMenu && renderMenu() }
 				</CardHeading>
-<<<<<<< HEAD:client/components/blogging-prompt-card/index.jsx
 				<PromptsNavigation
 					siteId={ siteId }
 					prompts={ prompts }
 					tracksPrefix={ getTracksPrefix() }
+					index={ index }
 				/>
-=======
-				<PromptsNavigation prompts={ prompts } index={ index } />
->>>>>>> 93c3eca481 (Pass index of prompts to card):client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
 			</Card>
 		</div>
 	);

--- a/client/components/blogging-prompt-card/index.jsx
+++ b/client/components/blogging-prompt-card/index.jsx
@@ -15,7 +15,11 @@ import PromptsNavigation from './prompts-navigation';
 
 import './style.scss';
 
+<<<<<<< HEAD:client/components/blogging-prompt-card/index.jsx
 const BloggingPromptCard = ( { siteId, viewContext, showMenu } ) => {
+=======
+const BloggingPromptCard = ( { index } ) => {
+>>>>>>> 93c3eca481 (Pass index of prompts to card):client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
@@ -78,11 +82,15 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu } ) => {
 					</span>
 					{ showMenu && renderMenu() }
 				</CardHeading>
+<<<<<<< HEAD:client/components/blogging-prompt-card/index.jsx
 				<PromptsNavigation
 					siteId={ siteId }
 					prompts={ prompts }
 					tracksPrefix={ getTracksPrefix() }
 				/>
+=======
+				<PromptsNavigation prompts={ prompts } index={ index } />
+>>>>>>> 93c3eca481 (Pass index of prompts to card):client/my-sites/customer-home/cards/features/blogging-prompt/index.jsx
 			</Card>
 		</div>
 	);

--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -10,23 +10,14 @@ import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import NoResponsesIcon from './no-responses-icon';
 import './style.scss';
 
-<<<<<<< HEAD:client/components/blogging-prompt-card/prompts-navigation.jsx
-const PromptsNavigation = ( { siteId, prompts, tracksPrefix } ) => {
+const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-=======
-const PromptsNavigation = ( { prompts, index } ) => {
-	const dispatch = useDispatch();
-	const translate = useTranslate();
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
->>>>>>> 93c3eca481 (Pass index of prompts to card):client/my-sites/customer-home/cards/features/blogging-prompt/prompts-navigation.jsx
 	const editorUrl = useSelector( ( state ) => getEditorUrl( state, siteId ) );
-	const [ promptIndex, setPromptIndex ] = useState( 0 );
 	const backIcon = 'arrow-left';
 	const forwardIcon = 'arrow-right';
 
 	const initialIndex = index ? index % prompts.length : 0;
-
 	const [ promptIndex, setPromptIndex ] = useState( initialIndex );
 
 	const getPrompt = () => {

--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -10,13 +10,24 @@ import getEditorUrl from 'calypso/state/selectors/get-editor-url';
 import NoResponsesIcon from './no-responses-icon';
 import './style.scss';
 
+<<<<<<< HEAD:client/components/blogging-prompt-card/prompts-navigation.jsx
 const PromptsNavigation = ( { siteId, prompts, tracksPrefix } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+=======
+const PromptsNavigation = ( { prompts, index } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+>>>>>>> 93c3eca481 (Pass index of prompts to card):client/my-sites/customer-home/cards/features/blogging-prompt/prompts-navigation.jsx
 	const editorUrl = useSelector( ( state ) => getEditorUrl( state, siteId ) );
 	const [ promptIndex, setPromptIndex ] = useState( 0 );
 	const backIcon = 'arrow-left';
 	const forwardIcon = 'arrow-right';
+
+	const initialIndex = index ? index % prompts.length : 0;
+
+	const [ promptIndex, setPromptIndex ] = useState( initialIndex );
 
 	const getPrompt = () => {
 		return prompts !== undefined ? prompts[ promptIndex ] : null;

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -43,11 +43,12 @@ class PostLifecycle extends Component {
 					className="reader-stream__blogging-prompt"
 					key={ 'blogging-prompt-card-' + postKey.index }
 				>
-<<<<<<< HEAD
-					<BloggingPromptCard siteId={ siteId } viewContext="reader" showMenu={ false } />
-=======
-					<BloggingPromptCard index={ postKey.index } />
->>>>>>> 93c3eca481 (Pass index of prompts to card)
+					<BloggingPromptCard
+						siteId={ siteId }
+						viewContext="reader"
+						showMenu={ false }
+						index={ postKey.index }
+					/>
 				</div>
 			);
 		} else if ( streamKey.indexOf( 'rec' ) > -1 ) {

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -43,7 +43,11 @@ class PostLifecycle extends Component {
 					className="reader-stream__blogging-prompt"
 					key={ 'blogging-prompt-card-' + postKey.index }
 				>
+<<<<<<< HEAD
 					<BloggingPromptCard siteId={ siteId } viewContext="reader" showMenu={ false } />
+=======
+					<BloggingPromptCard index={ postKey.index } />
+>>>>>>> 93c3eca481 (Pass index of prompts to card)
 				</div>
 			);
 		} else if ( streamKey.indexOf( 'rec' ) > -1 ) {

--- a/client/reader/stream/utils.js
+++ b/client/reader/stream/utils.js
@@ -90,8 +90,8 @@ export function getDistanceBetweenRecs( totalSubs ) {
 	);
 }
 
-const MIN_DISTANCE_BETWEEN_PROMPTS = 10;
-const MAX_DISTANCE_BETWEEN_PROMPTS = 50;
+const MIN_DISTANCE_BETWEEN_PROMPTS = 1;
+const MAX_DISTANCE_BETWEEN_PROMPTS = 5;
 
 export function getDistanceBetweenPrompts( totalSubs ) {
 	// the distance between recs changes based on how many subscriptions the user has.
@@ -120,12 +120,15 @@ export function injectPrompts( posts, itemsBetweenPrompts ) {
 		return posts;
 	}
 
+	let promptIndex = 0;
+
 	return flatMap( posts, ( post, index ) => {
 		if ( index && index % itemsBetweenPrompts === 0 ) {
 			const promptBlock = {
 				isPromptBlock: true,
-				index: index,
+				index: promptIndex,
 			};
+			promptIndex++;
 			return [ promptBlock, post ];
 		}
 		return post;

--- a/client/reader/stream/utils.js
+++ b/client/reader/stream/utils.js
@@ -90,8 +90,8 @@ export function getDistanceBetweenRecs( totalSubs ) {
 	);
 }
 
-const MIN_DISTANCE_BETWEEN_PROMPTS = 1;
-const MAX_DISTANCE_BETWEEN_PROMPTS = 5;
+const MIN_DISTANCE_BETWEEN_PROMPTS = 10;
+const MAX_DISTANCE_BETWEEN_PROMPTS = 50;
 
 export function getDistanceBetweenPrompts( totalSubs ) {
 	// the distance between recs changes based on how many subscriptions the user has.


### PR DESCRIPTION
This PR passes an index when rendering the blogging prompt card to allow reader to render a different prompt each time as the user scrolls down the page.

This will make the prompts more interesting and should help with engagement.

### Testing

* Go to Following feed on Reader - http://calypso.localhost:3000/read
* The first prompt should be the first on the list (where the left arrow is disabled)
<img width="612" alt="Screenshot 2023-02-14 at 21 46 55" src="https://user-images.githubusercontent.com/5560595/218870526-2641784a-2ac7-41e6-8748-7b87afee14a2.png">
* Scroll to the next prompt and confirm the prompt increments by 1 (you can check the `Post Answer` URL to see the prompt ID - i.e. http://calypso.localhost:3000/post/testreader9.wordpress.com?answer_prompt=1846
* Scroll through all the prompts until you get to the last prompt ( where the right arrow is disabled)
<img width="609" alt="Screenshot 2023-02-14 at 21 49 25" src="https://user-images.githubusercontent.com/5560595/218870962-562899bb-6165-4db7-8f97-cb6a138dee06.png">
* Scroll to the next prompt and it should start from the first prompt again (where the left arrow is disabled).

