### PR TITLE
Jetpack Pro Dashboard: fix an issue that makes the tooltip remain on the screen when turning on/off Downtime Monitoring

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -141,8 +141,11 @@ export default function ToggleActivateMonitoring( {
 		<>
 			<span
 				ref={ statusContentRef }
+				role="button"
+				tabIndex={ 0 }
 				onMouseEnter={ handleShowTooltip }
 				onMouseLeave={ handleHideTooltip }
+				onMouseDown={ handleHideTooltip }
 				className={ classNames( 'toggle-activate-monitoring__toggle-button', {
 					[ 'sites-overview__disabled' ]: siteError,
 				} ) }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@automattic/components';
 import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
-import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { ReactChild, useState, useRef } from 'react';
 import { useSelector } from 'react-redux';
@@ -137,6 +136,23 @@ export default function ToggleActivateMonitoring( {
 		);
 	};
 
+	const toggleContent = (
+		<ToggleControl
+			onChange={ handleToggleActivateMonitoring }
+			checked={ isChecked }
+			disabled={ isLoading || siteError }
+			label={ isChecked && currentSettings() }
+		/>
+	);
+
+	if ( siteError ) {
+		return (
+			<span className="toggle-activate-monitoring__toggle-button sites-overview__disabled">
+				{ toggleContent }
+			</span>
+		);
+	}
+
 	return (
 		<>
 			<span
@@ -146,16 +162,9 @@ export default function ToggleActivateMonitoring( {
 				onMouseEnter={ handleShowTooltip }
 				onMouseLeave={ handleHideTooltip }
 				onMouseDown={ handleHideTooltip }
-				className={ classNames( 'toggle-activate-monitoring__toggle-button', {
-					[ 'sites-overview__disabled' ]: siteError,
-				} ) }
+				className="toggle-activate-monitoring__toggle-button"
 			>
-				<ToggleControl
-					onChange={ handleToggleActivateMonitoring }
-					checked={ isChecked }
-					disabled={ isLoading || siteError }
-					label={ isChecked && currentSettings() }
-				/>
+				{ toggleContent }
 			</span>
 			{ showNotificationSettings && (
 				<NotificationSettings

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -255,8 +255,11 @@ export default function SiteStatusContent( {
 				<>
 					<span
 						ref={ statusContentRef }
+						role="button"
+						tabIndex={ 0 }
 						onMouseEnter={ handleShowTooltip }
 						onMouseLeave={ handleHideTooltip }
+						onMouseDown={ handleHideTooltip }
 						className="sites-overview__row-status"
 					>
 						{ updatedContent }


### PR DESCRIPTION
#### Proposed Changes

This PR fixes an issue that makes the tooltip remain on the screen when turning on/off Downtime Monitoring

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/downtime-monitor-tooltip-hide-on-mouse-leave` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Hover over the monitor column of any site and verify that the tooltip is shown and is hidden when the cursor is moved outside the monitor column. 
4. Enable/Disable monitor and verify that the tooltip is not shown until the cursor is moved on the monitor column again.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>

https://user-images.githubusercontent.com/10586875/218997618-fd46cf54-c101-445d-b124-df21b10ba48e.mov


</td>
<td>

https://user-images.githubusercontent.com/10586875/218997691-e62676ca-d69c-4cf5-944f-c5035f5f0b5b.mov


</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related to 1202619025189113-as-1203783994388586