### PR TITLE
Domains: Add domain suggestion `position` tracking

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -96,7 +96,7 @@ class DomainRegistrationSuggestion extends Component {
 	}
 
 	onButtonClick = () => {
-		const { suggestion, railcarId } = this.props;
+		const { suggestion, railcarId, uiPosition } = this.props;
 
 		if ( this.isUnavailableDomain( suggestion.domain_name ) ) {
 			return;
@@ -109,7 +109,7 @@ class DomainRegistrationSuggestion extends Component {
 			} );
 		}
 
-		this.props.onButtonClick( suggestion );
+		this.props.onButtonClick( suggestion, uiPosition );
 	};
 
 	isUnavailableDomain = ( domain ) => {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -578,12 +578,13 @@ class RegisterDomainStep extends Component {
 	rejectTrademarkClaim = () => {
 		this.setState( {
 			selectedSuggestion: null,
+			selectedSuggestionPosition: null,
 			trademarkClaimsNoticeInfo: null,
 		} );
 	};
 
 	acceptTrademarkClaim = () => {
-		this.props.onAddDomain( this.state.selectedSuggestion );
+		this.props.onAddDomain( this.state.selectedSuggestion, this.state.selectedSuggestionPosition );
 	};
 
 	renderTrademarkClaimsNotice() {
@@ -1326,7 +1327,7 @@ class RegisterDomainStep extends Component {
 		return <FreeDomainExplainer onSkip={ this.props.hideFreePlan } />;
 	}
 
-	onAddDomain = ( suggestion ) => {
+	onAddDomain = ( suggestion, position ) => {
 		const domain = get( suggestion, 'domain_name' );
 		const { premiumDomains } = this.state;
 
@@ -1364,13 +1365,14 @@ class RegisterDomainStep extends Component {
 						this.setState( {
 							trademarkClaimsNoticeInfo: trademarkClaimsNoticeInfo,
 							selectedSuggestion: suggestion,
+							selectedSuggestionPosition: position,
 						} );
 					} else {
-						this.props.onAddDomain( suggestion );
+						this.props.onAddDomain( suggestion, position );
 					}
 				} );
 		} else {
-			this.props.onAddDomain( suggestion );
+			this.props.onAddDomain( suggestion, position );
 		}
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -26,7 +26,7 @@ import type { DomainSuggestion, DomainForm } from '@automattic/data-stores';
 interface DomainFormControlProps {
 	analyticsSection: string;
 	flow: string | null;
-	onAddDomain: ( suggestion: DomainSuggestion ) => void;
+	onAddDomain: ( suggestion: DomainSuggestion, position: number ) => void;
 	onAddMapping: ( domain: string ) => void;
 	onAddTransfer: ( { domain, authCode }: { domain: string; authCode: string } ) => void;
 	onSkip: ( _googleAppsCartItem?: any, shouldHideFreePlan?: boolean ) => void;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -192,11 +192,12 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		submit?.();
 	};
 
-	const handleAddDomain = ( suggestion: DomainSuggestion ) => {
+	const handleAddDomain = ( suggestion: DomainSuggestion, position: number ) => {
 		dispatch(
 			recordAddDomainButtonClick(
 				suggestion.domain_name,
 				getAnalyticsSection(),
+				position,
 				suggestion?.is_premium
 			)
 		);

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -81,9 +81,9 @@ class DomainSearch extends Component {
 		} );
 	};
 
-	handleAddRemoveDomain = ( suggestion ) => {
+	handleAddRemoveDomain = ( suggestion, position ) => {
 		if ( ! hasDomainInCart( this.props.cart, suggestion.domain_name ) ) {
-			this.addDomain( suggestion );
+			this.addDomain( suggestion, position );
 		} else {
 			this.removeDomain( suggestion );
 		}
@@ -133,7 +133,7 @@ class DomainSearch extends Component {
 		}
 	}
 
-	async addDomain( suggestion ) {
+	async addDomain( suggestion, position ) {
 		const {
 			domain_name: domain,
 			product_slug: productSlug,
@@ -141,7 +141,7 @@ class DomainSearch extends Component {
 			is_premium: isPremium,
 		} = suggestion;
 
-		this.props.recordAddDomainButtonClick( domain, 'domains', isPremium );
+		this.props.recordAddDomainButtonClick( domain, 'domains', position, isPremium );
 
 		let registration = domainRegistration( {
 			domain,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -160,7 +160,7 @@ class DomainsStep extends Component {
 		);
 	};
 
-	handleAddDomain = ( suggestion ) => {
+	handleAddDomain = ( suggestion, position ) => {
 		const stepData = {
 			stepName: this.props.stepName,
 			suggestion,
@@ -169,6 +169,7 @@ class DomainsStep extends Component {
 		this.props.recordAddDomainButtonClick(
 			suggestion.domain_name,
 			this.getAnalyticsSection(),
+			position,
 			suggestion?.is_premium
 		);
 		this.props.saveSignupStep( stepData );

--- a/client/state/domains/actions.js
+++ b/client/state/domains/actions.js
@@ -6,7 +6,7 @@ import {
 
 import 'calypso/state/domains/init';
 
-export const recordAddDomainButtonClick = ( domainName, section, isPremium = false ) =>
+export const recordAddDomainButtonClick = ( domainName, section, position, isPremium = false ) =>
 	composeAnalytics(
 		recordGoogleEvent(
 			'Domain Search',
@@ -16,6 +16,7 @@ export const recordAddDomainButtonClick = ( domainName, section, isPremium = fal
 		),
 		recordTracksEvent( 'calypso_domain_search_add_button_click', {
 			domain_name: domainName,
+			position,
 			section,
 			is_premium: isPremium,
 		} )


### PR DESCRIPTION
We never added tracking to the domain suggestion's position. This PR fixes it by adding it to all flows where it gets recorded.

#### Changes proposed in this Pull Request
Includes the `position` property in the `calypso_map_domain_step_add_domain_click` tracks event.

#### Testing instructions
- To test it properly, you must enable the Calypso Tracks Events logging in your console. You can do it by following the instructions here: PCYsg-cae-p2
  - You can also add the `calypso_domain_search_add_button_click` term to the console log filter, which makes it easier to view our specific event.
- After that, ensure that when you select a domain from the search list, you'll see its `position` property being recorded in `calypso_domain_search_add_button_click`.
- You should see something like this (where `position` is the suggestion's position in the results list): 

![image](https://user-images.githubusercontent.com/18705930/219487451-e38aa982-b849-4d48-9df8-3b14960cac82.png)

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] (N/A) [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] (N/A) Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] (N/A) Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] (N/A) Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] (N/A) For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?