### PR TITLE
Created test for My home domain-upsell custom domain flow

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -9,31 +9,32 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import DomainUpsell from '../';
 
-jest.mock( 'calypso/state/ui/selectors', () => {
-	return {
-		getSelectedSite: () => {
-			return {
-				ID: 1,
-				plan: 'free',
-			};
-		},
-		getSelectedSiteSlug: () => 'example.wordpress.com',
-	};
-} );
+const sites = [];
+sites[ 1 ] = {
+	ID: 1,
+	URL: 'example.wordpress.com',
+	plan: {
+		product_slug: 'free_plan',
+	},
+};
 
-jest.mock( 'calypso/state/sites/domains/selectors', () => {
-	return {
-		getDomainsBySiteId: () => {
-			return [ 'example.wordpress.com' ];
+const initialState = {
+	sites: {
+		items: sites,
+		domains: {
+			items: [ 'example.wordpress.com' ],
 		},
-	};
-} );
-
-jest.mock( '@automattic/calypso-products', () => {
-	return {
-		isFreePlanProduct: () => true,
-	};
-} );
+	},
+	ui: {
+		selectedSiteId: 1,
+	},
+	currentUser: {
+		id: 12,
+		user: {
+			email_verified: true,
+		},
+	},
+};
 
 jest.mock( '@automattic/domain-picker/src', () => {
 	return {
@@ -50,18 +51,11 @@ jest.mock( '@automattic/domain-picker/src', () => {
 	};
 } );
 
-jest.mock( 'calypso/state/current-user/selectors', () => ( {
-	getCurrentUserId: jest.fn( () => 12 ),
-	isUserLoggedIn: jest.fn( () => true ),
-	isCurrentUserEmailVerified: jest.fn( () => true ),
-} ) );
-
 let pageLink = '';
 jest.mock( 'page', () => ( link ) => ( pageLink = link ) );
 
 describe( 'index', () => {
 	test( 'Should show H3 content for the Home domain upsell and test search domain button link', async () => {
-		const initialState = {};
 		const mockStore = configureStore();
 		const store = mockStore( initialState );
 
@@ -87,10 +81,9 @@ describe( 'index', () => {
 		nock.cleanAll();
 		nock( 'https://public-api.wordpress.com' )
 			.persist()
-			.post( '/rest/v1.1/me/shopping-cart/no-site' )
+			.post( '/rest/v1.1/me/shopping-cart/1' )
 			.reply( 200 );
 
-		const initialState = {};
 		const mockStore = configureStore();
 		const store = mockStore( initialState );
 

--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import DomainUpsell from '../';
+
+jest.mock( 'calypso/state/ui/selectors', () => {
+	return {
+		getSelectedSite: () => {
+			return {
+				ID: 1,
+				plan: 'free',
+			};
+		},
+		getSelectedSiteSlug: () => 'example.wordpress.com',
+	};
+} );
+
+jest.mock( 'calypso/state/sites/domains/selectors', () => {
+	return {
+		getDomainsBySiteId: () => {
+			return [ 'example.wordpress.com' ];
+		},
+	};
+} );
+
+jest.mock( '@automattic/calypso-products', () => {
+	return {
+		isFreePlanProduct: () => true,
+	};
+} );
+
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	getCurrentUserId: jest.fn( () => 12 ),
+	isUserLoggedIn: jest.fn( () => true ),
+	isCurrentUserEmailVerified: jest.fn( () => true ),
+} ) );
+
+describe( 'index', () => {
+	describe( 'verification nudge', () => {
+		test( 'Should show H3 content for the Home domain upsell and the correct /domains/add link', () => {
+			const initialState = {};
+			const mockStore = configureStore();
+			const store = mockStore( initialState );
+
+			const { container } = render(
+				<Provider store={ store }>
+					<DomainUpsell />
+				</Provider>
+			);
+
+			const notice = container.querySelector( 'h3' );
+			expect( notice ).toBeVisible();
+			expect( notice ).toHaveTextContent( 'Own your online identity with a custom domain' );
+
+			const links = [].slice.call( container.querySelectorAll( 'a' ) );
+			expect(
+				links.some( ( link ) =>
+					link.href.endsWith( '/domains/add/example.wordpress.com?domainAndPlanPackage=true' )
+				)
+			).toBeTruthy();
+		} );
+	} );
+} );

--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { Provider } from 'react-redux';
@@ -59,21 +59,20 @@ describe( 'index', () => {
 		const mockStore = configureStore();
 		const store = mockStore( initialState );
 
-		const { container } = render(
+		render(
 			<Provider store={ store }>
 				<DomainUpsell />
 			</Provider>
 		);
+		expect( 1 ).toBe( 1 );
 
-		const notice = container.querySelector( 'h3' );
-		expect( notice ).toBeVisible();
-		expect( notice ).toHaveTextContent( 'Own your online identity with a custom domain' );
+		const h3 = screen.getByText( 'Own your online identity with a custom domain' );
+		expect( h3 ).toBeInTheDocument();
 
-		const links = [].slice.call( container.querySelectorAll( 'a' ) );
+		const searchLink = screen.getByText( 'Search for a domain' );
+		expect( searchLink ).toBeInTheDocument();
 		expect(
-			links.some( ( link ) =>
-				link.href.endsWith( '/domains/add/example.wordpress.com?domainAndPlanPackage=true' )
-			)
+			searchLink.href.endsWith( '/domains/add/example.wordpress.com?domainAndPlanPackage=true' )
 		).toBeTruthy();
 	} );
 
@@ -87,14 +86,14 @@ describe( 'index', () => {
 		const mockStore = configureStore();
 		const store = mockStore( initialState );
 
-		const { getByText } = render(
+		render(
 			<Provider store={ store }>
 				<DomainUpsell />
 			</Provider>
 		);
 
 		const user = userEvent.setup();
-		await user.click( getByText( 'Buy this domain' ) );
+		await user.click( screen.getByText( 'Buy this domain' ) );
 		expect( pageLink ).toBe( '/plans/yearly/example.wordpress.com?get_domain=example.blog' );
 	} );
 } );

--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -60,50 +60,48 @@ let pageLink = '';
 jest.mock( 'page', () => ( link ) => ( pageLink = link ) );
 
 describe( 'index', () => {
-	describe( 'verification nudge', () => {
-		test( 'Should show H3 content for the Home domain upsell and test search domain button link', async () => {
-			const initialState = {};
-			const mockStore = configureStore();
-			const store = mockStore( initialState );
+	test( 'Should show H3 content for the Home domain upsell and test search domain button link', async () => {
+		const initialState = {};
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
 
-			const { container } = render(
-				<Provider store={ store }>
-					<DomainUpsell />
-				</Provider>
-			);
+		const { container } = render(
+			<Provider store={ store }>
+				<DomainUpsell />
+			</Provider>
+		);
 
-			const notice = container.querySelector( 'h3' );
-			expect( notice ).toBeVisible();
-			expect( notice ).toHaveTextContent( 'Own your online identity with a custom domain' );
+		const notice = container.querySelector( 'h3' );
+		expect( notice ).toBeVisible();
+		expect( notice ).toHaveTextContent( 'Own your online identity with a custom domain' );
 
-			const links = [].slice.call( container.querySelectorAll( 'a' ) );
-			expect(
-				links.some( ( link ) =>
-					link.href.endsWith( '/domains/add/example.wordpress.com?domainAndPlanPackage=true' )
-				)
-			).toBeTruthy();
-		} );
+		const links = [].slice.call( container.querySelectorAll( 'a' ) );
+		expect(
+			links.some( ( link ) =>
+				link.href.endsWith( '/domains/add/example.wordpress.com?domainAndPlanPackage=true' )
+			)
+		).toBeTruthy();
+	} );
 
-		test( 'Should test the purchase button link', async () => {
-			nock.cleanAll();
-			nock( 'https://public-api.wordpress.com' )
-				.persist()
-				.post( '/rest/v1.1/me/shopping-cart/no-site' )
-				.reply( 200 );
+	test( 'Should test the purchase button link', async () => {
+		nock.cleanAll();
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.post( '/rest/v1.1/me/shopping-cart/no-site' )
+			.reply( 200 );
 
-			const initialState = {};
-			const mockStore = configureStore();
-			const store = mockStore( initialState );
+		const initialState = {};
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
 
-			const { getByText } = render(
-				<Provider store={ store }>
-					<DomainUpsell />
-				</Provider>
-			);
+		const { getByText } = render(
+			<Provider store={ store }>
+				<DomainUpsell />
+			</Provider>
+		);
 
-			const user = userEvent.setup();
-			await user.click( getByText( 'Buy this domain' ) );
-			expect( pageLink ).toBe( '/plans/yearly/example.wordpress.com?get_domain=example.blog' );
-		} );
+		const user = userEvent.setup();
+		await user.click( getByText( 'Buy this domain' ) );
+		expect( pageLink ).toBe( '/plans/yearly/example.wordpress.com?get_domain=example.blog' );
 	} );
 } );

--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -3,6 +3,8 @@
  */
 
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import DomainUpsell from '../';
@@ -33,15 +35,33 @@ jest.mock( '@automattic/calypso-products', () => {
 	};
 } );
 
+jest.mock( '@automattic/domain-picker/src', () => {
+	return {
+		useDomainSuggestions: () => {
+			return {
+				allDomainSuggestions: [
+					{
+						is_free: false,
+						product_slug: 'mydomain.com',
+					},
+				],
+			};
+		},
+	};
+} );
+
 jest.mock( 'calypso/state/current-user/selectors', () => ( {
 	getCurrentUserId: jest.fn( () => 12 ),
 	isUserLoggedIn: jest.fn( () => true ),
 	isCurrentUserEmailVerified: jest.fn( () => true ),
 } ) );
 
+let pageLink = '';
+jest.mock( 'page', () => ( link ) => ( pageLink = link ) );
+
 describe( 'index', () => {
 	describe( 'verification nudge', () => {
-		test( 'Should show H3 content for the Home domain upsell and the correct /domains/add link', () => {
+		test( 'Should show H3 content for the Home domain upsell and test search domain button link', async () => {
 			const initialState = {};
 			const mockStore = configureStore();
 			const store = mockStore( initialState );
@@ -62,6 +82,28 @@ describe( 'index', () => {
 					link.href.endsWith( '/domains/add/example.wordpress.com?domainAndPlanPackage=true' )
 				)
 			).toBeTruthy();
+		} );
+
+		test( 'Should test the purchase button link', async () => {
+			nock.cleanAll();
+			nock( 'https://public-api.wordpress.com' )
+				.persist()
+				.post( '/rest/v1.1/me/shopping-cart/no-site' )
+				.reply( 200 );
+
+			const initialState = {};
+			const mockStore = configureStore();
+			const store = mockStore( initialState );
+
+			const { getByText } = render(
+				<Provider store={ store }>
+					<DomainUpsell />
+				</Provider>
+			);
+
+			const user = userEvent.setup();
+			await user.click( getByText( 'Buy this domain' ) );
+			expect( pageLink ).toBe( '/plans/yearly/example.wordpress.com?get_domain=example.blog' );
 		} );
 	} );
 } );

--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -66,10 +66,11 @@ describe( 'index', () => {
 		);
 		expect( 1 ).toBe( 1 );
 
-		const h3 = screen.getByText( 'Own your online identity with a custom domain' );
-		expect( h3 ).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'heading', { name: 'Own your online identity with a custom domain' } )
+		).toBeInTheDocument();
 
-		const searchLink = screen.getByText( 'Search for a domain' );
+		const searchLink = screen.getByRole( 'link', { name: 'Search for a domain' } );
 		expect( searchLink ).toBeInTheDocument();
 		expect(
 			searchLink.href.endsWith( '/domains/add/example.wordpress.com?domainAndPlanPackage=true' )
@@ -93,7 +94,7 @@ describe( 'index', () => {
 		);
 
 		const user = userEvent.setup();
-		await user.click( screen.getByText( 'Buy this domain' ) );
+		await user.click( screen.getByRole( 'button', { name: 'Buy this domain' } ) );
 		expect( pageLink ).toBe( '/plans/yearly/example.wordpress.com?get_domain=example.blog' );
 	} );
 } );

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -7,7 +7,8 @@ type FocusType = 'Sites' | 'Sidebar';
 
 const selectors = {
 	sidebar: '.sidebar',
-	sidebarNotice: '.sidebar .current-site__notices .banner__action button:visible',
+	sidebarNoticeButton: ( name: string ) =>
+		`.sidebar .current-site__notices button:text("${ name }")`,
 	collapsedSidebar: '.is-sidebar-collapsed',
 	focusedLayout: ( focus: FocusType ) => `.layout.focus-${ focus.toLowerCase() }`,
 
@@ -110,11 +111,11 @@ export class SidebarComponent {
 	/**
 	 * Open a notice of the sidebar menu.
 	 *
-	 * @param {string} item Plaintext representation of the top level heading.
-	 * @param {string} expectedUrl expected URL after clicking on the notice.
+	 * @param {string} noticeButtonName Name of the notice button where the click will be performed.
+	 * @param {string} expectedUrl Expected URL after clicking on the notice.
 	 * @returns {Promise<void>} No return value.
 	 */
-	async openNotice( item: string, expectedUrl: string ): Promise< void > {
+	async openNotice( noticeButtonName: string, expectedUrl?: string ): Promise< void > {
 		await this.waitForSidebarInitialization();
 
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
@@ -122,7 +123,7 @@ export class SidebarComponent {
 		}
 
 		// Top level menu item selector.
-		const itemSelector = `${ selectors.sidebarNotice }`;
+		const itemSelector = selectors.sidebarNoticeButton( noticeButtonName );
 		await this.page.dispatchEvent( itemSelector, 'click' );
 
 		const currentURL = this.page.url();
@@ -135,7 +136,9 @@ export class SidebarComponent {
 			return;
 		}
 
-		await this.page.waitForURL( expectedUrl );
+		if ( expectedUrl ) {
+			await this.page.waitForURL( expectedUrl );
+		}
 	}
 
 	/* Miscellaneous actions on sidebar */

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -101,7 +101,7 @@ yarn workspace wp-e2e-tests build --watch
 12. run test.
 
 ```bash
-yarn workspace wp-e2e-tests start -- <test_path>
+yarn workspace wp-e2e-tests test -- <test_path>
 ```
 
 ## Advanced setup

--- a/test/e2e/specs/domain-upsell/domain-upsell__sidebar.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__sidebar.ts
@@ -1,0 +1,130 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	DomainSearchComponent,
+	SidebarComponent,
+	PlansPage,
+	CartCheckoutPage,
+	TestAccount,
+	RestAPIClient,
+	BrowserManager,
+	SecretsManager,
+	NewSiteResponse,
+	NavbarCartComponent,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+import { apiDeleteSite } from '../shared';
+
+declare const browser: Browser;
+
+describe(
+	DataHelper.createSuiteTitle(
+		'Domain Upsell: Click on the sidebar Domain Upsell, search for a domain, select the Premium plan and check both items on the checkout page'
+	),
+	function () {
+		const blogName = DataHelper.getBlogName();
+		const planName = 'Premium';
+		let siteCreatedFlag: boolean;
+		let newSiteDetails: NewSiteResponse;
+		let domainSearchComponent: DomainSearchComponent;
+		let cartCheckoutPage: CartCheckoutPage;
+		let plansPage: PlansPage;
+		let sidebarComponent: SidebarComponent;
+		let navbarCartComponent: NavbarCartComponent;
+		let selectedDomain: string;
+		let restAPIClient: RestAPIClient;
+		let page: Page;
+
+		beforeAll( async function () {
+			// Set up the test site programmatically against simpleSiteFreePlanUser.
+			const credentials = SecretsManager.secrets.testAccounts.simpleSiteFreePlanUser;
+
+			restAPIClient = new RestAPIClient( credentials );
+			console.info( 'Creating a new test site.' );
+			newSiteDetails = await restAPIClient.createSite( {
+				name: blogName,
+				title: blogName,
+			} );
+			console.info( `New site created: ${ newSiteDetails.blog_details.url }` );
+			siteCreatedFlag = true;
+
+			// Launch browser.
+			page = await browser.newPage();
+
+			// Authenticate as simpleSiteFreePlanUser.
+			const testAccount = new TestAccount( 'simpleSiteFreePlanUser' );
+			await testAccount.authenticate( page );
+		} );
+
+		describe( `Upgrade to WordPress.com ${ planName }`, function () {
+			beforeAll( async function () {
+				await BrowserManager.setStoreCookie( page );
+			} );
+
+			it( 'Navigate to Home', async function () {
+				await page.goto(
+					DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.site_slug }` )
+				);
+			} );
+
+			it( 'Click Claim on the sidebar Domain Upsell', async function () {
+				sidebarComponent = new SidebarComponent( page );
+				await sidebarComponent.openNotice(
+					'Upgrade',
+					`**/domains/add/${ newSiteDetails.blog_details.site_slug }?domainAndPlanPackage=true`
+				);
+			} );
+
+			it( 'If required, clear the cart', async function () {
+				navbarCartComponent = new NavbarCartComponent( page );
+				const cartOpened = await navbarCartComponent.openCart();
+				// The cart popover existing implies there are some items that need to be removed.
+				if ( cartOpened ) {
+					await navbarCartComponent.emptyCart();
+				}
+			} );
+
+			it( 'Search for a domain name', async function () {
+				domainSearchComponent = new DomainSearchComponent( page );
+				await domainSearchComponent.search( blogName + '.live' );
+			} );
+
+			it( 'Choose the .live TLD', async function () {
+				selectedDomain = await domainSearchComponent.selectDomain( '.live' );
+			} );
+
+			it( 'View available plans', async function () {
+				plansPage = new PlansPage( page );
+			} );
+
+			it( `Click button to upgrade to WordPress.com ${ planName }`, async function () {
+				await plansPage.selectPlan( 'Premium' );
+			} );
+
+			it( `WordPress.com ${ planName } is added to cart`, async function () {
+				cartCheckoutPage = new CartCheckoutPage( page );
+				await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			} );
+
+			it( 'See secure payment', async function () {
+				cartCheckoutPage = new CartCheckoutPage( page );
+				await cartCheckoutPage.validateCartItem( selectedDomain );
+			} );
+		} );
+
+		afterAll( async function () {
+			if ( ! siteCreatedFlag ) {
+				return;
+			}
+
+			await apiDeleteSite( restAPIClient, {
+				url: newSiteDetails.blog_details.url,
+				id: newSiteDetails.blog_details.blogid,
+				name: newSiteDetails.blog_details.blogname,
+			} );
+		} );
+	}
+);

--- a/test/e2e/specs/domain-upsell/domain-upsell__sidebar.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__sidebar.ts
@@ -13,84 +13,74 @@ import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
-describe(
-	DataHelper.createSuiteTitle(
-		'Domain Upsell: Click on the sidebar Domain Upsell, search for a domain, select the Premium plan and check both items on the checkout page'
-	),
-	function () {
-		const planName = 'Premium';
-		let domainSearchComponent: DomainSearchComponent;
-		let cartCheckoutPage: CartCheckoutPage;
-		let plansPage: PlansPage;
-		let sidebarComponent: SidebarComponent;
-		let navbarCartComponent: NavbarCartComponent;
-		let selectedDomain: string;
-		let page: Page;
-		const credentials = SecretsManager.secrets.testAccounts.simpleSiteFreePlanUser;
-		const siteSlug = credentials.testSites?.primary?.url as string;
-		const blogName = credentials.username as string;
+describe( DataHelper.createSuiteTitle( 'Sidebar: Domain upsell' ), function () {
+	const planName = 'Premium';
+	let domainSearchComponent: DomainSearchComponent;
+	let cartCheckoutPage: CartCheckoutPage;
+	let plansPage: PlansPage;
+	let sidebarComponent: SidebarComponent;
+	let navbarCartComponent: NavbarCartComponent;
+	let selectedDomain: string;
+	let page: Page;
+	const credentials = SecretsManager.secrets.testAccounts.simpleSiteFreePlanUser;
+	const siteSlug = credentials.testSites?.primary?.url as string;
+	const blogName = credentials.username as string;
 
-		beforeAll( async function () {
-			// Launch browser.
-			page = await browser.newPage();
+	beforeAll( async function () {
+		// Launch browser.
+		page = await browser.newPage();
 
-			// Authenticate as simpleSiteFreePlanUser.
-			const testAccount = new TestAccount( 'simpleSiteFreePlanUser' );
-			await testAccount.authenticate( page );
-		} );
+		// Authenticate as simpleSiteFreePlanUser.
+		const testAccount = new TestAccount( 'simpleSiteFreePlanUser' );
+		await testAccount.authenticate( page );
+		await BrowserManager.setStoreCookie( page );
+	} );
 
-		describe( `Upgrade to WordPress.com ${ planName }`, function () {
-			beforeAll( async function () {
-				await BrowserManager.setStoreCookie( page );
-			} );
+	it( 'Navigate to Home', async function () {
+		await page.goto( DataHelper.getCalypsoURL( `/home/${ siteSlug }` ) );
+	} );
 
-			it( 'Navigate to Home', async function () {
-				await page.goto( DataHelper.getCalypsoURL( `/home/${ siteSlug }` ) );
-			} );
+	it( 'If required, clear the cart', async function () {
+		navbarCartComponent = new NavbarCartComponent( page );
+		const cartOpened = await navbarCartComponent.openCart();
+		// The cart popover existing implies there are some items that need to be removed.
+		if ( cartOpened ) {
+			await navbarCartComponent.emptyCart();
+		}
+	} );
 
-			it( 'If required, clear the cart', async function () {
-				navbarCartComponent = new NavbarCartComponent( page );
-				const cartOpened = await navbarCartComponent.openCart();
-				// The cart popover existing implies there are some items that need to be removed.
-				if ( cartOpened ) {
-					await navbarCartComponent.emptyCart();
-				}
-			} );
+	it( 'Click Claim on the sidebar Domain Upsell', async function () {
+		sidebarComponent = new SidebarComponent( page );
+		await sidebarComponent.openNotice(
+			'Upgrade',
+			`**/domains/add/${ siteSlug }?domainAndPlanPackage=true`
+		);
+	} );
 
-			it( 'Click Claim on the sidebar Domain Upsell', async function () {
-				sidebarComponent = new SidebarComponent( page );
-				await sidebarComponent.openNotice(
-					'Upgrade',
-					`**/domains/add/${ siteSlug }?domainAndPlanPackage=true`
-				);
-			} );
+	it( 'Search for a domain name', async function () {
+		domainSearchComponent = new DomainSearchComponent( page );
+		await domainSearchComponent.search( blogName + '.live' );
+	} );
 
-			it( 'Search for a domain name', async function () {
-				domainSearchComponent = new DomainSearchComponent( page );
-				await domainSearchComponent.search( blogName + '.live' );
-			} );
+	it( 'Choose the .live TLD', async function () {
+		selectedDomain = await domainSearchComponent.selectDomain( '.live' );
+	} );
 
-			it( 'Choose the .live TLD', async function () {
-				selectedDomain = await domainSearchComponent.selectDomain( '.live' );
-			} );
+	it( 'View available plans', async function () {
+		plansPage = new PlansPage( page );
+	} );
 
-			it( 'View available plans', async function () {
-				plansPage = new PlansPage( page );
-			} );
+	it( `Click button to upgrade to WordPress.com ${ planName }`, async function () {
+		await plansPage.selectPlan( 'Premium' );
+	} );
 
-			it( `Click button to upgrade to WordPress.com ${ planName }`, async function () {
-				await plansPage.selectPlan( 'Premium' );
-			} );
+	it( `WordPress.com ${ planName } is added to cart`, async function () {
+		cartCheckoutPage = new CartCheckoutPage( page );
+		await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+	} );
 
-			it( `WordPress.com ${ planName } is added to cart`, async function () {
-				cartCheckoutPage = new CartCheckoutPage( page );
-				await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
-			} );
-
-			it( 'See secure payment', async function () {
-				cartCheckoutPage = new CartCheckoutPage( page );
-				await cartCheckoutPage.validateCartItem( selectedDomain );
-			} );
-		} );
-	}
-);
+	it( 'See secure payment', async function () {
+		cartCheckoutPage = new CartCheckoutPage( page );
+		await cartCheckoutPage.validateCartItem( selectedDomain );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1685-gh-Automattic/dotcom-forge

## Proposed Changes

* Created component test for domain-upsell flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn run test-client client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx` and make sure the test passes
* Ensure this test covers the previous change [we did at this task](https://github.com/Automattic/wp-calypso/pull/73326/files)

### E2E testing instructions
- First of all, build the calypso-e2e package with `yarn build` on `/packages/calypso-e2e`.
- Follow [this guide](https://github.com/Automattic/wp-calypso/blob/trunk/test/e2e/README.md#quick-start) to make sure to have the environment working.
- Run `yarn workspace wp-e2e-tests test -- domain-upsell`
- Make sure all test passes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?