### PR TITLE
Jetpack Pro Dashboard: update success/error notification duration to 3000ms for the downtime monitoring notification actions

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
@@ -9,6 +9,8 @@ import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import SitesOverviewContext from './sites-overview/context';
 import type { Site, UpdateMonitorSettingsParams } from './sites-overview/types';
 
+const NOTIFICATION_DURATION = 3000;
+
 function getRejectedAndFulfilledRequests(
 	promises: any[],
 	requests: { site: { blog_id: number; url: string } }[]
@@ -141,7 +143,7 @@ export function useToggleActivateMonitor(
 						}
 					);
 				}
-				dispatch( successNotice( successMessage ) );
+				dispatch( successNotice( successMessage, { duration: NOTIFICATION_DURATION } ) );
 			}
 
 			if ( totalRejected ) {
@@ -173,7 +175,7 @@ export function useToggleActivateMonitor(
 						}
 					);
 				}
-				dispatch( errorNotice( errorMessage ) );
+				dispatch( errorNotice( errorMessage, { duration: NOTIFICATION_DURATION } ) );
 			}
 		},
 		[ dispatch, sites, toggleActivateMonitoring, translate ]
@@ -278,7 +280,7 @@ export function useUpdateMonitorSettings( sites: Array< { blog_id: number; url: 
 						}
 					);
 				}
-				dispatch( successNotice( successMessage ) );
+				dispatch( successNotice( successMessage, { duration: NOTIFICATION_DURATION } ) );
 			}
 
 			if ( totalRejected ) {
@@ -306,7 +308,7 @@ export function useUpdateMonitorSettings( sites: Array< { blog_id: number; url: 
 						}
 					);
 				}
-				dispatch( errorNotice( errorMessage ) );
+				dispatch( errorNotice( errorMessage, { duration: NOTIFICATION_DURATION } ) );
 			}
 		},
 		[ dispatch, sites, translate, updateMonitorSettings ]


### PR DESCRIPTION
#### Proposed Changes

This PR updates the success/error notification duration to 3000ms for the downtime monitoring notification actions.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/notification-duration-for-downtime-monitoring` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Perform various monitor actions like enable/disable monitor, save notification settings, and all the bulk actions.
4. Verify that the notification gets cleared after 3000ms of duration.
5. Verify the same for error notification by blocking the API request domain  using the dev tool

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related to 1202619025189113-as-1203783994388580