### PR TITLE
Fix: Handle the mobile style of the pricing-plans block

### DIFF
--- a/apps/happy-blocks/src/pricing-plans/view.scss
+++ b/apps/happy-blocks/src/pricing-plans/view.scss
@@ -163,7 +163,6 @@ $brand-display: "SF Pro Display", $sans;
 			font-family: $brand-text;
 			font-weight: 400;
 			font-size: 0.875rem;
-			line-height: 1.33;
 			align-items: center;
 			letter-spacing: -0.24px;
 			color: $studio-gray-80;
@@ -180,11 +179,13 @@ $brand-display: "SF Pro Display", $sans;
 
 			p {
 				margin: 0;
-				line-height: 1.57;
+				line-height: 1.33;
 			}
 
 			@include break-medium {
-				line-height: 1.57;
+				p {
+					line-height: 1.57;
+				}
 			}
 		}
 	}

--- a/apps/happy-blocks/src/pricing-plans/view.scss
+++ b/apps/happy-blocks/src/pricing-plans/view.scss
@@ -1,6 +1,8 @@
 @import "~@automattic/typography/styles/variables";
 @import "~@automattic/color-studio/dist/color-variables";
 @import "~@wordpress/base-styles/colors";
+@import "~@wordpress/base-styles/breakpoints";
+@import "~@wordpress/base-styles/mixins";
 
 $brand-text: "SF Pro Text", $sans;
 $brand-display: "SF Pro Display", $sans;
@@ -120,7 +122,12 @@ $brand-display: "SF Pro Display", $sans;
 
 	&__tab {
 		display: flex;
+		flex-direction: column;
 		gap: 24px;
+
+		@include break-medium {
+			flex-direction: row;
+		}
 	}
 
 	&__header {
@@ -142,7 +149,6 @@ $brand-display: "SF Pro Display", $sans;
 			font-size: 0.75rem;
 			line-height: 1.66;
 			color: $studio-gray-60;
-			margin-bottom: 8px;
 		}
 
 		&-learn-more {
@@ -157,10 +163,11 @@ $brand-display: "SF Pro Display", $sans;
 			font-family: $brand-text;
 			font-weight: 400;
 			font-size: 0.875rem;
-			line-height: 1.57;
+			line-height: 1.33;
 			align-items: center;
 			letter-spacing: -0.24px;
 			color: $studio-gray-80;
+			margin-top: 8px;
 
 			p:first-of-type {
 				overflow: hidden;
@@ -173,6 +180,10 @@ $brand-display: "SF Pro Display", $sans;
 
 			p {
 				margin: 0;
+				line-height: 1.57;
+			}
+
+			@include break-medium {
 				line-height: 1.57;
 			}
 		}


### PR DESCRIPTION
## Proposed Changes

* To address the mobile style of the pricing-plans block (related issue: 272-gh-Automattic/lighthouse-forums)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply this PR
2. `cd apps/happy-blocks && yarn dev --sync`
3. Go to the a topic page with the pricing-plans block, and you will see the following fixes:

<img width="354" alt="mobile" src="https://user-images.githubusercontent.com/21308003/218999324-2cb9da7d-b22d-4166-b800-f4e86d55e210.png">

4. On the desktop the style of the block should work great:

<img width="677" alt="desktop" src="https://user-images.githubusercontent.com/21308003/218999457-fe12583a-1a69-4c9d-a50b-1a6f63b3f758.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
