### PR TITLE
Create a post-purchase "treatment" with discount countdown timer

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
@@ -9,6 +9,43 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import './style.scss';
 
 export class BusinessPlanUpgradeUpsell extends PureComponent {
+	constructor( props ) {
+		super( props );
+		this.state = { hours: 0, minutes: 0, seconds: 0 };
+	}
+
+	componentDidMount() {
+		const discountEndDate =
+			moment.utc( this.props.currentPlan?.subscribedDate ).unix() + 24 * 60 * 60;
+		this.getDiscountTimeRemaining( discountEndDate );
+		this.timerID = setInterval( () => this.getDiscountTimeRemaining( discountEndDate ), 1000 );
+	}
+
+	componentWillUnmount() {
+		clearInterval( this.timerID );
+	}
+
+	getDiscountTimeRemaining( discountEndDate ) {
+		const timeDiff = discountEndDate - moment.utc().unix();
+		if ( timeDiff <= 0 ) {
+			clearInterval( this.timerID );
+			this.setState( {
+				hours: 0,
+				minutes: 0,
+				seconds: 0,
+			} );
+			return;
+		}
+
+		this.setState( {
+			hours: Math.floor( ( timeDiff / ( 60 * 60 ) ) % 24 ),
+			minutes: Math.floor( ( timeDiff / 60 ) % 60 ),
+			seconds: Math.floor( timeDiff % 60 )
+				.toString()
+				.padStart( 2, '0' ),
+		} );
+	}
+
 	render() {
 		const { receiptId, translate } = this.props;
 
@@ -74,27 +111,13 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 			planDiscountedRawPrice,
 			currencyCode,
 			hasSevenDayRefundPeriod,
-			currentPlan,
 		} = this.props;
 
-		const getTimeLeftFromSecondsLeft = ( timeDiff ) => {
-			return {
-				hours: Math.floor( ( timeDiff / ( 60 * 60 ) ) % 24 ),
-				minutes: Math.floor( ( timeDiff / 60 ) % 60 ),
-				seconds: Math.floor( timeDiff % 60 )
-					.toString()
-					.padStart( 2, '0' ),
-			};
+		const { hours, minutes, seconds } = {
+			hours: this.state.hours,
+			minutes: this.state.minutes,
+			seconds: this.state.seconds,
 		};
-
-		const expiryDate = moment.utc( currentPlan?.subscribedDate ).unix() + 24 * 60 * 60;
-		const now = moment.utc().unix();
-		const isBeforeExpiry = currentPlan && now <= expiryDate;
-		const { hours, minutes, seconds } = getTimeLeftFromSecondsLeft( expiryDate - now );
-		console.log( 'expiryDate', expiryDate );
-		console.log( 'expiryDateb', moment.utc( currentPlan?.subscribedDate ).unix() );
-		console.log( 'expiryDate-now', now );
-		console.log( 'expiryDate', isBeforeExpiry );
 
 		return (
 			<>

--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
@@ -1,4 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
+import moment from 'moment';
 import { PureComponent } from 'react';
 import formatCurrency from 'calypso/../packages/format-currency/src';
 import upsellImage from 'calypso/assets/images/checkout-upsell/upsell-rocket-2.png';
@@ -73,7 +74,28 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 			planDiscountedRawPrice,
 			currencyCode,
 			hasSevenDayRefundPeriod,
+			currentPlan,
 		} = this.props;
+
+		const getTimeLeftFromSecondsLeft = ( timeDiff ) => {
+			return {
+				hours: Math.floor( ( timeDiff / ( 60 * 60 ) ) % 24 ),
+				minutes: Math.floor( ( timeDiff / 60 ) % 60 ),
+				seconds: Math.floor( timeDiff % 60 )
+					.toString()
+					.padStart( 2, '0' ),
+			};
+		};
+
+		const expiryDate = moment.utc( currentPlan?.subscribedDate ).unix() + 24 * 60 * 60;
+		const now = moment.utc().unix();
+		const isBeforeExpiry = currentPlan && now <= expiryDate;
+		const { hours, minutes, seconds } = getTimeLeftFromSecondsLeft( expiryDate - now );
+		console.log( 'expiryDate', expiryDate );
+		console.log( 'expiryDateb', moment.utc( currentPlan?.subscribedDate ).unix() );
+		console.log( 'expiryDate-now', now );
+		console.log( 'expiryDate', isBeforeExpiry );
+
 		return (
 			<>
 				<div className="business-plan-upgrade-upsell-new-design__column-pane">
@@ -151,6 +173,14 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 							}
 						) }
 					</p>
+					<div className="business-plan-upgrade-upsell-new-design__countdown-counter">
+						<span>
+							{ translate( 'Discount ends in %(hours)dh %(minutes)dm %(seconds)ss', {
+								args: { hours, minutes, seconds },
+								comment: 'The end string will look like "Discount ends in 6h 2m 20s"',
+							} ) }
+						</span>
+					</div>
 				</div>
 			</>
 		);

--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/style.scss
@@ -134,9 +134,6 @@ main.business-plan-upgrade-upsell-new-design.main {
 		text-align: center;
 		margin-bottom: 20px;
 	}
-	&__countdown-counter span {
-		padding-left: 5px;
-	}
 
 	&__footer &__decline-offer-button {
 		color: var(--color-primary);

--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/style.scss
@@ -126,6 +126,18 @@ main.business-plan-upgrade-upsell-new-design.main {
 		}
 	}
 
+	&__countdown-counter {
+		display: block;
+		padding: 10px;
+		border-radius: 0;
+		background: #f5f1e1;
+		text-align: center;
+		margin-bottom: 20px;
+	}
+	&__countdown-counter span {
+		padding-left: 5px;
+	}
+
 	&__footer &__decline-offer-button {
 		color: var(--color-primary);
 

--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/treatment.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/treatment.jsx
@@ -1,5 +1,4 @@
 import { Button, Gridicon } from '@automattic/components';
-import moment from 'moment';
 import { PureComponent } from 'react';
 import upsellImage from 'calypso/assets/images/checkout-upsell/upsell-rocket-2.png';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -14,8 +13,9 @@ export class BusinessPlanUpgradeUpsellTreatment extends PureComponent {
 	}
 
 	componentDidMount() {
-		const discountEndDate =
-			moment.utc( this.props.currentPlan?.subscribedDate ).unix() + 24 * 60 * 60;
+		const subscribedDate = this.props.currentPlan?.subscribedDate;
+		const discountEndDate = this.getUnixTimestamp( subscribedDate ) + 24 * 60 * 60; // add 24 hours
+
 		this.getDiscountTimeRemaining( discountEndDate );
 		this.timerID = setInterval( () => this.getDiscountTimeRemaining( discountEndDate ), 1000 );
 	}
@@ -24,8 +24,13 @@ export class BusinessPlanUpgradeUpsellTreatment extends PureComponent {
 		clearInterval( this.timerID );
 	}
 
+	getUnixTimestamp( timestamp ) {
+		const date = timestamp ? new Date( Date.parse( timestamp ) ) : new Date();
+		return Math.floor( date.getTime() / 1000 ); // divide by 1000 to get seconds instead of milliseconds
+	}
+
 	getDiscountTimeRemaining( discountEndDate ) {
-		const timeDiff = discountEndDate - moment.utc().unix();
+		const timeDiff = discountEndDate - this.getUnixTimestamp();
 		if ( timeDiff <= 0 ) {
 			clearInterval( this.timerID );
 			this.setState( {

--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/treatment.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/treatment.jsx
@@ -173,14 +173,20 @@ export class BusinessPlanUpgradeUpsellTreatment extends PureComponent {
 						) }
 					</p>
 					<p>
-						{ translate( "Upgrade now and we'll give you {{b}}15% off your first %(term)s{{/b}}.", {
-							components: {
-								b: <b />,
-							},
-							args: {
-								term: hasSevenDayRefundPeriod ? 'month' : 'year',
-							},
-						} ) }
+						{ translate(
+							"Upgrade now and we'll give you {{b}}%(discount)d% off your first %(term)s{{/b}}.",
+							{
+								components: {
+									b: <b />,
+								},
+								args: {
+									discount: 15,
+									term: hasSevenDayRefundPeriod ? 'month' : 'year',
+									comment:
+										'%(discount)d is a percentage like 15% and %(term)s will be either "month" or "year"',
+								},
+							}
+						) }
 					</p>
 					<div className="business-plan-upgrade-upsell-new-design__countdown-counter">
 						<span>

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { isMonthly, getPlanByPathSlug, TERM_MONTHLY } from '@automattic/calypso-products';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CompactCard, Gridicon } from '@automattic/components';
@@ -55,6 +56,7 @@ import {
 } from 'calypso/state/stored-cards/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { BusinessPlanUpgradeUpsell } from './business-plan-upgrade-upsell';
+import { BusinessPlanUpgradeUpsellTreatment } from './business-plan-upgrade-upsell/treatment';
 import PurchaseModal from './purchase-modal';
 import { extractStoredCardMetaValue } from './purchase-modal/util';
 import { QuickstartSessionsRetirement } from './quickstart-sessions-retirement';
@@ -292,6 +294,23 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 				);
 
 			case BUSINESS_PLAN_UPGRADE_UPSELL:
+				if ( config.isEnabled( 'upsell/post-purchase-treatment' ) ) {
+					return isLoading ? (
+						this.renderGenericPlaceholder()
+					) : (
+						<BusinessPlanUpgradeUpsellTreatment
+							currencyCode={ currencyCode }
+							planRawPrice={ planRawPrice }
+							planDiscountedRawPrice={ planDiscountedRawPrice }
+							receiptId={ receiptId }
+							translate={ translate }
+							handleClickAccept={ this.handleClickAccept }
+							handleClickDecline={ this.handleClickDecline }
+							hasSevenDayRefundPeriod={ hasSevenDayRefundPeriod }
+							currentPlan={ currentPlan }
+						/>
+					);
+				}
 				return isLoading ? (
 					this.renderGenericPlaceholder()
 				) : (

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -45,6 +45,7 @@ import {
 	getPlansBySiteId,
 	getSitePlanRawPrice,
 	getPlanDiscountedRawPrice,
+	getCurrentPlan,
 } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import {
@@ -100,6 +101,7 @@ export interface UpsellNudgeAutomaticProps extends WithShoppingCartProps {
 	translate: ReturnType< typeof useTranslate >;
 	cards: PaymentMethod[];
 	currentPlanTerm: string;
+	currentPlan?: object;
 }
 
 export type UpsellNudgeProps = UpsellNudgeManualProps & UpsellNudgeAutomaticProps;
@@ -261,6 +263,7 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 		const {
 			receiptId,
 			currencyCode,
+			currentPlan,
 			currentPlanTerm,
 			planRawPrice,
 			planDiscountedRawPrice,
@@ -301,6 +304,7 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 						handleClickAccept={ this.handleClickAccept }
 						handleClickDecline={ this.handleClickDecline }
 						hasSevenDayRefundPeriod={ hasSevenDayRefundPeriod }
+						currentPlan={ currentPlan }
 					/>
 				);
 
@@ -546,6 +550,7 @@ export default connect(
 		const areStoredCardsLoading = hasLoadedCardsFromServer ? isFetchingCards : true;
 		const cards = getStoredCards( state );
 
+		const currentPlan = getCurrentPlan( state, selectedSiteId ) ?? undefined;
 		const currentPlanTerm = getCurrentPlanTerm( state, selectedSiteId ?? 0 ) ?? TERM_MONTHLY;
 		const productSlug = getProductSlug( upsellType, upgradeItem ?? '', currentPlanTerm );
 		const productProperties = pick( getProductBySlug( state, productSlug ?? '' ), [
@@ -563,6 +568,7 @@ export default connect(
 		return {
 			cards,
 			currencyCode: getCurrentUserCurrencyCode( state ),
+			currentPlan,
 			currentPlanTerm,
 			isLoading:
 				areStoredCardsLoading ||

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -323,7 +323,6 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 						handleClickAccept={ this.handleClickAccept }
 						handleClickDecline={ this.handleClickDecline }
 						hasSevenDayRefundPeriod={ hasSevenDayRefundPeriod }
-						currentPlan={ currentPlan }
 					/>
 				);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1605

## Proposed Changes

* This PR creates a "treatment" version of the post-purchase upsell that will be used in an upcoming a/b experiment.
* The "treatment" contains a countdown timer that counts down 24 hours from the purchase of the Premium plan.
* The "treatment" can be viewed using a temporary feature flag `upsell/post-purchase-treatment`
* The "treatment" has a new line of copy "Upgrade now and we'll give you 15% off your first year." (or month)

> **Note** This PR does not actually apply the discount. Lets tackle that in a different PR.

Before | After
--|--
![countdown-before](https://user-images.githubusercontent.com/140841/219508109-ea1c284f-72cc-41cc-bf8c-1ae5c8417837.png)  | ![countdown-after](https://user-images.githubusercontent.com/140841/219508084-30db3830-ad79-4f6e-93de-1a8474a1289d.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Purchase a Premium plan. You should see the same upsell that we currently have in production.
* If you add `?flags=upsell/post-purchase-treatment` to the end of the URL, it will load the new "treatment" upsell.
* Confirm that the countdown is correct and the copy makes sense.
* Refresh the page. The countdown should not start over.
* Modify the code so the discount time has passed. Does the timer look ok zeroed out?
* Does it look good on small screens and mobile?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
