### PR TITLE
Enabled Unified Importer on wpcalypso.wordpress.com

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -91,6 +91,7 @@
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
+		"newsletter/stats": false,
 		"network-connection": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,
@@ -164,8 +165,7 @@
 		"user-management-revamp": true,
 		"woop": false,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": true,
-		"newsletter/stats": false
+		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -53,6 +53,7 @@
 		"hosting/datacenter-picker": true,
 		"i18n/translation-scanner": true,
 		"importers/substack": true,
+		"importer/unified": true,
 		"inline-help": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/api-cache": true,


### PR DESCRIPTION
This PR enables the Unified Importer on [wpcalypso](https://wpcalypso.wordpress.com/).

## Proposed Changes

* Add `importer/unified` to `wpcalypso.json`

## Testing Instructions

Nothing to test here.