### PR TITLE
State: Add selector for retrieving domain passed from upsell flow

### DIFF
--- a/client/state/selectors/get-domain-from-home-upsell-in-query.ts
+++ b/client/state/selectors/get-domain-from-home-upsell-in-query.ts
@@ -1,0 +1,16 @@
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns the get_domain query param if present or null.
+ *
+ * @param {Object}   state Global state tree
+ * @returns {?string}       The domain as a string or null
+ */
+export const getDomainFromHomeUpsellInQuery = function ( state: AppState ): string | null {
+	const queryArgs = getCurrentQueryArguments( state );
+	const domain = queryArgs?.get_domain;
+	return domain ? domain.toString() : null;
+};
+
+export default getDomainFromHomeUpsellInQuery;

--- a/client/state/selectors/test/get-domain-from-home-upsell-in-query.js
+++ b/client/state/selectors/test/get-domain-from-home-upsell-in-query.js
@@ -1,0 +1,64 @@
+import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
+
+describe( '#getDomainFromHomeUpsellInQuery', () => {
+	test( 'should return null when no argument', () => {
+		expect( getDomainFromHomeUpsellInQuery() ).toBeNull();
+	} );
+
+	test( 'should return null if no get_domain query present', () => {
+		const state = {
+			route: {
+				query: {
+					current: {
+						foo: 'bar',
+					},
+				},
+			},
+		};
+		expect( getDomainFromHomeUpsellInQuery( state ) ).toBeNull();
+	} );
+
+	test( 'should return null when get_domain present but empty', () => {
+		const state = {
+			route: {
+				query: {
+					current: {
+						get_domain: '',
+					},
+				},
+			},
+		};
+
+		expect( getDomainFromHomeUpsellInQuery( state ) ).toBeNull();
+	} );
+
+	test( 'should return domain as string when get_domain query present', () => {
+		const state = {
+			route: {
+				query: {
+					current: {
+						get_domain: 'foo.com',
+					},
+				},
+			},
+		};
+
+		// toBe is a strict equality check here.
+		expect( getDomainFromHomeUpsellInQuery( state ) ).toBe( 'foo.com' );
+	} );
+
+	test( 'should return domain as string when CSV get_domain query present', () => {
+		const state = {
+			route: {
+				query: {
+					current: {
+						get_domain: 'foo.com, bar.com',
+					},
+				},
+			},
+		};
+
+		// toBe is a strict equality check here.
+		expect( getDomainFromHomeUpsellInQuery( state ) ).toBe( 'foo.com, bar.com' );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1491

## Proposed Changes

Adds the state selector `getDomainFromHomeUpsellInQuery` for retrieving the `get_domain` parameter passed from the domain upsell flow. This is used in the plans' components and is necessary for the refactors going into https://github.com/Automattic/wp-calypso/pull/73230

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* code review
* unit tests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
