### PR TITLE
Fix eCommerce Trial "Plans" page section nav

### DIFF
--- a/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
@@ -2,6 +2,46 @@
 
 body.is-section-plans.is-ecommerce-trial-plan {
 
+	// Overwrite section nav styles so they look like the desktop version on mobile as well
+	.section-nav {
+		.section-nav__mobile-header {
+			display: none;
+		}
+
+		.section-nav-group {
+			display: flex;
+		}
+
+		.section-nav-tabs__list {
+			display: flex;
+		}
+
+		.section-nav-tab {
+			border-bottom: 2px solid transparent;
+
+			&.is-selected {
+				border-bottom-color: var(--color-neutral-100);
+
+				.section-nav-tab__link {
+					background: none;
+				}
+
+				.section-nav-tab__text {
+					color: var(--color-neutral-100);
+				}
+			}
+		}
+
+		.section-nav-tab__link {
+			display: block;
+			font-weight: inherit;
+		}
+
+		.section-nav-tab__text {
+			display: inline;
+		}
+	}
+
 	&.color-scheme {
 		--color-surface-backdrop: var(--color-surface);
 	}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/73320

## Proposed Changes

* This PR overwrites the section nav `<SectionNav />` `[ My Plan | Plans ]` styles, so it looks on mobile the same as on desktop, only for eCommerce trial pages.

## Testing Instructions

- Open calypso live
- Navigate to the Plans | My Plan pages (`/plans/<site-slug>`) for a blog in the eCommerce trial.
- Use mobile mode
- Check the nav section
- Switch to a non-trial site and check that it was not affected by this change

Before:
![image](https://user-images.githubusercontent.com/3801502/219458928-f1a221f2-0914-4858-a41b-c594492b0bbb.png)

After:
![image](https://user-images.githubusercontent.com/3801502/219458632-332f70ff-fc6c-46e8-a886-5940754b88ab.png)
