### PR TITLE
WooExpress: The trial progress ring should decrease instead of increase

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/index.tsx
@@ -41,7 +41,7 @@ const ECommerceTrialBanner = ( props: ECommerceTrialBannerProps ) => {
 	/**
 	 * Trial progress from 0 to 1
 	 */
-	const trialProgress = 1 - eCommerceTrialDaysLeft / trialDuration;
+	const trialProgress = eCommerceTrialDaysLeft / trialDuration;
 	const eCommerceTrialDaysLeftToDisplay = isTrialExpired ? 0 : eCommerceTrialDaysLeft;
 
 	// moment.js doesn't have a format option to display the long form in a localized way without the year

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/index.tsx
@@ -41,7 +41,7 @@ const ECommerceTrialBanner = ( props: ECommerceTrialBannerProps ) => {
 	/**
 	 * Trial progress from 0 to 1
 	 */
-	const trialProgress = eCommerceTrialDaysLeft / trialDuration;
+	const trialProgress = Math.min( eCommerceTrialDaysLeft / trialDuration, 1 );
 	const eCommerceTrialDaysLeftToDisplay = isTrialExpired ? 0 : eCommerceTrialDaysLeft;
 
 	// moment.js doesn't have a format option to display the long form in a localized way without the year


### PR DESCRIPTION
## Proposed Changes

* The trial progress ring is increasing as the days pass. But it should decrease.

**Before**
<img width="254" alt="Screen Shot 2023-02-16 at 11 21 19" src="https://user-images.githubusercontent.com/1234758/219390421-f9f0d933-f84b-47b4-8235-dba432bcfb9c.png">

**Now**
<img width="295" alt="Screen Shot 2023-02-16 at 11 19 45" src="https://user-images.githubusercontent.com/1234758/219390004-8df55f9a-760c-4a3d-84b5-55575e35beee.png">

## Testing Instructions

* Navigate to `/plans/my-plan/:siteSlug` on a WooExpress site.
* The ring should represent the number of days left in the trial, not how many days have passed.

Closes #73432 #73312 #73390