### PR TITLE
Stats: GET params should be passed as object

### DIFF
--- a/client/data/stats/use-has-never-published-post.ts
+++ b/client/data/stats/use-has-never-published-post.ts
@@ -31,8 +31,11 @@ function fetchHasNeverPublishedPost(
 	siteId: number | null,
 	includePages: boolean
 ): Promise< boolean > {
-	return wpcom.req.get( {
-		path: `/sites/${ siteId }/site-has-never-published-post?include-pages=${ includePages }`,
-		apiNamespace: 'wpcom/v2',
-	} );
+	return wpcom.req.get(
+		{
+			path: `/sites/${ siteId }/site-has-never-published-post`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{ 'include-pages': includePages }
+	);
 }


### PR DESCRIPTION
## Proposed Changes

GET params should be passed as object for the underlying mechanism to deal with the formatting etc. In this case, permanent links could be disabled, so it's not always safe to access `/wp-json/xx/xx/xx`. And also that's why it's not safe to just append the params after the path.

## Testing Instructions
- Please follow instructions in https://github.com/Automattic/jetpack/pull/28935

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
