### PR TITLE
Try: Storage addon in addons grid

### DIFF
--- a/client/my-sites/add-ons/hooks/use-add-on-feature-slugs.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-feature-slugs.ts
@@ -5,13 +5,15 @@ import {
 	WPCOM_FEATURES_PREMIUM_THEMES,
 	WPCOM_FEATURES_CUSTOM_DESIGN,
 	WPCOM_FEATURES_NO_ADVERTS,
+	PRODUCT_WPCOM_10_GB_STORAGE,
+	FEATURE_1GB_STORAGE,
 } from '@automattic/calypso-products';
 
 /**
  * Returns any relevant feature slugs for a given add-on.
  * Add-ons are currently uniquely identified by their product slugs.
  */
-const useAddOnFeatureSlugs = ( addOnProductSlug: string ) => {
+const useAddOnFeatureSlugs = ( addOnProductSlug: string ): string[] | null => {
 	switch ( addOnProductSlug ) {
 		case PRODUCT_WPCOM_UNLIMITED_THEMES:
 			return [ WPCOM_FEATURES_PREMIUM_THEMES ];
@@ -19,6 +21,8 @@ const useAddOnFeatureSlugs = ( addOnProductSlug: string ) => {
 			return [ WPCOM_FEATURES_CUSTOM_DESIGN ];
 		case PRODUCT_NO_ADS:
 			return [ WPCOM_FEATURES_NO_ADVERTS ];
+		case PRODUCT_WPCOM_10_GB_STORAGE:
+			return [ FEATURE_1GB_STORAGE ];
 		default:
 			return null;
 	}

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -10,9 +10,9 @@ import {
 	getProductDescription,
 	getProductName,
 } from 'calypso/state/products-list/selectors';
-import isStorageAddonAvailable from 'calypso/state/selectors/is-storage-addon-available';
 import customDesignIcon from '../icons/custom-design';
 import unlimitedThemesIcon from '../icons/unlimited-themes';
+import isStorageAddonAvailable from '../is-storage-addon-available';
 import useAddOnDisplayCost from './use-add-on-display-cost';
 import useAddOnFeatureSlugs from './use-add-on-feature-slugs';
 export interface AddOnMeta {

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -1,31 +1,48 @@
 import {
 	PRODUCT_WPCOM_CUSTOM_DESIGN,
 	PRODUCT_WPCOM_UNLIMITED_THEMES,
+	PRODUCT_WPCOM_10_GB_STORAGE,
 } from '@automattic/calypso-products';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import {
 	getProductBySlug,
 	getProductDescription,
 	getProductName,
 } from 'calypso/state/products-list/selectors';
+import isStorageAddonAvailable from 'calypso/state/selectors/is-storage-addon-available';
 import customDesignIcon from '../icons/custom-design';
 import unlimitedThemesIcon from '../icons/unlimited-themes';
 import useAddOnDisplayCost from './use-add-on-display-cost';
 import useAddOnFeatureSlugs from './use-add-on-feature-slugs';
-
 export interface AddOnMeta {
 	productSlug: string;
 	featureSlugs?: string[] | null;
 	icon: JSX.Element;
 	featured?: boolean; // irrelevant to "featureSlugs"
 	name: string | React.ReactChild | null;
+	overrides?: Partial< Record< keyof AddOnMeta, React.ReactChild > > | null;
 	description: string | React.ReactChild | null;
 	displayCost: string | React.ReactChild | null;
 }
 
 // some memoization. executes far too many times
 const useAddOns = (): ( AddOnMeta | null )[] => {
+	const translate = useTranslate();
+	const storageAddon = {
+		productSlug: PRODUCT_WPCOM_10_GB_STORAGE,
+		featureSlugs: useAddOnFeatureSlugs( PRODUCT_WPCOM_10_GB_STORAGE ),
+		icon: customDesignIcon,
+		overrides: {
+			description: translate( 'Add 10 GB of high-performance SSD storage space to your site.' ),
+			name: translate( 'Additional Storage Space' ),
+		},
+		displayCost: useAddOnDisplayCost( PRODUCT_WPCOM_10_GB_STORAGE ),
+		featured: true,
+	};
+
 	const addOnsActive = [
+		...( isStorageAddonAvailable() ? [ storageAddon ] : [] ),
 		{
 			productSlug: PRODUCT_WPCOM_UNLIMITED_THEMES,
 			featureSlugs: useAddOnFeatureSlugs( PRODUCT_WPCOM_UNLIMITED_THEMES ),
@@ -47,8 +64,9 @@ const useAddOns = (): ( AddOnMeta | null )[] => {
 	return useSelector( ( state ): ( AddOnMeta | null )[] => {
 		return addOnsActive.map( ( addOn ) => {
 			const product = getProductBySlug( state, addOn.productSlug );
-			const name = getProductName( state, addOn.productSlug );
-			const description = getProductDescription( state, addOn.productSlug );
+			const name = addOn.overrides?.name ?? getProductName( state, addOn.productSlug );
+			const description =
+				addOn.overrides?.description ?? getProductDescription( state, addOn.productSlug );
 
 			if ( ! product ) {
 				// will not render anything if product not fetched from API

--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -6,6 +6,7 @@ export const PRODUCT_WPCOM_SEARCH = 'wpcom_search';
 export const PRODUCT_WPCOM_SEARCH_MONTHLY = 'wpcom_search_monthly';
 export const PRODUCT_WPCOM_UNLIMITED_THEMES = 'unlimited_themes';
 export const PRODUCT_WPCOM_CUSTOM_DESIGN = 'custom-design';
+export const PRODUCT_WPCOM_10_GB_STORAGE = '1gb_space_upgrade';
 
 export const WPCOM_SEARCH_PRODUCTS = <const>[ PRODUCT_WPCOM_SEARCH, PRODUCT_WPCOM_SEARCH_MONTHLY ];
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1510

## Proposed Changes

* Testing to add a storage add-on to the add-ons route in Calypso.
* Adding overrides for title and description, so we can optionally define these in Calypso vs pulling them from the API. 
* Need to add actual copy, icon, dropdown toggle probably.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /add-ons?flags=storage-addon and you should see this addon listed among the other ones. 
* Clicking it will take you to checkout
* Note, does not currently work with the Premium plan, but other plans (Free, Business, etc.) should allow you to Purchase it. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
