### PR TITLE
Domains: Include `busy` state for trademark notice's buttons

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -588,12 +588,13 @@ class RegisterDomainStep extends Component {
 
 	renderTrademarkClaimsNotice() {
 		const { isSignupStep } = this.props;
-		const { selectedSuggestion, trademarkClaimsNoticeInfo } = this.state;
+		const { selectedSuggestion, trademarkClaimsNoticeInfo, isLoading } = this.state;
 		const domain = get( selectedSuggestion, 'domain_name' );
 
 		return (
 			<TrademarkClaimsNotice
 				domain={ domain }
+				isLoading={ isLoading }
 				isSignupStep={ isSignupStep }
 				onAccept={ this.acceptTrademarkClaim }
 				onGoBack={ this.rejectTrademarkClaim }

--- a/client/components/domains/trademark-claims-notice/index.jsx
+++ b/client/components/domains/trademark-claims-notice/index.jsx
@@ -189,7 +189,7 @@ class TrademarkClaimsNotice extends Component {
 	};
 
 	renderTrademarkClaimsNotice = () => {
-		const { hasScrolledToBottom, showFullNotice, trademarkClaimsNoticeInfo, isLoading } =
+		const { hasScrolledToBottom, isLoading, showFullNotice, trademarkClaimsNoticeInfo } =
 			this.state;
 
 		return (

--- a/client/components/domains/trademark-claims-notice/index.jsx
+++ b/client/components/domains/trademark-claims-notice/index.jsx
@@ -39,6 +39,7 @@ class TrademarkClaimsNotice extends Component {
 
 	getDefaultState() {
 		return {
+			isLoading: false,
 			hasScrolledToBottom: false,
 			showFullNotice: false,
 			trademarkClaimsNoticeInfo: this.props.trademarkClaimsNoticeInfo,
@@ -151,13 +152,23 @@ class TrademarkClaimsNotice extends Component {
 	onAccept = () => {
 		const { domain } = this.props;
 		this.props.recordAcknowledgeTrademarkButtonClickInTrademarkNotice( domain );
-		this.props.onAccept();
+		this.setState(
+			{
+				isLoading: true,
+			},
+			this.props.onAccept
+		);
 	};
 
 	onReject = () => {
 		const { domain } = this.props;
 		this.props.recordChooseAnotherDomainButtonClickInTrademarkNotice( domain );
-		this.props.onReject();
+		this.setState(
+			{
+				isLoading: true,
+			},
+			this.props.onReject
+		);
 	};
 
 	renderPlaceholder = () => {
@@ -178,7 +189,8 @@ class TrademarkClaimsNotice extends Component {
 	};
 
 	renderTrademarkClaimsNotice = () => {
-		const { hasScrolledToBottom, showFullNotice, trademarkClaimsNoticeInfo } = this.state;
+		const { hasScrolledToBottom, showFullNotice, trademarkClaimsNoticeInfo, isLoading } =
+			this.state;
 
 		return (
 			<Fragment>
@@ -186,9 +198,10 @@ class TrademarkClaimsNotice extends Component {
 				{ /*{ showFullNotice ? this.renderNotice() : this.renderShowNoticeLink() }*/ }
 				{ showFullNotice ? (
 					<TrademarkNotice
-						buttonsEnabled={ hasScrolledToBottom }
+						buttonsEnabled={ ! isLoading && hasScrolledToBottom }
 						onAccept={ this.onAccept }
 						onReject={ this.onReject }
+						isLoading={ isLoading }
 						trademarkClaimsInfo={ trademarkClaimsNoticeInfo }
 					/>
 				) : (

--- a/client/components/domains/trademark-claims-notice/trademark-notice.jsx
+++ b/client/components/domains/trademark-claims-notice/trademark-notice.jsx
@@ -33,16 +33,21 @@ class TrademarkNotice extends Component {
 	};
 
 	renderNoticeActions = () => {
-		const { buttonsEnabled, onAccept, onReject, translate } = this.props;
+		const { buttonsEnabled, onAccept, onReject, translate, isLoading } = this.props;
 
 		return (
 			<div className="trademark-claims-notice__layout">
 				<div className="trademark-claims-notice__actions-background">
 					<CompactCard className="trademark-claims-notice__actions">
-						<Button borderless onClick={ onReject } disabled={ ! buttonsEnabled }>
+						<Button
+							busy={ isLoading }
+							borderless
+							onClick={ onReject }
+							disabled={ ! buttonsEnabled }
+						>
 							{ translate( 'Choose Another Domain' ) }
 						</Button>
-						<Button primary onClick={ onAccept } disabled={ ! buttonsEnabled }>
+						<Button busy={ isLoading } primary onClick={ onAccept } disabled={ ! buttonsEnabled }>
 							{ translate( 'Acknowledge Trademark' ) }
 						</Button>
 					</CompactCard>


### PR DESCRIPTION
Just adds the `busy` state for the inner `Button`s within the trademark notice component.

## Testing Instructions
- Search for an available domain that has TCN info (or hack the back end to return a false positive for availability checks). For example `dairyqueen.dev`.
- Make sure that when clicking on the "Acknowledge Trademark" button toggles the `busy` effect for the buttons, same as in this video:

https://user-images.githubusercontent.com/18705930/219492118-a56f9b6f-bc1c-4c8a-8bcc-180264a85c19.mov


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] (N/A) Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] (N/A) Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] (N/A) Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] (N/A) For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
