### PR TITLE
Jetpack Pro Dashboard: implement inline notices & fix style mismatch in the plugin details page

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/index.tsx
@@ -6,7 +6,6 @@ import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QueryJetpackSitesFeatures from 'calypso/components/data/query-jetpack-sites-features';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
-import PluginNotices from 'calypso/my-sites/plugins/notices';
 import PluginDetailsBody from 'calypso/my-sites/plugins/plugin-details-body';
 import PluginDetailsHeader from 'calypso/my-sites/plugins/plugin-details-header';
 import PluginAvailableOnSitesList from 'calypso/my-sites/plugins/plugin-management-v2/plugin-details-v2/plugin-available-on-sites-list';
@@ -84,11 +83,6 @@ export default function PluginDetailsV2( {
 				className="plugin-details-v2__header"
 				compactBreadcrumb={ false }
 				navigationItems={ breadcrumbs }
-			/>
-			<PluginNotices
-				pluginId={ fullPlugin.id }
-				sites={ sitesWithPlugins }
-				plugins={ [ fullPlugin ] }
 			/>
 			<div className="plugin-details-v2__top-container">
 				<div className="plugin-details__page legacy">

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/index.tsx
@@ -92,7 +92,7 @@ export default function PluginDetailsV2( {
 			/>
 			<div className="plugin-details-v2__top-container">
 				<div className="plugin-details__page legacy">
-					<div className="plugin-details__layout plugin-details__top-section">
+					<div>
 						<div className="plugin-details__layout-col-left">
 							<PluginDetailsHeader
 								isJetpackCloud

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -101,9 +101,15 @@ export default function PluginRowFormatter( {
 
 	const allStatuses = getPluginActionStatuses( state );
 
-	const currentSiteStatuses = allStatuses.filter(
+	let currentSiteStatuses = allStatuses.filter(
 		( status ) => status.pluginId === item.id && status.action !== UPDATE_PLUGIN
 	);
+
+	if ( 'site-name' === columnKey ) {
+		currentSiteStatuses = currentSiteStatuses.filter(
+			( status ) => parseInt( status.siteId ) === selectedSite?.ID
+		);
+	}
 
 	const pluginActionStatus =
 		currentSiteStatuses.length > 0 ? (
@@ -120,6 +126,9 @@ export default function PluginRowFormatter( {
 					<span className="plugin-row-formatter__site-name">{ selectedSite?.domain }</span>
 					{ /* Overlay for small screen is added in the card component */ }
 					{ ! isSmallScreen && <span className="plugin-row-formatter__overlay"></span> }
+					{ pluginActionStatus && (
+						<div className="plugin-row-formatter__action-status">{ pluginActionStatus }</div>
+					) }
 				</span>
 			);
 		case 'plugin':

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/style.scss
@@ -156,3 +156,10 @@ a.button.plugin-row-formatter__plugin-name-card {
 		}
 	}
 }
+
+.plugin-row-formatter__action-status {
+	margin-block-start: 12px;
+	@include break-xlarge {
+		margin-block-start: 6px;
+	}
+}

--- a/client/my-sites/plugins/plugin-management-v2/test/plugin-row-formatter.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/plugin-row-formatter.test.tsx
@@ -4,7 +4,6 @@
 import userEvent from '@testing-library/user-event';
 import moment from 'moment';
 import React from 'react';
-import { ACTIVATE_PLUGIN } from 'calypso/lib/plugins/constants';
 import documentHead from 'calypso/state/document-head/reducer';
 import plugins from 'calypso/state/plugins/reducer';
 import productsList from 'calypso/state/products-list/reducer';
@@ -26,14 +25,6 @@ const initialReduxState = {
 			isRequestingAll: false,
 			plugins: {
 				[ `${ site.ID }` ]: [ plugin ],
-			},
-			status: {
-				[ `${ site.ID }` ]: {
-					[ plugin.id ]: {
-						status: 'completed',
-						action: ACTIVATE_PLUGIN,
-					},
-				},
 			},
 		},
 	},

--- a/client/my-sites/plugins/plugin-management-v2/types.ts
+++ b/client/my-sites/plugins/plugin-management-v2/types.ts
@@ -5,6 +5,7 @@ import {
 	ENABLE_AUTOUPDATE_PLUGIN,
 	REMOVE_PLUGIN,
 	UPDATE_PLUGIN,
+	INSTALL_PLUGIN,
 } from 'calypso/lib/plugins/constants';
 import {
 	PLUGIN_INSTALLATION_COMPLETED,
@@ -59,7 +60,8 @@ export type PluginActionTypes =
 	| typeof DISABLE_AUTOUPDATE_PLUGIN
 	| typeof ENABLE_AUTOUPDATE_PLUGIN
 	| typeof REMOVE_PLUGIN
-	| typeof UPDATE_PLUGIN;
+	| typeof UPDATE_PLUGIN
+	| typeof INSTALL_PLUGIN;
 
 export type PluginActionStatus =
 	| typeof PLUGIN_INSTALLATION_IN_PROGRESS

--- a/client/my-sites/plugins/plugin-management-v2/utils/get-plugin-action-status-messages.ts
+++ b/client/my-sites/plugins/plugin-management-v2/utils/get-plugin-action-status-messages.ts
@@ -7,6 +7,7 @@ import {
 	ENABLE_AUTOUPDATE_PLUGIN,
 	REMOVE_PLUGIN,
 	UPDATE_PLUGIN,
+	INSTALL_PLUGIN,
 } from 'calypso/lib/plugins/constants';
 import {
 	PLUGIN_INSTALLATION_COMPLETED,
@@ -159,6 +160,11 @@ export const getPluginActionStatusMessages = (
 				? translate( 'Failed' )
 				: translate( 'Failed on %(count)s site', 'Failed on %(count)s sites', translationArgs ),
 			[ PLUGIN_INSTALLATION_UP_TO_DATE ]: translate( 'Plugin already up to date' ),
+		},
+		[ INSTALL_PLUGIN ]: {
+			[ PLUGIN_INSTALLATION_IN_PROGRESS ]: translate( 'Installing' ),
+			[ PLUGIN_INSTALLATION_COMPLETED ]: translate( 'Installed' ),
+			[ PLUGIN_INSTALLATION_ERROR ]: translate( 'Failed to install' ),
 		},
 	};
 };


### PR DESCRIPTION
#### Proposed Changes

This PR implements inline notices & fixes style mismatches in the plugin details page

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_** We are not removing PluginNotices component from Calypso Blue as there could be other actions which are using that component

**Instructions**

1. Run `git checkout add/implement-inline-notices-in-plugin-details-page` and `yarn start`
2. After the server starts, run `yarn start-jetpack-cloud-p`
3. Open http://jetpack.cloud.localhost:3001/, and you'll be redirected to the /dashboard.
4. Perform all the plugin actions(activate, auto-update, remove plugin, install plugin, etc) and verify that you can see inline notices for the actions and no longer see the notices on top-right. Also, perform these actions in Calypso Blue by visiting http://calypso.localhost:3000/

Deactivate plugin

<img width="1646" alt="Screenshot 2023-02-16 at 1 47 58 PM" src="https://user-images.githubusercontent.com/10586875/219343325-9e7b1c5f-4f22-43b0-9c62-66a66f73d569.png">

Install plugin

<img width="1646" alt="Screenshot 2023-02-16 at 1 48 05 PM" src="https://user-images.githubusercontent.com/10586875/219343338-670e4302-255e-4692-85bb-e152db0f8ac5.png">

Remove plugin

<img width="1646" alt="Screenshot 2023-02-16 at 1 48 18 PM" src="https://user-images.githubusercontent.com/10586875/219343343-65363187-43ae-41aa-9cdf-439a1cadc70f.png">

Mobile view 

<img width="313" alt="Screenshot 2023-02-16 at 1 46 57 PM" src="https://user-images.githubusercontent.com/10586875/219343309-1b767c66-e9ff-4016-a36d-ffbb33906959.png">

5. Verify the style fixes for the plugin details page in the mobile screen.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="233" alt="Screenshot 2023-02-16 at 1 43 05 PM" src="https://user-images.githubusercontent.com/10586875/219342864-7fe98f17-6578-43da-b520-f68026f508b2.png">
</td>
<td>
<img width="208" alt="Screenshot 2023-02-16 at 1 46 07 PM" src="https://user-images.githubusercontent.com/10586875/219342873-c79a4eb9-67fd-4ee7-b80b-a054f514bf4d.png">
</td>
</tr>
</table

6. Verify the same in Calypso Blue by running `yarn start`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related to 1202619025189113-as-1203983335493162 & 1202619025189113-as-1202927891445239