### PR TITLE
add ItemPrice component.

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -21,7 +21,7 @@ type OwnProps = {
 	expiryDate?: Moment;
 };
 
-const Placeholder: React.FC< OwnProps > = ( { billingTerm, expiryDate } ) => {
+const Placeholder: React.FC< OwnProps > = ( { billingTerm, expiryDate, discountedPrice } ) => {
 	return (
 		<>
 			<PlanPrice
@@ -30,8 +30,7 @@ const Placeholder: React.FC< OwnProps > = ( { billingTerm, expiryDate } ) => {
 				rawPrice={ 0.01 }
 				currencyCode="USD"
 			/>
-			{ /* Remove this secondary <PlanPrice/> placeholder if we're not showing discounted prices */ }
-			<PlanPrice discounted rawPrice={ 0.01 } currencyCode="USD" />
+			{ discountedPrice && <PlanPrice discounted rawPrice={ 0.01 } currencyCode="USD" /> }
 			<TimeFrame expiryDate={ expiryDate } billingTerm={ billingTerm } />
 		</>
 	);

--- a/client/components/jetpack/card/jetpack-rna-dialog-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-rna-dialog-card/index.tsx
@@ -28,7 +28,7 @@ const JetpackRnaDialogCard: React.FC< RnaDialogCardProps > = ( {
 			} ) }
 		>
 			<div className="jetpack-rna-dialog-card__body">
-				<div className="jetpack-rna-dialog-card__content">{ children && children }</div>
+				<div className="jetpack-rna-dialog-card__content">{ children }</div>
 			</div>
 			<div
 				className="jetpack-rna-dialog-card__footer"

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
@@ -81,8 +81,8 @@ const JetpackCompletePage: React.FC< Props > = ( {
 							all CRM extensions, and extra storage for backups and video.
 						</p>
 
-						<ItemPrice item={ item } siteId={ siteId } />
 						<ItemsIncluded />
+						<ItemPrice item={ item } siteId={ siteId } />
 					</>
 				</JetpackRnaDialogCard>
 			</Main>

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
@@ -1,17 +1,25 @@
+/* eslint-disable no-console */
 //TODO: Remove this eslnit exception when whole component/child components are finished.
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import { PLAN_JETPACK_COMPLETE } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import rnaImageComplete from 'calypso/assets/images/jetpack/rna-image-complete.png';
 import rnaImageComplete2xRetina from 'calypso/assets/images/jetpack/rna-image-complete@2x.png';
+import QueryIntroOffers from 'calypso/components/data/query-intro-offers';
+import QueryJetpackSaleCoupon from 'calypso/components/data/query-jetpack-sale-coupon';
 import QueryJetpackUserLicensesCounts from 'calypso/components/data/query-jetpack-user-licenses-counts';
+import QueryProductsList from 'calypso/components/data/query-products-list';
+import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import JetpackRnaDialogCard from 'calypso/components/jetpack/card/jetpack-rna-dialog-card';
 import Main from 'calypso/components/main';
 import { JPC_PATH_PLANS } from 'calypso/jetpack-connect/constants';
+import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
 import { successNotice } from 'calypso/state/notices/actions';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import { QueryArgs, Duration } from '../types';
+import { ItemPrice } from './item-price';
 import ItemsIncluded from './items-included';
 import ShowLicenseActivationLinkIfAvailable from './show-license-activation-link-if-available';
 import './style.scss';
@@ -33,6 +41,7 @@ const JetpackCompletePage: React.FC< Props > = ( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
+	const item = slugToSelectorProduct( PLAN_JETPACK_COMPLETE );
 
 	useEffect( () => {
 		if ( window.location.pathname.startsWith( JPC_PATH_PLANS ) ) {
@@ -44,6 +53,11 @@ const JetpackCompletePage: React.FC< Props > = ( {
 	return (
 		<>
 			<QueryJetpackUserLicensesCounts />
+			<QueryProductsList type="jetpack" />
+			{ siteId && <QueryIntroOffers siteId={ siteId ?? 'none' } /> }
+			{ siteId && <QuerySiteProducts siteId={ siteId } /> }
+			<QueryJetpackSaleCoupon />
+
 			<Main className="jetpack-complete-page__main" wideLayout>
 				<ShowLicenseActivationLinkIfAvailable siteId={ siteId } />
 				<JetpackRnaDialogCard
@@ -66,6 +80,8 @@ const JetpackCompletePage: React.FC< Props > = ( {
 							The full Jetpack suite with real-time security, instant site search, ad-free video,
 							all CRM extensions, and extra storage for backups and video.
 						</p>
+
+						<ItemPrice item={ item } siteId={ siteId } />
 						<ItemsIncluded />
 					</>
 				</JetpackRnaDialogCard>

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable no-console */
 //TODO: Remove this eslnit exception when whole component/child components are finished.
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { PLAN_JETPACK_COMPLETE } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import rnaImageComplete from 'calypso/assets/images/jetpack/rna-image-complete.png';
 import rnaImageComplete2xRetina from 'calypso/assets/images/jetpack/rna-image-complete@2x.png';

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/item-price/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/item-price/index.tsx
@@ -22,7 +22,7 @@ export const ItemPrice: React.FC< Props > = ( { item, siteId } ) => {
 
 	return (
 		item && (
-			<div className="item-price is-compact">
+			<div className="item-price__complete">
 				<DisplayPrice
 					isFree={ item.isFree }
 					discountedPriceDuration={ discountedPriceDuration }

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/item-price/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/item-price/index.tsx
@@ -1,0 +1,41 @@
+import { useSelector } from 'react-redux';
+import DisplayPrice from 'calypso/components/jetpack/card/jetpack-product-card/display-price';
+import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
+import useItemPrice from 'calypso/my-sites/plans/jetpack-plans/use-item-price';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+
+import './style.scss';
+
+interface Props {
+	item: SelectorProduct | null;
+	siteId: number | null;
+}
+
+export const ItemPrice: React.FC< Props > = ( { item, siteId } ) => {
+	const {
+		originalPrice,
+		discountedPrice,
+		discountedPriceDuration,
+		isFetching: pricesAreFetching,
+	} = useItemPrice( siteId, item, item?.monthlyProductSlug || '' );
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
+
+	return (
+		item && (
+			<div className="item-price is-compact">
+				<DisplayPrice
+					isFree={ item.isFree }
+					discountedPriceDuration={ discountedPriceDuration }
+					discountedPrice={ discountedPrice }
+					discountedPriceFirst
+					currencyCode={ item.displayCurrency || currencyCode }
+					originalPrice={ originalPrice ?? 0 }
+					pricesAreFetching={ pricesAreFetching }
+					belowPriceText={ item.belowPriceText }
+					billingTerm={ item.displayTerm || item.term }
+					productName={ item.displayName }
+				/>
+			</div>
+		)
+	);
+};

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/item-price/style.scss
@@ -45,7 +45,10 @@
 
 .display-price__billing-time-frame {
 	display: table;
-	margin-top: 7px;
+	margin-top: 12px;
+	@include break-medium {
+		margin-bottom: 7px;
+	}
 }
 
 .item-price__complete .display-price.is-placeholder .plan-price {

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/item-price/style.scss
@@ -1,0 +1,113 @@
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.display-price .display-price__prices {
+	display: block;
+
+	.plan-price__currency-symbol,
+	.plan-price__integer,
+	.plan-price__fraction {
+		color: var(--studio-gray-40);
+	}
+
+	.plan-price__currency-symbol {
+		font-size: $font-title-medium;
+		line-height: 20;
+	}
+	.plan-price__integer {
+		font-size: $font-headline-large;
+		line-height: 40;
+	}
+	.plan-price__fraction {
+		font-size: $font-body;
+		line-height: normal;
+		margin-top: 0;
+	}
+
+	.plan-price.is-original {
+		.plan-price__currency-symbol,
+		.plan-price__integer,
+		.plan-price__fraction {
+			position: static;
+		}
+	}
+
+	.plan-price.is-original::before,
+	.is-placeholder .plan-price::after {
+		display: none;
+	}
+
+	&__billing-time-frame {
+		margin-top: 0;
+		color: var(--studio-gray-40);
+		font-size: $font-body;
+		line-height: auto;
+
+		@include break-mobile {
+			margin-top: 3px;
+		}
+	}
+
+	@include break-mobile {
+		display: flex;
+		align-items: center;
+		min-height: 24px;
+	}
+}
+
+// .item-price .display-price:not(.is-placeholder) {
+// 	max-height: 24px;
+
+// 	.plan-price.is-original {
+// 		color: var(--studio-gray-50);
+// 		text-decoration: line-through;
+// 		font-weight: 600;
+// 	}
+
+// 	.plan-price.is-discounted {
+// 		color: var(--studio-gray-100);
+// 		font-weight: 700;
+// 	}
+
+// 	.plan-price.is-discounted .plan-price__fraction {
+// 		font-weight: inherit;
+// 	}
+
+// 	.display-price__billing-time-frame {
+// 		margin-top: 3px;
+// 	}
+// }
+
+// .item-price .display-price.is-placeholder {
+// 	display: inline-flex;
+// 	align-items: center;
+// 	max-height: 24px;
+
+// 	.plan-price {
+// 		max-height: 40px;
+// 	}
+
+// 	.display-price__billing-time-frame {
+// 		max-height: 40px;
+// 		margin-top: 0;
+// 	}
+// }
+
+// /*
+// Hack to fix line-through not showing in the middle of the text in firefox browser.
+// */
+// @-moz-document url-prefix() {
+// 	.plan-price {
+// 		/* stylelint-disable-next-line scales/font-sizes */
+// 		font-size: 1.4rem;
+// 	}
+// }
+
+// .item-price.is-compact .display-price .display-price__billing-time-frame .normal {
+// 	display: none;
+// }
+
+// .item-price.is-compact .display-price .display-price__billing-time-frame .compact {
+// 	display: inline-block;
+// }

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/item-price/style.scss
@@ -2,112 +2,53 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.display-price .display-price__prices {
-	display: block;
+.item-price__complete .display-price {
+	font-family: Inter, $sans;
+	margin-bottom: 32px;
 
-	.plan-price__currency-symbol,
-	.plan-price__integer,
-	.plan-price__fraction {
-		color: var(--studio-gray-40);
-	}
-
-	.plan-price__currency-symbol {
-		font-size: $font-title-medium;
-		line-height: 20;
-	}
-	.plan-price__integer {
-		font-size: $font-headline-large;
-		line-height: 40;
-	}
-	.plan-price__fraction {
-		font-size: $font-body;
-		line-height: normal;
-		margin-top: 0;
+	@include break-medium {
+		margin-bottom: 24px;
 	}
 
+	.plan-price.is-discounted,
 	.plan-price.is-original {
-		.plan-price__currency-symbol,
-		.plan-price__integer,
+
+		.plan-price__currency-symbol {
+			font-size: $font-title-medium;
+			font-weight: 400;
+			line-height: 20px;
+			margin-top: 0;
+		}
+
+		.plan-price__integer {
+			font-family: "SF Pro Display", $sans;
+			line-height: 40px;
+		}
+
 		.plan-price__fraction {
-			position: static;
+			line-height: $font-title-medium;
+			vertical-align: super;
+			font-size: 0.75rem;
 		}
-	}
-
-	.plan-price.is-original::before,
-	.is-placeholder .plan-price::after {
-		display: none;
-	}
-
-	&__billing-time-frame {
-		margin-top: 0;
-		color: var(--studio-gray-40);
-		font-size: $font-body;
-		line-height: auto;
-
-		@include break-mobile {
-			margin-top: 3px;
-		}
-	}
-
-	@include break-mobile {
-		display: flex;
-		align-items: center;
-		min-height: 24px;
 	}
 }
 
-// .item-price .display-price:not(.is-placeholder) {
-// 	max-height: 24px;
+.item-price__complete .display-price:not(.is-placeholder) {
+	.plan-price.is-discounted {
+		color: var(--studio-gray-100);
+	}
 
-// 	.plan-price.is-original {
-// 		color: var(--studio-gray-50);
-// 		text-decoration: line-through;
-// 		font-weight: 600;
-// 	}
+	.plan-price.is-original {
+		color: var(--studio-gray-20);
+	}
+}
 
-// 	.plan-price.is-discounted {
-// 		color: var(--studio-gray-100);
-// 		font-weight: 700;
-// 	}
+.display-price__billing-time-frame {
+	display: table;
+	margin-top: 7px;
+}
 
-// 	.plan-price.is-discounted .plan-price__fraction {
-// 		font-weight: inherit;
-// 	}
-
-// 	.display-price__billing-time-frame {
-// 		margin-top: 3px;
-// 	}
-// }
-
-// .item-price .display-price.is-placeholder {
-// 	display: inline-flex;
-// 	align-items: center;
-// 	max-height: 24px;
-
-// 	.plan-price {
-// 		max-height: 40px;
-// 	}
-
-// 	.display-price__billing-time-frame {
-// 		max-height: 40px;
-// 		margin-top: 0;
-// 	}
-// }
-
-// /*
-// Hack to fix line-through not showing in the middle of the text in firefox browser.
-// */
-// @-moz-document url-prefix() {
-// 	.plan-price {
-// 		/* stylelint-disable-next-line scales/font-sizes */
-// 		font-size: 1.4rem;
-// 	}
-// }
-
-// .item-price.is-compact .display-price .display-price__billing-time-frame .normal {
-// 	display: none;
-// }
-
-// .item-price.is-compact .display-price .display-price__billing-time-frame .compact {
-// 	display: inline-block;
-// }
+.item-price__complete .display-price.is-placeholder .plan-price {
+	transform: unset;
+	transform: none;
+}

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/items-included/style.scss
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/items-included/style.scss
@@ -56,7 +56,7 @@
 	list-style-type: none;
 	margin: 0;
 	row-gap: 1rem;
-	padding-bottom: 32px;
+	padding-bottom: 45px;
 }
 
 @media ( min-width: $break-medium ) {

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/items-included/style.scss
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/items-included/style.scss
@@ -56,6 +56,7 @@
 	list-style-type: none;
 	margin: 0;
 	row-gap: 1rem;
+	padding-bottom: 32px;
 }
 
 @media ( min-width: $break-medium ) {


### PR DESCRIPTION
This PR Adds the Jetpack Complete price component (displays the price of Jetpack complete) to the Offer Jetpack Complete immediately project page.

Asana Task: 1203759331596262-as-1203791007934531/f
Project Thread: p1HpG7-jYo-p2
Figma Design: R1U6Ww74mdgMrKUJ21BnTL-fi-3061%3A11111

## Proposed Changes

- Added price component and adjusted styles to match Figma design.
- Improved the prices loading placeholder css (while prices are still loading).

## Testing Instructions

* boot up this PR 
    * Run `git fetch && git checkout add/offer-complete-price-component`
    * Run `yarn start`
* OR use the Live Link provided below
* Create a new JN site
* Navigate to `wordpress.com/jetpack/connect/plans/complete/[JN Site]`.  If using the Live Link, please append `?flags=jetpack/offer-complete-after-activation` to the url.
* Verify the price component is displayed for Jetpack Complete.
* Verify fonts, color, spacing, etc matches Figma design.
* Verify the loading placeholder looks appropriate (while waiting for prices to load).
* ***Bonus:** Test with other currencies, make sure everything looks ok, and prices appear to be correct.

## Screenshots:

**DESKTOP**

![Markup 2023-02-18 at 12 56 07](https://user-images.githubusercontent.com/11078128/219881832-280372e7-a06a-4d2d-b231-2c2fd2115b0c.png)

.
**MOBILE**

![Markup 2023-02-18 at 12 57 49](https://user-images.githubusercontent.com/11078128/219881860-f40c990a-9dbf-4222-a5ec-c0b6f60d1dbb.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203791007934531