### PR TITLE
Hosting Config: Switch headings and buttons to sentence case

### DIFF
--- a/client/my-sites/hosting/github/github-connect-card/index.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/index.tsx
@@ -16,7 +16,7 @@ export const GithubConnectCard = ( { connection }: GithubConnectCardProps ) => {
 	return (
 		<Card className="github-hosting-card">
 			<img className="github-hosting-icon" src={ iconGitHub } alt="" />
-			<CardHeading>{ __( 'Connect Branch' ) }</CardHeading>
+			<CardHeading>{ __( 'Connect branch' ) }</CardHeading>
 			<DisconnectGitHubExpander connection={ connection } />
 		</Card>
 	);

--- a/client/my-sites/hosting/phpmyadmin-card/index.js
+++ b/client/my-sites/hosting/phpmyadmin-card/index.js
@@ -59,7 +59,7 @@ export default function PhpMyAdminCard( { disabled } ) {
 	return (
 		<Card className="phpmyadmin-card">
 			<MaterialIcon icon="dns" size={ 32 } />
-			<CardHeading id="database-access">{ translate( 'Database Access' ) }</CardHeading>
+			<CardHeading id="database-access">{ translate( 'Database access' ) }</CardHeading>
 			<p>
 				{ translate(
 					'For the tech-savvy, manage your database with phpMyAdmin and run a wide range of operations with MySQL.'

--- a/client/my-sites/hosting/restore-plan-software-card/index.js
+++ b/client/my-sites/hosting/restore-plan-software-card/index.js
@@ -37,14 +37,14 @@ export default function RestorePlanSoftwareCard() {
 	return (
 		<Card className="restore-plan-software-card">
 			<MaterialIcon icon="apps" />
-			<CardHeading>{ translate( 'Restore Plugins and Themes' ) }</CardHeading>
+			<CardHeading>{ translate( 'Restore plugins and themes' ) }</CardHeading>
 			<p>
 				{ translate(
 					'If your website is missing plugins and themes that come with your plan, you may restore them here.'
 				) }
 			</p>
 			<Button primary onClick={ requestRestore }>
-				{ translate( "Restore Plugins and Themes for My Website's Plan" ) }
+				{ translate( "Restore plugins and themes for my website's plan" ) }
 			</Button>
 		</Card>
 	);

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -313,7 +313,7 @@ export const SftpCard = ( {
 					<FormLabel htmlFor="password">{ translate( 'Password' ) }</FormLabel>
 					{ renderPasswordField() }
 					{ siteHasSshFeature && (
-						<SftpSshLabel htmlFor="ssh">{ translate( 'SSH Access' ) }</SftpSshLabel>
+						<SftpSshLabel htmlFor="ssh">{ translate( 'SSH access' ) }</SftpSshLabel>
 					) }
 					{ siteHasSshFeature && renderSshField() }
 					<ReauthRequired twoStepAuthorization={ twoStepAuthorization }>

--- a/client/my-sites/hosting/sftp-card/ssh-keys.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-keys.tsx
@@ -91,7 +91,7 @@ function SshKeys( { siteId, siteSlug, username, disabled }: SshKeysProps ) {
 	return (
 		<div className="ssh-keys">
 			<label htmlFor="attach-ssh-key" className="form-label">
-				{ __( 'SSH Keys' ) }
+				{ __( 'SSH keys' ) }
 			</label>
 
 			{ keys?.map( ( sshKey ) => (

--- a/client/my-sites/hosting/web-server-logs-card/index.js
+++ b/client/my-sites/hosting/web-server-logs-card/index.js
@@ -246,7 +246,7 @@ const WebServerLogsCard = ( props ) => {
 				<div className="web-server-logs-card__dates">
 					<div className="web-server-logs-card__start">
 						<FormFieldset>
-							<FormLabel>{ translate( 'Log Start:' ) }</FormLabel>
+							<FormLabel>{ translate( 'Log start:' ) }</FormLabel>
 							<FormTextInput
 								value={ startDateTime }
 								onChange={ updateStartDateTime }
@@ -261,7 +261,7 @@ const WebServerLogsCard = ( props ) => {
 					</div>
 					<div className="web-server-logs-card__end">
 						<FormFieldset>
-							<FormLabel>{ translate( 'Log End:' ) }</FormLabel>
+							<FormLabel>{ translate( 'Log end:' ) }</FormLabel>
 							<FormTextInput
 								value={ endDateTime }
 								onChange={ updateEndDateTime }
@@ -299,7 +299,7 @@ const WebServerLogsCard = ( props ) => {
 	return (
 		<Card className="web-server-logs-card">
 			<MaterialIcon icon="settings" size={ 32 } />
-			<CardHeading>{ translate( 'Download Web Server Logs' ) }</CardHeading>
+			<CardHeading>{ translate( 'Download web server logs' ) }</CardHeading>
 			{ getContent() }
 		</Card>
 	);

--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -130,7 +130,7 @@ const WebServerSettingsCard = ( {
 
 		return (
 			<FormFieldset>
-				<FormLabel>{ translate( 'PHP Version' ) }</FormLabel>
+				<FormLabel>{ translate( 'PHP version' ) }</FormLabel>
 				<FormSelect
 					disabled={ disabled || isUpdatingPhpVersion }
 					className="web-server-settings-card__php-version-select"
@@ -161,7 +161,7 @@ const WebServerSettingsCard = ( {
 						busy={ isUpdatingPhpVersion }
 						disabled={ isUpdatingPhpVersion }
 					>
-						<span>{ translate( 'Update PHP Version' ) }</span>
+						<span>{ translate( 'Update PHP version' ) }</span>
 					</Button>
 				) }
 			</FormFieldset>
@@ -210,7 +210,7 @@ const WebServerSettingsCard = ( {
 		return (
 			<FormFieldset>
 				<FormLabel htmlFor="staticFile404Select">
-					{ translate( 'Handling Requests for Nonexistent Assets', {
+					{ translate( 'Handling requests for nonexistent assets', {
 						comment:
 							'How the web server handles requests for nonexistent asset files. ' +
 							'For example, file types like JavaScript, CSS, and images are considered assets.',
@@ -267,7 +267,7 @@ const WebServerSettingsCard = ( {
 			<QuerySitePhpVersion siteId={ siteId } />
 			<QuerySiteStaticFile404 siteId={ siteId } />
 			<MaterialIcon icon="build" size={ 32 } />
-			<CardHeading id="web-server-settings">{ translate( 'Web Server Settings' ) }</CardHeading>
+			<CardHeading id="web-server-settings">{ translate( 'Web server settings' ) }</CardHeading>
 			<p>
 				{ translate(
 					'For sites with specialized needs, fine-tune how the web server runs your website.'


### PR DESCRIPTION
See p1676381941241629-slack-C9EJ7KSGH

## Proposed Changes

Switches a variety of headings and buttons to sentence case.

### Before

<img width="787" alt="image" src="https://user-images.githubusercontent.com/36432/219052374-08974f4d-16c3-45ff-946a-2a5ed79a6147.png">

### After

<img width="824" alt="image" src="https://user-images.githubusercontent.com/36432/219052002-6d546fed-af75-43b0-b0ce-d6a1dca74724.png">

## Testing Instructions

1. Navigate to `/hosting-config`.
2. Verify headings and labels are sentence case instead of title case.