### PR TITLE
Add/domain upsell write and build flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,7 +1,7 @@
 import { Gridicon, CircularProgressBar } from '@automattic/components';
 import { useRef, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { FREE_FLOW, StepNavigationLink } from 'calypso/../packages/onboarding/src';
+import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
 import Badge from 'calypso/components/badge';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import Tooltip from 'calypso/components/tooltip';
@@ -12,7 +12,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import Checklist from './checklist';
-import { getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
+import { filterDomainUpsellTask, getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
 import { tasks } from './tasks';
 import { getLaunchpadTranslations } from './translations';
 import { Task } from './types';
@@ -78,12 +78,8 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 	const currentTask = getTasksProgress( enhancedTasks );
 	const launchTask = enhancedTasks?.find( ( task ) => task.isLaunchTask === true );
 
-	// Free flow - remove domain_upsell task if user is on paid plan
-	if ( flow === FREE_FLOW && ! site?.plan?.is_free && enhancedTasks ) {
-		enhancedTasks = enhancedTasks?.filter( ( task ) => {
-			return task.id !== 'domain_upsell';
-		} );
-	}
+	// Free, Write & Build flows - remove domain_upsell task if user is on paid plan
+	enhancedTasks = filterDomainUpsellTask( flow, enhancedTasks, site );
 
 	const showLaunchTitle = launchTask && ! launchTask.disabled;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -4,6 +4,7 @@ import {
 	PLAN_PREMIUM,
 	FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
 } from '@automattic/calypso-products';
+import { FREE_FLOW, BUILD_FLOW, WRITE_FLOW } from '@automattic/onboarding';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -340,4 +341,20 @@ export function getArrayOfFilteredTasks( tasks: Task[], flow: string | null ) {
 			return accumulator;
 		}, [] as Task[] )
 	);
+}
+
+// Returns enhanced task list with domain_upsell task removed
+// Only applies to Free, Write & Build flow sites with paid plan
+export function filterDomainUpsellTask(
+	flow: string | null,
+	enhancedTasks: Task[] | null,
+	site: SiteDetails | null
+) {
+	const flowsAffected = [ FREE_FLOW, BUILD_FLOW, WRITE_FLOW ];
+	if ( flow && flowsAffected.includes( flow ) && enhancedTasks && ! site?.plan?.is_free ) {
+		return enhancedTasks?.filter( ( task ) => {
+			return task.id !== 'domain_upsell';
+		} );
+	}
+	return enhancedTasks;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -141,6 +141,7 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 	build: [
 		'setup_general',
 		'design_selected',
+		'domain_upsell',
 		'first_post_published',
 		'design_edited',
 		'site_launched',
@@ -148,6 +149,7 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 	write: [
 		'setup_write',
 		'design_selected',
+		'domain_upsell',
 		'first_post_published',
 		'design_edited',
 		'site_launched',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -1,9 +1,16 @@
 /**
  * @jest-environment jsdom
  */
-import { getArrayOfFilteredTasks, getEnhancedTasks } from '../task-helper';
+import { filterDomainUpsellTask, getArrayOfFilteredTasks, getEnhancedTasks } from '../task-helper';
 import { tasks, launchpadFlowTasks } from '../tasks';
-import { buildTask } from './lib/fixtures';
+import {
+	LINK_IN_BIO_FLOW,
+	FREE_FLOW,
+	WRITE_FLOW,
+	BUILD_FLOW,
+	NEWSLETTER_FLOW,
+} from './../../../../../../../../packages/onboarding/src/utils/flows';
+import { buildTask, buildSiteDetails, defaultSiteDetails } from './lib/fixtures';
 
 describe( 'Task Helpers', () => {
 	describe( 'getEnhancedTasks', () => {
@@ -81,6 +88,82 @@ describe( 'Task Helpers', () => {
 				expect( getArrayOfFilteredTasks( tasks, 'newsletter' ) ).toEqual(
 					tasks.filter( ( task ) => launchpadFlowTasks[ 'newsletter' ].includes( task.id ) )
 				);
+			} );
+		} );
+	} );
+
+	describe( 'filterDomainUpsellTask', () => {
+		describe( 'when site plan is free and affected flow (free, build, write)', () => {
+			it( 'return original enhanceTasks', () => {
+				const task = buildTask( {
+					id: 'domain_upsell',
+					completed: false,
+					disabled: true,
+					taskType: 'blog',
+					title: 'domain upsell task',
+				} );
+				const tasks = [ task ];
+				const site = defaultSiteDetails;
+				const freeFlow = FREE_FLOW;
+				const writeFlow = WRITE_FLOW;
+				const buildFlow = BUILD_FLOW;
+				expect( filterDomainUpsellTask( freeFlow, tasks, site ) ).toBe( tasks );
+				expect( filterDomainUpsellTask( writeFlow, tasks, site ) ).toBe( tasks );
+				expect( filterDomainUpsellTask( buildFlow, tasks, site ) ).toBe( tasks );
+			} );
+		} );
+
+		describe( 'when unaffected flow', () => {
+			it( 'return original enhanceTasks', () => {
+				const task = buildTask( {
+					id: 'domain_upsell',
+					completed: false,
+					disabled: true,
+					taskType: 'blog',
+					title: 'domain upsell task',
+				} );
+				const tasks = [ task ];
+				const site = defaultSiteDetails;
+				const newsletterFlow = NEWSLETTER_FLOW;
+				expect( filterDomainUpsellTask( newsletterFlow, tasks, site ) ).toBe( tasks );
+			} );
+		} );
+
+		describe( 'when site plan is not free and affected flow (free, build, write)', () => {
+			it( 'return enhanceTask array with domain_upsell task removed', () => {
+				const task = buildTask( {
+					id: 'domain_upsell',
+					completed: false,
+					disabled: true,
+					taskType: 'blog',
+					title: 'domain upsell task',
+				} );
+				const tasks = [ task ];
+				const site = buildSiteDetails( { plan: { is_free: false } } );
+
+				const freeFlow = FREE_FLOW;
+				const writeFlow = WRITE_FLOW;
+				const buildFlow = BUILD_FLOW;
+				expect( filterDomainUpsellTask( freeFlow, tasks, site ) ).toHaveLength( 0 );
+				expect( filterDomainUpsellTask( writeFlow, tasks, site ) ).toHaveLength( 0 );
+				expect( filterDomainUpsellTask( buildFlow, tasks, site ) ).toHaveLength( 0 );
+			} );
+		} );
+
+		describe( 'when site plan is not free and not affected flow', () => {
+			it( 'return enhanceTask array with domain_upsell task removed', () => {
+				const tasks = buildTask( {
+					id: 'domain_upsell',
+					completed: false,
+					disabled: true,
+					taskType: 'blog',
+					title: 'domain upsell task',
+				} );
+				const site = buildSiteDetails( {} );
+				const newsletterFlow = NEWSLETTER_FLOW;
+				const linkInBioFlow = LINK_IN_BIO_FLOW;
+				expect( filterDomainUpsellTask( newsletterFlow, tasks, site ) ).toBe( tasks );
+				expect( filterDomainUpsellTask( linkInBioFlow, tasks, site ) ).toBe( tasks );
 			} );
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72874

## Proposed Changes

* Add domain upsell task to the launchpad for write and build flows

![image](https://user-images.githubusercontent.com/10482592/219435854-0d744495-8cd3-4497-acc6-a057d6ce33e2.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Create a new `build` flow site, select a free domain and free plan.
* Navigate to the launchpad and confirm that the `Choose a domain` task is visible in the task checklist.
* Click the task and confirm that it navigates to `domains/add/{siteSlug}?domainAndPlanPackage=true`
* Select a new domain and paid plan.
* Navigate back to the launchpad and confirm the `Choose a domain` task is no longer visible
* Repeat the steps above for the `free` and `write` flows.
* Confirm the launchpad test cases are still passing: `npm run test-client client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
