### PR TITLE
Add Jetpack CI infrastructure to target Jetpack tests against staging

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -49,8 +49,17 @@ object WPComTests : Project({
 	// Editor Tracking Edge
 	buildType(editorTrackingBuildType("desktop", "c752ca9a-e77d-11ec-8fea-0242ac120002", atomic=false, edge=true));
 
-	buildType(jetpackPlaywrightBuildType("desktop", "68fe6336-5869-4244-b236-cca23ba03487"));
-	buildType(jetpackPlaywrightBuildType("mobile", "a80b5c10-1fef-4c7f-9e2c-5c5c30d637c8"));
+	// Jetpack for Connected Non-WPCOM Sites
+	buildType(jetpackPlaywrightBuildType("desktop", "68fe6336-5869-4244-b236-cca23ba03487", "not-wpcom"));
+	buildType(jetpackPlaywrightBuildType("mobile", "a80b5c10-1fef-4c7f-9e2c-5c5c30d637c8", "not-wpcom"));
+
+	// Jetpack for WPCOM Sites Running Staging
+	buildType(jetpackPlaywrightBuildType("desktop", "3007d7a1-5642-4dbf-9935-d93f3cdb4dcc", "wpcom-staging"));
+	buildType(jetpackPlaywrightBuildType("mobile", "ccfe7d2c-8f04-406b-8b83-3db6c8475661", "wpcom-staging"));
+
+	// Jetpack for WPCOM Sites Running Prod
+	buildType(jetpackPlaywrightBuildType("desktop", "de6df2e1-3bad-46a4-9764-9c7e0974d4ff", "wpcom-production"));
+	buildType(jetpackPlaywrightBuildType("mobile", "79479054-e30e-4177-937f-4197c4846a0f", "wpcom-production"));
 
 	buildType(I18NTests);
 	buildType(P2E2ETests)
@@ -172,12 +181,12 @@ fun editorTrackingBuildType( targetDevice: String, buildUuid: String, atomic: Bo
 	)
 }
 
-fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String): E2EBuildType {
+fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpackTarget: string = "wpcom-production" ): E2EBuildType {
 	return E2EBuildType (
 		buildId = "WPComTests_jetpack_Playwright_$targetDevice",
 		buildUuid = buildUuid,
-		buildName = "Jetpack E2E Tests ($targetDevice)",
-		buildDescription = "Runs Jetpack E2E tests as $targetDevice",
+		buildName = "Jetpack E2E Tests [$jetpackTarget] ($targetDevice)",
+		buildDescription = "Runs Jetpack E2E tests as $targetDevice against Jetpack install $jetpackTarget",
 		testGroup = "jetpack",
 		buildParams = {
 			text(
@@ -188,14 +197,18 @@ fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String): E2EBui
 				allowEmpty = false
 			)
 			param("env.VIEWPORT_NAME", "$targetDevice")
-			checkbox(
-				name = "env.TEST_ON_JETPACK",
-				value = "true",
-				label = "Test on Jetpack",
-				description = "Use a Jetpack blog to test against",
-				checked = "true",
-				unchecked = "false"
+			select(
+				name = "env.JETPACK_TARGET",
+				value = jetpackTarget,
+				label = 'Jetpack Target',
+				description = 'Which Jetpack install are we targeting through Calypso?',
+				options = [
+					"wpcom-production",
+					"wpcom-staging",
+					"not-wpcom"
+				]
 			)
+
 		},
 		buildFeatures = {},
 		buildTriggers = {

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -200,13 +200,13 @@ fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpack
 			select(
 				name = "env.JETPACK_TARGET",
 				value = jetpackTarget,
-				label = 'Jetpack Target',
-				description = 'Which Jetpack install are we targeting through Calypso?',
-				options = [
+				label = "Jetpack Target",
+				description = "Which Jetpack install are we targeting through Calypso?",
+				options = listOf(
 					"wpcom-production",
 					"wpcom-staging",
 					"not-wpcom"
-				]
+				)
 			)
 
 		},

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -183,9 +183,9 @@ fun editorTrackingBuildType( targetDevice: String, buildUuid: String, atomic: Bo
 
 fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpackTarget: String = "wpcom-production" ): E2EBuildType {
 	return E2EBuildType (
-		buildId = "WPComTests_jetpack_Playwright_$jetpackTarget_$targetDevice",
+		buildId = "WPComTests_jetpack_Playwright_${jetpackTarget}_$targetDevice",
 		buildUuid = buildUuid,
-		buildName = "Jetpack E2E Tests [$jetpackTarget] ($targetDevice)",
+		buildName = "Jetpack E2E Tests [${jetpackTarget}] ($targetDevice)",
 		buildDescription = "Runs Jetpack E2E tests as $targetDevice against Jetpack install $jetpackTarget",
 		testGroup = "jetpack",
 		buildParams = {

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -181,7 +181,7 @@ fun editorTrackingBuildType( targetDevice: String, buildUuid: String, atomic: Bo
 	)
 }
 
-fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpackTarget: string = "wpcom-production" ): E2EBuildType {
+fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpackTarget: String = "wpcom-production" ): E2EBuildType {
 	return E2EBuildType (
 		buildId = "WPComTests_jetpack_Playwright_$targetDevice",
 		buildUuid = buildUuid,

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -50,16 +50,16 @@ object WPComTests : Project({
 	buildType(editorTrackingBuildType("desktop", "c752ca9a-e77d-11ec-8fea-0242ac120002", atomic=false, edge=true));
 
 	// Jetpack for Connected Non-WPCOM Sites
-	buildType(jetpackPlaywrightBuildType("desktop", "68fe6336-5869-4244-b236-cca23ba03487", "not-wpcom"));
-	buildType(jetpackPlaywrightBuildType("mobile", "a80b5c10-1fef-4c7f-9e2c-5c5c30d637c8", "not-wpcom"));
+	buildType(jetpackPlaywrightBuildType("desktop", "68fe6336-5869-4244-b236-cca23ba03487", jetpackTarget="remote-site"));
+	buildType(jetpackPlaywrightBuildType("mobile", "a80b5c10-1fef-4c7f-9e2c-5c5c30d637c8", jetpackTarget="remote-site"));
 
 	// Jetpack for WPCOM Sites Running Staging
-	buildType(jetpackPlaywrightBuildType("desktop", "3007d7a1-5642-4dbf-9935-d93f3cdb4dcc", "wpcom-staging"));
-	buildType(jetpackPlaywrightBuildType("mobile", "ccfe7d2c-8f04-406b-8b83-3db6c8475661", "wpcom-staging"));
+	buildType(jetpackPlaywrightBuildType("desktop", "3007d7a1-5642-4dbf-9935-d93f3cdb4dcc", jetpackTarget="wpcom-staging"));
+	buildType(jetpackPlaywrightBuildType("mobile", "ccfe7d2c-8f04-406b-8b83-3db6c8475661", jetpackTarget="wpcom-staging"));
 
 	// Jetpack for WPCOM Sites Running Prod
-	buildType(jetpackPlaywrightBuildType("desktop", "de6df2e1-3bad-46a4-9764-9c7e0974d4ff", "wpcom-production"));
-	buildType(jetpackPlaywrightBuildType("mobile", "79479054-e30e-4177-937f-4197c4846a0f", "wpcom-production"));
+	buildType(jetpackPlaywrightBuildType("desktop", "de6df2e1-3bad-46a4-9764-9c7e0974d4ff", jetpackTarget="wpcom-production"));
+	buildType(jetpackPlaywrightBuildType("mobile", "79479054-e30e-4177-937f-4197c4846a0f", jetpackTarget="wpcom-production"));
 
 	buildType(I18NTests);
 	buildType(P2E2ETests)
@@ -205,7 +205,7 @@ fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpack
 				options = listOf(
 					"wpcom-production",
 					"wpcom-staging",
-					"not-wpcom"
+					"remote-site"
 				)
 			)
 

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -183,7 +183,7 @@ fun editorTrackingBuildType( targetDevice: String, buildUuid: String, atomic: Bo
 
 fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpackTarget: String = "wpcom-production" ): E2EBuildType {
 	return E2EBuildType (
-		buildId = "WPComTests_jetpack_Playwright_$targetDevice",
+		buildId = "WPComTests_jetpack_Playwright_$jetpackTarget_$targetDevice",
 		buildUuid = buildUuid,
 		buildName = "Jetpack E2E Tests [$jetpackTarget] ($targetDevice)",
 		buildDescription = "Runs Jetpack E2E tests as $targetDevice against Jetpack install $jetpackTarget",

--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -110,7 +110,11 @@ const castKnownEnvVariable = ( name: string, value: string ): EnvVariableValue =
 			break;
 		}
 		case 'JETPACK_TARGET': {
-			const supportedValues: JetpackTarget[] = [ 'not-wpcom', 'wpcom-production', 'wpcom-staging' ];
+			const supportedValues: JetpackTarget[] = [
+				'remote-site',
+				'wpcom-production',
+				'wpcom-staging',
+			];
 			if ( ! supportedValues.includes( output as JetpackTarget ) ) {
 				throw new Error(
 					`Unknown JETPACK_TARGET value: ${ output }.\nSupported values: ${ supportedValues.join(

--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -107,6 +107,7 @@ const castKnownEnvVariable = ( name: string, value: string ): EnvVariableValue =
 					`Invalid CALYPSO_BASE_URL value: ${ output }.\nYou must provide a valid URL.`
 				);
 			}
+			break;
 		}
 		case 'JETPACK_TARGET': {
 			const supportedValues: JetpackTarget[] = [ 'not-wpcom', 'wpcom-production', 'wpcom-staging' ];
@@ -117,6 +118,7 @@ const castKnownEnvVariable = ( name: string, value: string ): EnvVariableValue =
 					) }`
 				);
 			}
+			break;
 		}
 	}
 

--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -1,8 +1,12 @@
 import path from 'path';
 import { getMag16Locales, getViewports } from './data-helper';
 import { TEST_ACCOUNT_NAMES } from './secrets';
+import {
+	SupportedEnvVariables,
+	EnvVariableValue,
+	JetpackTarget,
+} from './types/env-variables.types';
 import { TestAccountName } from '.';
-import type { SupportedEnvVariables, EnvVariableValue } from './types/env-variables.types';
 
 const VIEWPORT_NAMES = getViewports();
 const MAG16_LOCALES = getMag16Locales();
@@ -18,7 +22,7 @@ const defaultEnvVariables: SupportedEnvVariables = {
 	COOKIES_PATH: path.join( process.cwd(), 'cookies' ),
 	ARTIFACTS_PATH: path.join( process.cwd(), 'results' ),
 	TEST_ON_ATOMIC: false,
-	TEST_ON_JETPACK: false,
+	JETPACK_TARGET: 'wpcom-production',
 	CALYPSO_BASE_URL: 'https://wordpress.com',
 	BROWSER_NAME: 'chromium',
 	ALLURE_RESULTS_PATH: '',
@@ -101,6 +105,16 @@ const castKnownEnvVariable = ( name: string, value: string ): EnvVariableValue =
 			} catch ( error ) {
 				throw new Error(
 					`Invalid CALYPSO_BASE_URL value: ${ output }.\nYou must provide a valid URL.`
+				);
+			}
+		}
+		case 'JETPACK_TARGET': {
+			const supportedValues: JetpackTarget[] = [ 'not-wpcom', 'wpcom-production', 'wpcom-staging' ];
+			if ( ! supportedValues.includes( output as JetpackTarget ) ) {
+				throw new Error(
+					`Unknown JETPACK_TARGET value: ${ output }.\nSupported values: ${ supportedValues.join(
+						' | '
+					) }`
 				);
 			}
 		}

--- a/packages/calypso-e2e/src/types/env-variables.types.ts
+++ b/packages/calypso-e2e/src/types/env-variables.types.ts
@@ -7,6 +7,7 @@ export type EnvVariables = {
 
 export type ViewportName = string;
 export type TestLocales = string[];
+export type JetpackTarget = 'not-wpcom' | 'wpcom-production' | 'wpcom-staging';
 
 export interface SupportedEnvVariables extends EnvVariables {
 	VIEWPORT_NAME: ViewportName;
@@ -20,7 +21,7 @@ export interface SupportedEnvVariables extends EnvVariables {
 	SLOW_MO: number;
 	TIMEOUT: number;
 	TEST_ON_ATOMIC: boolean;
-	TEST_ON_JETPACK: boolean;
+	JETPACK_TARGET: JetpackTarget;
 	CALYPSO_BASE_URL: string;
 	BROWSER_NAME: string;
 	ALLURE_RESULTS_PATH: string;

--- a/packages/calypso-e2e/src/types/env-variables.types.ts
+++ b/packages/calypso-e2e/src/types/env-variables.types.ts
@@ -7,7 +7,7 @@ export type EnvVariables = {
 
 export type ViewportName = string;
 export type TestLocales = string[];
-export type JetpackTarget = 'not-wpcom' | 'wpcom-production' | 'wpcom-staging';
+export type JetpackTarget = 'remote-site' | 'wpcom-production' | 'wpcom-staging';
 
 export interface SupportedEnvVariables extends EnvVariables {
 	VIEWPORT_NAME: ViewportName;

--- a/test/e2e/docs/environment_variables.md
+++ b/test/e2e/docs/environment_variables.md
@@ -15,10 +15,10 @@ Environment Variables control much of the runtime configuration for E2E tests.
 | COOKIES_PATH          | Path on disk to the saved authenticated cookies.                    | ./cookies/                                        |
 | GUTENBERG_EDGE        | Use the bleeding edge Gutenberg build.                              | false                                             |
 | HEADLESS              | Configure browser headless/headful mode.                            | false                                             |
+| JETPACK_TARGET        | Which Jetpack install we are targeting through Calypso              | wpcom-production                                  |
 | SLOW_MO               | Slow down the execution by given milliseconds.                      | 0                                                 |
 | TEST_LOCALES          | The locales to target for I18N testing                              | A long list of currently supported locales.       |
 | TEST_ON_ATOMIC        | Use a user with an Atomic site.                                     | false                                             |
-| TEST_ON_JETPACK       | Use a user with a jetpack connected site.                           | false                                             |
 | VIEWPORT_NAME         | Specify the viewport to be used.                                    | desktop                                           |
 
 <!-- When adding new rows, run the following command to sort the resulting sub-table in alphabetical order:

--- a/test/e2e/specs/appearance/theme__details-preview-activate.ts
+++ b/test/e2e/specs/appearance/theme__details-preview-activate.ts
@@ -20,9 +20,10 @@ import { Browser, Page } from 'playwright';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
-	const accountName = envVariables.TEST_ON_JETPACK
-		? 'jetpackUser'
-		: getTestAccountByFeature( envToFeatureKey( envVariables ) );
+	const accountName =
+		envVariables.JETPACK_TARGET === 'not-wpcom'
+			? 'jetpackUser'
+			: getTestAccountByFeature( envToFeatureKey( envVariables ) );
 	const testAccount = new TestAccount( accountName );
 	const testAccountSiteDomain = testAccount.getSiteURL( { protocol: false } );
 	let sidebarComponent: SidebarComponent;

--- a/test/e2e/specs/appearance/theme__details-preview-activate.ts
+++ b/test/e2e/specs/appearance/theme__details-preview-activate.ts
@@ -21,7 +21,7 @@ declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Theme: Preview and Activate' ), () => {
 	const accountName =
-		envVariables.JETPACK_TARGET === 'not-wpcom'
+		envVariables.JETPACK_TARGET === 'remote-site'
 			? 'jetpackUser'
 			: getTestAccountByFeature( envToFeatureKey( envVariables ) );
 	const testAccount = new TestAccount( accountName );

--- a/test/e2e/specs/appearance/theme__popover-preview.ts
+++ b/test/e2e/specs/appearance/theme__popover-preview.ts
@@ -21,9 +21,10 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), function () {
 	// This test will use this specific theme as it will never be active.
 	const themeName = 'Twenty Seventeen';
-	const accountName = envVariables.TEST_ON_JETPACK
-		? 'jetpackUser'
-		: getTestAccountByFeature( envToFeatureKey( envVariables ) );
+	const accountName =
+		envVariables.JETPACK_TARGET === 'not-wpcom'
+			? 'jetpackUser'
+			: getTestAccountByFeature( envToFeatureKey( envVariables ) );
 	const testAccount = new TestAccount( accountName );
 	const testAccountSiteDomain = testAccount.getSiteURL( { protocol: false } );
 

--- a/test/e2e/specs/appearance/theme__popover-preview.ts
+++ b/test/e2e/specs/appearance/theme__popover-preview.ts
@@ -22,7 +22,7 @@ describe( DataHelper.createSuiteTitle( 'Theme: Preview' ), function () {
 	// This test will use this specific theme as it will never be active.
 	const themeName = 'Twenty Seventeen';
 	const accountName =
-		envVariables.JETPACK_TARGET === 'not-wpcom'
+		envVariables.JETPACK_TARGET === 'remote-site'
 			? 'jetpackUser'
 			: getTestAccountByFeature( envToFeatureKey( envVariables ) );
 	const testAccount = new TestAccount( accountName );


### PR DESCRIPTION
Related to #

## Proposed Changes

See discussion here: pd5faL-rf-p2

In short, we want to expand the Jetpack E2E testing we're doing on WPCOM!

Currently, we just use the `TEST_ON_JETPACK` env var flag to switch to an account that has a site hosted on Pressable, but then Jetpack connected to be used in Calypso.

As discussed in the P2, we want to also start running tests against the Jetpack installation on WPCOM, especially in its staging mode during releases.

So, we've made a new env var: `JETPACK_TARGET`. It can be one of three values:
1. `wpcom-production`: this is the jetpack install that any ye-old WPCOM site is using! The baseline, the deafult.
2. `wpcom-staging`: during jetpack releases on WPCOM, a couple of sites have access to the new release in its staging form. We target that staging version on WPCOM here.
3. `not-wpcom`: this represents what we used to target with jetpack testing: a site hosted elsewhere (not on WPCOM) that we've since Jetpack connected and are testing through Calypso. 

There are new CI builds to represent these different options!

We'll be enabling more tests and users for these different cases in a future PR!

## Testing Instructions

- [ ] No TeamCity errors
- [ ] The previous Jetpack tests should continue to target a site hosted on Pressable and pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?