### PR TITLE
Update woocommerce free trial loading screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -368,7 +368,7 @@ button {
 		display: none;
 	}
 	.loading-bar {
-		background-color: #e5cfe8;
+		background-color: var(--studio-woocommerce-purple-5);
 		width: 520px;
 		max-width: 100%;
 		margin-left: auto;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -368,6 +368,7 @@ button {
 		display: none;
 	}
 	.loading-bar {
+		background-color: #e5cfe8;
 		width: 520px;
 		max-width: 100%;
 		margin-left: auto;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -53,6 +53,12 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 		return __( "Woo! We're creating your store" );
 	};
 
+	const getSubTitle = () => {
+		return __(
+			'#FunWooFact: Did you know that Woo powers almost 4 million stores worldwide? You’re in good company.'
+		);
+	};
+
 	return (
 		<>
 			<DocumentHead title={ getCurrentMessage() } />
@@ -71,6 +77,7 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 							) : (
 								<LoadingEllipsis />
 							) }
+							<p className="processing-step__subtitle">{ getSubTitle() }</p>
 						</div>
 					</>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -50,7 +50,7 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 	}, [] );
 
 	const getCurrentMessage = () => {
-		return __( 'Woo! We’re creating your store ' );
+		return __( 'Woo! We’re creating your store' );
 	};
 
 	const getSubTitle = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -50,7 +50,7 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 	}, [] );
 
 	const getCurrentMessage = () => {
-		return __( "Woo! We're creating your store" );
+		return __( 'Woo! We’re creating your store ' );
 	};
 
 	const getSubTitle = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/styles.scss
@@ -3,21 +3,31 @@
 
 
 .wooexpress.assign-trial-plan {
-	padding: 1.5em;
+	padding: 0;
 	max-width: 540px;
 	text-align: center;
 	margin: 0 auto;
+
+	.assign-trial-step {
+		padding: 1em;
+		max-width: 540px;
+		text-align: center;
+		margin: 16vh auto 0;
+	}
+
+	> .assign-trial-step {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		margin-top: 25vh;
+	}
 
 	.step-container {
 		display: flex;
 	}
 
-	.step-container__content {
-		width: 100%;
-		margin-top: 16vh;
-	}
-
-	.assign-trial-step {
-		max-width: 540px;
+	.assign-trial-step__progress-step {
+		line-height: 40px;
+		letter-spacing: -0.4px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/styles.scss
@@ -16,4 +16,8 @@
 		width: 100%;
 		margin-top: 16vh;
 	}
+
+	.assign-trial-step {
+		max-width: 540px;
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/types.ts
@@ -1,0 +1,5 @@
+export interface LoadingMessage {
+	title: string;
+	subtitle?: string;
+	duration: number;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
@@ -3,7 +3,7 @@ import { isWooExpressFlow } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
-import { LoadingMessage } from './types';
+import type { LoadingMessage } from './types';
 
 const SiteIntent = Onboard.SiteIntent;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
@@ -1,4 +1,5 @@
 import { Onboard } from '@automattic/data-stores';
+import { isWooExpressFlow } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
@@ -18,6 +19,34 @@ export function useProcessingLoadingMessages( flow?: string | null ) {
 			{ title: __( 'Enabling encryption' ), duration: 5000 },
 			{ title: __( 'Applying a shiny top coat' ), duration: 4000 },
 		];
+	}
+
+	if ( isWooExpressFlow( flow ) ) {
+		return stepData.currentStep === 'siteCreationStep'
+			? [
+					{
+						title: __( 'Woo! We’re creating your store' ),
+						subtitle: __(
+							'#FunWooFact: Did you know that Woo powers almost 4 million stores worldwide? You’re in good company.'
+						),
+						duration: 1000,
+					},
+			  ]
+			: [
+					{
+						title: __( 'Applying the finishing touches' ),
+						subtitle: __(
+							'#FunWooFact: There are more than 150 WooCommerce meetups held all over the world! A great way to meet fellow store owners.'
+						),
+						duration: 6000,
+					},
+					{
+						title: __( 'Turning on the lights' ),
+						subtitle: __( '#FunWooFact: Our favorite color is purple 💜' ),
+						// Set a very long duration to make sure it shows until the step is completed
+						duration: 60000,
+					},
+			  ];
 	}
 
 	switch ( stepData.intent ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
@@ -30,7 +30,7 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 						subtitle: __(
 							'#FunWooFact: Did you know that Woo powers almost 4 million stores worldwide? You’re in good company.'
 						),
-						duration: 1000,
+						duration: 2000,
 					},
 			  ]
 			: [
@@ -39,13 +39,13 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 						subtitle: __(
 							'#FunWooFact: There are more than 150 WooCommerce meetups held all over the world! A great way to meet fellow store owners.'
 						),
-						duration: 6000,
+						duration: 10000,
 					},
 					{
 						title: __( 'Turning on the lights' ),
 						subtitle: __( '#FunWooFact: Our favorite color is purple 💜' ),
 						// Set a very long duration to make sure it shows until the step is completed
-						duration: 60000,
+						duration: 150000,
 					},
 			  ];
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.ts
@@ -3,10 +3,11 @@ import { isWooExpressFlow } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
+import { LoadingMessage } from './types';
 
 const SiteIntent = Onboard.SiteIntent;
 
-export function useProcessingLoadingMessages( flow?: string | null ) {
+export function useProcessingLoadingMessages( flow?: string | null ): LoadingMessage[] {
 	const { __ } = useI18n();
 	let loadingMessages = [];
 
@@ -21,7 +22,7 @@ export function useProcessingLoadingMessages( flow?: string | null ) {
 		];
 	}
 
-	if ( isWooExpressFlow( flow ) ) {
+	if ( isWooExpressFlow( flow || null ) ) {
 		return stepData.currentStep === 'siteCreationStep'
 			? [
 					{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-videopress-loading-messages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-videopress-loading-messages.ts
@@ -1,6 +1,7 @@
 import { useI18n } from '@wordpress/react-i18n';
+import { LoadingMessage } from './types';
 
-export function useVideoPressLoadingMessages() {
+export function useVideoPressLoadingMessages(): LoadingMessage[] {
 	const { __ } = useI18n();
 	return [
 		{ title: __( 'Setting up your video site' ), duration: 5000 },

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-videopress-loading-messages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-videopress-loading-messages.ts
@@ -1,5 +1,5 @@
 import { useI18n } from '@wordpress/react-i18n';
-import { LoadingMessage } from './types';
+import type { LoadingMessage } from './types';
 
 export function useVideoPressLoadingMessages(): LoadingMessage[] {
 	const { __ } = useI18n();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -96,6 +96,10 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ hasActionSuccessfullyRun ] );
 
+	const getSubtitle = () => {
+		return props.subtitle || loadingMessages[ currentMessageIndex ]?.subtitle;
+	};
+
 	const flowName = props.flow || '';
 	const isJetpackPowered = isNewsletterOrLinkInBioFlow( flowName );
 	const isWooCommercePowered = flowName === ECOMMERCE_FLOW;
@@ -104,6 +108,8 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	if ( isLinkInBioFlow( flowName ) || isFreeFlow( flowName ) ) {
 		return <TailoredFlowPreCheckoutScreen flowName={ flowName } />;
 	}
+
+	const subtitle = getSubtitle();
 
 	return (
 		<>
@@ -124,7 +130,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 							) : (
 								<LoadingEllipsis />
 							) }
-							{ props.subtitle && <p className="processing-step__subtitle">{ props.subtitle }</p> }
+							{ subtitle && <p className="processing-step__subtitle">{ subtitle }</p> }
 						</div>
 					</>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -154,6 +154,17 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			: __( 'Creating your site' );
 	};
 
+	const getSubTitle = () => {
+		if ( isWooExpressFlow( flow ) ) {
+			return __(
+				'#FunWooFact: Did you know that Woo powers almost 4 million stores worldwide? You’re in good company.'
+			);
+		}
+		return null;
+	};
+
+	const subTitle = getSubTitle();
+
 	return (
 		<>
 			<DocumentHead title={ getCurrentMessage() } />
@@ -171,6 +182,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 						) : (
 							<LoadingEllipsis />
 						) }
+						{ subTitle && <p className="processing-step__subtitle">{ subTitle }</p> }
 					</>
 				}
 				stepProgress={ stepProgress }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -150,7 +150,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 
 	const getCurrentMessage = () => {
 		return isWooExpressFlow( flow )
-			? __( 'Woo! We’re creating your store ' )
+			? __( 'Woo! We’re creating your store' )
 			: __( 'Creating your site' );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -150,7 +150,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 
 	const getCurrentMessage = () => {
 		return isWooExpressFlow( flow )
-			? __( "Woo! We're creating your store" )
+			? __( 'Woo! We’re creating your store ' )
 			: __( 'Creating your site' );
 	};
 

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -92,7 +92,9 @@ const wooexpress: Flow = {
 
 			switch ( currentStep ) {
 				case 'siteCreationStep': {
-					return navigate( 'processing' );
+					return navigate( 'processing', {
+						currentStep,
+					} );
 				}
 
 				case 'processing': {
@@ -120,7 +122,9 @@ const wooexpress: Flow = {
 				}
 
 				case 'waitForAtomic': {
-					return navigate( 'processing' );
+					return navigate( 'processing', {
+						currentStep,
+					} );
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71441

## Proposed Changes

* Update WooCommerce free trial loading screen on WordPress.com to match the design (lD0gTB4IqGsmSmsnjZNaP6-fi-1%3A1461).


## Testing Instructions

* Go to http://calypso.localhost:3000/setup/wooexpress
* You should see the following loading messages in order
   1. Woo! We’re creating your store 
   2. Applying the finishing touches
   3. Turning on the lights
* Make sure the screen matches the design

https://user-images.githubusercontent.com/4344253/218900219-947e70e2-45d4-4aaa-bb8c-b1715707f1f2.mov


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


<img width="1440" alt="Loader - New store - 18" src="https://user-images.githubusercontent.com/4344253/221081338-f49b8fd0-d05d-4cd0-a69f-866ddc556440.png">

<img width="1440" alt="Loader - New store - 19" src="https://user-images.githubusercontent.com/4344253/221081267-604c9a0d-aac9-455f-be42-548165e33b32.png">
7d7fa5d.png">
<img width="1440" alt="Loader - New store - 20" src="https://user-images.githubusercontent.com/4344253/221081276-89465225-05e4-454b-8f2f-bfd245cb4454.png">

