### PR TITLE
Use sentence case for 'Back to sites'

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -222,7 +222,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			stepName="domains"
 			isWideLayout={ true }
 			hideBack={ ! isCopySiteFlow( flow ) }
-			backLabelText={ __( 'Back to Sites' ) }
+			backLabelText={ __( 'Back to sites' ) }
 			hideSkip={ true }
 			flowName={ isCopySiteFlow( flow ) ? ( flow as string ) : 'linkInBio' }
 			stepContent={ <div className="domains__content">{ renderContent() }</div> }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -823,7 +823,7 @@ class DomainsStep extends Component {
 		const [ sitesBackLabelText, defaultBackUrl ] =
 			userSiteCount && userSiteCount === 1
 				? [ translate( 'Back to My Home' ), '/home' ]
-				: [ translate( 'Back to Sites' ), '/sites' ];
+				: [ translate( 'Back to sites' ), '/sites' ];
 
 		if ( previousStepBackUrl ) {
 			backUrl = previousStepBackUrl;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -397,7 +397,7 @@ export class PlansStep extends Component {
 
 		if ( 0 === positionInFlow && hasInitializedSitesBackUrl ) {
 			backUrl = hasInitializedSitesBackUrl;
-			backLabelText = translate( 'Back to Sites' );
+			backLabelText = translate( 'Back to sites' );
 		}
 
 		let queryParams;

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -84,7 +84,7 @@ class SiteType extends Component {
 				stepContent={ this.renderStepContent() }
 				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 				backUrl={ hasInitializedSitesBackUrl }
-				backLabelText={ hasInitializedSitesBackUrl ? translate( 'Back to Sites' ) : null }
+				backLabelText={ hasInitializedSitesBackUrl ? translate( 'Back to sites' ) : null }
 			/>
 		);
 	}


### PR DESCRIPTION
See conversation in p1676476120590139/1676381941.241629-slack-C9EJ7KSGH

## Proposed Changes

Switches 'Back to Sites' to 'Back to sites':

<img width="563" alt="image" src="https://user-images.githubusercontent.com/36432/219155085-45668055-1c49-413c-83c4-db44c97b060c.png">


## Testing Instructions

1. Navigate to `/sites`.
2. Click 'Add new site'.
3. Verify the back button appears as depicted in the screenshot.