### PR TITLE
Purchases: Remove redundant title case formatting for service titles in billing history

### DIFF
--- a/client/me/purchases/billing-history/billing-history-list.jsx
+++ b/client/me/purchases/billing-history/billing-history-list.jsx
@@ -4,7 +4,6 @@ import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import titleCase from 'to-title-case';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Pagination from 'calypso/components/pagination';
 import { capitalPDangit } from 'calypso/lib/formatting';
@@ -71,7 +70,7 @@ class BillingHistoryList extends Component {
 
 		return this.serviceNameDescription( {
 			...transactionItem,
-			plan: capitalPDangit( titleCase( transactionItem.variation ) ),
+			plan: capitalPDangit( transactionItem.variation ),
 		} );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 549-gh-Automattic/i18n-issues

It appears that we are applying additional title case formatting for the service name field of the items in the billing history list. The title case formatting is causing some unintended alterations of the translated string and therefore should be removed.

Additionally, it seems like the title case is not really needed, as the service name is being used without any additional formatting in other sections (e.g. [billing-history/receipt](https://github.com/Automattic/wp-calypso/blob/7bca130291db0f8a0af6cb7262bc4cdbedeca99f/client/me/purchases/billing-history/receipt.jsx#L285)).

## Proposed Changes

* Remove redundant `titleCase()` formatting for service name in Purchases Billing History list. 

**Before:**
![CleanShot 2023-02-14 at 15 36 09](https://user-images.githubusercontent.com/2722412/218757891-8c6d90c2-3a13-432d-80f3-7a2908f2395f.png)

**After:**
![CleanShot 2023-02-14 at 15 35 47](https://user-images.githubusercontent.com/2722412/218757927-88758f82-1978-472b-bafb-66df140c004c.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot Calypso locally or use calypso.live image.
* Change UI to any of the Mag-16 languages.
* Navigate to `/me/purchases/billing/`
* Confirm `Domain Registration` string is matching [the original capitalization of the related translation.](https://translate.wordpress.com/projects/wpcom/-all-translated/42132/).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
