### PR TITLE
Launchpad: Change Circular Progress Bar Style

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -98,7 +98,8 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 				{ currentTask && enhancedTasks?.length && (
 					<div className="launchpad__progress-bar-container">
 						<CircularProgressBar
-							size={ 52 }
+							size={ 40 }
+							enableDesktopScaling
 							currentStep={ currentTask }
 							numberOfSteps={ enhancedTasks?.length }
 						/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -98,8 +98,8 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 				{ currentTask && enhancedTasks?.length && (
 					<div className="launchpad__progress-bar-container">
 						<CircularProgressBar
-							size={ 40 }
-							enableDesktopScaling={ true }
+							size={ 52 }
+							enableDesktopScaling
 							currentStep={ currentTask }
 							numberOfSteps={ enhancedTasks?.length }
 						/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -99,7 +99,6 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 					<div className="launchpad__progress-bar-container">
 						<CircularProgressBar
 							size={ 52 }
-							enableDesktopScaling
 							currentStep={ currentTask }
 							numberOfSteps={ enhancedTasks?.length }
 						/>

--- a/packages/components/src/circular-progress-bar/style.scss
+++ b/packages/components/src/circular-progress-bar/style.scss
@@ -7,8 +7,8 @@
 
 	&.desktop-scaling {
 		@include break-mobile {
-			// mobile: 40px, desktop: 48px (1.2x scale)
-			transform: scale(1.2);
+			// desktop - 30% upscale
+			transform: scale(1.3);
 		}
 	}
 
@@ -24,8 +24,8 @@
 	}
 
 	&-text {
-		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-		font-size: 0.75rem;
+		font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+		font-size: 15px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		letter-spacing: 0.05em;
 
 		// center the text inside the circle

--- a/packages/components/src/circular-progress-bar/style.scss
+++ b/packages/components/src/circular-progress-bar/style.scss
@@ -8,7 +8,7 @@
 	&.desktop-scaling {
 		@include break-mobile {
 			// mobile first, upscale for desktop
-			transform: scale(1.2);
+			transform: scale(1.3);
 		}
 	}
 
@@ -25,7 +25,8 @@
 
 	&-text {
 		font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-		font-size: 15px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 11.5px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-weight: 500;
 		letter-spacing: 0.05em;
 
 		// center the text inside the circle

--- a/packages/components/src/circular-progress-bar/style.scss
+++ b/packages/components/src/circular-progress-bar/style.scss
@@ -7,8 +7,8 @@
 
 	&.desktop-scaling {
 		@include break-mobile {
-			// desktop - 30% upscale
-			transform: scale(1.3);
+			// mobile first, upscale for desktop
+			transform: scale(1.2);
 		}
 	}
 

--- a/packages/components/src/circular-progress-bar/style.scss
+++ b/packages/components/src/circular-progress-bar/style.scss
@@ -25,7 +25,8 @@
 
 	&-text {
 		font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-		font-size: 11.5px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		font-size: 11.5px; // 11.5px mobile, 15px desktop (30% upscaling)
 		font-weight: 500;
 		letter-spacing: 0.05em;
 


### PR DESCRIPTION
Fixes #73273 

### Time Estimate
Review: Short
Test: Short

### Proposed Changes
This PR contains styling changes for the circular progress bar:
1. Font family: System
2. Font size: 11.5px mobile, 15px desktop
3. Size: 40px mobile, 52px desktop

<img width="434" alt="image" src="https://user-images.githubusercontent.com/20927667/218754226-8f44bf6d-db56-4b07-be51-86b8e065aba6.png">


### Testing
1. Checkout this branch
2. Go to the Launchpad screen (create a new site or use existing)
3. Verify the styling changes look good