### PR TITLE
Jetpack Pro Dashboard: implement updated site connectivity issues UX

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-error-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-error-content.tsx
@@ -17,11 +17,7 @@ export default function SiteErrorContent( { siteUrl }: { siteUrl: string } ) {
 				<Gridicon size={ 18 } icon="notice-outline" />
 			</span>
 			<span className="sites-overview__error-message sites-overview__error-message-large-screen">
-				{ translate( 'Jetpack is unable to connect to %(siteUrl)s', {
-					args: {
-						siteUrl,
-					},
-				} ) }
+				{ translate( 'Jetpack is unable to connect to this site' ) }
 			</span>
 			<span className="sites-overview__error-message sites-overview__error-message-small-screen">
 				{ translate( 'Jetpack is unable to connect' ) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -51,6 +51,7 @@ export default function SiteTableRow( { columns, item, setExpanded, isExpanded }
 		selectedLicenses?.length && ! currentSiteHasSelectedLicenses;
 
 	const hideBorderBottom = isExpanded || site.error;
+	const showSiteError = site.error || ! isSiteConnected;
 
 	return (
 		<Fragment>
@@ -58,6 +59,7 @@ export default function SiteTableRow( { columns, item, setExpanded, isExpanded }
 				className={ classNames( 'site-table__table-row', {
 					'site-table__table-row-disabled': shouldDisableLicenseSelection,
 					'site-table__table-row-active': currentSiteHasSelectedLicenses,
+					'site-table__table-row-site-error': showSiteError,
 				} ) }
 				onClick={ ( event ) => {
 					if ( ! shouldDisableLicenseSelection ) {
@@ -71,6 +73,9 @@ export default function SiteTableRow( { columns, item, setExpanded, isExpanded }
 			>
 				{ columns.map( ( column ) => {
 					const row = item[ column.key ];
+					if ( showSiteError && column.key !== 'site' ) {
+						return null;
+					}
 					if ( row.type ) {
 						return (
 							<td
@@ -89,6 +94,11 @@ export default function SiteTableRow( { columns, item, setExpanded, isExpanded }
 						);
 					}
 				} ) }
+				{ showSiteError && (
+					<td className="site-table__error" colSpan={ columns.length - 1 }>
+						<SiteErrorContent siteUrl={ site.value.url } />
+					</td>
+				) }
 				<td
 					className={ classNames( 'site-table__actions', {
 						'site-table__td-without-border-bottom': hideBorderBottom,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
@@ -5,10 +5,6 @@
 	&:hover {
 		background: var(--studio-gray-0);
 
-		+.site-table__connection-error {
-			background: var(--studio-gray-0);
-		}
-
 		.sites-overview__overlay {
 			background: linear-gradient(to right, rgba(246, 247, 247, 0.8) 30%, rgba(246, 247, 247, 1) 100%);
 		}
@@ -34,12 +30,6 @@
 	}
 }
 
-.site-table__connection-error {
-	td {
-		padding: 0;
-	}
-}
-
 td.site-table__actions {
 	padding: 0;
 	width: 50px;
@@ -55,3 +45,16 @@ td.site-table__td-without-border-bottom {
 	right: 0;
 	top: 2px;
 }
+td.site-table__error {
+	padding: 0 16px;
+}
+
+tr.site-table__table-row-site-error {
+	background: var(--studio-red-0);
+	&:hover,
+	&:hover .sites-overview__overlay,
+	.sites-overview__overlay {
+		background: var(--studio-red-0);
+	}
+}
+

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
@@ -105,7 +105,7 @@ describe( '<SiteTableRow>', () => {
 
 	test( 'should render correctly and have the error message and the link to fix the issue', async () => {
 		await waitFor( () => {
-			expect( getByText( 'Jetpack is unable to connect to test.jurassic.ninja' ) ).toBeVisible();
+			expect( getByText( 'Jetpack is unable to connect to this site' ) ).toBeVisible();
 			expect( getByText( /fix now/i ) ).toBeVisible();
 		} );
 	} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -188,8 +188,10 @@
 	display: flex;
 	align-items: center;
 	height: 40px;
+	position: relative;
 	@include break-xlarge {
-		margin: 8px;
+		margin: 0;
+		height: inherit;
 	}
 }
 .sites-overview__error-icon {
@@ -202,6 +204,7 @@
 	justify-content: center;
 	@include break-xlarge {
 		width: auto;
+		padding: 16px;
 	}
 }
 .sites-overview__error-message {
@@ -224,10 +227,12 @@
 }
 .sites-overview__error-message-link {
 	font-size: 0.75rem;
-	color: #bbb !important;
+	color: var(--studio-white) !important;
 	padding: 6px;
 	position: absolute;
 	inset-inline-end: 16px;
+	text-decoration: underline;
+	font-weight: 500;
 }
 .sites-overview__badge {
 	font-size: 0.75rem !important;


### PR DESCRIPTION
#### Proposed Changes

This PR implements the updated site connectivity issue UX in the Jetpack Pro Dashboard.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_** These changes are not behind a feature flag and will be effective in production immediately after merging.


**Instructions**

1. Run `git checkout update/site-connectivity-error-in-dashboard` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Make sure you have sites with connectivity issues.
4. Verify that the UI for sites with connectivity issues is as below

When Expandable block is enabled

<img width="1624" alt="Screenshot 2023-02-20 at 11 52 21 AM" src="https://user-images.githubusercontent.com/10586875/220028488-d509c4e8-23fc-452a-b319-b9ee21945402.png">

<img width="1624" alt="Screenshot 2023-02-20 at 11 56 22 AM" src="https://user-images.githubusercontent.com/10586875/220028573-f4ce2e52-bda6-4429-862e-a3ebe0c86125.png">

When Expandable block is not enabled(This is how it'll be visible in production)

<img width="1624" alt="Screenshot 2023-02-20 at 12 05 34 PM" src="https://user-images.githubusercontent.com/10586875/220030881-43126e60-9245-468d-8efd-c2db67d55964.png">

<img width="1624" alt="Screenshot 2023-02-20 at 12 05 39 PM" src="https://user-images.githubusercontent.com/10586875/220030909-c6a0fc1f-a081-4d1d-be5b-439fe2cd7a2a.png">


5. Verify the same for smaller screen devices(<1080px)

<img width="302" alt="Screenshot 2023-02-14 at 10 54 31 AM" src="https://user-images.githubusercontent.com/10586875/218670355-cf89a65b-6d93-4f06-a353-1ba666040cd1.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related to 1203940061556608-as-1203942568423023