### PR TITLE
Launchpad: Add flow and link to update design

### DIFF
--- a/client/landing/stepper/declarative-flow/design-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/design-post-setup.ts
@@ -1,4 +1,3 @@
-// import { useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import {
 	setSignupCompleteSlug,
@@ -7,7 +6,6 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useQuery } from '../hooks/use-query';
 import { useSiteSlug } from '../hooks/use-site-slug';
-// import { ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import DesignSetup from './internals/steps-repository/design-setup';
 import Processing from './internals/steps-repository/processing-step';
@@ -26,11 +24,10 @@ const designSetup: Flow = {
 		];
 	},
 
-	useStepNavigation( currentStep ) {
+	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
 		const siteSlug = useSiteSlug();
 		const flowToReturnTo = useQuery().get( 'flowToReturnTo' ) || 'free';
-		// const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, 'design-post-setup', flowName, currentStep );
@@ -56,10 +53,7 @@ const designSetup: Flow = {
 							) }?redirect_to=${ returnUrl }&signup=1`
 						);
 					}
-					return window.location.assign(
-						`/setup/design-post-setup/processing?siteSlug=${ siteSlug }`
-					);
-				//return navigate( `processing?siteSlug=${ siteSlug }` );
+					return navigate( `processing?siteSlug=${ siteSlug }` );
 			}
 		}
 

--- a/client/landing/stepper/declarative-flow/design-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/design-post-setup.ts
@@ -1,0 +1,70 @@
+// import { useSelect } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
+import {
+	setSignupCompleteSlug,
+	persistSignupDestination,
+	setSignupCompleteFlowName,
+} from 'calypso/signup/storageUtils';
+import { useQuery } from '../hooks/use-query';
+import { useSiteSlug } from '../hooks/use-site-slug';
+// import { ONBOARD_STORE } from '../stores';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import DesignSetup from './internals/steps-repository/design-setup';
+import Processing from './internals/steps-repository/processing-step';
+import { ProvidedDependencies } from './internals/types';
+import type { Flow } from './internals/types';
+
+const designSetup: Flow = {
+	name: 'design-post-setup',
+	get title() {
+		return translate( 'Choose Design' );
+	},
+	useSteps() {
+		return [
+			{ slug: 'designSetup', component: DesignSetup },
+			{ slug: 'processing', component: Processing },
+		];
+	},
+
+	useStepNavigation( currentStep ) {
+		const flowName = this.name;
+		const siteSlug = useSiteSlug();
+		const flowToReturnTo = useQuery().get( 'flowToReturnTo' ) || 'free';
+		// const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, 'design-post-setup', flowName, currentStep );
+			switch ( currentStep ) {
+				case 'processing':
+					return window.location.assign(
+						`/setup/${ flowToReturnTo }/launchpad?siteSlug=${ siteSlug }`
+					);
+
+				case 'designSetup':
+					if ( providedDependencies?.goToCheckout ) {
+						const destination = `/setup/${ flowToReturnTo }/launchpad?siteSlug=${ providedDependencies.siteSlug }`;
+						persistSignupDestination( destination );
+						setSignupCompleteSlug( providedDependencies?.siteSlug );
+						setSignupCompleteFlowName( flowToReturnTo );
+						const returnUrl = encodeURIComponent(
+							`/setup/${ flowToReturnTo }/launchpad?siteSlug=${ providedDependencies?.siteSlug }`
+						);
+
+						return window.location.assign(
+							`/checkout/${ encodeURIComponent(
+								( providedDependencies?.siteSlug as string ) ?? ''
+							) }?redirect_to=${ returnUrl }&signup=1`
+						);
+					}
+					return window.location.assign(
+						`/setup/design-post-setup/processing?siteSlug=${ siteSlug }`
+					);
+				//return navigate( `processing?siteSlug=${ siteSlug }` );
+			}
+		}
+
+		return { submit };
+	},
+};
+
+export default designSetup;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -75,7 +75,7 @@ button {
 .free-post-setup,
 .free,
 .with-theme-assembler,
-.design-post-setup {
+.update-design {
 	padding: 60px 0 0;
 	box-sizing: border-box;
 

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -74,7 +74,8 @@ button {
 .free-setup,
 .free-post-setup,
 .free,
-.with-theme-assembler {
+.with-theme-assembler,
+.design-post-setup {
 	padding: 60px 0 0;
 	box-sizing: border-box;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -669,7 +669,7 @@ $break-design-preview: 1024px;
 }
 
 // Free flow
-.design-post-setup.design-setup,
+.update-design.design-setup,
 .free.design-setup {
 	.step-container:not(.design-setup__preview) {
 		.navigation-link {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -669,7 +669,7 @@ $break-design-preview: 1024px;
 }
 
 // Free flow
-
+.design-post-setup.design-setup,
 .free.design-setup {
 	.step-container:not(.design-setup__preview) {
 		.navigation-link {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -163,6 +163,12 @@ export function getEnhancedTasks(
 				case 'design_selected':
 					taskData = {
 						title: translate( 'Select a design' ),
+						actionDispatch: () => {
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
+							window.location.assign(
+								`/setup/design-post-setup/designSetup?siteSlug=${ siteSlug }&flowToReturnTo=${ flow }`
+							);
+						},
 					};
 					break;
 				case 'setup_link_in_bio':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -166,7 +166,7 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								`/setup/design-post-setup/designSetup?siteSlug=${ siteSlug }&flowToReturnTo=${ flow }`
+								`/setup/update-design/designSetup?siteSlug=${ siteSlug }&flowToReturnTo=${ flow }`
 							);
 						},
 					};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -29,7 +29,7 @@ export const tasks: Task[] = [
 	{
 		id: 'design_selected',
 		completed: true,
-		disabled: true,
+		disabled: false,
 		taskType: 'blog',
 	},
 	{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -3,6 +3,7 @@ import {
 	isNewsletterOrLinkInBioFlow,
 	isLinkInBioFlow,
 	isFreeFlow,
+	isUpdateDesignFlow,
 	ECOMMERCE_FLOW,
 	isWooExpressFlow,
 } from '@automattic/onboarding';
@@ -101,7 +102,7 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	const isWooCommercePowered = flowName === ECOMMERCE_FLOW;
 
 	// Currently we have the Domains and Plans only for link in bio
-	if ( isLinkInBioFlow( flowName ) || isFreeFlow( flowName ) ) {
+	if ( isLinkInBioFlow( flowName ) || isFreeFlow( flowName ) || isUpdateDesignFlow( flowName ) ) {
 		return <TailoredFlowPreCheckoutScreen flowName={ flowName } />;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
@@ -10,7 +10,8 @@
 	.newsletter,
 	.link-in-bio,
 	.link-in-bio-tld,
-	.free {
+	.free,
+	.update-design {
 		.signup-header {
 			.signup-header__right {
 				visibility: hidden;
@@ -69,7 +70,8 @@
 	}
 
 	.newsletter,
-	.free {
+	.free,
+	.update-design {
 		.processing-step__container {
 			background-color: #a2dafe;
 			background-image:

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -56,6 +56,11 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 	'free-post-setup': () =>
 		import( /* webpackChunkName: "free-post-setup-flow" */ '../declarative-flow/free-post-setup' ),
 
+	'design-post-setup': () =>
+		import(
+			/* webpackChunkName: "design-post-setup-flow" */ '../declarative-flow/design-post-setup'
+		),
+
 	build: () => import( /* webpackChunkName: "build-flow" */ '../declarative-flow/build' ),
 	write: () => import( /* webpackChunkName: "write-flow" */ '../declarative-flow/write' ),
 };

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -56,10 +56,8 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 	'free-post-setup': () =>
 		import( /* webpackChunkName: "free-post-setup-flow" */ '../declarative-flow/free-post-setup' ),
 
-	'design-post-setup': () =>
-		import(
-			/* webpackChunkName: "design-post-setup-flow" */ '../declarative-flow/design-post-setup'
-		),
+	'update-design': () =>
+		import( /* webpackChunkName: "update-design-flow" */ '../declarative-flow/update-design' ),
 
 	build: () => import( /* webpackChunkName: "build-flow" */ '../declarative-flow/build' ),
 	write: () => import( /* webpackChunkName: "write-flow" */ '../declarative-flow/write' ),

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -12,8 +12,8 @@ import Processing from './internals/steps-repository/processing-step';
 import { ProvidedDependencies } from './internals/types';
 import type { Flow } from './internals/types';
 
-const designSetup: Flow = {
-	name: 'design-post-setup',
+const updateDesign: Flow = {
+	name: 'update-design',
 	get title() {
 		return translate( 'Choose Design' );
 	},
@@ -30,7 +30,7 @@ const designSetup: Flow = {
 		const flowToReturnTo = useQuery().get( 'flowToReturnTo' ) || 'free';
 
 		function submit( providedDependencies: ProvidedDependencies = {} ) {
-			recordSubmitStep( providedDependencies, 'design-post-setup', flowName, currentStep );
+			recordSubmitStep( providedDependencies, 'update-design', flowName, currentStep );
 			switch ( currentStep ) {
 				case 'processing':
 					return window.location.assign(
@@ -61,4 +61,4 @@ const designSetup: Flow = {
 	},
 };
 
-export default designSetup;
+export default updateDesign;

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -18,6 +18,7 @@ export const WRITE_FLOW = 'write';
 export const SITE_SETUP_FLOW = 'site-setup';
 export const WITH_THEME_FLOW = 'with-theme';
 export const WITH_THEME_ASSEMBLER_FLOW = 'with-theme-assembler';
+export const UPDATE_DESIGN_FLOW = 'update-design';
 
 export const isLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(
@@ -71,6 +72,10 @@ export const isWooExpressFlow = ( flowName: string | null ) => {
 
 export const isBuildFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ BUILD_FLOW ].includes( flowName ) );
+};
+
+export const isUpdateDesignFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ UPDATE_DESIGN_FLOW ].includes( flowName ) );
 };
 
 export const isSiteAssemblerFlow = ( flowName: string | null ) => {


### PR DESCRIPTION
### Proposed Changes

For our general flows, we want to provide a link from launchpad back to the design/theme selection screen. To do that, this PR makes the following changes: 
  - Adds a new update-design new flow that just uses the same designSetup screen as usual. 
  - Adds a link from launchpad to the new update-design flow/screen. 

### Testing Instructions

Review Time: Medium
Testing Time: Short

1) Check out this branch and run yarn and yarn start if needed. 
2) Go to http://calypso.localhost:3000/setup/free/intro and start a free site. 
3) Go all the way through to Launchpad.
4) TEST: Confirm the 'Choose Design' link is now active. 
5) TEST: Click the 'Choose Design link and confirm you go to the design picker screen.
6) TEST: Choose a new theme. Confirm you are taken back to Launchpad and that your new theme shows in the preview.
7) TEST: Also just make sure that everything else about the flow back-and-forth between launchpad and design selection looks and feels as it should. 