### PR TITLE
WooExpress: Fixes the padding for RTL languages

### DIFF
--- a/client/my-sites/plans/modernized-layout.tsx
+++ b/client/my-sites/plans/modernized-layout.tsx
@@ -134,10 +134,18 @@ const ModernizedLayout: React.FunctionComponent< { dropShadowOnHeader?: boolean 
 			// this overrides the default .layout__content that adds unwanted padding
 			& .layout__content,
 			&.theme-default .focus-content .layout__content {
-				padding: ${ layoutContentPaddingTop } 0 0 0;
+				:not( .rtl ) & {
+					padding: ${ layoutContentPaddingTop } 0 0 0;
 
-				@media ( min-width: ${ sidebarAppearanceBreakPoint } ) {
-					padding: ${ layoutContentPaddingTop } 0 0 calc( var( --sidebar-width-max ) + 1px );
+					@media ( min-width: ${ sidebarAppearanceBreakPoint } ) {
+						padding: ${ layoutContentPaddingTop } 0 0 calc( var( --sidebar-width-max ) + 1px );
+					}
+				}
+
+				.rtl & {
+					@media ( min-width: ${ sidebarAppearanceBreakPoint } ) {
+						padding: ${ layoutContentPaddingTop } calc( var( --sidebar-width-max ) + 1px ) 0 0;
+					}
 				}
 
 				.jetpack-colophon {

--- a/client/my-sites/plans/modernized-layout.tsx
+++ b/client/my-sites/plans/modernized-layout.tsx
@@ -134,18 +134,11 @@ const ModernizedLayout: React.FunctionComponent< { dropShadowOnHeader?: boolean 
 			// this overrides the default .layout__content that adds unwanted padding
 			& .layout__content,
 			&.theme-default .focus-content .layout__content {
-				:not( .rtl ) & {
-					padding: ${ layoutContentPaddingTop } 0 0 0;
+				padding: 0;
+				padding-block-start: ${ layoutContentPaddingTop };
 
-					@media ( min-width: ${ sidebarAppearanceBreakPoint } ) {
-						padding: ${ layoutContentPaddingTop } 0 0 calc( var( --sidebar-width-max ) + 1px );
-					}
-				}
-
-				.rtl & {
-					@media ( min-width: ${ sidebarAppearanceBreakPoint } ) {
-						padding: ${ layoutContentPaddingTop } calc( var( --sidebar-width-max ) + 1px ) 0 0;
-					}
+				@media ( min-width: ${ sidebarAppearanceBreakPoint } ) {
+					padding-inline-start: calc( var( --sidebar-width-max ) + 1px );
 				}
 
 				.jetpack-colophon {


### PR DESCRIPTION
## Proposed Changes

* Fixes the padding for RTL languages on the My Plans and Plans page.

**Before**
<img width="1512" alt="Screen Shot 2023-02-15 at 17 17 58" src="https://user-images.githubusercontent.com/1234758/219446538-a990866b-b7a7-4f35-9be4-036253d9e363.png">

**After**
<img width="1512" alt="Screen Shot 2023-02-16 at 14 47 53" src="https://user-images.githubusercontent.com/1234758/219446682-5a7102a0-37f4-408a-b012-2699627c1aaa.png">

## Testing Instructions

* Navigate to `/me/account` and set an RTL language on the `Interface Language` option. In my case I selected Hebrew.
* Navigate to `/plans/my-plans/:siteSlug` and `/plans/:siteSlug`
* The padding should be fixed now

Closes #73392
