### PR TITLE
Remove automatic authorization away from the page

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -181,8 +181,6 @@ export class JetpackAuthorize extends Component {
 			return this.redirect();
 		} else if ( nextProps.isAlreadyOnSitesList && alreadyAuthorized ) {
 			return this.redirect();
-		} else if ( this.isFromJetpackMigration() && nextProps.isAlreadyOnSitesList ) {
-			return this.redirect();
 		}
 		if (
 			authorizeError &&


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73316

## Proposed Changes

* Since we're handling the authorization part inside the plugin, we don't want the redirects to trigger in case anything is wrong.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a testing JN site with [Migration plugin](https://jurassic.ninja/create/?jetpack-beta&branches.jetpack-migration=master&wp-debug-log) .
* Navigate to `Move to WordPress.com` and click `Get started`.
* You'll be redirect to wordpress.com domain, replace it with `calypso.localhost:3000`
* Click the `Approve` button on the page.
* See if it brings you to migrationHandler page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
