### PR TITLE
Stats: change subscribers card to use StatsListCard

### DIFF
--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -6,7 +6,7 @@ import { flowRight, get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
-import SectionHeader from 'calypso/components/section-header';
+import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import {
@@ -18,6 +18,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ErrorPanel from '../stats-error';
 import StatsList from '../stats-list';
 import StatsListLegend from '../stats-list/legend';
+import StatsListCard from '../stats-list/stats-list-card';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsModuleSelectDropdown from '../stats-module/select-dropdown';
 
@@ -49,7 +50,7 @@ class StatModuleFollowers extends Component {
 	};
 
 	filterSelect() {
-		const { emailData, wpcomData } = this.props;
+		const { emailData, wpcomData, isInsightsPageGridEnabled } = this.props;
 		const hasEmailFollowers = !! get( emailData, 'subscribers', [] ).length;
 		const hasWpcomFollowers = !! get( wpcomData, 'subscribers', [] ).length;
 		if ( ! hasWpcomFollowers || ! hasEmailFollowers ) {
@@ -67,7 +68,11 @@ class StatModuleFollowers extends Component {
 			},
 		];
 
-		return <StatsModuleSelectDropdown options={ options } onSelect={ this.changeFilter } />;
+		return isInsightsPageGridEnabled ? (
+			<SimplifiedSegmentedControl options={ options } onSelect={ this.changeFilter } />
+		) : (
+			<StatsModuleSelectDropdown options={ options } onSelect={ this.changeFilter } />
+		);
 	}
 
 	render() {
@@ -85,6 +90,7 @@ class StatModuleFollowers extends Component {
 			emailQuery,
 			wpcomQuery,
 			isOdysseyStats,
+			isInsightsPageGridEnabled,
 		} = this.props;
 		const isLoading = requestingWpcomFollowers || requestingEmailFollowers;
 		const hasEmailFollowers = !! get( emailData, 'subscribers', [] ).length;
@@ -113,80 +119,116 @@ class StatModuleFollowers extends Component {
 		// Limit scope for Odyssey stats, as the Followers page is not yet available.
 		summaryPageLink = ! isOdysseyStats ? summaryPageLink : null;
 
+		const data =
+			this.state.activeFilter === 'email'
+				? emailData?.subscribers ?? []
+				: wpcomData?.subscribers ?? [];
+
 		return (
-			<div className="list-followers">
+			<>
 				{ siteId && (
 					<QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ wpcomQuery } />
 				) }
 				{ siteId && (
 					<QuerySiteStats statType="statsFollowers" siteId={ siteId } query={ emailQuery } />
 				) }
-				<SectionHeader label={ translate( 'Subscribers' ) } href={ summaryPageLink } />
-				<Card className={ classNames( ...classes ) }>
-					<div className="followers">
-						<div className="module-content">
-							{ noData && ! hasError && ! isLoading && (
+				{ isInsightsPageGridEnabled && (
+					<StatsListCard
+						moduleType="followers"
+						data={ data }
+						title={ translate( 'Subscriber' ) }
+						emptyMessage={ translate( 'No subscribers' ) }
+						mainItemLabel={ translate( 'Subscriber' ) }
+						metricLabel={ translate( 'Since' ) }
+						splitHeader
+						useShortNumber
+						showMore={ summaryPageLink }
+						error={
+							noData &&
+							! hasError &&
+							! requestingWpcomFollowers && (
 								<ErrorPanel
 									className="is-empty-message"
 									message={ translate( 'No subscribers' ) }
 								/>
-							) }
-
-							{ this.filterSelect() }
-
-							<div className="tab-content wpcom-followers stats-async-metabox-wrapper">
-								<div className="module-content-text module-content-text-stat">
-									{ wpcomData && !! wpcomData.total_wpcom && (
-										<p>
-											{ translate( 'Total WordPress.com subscribers' ) }:{ ' ' }
-											{ numberFormat( wpcomData.total_wpcom ) }
-										</p>
+							)
+						}
+						loader={ isLoading && <StatsModulePlaceholder isLoading={ isLoading } /> }
+						toggleControl={ this.filterSelect() }
+						className="stats__modernised-followers"
+					/>
+				) }
+				{ ! isInsightsPageGridEnabled && (
+					<div className="list-followers">
+						<Card className={ classNames( ...classes ) }>
+							<div className="followers">
+								<div className="module-content">
+									{ noData && ! hasError && ! isLoading && (
+										<ErrorPanel
+											className="is-empty-message"
+											message={ translate( 'No subscribers' ) }
+										/>
 									) }
+
+									{ this.filterSelect() }
+
+									<div className="tab-content wpcom-followers stats-async-metabox-wrapper">
+										<div className="module-content-text module-content-text-stat">
+											{ wpcomData && !! wpcomData.total_wpcom && (
+												<p>
+													{ translate( 'Total WordPress.com subscribers' ) }:{ ' ' }
+													{ numberFormat( wpcomData.total_wpcom ) }
+												</p>
+											) }
+										</div>
+										<StatsListLegend
+											value={ translate( 'Since' ) }
+											label={ translate( 'Subscriber' ) }
+										/>
+										{ hasWpcomFollowers && (
+											<StatsList moduleName="wpcomFollowers" data={ wpcomData.subscribers } />
+										) }
+										{ hasWpcomQueryFailed && <ErrorPanel className="is-error" /> }
+									</div>
+
+									<div className="tab-content email-followers stats-async-metabox-wrapper">
+										<div className="module-content-text module-content-text-stat">
+											{ emailData && !! emailData.total_email && (
+												<p>
+													{ translate( 'Total Email Subscribers' ) }:{ ' ' }
+													{ numberFormat( emailData.total_email ) }
+												</p>
+											) }
+										</div>
+
+										<StatsListLegend
+											value={ translate( 'Since' ) }
+											label={ translate( 'Subscriber' ) }
+										/>
+										{ hasEmailFollowers && (
+											<StatsList moduleName="EmailFollowers" data={ emailData.subscribers } />
+										) }
+										{ hasEmailQueryFailed && <ErrorPanel className="network-error" /> }
+									</div>
+
+									<StatsModulePlaceholder isLoading={ isLoading } />
 								</div>
-								<StatsListLegend
-									value={ translate( 'Since' ) }
-									label={ translate( 'Subscriber' ) }
-								/>
-								{ hasWpcomFollowers && (
-									<StatsList moduleName="wpcomFollowers" data={ wpcomData.subscribers } />
+								{ ( ( wpcomData && wpcomData.subscribers.length !== wpcomData.total_wpcom ) ||
+									( emailData && emailData.subscribers.length !== emailData.total_email ) ) && (
+									<div key="view-all" className="module-expand">
+										<a href={ summaryPageLink }>
+											{ translate( 'View all', {
+												context: 'Stats: Button label to expand a panel',
+											} ) }
+											<span className="right" />
+										</a>
+									</div>
 								) }
-								{ hasWpcomQueryFailed && <ErrorPanel className="is-error" /> }
 							</div>
-
-							<div className="tab-content email-followers stats-async-metabox-wrapper">
-								<div className="module-content-text module-content-text-stat">
-									{ emailData && !! emailData.total_email && (
-										<p>
-											{ translate( 'Total Email Subscribers' ) }:{ ' ' }
-											{ numberFormat( emailData.total_email ) }
-										</p>
-									) }
-								</div>
-
-								<StatsListLegend
-									value={ translate( 'Since' ) }
-									label={ translate( 'Subscriber' ) }
-								/>
-								{ hasEmailFollowers && (
-									<StatsList moduleName="EmailFollowers" data={ emailData.subscribers } />
-								) }
-								{ hasEmailQueryFailed && <ErrorPanel className="network-error" /> }
-							</div>
-
-							<StatsModulePlaceholder isLoading={ isLoading } />
-						</div>
-						{ ( ( wpcomData && wpcomData.subscribers.length !== wpcomData.total_wpcom ) ||
-							( emailData && emailData.subscribers.length !== emailData.total_email ) ) && (
-							<div key="view-all" className="module-expand">
-								<a href={ summaryPageLink }>
-									{ translate( 'View all', { context: 'Stats: Button label to expand a panel' } ) }
-									<span className="right" />
-								</a>
-							</div>
-						) }
+						</Card>
 					</div>
-				</Card>
-			</div>
+				) }
+			</>
 		);
 	}
 }
@@ -220,6 +262,7 @@ const connectComponent = connect(
 			siteId,
 			siteSlug,
 			isOdysseyStats: config.isEnabled( 'is_running_in_jetpack_site' ),
+			isInsightsPageGridEnabled: config.isEnabled( 'stats/insights-page-grid' ),
 		};
 	},
 	{ recordGoogleEvent }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72135 but doesn't fix it all

## Proposed Changes

* WIP

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
