### PR TITLE
Write Flow Launchpad: Change setup task text to Set up your site

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -73,7 +73,7 @@ export function getEnhancedTasks(
 			switch ( task.id ) {
 				case 'setup_write':
 					taskData = {
-						title: translate( 'Personalize your site' ),
+						title: translate( 'Set up your site' ),
 					};
 					break;
 				case 'setup_free':


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Estimated Time to Test / Review:
- Test -> Short
- Review -> Short

## Proposed Changes

Quick improvement to the write flow for the pattern assembler as described in paYE8P-2wq-p2 `Personalize your site might sound very similar to design or change your site, so perhaps we should name it differently: E.g. “Set up your site”`

In this PR we change the text from Personalize your site to Set up your site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site through the general onboarding write flow 
  * Visit wordpress.com/start
  * Follow steps and choose `Write & Publish` as the site's goal
* Navigate to the Launchpad
* Verify that the setup write flow task has text changed from "Personalize your site" to "Set up your site"

![Screenshot 2023-02-16 at 10 53 21 AM copy](https://user-images.githubusercontent.com/5414230/219460614-ade99fd3-2a94-4d96-9b6a-58affc96021f.jpg)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?