### PR TITLE
Blaze: Improve /advertising flow experience

### DIFF
--- a/client/my-sites/promote-post/components/post-item/index.tsx
+++ b/client/my-sites/promote-post/components/post-item/index.tsx
@@ -10,6 +10,7 @@ import { recordDSPEntryPoint } from 'calypso/lib/promote-post';
 import resizeImageUrl from 'calypso/lib/resize-image-url';
 import { useRouteModal } from 'calypso/lib/route-modal';
 import PostRelativeTimeStatus from 'calypso/my-sites/post-relative-time-status';
+import PostActionCounts from 'calypso/my-sites/post-type-list/post-action-counts';
 import { getPostType } from 'calypso/my-sites/promote-post/utils';
 
 export type Post = {
@@ -71,6 +72,7 @@ export default function PostItem( { post }: Props ) {
 							<Gridicon icon="external" size={ 12 } className="post-item__external-icon" />
 						</a>
 					</span>
+					<PostActionCounts globalId={ post.global_ID } />
 				</div>
 			</div>
 

--- a/client/my-sites/promote-post/components/posts-list-banner/index.tsx
+++ b/client/my-sites/promote-post/components/posts-list-banner/index.tsx
@@ -1,4 +1,4 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import promoteMenuIllustration from 'calypso/assets/images/customer-home/illustration--blaze.svg';
 import './style.scss';
@@ -19,18 +19,16 @@ export default function PostsListBanner() {
 			</div>
 			<div>
 				<div className="posts-list-banner__title wp-brand-font">
-					{ translate( 'Promote your content with Blaze' ) }
+					{ translate( 'Get more visitors to your site' ) }
 				</div>
 				<div className="posts-list-banner__description">
 					{ translate(
-						'Reach more people promoting your work to the larger WordPress.com community of blogs and sites. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-						{
-							components: {
-								learnMoreLink: learnMoreLink,
-							},
-						}
+						'Reach more people promoting your work to the larger WordPress.com community of blogs and sites.'
 					) }
 				</div>
+				<Button compact className="posts-list-banner__learn-more">
+					<span>{ learnMoreLink }</span>
+				</Button>
 				<div className="posts-list-banner__footer">
 					<Gridicon icon="my-sites" />
 					{ translate( 'WordPress.com Ads' ) }

--- a/client/my-sites/promote-post/components/posts-list-banner/style.scss
+++ b/client/my-sites/promote-post/components/posts-list-banner/style.scss
@@ -26,4 +26,8 @@
 		}
 	}
 
+	.posts-list-banner__learn-more {
+		margin-top: 10px;
+	}
+
 }

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -157,7 +157,7 @@ export default function PromotedPosts( { tab }: Props ) {
 				align="left"
 			/>
 
-			{ ! campaignsIsLoading && <PostsListBanner /> }
+			{ ! campaignsIsLoading && ! campaignsData?.length && <PostsListBanner /> }
 
 			<PromotePostTabBar tabs={ tabs } selectedTab={ selectedTab } />
 			{ selectedTab === 'campaigns' ? (

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -12,7 +12,6 @@ import useCampaignsQuery from 'calypso/data/promote-post/use-promote-post-campai
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { usePromoteWidget, PromoteWidgetStatus } from 'calypso/lib/promote-post';
 import CampaignsList from 'calypso/my-sites/promote-post/components/campaigns-list';
-import { Post } from 'calypso/my-sites/promote-post/components/post-item';
 import PostsList from 'calypso/my-sites/promote-post/components/posts-list';
 import PostsListBanner from 'calypso/my-sites/promote-post/components/posts-list-banner';
 import PromotePostTabBar from 'calypso/my-sites/promote-post/components/promoted-post-filter';
@@ -33,6 +32,7 @@ const queryPost = {
 	number: 20, // max supported by /me/posts endpoint for all-sites mode
 	status: 'publish', // do not allow private or unpublished posts
 	type: 'post',
+	order_by: 'comment_count',
 };
 const queryPage = {
 	...queryPost,
@@ -47,19 +47,6 @@ const queryProducts = {
 export type DSPMessage = {
 	errorCode?: string;
 };
-
-function sortItemsByPublishedDate( items: Post[] ) {
-	return items.slice( 0 ).sort( function ( a, b ) {
-		if ( a.date && b.date ) {
-			const dateCompare = Date.parse( b.date ) - Date.parse( a.date );
-			if ( 0 !== dateCompare ) {
-				return dateCompare;
-			}
-		}
-		// ...otherwise, we return the greater of the two item IDs
-		return b.ID - a.ID;
-	} );
-}
 
 const ERROR_NO_LOCAL_USER = 'no_local_user';
 
@@ -154,11 +141,7 @@ export default function PromotedPosts( { tab }: Props ) {
 		);
 	}
 
-	const content = sortItemsByPublishedDate( [
-		...( posts || [] ),
-		...( pages || [] ),
-		...( products || [] ),
-	] );
+	const content = [ ...( posts || [] ), ...( pages || [] ), ...( products || [] ) ];
 
 	const isLoading = isLoadingPage && isLoadingPost && isLoadingProducts;
 
@@ -174,7 +157,7 @@ export default function PromotedPosts( { tab }: Props ) {
 				align="left"
 			/>
 
-			{ ! campaignsIsLoading && ! campaignsData?.length && <PostsListBanner /> }
+			{ ! campaignsIsLoading && <PostsListBanner /> }
 
 			<PromotePostTabBar tabs={ tabs } selectedTab={ selectedTab } />
 			{ selectedTab === 'campaigns' ? (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1442-gh-Automattic/dotcom-forge

## Proposed Changes

- In the post list on /advertising, we now have comments and likes
- Sorted posts by popularity, comments for now, as we need to investigate if it's viable sorting it by views: 1693-gh-Automattic/dotcom-forge
- Changed the "Learn more" button on the top card.
- Changed the `Promote your content with Blaze` copy to `Get more visitors to your site`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access /advertising and ensure the proposed changes are there:

<img width="1201" alt="image" src="https://user-images.githubusercontent.com/1044309/219689638-bb19f190-43b3-43b0-b0d4-f461892f4d2d.png">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?