### PR TITLE
i18n: Fix translate function alias in People section

### DIFF
--- a/client/my-sites/people/people-section-add-nav/index.tsx
+++ b/client/my-sites/people/people-section-add-nav/index.tsx
@@ -10,19 +10,19 @@ interface Props {
 	selectedFilter: string;
 }
 function PeopleSectionAddNav( props: Props ) {
-	const _ = useTranslate();
+	const translate = useTranslate();
 	const { selectedFilter } = props;
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 
 	const filters = [
 		{
 			id: 'team',
-			title: _( 'Add to team' ),
+			title: translate( 'Add to team' ),
 			path: '/people/new/' + site?.slug,
 		},
 		{
 			id: 'subscribers',
-			title: _( 'Add subscribers' ),
+			title: translate( 'Add subscribers' ),
 			path: '/people/add-subscribers/' + site?.slug,
 		},
 	];

--- a/client/my-sites/people/people-section-nav-compact/index.tsx
+++ b/client/my-sites/people/people-section-nav-compact/index.tsx
@@ -11,21 +11,21 @@ interface Props {
 	filterCount?: { [ key: string ]: undefined | number };
 }
 function PeopleSectionNavCompact( props: Props ) {
-	const _ = useTranslate();
+	const translate = useTranslate();
 	const { selectedFilter, searchTerm, filterCount } = props;
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const searchPlaceholder =
-		selectedFilter === 'subscribers' ? _( 'Search by email...' ) : undefined;
+		selectedFilter === 'subscribers' ? translate( 'Search by email…' ) : undefined;
 
 	const filters = [
 		{
 			id: 'team',
-			title: _( 'Team' ),
+			title: translate( 'Team' ),
 			path: '/people/team/' + site?.slug,
 		},
 		{
 			id: 'subscribers',
-			title: _( 'Subscribers' ),
+			title: translate( 'Subscribers' ),
 			path: '/people/subscribers/' + site?.slug,
 		},
 	];

--- a/client/my-sites/people/subscriber-details/index.tsx
+++ b/client/my-sites/people/subscriber-details/index.tsx
@@ -24,7 +24,7 @@ interface Props {
 	subscriberType: string;
 }
 export default function SubscriberDetails( props: Props ) {
-	const _ = useTranslate();
+	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const dispatch = useDispatch();
 	const { removeFollower, isSuccess: isRemoveFollowerSuccess } = useRemoveFollowerMutation();
@@ -84,12 +84,14 @@ export default function SubscriberDetails( props: Props ) {
 			<div>
 				<p>
 					{ subscriberType === 'wpcom' &&
-						_(
+						translate(
 							'Removing followers makes them stop receiving updates from your site. ' +
 								'If they choose to, they can still visit your site, and follow it again.'
 						) }
 					{ subscriberType === 'email' &&
-						_( 'Removing email subscribers makes them stop receiving updates from your site.' ) }
+						translate(
+							'Removing email subscribers makes them stop receiving updates from your site.'
+						) }
 				</p>
 			</div>,
 			( accepted: boolean ) => {
@@ -110,7 +112,7 @@ export default function SubscriberDetails( props: Props ) {
 					);
 				}
 			},
-			_( 'Remove', { context: 'Confirm Remove follower button text.' } )
+			translate( 'Remove', { context: 'Confirm Remove follower button text.' } )
 		);
 	}
 
@@ -121,14 +123,14 @@ export default function SubscriberDetails( props: Props ) {
 			<FormattedHeader
 				brandFont
 				className="people__page-heading"
-				headerText={ _( 'Users' ) }
-				subHeaderText={ _( 'People who have subscribed to your site and team members.' ) }
+				headerText={ translate( 'Users' ) }
+				subHeaderText={ translate( 'People who have subscribed to your site and team members.' ) }
 				align="left"
 				hasScreenOptions
 			/>
 
 			<HeaderCake isCompact onClick={ onBackClick }>
-				{ _( 'User Details' ) }
+				{ translate( 'User Details' ) }
 			</HeaderCake>
 
 			{ templateState === 'loading' && (
@@ -138,7 +140,7 @@ export default function SubscriberDetails( props: Props ) {
 			) }
 
 			{ templateState === 'not-found' && (
-				<EmptyContent title={ _( 'The requested subscriber does not exist.' ) } />
+				<EmptyContent title={ translate( 'The requested subscriber does not exist.' ) } />
 			) }
 
 			{ templateState === 'default' && (
@@ -152,10 +154,10 @@ export default function SubscriberDetails( props: Props ) {
 					<div className="people-member-details__meta">
 						{ subscriber?.date_subscribed && (
 							<div className="people-member-details__meta-item">
-								<strong>{ _( 'Status' ) }</strong>
+								<strong>{ translate( 'Status' ) }</strong>
 								<div>
 									<span className="people-member-details__meta-status-active">
-										{ _( 'Active' ) }
+										{ translate( 'Active' ) }
 									</span>
 								</div>
 							</div>
@@ -163,7 +165,7 @@ export default function SubscriberDetails( props: Props ) {
 
 						{ subscriber?.date_subscribed && (
 							<div className="people-member-details__meta-item">
-								<strong>{ _( 'Subscriber since' ) }</strong>
+								<strong>{ translate( 'Subscriber since' ) }</strong>
 								<div>
 									<span>{ moment( subscriber?.date_subscribed ).format( 'LLL' ) }</span>
 								</div>
@@ -172,7 +174,7 @@ export default function SubscriberDetails( props: Props ) {
 
 						{ subscriber?.url && (
 							<div className="people-member-details__meta-item">
-								<strong>{ _( 'Source' ) }</strong>
+								<strong>{ translate( 'Source' ) }</strong>
 								<div>
 									<span>{ subscriber.url }</span>
 								</div>

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -22,7 +22,7 @@ interface Props {
 	search?: string;
 }
 function SubscribersTeam( props: Props ) {
-	const _ = useTranslate();
+	const translate = useTranslate();
 	const { filter, search } = props;
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 
@@ -50,8 +50,8 @@ function SubscribersTeam( props: Props ) {
 			<FormattedHeader
 				brandFont
 				className="people__page-heading"
-				headerText={ _( 'Users' ) }
-				subHeaderText={ _(
+				headerText={ translate( 'Users' ) }
+				subHeaderText={ translate(
 					'Invite subscribers and team members to your site and manage their access settings. {{learnMore}}Learn more{{/learnMore}}.',
 					{
 						components: {

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -23,7 +23,7 @@ interface Props {
 	followersQuery: FollowersQuery;
 }
 function Subscribers( props: Props ) {
-	const _ = useTranslate();
+	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { search, followersQuery } = props;
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
@@ -87,17 +87,21 @@ function Subscribers( props: Props ) {
 				<>
 					<PeopleListSectionHeader
 						isPlaceholder={ isLoading }
-						label={ _( 'You have %(number)d subscriber', 'You have %(number)d subscribers', {
-							args: { number: subscribersTotal },
-							count: subscribersTotal as number,
-						} ) }
+						label={ translate(
+							'You have %(number)d subscriber',
+							'You have %(number)d subscribers',
+							{
+								args: { number: subscribersTotal },
+								count: subscribersTotal as number,
+							}
+						) }
 					>
 						<Button compact primary href={ addSubscribersLink }>
-							{ _( 'Add subscribers' ) }
+							{ translate( 'Add subscribers' ) }
 						</Button>
 						<EllipsisMenu compact position="bottom">
 							<PopoverMenuItem href={ downloadCsvLink } onClick={ onDownloadCsvClick }>
-								{ _( 'Download email subscribers as CSV' ) }
+								{ translate( 'Download email subscribers as CSV' ) }
 							</PopoverMenuItem>
 						</EllipsisMenu>
 					</PeopleListSectionHeader>
@@ -126,7 +130,7 @@ function Subscribers( props: Props ) {
 							{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
 							{ /* @ts-ignore */ }
 							<EmailVerificationGate
-								noticeText={ _( 'You must verify your email to add subscribers.' ) }
+								noticeText={ translate( 'You must verify your email to add subscribers.' ) }
 								noticeStatus="is-info"
 							>
 								<AddSubscriberForm
@@ -145,7 +149,7 @@ function Subscribers( props: Props ) {
 				<Card>
 					<NoResults
 						image="/calypso/images/people/mystery-person.svg"
-						text={ _( 'No results found for {{em}}%(searchTerm)s{{/em}}', {
+						text={ translate( 'No results found for {{em}}%(searchTerm)s{{/em}}', {
 							args: { searchTerm: search },
 							components: { em: <em /> },
 						} ) }

--- a/client/my-sites/people/team-invites-accepted/index.tsx
+++ b/client/my-sites/people/team-invites-accepted/index.tsx
@@ -13,7 +13,7 @@ import type { Invite } from '../team-invites/types';
 import './style.scss';
 
 function TeamInvitesAccepted() {
-	const _ = useTranslate();
+	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
@@ -28,8 +28,8 @@ function TeamInvitesAccepted() {
 	function showPrompt() {
 		accept(
 			<div>
-				<h1>{ _( 'Clear All Accepted' ) }</h1>
-				<p>{ _( 'Are you sure you wish to clear all accepted invites?' ) }</p>
+				<h1>{ translate( 'Clear All Accepted' ) }</h1>
+				<p>{ translate( 'Are you sure you wish to clear all accepted invites?' ) }</p>
 			</div>,
 			( accepted: boolean ) => {
 				if ( ! accepted ) {
@@ -39,7 +39,7 @@ function TeamInvitesAccepted() {
 				const ids = acceptedInvites ? acceptedInvites?.map( ( x ) => x.key ) : [];
 				dispatch( deleteInvites( siteId, ids ) );
 			},
-			_( 'Clear all' )
+			translate( 'Clear all' )
 		);
 	}
 
@@ -64,7 +64,7 @@ function TeamInvitesAccepted() {
 			{ !! acceptedInvites?.length && (
 				<>
 					<PeopleListSectionHeader
-						label={ _(
+						label={ translate(
 							'%(numberPeople)d user has accepted your invite',
 							'%(numberPeople)d users have accepted your invites',
 							{
@@ -76,7 +76,7 @@ function TeamInvitesAccepted() {
 						) }
 					>
 						<Button compact busy={ isDeleting } onClick={ onClearAll }>
-							{ _( 'Clear all invites' ) }
+							{ translate( 'Clear all invites' ) }
 						</Button>
 					</PeopleListSectionHeader>
 					<Card className="people-team-invites-accepted-list">

--- a/client/my-sites/people/team-invites/index.tsx
+++ b/client/my-sites/people/team-invites/index.tsx
@@ -11,7 +11,7 @@ import type { Invite } from './types';
 import './style.scss';
 
 function TeamInvites() {
-	const _ = useTranslate();
+	const translate = useTranslate();
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const siteId = site?.ID as number;
 	const pendingInvites = useSelector( ( state ) => getPendingInvitesForSite( state, siteId ) );
@@ -38,7 +38,7 @@ function TeamInvites() {
 			{ !! pendingInvites?.length && (
 				<>
 					<PeopleListSectionHeader
-						label={ _(
+						label={ translate(
 							'You have a pending invite for %(number)d user',
 							'You have a pending invite for %(number)d users',
 							{

--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -16,7 +16,7 @@ interface Props {
 	usersQuery: UsersQuery;
 }
 function TeamMembers( props: Props ) {
-	const _ = useTranslate();
+	const translate = useTranslate();
 	const { search, usersQuery } = props;
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 
@@ -33,20 +33,22 @@ function TeamMembers( props: Props ) {
 	}
 
 	function getHeaderLabel() {
-		const options = {
-			args: { number: membersTotal, searchTerm: search },
-			count: membersTotal as number,
-		};
-
 		if ( search && membersTotal ) {
-			return _(
+			return translate(
 				'%(number)d Person Matching {{em}}"%(searchTerm)s"{{/em}}',
 				'%(number)d People Matching {{em}}"%(searchTerm)s"{{/em}}',
-				{ ...options, components: { em: <em /> } }
+				{
+					args: { number: membersTotal, searchTerm: search },
+					count: membersTotal as number,
+					components: { em: <em /> },
+				}
 			);
 		}
 
-		return _( 'You have %(number)d team member', 'You have %(number)d team members', options );
+		return translate( 'You have %(number)d team member', 'You have %(number)d team members', {
+			args: { number: membersTotal, searchTerm: search },
+			count: membersTotal as number,
+		} );
 	}
 
 	function renderPerson( user: Member ) {
@@ -77,7 +79,7 @@ function TeamMembers( props: Props ) {
 				<>
 					<PeopleListSectionHeader isPlaceholder={ isLoading } label={ getHeaderLabel() }>
 						<Button compact primary href={ addTeamMemberLink }>
-							{ _( 'Add a team member' ) }
+							{ translate( 'Add a team member' ) }
 						</Button>
 					</PeopleListSectionHeader>
 					<Card className="people-team-members-list">
@@ -102,7 +104,7 @@ function TeamMembers( props: Props ) {
 				<Card>
 					<NoResults
 						image="/calypso/images/people/mystery-person.svg"
-						text={ _( 'No results found for {{em}}%(searchTerm)s{{/em}}', {
+						text={ translate( 'No results found for {{em}}%(searchTerm)s{{/em}}', {
 							args: { searchTerm: search },
 							components: { em: <em /> },
 						} ) }


### PR DESCRIPTION
Related to 560-gh-Automattic/i18n-issues

## Proposed Changes

The string extraction process is based on [static code analysis and depends on using specific aliases](https://github.com/Automattic/wp-calypso/blob/d2f075e3a9ab2b11c902f0d4eb7334381ccf9ce8/packages/babel-plugin-i18n-calypso/README.md#L3) for the translate functions - `translate` for `i18n-calypso` and `__, _n, _x, _nx` for `@wordpress/i18n`.

* Rename `useTranslate()` translate function alias from `_` to `translate` in People section components.

![CleanShot 2023-02-14 at 10 35 29](https://user-images.githubusercontent.com/2722412/218714094-d1f4f9a9-175c-4054-909c-b9a0ae8ad8d2.png)

## Testing Instructions

* Code review.
* Inspect Translate job artifacts in TeamCity and confirm `localci-new-strings.pot` contains the strings.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
