### PR TITLE
Stats: hide email stats for Odyssey

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -321,7 +321,8 @@ class StatsSite extends Component {
 							statType="statsVideoPlays"
 							showSummaryLink
 						/>
-						{ config.isEnabled( 'newsletter/stats' ) && (
+						{ /** Enable Email module when Odyssey is ready. */ }
+						{ config.isEnabled( 'newsletter/stats' ) && ! isOdysseyStats && (
 							<>
 								<StatsModule
 									additionalColumns={ {

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -321,7 +321,6 @@ class StatsSite extends Component {
 							statType="statsVideoPlays"
 							showSummaryLink
 						/>
-						{ /** Enable Email module when Odyssey is ready. */ }
 						{ config.isEnabled( 'newsletter/stats' ) && ! isOdysseyStats && (
 							<>
 								<StatsModule


### PR DESCRIPTION
## Proposed Changes

Hides Email Stats module for Odyssey Stats, because firstly the back end of Odyssey doesn't support Email Stats yet and secondly Email Stats might not needed in Odyssey. Either way, we'd like to hide it for Odyssey ATM.

Odyssey has its own [route settings](https://github.com/Automattic/wp-calypso/blob/trunk/apps/odyssey-stats/src/routes.js), so we don't need to change [the routes in Calypso](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/stats/index.js).

Related: pdtkmj-Yl-p2#comment-2029

## Testing Instructions
* Set `newsletter/stats` to `true` in `config/production.json`
* Verify Odyssey with Option 1 in `PejTkB-3E-p2`
* Ensure `Emails` section is not showing on the Traffic page

<img width="345" alt="Screenshot 2023-02-15 at 12 05 44 PM" src="https://user-images.githubusercontent.com/1425433/218883332-686569c4-eaed-4e2d-9ddf-7e921184a667.png">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?