### PR TITLE
Fix padding left at plans page for the experiment users

### DIFF
--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -120,7 +120,7 @@ class DomainSearch extends Component {
 	}
 
 	componentWillUnmount() {
-		if ( this.props.domainSidebarExperimentUser ) {
+		if ( document.body.classList.contains( 'is-domain-sidebar-experiment-user' ) ) {
 			document.body.classList.remove( 'is-domain-sidebar-experiment-user' );
 		}
 

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -5,8 +5,8 @@ import {
 	PLAN_FREE,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	isFreePlan,
-	is2023PricingGridEnabled,
 } from '@automattic/calypso-products';
+import { is2023PricingGridEnabled } from '@automattic/calypso-products/src/plans-utilities';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { addQueryArgs } from '@wordpress/url';
@@ -144,8 +144,11 @@ class Plans extends Component {
 
 	componentDidMount() {
 		this.redirectIfInvalidPlanInterval();
+
 		if ( this.props.domainSidebarExperimentUser ) {
 			document.body.classList.add( 'is-domain-sidebar-experiment-user' );
+		} else {
+			document.body.classList.remove( 'is-domain-sidebar-experiment-user' );
 		}
 
 		// Scroll to the top
@@ -156,7 +159,7 @@ class Plans extends Component {
 
 	componentWillUnmount() {
 		if ( this.props.domainSidebarExperimentUser ) {
-			document.body.classList.remove( 'is-domain-sidebar-experiment-user' );
+			document.body.classList.remove( 'is-domain-sidebar-experiment-user2' );
 		}
 	}
 

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -159,7 +159,7 @@ class Plans extends Component {
 
 	componentWillUnmount() {
 		if ( this.props.domainSidebarExperimentUser ) {
-			document.body.classList.remove( 'is-domain-sidebar-experiment-user2' );
+			document.body.classList.remove( 'is-domain-sidebar-experiment-user' );
 		}
 	}
 

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -147,8 +147,6 @@ class Plans extends Component {
 
 		if ( this.props.domainSidebarExperimentUser ) {
 			document.body.classList.add( 'is-domain-sidebar-experiment-user' );
-		} else {
-			document.body.classList.remove( 'is-domain-sidebar-experiment-user' );
 		}
 
 		// Scroll to the top
@@ -158,7 +156,7 @@ class Plans extends Component {
 	}
 
 	componentWillUnmount() {
-		if ( this.props.domainSidebarExperimentUser ) {
+		if ( document.body.classList.contains( 'is-domain-sidebar-experiment-user' ) ) {
 			document.body.classList.remove( 'is-domain-sidebar-experiment-user' );
 		}
 	}

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -111,10 +111,4 @@ body.is-section-plans.is-domain-sidebar-experiment-user {
 			color: var(--studio-orange-40);
 		}
 	}
-
-	.plans-features-main__group.is-scrollable:not(.is-2023-pricing-grid) {
-		@media ( min-width: 1800px ) {
-			margin-left: -360px;
-		}
-	}
 }

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -8,9 +8,9 @@
 body.is-section-plans.is-domain-sidebar-experiment-user {
 	background: var(--color-body-background);
 
-	// .layout__content {
-	// 	padding-left: 0 !important;
-	// }
+	.layout__content {
+		padding-left: 0 !important;
+	}
 
 	.plans__has-sidebar {
 		.section-nav {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/73337

## Proposed Changes

* Fixed padding-left at plans page for the experiment users:


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the padding on the plans page (experiment) is correct:


<img width="1246" alt="image" src="https://user-images.githubusercontent.com/1044309/218877672-da8e9c3d-1088-4df4-aa27-717a1c741487.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
