### PR TITLE
BackupRetention: Load retention setting when site has a valid plan

### DIFF
--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -4,8 +4,6 @@ import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useStorageText } from 'calypso/components/backup-storage-space/hooks';
-import { useQueryRewindPolicies } from 'calypso/components/data/query-rewind-policies';
-import { useQueryRewindSize } from 'calypso/components/data/query-rewind-size';
 import { updateBackupRetention } from 'calypso/state/rewind/retention/actions';
 import { BACKUP_RETENTION_UPDATE_REQUEST } from 'calypso/state/rewind/retention/constants';
 import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
@@ -30,9 +28,6 @@ const BackupRetentionManagement: FunctionComponent = () => {
 
 	const siteId = useSelector( getSelectedSiteId ) as number;
 
-	// Query dependencies
-	useQueryRewindSize( siteId );
-	useQueryRewindPolicies( siteId );
 	const requestingSize = useSelector( ( state ) => isRequestingRewindSize( state, siteId ) );
 	const requestingPolicies = useSelector( ( state ) =>
 		isRequestingRewindPolicies( state, siteId )

--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -9,6 +9,7 @@ import DisconnectSite from 'calypso/my-sites/site-settings/disconnect-site';
 import ConfirmDisconnection from 'calypso/my-sites/site-settings/disconnect-site/confirm';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import NoSitesPurchasesMessage from './empty-content';
+import HasRetentionCapabilitiesSwitch from './has-retention-capabilities-switch';
 import HasSiteCredentialsSwitch from './has-site-credentials-switch';
 import AdvancedCredentialsLoadingPlaceholder from './loading';
 import SettingsPage from './main';
@@ -26,7 +27,12 @@ export const advancedCredentials: PageJS.Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			{ config.isEnabled( 'jetpack/backup-retention-settings' ) ? (
-				<BackupRetentionManagement />
+				<HasRetentionCapabilitiesSwitch
+					siteId={ siteId }
+					trueComponent={ <BackupRetentionManagement /> }
+					falseComponent={ null }
+					loadingComponent={ null }
+				/>
 			) : null }
 			<HasSiteCredentialsSwitch
 				siteId={ siteId }

--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -31,7 +31,7 @@ export const advancedCredentials: PageJS.Callback = ( context, next ) => {
 					siteId={ siteId }
 					trueComponent={ <BackupRetentionManagement /> }
 					falseComponent={ null }
-					loadingComponent={ null }
+					loadingComponent={ <AdvancedCredentialsLoadingPlaceholder /> } // Let's use the same placeholder for now
 				/>
 			) : null }
 			<HasSiteCredentialsSwitch

--- a/client/jetpack-cloud/sections/settings/has-retention-capabilities-switch.tsx
+++ b/client/jetpack-cloud/sections/settings/has-retention-capabilities-switch.tsx
@@ -1,0 +1,67 @@
+import { FunctionComponent, ReactNode, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import QueryRewindPolicies from 'calypso/components/data/query-rewind-policies';
+import QueryRewindSize from 'calypso/components/data/query-rewind-size';
+import RenderSwitch from 'calypso/components/jetpack/render-switch';
+import getRewindBytesAvailable from 'calypso/state/rewind/selectors/get-rewind-bytes-available';
+import getRewindPoliciesRequestStatus from 'calypso/state/rewind/selectors/get-rewind-policies-request-status';
+import getRewindSizeRequestStatus from 'calypso/state/rewind/selectors/get-rewind-size-request-status';
+import isRequestingRewindPolicies from 'calypso/state/rewind/selectors/is-requesting-rewind-policies';
+import isRequestingRewindSize from 'calypso/state/rewind/selectors/is-requesting-rewind-size';
+
+type Props = {
+	siteId: number;
+	trueComponent: ReactNode;
+	falseComponent: ReactNode;
+	loadingComponent?: ReactNode;
+};
+
+const HasRetentionCapabilitiesSwitch: FunctionComponent< Props > = ( {
+	siteId,
+	trueComponent,
+	falseComponent,
+	loadingComponent,
+} ) => {
+	const fetchingSize = useSelector( ( state ) => isRequestingRewindSize( state, siteId ) );
+	const fetchingPolicies = useSelector( ( state ) => isRequestingRewindPolicies( state, siteId ) );
+
+	const sizeStatus = useSelector( ( state ) => getRewindSizeRequestStatus( state, siteId ) );
+	const policiesStatus = useSelector( ( state ) =>
+		getRewindPoliciesRequestStatus( state, siteId )
+	);
+
+	const isFetching = fetchingSize || fetchingPolicies;
+	const hasLoaded = sizeStatus === 'success' && policiesStatus === 'success';
+
+	const storageLimitBytes = useSelector( ( state ) =>
+		getRewindBytesAvailable( state, siteId )
+	) as number;
+
+	const loadingCondition = useCallback(
+		() => ! hasLoaded || isFetching,
+		[ hasLoaded, isFetching ]
+	);
+
+	const renderCondition = useCallback(
+		() => hasLoaded && storageLimitBytes > 0,
+		[ hasLoaded, storageLimitBytes ]
+	);
+
+	return (
+		<RenderSwitch
+			queryComponent={
+				<>
+					<QueryRewindPolicies siteId={ siteId } />
+					<QueryRewindSize siteId={ siteId } />
+				</>
+			}
+			trueComponent={ trueComponent }
+			falseComponent={ falseComponent }
+			loadingComponent={ loadingComponent }
+			loadingCondition={ loadingCondition }
+			renderCondition={ renderCondition }
+		/>
+	);
+};
+
+export default HasRetentionCapabilitiesSwitch;

--- a/client/jetpack-cloud/sections/settings/loading/style.scss
+++ b/client/jetpack-cloud/sections/settings/loading/style.scss
@@ -1,6 +1,7 @@
 .loading {
 	max-width: 720px;
 	margin: 0 auto;
+	margin-bottom: 16px;
 	padding: 0 16px;
 
 	&__placeholder {


### PR DESCRIPTION
It is expected to load the new backup retention setting when the site has an appropriate plan.
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73303 and p1676396557689279-slack-C04J59E8W57

## Proposed Changes

* Use `RenderSwitch` component to render the new setting.
* Query rewind size and policies from the new render switch instead of `BackupRetentionManagement` component.

## Demo

[screencast-github.com.webm](https://user-images.githubusercontent.com/1488641/218930043-b8cf6b6a-9ea8-4ff6-8b41-ef35230c1863.webm)

## Testing Instructions
* Start a Jetpack Cloud live branch
* Select a site with a backup plan that has storage limit like Jetpack Backup 10 GB. 
* Navigate to Settings and wait for the new setting to render. It should render.
* Now select a site without a backup plan or with a plan with no storage limit.
* Navigate to Settings and ensure that it is not rendering the setting.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?