### PR TITLE
Get Apps: Localize link to apps.wordpress.com/get

### DIFF
--- a/client/blocks/get-apps/mobile-download-card.jsx
+++ b/client/blocks/get-apps/mobile-download-card.jsx
@@ -203,7 +203,9 @@ class MobileDownloadCard extends Component {
 								a: (
 									<a
 										className="get-apps__jetpack-branded-link"
-										href="https://apps.wordpress.com/get?campaign=calypso-get-apps-link"
+										href={ localizeUrl(
+											'https://apps.wordpress.com/get?campaign=calypso-get-apps-link'
+										) }
 									/>
 								),
 							},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 562-gh-Automattic/i18n-issues

## Proposed Changes

* Localize link to `apps.wordpress.com/get` on Get Apps section.

![CleanShot 2023-02-14 at 11 56 06](https://user-images.githubusercontent.com/2722412/218714283-c45fe554-6af1-456c-97d9-756fca9c1b81.png)

## Testing Instructions

* Boot Calypso locally or use calypso.live image.
* Change UI to any of the Mag-16 languages.
* Navigate to `/me/get-apps/`
* Confirm `wp.com/app` links to `apps.wordpress.com/[locale]/get/`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
