### PR TITLE
Plans: Replace priceAsString with formatCurrency

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -1,6 +1,7 @@
+import formatCurrency from '@automattic/format-currency';
 import { TranslateResult } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
-import PlanPrice, { priceAsString } from 'calypso/my-sites/plan-price';
+import PlanPrice from 'calypso/my-sites/plan-price';
 import PriceAriaLabel from './price-aria-label';
 import TimeFrame from './time-frame';
 import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';
@@ -104,7 +105,9 @@ const Paid: React.FC< OwnProps > = ( props ) => {
 		return <Placeholder { ...props } />;
 	}
 
-	const formattedOriginalPrice = priceAsString( originalPrice, currencyCode );
+	const formattedOriginalPrice = formatCurrency( originalPrice, currencyCode, {
+		stripZeros: true,
+	} );
 
 	let priceComponent = isDiscounted ? (
 		<DiscountedPrice { ...props } finalPrice={ finalPrice } />

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -218,16 +218,6 @@ function PriceWithoutHtml( {
 	return <>{ priceObj.integer }</>;
 }
 
-export function priceAsString( price: number, currencyCode: string, isSmallestUnit = false ) {
-	const priceObj = getCurrencyObject( price, currencyCode, { isSmallestUnit } );
-	return (
-		priceObj.symbol +
-		( priceObj.hasNonZeroFraction
-			? `${ priceObj.integer }${ priceObj.fraction }`
-			: priceObj.integer )
-	);
-}
-
 function FlatPriceDisplay( {
 	smallerPrice,
 	higherPrice,

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
@@ -1,9 +1,10 @@
+import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import TimeFrame from 'calypso/components/jetpack/card/jetpack-product-card/display-price/time-frame';
-import PlanPrice, { priceAsString } from 'calypso/my-sites/plan-price';
+import PlanPrice from 'calypso/my-sites/plan-price';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { useItemPriceCompact } from '../product-store/hooks/use-item-price-compact';
 import ItemPriceMessage from '../product-store/item-price/item-price-message';
@@ -85,7 +86,9 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 								<TimeFrame
 									billingTerm={ billingTerm }
 									discountedPriceDuration={ discountedPriceDuration }
-									formattedOriginalPrice={ priceAsString( originalPrice, currencyCode ) }
+									formattedOriginalPrice={ formatCurrency( originalPrice, currencyCode, {
+										stripZeros: true,
+									} ) }
 								/>
 							</div>
 						</div>


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/73063, a helper function called `priceAsString()` was added to the `PlanPrice` component file to be used by Jetpack product cards on the `/plans` page (it was not actually used by `PlanPrice` but presumably it was added there because that component can be used to display prices in HTML?). The goal of this function was to format a raw price into a localized format without HTML. It operated using the `getCurrencyObject()` export of the `@automattic/format-currency` package, building up the formatted string from its parts.

However, the main export of the `@automattic/format-currency` package is the function `formatCurrency()`, which does exactly this behavior, and does it more accurately for all locales (see pbOQVh-2WH-p2). `getCurrencyObject()` is only made available to build HTML with a price.

## Proposed Changes

This PR removes the unnecessary `priceAsString()` function and replaces its call-sites with calls to `formatCurrency()` instead. I've specified `stripZeros: true` for each call because that behavior was included implicitly in `priceAsString()`. (The function also included an optional parameter for `isSmallestUnit` but it was never used so I've excluded it from the new calls.)

## Testing Instructions

This code is all TypeScript so little testing should be required. However, we can run through the testing instructions of https://github.com/Automattic/wp-calypso/pull/73063 to be sure:

* Apply this patch to your testing environment or use the Calypso live link.
* Check the `/pricing` page for the Jetpack Cloud environment.
* Check the language next to the pricing for the VaultPress Backup and Social Basic, it should read something like "for the first month, then $10 /month billed yearly".
* Click the "More about" link for both these products to view the lightbox - the same language should be used within the lightbox.

![Screen Shot 2023-02-07 at 4 27 12 PM](https://user-images.githubusercontent.com/18016357/217372118-ab253278-4037-4363-a622-2297e545c42e.png)
![Screen Shot 2023-02-07 at 4 26 58 PM](https://user-images.githubusercontent.com/18016357/217372121-9f806570-2b9e-456f-880f-891e0f3cc08c.png)

