### PR TITLE
Virtual Themes: Update Tracks events

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -16,6 +16,7 @@ export function recordPreviewedDesign( {
 	recordTracksEvent( 'calypso_signup_design_preview_select', {
 		...getDesignEventProps( { flow, intent, design, styleVariation } ),
 		...getDesignTypeProps( design ),
+		...getVirtualDesignProps( design, styleVariation ),
 	} );
 }
 
@@ -72,12 +73,8 @@ export function getDesignEventProps( {
 	design: Design;
 	styleVariation?: StyleVariation;
 } ) {
-	let variationSlugSuffix = '';
-	if ( styleVariation && styleVariation.slug !== 'default' ) {
-		variationSlugSuffix = `-${ styleVariation.slug }`;
-	} else if ( design.is_virtual && design.style_variation?.slug ) {
-		variationSlugSuffix = `-${ design.style_variation.slug }`;
-	}
+	const variationSlugSuffix =
+		styleVariation && styleVariation.slug !== 'default' ? `-${ styleVariation.slug }` : '';
 
 	return {
 		flow,
@@ -89,6 +86,17 @@ export function getDesignEventProps( {
 		design_type: design.design_type,
 		is_premium: design.is_premium,
 		has_style_variations: ( design.style_variations || [] ).length > 0,
+	};
+}
+
+export function getVirtualDesignProps( design: Design, styleVariation?: StyleVariation ) {
+	const variationSlugSuffix =
+		! styleVariation && design.is_virtual && design.style_variation?.slug
+			? `-${ design.style_variation.slug }`
+			: '';
+
+	return {
+		slug: design.slug + variationSlugSuffix,
 		is_virtual: design.is_virtual,
 	};
 }

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -72,8 +72,12 @@ export function getDesignEventProps( {
 	design: Design;
 	styleVariation?: StyleVariation;
 } ) {
-	const variationSlugSuffix =
-		styleVariation && styleVariation.slug !== 'default' ? `-${ styleVariation.slug }` : '';
+	let variationSlugSuffix = '';
+	if ( styleVariation && styleVariation.slug !== 'default' ) {
+		variationSlugSuffix = `-${ styleVariation.slug }`;
+	} else if ( design.is_virtual && design.style_variation?.slug ) {
+		variationSlugSuffix = `-${ design.style_variation.slug }`;
+	}
 
 	return {
 		flow,
@@ -85,5 +89,6 @@ export function getDesignEventProps( {
 		design_type: design.design_type,
 		is_premium: design.is_premium,
 		has_style_variations: ( design.style_variations || [] ).length > 0,
+		is_virtual: design.is_virtual,
 	};
 }

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -90,10 +90,12 @@ export function getDesignEventProps( {
 }
 
 export function getVirtualDesignProps( design: Design, styleVariation?: StyleVariation ) {
-	const variationSlugSuffix =
-		! styleVariation && design.is_virtual && design.style_variation?.slug
-			? `-${ design.style_variation.slug }`
-			: '';
+	let variationSlugSuffix = '';
+	if ( styleVariation && styleVariation.slug !== 'default' ) {
+		variationSlugSuffix = `-${ styleVariation.slug }`;
+	} else if ( ! styleVariation && design.preselected_style_variation ) {
+		variationSlugSuffix = `-${ design.preselected_style_variation.slug }`;
+	}
 
 	return {
 		slug: design.slug + variationSlugSuffix,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -244,16 +244,13 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	function previewDesign( design: Design, styleVariation?: StyleVariation ) {
 		recordPreviewedDesign( { flow, intent, design, styleVariation } );
 
-		if ( design.is_virtual ) {
+		if ( ! design.is_virtual ) {
+			setSelectedDesign( design );
+		} else {
 			const parentDesign = staticDesigns.find(
 				( staticDesign ) => staticDesign.slug === design.slug && ! staticDesign.is_virtual
 			);
 			setSelectedDesign( parentDesign );
-			if ( ! styleVariation && design.style_variation ) {
-				setSelectedStyleVariation( design.style_variation );
-			}
-		} else {
-			setSelectedDesign( design );
 		}
 
 		if ( styleVariation ) {
@@ -262,6 +259,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				...getVirtualDesignProps( design, styleVariation ),
 			} );
 			setSelectedStyleVariation( styleVariation );
+		} else if ( design.preselected_style_variation ) {
+			setSelectedStyleVariation( design.preselected_style_variation );
 		}
 
 		setIsPreviewingDesign( true );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -78,6 +78,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const siteVerticalId = useSelect(
 		( select ) => ( site && select( SITE_STORE ).getSiteVerticalId( site.ID ) ) || ''
 	);
+	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 
 	const isAtomic = useSelect( ( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID ) );
 	useEffect( () => {
@@ -129,6 +130,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		{
 			enabled: true,
 			select: selectStarterDesigns,
+			shouldLimitGlobalStyles,
 		}
 	);
 
@@ -240,7 +242,18 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 	function previewDesign( design: Design, styleVariation?: StyleVariation ) {
 		recordPreviewedDesign( { flow, intent, design, styleVariation } );
-		setSelectedDesign( design );
+
+		if ( design.is_virtual ) {
+			const parentDesign = staticDesigns.find(
+				( staticDesign ) => staticDesign.slug === design.slug && ! staticDesign.is_virtual
+			);
+			setSelectedDesign( parentDesign );
+			if ( ! styleVariation && design.style_variation ) {
+				setSelectedStyleVariation( design.style_variation );
+			}
+		} else {
+			setSelectedDesign( design );
+		}
 
 		if ( styleVariation ) {
 			recordTracksEvent(
@@ -358,8 +371,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	}
 
 	// ********** Logic for Premium Global Styles
-
-	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 	const [ showPremiumGlobalStylesModal, setShowPremiumGlobalStylesModal ] = useState( false );
 
 	function unlockPremiumGlobalStyles() {
@@ -707,7 +718,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			isPremiumThemeAvailable={ isPremiumThemeAvailable }
 			purchasedThemes={ purchasedThemes }
 			currentPlanFeatures={ currentPlanFeatures }
-			shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 		/>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -38,6 +38,7 @@ import {
 	getDesignTypeProps,
 	recordPreviewedDesign,
 	recordSelectedDesign,
+	getVirtualDesignProps,
 } from '../../analytics/record-design';
 import { getCategorizationOptions } from './categories';
 import { DEFAULT_VARIATION_SLUG, RETIRING_DESIGN_SLUGS, STEP_NAME } from './constants';
@@ -256,10 +257,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		}
 
 		if ( styleVariation ) {
-			recordTracksEvent(
-				'calypso_signup_design_picker_style_variation_button_click',
-				getEventPropsByDesign( design, styleVariation )
-			);
+			recordTracksEvent( 'calypso_signup_design_picker_style_variation_button_click', {
+				...getEventPropsByDesign( design, styleVariation ),
+				...getVirtualDesignProps( design, styleVariation ),
+			} );
 			setSelectedStyleVariation( styleVariation );
 		}
 

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -99,22 +99,22 @@ function apiStarterDesignsStaticToDesign(
 		price,
 		style_variations,
 		software_sets,
-		is_virtual,
 		style_variation_slug,
 	} = design;
+	const is_virtual = design.is_virtual && !! style_variation_slug;
+
 	const is_premium =
 		( design.recipe.stylesheet && design.recipe.stylesheet.startsWith( 'premium/' ) ) ||
-		( shouldLimitGlobalStyles && is_virtual && !! style_variation_slug ) ||
+		( shouldLimitGlobalStyles && is_virtual ) ||
 		false;
 
 	const is_bundled_with_woo_commerce = ( design.software_sets || [] ).some(
 		( { slug } ) => slug === 'woo-on-plans'
 	);
 
-	const style_variation =
-		is_virtual && style_variation_slug
-			? style_variations?.find( ( { slug } ) => slug === style_variation_slug )
-			: null;
+	const preselected_style_variation = is_virtual
+		? style_variations?.find( ( { slug } ) => slug === style_variation_slug )
+		: undefined;
 
 	return {
 		slug,
@@ -130,7 +130,7 @@ function apiStarterDesignsStaticToDesign(
 		design_type: is_premium ? 'premium' : 'standard',
 		style_variations,
 		is_virtual,
-		style_variation,
+		preselected_style_variation,
 		// Deprecated; used for /start flow
 		features: [],
 		template: '',

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -21,6 +21,7 @@ interface StarterDesignsQueryParams {
 interface Options extends QueryOptions< StarterDesignsResponse, unknown > {
 	enabled?: boolean;
 	select?: ( response: StarterDesigns ) => StarterDesigns;
+	shouldLimitGlobalStyles?: boolean;
 }
 
 interface StarterDesignsResponse {
@@ -51,7 +52,7 @@ interface GeneratedDesign {
 
 export function useStarterDesignsQuery(
 	queryParams: StarterDesignsQueryParams,
-	{ select, ...queryOptions }: Options = {}
+	{ select, shouldLimitGlobalStyles, ...queryOptions }: Options = {}
 ): UseQueryResult< StarterDesigns > {
 	return useQuery( [ 'starter-designs', queryParams ], () => fetchStarterDesigns( queryParams ), {
 		select: ( response: StarterDesignsResponse ) => {
@@ -60,7 +61,9 @@ export function useStarterDesignsQuery(
 					designs: response.generated?.designs?.map( apiStarterDesignsGeneratedToDesign ),
 				},
 				static: {
-					designs: response.static?.designs?.map( apiStarterDesignsStaticToDesign ),
+					designs: response.static?.designs?.map( ( design ) =>
+						apiStarterDesignsStaticToDesign( design, shouldLimitGlobalStyles )
+					),
 				},
 			};
 
@@ -82,7 +85,10 @@ function fetchStarterDesigns(
 	} );
 }
 
-function apiStarterDesignsStaticToDesign( design: StaticDesign ): Design {
+function apiStarterDesignsStaticToDesign(
+	design: StaticDesign,
+	shouldLimitGlobalStyles?: boolean
+): Design {
 	const {
 		slug,
 		title,
@@ -97,14 +103,18 @@ function apiStarterDesignsStaticToDesign( design: StaticDesign ): Design {
 		style_variation_slug,
 	} = design;
 	const is_premium =
-		( design.recipe.stylesheet && design.recipe.stylesheet.startsWith( 'premium/' ) ) || false;
+		( design.recipe.stylesheet && design.recipe.stylesheet.startsWith( 'premium/' ) ) ||
+		( shouldLimitGlobalStyles && is_virtual && !! style_variation_slug ) ||
+		false;
 
 	const is_bundled_with_woo_commerce = ( design.software_sets || [] ).some(
 		( { slug } ) => slug === 'woo-on-plans'
 	);
 
 	const style_variation =
-		style_variations?.find( ( { slug } ) => slug === style_variation_slug ) ?? null;
+		is_virtual && style_variation_slug
+			? style_variations?.find( ( { slug } ) => slug === style_variation_slug )
+			: null;
 
 	return {
 		slug,

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -115,10 +115,9 @@ const useTrackDesignView = ( {
 
 				const trackingCategory = category === SHOW_ALL_SLUG ? undefined : category;
 
-				let variationSlugSuffix = '';
-				if ( design.is_virtual && design.style_variation?.slug ) {
-					variationSlugSuffix = `-${ design.style_variation.slug }`;
-				}
+				const variationSlugSuffix = design.preselected_style_variation
+					? `-${ design.preselected_style_variation.slug }`
+					: '';
 
 				recordTracksEvent( 'calypso_design_picker_design_display', {
 					category: trackingCategory,
@@ -170,11 +169,9 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	const { __ } = useI18n();
 	const {
 		is_premium: isPremium = false,
-		is_virtual,
-		style_variation,
+		preselected_style_variation,
 		style_variations = [],
 	} = design;
-	const isVirtual = is_virtual && style_variation;
 	const shouldUpgrade = isPremium && ! isPremiumThemeAvailable && ! hasPurchasedTheme;
 	const currentSiteCanInstallWoo = currentPlanFeatures?.includes( FEATURE_WOOP ) ?? false;
 
@@ -202,7 +199,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 			badge = <WooCommerceBundledBadge />;
 		} else if ( isPremium ) {
 			const toolTip =
-				shouldUpgrade && isVirtual
+				shouldUpgrade && preselected_style_variation
 					? __( 'Unlock this style, and tons of other features, by upgrading to a Premium plan.' )
 					: undefined;
 			badge = (
@@ -223,8 +220,8 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	}
 
 	const getTitle = () => {
-		if ( design.is_virtual && design.style_variation ) {
-			return `${ design.title } – ${ design.style_variation.title }`;
+		if ( design.preselected_style_variation ) {
+			return `${ design.title } – ${ design.preselected_style_variation.title }`;
 		}
 
 		return design.title;

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -115,12 +115,18 @@ const useTrackDesignView = ( {
 
 				const trackingCategory = category === SHOW_ALL_SLUG ? undefined : category;
 
+				let variationSlugSuffix = '';
+				if ( design.is_virtual && design.style_variation?.slug ) {
+					variationSlugSuffix = `-${ design.style_variation.slug }`;
+				}
+
 				recordTracksEvent( 'calypso_design_picker_design_display', {
 					category: trackingCategory,
 					design_type: design.design_type,
 					is_premium: design.is_premium,
 					is_premium_available: isPremiumThemeAvailable,
-					slug: design.slug,
+					slug: design.slug + variationSlugSuffix,
+					is_virtual: design.is_virtual,
 				} );
 
 				if ( category ) {
@@ -150,7 +156,6 @@ interface DesignButtonProps {
 	onCheckout?: any;
 	verticalId?: string;
 	currentPlanFeatures?: string[];
-	shouldLimitGlobalStyles?: boolean;
 }
 
 const DesignButton: React.FC< DesignButtonProps > = ( {
@@ -161,12 +166,15 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	hasPurchasedTheme = false,
 	verticalId,
 	currentPlanFeatures,
-	shouldLimitGlobalStyles,
 } ) => {
 	const { __ } = useI18n();
-	const { is_premium = false, is_virtual, style_variation, style_variations = [] } = design;
-	const isLimitedVirtual = shouldLimitGlobalStyles && is_virtual && style_variation;
-	const isPremium = is_premium || isLimitedVirtual;
+	const {
+		is_premium: isPremium = false,
+		is_virtual,
+		style_variation,
+		style_variations = [],
+	} = design;
+	const isVirtual = is_virtual && style_variation;
 	const shouldUpgrade = isPremium && ! isPremiumThemeAvailable && ! hasPurchasedTheme;
 	const currentSiteCanInstallWoo = currentPlanFeatures?.includes( FEATURE_WOOP ) ?? false;
 
@@ -194,7 +202,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 			badge = <WooCommerceBundledBadge />;
 		} else if ( isPremium ) {
 			const toolTip =
-				shouldUpgrade && isLimitedVirtual
+				shouldUpgrade && isVirtual
 					? __( 'Unlock this style, and tons of other features, by upgrading to a Premium plan.' )
 					: undefined;
 			badge = (
@@ -214,14 +222,6 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 		);
 	}
 
-	const previewDesign = ( styleVariation?: StyleVariation ) => {
-		if ( design.is_virtual && design.style_variation ) {
-			const parentDesign = { ...design, is_virtual: false, style_variation: null };
-			return onPreview( parentDesign, styleVariation ?? design.style_variation );
-		}
-		return onPreview( design, styleVariation );
-	};
-
 	const getTitle = () => {
 		if ( design.is_virtual && design.style_variation ) {
 			return `${ design.title } – ${ design.style_variation.title }`;
@@ -234,7 +234,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 		<div className="design-picker__design-option">
 			<button
 				data-e2e-button={ isPremium ? 'paidOption' : 'freeOption' }
-				onClick={ () => previewDesign() }
+				onClick={ () => onPreview( design ) }
 			>
 				<span
 					className={ classnames(
@@ -255,7 +255,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 							<div className="design-picker__options-style-variations">
 								<StyleVariationBadges
 									variations={ style_variations }
-									onClick={ ( variation ) => previewDesign( variation ) }
+									onClick={ ( variation ) => onPreview( design, variation ) }
 								/>
 							</div>
 						) }
@@ -397,7 +397,6 @@ interface DesignPickerProps {
 	onCheckout?: any;
 	purchasedThemes?: string[];
 	currentPlanFeatures?: string[];
-	shouldLimitGlobalStyles?: boolean;
 }
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
@@ -413,7 +412,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	verticalId,
 	purchasedThemes,
 	currentPlanFeatures,
-	shouldLimitGlobalStyles,
 } ) => {
 	const hasCategories = !! categorization?.categories.length;
 	const filteredStaticDesigns = useMemo( () => {
@@ -448,7 +446,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						verticalId={ verticalId }
 						hasPurchasedTheme={ wasThemePurchased( purchasedThemes, design ) }
 						currentPlanFeatures={ currentPlanFeatures }
-						shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 					/>
 				) ) }
 				{ categorization?.selection === SHOW_GENERATED_DESIGNS_SLUG &&
@@ -482,7 +479,6 @@ export interface UnifiedDesignPickerProps {
 	onCheckout?: any;
 	purchasedThemes?: string[];
 	currentPlanFeatures?: string[];
-	shouldLimitGlobalStyles?: boolean;
 }
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
@@ -500,7 +496,6 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	onCheckout,
 	purchasedThemes,
 	currentPlanFeatures,
-	shouldLimitGlobalStyles,
 } ) => {
 	const translate = useTranslate();
 	const hasCategories = !! categorization?.categories.length;
@@ -537,7 +532,6 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					onCheckout={ onCheckout }
 					purchasedThemes={ purchasedThemes }
 					currentPlanFeatures={ currentPlanFeatures }
-					shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 				/>
 				{ ( ! isShowAll || ! hasGeneratedDesigns ) && bottomAnchorContent }
 			</div>

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -97,7 +97,7 @@ export interface Design {
 	software_sets?: SoftwareSet[];
 	is_bundled_with_woo_commerce?: boolean;
 	is_virtual?: boolean;
-	style_variation?: StyleVariation | null; // Style variation used by virtual themes.
+	preselected_style_variation?: StyleVariation; // Preselected style variation on virtual themes.
 
 	/** @deprecated used for Gutenboarding (/new flow) */
 	stylesheet?: string;

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -10,7 +10,7 @@ export const getDesignPreviewUrl = (
 	design: Design,
 	options: DesignPreviewOptions = {}
 ): string => {
-	const { recipe, slug, is_virtual, style_variation } = design;
+	const { recipe, slug, preselected_style_variation } = design;
 
 	//Anchor.fm themes get previews from their starter sites, ${slug}starter.wordpress.com
 	if ( [ 'hannah', 'riley', 'gilbert' ].indexOf( slug ) >= 0 ) {
@@ -35,7 +35,7 @@ export const getDesignPreviewUrl = (
 		source_site: 'patternboilerplates.wordpress.com',
 		use_screenshot_overrides: options.use_screenshot_overrides,
 		remove_assets: options.remove_assets,
-		...( is_virtual && style_variation && { style_variation: style_variation.title } ),
+		...( preselected_style_variation && { style_variation: preselected_style_variation.title } ),
 	} );
 
 	// The preview url is sometimes used in a `background-image: url()` CSS rule and unescaped


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1602

## Proposed Changes

- Updates the Tracks events used in the design picker step of the onboarding to monitor the usage of virtual themes.
- Also took the opportunity to slightly refactor the logic to make easier the tracking and to make clear that virtual themes have a preselected style variation.

**Updated events**

- `calypso_design_picker_design_display`: when a theme or virtual theme is displayed in the design picker.
- `calypso_signup_design_preview_select`: when a theme or virtual theme is selected in the design picker.
- `calypso_signup_design_picker_style_variation_button_click`: when a variation of a theme or virtual theme is selected through the discs UI in the design picker.

Events from the design preview screen are unaffected from these changes, since the concept of virtual theme is very fuzzy there (the same screen can be accessed from either a virtual theme or a regular theme).

**Updated properties**

The following changes have been applied to the properties of the events listed above:

- Added new `is_virtual` property to indicate whether the tracked theme is virtual.
- Updated the `slug` property to append the style variation slug of virtual themes.
- Updated the `is_premium` property to track all virtual themes as premium.

## Testing Instructions

- Use the Calypso live link below
- Open the Networks tab in the browser devtools
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>&flags=virtual-themes/onboarding`
- Scroll down and observe the `t.gif` requests
- Make sure the `calypso_design_picker_design_display` is tracked appropriately for both regular and virtual themes (check the `slug`, `is_virtual`, and `is_premium` properties)
- Select a regular theme and observe the `t.gif` requests
- Make sure the `calypso_signup_design_preview_select` is tracked appropriately (check the `slug`, `is_virtual`, and `is_premium` properties)
- Exit the design preview and go back to the design picker
- Select a virtual theme and observe the `t.gif` requests
- Make sure the `calypso_signup_design_preview_select` is tracked appropriately (check the `slug`, `is_virtual`, and `is_premium` properties)
- Exit the design preview and go back to the design picker
- Select a style variation of a regular theme through the discs UI
- Make sure the `calypso_signup_design_picker_style_variation_button_click ` is tracked appropriately (check the `slug`, `is_virtual`, and `is_premium` properties)
- Exit the design preview and go back to the design picker
- Select a style variation of a virtual theme through the discs UI
- Make sure the `calypso_signup_design_picker_style_variation_button_click ` is tracked appropriately (check the `slug`, `is_virtual`, and `is_premium` properties)