### PR TITLE
i18n: Fix translate function alias in Team Invite components

### DIFF
--- a/client/my-sites/people/team-invite/hooks/use-inviting-notifications.ts
+++ b/client/my-sites/people/team-invite/hooks/use-inviting-notifications.ts
@@ -5,7 +5,7 @@ import { getSendInviteState } from 'calypso/state/invites/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 
 export function useInvitingNotifications( tokenValues: string[] ) {
-	const _ = useTranslate();
+	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { error, errorType, success, failure, progress } = useSelector( getSendInviteState );
 	const [ prevProgress, setPrevProgress ] = useState( progress );
@@ -20,9 +20,9 @@ export function useInvitingNotifications( tokenValues: string[] ) {
 		let msg;
 
 		if ( errorType === 'partial' ) {
-			msg = _( 'Some invitations failed to send' );
+			msg = translate( 'Some invitations failed to send' );
 		} else {
-			msg = _( 'Invitation failed to send', 'Invitations failed to send', {
+			msg = translate( 'Invitation failed to send', 'Invitations failed to send', {
 				count: tokenValues.length,
 				context: 'Displayed in a notice when all invitations failed to send.',
 			} );
@@ -31,12 +31,12 @@ export function useInvitingNotifications( tokenValues: string[] ) {
 	}
 
 	function showInvitingFailureNotice() {
-		const msg = _( "Sorry, we couldn't process your invitations. Please try again later." );
+		const msg = translate( "Sorry, we couldn't process your invitations. Please try again later." );
 		dispatch( errorNotice( msg, noticeConfig ) );
 	}
 
 	function showInvitingSuccessNotice() {
-		const msg = _( 'Invitation sent successfully', 'Invitations sent successfully', {
+		const msg = translate( 'Invitation sent successfully', 'Invitations sent successfully', {
 			count: tokenValues.length,
 		} );
 		dispatch( successNotice( msg, noticeConfig ) );

--- a/client/my-sites/people/team-invite/hooks/use-validation-notifications.ts
+++ b/client/my-sites/people/team-invite/hooks/use-validation-notifications.ts
@@ -5,7 +5,7 @@ import { getTokenValidation } from 'calypso/state/invites/selectors';
 import { warningNotice } from 'calypso/state/notices/actions';
 
 export function useValidationNotifications() {
-	const _ = useTranslate();
+	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const { failure } = useSelector( getTokenValidation );
@@ -14,7 +14,7 @@ export function useValidationNotifications() {
 
 	function showValidationFailureNotice() {
 		dispatch(
-			warningNotice( _( 'Oops, something went wrong with the form validation.' ), {
+			warningNotice( translate( 'Oops, something went wrong with the form validation.' ), {
 				duration: 3000,
 			} )
 		);

--- a/client/my-sites/people/team-invite/index.tsx
+++ b/client/my-sites/people/team-invite/index.tsx
@@ -28,7 +28,7 @@ interface Props {
 	site: SiteDetails;
 }
 function TeamInvite( props: Props ) {
-	const _ = useTranslate();
+	const translate = useTranslate();
 
 	const { site } = props;
 	const siteId = site.ID;
@@ -55,13 +55,13 @@ function TeamInvite( props: Props ) {
 			<Main>
 				<PageViewTracker path="/people/new/:site" title="People > Invite People" />
 				<HeaderCake onClick={ goBack }>
-					{ _( 'Add team members to %(sitename)s', {
+					{ translate( 'Add team members to %(sitename)s', {
 						args: { sitename: site.name },
 					} ) }
 				</HeaderCake>
 				<PeopleSectionAddNav selectedFilter="team" />
 				<EmptyContent
-					title={ _( 'Oops, only administrators can invite other people' ) }
+					title={ translate( 'Oops, only administrators can invite other people' ) }
 					illustration="/calypso/images/illustrations/illustration-empty-results.svg"
 				/>
 			</Main>
@@ -75,7 +75,7 @@ function TeamInvite( props: Props ) {
 			{ siteId && isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 
 			<HeaderCake onClick={ goBack }>
-				{ _( 'Add team members to %(sitename)s', {
+				{ translate( 'Add team members to %(sitename)s', {
 					args: { sitename: site.name },
 				} ) }
 			</HeaderCake>
@@ -108,7 +108,7 @@ function TeamInvite( props: Props ) {
 
 			{ isSiteForTeams && (
 				<>
-					<SectionHeader label={ _( 'Invite Link' ) } />
+					<SectionHeader label={ translate( 'Invite Link' ) } />
 					<Card className="invite-people__link">
 						{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
 						{ /* @ts-ignore */ }

--- a/client/my-sites/people/team-invite/invite-form.tsx
+++ b/client/my-sites/people/team-invite/invite-form.tsx
@@ -29,16 +29,16 @@ interface Props {
 }
 
 function InviteForm( props: Props ) {
-	const _ = useTranslate();
+	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { onInviteSuccess } = props;
 
 	const emailControlPlaceholder = [
-		_( 'sibling@example.com' ),
-		_( 'parents@example.com' ),
-		_( 'friend@example.com' ),
+		translate( 'sibling@example.com' ),
+		translate( 'parents@example.com' ),
+		translate( 'friend@example.com' ),
 	];
-	const defaultEmailControlPlaceholder = _( 'Add another email or username' );
+	const defaultEmailControlPlaceholder = translate( 'Add another email or username' );
 
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const siteId = site?.ID as number;
@@ -148,7 +148,7 @@ function InviteForm( props: Props ) {
 				target="_blank"
 				href={ localizeUrl( 'https://wordpress.com/support/user-roles/' ) }
 			>
-				{ _( 'Learn more' ) }
+				{ translate( 'Learn more' ) }
 			</Button>
 		);
 	}
@@ -174,7 +174,9 @@ function InviteForm( props: Props ) {
 
 			{ [ ...Array( tokenControlNum ) ].map( ( v, i ) => (
 				<FormFieldset key={ i }>
-					{ ! i && <FormLabel htmlFor={ `token-${ i }` }>{ _( 'Email or Username' ) }</FormLabel> }
+					{ ! i && (
+						<FormLabel htmlFor={ `token-${ i }` }>{ translate( 'Email or Username' ) }</FormLabel>
+					) }
 					<div className="form-field-wrapper">
 						<FormTextInput
 							id={ `token-${ i }` }
@@ -216,18 +218,18 @@ function InviteForm( props: Props ) {
 						borderless={ true }
 						onClick={ () => setShowMsg( true ) }
 					>
-						{ _( '+ Add a message' ) }
+						{ translate( '+ Add a message' ) }
 					</Button>
 				) }
 				{ showMsg && (
 					<>
-						<FormLabel htmlFor="message">{ _( 'Message' ) }</FormLabel>
+						<FormLabel htmlFor="message">{ translate( 'Message' ) }</FormLabel>
 						<FormTextarea
 							// eslint-disable-next-line jsx-a11y/no-autofocus
 							autoFocus
 							id="message"
 							value={ message }
-							placeholder={ _( 'This message will be sent along with invitation emails.' ) }
+							placeholder={ translate( 'This message will be sent along with invitation emails.' ) }
 							onChange={ ( e: ChangeEvent< HTMLInputElement > ) => setMessage( e.target.value ) }
 						/>
 					</>
@@ -240,7 +242,7 @@ function InviteForm( props: Props ) {
 				busy={ invitingProgress }
 				className="team-invite-form__submit-btn"
 			>
-				{ _( 'Send invitation' ) }
+				{ translate( 'Send invitation' ) }
 			</Button>
 		</form>
 	);

--- a/client/my-sites/people/team-invite/invite-link-form.tsx
+++ b/client/my-sites/people/team-invite/invite-link-form.tsx
@@ -15,7 +15,7 @@ interface Props {
 	siteId: number;
 }
 export function InviteLinkForm( props: Props ) {
-	const _ = useTranslate();
+	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { siteId } = props;
 
@@ -56,7 +56,7 @@ export function InviteLinkForm( props: Props ) {
 		accept(
 			<div>
 				<p>
-					{ _(
+					{ translate(
 						'Once this invite link is disabled, nobody will be able to use it to join your team. Are you sure?'
 					) }
 				</p>
@@ -66,7 +66,7 @@ export function InviteLinkForm( props: Props ) {
 					dispatch( disableInviteLinks( siteId ) );
 				}
 			},
-			_( 'Disable' )
+			translate( 'Disable' )
 		);
 	}
 
@@ -82,7 +82,7 @@ export function InviteLinkForm( props: Props ) {
 	return (
 		<>
 			<div className="invite-people__link-instructions">
-				{ _(
+				{ translate(
 					'Use this link to onboard your team members without having to invite them one by one. ' +
 						'{{strong}}Anybody visiting this URL will be able to sign up to your organization,{{/strong}} ' +
 						'even if they received the link from somebody else, so make sure that you share it with trusted people.',
@@ -96,7 +96,7 @@ export function InviteLinkForm( props: Props ) {
 					className="invite-people__link-generate"
 					busy={ isGeneratingInviteLinks }
 				>
-					{ _( 'Generate new link' ) }
+					{ translate( 'Generate new link' ) }
 				</Button>
 			) }
 
@@ -130,8 +130,8 @@ export function InviteLinkForm( props: Props ) {
 							text={ activeInviteLink.link }
 							onCopy={ onInviteLinkCopy }
 						>
-							{ showCopyConfirmation && _( 'Copied!' ) }
-							{ ! showCopyConfirmation && _( 'Copy link' ) }
+							{ showCopyConfirmation && translate( 'Copied!' ) }
+							{ ! showCopyConfirmation && translate( 'Copy link' ) }
 						</ClipboardButton>
 					</div>
 
@@ -142,7 +142,7 @@ export function InviteLinkForm( props: Props ) {
 						<span>
 							(
 							<button className="invite-people__link-disable" onClick={ disableLinks }>
-								{ _( 'Disable invite link' ) }
+								{ translate( 'Disable invite link' ) }
 							</button>
 							)
 						</span>

--- a/client/my-sites/people/team-invite/sso-notice.tsx
+++ b/client/my-sites/people/team-invite/sso-notice.tsx
@@ -11,7 +11,7 @@ interface Props {
 	children?: ReactChild | ReactChildren;
 }
 export default function SsoNotice( props: Props ) {
-	const _ = useTranslate();
+	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const { siteId, children } = props;
@@ -25,9 +25,9 @@ export default function SsoNotice( props: Props ) {
 			<Notice
 				status="is-warning"
 				showDismiss={ false }
-				text={ _( 'Inviting users requires WordPress.com sign in' ) }
+				text={ translate( 'Inviting users requires WordPress.com sign in' ) }
 			>
-				<NoticeAction onClick={ enableSSO }>{ _( 'Enable' ) }</NoticeAction>
+				<NoticeAction onClick={ enableSSO }>{ translate( 'Enable' ) }</NoticeAction>
 			</Notice>
 			<FeatureExample>{ children }</FeatureExample>
 		</div>


### PR DESCRIPTION
Related to 561-gh-Automattic/i18n-issues

## Proposed Changes

The string extraction process is based on [static code analysis and depends on using specific aliases](https://github.com/Automattic/wp-calypso/blob/d2f075e3a9ab2b11c902f0d4eb7334381ccf9ce8/packages/babel-plugin-i18n-calypso/README.md#L3) for the translate functions - `translate` for `i18n-calypso` and `__, _n, _x, _nx` for `@wordpress/i18n`.

* Rename `useTranslate()` translate function alias from `_` to `translate` in Team Invite section components.

![CleanShot 2023-02-14 at 10 36 35](https://user-images.githubusercontent.com/2722412/218713939-1f36cb8e-8128-47ce-9333-08a2373d93a8.png)

## Testing Instructions

* Code review.
* Inspect Translate job artifacts in TeamCity and confirm `localci-new-strings.pot` contains the strings.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
