### PR TITLE
BackupRetention: Fix default selected option to prioritize customer-defined retention

### DIFF
--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -52,19 +52,7 @@ const BackupRetentionManagement: FunctionComponent = () => {
 	const [ storageUpgradeRequired, setStorageUpgradeRequired ] = useState( false );
 
 	// The retention days that currently applies for this customer.
-	const [ currentRetentionPlan, setCurrentRetentionPlan ] = useState( 0 );
-	useEffect( () => {
-		if ( isFetching ) {
-			return;
-		}
-
-		if ( customerRetentionPeriod ) {
-			setCurrentRetentionPlan( customerRetentionPeriod );
-		} else if ( planRetentionPeriod ) {
-			setCurrentRetentionPlan( planRetentionPeriod );
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ customerRetentionPeriod, planRetentionPeriod ] );
+	const currentRetentionPlan = customerRetentionPeriod || planRetentionPeriod || 0;
 
 	const storageLimitBytes = useSelector( ( state ) =>
 		getRewindBytesAvailable( state, siteId )
@@ -152,10 +140,10 @@ const BackupRetentionManagement: FunctionComponent = () => {
 
 	// Set the retention period selected when we fetch the current plan retention period
 	useEffect( () => {
-		if ( currentRetentionPlan && ! retentionSelected ) {
+		if ( ! isFetching ) {
 			setRetentionSelected( currentRetentionPlan );
 		}
-	}, [ currentRetentionPlan, retentionSelected ] );
+	}, [ currentRetentionPlan, isFetching ] );
 
 	useEffect( () => {
 		if (


### PR DESCRIPTION
This PR aims to fix the default retention option to prioritize selecting customer-defined retention by default.

To reproduce the issue, you could access the settings page in Jetpack Cloud with any site with a storage limit (like Jetpack Backup 10 GB) and it will check the retention option according to their plan, and not the one they updated previously.

The expected behavior is to prioritize selecting the customer-defined retention.

| Before | After (expected) |
|---|---|
| ![image](https://user-images.githubusercontent.com/1488641/219229174-55a7a45c-ecfa-44cc-bbc5-31ff4d35c8ab.png) | ![image](https://user-images.githubusercontent.com/1488641/219229202-663158fa-3c09-431a-8e83-81b8ebaa8ee6.png) |

## Proposed Changes

* Fix to ensure we are deciding whether the default option is the one the customer defined previously or the plan retention period by default.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start a Jetpack Cloud live branch
* Navigate to Settings and wait for the new setting to load.
* The Update settings button will be disabled when the current plan or an option that requires an upgrade are selected.
* You could try to update the days of backups saved. The way to re-confirm it was properly saved is refreshing the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
