### PR TITLE
Stats: Release the latest post card on the Insights page

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/latest-post-card.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/latest-post-card.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { PostStatsCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
@@ -28,6 +29,7 @@ export default function LatestPostCard( {
 	siteSlug: string;
 } ) {
 	const translate = useTranslate();
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	const posts = useSelector( ( state ) =>
 		getPostsForQuery( state, siteId, { status: 'publish', number: 1 } )
@@ -64,6 +66,7 @@ export default function LatestPostCard( {
 					viewCount={ latestPostData?.viewCount }
 					commentCount={ latestPostData?.commentCount }
 					titleLink={ `/stats/post/${ latestPost.ID }/${ siteSlug }` }
+					uploadHref={ ! isOdysseyStats ? `/post/${ siteSlug }/${ latestPost.ID }` : undefined }
 				/>
 			) }
 		</>

--- a/client/my-sites/stats/all-time-highlights-section/style.scss
+++ b/client/my-sites/stats/all-time-highlights-section/style.scss
@@ -65,7 +65,8 @@ $mobile-layout-breakpoint: $break-small;
 			margin-left: 24px;
 		}
 
-		.post-stats-card__thumbnail {
+		.post-stats-card__thumbnail,
+		.post-stats-card__upload {
 			margin-left: auto;
 		}
 	}

--- a/client/my-sites/stats/all-time-highlights-section/style.scss
+++ b/client/my-sites/stats/all-time-highlights-section/style.scss
@@ -59,7 +59,7 @@ $mobile-layout-breakpoint: $break-small;
 	.post-stats-card {
 		flex: 1;
 		max-height: unset;
-		grid-template-columns: minmax(10px, 550px) minmax(0, auto);
+		grid-template-columns: minmax(200px, 550px) minmax(0, auto);
 
 		&:not(:first-child) {
 			margin-left: 24px;

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -117,7 +117,7 @@
 		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
-		"stats/latest-post-stats": false,
+		"stats/latest-post-stats": true,
 		"stats/most-popular-post": false,
 		"stats/new-video-summary": false,
 		"stepper-woocommerce-poc": true,

--- a/config/production.json
+++ b/config/production.json
@@ -137,7 +137,7 @@
 		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
-		"stats/latest-post-stats": false,
+		"stats/latest-post-stats": true,
 		"stats/most-popular-post": false,
 		"stats/new-video-summary": false,
 		"stepper-woocommerce-poc": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -134,7 +134,7 @@
 		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
-		"stats/latest-post-stats": false,
+		"stats/latest-post-stats": true,
 		"stats/most-popular-post": false,
 		"stats/new-video-summary": false,
 		"stepper-woocommerce-poc": true,

--- a/config/test.json
+++ b/config/test.json
@@ -97,7 +97,7 @@
 		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
-		"stats/latest-post-stats": false,
+		"stats/latest-post-stats": true,
 		"stats/most-popular-post": false,
 		"stats/new-video-summary": false,
 		"stepper-woocommerce-poc": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -143,7 +143,7 @@
 		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
-		"stats/latest-post-stats": false,
+		"stats/latest-post-stats": true,
 		"stats/most-popular-post": false,
 		"stats/new-video-summary": false,
 		"stepper-woocommerce-poc": true,

--- a/packages/components/src/post-stats-card/index.tsx
+++ b/packages/components/src/post-stats-card/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { eye } from '@automattic/components/src/icons';
 import { Icon, commentContent, starEmpty } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -31,6 +32,15 @@ export default function PostStatsCard( {
 	const translate = useTranslate();
 	const parsedDate = useMemo( () => new Date( post?.date ).toLocaleDateString(), [ post?.date ] );
 	const TitleTag = titleLink ? 'a' : 'div';
+
+	const recordClickOnUploadImageButton = () => {
+		recordTracksEvent( 'calypso_stats_insights_upload_image_button_click', { href: uploadHref } );
+
+		if ( uploadHref ) {
+			window.location.href = uploadHref;
+		}
+	};
+
 	return (
 		<Card className="post-stats-card">
 			<div className="post-stats-card__heading">{ heading }</div>
@@ -84,7 +94,10 @@ export default function PostStatsCard( {
 			) }
 			{ uploadHref && ! post?.post_thumbnail && (
 				<div className="post-stats-card__upload">
-					<Button className="post-stats-card__upload-btn" href={ uploadHref }>
+					<Button
+						className="post-stats-card__upload-btn"
+						onClick={ recordClickOnUploadImageButton }
+					>
 						{ translate( 'Add featured image' ) }
 					</Button>
 				</div>

--- a/packages/components/src/post-stats-card/index.tsx
+++ b/packages/components/src/post-stats-card/index.tsx
@@ -2,7 +2,7 @@ import { eye } from '@automattic/components/src/icons';
 import { Icon, commentContent, starEmpty } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { Card, ShortenedNumber } from '../';
+import { Card, ShortenedNumber, Button } from '../';
 import './style.scss';
 
 type PostStatsCardProps = {
@@ -16,6 +16,7 @@ type PostStatsCardProps = {
 		title: string;
 	};
 	titleLink?: string | undefined;
+	uploadHref?: string | undefined;
 };
 
 export default function PostStatsCard( {
@@ -25,6 +26,7 @@ export default function PostStatsCard( {
 	post,
 	viewCount,
 	titleLink,
+	uploadHref,
 }: PostStatsCardProps ) {
 	const translate = useTranslate();
 	const parsedDate = useMemo( () => new Date( post?.date ).toLocaleDateString(), [ post?.date ] );
@@ -79,6 +81,13 @@ export default function PostStatsCard( {
 						textOnly: true,
 					} ) }
 				/>
+			) }
+			{ uploadHref && ! post?.post_thumbnail && (
+				<div className="post-stats-card__upload">
+					<Button className="post-stats-card__upload-btn" href={ uploadHref }>
+						{ translate( 'Add featured image' ) }
+					</Button>
+				</div>
 			) }
 		</Card>
 	);

--- a/packages/components/src/post-stats-card/style.scss
+++ b/packages/components/src/post-stats-card/style.scss
@@ -84,7 +84,8 @@ $break-wpcom-smallest: 320px;
 	color: var(--studio-gray-100);
 }
 
-.post-stats-card__thumbnail {
+.post-stats-card__thumbnail,
+.post-stats-card__upload {
 	border-radius: 0 $border-radius $border-radius 0;
 	grid-area: thumbnail;
 	height: calc(100% + #{$card-padding * 2});
@@ -92,6 +93,35 @@ $break-wpcom-smallest: 320px;
 	max-width: 300px;
 	object-fit: cover;
 	width: calc(100% + #{$card-padding});
+}
+
+.post-stats-card__upload {
+	max-width: 500px;
+	min-width: 250px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-color: var(--studio-gray-0);
+	border-left: 1px solid var(--studio-gray-5);
+	box-sizing: border-box;
+}
+
+.post-stats-card__upload-btn {
+	color: var(--studio-gray-100);
+	font-family: $font-sf-pro-display;
+	font-size: $font-body-small;
+	font-weight: 500;
+	line-height: 20px;
+	letter-spacing: 0.32px;
+	border: 1px solid var(--studio-gray-5);
+	border-radius: 4px;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+@media ( max-width: $break-large ) {
+	.post-stats-card__upload {
+		display: none;
+	}
 }
 
 @media ( max-width: $break-small ) {

--- a/packages/components/src/post-stats-card/style.scss
+++ b/packages/components/src/post-stats-card/style.scss
@@ -97,7 +97,7 @@ $break-wpcom-smallest: 320px;
 
 .post-stats-card__upload {
 	max-width: 500px;
-	min-width: 250px;
+	padding: 0 12px;
 	display: flex;
 	align-items: center;
 	justify-content: center;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #70854 

## Proposed Changes

* Enable the feature flag `stats/latest-post-stats` for all environments.
* Add the feature image upload link inside the latest post card when there is no thumbnail.
* Track click events with the key `calypso_stats_insights_upload_image_button_click`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the `Stats` > `Insights` page.
* Ensure there is the latest post card appended to the `All-time highlights` section and the `Latest post summary` is removed.
* Ensure the image upload link is redirecting to the post edit page ( `/post/${site-slug}/${post-id}` ).

<img width="959" alt="截圖 2023-02-14 上午4 21 35" src="https://user-images.githubusercontent.com/6869813/218566418-e366d199-243d-4d3c-99d0-c916ff26378c.png">

* Ensure the latest post card is in line with the design for PC and mobile.

|PC|Mobile|
|-|-|
|<img width="1274" alt="截圖 2023-02-14 上午2 15 29" src="https://user-images.githubusercontent.com/6869813/218539878-f3d973e6-8d88-4027-b90e-40e7d1abe03d.png">|<img width="462" alt="截圖 2023-02-14 上午2 15 50" src="https://user-images.githubusercontent.com/6869813/218540045-4daff77c-6700-418b-8378-d00c18001030.png">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
