### PR TITLE
Premium Global Styles: Extend Gating to Older Sites

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -295,17 +295,24 @@ function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
 		return false;
 	}
 
-	// Non-Simple sites are edge cases; other conditions will determine whether they can use GS.
-	if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
-		return false;
-	}
-
 	// If the exemption check has already been performed, just return if the site is exempt.
 	if ( wpcom_global_styles_has_blog_sticker( 'wpcom-premium-global-styles-exemption-checked', $blog_id ) ) {
 		return wpcom_global_styles_has_blog_sticker( 'wpcom-premium-global-styles-exempt', $blog_id );
 	}
 
+	// Non-Simple sites are edge cases; other conditions will determine whether they can use GS.
+	if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+		return false;
+	}
+
 	switch_to_blog( $blog_id );
+
+	// If the current user cannot modify the `wp_global_styles` CPT, the exemption check is not needed;
+	// other conditions will determine whether they can use GS.
+	$wp_global_styles_cpt = get_post_type_object( 'wp_global_styles' );
+	if ( ! current_user_can( $wp_global_styles_cpt->cap->publish_posts ) ) {
+		return false;
+	}
 
 	add_blog_sticker( 'wpcom-premium-global-styles-exemption-checked', null, null, $blog_id );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -286,6 +286,9 @@ function wpcom_global_styles_in_use() {
  * it was created before the Premium Global Styles launch date (2022-12-15)
  * and had already customized its Global Styles.
  *
+ * We use blog stickers and other strategies to only perform the intensive check
+ * when strictly needed.
+ *
  * @param  int $blog_id Blog ID.
  * @return bool Whether the site is exempt from Premium Global Styles.
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -45,10 +45,10 @@ function wpcom_should_limit_global_styles( $blog_id = 0 ) {
 	}
 
 	// Do not limit Global Styles on sites created before we made it a paid feature (2022-12-15),
-	// that have never used Global Styles.
+	// that had already used Global Styles.
 	if (
 		$blog_id < 213403000 &&
-		defined( 'IS_WPCOM' ) && IS_WPCOM && ! wpcom_global_styles_has_been_used( $blog_id )
+		defined( 'IS_WPCOM' ) && IS_WPCOM && wpcom_global_styles_has_been_used( $blog_id )
 	) {
 		return false;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -223,6 +223,22 @@ function wpcom_track_global_styles( $blog_id, $post, $updated ) {
 add_action( 'save_post_wp_global_styles', 'wpcom_track_global_styles', 10, 3 );
 
 /**
+ * Check if a `wp_global_styles` post contains custom Global Styles.
+ *
+ * @param array $wp_global_styles_post The `wp_global_styles` post.
+ * @return bool Whether the post contains custom Global Styles.
+ */
+function wpcom_global_styles_in_use_by_wp_global_styles_post( array $wp_global_styles_post = array() ) {
+	if ( ! isset( $wp_global_styles_post['post_content'] ) ) {
+		return false;
+	}
+
+	$global_style_keys    = array_keys( json_decode( $wp_global_styles_post['post_content'], true ) ?? array() );
+	$global_styles_in_use = count( array_diff( $global_style_keys, array( 'version', 'isGlobalStylesUserThemeJSON' ) ) ) > 0;
+	return $global_styles_in_use;
+}
+
+/**
  * Checks if the current blog has custom styles in use.
  *
  * @return bool Returns true if custom styles are in use.
@@ -238,14 +254,7 @@ function wpcom_global_styles_in_use() {
 
 	$user_cpt = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme() );
 
-	if ( ! isset( $user_cpt['post_content'] ) ) {
-		do_action( 'global_styles_log', 'global_styles_not_in_use' );
-		return false;
-	}
-
-	$global_style_keys = array_keys( json_decode( $user_cpt['post_content'], true ) ?? array() );
-
-	$global_styles_in_use = count( array_diff( $global_style_keys, array( 'version', 'isGlobalStylesUserThemeJSON' ) ) ) > 0;
+	$global_styles_in_use = wpcom_global_styles_in_use_by_wp_global_styles_post( $user_cpt );
 
 	if ( $global_styles_in_use ) {
 		do_action( 'global_styles_log', 'global_styles_in_use' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -34,19 +34,19 @@ function wpcom_should_limit_global_styles( $blog_id = 0 ) {
 		}
 	}
 
-	// Do not limit Global Styles on demo sites.
+	// Do not limit Global Styles on theme demo sites.
 	if ( wpcom_global_styles_has_blog_sticker( 'theme-demo-site', $blog_id ) ) {
+		return false;
+	}
+
+	// Do not limit Global Styles if the site paid for it.
+	if ( wpcom_site_has_feature( WPCOM_Features::GLOBAL_STYLES, $blog_id ) ) {
 		return false;
 	}
 
 	// Do not limit Global Styles on sites created before we made it a paid feature (2022-12-15),
 	// that had already used Global Styles.
 	if ( wpcom_premium_global_styles_is_site_exempt( $blog_id ) ) {
-		return false;
-	}
-
-	// Do not limit Global Styles if the site paid for it.
-	if ( wpcom_site_has_feature( WPCOM_Features::GLOBAL_STYLES, $blog_id ) ) {
 		return false;
 	}
 
@@ -300,9 +300,10 @@ function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
 		return wpcom_global_styles_has_blog_sticker( 'wpcom-premium-global-styles-exempt', $blog_id );
 	}
 
-	// Non-Simple sites are edge cases; other conditions will determine whether they can use GS.
+	// Non-Simple sites on a lower plan are temporary edge cases.
+	// We exempt them to prevent unexpected temporary changes in their styles.
 	if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
-		return false;
+		return true;
 	}
 
 	switch_to_blog( $blog_id );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -315,6 +315,7 @@ function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
 	// other conditions will determine whether they can use GS.
 	$wp_global_styles_cpt = get_post_type_object( 'wp_global_styles' );
 	if ( ! current_user_can( $wp_global_styles_cpt->cap->publish_posts ) ) {
+		restore_current_blog();
 		return false;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1657

## Proposed Changes

* Extend the Global Styles gating to older sites that never used Global Styles before.

Premium Global Styles has been soft-launched to sites created after 15 Dec 2022; we are now extending it to older sites, as long as they never customized Global Styles before.

To avoid performing this expensive check every time, we will label older sites with the `wpcom-premium-global-styles-exemption-checked` sticker and with the `wpcom-premium-global-styles-exempt` to identify those that are exempt from Premium Global Styles (meaning: they had used Global Styles before).

Since stickers are not available on Atomic, we will ignore the edge case of Atomic Free sites, as they are not enough to justify the effort required.
Having said that, I'm open to alternative solutions!

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply these changes to the sandbox with `install-plugin.sh etk try/extend-global-styles-gating`.
* Pick two Free sites created before 15 Dec 2022.
  * One should have used Global Styles in the past.
  * The other shouldn't. If no such site exists, it should be enough to delete all its `wp_global_styles` posts.
* Test on these kind of sites:
  * A: Free site created before 15 Dec 2022, that has used GS in the past.
  * B: Free site created before 15 Dec 2022, that has never used GS. If no such site exists, it should be enough to delete all its `wp_global_styles` posts.
  * C: Free site created after 15 Dec 2022.
  * D: Premium site created before 15 Dec 2022.
  * E: Premium site created after 15 Dec 2022.
* Sandbox all sites.
* Site A:
  * Ensure it has "unlimited" GS (which is the current behaviour).
* Site B:
  * Ensure it gets a `wpcom-premium-global-styles-exempt` sticker, and has limited GS (new behaviour).
* Site C:
  * Ensure it has limited GS (current behaviour).
* Site D and E:
  * Ensure they have unlimited GS (current behaviour). 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
