### PR TITLE
DRAFT - Launchpad: Add domain upsell banner to web preview

### DIFF
--- a/client/components/domains/domain-upsell-callout/index.jsx
+++ b/client/components/domains/domain-upsell-callout/index.jsx
@@ -1,31 +1,39 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { isFreePlanProduct } from '@automattic/calypso-products';
+// import { isFreePlanProduct } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
+import classnames from 'classnames';
 import page from 'page';
 import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
+// import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
-import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
-import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+// import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+// import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+// import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
-const DomainUpsellCallout = ( { trackEvent } ) => {
+const DomainUpsellCallout = ( { trackEvent, isLaunchpad, isPhone } ) => {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
+	// INFO
+	// Currently the site object is undefined when rendering this component inside the Launchpad and it's causing a lot of problems
+	// I am assuming it's reading from the wrong store since this component is currently used in the block editor
+	// I was expecting the useSite() to work here since that's what we're using in Launchpad but for some reason it's undefined
+	// Maybe we should consider passing the site as a prop if we are unable to fix the selectors here
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	// const site = useSite();
 	const trackEventView = `calypso_${ trackEvent }_view`;
 	const trackEventClick = `calypso_${ trackEvent }_click`;
 	const trackEventDismiss = `calypso_${ trackEvent }_dismiss`;
 	const dismissPreference = `${ trackEvent }-${ site?.ID }`;
-	const isEmailVerified = useSelector( ( state ) => isCurrentUserEmailVerified( state ) );
-	const siteDomains = useSelector( ( state ) => getDomainsBySiteId( state, site?.ID ) );
-	const hasPreferences = useSelector( hasReceivedRemotePreferences );
-	const isDismissed = useSelector( ( state ) => getPreference( state, dismissPreference ) );
+	// const isEmailVerified = useSelector( ( state ) => isCurrentUserEmailVerified( state ) );
+	// const siteDomains = useSelector( ( state ) => getDomainsBySiteId( state, site?.ID ) );
+	// const hasPreferences = useSelector( hasReceivedRemotePreferences );
+	// const isDismissed = useSelector( ( state ) => getPreference( state, dismissPreference ) );
 
 	const getCtaClickHandler = useCallback( () => {
 		recordTracksEvent( trackEventClick );
@@ -37,25 +45,38 @@ const DomainUpsellCallout = ( { trackEvent } ) => {
 		dispatch( savePreference( dismissPreference, 1 ) );
 	};
 
-	if (
-		! site ||
-		! hasPreferences ||
-		isDismissed ||
-		siteDomains.length > 1 ||
-		! isEmailVerified ||
-		! isFreePlanProduct( site.plan )
-	) {
-		return null;
-	}
+	// INFO
+	// I'm bypassing all of these checks to make sure the component renders inside Launchpad but we should come back to this and decide which one of these checks makes sense inside Launchpad and keep them
+	// if (
+	// 	! site ||
+	// 	! hasPreferences ||
+	// 	isDismissed ||
+	// 	siteDomains.length > 1 ||
+	// 	! isEmailVerified ||
+	// 	! isFreePlanProduct( site.plan )
+	// ) {
+	// 	return null;
+	// }
 
 	return (
 		<>
 			<TrackComponentView eventName={ trackEventView } />
-			<div className="domain-upsell-callout">
+			<div
+				className={ classnames( 'domain-upsell-callout', {
+					// INFO
+					// I'm using these CSS classes to apply custom styles for our Launchpad use case
+					'is-launchpad': isLaunchpad,
+					'is-phone': isPhone,
+				} ) }
+			>
 				<div className="domain-upsell-callout__content">
 					<div className="domain-upsell-callout__content-text">
 						<Gridicon icon="globe" size={ 16 } className="domain-upsell-callout__icon" />
-						<span className="domain-upsell-callout__domain-name">{ site.domain }</span>
+						<span className="domain-upsell-callout__domain-name">
+							{ /* INFO */ }
+							{ /* I am hardcoding the site slug here since the site object is undefined and it's breaking the component */ }
+							sharpirate.wordpress.com
+						</span>
 						<button className="domain-upsell-callout__button" onClick={ getCtaClickHandler }>
 							<span className="domain-upsell-callout__button-text-desktop">
 								{ __( 'Customize your domain' ) }
@@ -64,12 +85,16 @@ const DomainUpsellCallout = ( { trackEvent } ) => {
 								{ __( 'Customize' ) }
 							</span>
 						</button>
-						<Gridicon
-							icon="cross"
-							size={ 16 }
-							className="domain-upsell-callout__dismiss-icon"
-							onClick={ getDismissClickHandler }
-						/>
+						{ /* INFO */ }
+						{ /* We don't want the close button as per our Launchpad design */ }
+						{ ! isLaunchpad && (
+							<Gridicon
+								icon="cross"
+								size={ 16 }
+								className="domain-upsell-callout__dismiss-icon"
+								onClick={ getDismissClickHandler }
+							/>
+						) }
 					</div>
 				</div>
 			</div>

--- a/client/components/domains/domain-upsell-callout/style.scss
+++ b/client/components/domains/domain-upsell-callout/style.scss
@@ -72,3 +72,29 @@ body.is-section-posts .domain-upsell-callout {
 		cursor: pointer;
 	}
 }
+
+// Launchpad specific styles
+.domain-upsell-callout.is-launchpad {
+	position: relative;
+	transform: none;
+	left: 0;
+	width: 100%;
+
+	&.is-phone {
+		@include break-large {
+			// INFO
+			// This is matching the web preview width on mobile screens but it clips off the domain banner a bit so maybe we should consider bumping up that width here
+			max-width: 340px;
+		}
+	}
+
+	.domain-upsell-callout__content {
+		background: #f6f7f7;
+		border-radius: 40px 40px 0 0;  /* stylelint-disable-line scales/radii */
+		padding-top: 10px;
+	}
+
+	.domain-upsell-callout__content-text {
+		background: none;
+	}
+}

--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -63,8 +63,8 @@ export class WebPreviewModal extends Component {
 		fixedViewportWidth: PropTypes.number,
 		// Prevents tabbing into the iframe.
 		disableTabbing: PropTypes.bool,
-		// Edit overlay that redirects to the Site Editor
-		enableEditOverlay: PropTypes.bool,
+		// Allow Launchpad specific customizations
+		isLaunchpad: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -83,7 +83,7 @@ export class WebPreviewModal extends Component {
 		hasSidebar: false,
 		overridePost: null,
 		autoHeight: false,
-		enableEditOverlay: false,
+		isLaunchpad: false,
 	};
 
 	constructor( props ) {

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -377,6 +377,9 @@ export default class WebPreviewContent extends Component {
 			( this.props.showPreview || ! this.props.isModalWindow ) &&
 			this.state.device !== 'seo';
 
+		const shouldShowDomainUpsellForNonLaunchpad =
+			this.props.showExternal && this.props.isModalWindow && ! this.props.isPrivateAtomic;
+
 		return (
 			<div className={ className } ref={ this.setWrapperElement }>
 				<ToolbarComponent
@@ -391,8 +394,14 @@ export default class WebPreviewContent extends Component {
 					isLoading={ this.state.isLoadingSubpage }
 					isSticky={ this.props.isStickyToolbar }
 				/>
-				{ this.props.showExternal && this.props.isModalWindow && ! this.props.isPrivateAtomic && (
-					<DomainUpsellCallout trackEvent="site_preview_domain_upsell_callout" />
+				{ /* INFO */ }
+				{ /* Currently I'm bypassing all of the conditions inside shouldShowDomainUpsellForNonLaunchpad in favor if the isLaunchpad prop is true for easier testing but we should come back to this and figure out which of these conditions we should keep for launchpad*/ }
+				{ ( shouldShowDomainUpsellForNonLaunchpad || this.props.isLaunchpad ) && (
+					<DomainUpsellCallout
+						isPhone={ this.state.device === 'phone' }
+						isLaunchpad={ this.props.isLaunchpad }
+						trackEvent="site_preview_domain_upsell_callout"
+					/>
 				) }
 				{ this.props.belowToolbar }
 				{ ( ! isLoaded || this.state.isLoadingSubpage ) && <SpinnerLine /> }
@@ -412,17 +421,18 @@ export default class WebPreviewContent extends Component {
 					{ 'seo' !== this.state.device && (
 						<div
 							onMouseEnter={ () => {
-								if ( this.props.enableEditOverlay ) {
+								if ( this.props.isLaunchpad ) {
 									this.setState( { showIFrameOverlay: true } );
 								}
 							} }
 							onMouseLeave={ () => {
-								if ( this.props.enableEditOverlay ) {
+								if ( this.props.isLaunchpad ) {
 									this.setState( { showIFrameOverlay: false } );
 								}
 							} }
 							className={ classNames( 'web-preview__frame-wrapper', {
 								'is-resizable': ! this.props.isModalWindow,
+								'is-launchpad': this.props.isLaunchpad,
 							} ) }
 						>
 							<iframe
@@ -431,7 +441,7 @@ export default class WebPreviewContent extends Component {
 								style={ {
 									...this.state.iframeStyle,
 									height: this.state.viewport?.height,
-									pointerEvents: this.props.enableEditOverlay ? 'auto' : 'all',
+									pointerEvents: this.props.isLaunchpad ? 'auto' : 'all',
 								} }
 								src="about:blank"
 								onLoad={ () => this.setLoaded( 'iframe-onload' ) }
@@ -440,7 +450,7 @@ export default class WebPreviewContent extends Component {
 								scrolling={ autoHeight ? 'no' : undefined }
 								tabIndex={ disableTabbing ? -1 : 0 }
 							/>
-							{ this.props.enableEditOverlay && (
+							{ this.props.isLaunchpad && (
 								<div
 									className="web-preview__frame-edit-overlay"
 									style={ {
@@ -558,7 +568,7 @@ WebPreviewContent.propTypes = {
 	// Uses the CSS selector to scroll to it
 	scrollToSelector: PropTypes.string,
 	// Edit overlay that redirects to the Site Editor
-	enableEditOverlay: PropTypes.bool,
+	isLaunchpad: PropTypes.bool,
 };
 
 WebPreviewContent.defaultProps = {
@@ -584,5 +594,5 @@ WebPreviewContent.defaultProps = {
 	autoHeight: false,
 	inlineCss: null,
 	scrollToSelector: null,
-	enableEditOverlay: false,
+	isLaunchpad: false,
 };

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -285,6 +285,10 @@ a.web-preview__external.button {
 	display: flex;
 	flex-direction: column;
 	position: relative;
+	// INFO
+	// I am using this to fix the alignment issue when using the phone preview because it aligns the banner to the left otherwise
+	// This is potentially dangerous because it could affect other places so if we keep this we should test all other web previews
+	align-items: center;
 }
 
 .web-preview__loading-message-wrapper {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -113,7 +113,9 @@ const LaunchpadSitePreview = ( {
 				defaultViewportDevice={ defaultDevice }
 				devicesToShow={ devicesToShow }
 				showSiteAddressBar={ false }
-				enableEditOverlay
+				// INFO
+				// I've renamed the "enableEditOverlay" prop to a more generic name "isLaunchpad" since I'm using it to customize the domain upsell component inside the web preview
+				isLaunchpad
 			/>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -485,13 +485,23 @@
 
 	}
 
+	.is-phone .web-preview__frame-wrapper.is-resizable.is-launchpad {
+		.web-preview__frame-edit-overlay {
+			@include break-large {
+				border-radius: 0 0 40px 40px; /* stylelint-disable-line scales/radii */
+			}
+		}
+	}
+
 	.web-preview__frame-wrapper.is-resizable {
 		transition: max-width 0.2s linear;
 		margin: 0;
 		padding: 0;
 		background-color: transparent;
 		position: relative;
-		max-width: 95%;
+		// This makes the iframe smaller than the upsell domain banner so we have to remove this
+		// If we want to match the current styling on prod we could probably move this to a higher parent component so it affects both the iframe and the banner
+		// max-width: 95%;
 
 		@include break-large {
 			height: 880px;
@@ -523,6 +533,29 @@
 				border-color: #c3c4c7;
 				border-width: 2px;
 				cursor: pointer;
+			}
+		}
+	}
+
+	// INFO
+	// When have to remove the top border radius from the iframe and apply it to the domain upsell banner instead
+	// We have to make sure all of these cases look good:
+	// Desktop screen - desktop preview and phone preview
+	// Mobile screen - desktop preview and phone preview
+	.web-preview__frame-wrapper.is-resizable.is-launchpad {
+		.web-preview__frame-edit-overlay {
+			border-radius: 0 0 40px 40px;  /* stylelint-disable-line scales/radii */
+		}
+
+		@include break-large {
+			border-radius: 0 0 20px 20px; /* stylelint-disable-line scales/radii */
+		}
+
+		.web-preview__frame {
+			border-radius: 0 0 40px 40px; /* stylelint-disable-line scales/radii */
+
+			@include break-large {
+				border-radius: 0 0 20px 20px; /* stylelint-disable-line scales/radii */
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/73324

<img width="2281" alt="image" src="https://user-images.githubusercontent.com/20927667/219363733-de0b7b71-eccc-4bcb-86b3-60f58ea4774f.png">

### Proposed Changes
This PR adds the domain upsell banner component to the top of the web preview on the Launchpad screen

### Testing
1. Checkout this branch
2. Go to the Launchpad screen on any Launchpad-enabled site
3. You should see the domain upsell banner on top of the web preview