### PR TITLE
Add second upsell nudge to themes page

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -7,7 +7,7 @@ import { Icon, addTemplate, brush, cloudUpload } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { isEmpty, times } from 'lodash';
 import PropTypes from 'prop-types';
-import { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { connect, useSelector } from 'react-redux';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
 import Theme from 'calypso/components/theme';
@@ -82,15 +82,21 @@ export const ThemesList = ( props ) => {
 		);
 	}
 
+	const SecondUpsellNudge = props.upsellBanner && (
+		<div className="second-upsell-wrapper">
+			{ React.cloneElement( props.upsellBanner, {
+				event: `${ props.upsellBanner.props.event }_second_upsell_nudge`,
+			} ) }
+		</div>
+	);
+
 	return (
 		<div className="themes-list">
 			{ props.themes.map( ( theme, index ) => (
 				<ThemeBlock key={ 'theme-block' + index } theme={ theme } index={ index } { ...props } />
 			) ) }
 			{ /* Add a second plan upsell at 7th row and the behavior is controlled by CSS */ }
-			{ props.themes.length > 0 && (
-				<div className="second-upsell-wrapper">{ props.upsellBanner }</div>
-			) }
+			{ props.themes.length > 0 && SecondUpsellNudge }
 			{ /* The Pattern Assembler CTA will display on the 9th row and the behavior is controlled by CSS */ }
 			{ isPatternAssemblerCTAEnabled && props.themes.length > 0 && (
 				<PatternAssemblerCta onButtonClick={ goToSiteAssemblerFlow } />

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -87,6 +87,10 @@ export const ThemesList = ( props ) => {
 			{ props.themes.map( ( theme, index ) => (
 				<ThemeBlock key={ 'theme-block' + index } theme={ theme } index={ index } { ...props } />
 			) ) }
+			{ /* Add a second plan upsell at 7th row and the behavior is controlled by CSS */ }
+			{ props.themes.length > 0 && (
+				<div className="second-upsell-wrapper">{ props.upsellBanner }</div>
+			) }
 			{ /* The Pattern Assembler CTA will display on the 9th row and the behavior is controlled by CSS */ }
 			{ isPatternAssemblerCTAEnabled && props.themes.length > 0 && (
 				<PatternAssemblerCta onButtonClick={ goToSiteAssemblerFlow } />

--- a/client/components/themes-list/style.scss
+++ b/client/components/themes-list/style.scss
@@ -27,6 +27,7 @@
 	.second-upsell-wrapper {
 		grid-column: 1/-1;
 		grid-row-start: 7;
+		padding: 0 16px;
 
 		.upsell-nudge {
 			margin-top: 0;

--- a/client/components/themes-list/style.scss
+++ b/client/components/themes-list/style.scss
@@ -23,6 +23,16 @@
 		box-shadow: 0 0 0 1px var(--color-border-subtle);
 		margin: 0 16px 48px;
 	}
+
+	.second-upsell-wrapper {
+		grid-column: 1/-1;
+		grid-row-start: 7;
+
+		.upsell-nudge {
+			margin-top: 0;
+			margin-bottom: 2rem;
+		}
+	}
 }
 
 .themes-list__empty-search-text {

--- a/client/components/themes-list/style.scss
+++ b/client/components/themes-list/style.scss
@@ -30,8 +30,8 @@
 		padding: 0 16px;
 
 		.upsell-nudge {
-			margin-top: 0;
-			margin-bottom: 2rem;
+			margin-top: 0 !important;
+			margin-bottom: 2rem !important;
 		}
 	}
 }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -435,6 +435,7 @@ class ThemeShowcase extends Component {
 			vertical: this.props.vertical,
 			siteId: this.props.siteId,
 			upsellUrl: this.props.upsellUrl,
+			upsellBanner: this.props.upsellBanner,
 			search: search,
 			tier: this.props.tier,
 			defaultOption: this.props.defaultOption,

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -225,7 +225,7 @@ class ThemesSelection extends Component {
 	};
 
 	render() {
-		const { source, query, upsellUrl, siteId } = this.props;
+		const { source, query, upsellUrl, upsellBanner, siteId } = this.props;
 
 		const themes = this.props.customizedThemesList || this.props.themes;
 
@@ -237,6 +237,7 @@ class ThemesSelection extends Component {
 				) }
 				<ThemesList
 					upsellUrl={ upsellUrl }
+					upsellBanner={ upsellBanner }
 					themes={ themes }
 					wpOrgThemes={ this.props.wpOrgThemes }
 					fetchNextPage={ this.fetchNextPage }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73110 

## Proposed Changes

https://user-images.githubusercontent.com/6586048/218977555-dd64d30d-4710-469e-afdc-f74e18f0ed9e.mp4

* Add second upsell nudge to /themes

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /themes/:site
* Check tracks event for suffix `_second_upsell_nudge`
* Test for all screen sizes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
