### PR TITLE
Use centralised formatCurrency() function for ecommerce trial plans

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -5,7 +5,7 @@ import {
 	PLAN_ECOMMERCE_MONTHLY,
 } from '@automattic/calypso-products';
 import { Button, Card } from '@automattic/components';
-import { getCurrencyObject } from '@automattic/format-currency';
+import { formatCurrency } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useCallback, useMemo } from 'react';
@@ -40,8 +40,6 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 		currencyCode: getPlan( state, eCommercePlanAnnual.getProductId() )?.currency_code || '',
 	} ) );
 
-	const { symbol: currencySymbol } = getCurrencyObject( 0, eCommercePlanPrices.currencyCode );
-
 	const isAnnualSubscription = interval === 'yearly';
 	const targetECommercePlan = isAnnualSubscription ? eCommercePlanAnnual : eCommercePlanMonthly;
 
@@ -61,35 +59,42 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 
 	const monthlyPriceWrapper = <span className="e-commerce-trial-plans__price-card-value" />;
 	const priceDescription = <span className="e-commerce-trial-plans__price-card-interval" />;
-	const currencyWrapper = <span className="e-commerce-trial-plans__price-card-value-symbol" />;
 
 	const priceContent = isAnnualSubscription
 		? translate(
-				'{{monthlyPriceWrapper}}{{currencyWrapper}}%(currency)s{{/currencyWrapper}}%(monthlyPrice)s{{/monthlyPriceWrapper}} {{priceDescription}}per month, %(currency)s%(annualPrice)s billed annually{{/priceDescription}}',
+				'{{monthlyPriceWrapper}}%(monthlyPrice)s{{/monthlyPriceWrapper}} {{priceDescription}}per month, %(annualPrice)s billed annually{{/priceDescription}}',
 				{
 					args: {
-						currency: currencySymbol,
-						monthlyPrice: eCommercePlanPrices.annualPlanMonthlyPrice,
-						annualPrice: eCommercePlanPrices.annualPlanPrice,
+						monthlyPrice: formatCurrency(
+							eCommercePlanPrices.annualPlanMonthlyPrice,
+							eCommercePlanPrices.currencyCode,
+							{ stripZeros: true }
+						),
+						annualPrice: formatCurrency(
+							eCommercePlanPrices.annualPlanPrice,
+							eCommercePlanPrices.currencyCode,
+							{ stripZeros: true }
+						),
 					},
 					components: {
 						monthlyPriceWrapper,
 						priceDescription,
-						currencyWrapper,
 					},
 				}
 		  )
 		: translate(
-				'{{monthlyPriceWrapper}}{{currencyWrapper}}%(currency)s{{/currencyWrapper}}%(monthlyPrice)s{{/monthlyPriceWrapper}} {{priceDescription}}per month{{/priceDescription}}',
+				'{{monthlyPriceWrapper}}%(monthlyPrice)s{{/monthlyPriceWrapper}} {{priceDescription}}per month{{/priceDescription}}',
 				{
 					args: {
-						currency: currencySymbol,
-						monthlyPrice: eCommercePlanPrices.monthlyPlanPrice,
+						monthlyPrice: formatCurrency(
+							eCommercePlanPrices.monthlyPlanPrice,
+							eCommercePlanPrices.currencyCode,
+							{ stripZeros: true }
+						),
 					},
 					components: {
 						monthlyPriceWrapper,
 						priceDescription,
-						currencyWrapper,
 					},
 				}
 		  );

--- a/client/my-sites/plans/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/style.scss
@@ -66,8 +66,6 @@ body.is-section-plans.is-ecommerce-trial-plan {
 			width: 100%;
 
 			.e-commerce-trial-plans__price-card-cta {
-				width: 135px;
-
 				@media (max-width: $break-mobile) {
 					width: 100%;
 					margin-top: 25px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71387, #73223

## Proposed Changes

* This change updates the recently added eCommerce trial plans page to use the general-purpose `formatCurrency()` function to format prices in a locale-aware fashion - we were previously using the `getCurrencyObject()` function to find the currency symbol, but were manually setting up the currency location and symbol
* I also removed a `width` restriction on a button as that was going to cause trouble for some languages

At an implementation level, this _should_ ensure that we use `US$` as a prefix for USD in various cases, but I think there are cases where that is not the case, which I flagged on the original PR [here](https://github.com/Automattic/wp-calypso/pull/71387#issuecomment-1431105505).

Given that I am still seeing `$` for `USD` with my locale set to `en`, I am not sure this is a full fix for the original issue, but it does mean we will handle other currencies and locales correctly even if we're not handling USD as I think we should.

## Testing Instructions

There should be no functional change except when you have a currency and language/locale pairing that would switch the display order.
You can test this as follows:
* Run this branch locally or via the calypso.live branch
* Update your WordPress.com language to Italian (or another European language that defaults to showing the Euro symbol _after_ the value(
* Update your preferred currency to `EUR` via SA
* Navigate to _Upgrades_ -> _Plans_ for a site on the free eCommerce trial
* Verify that the price has the Euro symbol after the currency
* Verify that the CTA button doesn't wrap

## Screenshots

### Before

<img width="1056" alt="Screenshot 2023-02-15 at 13 04 46" src="https://user-images.githubusercontent.com/3376401/219011475-11d88673-8869-4d10-b6a6-4bcc4bce00db.png">

### After

<img width="1056" alt="Screenshot 2023-02-15 at 13 03 22" src="https://user-images.githubusercontent.com/3376401/219011358-bcc02e05-47eb-41f2-97c0-b1c8ac385d66.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [N/A] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?