### PR TITLE
WooExpress: Trial flow checks that WooCommerce is installed before completing

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -55,11 +55,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 
 	const username = useSelector( ( state ) => getCurrentUserName( state ) );
 
-	const { setPendingAction, setPluginsToVerify } = useDispatch( ONBOARD_STORE );
-
-	if ( isWooExpressFlow( flow ) ) {
-		setPluginsToVerify( [ 'woocommerce' ] );
-	}
+	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
 	let theme: string;
 	if ( isMigrationFlow( flow ) || isCopySiteFlow( flow ) ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -55,7 +55,11 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 
 	const username = useSelector( ( state ) => getCurrentUserName( state ) );
 
-	const { setPendingAction } = useDispatch( ONBOARD_STORE );
+	const { setPendingAction, setPluginsToVerify } = useDispatch( ONBOARD_STORE );
+
+	if ( isWooExpressFlow( flow ) ) {
+		setPluginsToVerify( [ 'woocommerce' ] );
+	}
 
 	let theme: string;
 	if ( isMigrationFlow( flow ) || isCopySiteFlow( flow ) ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-atomic/index.tsx
@@ -120,6 +120,7 @@ const WaitForAtomic: Step = function WaitForAtomic( { navigation, data } ) {
 
 		submit?.();
 
+		// Only trigger when the siteId changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ siteId ] );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
@@ -1,0 +1,120 @@
+import config from '@automattic/calypso-config';
+import { isWooExpressFlow } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+import wpcomRequest from 'wpcom-proxy-request';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { logToLogstash } from 'calypso/lib/logstash';
+import { ONBOARD_STORE } from '../../../../stores';
+import type { Step } from '../../types';
+
+export interface Plugin {
+	slug: string;
+}
+
+export interface PluginsResponse {
+	plugins: Plugin[];
+}
+
+export interface FailureInfo {
+	type: string;
+	code: number | string;
+	error: string;
+}
+
+export const installedStates = {
+	PENDING: 'pending',
+	INSTALLED: 'installed',
+	ERROR: 'error',
+} as const;
+
+const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
+
+const WaitForPluginInstall: Step = function WaitForAtomic( { navigation, data, flow } ) {
+	const { submit } = navigation;
+	const { setPendingAction } = useDispatch( ONBOARD_STORE );
+
+	const siteId = data?.siteId;
+	const siteSlug = data?.siteSlug;
+
+	const handlePluginCheckFailure = ( failureInfo: FailureInfo ) => {
+		recordTracksEvent( 'calypso_stepper_plugin_check_error', {
+			action: failureInfo.type,
+			site: siteId,
+			code: failureInfo.code,
+			error: failureInfo.error,
+		} );
+
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: failureInfo.error,
+			severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+			blog_id: siteId,
+			properties: {
+				env: config( 'env_id' ),
+				type: 'calypso_stepper_plugin_check_error',
+				action: failureInfo.type,
+				site: siteId,
+				code: failureInfo.code,
+			},
+		} );
+	};
+
+	useEffect( () => {
+		if ( ! siteId || ! siteSlug ) {
+			return;
+		}
+
+		setPendingAction( async () => {
+			const startTime = new Date().getTime();
+			const totalTimeout = 1000 * 300;
+			const maxFinishTime = startTime + totalTimeout;
+
+			// Poll for transfer status
+			let stopPollingPlugins = false;
+
+			while ( ! stopPollingPlugins ) {
+				await wait( 3000 );
+
+				try {
+					const response: PluginsResponse = await wpcomRequest( {
+						path: `/sites/${ siteId }/plugins`,
+						apiVersion: '1.1',
+					} );
+
+					// For WooExpress, we need to check for the WooCommerce plugin.
+					if ( response?.plugins && isWooExpressFlow( flow ) ) {
+						const woocommercePlugin = response?.plugins.find(
+							( plugin: { slug: string } ) => plugin.slug === 'woocommerce'
+						);
+
+						if ( woocommercePlugin ) {
+							stopPollingPlugins = true;
+						}
+					}
+				} catch ( err ) {
+					// Ignore errors. It's normal to get errors the first couple of times we poll. The timeout will eventually catch it if the failures continue.
+				}
+
+				if ( maxFinishTime < new Date().getTime() ) {
+					handlePluginCheckFailure( {
+						type: 'plugin_check_timeout',
+						error: 'plugin check took too long',
+						code: 'plugin_check_timeout',
+					} );
+					throw new Error( 'plugin check timeout' );
+				}
+			}
+
+			return { pluginsInstalled: true, siteSlug, siteId };
+		} );
+
+		submit?.();
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ siteId ] );
+
+	return null;
+};
+
+export default WaitForPluginInstall;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
@@ -71,7 +71,7 @@ const WaitForPluginInstall: Step = function WaitForAtomic( { navigation, data } 
 			const maxFinishTime = startTime + totalTimeout;
 
 			// Poll for transfer status. If there are no plugins to verify, we can skip this step.
-			let stopPollingPlugins = pluginsToVerify && pluginsToVerify.length > 0;
+			let stopPollingPlugins = ! pluginsToVerify || pluginsToVerify.length <= 0;
 
 			while ( ! stopPollingPlugins ) {
 				await wait( 500 );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
@@ -109,7 +109,7 @@ const WaitForPluginInstall: Step = function WaitForAtomic( { navigation, data } 
 		submit?.();
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ siteId ] );
+	}, [ siteId, siteSlug ] );
 
 	return null;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
@@ -74,7 +74,7 @@ const WaitForPluginInstall: Step = function WaitForAtomic( { navigation, data, f
 			let stopPollingPlugins = false;
 
 			while ( ! stopPollingPlugins ) {
-				await wait( 3000 );
+				await wait( 500 );
 
 				try {
 					const response: PluginsResponse = await wpcomRequest( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
@@ -96,7 +96,7 @@ const WaitForPluginInstall: Step = function WaitForAtomic( { navigation, data } 
 				if ( maxFinishTime < new Date().getTime() ) {
 					handlePluginCheckFailure( {
 						type: 'plugin_check_timeout',
-						error: 'plugin check took too long',
+						error: `plugin check took too long (${ totalTimeout / 1000 }s))`,
 						code: 'plugin_check_timeout',
 					} );
 					throw new Error( 'plugin check timeout' );

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -11,6 +11,7 @@ import ErrorStep from './internals/steps-repository/error-step';
 import ProcessingStep, { ProcessingResult } from './internals/steps-repository/processing-step';
 import SiteCreationStep from './internals/steps-repository/site-creation-step';
 import WaitForAtomic from './internals/steps-repository/wait-for-atomic';
+import WaitForPluginInstall from './internals/steps-repository/wait-for-plugin-install';
 import { AssertConditionState } from './internals/types';
 import type { AssertConditionResult, Flow, ProvidedDependencies } from './internals/types';
 
@@ -23,6 +24,7 @@ const wooexpress: Flow = {
 			{ slug: 'processing', component: ProcessingStep },
 			{ slug: 'assignTrialPlan', component: AssignTrialPlanStep },
 			{ slug: 'waitForAtomic', component: WaitForAtomic },
+			{ slug: 'waitForPluginInstall', component: WaitForPluginInstall },
 			{ slug: 'error', component: ErrorStep },
 		];
 	},
@@ -103,6 +105,10 @@ const wooexpress: Flow = {
 					}
 
 					if ( providedDependencies?.finishedWaitingForAtomic ) {
+						return navigate( 'waitForPluginInstall', { siteId, siteSlug } );
+					}
+
+					if ( providedDependencies?.pluginsInstalled ) {
 						return exitFlow( `/home/${ siteSlug }` );
 					}
 
@@ -120,6 +126,10 @@ const wooexpress: Flow = {
 				}
 
 				case 'waitForAtomic': {
+					return navigate( 'processing' );
+				}
+
+				case 'waitForPluginInstall': {
 					return navigate( 'processing' );
 				}
 			}

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -76,7 +76,8 @@ const wooexpress: Flow = {
 		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 		const siteSlugParam = useSiteSlugParam();
 
-		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const { setStepProgress, setPluginsToVerify } = useDispatch( ONBOARD_STORE );
+		setPluginsToVerify( [ 'woocommerce' ] );
 
 		const flowProgress = useSiteSetupFlowProgress( currentStep, intent );
 		setStepProgress( flowProgress );

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -458,6 +458,11 @@ export const setIsMigrateFromWp = ( isMigrateFromWp: boolean ) => ( {
 	isMigrateFromWp,
 } );
 
+export const setPluginsToVerify = ( pluginSlugs: string[] ) => ( {
+	type: 'SET_PLUGIN_SLUGS_TO_VERIFY' as const,
+	pluginSlugs,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -474,6 +479,7 @@ export type OnboardAction = ReturnType<
 	| typeof setIsRedirecting
 	| typeof setLastLocation
 	| typeof setPlanProductId
+	| typeof setPluginsToVerify
 	| typeof setRandomizedDesigns
 	| typeof setSelectedDesign
 	| typeof setSelectedStyleVariation

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -483,6 +483,16 @@ const isMigrateFromWp: Reducer< boolean, OnboardAction > = ( state = false, acti
 	return state;
 };
 
+const pluginsToVerify: Reducer< string[] | undefined, OnboardAction > = ( state, action ) => {
+	if ( action.type === 'SET_PLUGIN_SLUGS_TO_VERIFY' ) {
+		return action.pluginSlugs;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return undefined;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	anchorPodcastId,
 	anchorEpisodeId,
@@ -526,6 +536,7 @@ const reducer = combineReducers( {
 	planCartItem,
 	productCartItems,
 	isMigrateFromWp,
+	pluginsToVerify,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -63,3 +63,4 @@ export const getDomainForm = ( state: State ) => state.domainForm;
 export const getDomainCartItem = ( state: State ) => state.domainCartItem;
 export const getHideFreePlan = ( state: State ) => state.hideFreePlan;
 export const getIsMigrateFromWp = ( state: State ) => state.isMigrateFromWp;
+export const getPluginsToVerify = ( state: State ) => state.pluginsToVerify;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #73307

## Proposed Changes

Previously, we redirected to `/home` as soon as the Atomic transfer was complete. This lead to issues because, sometimes, WooCommerce wasn't finished installed before the redirect so we'd end up on the main dashboard instead of the WooCommerce launch checklist.

This adds a new step where we wait for WooCommerce to finish installing before we redirect.

## Testing Instructions

Prior to applying this patch, visit http://calypso.localhost:3000/setup/wooexpress/. In some cases, you may end up on `/home` instead of `/wp-admin/admin.php?page=wc-admin`. It seems slightly more likely to happen if you're sandboxed but you may have try multiple times to reproduce the behavior.

After applying the patch, you should always end up at `/wp-admin/admin.php?page=wc-admin`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
