### PR TITLE
WooExpress: Prevent negative value on the trial progress

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/index.tsx
@@ -39,10 +39,10 @@ const ECommerceTrialBanner = ( props: ECommerceTrialBannerProps ) => {
 	const trialDuration = trialEnd.diff( trialStart, 'days' );
 
 	/**
-	 * Trial progress from 0 to 1
+	 * Trial progress from 0 to 1.
+	 * Protect against values < 0 by wrapping the code in Math.max()
 	 */
-	const trialProgress =
-		eCommerceTrialDaysLeft <= trialDuration ? 1 - eCommerceTrialDaysLeft / trialDuration : 0;
+	const trialProgress = Math.max( 1 - eCommerceTrialDaysLeft / trialDuration, 0 );
 	const eCommerceTrialDaysLeftToDisplay = isTrialExpired ? 0 : eCommerceTrialDaysLeft;
 
 	// moment.js doesn't have a format option to display the long form in a localized way without the year

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/index.tsx
@@ -41,7 +41,8 @@ const ECommerceTrialBanner = ( props: ECommerceTrialBannerProps ) => {
 	/**
 	 * Trial progress from 0 to 1
 	 */
-	const trialProgress = 1 - eCommerceTrialDaysLeft / trialDuration;
+	const trialProgress =
+		eCommerceTrialDaysLeft <= trialDuration ? 1 - eCommerceTrialDaysLeft / trialDuration : 0;
 	const eCommerceTrialDaysLeftToDisplay = isTrialExpired ? 0 : eCommerceTrialDaysLeft;
 
 	// moment.js doesn't have a format option to display the long form in a localized way without the year


### PR DESCRIPTION
## Proposed Changes

* Prevents negative values for the trial progress, which would cause two dots to show up on the ring.

**Before**

<img width="1148" alt="Screen Shot 2023-02-15 at 15 29 41" src="https://user-images.githubusercontent.com/1234758/219121947-feb58738-f81d-49a0-b189-811f15f58287.png">

## Testing Instructions

* Navigate to `/plans/my-plan/:siteSlug` on a WooExpress site.
* TBD

Closes #73312
