### PR TITLE
Tooltip alignment polishing for the 2023 plan grid.

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -26,7 +26,7 @@ import formatCurrency from '@automattic/format-currency';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
-import { localize, LocalizeProps } from 'i18n-calypso';
+import { localize, LocalizeProps, TranslateResult } from 'i18n-calypso';
 import { last } from 'lodash';
 import page from 'page';
 import { Component, createRef } from 'react';
@@ -153,6 +153,20 @@ type PlanFeatures2023GridType = PlanFeatures2023GridProps &
 type PlanFeatures2023GridState = {
 	showPlansComparisonGrid: boolean;
 };
+
+type ServiceLogoProps = {
+	imgSrc: string;
+	imgAlt: string;
+	hoverText: TranslateResult;
+};
+
+const ServiceLogo = ( props: ServiceLogoProps ) => (
+	<div className="plan-features-2023-grid__plan-logo">
+		<Plans2023Tooltip text={ props.hoverText }>
+			<img src={ props.imgSrc } alt={ props.imgAlt } />{ ' ' }
+		</Plans2023Tooltip>
+	</div>
+);
 
 export class PlanFeatures2023Grid extends Component<
 	PlanFeatures2023GridType,
@@ -477,35 +491,29 @@ export class PlanFeatures2023Grid extends Component<
 					) }
 					<header className={ headerClasses }>
 						{ isBusinessPlan( planName ) && (
-							<Plans2023Tooltip
-								text={ translate(
+							<ServiceLogo
+								hoverText={ translate(
 									'WP Cloud gives you the tools you need to add scalable, highly available, extremely fast WordPress hosting.'
 								) }
-							>
-								<div className="plan-features-2023-grid__plan-logo">
-									<img src={ cloudLogo } alt="WP Cloud logo" />{ ' ' }
-								</div>
-							</Plans2023Tooltip>
+								imgSrc={ cloudLogo }
+								imgAlt="WP Cloud logo"
+							/>
 						) }
 						{ isEcommercePlan( planName ) && (
-							<Plans2023Tooltip
-								text={ translate(
+							<ServiceLogo
+								hoverText={ translate(
 									'Make your online store a reality with the power of WooCommerce.'
 								) }
-							>
-								<div className="plan-features-2023-grid__plan-logo">
-									<img src={ wooLogo } alt="WooCommerce logo" />{ ' ' }
-								</div>
-							</Plans2023Tooltip>
+								imgSrc={ wooLogo }
+								imgAlt="WooCommerce logo"
+							/>
 						) }
 						{ isWpcomEnterpriseGridPlan( planName ) && (
-							<Plans2023Tooltip
-								text={ translate( 'The trusted choice for enterprise WordPress hosting.' ) }
-							>
-								<div className="plan-features-2023-grid__plan-logo">
-									<img src={ vipLogo } alt="WPVIP logo" />{ ' ' }
-								</div>
-							</Plans2023Tooltip>
+							<ServiceLogo
+								hoverText={ translate( 'The trusted choice for enterprise WordPress hosting.' ) }
+								imgSrc={ vipLogo }
+								imgAlt="WPVIP logo"
+							/>
 						) }
 					</header>
 				</Container>

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -609,10 +609,17 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 											<Plans2023Tooltip text={ feature.getDescription?.() }>
 												{ feature.getTitle() }
 											</Plans2023Tooltip>
-											{ allJetpackFeatures.has( feature.getSlug() ) ? (
-												<JetpackIconContainer>
-													<JetpackLogo size={ 16 } />
-												</JetpackIconContainer>
+											{ allJetpackFeatures.has( feature.getSlug() ) ? ( // TODO: this shouldn't take a linear search.
+												<Plans2023Tooltip
+													text={ translate(
+														// TODO: extract the Jetpack logo + its tooltip out as a shared component with the plan info grid.
+														'Security, performance and growth tools made by the WordPress experts.'
+													) }
+												>
+													<JetpackIconContainer>
+														<JetpackLogo size={ 16 } />
+													</JetpackIconContainer>
+												</Plans2023Tooltip>
 											) : null }
 										</RowHead>
 										{ ( visiblePlansProperties ?? [] ).map( ( { planName } ) => {

--- a/client/my-sites/plan-features-2023-grid/plans-2023-tooltip.tsx
+++ b/client/my-sites/plan-features-2023-grid/plans-2023-tooltip.tsx
@@ -17,6 +17,7 @@ const StyledTooltip = styled( Tooltip )`
 		font-weight: 400;
 		font-size: 1em;
 		padding: 8px 10px;
+		top: -8px;
 	}
 `;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1485

## Proposed Changes

This PR addresses the calypso part of tooltip alignment issue reported in Automattic/martech#1485 by @lucasmendes-design 

First, the space between the hovered item and the tooltip should be updated to 8px. Currently it is simply using the default `top: -10px` defined here: https://github.com/Automattic/wp-calypso/blob/trunk/packages/components/src/popover/style.scss#L113. Thie PR overrides it into 8px. I don't know how to capture a screenshot and mark the pixel distance for this, so tips are welcome :) 

Second, the tooltip is not centerly-aligned to the logo. It is due to that the hovering element is the encapsulated `div` instead of the logo image itself. This PR rearranges the nesting and extracts that as `<ServiceLogo>` component to fix the issue:

Before:
<img width="369" alt="image" src="https://user-images.githubusercontent.com/1842898/218987338-648a4add-a86c-4c61-a404-314001407a76.png">

After:
<img width="322" alt="image" src="https://user-images.githubusercontent.com/1842898/218986991-3726bcb1-4fcb-4dec-94b0-81c71b48752c.png">

## Testing Instructions

1. Go to /start/plans and confirm the above changes hold true and not breaking anything else.
2. Do the same to /plans while logged-in.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
