### PR TITLE
BackupRetention: Add purchase flow

### DIFF
--- a/client/components/backup-retention-management/style.scss
+++ b/client/components/backup-retention-management/style.scss
@@ -29,6 +29,10 @@
 			color: var(--studio-gray-60);
 		}
 	}
+
+	.display-price__billing-time-frame .compact {
+		display: none;
+	}
 }
 
 .backup-retention-management .setting-title {

--- a/client/components/backup-retention-management/use-upsell-info.ts
+++ b/client/components/backup-retention-management/use-upsell-info.ts
@@ -1,0 +1,77 @@
+import {
+	PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_10GB_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_100GB_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_1TB_MONTHLY,
+	useJetpack100GbStorageAmountText,
+	useJetpack10GbStorageAmountText,
+	useJetpack1TbStorageAmountText,
+} from '@automattic/calypso-products';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import {
+	BYTES_10GB,
+	BYTES_1TB,
+	storageToUpsellProduct,
+} from 'calypso/components/backup-storage-space/usage-warning/use-upsell-slug';
+import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
+import useItemPrice from 'calypso/my-sites/plans/jetpack-plans/use-item-price';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import type { SelectorProductWithStorage } from 'calypso/components/backup-storage-space/usage-warning/use-upsell-slug';
+
+/**
+ * This hook is inspired in `calypso/components/backup-storage-space/usage-warning/use-upsell-slug`.
+ * The main difference is that this hook returns the best storage addon according to the space needed
+ * to fit an specific retention period that requires an storage upgrade.
+ */
+export default (
+	siteId: number,
+	currentSize: number,
+	retentionDays: number,
+	storageLimitBytes: number
+) => {
+	const TEN_GIGABYTES = useJetpack10GbStorageAmountText();
+	const HUNDRED_GIGABYTES = useJetpack100GbStorageAmountText();
+	const ONE_TERABYTES = useJetpack1TbStorageAmountText();
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+	const additionalBytesNeeded = currentSize * retentionDays - storageLimitBytes;
+
+	const upsellSlug = useMemo( () => {
+		const ADD_ON_STORAGE_MAP: Record< string, React.ReactChild > = {
+			[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_10GB_MONTHLY ]: TEN_GIGABYTES,
+			[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_100GB_MONTHLY ]: HUNDRED_GIGABYTES,
+			[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_1TB_MONTHLY ]: ONE_TERABYTES,
+		};
+
+		// Since 1TB is our max upgrade but the additional storage needed is greater than 1TB, then just return 1TB
+		if ( additionalBytesNeeded > BYTES_1TB ) {
+			return {
+				...slugToSelectorProduct( PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_1TB_MONTHLY ),
+				storage: ADD_ON_STORAGE_MAP[ PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_1TB_MONTHLY ],
+			} as SelectorProductWithStorage;
+		}
+
+		const matchedBytes =
+			Object.keys( storageToUpsellProduct )
+				.map( Number ) // .keys returns as strings, so convert it to a integer
+				.sort( ( a, b ) => a - b ) // order of keys is not always guaranteed, so sort it before we do the search
+				.find( ( bytes ) => bytes > additionalBytesNeeded ) ?? BYTES_10GB; // find the first add-on with storage above the current usage
+
+		const upsellSlugId = storageToUpsellProduct[ matchedBytes ];
+
+		return {
+			...slugToSelectorProduct( upsellSlugId ),
+			storage: ADD_ON_STORAGE_MAP[ upsellSlugId ],
+		} as SelectorProductWithStorage;
+	}, [ TEN_GIGABYTES, HUNDRED_GIGABYTES, ONE_TERABYTES, additionalBytesNeeded ] );
+
+	const { originalPrice, isFetching } = useItemPrice(
+		siteId,
+		upsellSlug,
+		upsellSlug?.monthlyProductSlug || ''
+	);
+
+	return useMemo(
+		() => ( { upsellSlug, originalPrice, isPriceFetching: isFetching as boolean, currencyCode } ),
+		[ upsellSlug, currencyCode, originalPrice, isFetching ]
+	);
+};

--- a/client/components/backup-storage-space/usage-warning/upsell.tsx
+++ b/client/components/backup-storage-space/usage-warning/upsell.tsx
@@ -26,7 +26,7 @@ type UpsellPriceProps = {
 	isPriceFetching: boolean | null;
 	currencyCode: string | null;
 };
-const UpsellPrice: React.FC< UpsellPriceProps > = ( {
+export const UpsellPrice: React.FC< UpsellPriceProps > = ( {
 	upsellSlug,
 	originalPrice,
 	isPriceFetching,

--- a/client/components/backup-storage-space/usage-warning/use-upsell-slug.ts
+++ b/client/components/backup-storage-space/usage-warning/use-upsell-slug.ts
@@ -24,7 +24,7 @@ import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getRewindBytesAvailable, getRewindBytesUsed } from 'calypso/state/rewind/selectors';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
-type SelectorProductWithStorage = SelectorProduct & {
+export type SelectorProductWithStorage = SelectorProduct & {
 	storage: React.ReactChild;
 };
 
@@ -41,11 +41,11 @@ const UPGRADEABLE_STORAGE_PRODUCT_SLUGS_T2 = [
 	PLAN_JETPACK_SECURITY_T2_MONTHLY,
 	PLAN_JETPACK_SECURITY_T2_YEARLY,
 ];
-const BYTES_10GB = 10737418240;
-const BYTES_100GB = 107374182400;
-const BYTES_1TB = 1073741824000;
+export const BYTES_10GB = 10737418240;
+export const BYTES_100GB = 107374182400;
+export const BYTES_1TB = 1073741824000;
 
-const storageToUpsellProduct: Record< number, string > = {
+export const storageToUpsellProduct: Record< number, string > = {
 	[ BYTES_10GB ]: PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_10GB_MONTHLY,
 	[ BYTES_100GB ]: PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_100GB_MONTHLY,
 	[ BYTES_1TB ]: PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_1TB_MONTHLY,

--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -24,12 +24,18 @@ export const advancedCredentials: PageJS.Callback = ( context, next ) => {
 	const siteId = getSelectedSiteId( context.store.getState() ) as number;
 	const sectionElt = <AdvancedCredentials action={ action } host={ host } role="main" />;
 
+	// This parameter is useful to redirect back from checkout page and select the retention period
+	// the customer previously selected.
+	const retention = Number.isInteger( Number( context.query.retention ) )
+		? Number( context.query.retention )
+		: undefined;
+
 	context.primary = (
 		<>
 			{ config.isEnabled( 'jetpack/backup-retention-settings' ) ? (
 				<HasRetentionCapabilitiesSwitch
 					siteId={ siteId }
-					trueComponent={ <BackupRetentionManagement /> }
+					trueComponent={ <BackupRetentionManagement defaultRetention={ retention } /> }
 					falseComponent={ null }
 					loadingComponent={ <AdvancedCredentialsLoadingPlaceholder /> } // Let's use the same placeholder for now
 				/>


### PR DESCRIPTION
The idea of this PR is to add an option to purchase a storage add-on to fit the customers' retention needs when a storage upgrade is required. This doesn't include the option to update automatically.

## Proposed Changes

When a customer selects a retention option that requires an upgrade:
* Display a message saying that this option requires an upgrade and present the add-on storage that fit their needs, its price and billing term. 
* Rename the button to `Purchase Storage`.
* When clicking the CTA, it will redirect to checkout page and will add the add-on to the cart.
* If going back or completing the purchase, it will redirect back to the settings page with the selected retention period.

## Demo

[retention-period-purchase-flow-demo](https://user-images.githubusercontent.com/1488641/219561824-e87ecbaf-fcde-42dc-9197-7337adcba65b.webm)

## Screenshots

![image](https://user-images.githubusercontent.com/1488641/219284431-480917e2-b0c1-4c32-a938-627f175974e5.png)

## Known issues

* ~After purchasing a storage add-on, it is taking approximately 5 minutes to invalidate the products cache, so when going back to the setting page the `Space included in plan` will not be updated instantly. An investigation is required.~ This has been addressed in D101810-code.
 
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Unfortunately, this one cannot be tested using Jetpack Cloud live branch, due to some restrictions redirecting back from checkout page to calypso.live domain.

* Checkout `add/backup-retention-purchase-flow` branch locally.
* Run `ENABLE_FEATURES=no-force-sympathy yarn start-jetpack-cloud`
* Navigate to Settings and wait for the new setting to load.
* Ensure the `Update settings` button is disabled when the current plan is selected.
* Click an option that requires an upgrade and validate:
  * It should display a message similar to:
    ![image](https://user-images.githubusercontent.com/1488641/219284597-0c661d4f-2b7d-42a4-908a-43b5db66ebd8.png)
  *  Ensure the CTA button is renamed to `Purchase storage`
  * Click on the CTA. It should redirect you to the checkout page and add the product to the cart.
  * After purchasing or going back, it should redirect you to the setting page.
    * The URL should have a `retention=NUMBER` query argument and the radio button with that option should be selected by default.
  * After purchasing, it is possible that you are not seeing the `Space included in plan` updated (see Known Issues section).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?