### PR TITLE
Checkout: allow redirect to jetpack.com and akismet.com

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
@@ -6,6 +6,7 @@ import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-
 
 const getAllowedHosts = ( siteSlug?: string ) => {
 	const basicHosts = [
+		'akismet.com',
 		'jetpack.com',
 		'jetpack.cloud.localhost',
 		'cloud.jetpack.com',

--- a/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/pending-page.ts
@@ -219,6 +219,8 @@ function isRedirectAllowed( url: string, siteSlug: string | undefined ): boolean
 		'calypso.localhost',
 		'jetpack.cloud.localhost',
 		'cloud.jetpack.com',
+		'jetpack.com',
+		'akismet.com',
 		siteSlug,
 	];
 

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -70,6 +70,13 @@ type ReceiptId = number;
 type ReceiptIdPlaceholder = ':receiptId';
 type ReceiptIdOrPlaceholder = ReceiptIdPlaceholder | PurchaseId | ReceiptId;
 
+const allowedExternalSites = [
+	'cloud.jetpack.com',
+	'jetpack.cloud.localhost',
+	'jetpack.com',
+	'akismet.com',
+];
+
 export interface PostCheckoutUrlArguments {
 	siteSlug?: string;
 	adminUrl?: string;
@@ -162,8 +169,8 @@ export default function getThankYouPageUrl( {
 			return sanitizedRedirectTo;
 		}
 
-		if ( hostname === 'cloud.jetpack.com' || hostname === 'jetpack.cloud.localhost' ) {
-			debug( 'returning Jetpack cloud redirectTo', redirectTo );
+		if ( allowedExternalSites.includes( hostname ) ) {
+			debug( 'returning Jetpack.com, Jetpack Cloud, or Akismet redirectTo', redirectTo );
 			return redirectTo;
 		}
 

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -602,6 +602,20 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( redirectTo );
 	} );
 
+	it( 'redirects to external redirectTo url if the hostame is jetpack.com', () => {
+		const adminUrl = 'https://my.site/wp-admin/';
+		const redirectTo = 'http://jetpack.com/';
+		const url = getThankYouPageUrl( { ...defaultArgs, adminUrl, redirectTo } );
+		expect( url ).toBe( redirectTo );
+	} );
+
+	it( 'redirects to external redirectTo url if the hostame is akismet.com', () => {
+		const adminUrl = 'https://my.site/wp-admin/';
+		const redirectTo = 'http://akismet.com/';
+		const url = getThankYouPageUrl( { ...defaultArgs, adminUrl, redirectTo } );
+		expect( url ).toBe( redirectTo );
+	} );
+
 	it( 'redirects to manage purchase page if there is a renewal', () => {
 		const cart = {
 			...getEmptyResponseCart(),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1201210512993648-as-1203969838580774

## Proposed Changes

The only external sites that are currently allowed after the checkout is cloud.jetpack.com and jetpack.cloud.localhost. This PR adds jetpack.com and akismet.com as well, so we are able to redirect the user to those sites after they purchase a product.

* Add jetpack.com and akismet.com to the list of allowed external sites in `getThankYouPageUrl`
* Update `pending-page` to allow the hostnames above
* Update use-valid-checkout-back-url to allow akismet.com

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Unit tests are applicable - `yarn test-client client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts`
* For manual tests, checkout this branch locally
* Run the project `yarn start`
* Go to the checkout passing `redirect_to=jetpack.com` http://calypso.localhost:3000/checkout/jetpack/jetpack_boost_monthly?&checkoutBackUrl=https://akismet.com&redirect_to=http://jetpack.com/
* Complete the purchase of a product (you can use this method to test PCYsg-IA-p2)
* Make sure you are redirected to the chosen page (i.e. jetpack.com in the example above)
* Go to this page http://calypso.localhost:3000/checkout/jetpack_boost_monthly?&checkoutBackUrl=https://akismet.com
* Click to close the checkout (X button on top left corner) and confirm
* Make sure it redirects you to https://akismet.com

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?