### PR TITLE
Stats: Deprecate the "stats/enhance-post-detail" feature flag

### DIFF
--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { PureComponent } from 'react';
@@ -27,8 +26,6 @@ class PostLikes extends PureComponent {
 		const likeUrl = like.site_ID && like.site_visible ? '/read/blogs/' + like.site_ID : null;
 		const LikeWrapper = likeUrl ? 'a' : 'span';
 
-		const isFeatured = config.isEnabled( 'stats/enhance-post-detail' );
-
 		return (
 			<LikeWrapper
 				key={ like.ID }
@@ -36,21 +33,14 @@ class PostLikes extends PureComponent {
 				className="post-likes__item"
 				onClick={ likeUrl ? this.trackLikeClick : null }
 			>
-				<Gravatar
-					user={ like }
-					alt={ like.login }
-					title={ like.login }
-					size={ isFeatured ? 32 : 24 }
-				/>
+				<Gravatar user={ like } alt={ like.login } title={ like.login } size={ 32 } />
 				{ showDisplayNames && <span className="post-likes__display-name">{ like.name }</span> }
 			</LikeWrapper>
 		);
 	};
 
 	renderExtraCount() {
-		const { likes, likeCount, showDisplayNames, translate, numberFormat } = this.props;
-
-		const isFeatured = config.isEnabled( 'stats/enhance-post-detail' );
+		const { likes, likeCount, translate, numberFormat } = this.props;
 
 		if ( ! likes || likeCount <= likes.length ) {
 			return null;
@@ -58,21 +48,9 @@ class PostLikes extends PureComponent {
 
 		const extraCount = likeCount - likes.length;
 
-		let message;
-		if ( showDisplayNames ) {
-			message = translate( '+ %(extraCount)s more', '+ %(extraCount)s more', {
-				count: extraCount,
-				args: { extraCount: numberFormat( extraCount ) },
-			} );
-		} else {
-			message = '+ ' + numberFormat( extraCount );
-		}
-
-		if ( isFeatured ) {
-			message = translate( '%(extraCount)s more', {
-				args: { extraCount: numberFormat( extraCount ) },
-			} );
-		}
+		const message = translate( '%(extraCount)s more', {
+			args: { extraCount: numberFormat( extraCount ) },
+		} );
 
 		return (
 			<span key="placeholder" className="post-likes__count">

--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { Card, PostStatsCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import Count from 'calypso/components/count';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { getPostStat } from 'calypso/state/stats/posts/selectors';
@@ -92,7 +93,7 @@ export default function PostDetailHighlightsSection( {
 					<Card className="highlight-card">
 						<div className="highlight-card-heading">
 							<span>{ translate( 'Post likes' ) }</span>
-							<span className="likes-count">{ post?.like_count || 0 }</span>
+							<Count count={ post?.like_count || 0 } />
 						</div>
 						{ !! postId && (
 							<PostLikes siteId={ siteId } postId={ postId } postType={ post?.type } />

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -97,7 +97,8 @@
 		line-height: 26px;
 	}
 
-	.likes-count {
+	// Overwrite the styles from component Count
+	.count {
 		margin-left: 8px;
 		padding: 4px 8px;
 		background-color: var(--color-neutral-5);
@@ -105,6 +106,7 @@
 		font-weight: 500;
 		font-size: $font-body-extra-small;
 		line-height: 20px;
+		border: 0;
 	}
 
 	.card.stats-post-likes {

--- a/client/my-sites/stats/stats-detail-months/index.jsx
+++ b/client/my-sites/stats/stats-detail-months/index.jsx
@@ -1,5 +1,3 @@
-import config from '@automattic/calypso-config';
-import { Card, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
@@ -7,30 +5,15 @@ import { connect } from 'react-redux';
 import QueryPostStats from 'calypso/components/data/query-post-stats';
 import QueryPosts from 'calypso/components/data/query-posts';
 import { getPostStats, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
-import StatsModuleContent from '../stats-module/content-text';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import toggleInfo from '../toggle-info';
 
 const StatsPostDetailMonths = ( props ) => {
-	const {
-		dataKey,
-		isRequesting,
-		opened,
-		postId,
-		numberFormat,
-		siteId,
-		stats,
-		title,
-		toggle,
-		total,
-		translate,
-	} = props;
+	const { dataKey, isRequesting, postId, numberFormat, siteId, stats, total, translate } = props;
 	const noData = ! stats;
-	const infoIcon = opened ? 'info' : 'info-outline';
 	const isLoading = isRequesting && noData;
 	const classes = {
 		'is-loading': isLoading,
-		'is-showing-info': opened,
 		'has-no-data': noData,
 	};
 
@@ -102,62 +85,16 @@ const StatsPostDetailMonths = ( props ) => {
 		tableBody = <tbody>{ tableRows }</tbody>;
 	}
 
-	const isFeatured = config.isEnabled( 'stats/enhance-post-detail' );
-	const tableWrapperClasses = classNames( {
-		'module-content-table': ! isFeatured,
-	} );
-
 	return (
-		<Card className={ classNames( 'stats-module', 'is-expanded', 'is-post-months', classes ) }>
+		<div className={ classNames( 'is-detail-months', classes ) }>
 			<QueryPostStats siteId={ siteId } postId={ postId } />
 			<QueryPosts siteId={ siteId } postId={ postId } />
-			<div className="module-header">
-				<h4 className="module-header-title">{ title }</h4>
-				<ul className="module-header-actions">
-					<li className="module-header-action toggle-info">
-						{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-						<a
-							href="#"
-							className="module-header-action-link"
-							aria-label={ translate( 'Show or hide panel information', {
-								context: 'Stats panel action',
-							} ) }
-							title={ translate( 'Show or hide panel information', {
-								context: 'Stats panel action',
-							} ) }
-							onClick={ toggle }
-						>
-							{ infoIcon ? <Gridicon icon={ infoIcon } /> : null }
-						</a>
-					</li>
-				</ul>
-			</div>
-			<StatsModuleContent className="module-content-text-info">
-				<p>
-					{ translate(
-						'This table gives you an overview of how many views your post or page has received.',
-						{
-							context: 'Info box description for post stats page in Stats',
-						}
-					) }
-				</p>
-				<span className="legend achievement">
-					{ translate( '%(value)s = The all-time highest value', {
-						args: { value: numberFormat( highest ) },
-						context: 'Legend for post stats page in Stats',
-					} ) }
-				</span>
-			</StatsModuleContent>
 			<StatsModulePlaceholder isLoading={ isLoading } />
-			<div className={ tableWrapperClasses }>
-				<div className="module-content-table-scroll">
-					<table cellPadding="0" cellSpacing="0">
-						{ tableHeader }
-						{ tableBody }
-					</table>
-				</div>
-			</div>
-		</Card>
+			<table cellPadding="0" cellSpacing="0">
+				{ tableHeader }
+				{ tableBody }
+			</table>
+		</div>
 	);
 };
 

--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
-import config from '@automattic/calypso-config';
-import { Card, Gridicon } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
@@ -11,25 +10,12 @@ import QueryPosts from 'calypso/components/data/query-posts';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { getSitePost } from 'calypso/state/posts/selectors';
 import { getPostStats, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
-import StatsModuleContent from '../stats-module/content-text';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import toggleInfo from '../toggle-info';
 
 const StatsPostDetailWeeks = ( props ) => {
-	const {
-		isRequesting,
-		opened,
-		post,
-		postId,
-		moment,
-		numberFormat,
-		siteId,
-		stats,
-		toggle,
-		translate,
-	} = props;
+	const { isRequesting, post, postId, moment, numberFormat, siteId, stats, translate } = props;
 	const noData = ! stats;
-	const infoIcon = opened ? 'info' : 'info-outline';
 	const isLoading = isRequesting && noData;
 	let tableHeader;
 	let tableRows;
@@ -38,7 +24,6 @@ const StatsPostDetailWeeks = ( props ) => {
 
 	const classes = {
 		'is-loading': isLoading,
-		'is-showing-info': opened,
 		'has-no-data': noData,
 	};
 
@@ -151,61 +136,16 @@ const StatsPostDetailWeeks = ( props ) => {
 		tableBody = <tbody>{ tableRows }</tbody>;
 	}
 
-	const isFeatured = config.isEnabled( 'stats/enhance-post-detail' );
-	const tableWrapperClasses = classNames( {
-		'module-content-table': ! isFeatured,
-	} );
-
 	return (
-		<Card className={ classNames( 'stats-module', 'is-expanded', 'is-detail-weeks', classes ) }>
+		<div className={ classNames( 'is-detail-weeks', classes ) }>
 			<QueryPostStats siteId={ siteId } postId={ postId } />
 			<QueryPosts siteId={ siteId } postId={ postId } />
-			<div className="module-header">
-				<h4 className="module-header-title">{ translate( 'Recent Weeks' ) }</h4>
-				<ul className="module-header-actions">
-					<li className="module-header-action toggle-info">
-						{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-						<a
-							href="#"
-							className="module-header-action-link"
-							aria-label={ translate( 'Show or hide panel information', {
-								textOnly: true,
-								context: 'Stats panel action',
-							} ) }
-							title={ translate( 'Show or hide panel information', {
-								textOnly: true,
-								context: 'Stats panel action',
-							} ) }
-							onClick={ toggle }
-						>
-							<Gridicon icon={ infoIcon } />
-						</a>
-					</li>
-				</ul>
-			</div>
-			<StatsModuleContent className="module-content-text-info">
-				<p>
-					{ translate(
-						'This table gives you an overview of how many views your post or page has received in the recent weeks.'
-					) }
-				</p>
-				<span className="legend achievement">
-					{ translate( '%(value)s = The highest recent value', {
-						args: { value: numberFormat( highest ) },
-						context: 'Legend for post stats page in Stats',
-					} ) }
-				</span>
-			</StatsModuleContent>
 			<StatsModulePlaceholder isLoading={ isLoading } />
-			<div className={ tableWrapperClasses }>
-				<div className="module-content-table-scroll">
-					<table cellPadding="0" cellSpacing="0">
-						{ tableHeader }
-						{ tableBody }
-					</table>
-				</div>
-			</div>
-		</Card>
+			<table cellPadding="0" cellSpacing="0">
+				{ tableHeader }
+				{ tableBody }
+			</table>
+		</div>
 	);
 };
 

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
@@ -27,10 +26,7 @@ import { getPostStat, isRequestingPostStats } from 'calypso/state/stats/posts/se
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PostDetailHighlightsSection from '../post-detail-highlights-section';
 import PostDetailTableSection from '../post-detail-table-section';
-import PostMonths from '../stats-detail-months';
-import PostWeeks from '../stats-detail-weeks';
 import StatsPlaceholder from '../stats-module/placeholder';
-import PostLikes from '../stats-post-likes';
 import PostSummary from '../stats-post-summary';
 
 class StatsPostDetail extends Component {
@@ -139,9 +135,7 @@ class StatsPostDetail extends Component {
 			noViewsLabel = translate( 'Your post has not received any views yet!' );
 		}
 
-		const isFeatured = config.isEnabled( 'stats/enhance-post-detail' );
-
-		return isFeatured ? (
+		return (
 			<Main fullWidthLayout>
 				<PageViewTracker
 					path={ `/stats/${ postType }/:post_id/:site` }
@@ -186,73 +180,6 @@ class StatsPostDetail extends Component {
 
 					<JetpackColophon />
 				</div>
-
-				<WebPreview
-					showPreview={ this.state.showPreview }
-					defaultViewportDevice="tablet"
-					previewUrl={ `${ previewUrl }?demo=true&iframe=true&theme_preview=true` }
-					externalUrl={ previewUrl }
-					onClose={ this.closePreview }
-				>
-					<Button href={ `/post/${ siteSlug }/${ postId }` }>{ translate( 'Edit' ) }</Button>
-				</WebPreview>
-			</Main>
-		) : (
-			<Main className="has-fixed-nav" wideLayout>
-				<PageViewTracker
-					path={ `/stats/${ postType }/:post_id/:site` }
-					title={ `Stats > Single ${ titlecase( postType ) }` }
-				/>
-				{ siteId && ! isLatestPostsHomepage && <QueryPosts siteId={ siteId } postId={ postId } /> }
-				{ siteId && <QueryPostStats siteId={ siteId } postId={ postId } /> }
-
-				<FixedNavigationHeader
-					navigationItems={ this.getNavigationItemsWithTitle( this.getTitle() ) }
-				>
-					{ showViewLink && (
-						<Button onClick={ this.openPreview }>
-							<span>{ actionLabel }</span>
-						</Button>
-					) }
-				</FixedNavigationHeader>
-
-				<StatsPlaceholder isLoading={ isLoading } />
-
-				{ ! isLoading && countViews === 0 && (
-					<EmptyContent
-						title={ noViewsLabel }
-						line={ translate( 'Learn some tips to attract more visitors' ) }
-						action={ translate( 'Get more traffic!' ) }
-						actionURL="https://wordpress.com/support/getting-more-views-and-traffic/"
-						actionTarget="blank"
-						illustration={ IllustrationStats }
-						illustrationWidth={ 150 }
-					/>
-				) }
-
-				{ ! isLoading && countViews > 0 && (
-					<div>
-						<PostSummary siteId={ siteId } postId={ postId } />
-						{ !! postId && <PostLikes siteId={ siteId } postId={ postId } postType={ postType } /> }
-						<PostMonths
-							dataKey="years"
-							title={ translate( 'Months and years' ) }
-							total={ translate( 'Total' ) }
-							siteId={ siteId }
-							postId={ postId }
-						/>
-						<PostMonths
-							dataKey="averages"
-							title={ translate( 'Average per day' ) }
-							total={ translate( 'Overall' ) }
-							siteId={ siteId }
-							postId={ postId }
-						/>
-						<PostWeeks siteId={ siteId } postId={ postId } />
-					</div>
-				) }
-
-				<JetpackColophon />
 
 				<WebPreview
 					showPreview={ this.state.showPreview }

--- a/client/my-sites/stats/stats-post-likes/index.jsx
+++ b/client/my-sites/stats/stats-post-likes/index.jsx
@@ -1,70 +1,26 @@
-import { Card, Gridicon } from '@automattic/components';
+import { Card } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 import { connect } from 'react-redux';
 import PostLikes from 'calypso/blocks/post-likes';
-import Count from 'calypso/components/count';
 import QueryPostLikes from 'calypso/components/data/query-post-likes';
 import { countPostLikes } from 'calypso/state/posts/selectors/count-post-likes';
-import StatsModuleContent from '../stats-module/content-text';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import toggleInfo from '../toggle-info';
 
 import './style.scss';
 
 export const StatsPostLikes = ( props ) => {
-	const { countLikes, opened, postId, postType, siteId, toggle, translate } = props;
-	const infoIcon = opened ? 'info' : 'info-outline';
+	const { countLikes, postId, postType, siteId } = props;
 	const isLoading = countLikes === null;
 	const classes = {
-		'is-showing-info': opened,
 		'is-loading': isLoading,
 	};
 
-	let likesListLabel;
-	let likesTitleLabel;
-
-	if ( postType === 'page' ) {
-		likesTitleLabel = translate( 'Page Likes' );
-		likesListLabel = translate( 'This panel shows the list of people who like your page.' );
-	} else {
-		likesTitleLabel = translate( 'Post Likes' );
-		likesListLabel = translate( 'This panel shows the list of people who like your post.' );
-	}
-
-	/* eslint-disable wpcalypso/jsx-classname-namespace, jsx-a11y/anchor-is-valid */
 	return (
-		<Card className={ classNames( 'stats-module', 'stats-post-likes', 'is-expanded', classes ) }>
+		<Card className={ classNames( 'stats-module', 'stats-post-likes', classes ) }>
 			<QueryPostLikes siteId={ siteId } postId={ postId } />
-			<div className="module-header">
-				<h4 className="module-header-title">
-					{ likesTitleLabel }
-					{ countLikes !== null && <Count count={ countLikes } /> }
-				</h4>
-				<ul className="module-header-actions">
-					<li className="module-header-action toggle-info">
-						<a
-							href="#"
-							className="module-header-action-link"
-							aria-label={ translate( 'Show or hide panel information', {
-								textOnly: true,
-								context: 'Stats panel action',
-							} ) }
-							title={ translate( 'Show or hide panel information', {
-								textOnly: true,
-								context: 'Stats panel action',
-							} ) }
-							onClick={ toggle }
-						>
-							<Gridicon icon={ infoIcon } />
-						</a>
-					</li>
-				</ul>
-			</div>
-			<StatsModuleContent className="module-content-text-info">
-				{ likesListLabel }
-			</StatsModuleContent>
 			<StatsModulePlaceholder isLoading={ isLoading } />
 			<div className="stats-post-likes__content">
 				<PostLikes siteId={ siteId } postId={ postId } postType={ postType } />

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -6,7 +5,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryPostStats from 'calypso/components/data/query-post-stats';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import SectionNav from 'calypso/components/section-nav';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { getPostStats, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 import DatePicker from '../stats-date-picker';
@@ -138,10 +136,7 @@ class StatsPostSummary extends Component {
 			selectedRecord = chartData[ chartData.length - 1 ];
 		}
 
-		const isFeatured = config.isEnabled( 'stats/enhance-post-detail' );
-
-		const summaryWrapperClass = classNames( 'stats-post-summary', {
-			'is-chart-tabs': isFeatured,
+		const summaryWrapperClass = classNames( 'stats-post-summary', 'is-chart-tabs', {
 			'is-period-year': this.state.period === 'year',
 		} );
 
@@ -149,50 +144,35 @@ class StatsPostSummary extends Component {
 			<div className={ summaryWrapperClass }>
 				<QueryPostStats siteId={ siteId } postId={ postId } />
 
-				{ isFeatured ? (
-					<StatsPeriodHeader>
-						<StatsPeriodNavigation showArrows={ false }>
-							<DatePicker period={ this.state.period } date={ selectedRecord?.startDate } isShort />
-						</StatsPeriodNavigation>
-						<SegmentedControl primary>
-							{ periods.map( ( { id, label } ) => (
-								<SegmentedControl.Item
-									key={ id }
-									onClick={ this.selectPeriod( id ) }
-									selected={ this.state.period === id }
-								>
-									{ label }
-								</SegmentedControl.Item>
-							) ) }
-						</SegmentedControl>
-					</StatsPeriodHeader>
-				) : (
-					<SectionNav>
-						<SegmentedControl compact>
-							{ periods.map( ( { id, label } ) => (
-								<SegmentedControl.Item
-									key={ id }
-									onClick={ this.selectPeriod( id ) }
-									selected={ this.state.period === id }
-								>
-									{ label }
-								</SegmentedControl.Item>
-							) ) }
-						</SegmentedControl>
-					</SectionNav>
-				) }
+				<StatsPeriodHeader>
+					<StatsPeriodNavigation showArrows={ false }>
+						<DatePicker period={ this.state.period } date={ selectedRecord?.startDate } isShort />
+					</StatsPeriodNavigation>
+					<SegmentedControl primary>
+						{ periods.map( ( { id, label } ) => (
+							<SegmentedControl.Item
+								key={ id }
+								onClick={ this.selectPeriod( id ) }
+								selected={ this.state.period === id }
+							>
+								{ label }
+							</SegmentedControl.Item>
+						) ) }
+					</SegmentedControl>
+				</StatsPeriodHeader>
 
 				<SummaryChart
 					isLoading={ isRequesting && ! chartData.length }
 					data={ chartData }
-					selected={ selectedRecord }
 					activeKey="period"
 					dataKey="value"
 					labelKey="periodLabel"
 					chartType="views"
 					sectionClass="is-views"
-					tabLabel={ translate( 'Views' ) }
+					selected={ selectedRecord }
 					onClick={ this.selectRecord }
+					tabLabel={ translate( 'Views' ) }
+					type="post"
 				/>
 			</div>
 		);

--- a/client/my-sites/stats/stats-summary/index.jsx
+++ b/client/my-sites/stats/stats-summary/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Card } from '@automattic/components';
 import { Icon, video } from '@wordpress/icons';
 import classNames from 'classnames';
@@ -24,6 +23,7 @@ class StatsSummaryChart extends Component {
 		sectionClass: PropTypes.string.isRequired,
 		selected: PropTypes.object,
 		tabLabel: PropTypes.string.isRequired,
+		type: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -104,7 +104,7 @@ class StatsSummaryChart extends Component {
 	}
 
 	render() {
-		const { dataKey, isLoading, chartType, labelKey, numberFormat, selected, tabLabel } =
+		const { dataKey, isLoading, chartType, labelKey, numberFormat, selected, tabLabel, type } =
 			this.props;
 		const label = selected ? ': ' + selected[ labelKey ] : '';
 		const tabOptions = {
@@ -115,12 +115,11 @@ class StatsSummaryChart extends Component {
 			label: tabLabel + label,
 		};
 
-		const isFeatured = config.isEnabled( 'stats/enhance-post-detail' );
+		// The StatsPostSummary has been modernized to fresh styling.
+		const isModernized = 'post' === type;
 
-		return isFeatured ? (
-			<div
-				className={ classNames( 'stats-module', 'is-summary-chart', { 'is-loading': isLoading } ) }
-			>
+		return isModernized ? (
+			<div className={ classNames( 'is-summary-chart', { 'is-loading': isLoading } ) }>
 				<StatsModulePlaceholder className="is-chart" isLoading={ isLoading } />
 				<ElementChart data={ this.buildChartData() } barClick={ this.barClick }>
 					{ this.renderEmptyState() }

--- a/client/my-sites/stats/stats-video-summary/index.jsx
+++ b/client/my-sites/stats/stats-video-summary/index.jsx
@@ -68,6 +68,7 @@ class StatsVideoSummary extends Component {
 					selected={ selectedBar }
 					onClick={ this.selectBar }
 					tabLabel={ tabLabel }
+					type="video"
 				/>
 			</div>
 		);

--- a/config/client.json
+++ b/config/client.json
@@ -25,7 +25,6 @@
 	"readerFollowingSource",
 	"siftscience_key",
 	"signup_url",
-	"stats/enhance-post-detail",
 	"stats/horizontal-bars-everywhere",
 	"stats/insights-page-grid",
 	"stats/latest-post-stats",

--- a/config/development.json
+++ b/config/development.json
@@ -169,7 +169,6 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": false,
-		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": true,
 		"stats/latest-post-stats": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -113,7 +113,6 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
 		"stats/latest-post-stats": false,

--- a/config/production.json
+++ b/config/production.json
@@ -133,7 +133,6 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
-		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
 		"stats/latest-post-stats": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -130,7 +130,6 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
 		"stats/latest-post-stats": false,

--- a/config/test.json
+++ b/config/test.json
@@ -93,7 +93,6 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
 		"stats/latest-post-stats": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -139,7 +139,6 @@
 		"signup/woo-verify-email": false,
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
-		"stats/enhance-post-detail": true,
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": false,
 		"stats/latest-post-stats": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72917 

## Proposed Changes

* Deprecate the feature flag `stats/enhance-post-detail`.
* Refactor `StatsPostLikes` with the new design.
* Remove redundant code from post-detail table components.
* Refactor `StatsPostSummary` with modernized `StatsSummaryChart`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Post Detail` page (`/stats/post/${post-id}/${site-slug}`).
* Ensure the enhanced post-detail content works as previously.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
