### PR TITLE
Replace deprecate custom breakpoint

### DIFF
--- a/client/components/theme-preview-modal/style.scss
+++ b/client/components/theme-preview-modal/style.scss
@@ -2,10 +2,8 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
-$break-design-preview: 1024px;
-
 @mixin break-design-preview() {
-	@media (min-width: #{ ($break-design-preview) }) {
+	@media (min-width: #{ ($break-xlarge) }) {
 		@content;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -6,10 +6,9 @@
 $gray-100: #101517;
 $gray-60: #50575e;
 $design-button-primary-color: rgb(17, 122, 201);
-$break-design-preview: 1024px;
 
 @mixin break-design-preview() {
-	@media (min-width: #{ ($break-design-preview) }) {
+	@media (min-width: #{ ($break-xlarge) }) {
 		@content;
 	}
 }

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -2,10 +2,8 @@
 @import "@wordpress/base-styles/mixins";
 @import "@automattic/typography/styles/fonts";
 
-$break-design-preview: 1024px;
-
 @mixin break-design-preview() {
-	@media (min-width: #{ ($break-design-preview) }) {
+	@media (min-width: #{ ($break-xlarge) }) {
 		@content;
 	}
 }
@@ -316,7 +314,7 @@ $break-design-preview: 1024px;
 
 	.theme-preview__frame-wrapper {
 		.theme-preview__frame {
-			@media ( max-width: $break-design-preview ) {
+			@media ( max-width: $break-xlarge ) {
 				border: 0;
 				border-radius: 0;
 				box-shadow: none;


### PR DESCRIPTION
## Proposed Changes

Currently, we are using `$break-design-preview` but replace it with [`$break-xlarge`](https://github.com/WordPress/gutenberg/blob/trunk/packages/base-styles/_breakpoints.scss?rgh-link-date=2023-01-04T03%3A00%3A33Z) defined in Gutenberg since it creates a maintenance issue where there are already multiple places in the codebase that has to redefine this custom breakpoint.

Close https://github.com/Automattic/wp-calypso/issues/71655

## Testing Instructions

Needs `themes/showcase-i4/details-and-preview` to be enabled for calypso.live.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `Appearance > Themes`
- Preview theme with style variation, and click `Open live demo`
- Confirm that the style switches at 1080px screen width

![312995db34d4fc47f5f3882fca3943a1](https://user-images.githubusercontent.com/5287479/219547925-df770e23-e69c-4b79-b8bd-b90c7bffa328.gif)

- Click `Add new site` on the admin page
- Click `Continue` to the `Nice job! Now it’s time to get creative.` page, and click `View designs`
- Preview theme with style variation on the `Pick a design` page
- Confirm that the style switches at 1080px screen width

[![Image from Gyazo](https://i.gyazo.com/2349597c370321d4f860284cf257bcad.gif)](https://gyazo.com/2349597c370321d4f860284cf257bcad)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
	- No, but fine for this PR
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
	- No, but fine for this PR
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
