### PR TITLE
Theme Showcase: Set backPath on component unmount

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -26,6 +26,7 @@ import getSiteFeaturesById from 'calypso/state/selectors/get-site-features';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { setBackPath } from 'calypso/state/themes/actions';
 import {
 	arePremiumThemesEnabled,
 	getThemeFilterTerms,
@@ -118,6 +119,10 @@ class ThemeShowcase extends Component {
 		) {
 			this.scrollToSearchInput();
 		}
+	}
+
+	componentWillUnmount() {
+		this.props.setBackPath( this.constructUrl( { searchString: this.props.search } ) );
 	}
 
 	isStaticFilter = ( tabFilter ) => {
@@ -561,4 +566,4 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
 	};
 };
 
-export default connect( mapStateToProps, null )( localize( ThemeShowcase ) );
+export default connect( mapStateToProps, { setBackPath } )( localize( ThemeShowcase ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73138

## Proposed Changes

This PR fixes the issue where when users click the page's back button (not the browser's) in the theme upload or theme detail page, they are redirected back to the theme showcase without retaining previous search/filter state. Since the search/filter state of the theme showcase is reflected in the URL, we can save the state by storing the URL in `backPath` when the theme showcase is about to be unmounted.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase `/themes` and set any search/filter condition.
* Click on any theme, and once in the detail page, click the "All themes" button.
* Ensure that the previous search/filter conditions are persisted.
* Ensure that both logged-in and logged-out Theme Showcase are tested.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
