### PR TITLE
Text updates on the pricing page

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/products-list.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/products-list.tsx
@@ -24,14 +24,14 @@ export const ProductsList: React.FC< ProductsListProps > = ( {
 	return (
 		<div className="jetpack-product-store__products-list">
 			<MostPopular
-				heading={ translate( 'Most popular bundles' ) }
+				heading={ translate( 'Bundle and save' ) }
 				items={ popularBundles }
 				onClickMoreInfoFactory={ onClickMoreInfoFactory }
 				siteId={ siteId }
 			/>
 
 			<AllItems
-				heading={ translate( 'All products' ) }
+				heading={ translate( 'Products with individual plugins' ) }
 				items={ allItems }
 				onClickMoreInfoFactory={ onClickMoreInfoFactory }
 				siteId={ siteId }

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1593,10 +1593,8 @@ const getPlanJetpackSecurityT1Details = (): IncompleteJetpackPlan => ( {
 				components: {
 					ul: <ul />,
 					li: <li />,
-					br: <br />,
 				},
-				comment:
-					'{{ul}}{{ul/}} represents an unorder list, {{li}}{/li} represent an item and {{br/}} represents a line break',
+				comment: '{{ul}}{{ul/}} represents an unorder list, and {{li}}{/li} represent a list item',
 			}
 		),
 	getLightboxDescription: () =>

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1696,12 +1696,9 @@ const getPlanJetpackCompleteDetails = (): IncompleteJetpackPlan => ( {
 			'Get the full Jetpack suite with real-time security tools, improved site performance, and tools to grow your business.{{br/}}{{br/}}',
 			{
 				components: {
-					ul: <ul />,
-					li: <li />,
 					br: <br />,
 				},
-				comment:
-					'{{ul}}{{ul/}} represents an unorder list, {{li}}{/li} represent an item and {{br/}} represents a line break',
+				comment: '{{br/}} represents a line break',
 			}
 		),
 	getLightboxDescription: () =>

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1588,7 +1588,16 @@ const getPlanJetpackSecurityT1Details = (): IncompleteJetpackPlan => ( {
 		),
 	getFeaturedDescription: () =>
 		translate(
-			'Easy-to-use, comprehensive WordPress site security including backups, malware scanning, and spam protection.'
+			'This bundle includes:{{br/}}{{ul}}{{li}}VaultPress Backup{{/li}}{{li}}Scan{{/li}}{{li}}Akismet Anti-spam{{/li}}{{/ul}}',
+			{
+				components: {
+					ul: <ul />,
+					li: <li />,
+					br: <br />,
+				},
+				comment:
+					'{{ul}}{{ul/}} represents an unorder list, {{li}}{/li} represent an item and {{br/}} represents a line break',
+			}
 		),
 	getLightboxDescription: () =>
 		translate(

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1588,7 +1588,7 @@ const getPlanJetpackSecurityT1Details = (): IncompleteJetpackPlan => ( {
 		),
 	getFeaturedDescription: () =>
 		translate(
-			'This bundle includes:{{br/}}{{ul}}{{li}}VaultPress Backup{{/li}}{{li}}Scan{{/li}}{{li}}Akismet Anti-spam{{/li}}{{/ul}}',
+			'This bundle includes:{{ul}}{{li}}VaultPress Backup{{/li}}{{li}}Scan{{/li}}{{li}}Akismet Anti-spam{{/li}}{{/ul}}',
 			{
 				components: {
 					ul: <ul />,
@@ -1693,7 +1693,16 @@ const getPlanJetpackCompleteDetails = (): IncompleteJetpackPlan => ( {
 		),
 	getFeaturedDescription: () =>
 		translate(
-			'Get the full Jetpack suite with real-time security tools, improved site performance, and tools to grow your business.'
+			'Get the full Jetpack suite with real-time security tools, improved site performance, and tools to grow your business.{{br/}}{{br/}}',
+			{
+				components: {
+					ul: <ul />,
+					li: <li />,
+					br: <br />,
+				},
+				comment:
+					'{{ul}}{{ul/}} represents an unorder list, {{li}}{/li} represent an item and {{br/}} represents a line break',
+			}
 		),
 	getLightboxDescription: () =>
 		translate(


### PR DESCRIPTION
Text updates on the pricing page to better promote the individual plugins.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

- Changing titles of the sections and Security blurb on the pricing page
- You can find more info on **pbNhbs-5o6-p2**

**Changes:**
 - **Bundle section – title:**
     - Most popular bundles -> Bundle and save
 - **Bundle section – blurbs:**
     - Removing blurbs and mentioning standalone plugins
 - **Individual plugin section – title:**
     - All products -> Products with individual plugin



## Testing Instructions

- Patch the changes
- Check if there is a typo
- If everything looks good, we can deploy the changes.

**Before**
<img width="1437" alt="Screen Shot 2023-02-15 at 14 55 11" src="https://user-images.githubusercontent.com/82706809/218966490-78c3da19-08b3-4ef0-8701-4b99edbb204b.png">

**After**
<img width="1440" alt="Screen Shot 2023-02-15 at 14 55 43" src="https://user-images.githubusercontent.com/82706809/218966587-59c9c94f-4cc1-461b-82dd-62484983fa69.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?