### PR TITLE
Plugins: Add getSites* selectors to selectors-ts

### DIFF
--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -17,15 +17,24 @@ import type { AppState } from 'calypso/types';
 
 import 'calypso/state/plugins/init';
 
+const emptyObject = {};
+const emptyArray = [];
+
+const getSortCompareNumber = ( a: string, b: string ) => {
+	if ( a < b ) {
+		return -1;
+	} else if ( a > b ) {
+		return 1;
+	}
+	return 0;
+};
+
 const getSiteIdsThatHavePlugins = createSelector(
 	( state: AppState ) => {
 		return Object.keys( state.plugins.installed.plugins ).map( ( siteId ) => Number( siteId ) );
 	},
 	( state: AppState ) => [ state.plugins.installed.plugins ]
 );
-
-const emptyObject = {};
-const emptyArray = [];
 
 /**
  * The server returns plugins store at state.plugins.installed.plugins are indexed by site, which means
@@ -183,12 +192,7 @@ export const getFilteredAndSortedPlugins = createSelector(
 		const sortedPluginListEntries = Object.values( pluginList ).sort( ( pluginA, pluginB ) => {
 			const pluginSlugALower = pluginA.slug.toLowerCase();
 			const pluginSlugBLower = pluginB.slug.toLowerCase();
-			if ( pluginSlugALower < pluginSlugBLower ) {
-				return -1;
-			} else if ( pluginSlugALower > pluginSlugBLower ) {
-				return 1;
-			}
-			return 0;
+			return getSortCompareNumber( pluginSlugALower, pluginSlugBLower );
 		} );
 
 		return sortedPluginListEntries;
@@ -269,13 +273,7 @@ export function getSitesWithPlugin( state: AppState, siteIds: number[], pluginSl
 	return pluginSites.sort( ( a, b ) => {
 		const siteTitleA = getSiteTitle( state, a )?.toLowerCase() || '';
 		const siteTitleB = getSiteTitle( state, b )?.toLowerCase() || '';
-		if ( siteTitleA < siteTitleB ) {
-			return -1;
-		}
-		if ( siteTitleA > siteTitleB ) {
-			return 1;
-		}
-		return 0;
+		return getSortCompareNumber( siteTitleA, siteTitleB );
 	} );
 }
 

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -25,6 +25,7 @@ const getSiteIdsThatHavePlugins = createSelector(
 );
 
 const emptyObject = {};
+const emptyArray = [];
 
 /**
  * The server returns plugins store at state.plugins.installed.plugins are indexed by site, which means
@@ -258,7 +259,7 @@ export const getPluginsOnSite = createSelector(
 export function getSitesWithPlugin( state: AppState, siteIds: number[], pluginSlug: string ) {
 	const plugin = getAllPluginsIndexedByPluginSlug( state )[ pluginSlug ];
 	if ( ! plugin ) {
-		return [];
+		return emptyArray;
 	}
 
 	// Filter the requested sites list by the list of sites for this plugin.

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -261,10 +261,10 @@ export function getSitesWithPlugin( state: AppState, siteIds: number[], pluginSl
 		return [];
 	}
 
-	// Filter the requested sites list by the list of sites for this plugin
+	// Filter the requested sites list by the list of sites for this plugin.
 	const pluginSites = siteIds.filter( ( siteId ) => plugin.sites.hasOwnProperty( siteId ) );
 
-	// return sortBy( pluginSites, ( siteId ) => getSiteTitle( state, siteId )?.toLowerCase() );
+	// Return the plugins sorted by title.
 	return pluginSites.sort( ( a, b ) => {
 		const siteTitleA = getSiteTitle( state, a )?.toLowerCase() || '';
 		const siteTitleB = getSiteTitle( state, b )?.toLowerCase() || '';

--- a/client/state/plugins/installed/test/selectors-ts.ts
+++ b/client/state/plugins/installed/test/selectors-ts.ts
@@ -5,6 +5,7 @@ import {
 	INSTALL_PLUGIN,
 } from 'calypso/lib/plugins/constants';
 import { userState } from 'calypso/state/selectors/test/fixtures/user-state';
+import { getSite } from 'calypso/state/sites/selectors';
 import {
 	getAllPluginsIndexedByPluginSlug,
 	getAllPluginsIndexedBySiteId,
@@ -13,6 +14,9 @@ import {
 	getPluginOnSite,
 	getPluginOnSites,
 	getPluginsOnSite,
+	getSiteObjectsWithPlugin,
+	getSitesWithPlugin,
+	getSitesWithoutPlugin,
 } from '../selectors-ts';
 import { akismet, helloDolly, jetpack } from './fixtures/plugins';
 
@@ -384,5 +388,55 @@ describe( 'getPluginsOnSite', () => {
 				},
 			},
 		] );
+	} );
+} );
+
+describe( 'getSitesWithPlugin', () => {
+	test( 'Should get an empty array if the requested site is not in the current state', () => {
+		expect( getSitesWithPlugin( state, [ nonExistingSiteId1 ], 'akismet' ) ).toHaveLength( 0 );
+	} );
+
+	test( "Should get an empty array if the requested plugin doesn't exist on any sites' state", () => {
+		expect( getSitesWithPlugin( state, [ siteOneId, siteTwoId ], 'vaultpress' ) ).toHaveLength( 0 );
+	} );
+
+	test( 'Should get an array of sites with the requested plugin', () => {
+		const siteIds = getSitesWithPlugin( state, [ siteOneId, siteTwoId ], 'jetpack' );
+		expect( siteIds ).toEqual( [ siteTwoId ] );
+	} );
+} );
+
+describe( 'getSiteObjectsWithPlugin', () => {
+	test( 'Should get an empty array if the requested site is not in the current state', () => {
+		expect( getSiteObjectsWithPlugin( state, [ nonExistingSiteId1 ], 'akismet' ) ).toHaveLength(
+			0
+		);
+	} );
+
+	test( "Should get an empty array if the requested plugin doesn't exist on any sites' state", () => {
+		expect(
+			getSiteObjectsWithPlugin( state, [ siteOneId, siteTwoId ], 'vaultpress' )
+		).toHaveLength( 0 );
+	} );
+
+	test( 'Should get an array of sites with the requested plugin', () => {
+		const siteIds = getSiteObjectsWithPlugin( state, [ siteOneId, siteTwoId ], 'jetpack' );
+		expect( siteIds ).toEqual( [ getSite( state, siteTwoId ) ] );
+	} );
+} );
+
+describe( 'getSitesWithoutPlugin', () => {
+	test( 'Should get an empty array if the requested site is not in the current state', () => {
+		expect( getSitesWithoutPlugin( state, [ nonExistingSiteId1 ], 'akismet' ) ).toHaveLength( 0 );
+	} );
+
+	test( "Should get an array of sites that don't have the plugin in their state", () => {
+		const siteIds = getSitesWithoutPlugin( state, [ siteOneId, siteTwoId ], 'akismet' );
+		expect( siteIds ).toEqual( [ siteTwoId ] );
+	} );
+
+	test( 'Should get an empty array if the requested plugin exists on all requested sites', () => {
+		const siteIds = getSitesWithoutPlugin( state, [ siteOneId, siteTwoId ], 'hello-dolly' );
+		expect( siteIds ).toHaveLength( 0 );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

This PR adds getSitesWithPlugin, getSiteObjectsWithPlugin, and getSitesWithoutPlugin to selectors-ts. It is a part of the ongoing improvements to the plugin selectors which began in https://github.com/Automattic/wp-calypso/pull/72363.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Review the code and tests, and ensure the tests pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
