### PR TITLE
WooExpress: Update "save" nudges in Plans page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -119,7 +119,11 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 						selected={ interval === 'yearly' }
 						path={ plansLink( '/plans', siteSlug, 'yearly', true ) }
 					>
-						<span>{ translate( 'Pay Annually' ) }</span>
+						<span>
+							{ translate( 'Pay Annually (Save %(percentageSavings)s%%)', {
+								args: { percentageSavings },
+							} ) }
+						</span>
 					</SegmentedControl.Item>
 				</SegmentedControl>
 			</div>
@@ -135,11 +139,13 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 				</div>
 				<div className="e-commerce-trial-plans__price-card-conditions">
 					{ priceContent }
-					<span className="e-commerce-trial-plans__price-card-savings">
-						{ translate( 'Save %(percentageSavings)s%% by paying annually', {
-							args: { percentageSavings },
-						} ) }
-					</span>
+					{ isAnnualSubscription && (
+						<span className="e-commerce-trial-plans__price-card-savings">
+							{ translate( 'Save %(percentageSavings)s%% by paying annually', {
+								args: { percentageSavings },
+							} ) }
+						</span>
+					) }
 				</div>
 				<div className="e-commerce-trial-plans__price-card-cta-wrapper">
 					<Button


### PR DESCRIPTION
## Proposed Changes

* We should not show the "Save X%..." copy when viewing monthly pricing
* We should update the copy to Pay Annually (Save X%) in the Pay Monthly | Pay Annually toggle

### Before
<img width="1095" alt="Screen Shot 2023-02-14 at 17 33 05" src="https://user-images.githubusercontent.com/1234758/218855738-2c3b0fa1-ceb8-4eb0-8786-01092199d0b2.png">
<img width="1121" alt="Screen Shot 2023-02-14 at 17 33 10" src="https://user-images.githubusercontent.com/1234758/218855759-6a11949c-9a38-41fe-885a-d7b1023ea839.png">

### After
<img width="1184" alt="Screen Shot 2023-02-14 at 17 07 14" src="https://user-images.githubusercontent.com/1234758/218852080-b408f2e0-9fb7-4497-a0d6-a7619f63eab3.png">
<img width="1198" alt="Screen Shot 2023-02-14 at 17 07 18" src="https://user-images.githubusercontent.com/1234758/218852091-93356663-57e2-40e4-a514-bab168835697.png">

## Testing Instructions

* On a WooExpress site, navigate to `/plans/:siteSlug`
* Ensure that the copy `Save x% by paying annually` is only displayed for the Anual tab
* Ensure that the toggle says for the annual plan says: `Pay Annually (Save x%)`

Closes #73313
