### PR TITLE
launchpad atomic launch bandaid.

### DIFF
--- a/client/landing/stepper/declarative-flow/build.ts
+++ b/client/landing/stepper/declarative-flow/build.ts
@@ -47,7 +47,7 @@ const build: Flow = {
 				case 'processing':
 					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
 						return window.location.replace(
-							`/home/${ providedDependencies?.siteSlug }?celebrateLaunch=true`
+							`/home/${ providedDependencies?.siteSlug }?celebrateLaunch=true&launchpadComplete=true`
 						);
 					}
 

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -82,7 +82,7 @@ const free: Flow = {
 				case 'processing':
 					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
 						return window.location.replace(
-							`/home/${ providedDependencies?.siteSlug }?celebrateLaunch=true`
+							`/home/${ providedDependencies?.siteSlug }?celebrateLaunch=true&launchpadComplete=true`
 						);
 					}
 

--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -101,7 +101,7 @@ const linkInBio: Flow = {
 				case 'processing':
 					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
 						return window.location.replace(
-							`/home/${ providedDependencies?.siteSlug }?celebrateLaunch=true`
+							`/home/${ providedDependencies?.siteSlug }?celebrateLaunch=true&launchpadComplete=true`
 						);
 					}
 					if ( providedDependencies?.goToCheckout ) {

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -105,7 +105,7 @@ const linkInBio: Flow = {
 				case 'processing':
 					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
 						return window.location.replace(
-							`/home/${ providedDependencies?.siteSlug }?celebrateLaunch=true`
+							`/home/${ providedDependencies?.siteSlug }?celebrateLaunch=true&launchpadComplete=true`
 						);
 					}
 

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -53,7 +53,7 @@ const write: Flow = {
 				case 'processing':
 					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
 						return window.location.replace(
-							`/home/${ providedDependencies?.siteSlug }?celebrateLaunch=true`
+							`/home/${ providedDependencies?.siteSlug }?celebrateLaunch=true&launchpadComplete=true`
 						);
 					}
 

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -54,7 +54,11 @@ export async function maybeRedirect( context, next ) {
 	}
 
 	const refetchedOptions = getSiteOptions( context.store.getState(), siteId );
-	const shouldRedirectToLaunchpad = refetchedOptions?.launchpad_screen === 'full';
+	const shouldRedirectToLaunchpad =
+		refetchedOptions?.launchpad_screen === 'full' &&
+		// Temporary hack/band-aid to resolve a stale issue with atomic that the requestSite
+		// dispatch above doesnt always seem to resolve.
+		! currentUrl?.includes( 'launchpadComplete=true' );
 
 	if ( shouldRedirectToLaunchpad ) {
 		// The new stepper launchpad onboarding flow isn't registered within the "page"


### PR DESCRIPTION
Currently our refetch of `requestSite` in the my home controller to get updated launchpad data is not consistently solving its intended purpose for atomic sites. (Updating the launchpad settings so that my home does not redirect back to launchpad immediately after launching from launchpad and directing into my home).

This is a naieve bandaid aimed to solve the initial bug of that flow, but we need to follow up on this with a better approach soon.



Related to #

## Proposed Changes

* a query arg as a temporary bandaid to limit unintentional launchpad redirects on atomic that can happen in a brief state of stale data cache.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* create a launcpad site
* upgrade to business, install a plugin like 'hello dolly', and wait for transfer
* after transfering, return to launchpad (on this branch) and launch the site. ensure we are not immediately redirected back to the launchpad.


![launchpad-atomic-launch](https://user-images.githubusercontent.com/28742426/219037474-d8171ec1-158e-49ed-a989-9821c86dc2ff.gif)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
