### PR TITLE
Plugins: Add getPluginOnSites and related selectors to selectors-ts

### DIFF
--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -240,5 +240,6 @@ export const getPluginsOnSite = createSelector(
 	},
 	( state, siteId, pluginSlugs ) => [
 		...pluginSlugs.map( ( pluginSlug ) => getPluginOnSite( state, siteId, pluginSlug ) ),
-	]
+	],
+	( state, siteId, pluginSlugs ) => [ siteId, ...pluginSlugs ].join()
 );

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -205,10 +205,8 @@ export function getPluginOnSites( state: AppState, siteIds: number[], pluginSlug
 		return undefined;
 	}
 
-	for ( const siteId of siteIds ) {
-		if ( plugin.sites[ siteId ] ) {
-			return plugin;
-		}
+	if ( siteIds.some( ( siteId ) => !! plugin.sites[ siteId ] ) ) {
+		return plugin;
 	}
 
 	return undefined;

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -212,25 +212,33 @@ export function getPluginOnSites( state: AppState, siteIds: number[], pluginSlug
 	return undefined;
 }
 
-export function getPluginOnSite( state: AppState, siteId: number, pluginSlug: string ) {
-	const plugin = getAllPluginsIndexedByPluginSlug( state )[ pluginSlug ];
+export const getPluginOnSite = createSelector(
+	( state: AppState, siteId: number, pluginSlug: string ) => {
+		const plugin = getAllPluginsIndexedByPluginSlug( state )[ pluginSlug ];
 
-	const { sites, ...pluginWithoutSites } = plugin;
+		const { sites, ...pluginWithoutSites } = plugin;
 
-	if ( ! plugin || ! plugin.sites[ siteId ] ) {
-		return undefined;
-	}
+		if ( ! plugin || ! plugin.sites[ siteId ] ) {
+			return undefined;
+		}
 
-	// To keep compatibility with some behavior that existed before the refactor
-	// in #73296 the returned object has the site specific data lifted onto it, and
-	// the sites property has only the site data for the requested site.
-	return {
-		...pluginWithoutSites,
-		...plugin.sites[ siteId ],
-		...{ sites: { [ siteId ]: plugin.sites[ siteId ] } },
-	};
-}
+		// To keep compatibility with some behavior that existed before the refactor
+		// in #73296 the returned object has the site specific data lifted onto it, and
+		// the sites property has only the site data for the requested site.
+		return {
+			...pluginWithoutSites,
+			...plugin.sites[ siteId ],
+			...{ sites: { [ siteId ]: plugin.sites[ siteId ] } },
+		};
+	},
+	( state ) => [ getAllPluginsIndexedByPluginSlug( state ) ]
+);
 
-export function getPluginsOnSite( state: AppState, siteId: number, pluginSlugs: string[] ) {
-	return pluginSlugs.map( ( pluginSlug ) => getPluginOnSite( state, siteId, pluginSlug ) );
-}
+export const getPluginsOnSite = createSelector(
+	( state: AppState, siteId: number, pluginSlugs: string[] ) => {
+		return pluginSlugs.map( ( pluginSlug ) => getPluginOnSite( state, siteId, pluginSlug ) );
+	},
+	( state, siteId, pluginSlugs ) => [
+		...pluginSlugs.map( ( pluginSlug ) => getPluginOnSite( state, siteId, pluginSlug ) ),
+	]
+);

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -221,6 +221,9 @@ export function getPluginOnSite( state: AppState, siteId: number, pluginSlug: st
 		return undefined;
 	}
 
+	// To keep compatibility with some behavior that existed before the refactor
+	// in #73296 the returned object has the site specific data lifted onto it, and
+	// the sites property has only the site data for the requested site.
 	return {
 		...pluginWithoutSites,
 		...plugin.sites[ siteId ],

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -217,17 +217,15 @@ export function getPluginOnSite( state: AppState, siteId: number, pluginSlug: st
 
 	const { sites, ...pluginWithoutSites } = plugin;
 
-	return plugin && plugin.sites[ siteId ]
-		? // Because this is a plugin for a single site context only the data for the selected
-		  // site is included. When I changed this file to TypeScript I found that some code
-		  // assumes it will be on the plugin object, while other code assumes it will be on the
-		  // sites object, so I included both.
-		  {
-				...pluginWithoutSites,
-				...plugin.sites[ siteId ],
-				...{ sites: { [ siteId ]: plugin.sites[ siteId ] } },
-		  }
-		: undefined;
+	if ( ! plugin || ! plugin.sites[ siteId ] ) {
+		return undefined;
+	}
+
+	return {
+		...pluginWithoutSites,
+		...plugin.sites[ siteId ],
+		...{ sites: { [ siteId ]: plugin.sites[ siteId ] } },
+	};
 }
 
 export function getPluginsOnSite( state: AppState, siteId: number, pluginSlugs: string[] ) {

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -15,7 +15,7 @@ const getSiteIdsThatHavePlugins = createSelector(
 	( state: AppState ) => {
 		return Object.keys( state.plugins.installed.plugins ).map( ( siteId ) => Number( siteId ) );
 	},
-	( state ) => [ state.plugins.installed.plugins ]
+	( state: AppState ) => [ state.plugins.installed.plugins ]
 );
 
 const emptyObject = {};
@@ -64,10 +64,12 @@ export const getAllPluginsIndexedByPluginSlug = createSelector(
 			{}
 		);
 	},
-	( state ) => [
+	( state: AppState ) => [
 		isRequestingForAllSites( state ),
 		getSiteIdsThatHavePlugins( state ),
-		...getSiteIdsThatHavePlugins( state ).map( ( siteId ) => isRequesting( state, siteId ) ),
+		...getSiteIdsThatHavePlugins( state ).map( ( siteId: number ) =>
+			isRequesting( state, siteId )
+		),
 	]
 ) as { ( state: AppState ): { [ pluginSlug: string ]: Plugin } };
 
@@ -127,7 +129,10 @@ export const getAllPluginsIndexedBySiteId = createSelector(
 			{}
 		);
 	},
-	( state ) => [ getAllPluginsIndexedByPluginSlug( state ), getSiteIdsThatHavePlugins( state ) ]
+	( state: AppState ) => [
+		getAllPluginsIndexedByPluginSlug( state ),
+		getSiteIdsThatHavePlugins( state ),
+	]
 ) as { ( state: AppState ): { [ siteId: number ]: { [ pluginSlug: string ]: Plugin } } };
 
 export const getFilteredAndSortedPlugins = createSelector(
@@ -231,15 +236,15 @@ export const getPluginOnSite = createSelector(
 			...{ sites: { [ siteId ]: plugin.sites[ siteId ] } },
 		};
 	},
-	( state ) => [ getAllPluginsIndexedByPluginSlug( state ) ]
+	( state: AppState ) => [ getAllPluginsIndexedByPluginSlug( state ) ]
 );
 
 export const getPluginsOnSite = createSelector(
 	( state: AppState, siteId: number, pluginSlugs: string[] ) => {
 		return pluginSlugs.map( ( pluginSlug ) => getPluginOnSite( state, siteId, pluginSlug ) );
 	},
-	( state, siteId, pluginSlugs ) => [
+	( state: AppState, siteId: number, pluginSlugs: string[] ) => [
 		...pluginSlugs.map( ( pluginSlug ) => getPluginOnSite( state, siteId, pluginSlug ) ),
 	],
-	( state, siteId, pluginSlugs ) => [ siteId, ...pluginSlugs ].join()
+	( state: AppState, siteId: number, pluginSlugs: string[] ) => [ siteId, ...pluginSlugs ].join()
 );

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -188,17 +188,14 @@ export const getFilteredAndSortedPlugins = createSelector(
 );
 
 export function getPluginsOnSites( state: AppState, plugins: Plugin[] ) {
-	return Object.values( plugins ).reduce(
-		( acc: { [ pluginSlug: string ]: Plugin }, plugin: Plugin ) => {
-			const siteIds = Object.keys( plugin.sites ).map( Number );
-			const pluginOnSites = getPluginOnSites( state, siteIds, plugin.slug );
-			if ( pluginOnSites ) {
-				acc[ plugin.slug ] = pluginOnSites;
-			}
-			return acc;
-		},
-		{}
-	);
+	return plugins.reduce( ( acc: { [ pluginSlug: string ]: Plugin }, plugin: Plugin ) => {
+		const siteIds = Object.keys( plugin.sites ).map( Number );
+		const pluginOnSites = getPluginOnSites( state, siteIds, plugin.slug );
+		if ( pluginOnSites ) {
+			acc[ plugin.slug ] = pluginOnSites;
+		}
+		return acc;
+	}, {} );
 }
 
 export function getPluginOnSites( state: AppState, siteIds: number[], pluginSlug: string ) {

--- a/client/state/plugins/installed/test/selectors-ts.ts
+++ b/client/state/plugins/installed/test/selectors-ts.ts
@@ -363,7 +363,7 @@ describe( 'getPluginOnSite', () => {
 	} );
 } );
 
-describe( 'getPuginsOnSite', () => {
+describe( 'getPluginsOnSite', () => {
 	test( 'Should get an array of undefined if the requested site is not in the current state', () => {
 		expect( getPluginsOnSite( state, siteThreeId, [ 'jetpack' ] ) ).toEqual( [ undefined ] );
 	} );

--- a/client/state/plugins/installed/test/selectors-ts.ts
+++ b/client/state/plugins/installed/test/selectors-ts.ts
@@ -280,7 +280,7 @@ describe( 'getPluginsOnSites', () => {
 		} );
 	} );
 
-	it( 'returns an empty object if the plugins have no sites', () => {
+	it( 'returns an empty object if the sites have no plugins', () => {
 		const plugins = [
 			{ ...jetpackWithSites, ...{ sites: {} } },
 			{ ...akismetWithSites, ...{ sites: {} } },

--- a/client/state/plugins/installed/test/selectors-ts.ts
+++ b/client/state/plugins/installed/test/selectors-ts.ts
@@ -290,6 +290,20 @@ describe( 'getPluginsOnSites', () => {
 
 		expect( result ).toEqual( {} );
 	} );
+
+	it( 'returns an empty object for an empty plugins array', () => {
+		const result = getPluginsOnSites( state, [] );
+
+		expect( result ).toEqual( {} );
+	} );
+
+	it( 'returns undefined for a plugin object with an invalid slug', () => {
+		const invalidPlugin = { ...jetpackWithSites, ...{ slug: 'invalid-slug' } };
+
+		const result = getPluginsOnSites( state, [ invalidPlugin ] );
+
+		expect( result ).toEqual( { 'invalid-plugin': undefined } );
+	} );
 } );
 
 describe( 'getPluginOnSites', () => {

--- a/client/state/plugins/installed/test/selectors-ts.ts
+++ b/client/state/plugins/installed/test/selectors-ts.ts
@@ -233,7 +233,7 @@ describe( 'getAllPluginsIndexedBySiteId', () => {
 
 describe( 'getFilteredAndSortedPlugins', () => {
 	test( 'Should get an empty array if the requested site is not in the current state', () => {
-		const plugins = getFilteredAndSortedPlugins( state, [ nonExistingSiteId ], undefined );
+		const plugins = getFilteredAndSortedPlugins( state, [ nonExistingSiteId1 ], undefined );
 		expect( plugins ).toHaveLength( 0 );
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR adds `getPluginsOnSites`, `getPluginOnSites`, `getPluginOnSite`, and `getPluginsOnSite` to selectors-ts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Review the code and tests, and ensure that the tests pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
