### PR TITLE
Stats: Fix post details page content for the Homepage that the post id is 0

### DIFF
--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -80,17 +80,18 @@ class PostLikes extends PureComponent {
 			noLikesLabel = translate( 'There are no likes on this post yet.' );
 		}
 
-		const isLoading = ! likes;
+		// Prevent loading for postId `0`
+		const isLoading = !! postId && ! likes;
 
 		const classes = classnames( 'post-likes', {
 			'has-display-names': showDisplayNames,
-			'no-likes': likeCount === 0,
+			'no-likes': ! likeCount,
 		} );
 		const extraProps = { onMouseEnter, onMouseLeave };
 
 		return (
 			<div className={ classes } { ...extraProps }>
-				<QueryPostLikes siteId={ siteId } postId={ postId } needsLikers={ true } />
+				{ !! postId && <QueryPostLikes siteId={ siteId } postId={ postId } needsLikers={ true } /> }
 				{ isLoading && (
 					<span key="placeholder" className="post-likes__count is-loading">
 						…
@@ -98,7 +99,7 @@ class PostLikes extends PureComponent {
 				) }
 				{ likes && likes.map( this.renderLike ) }
 				{ this.renderExtraCount() }
-				{ likeCount === 0 && noLikesLabel }
+				{ ! isLoading && ! likeCount && noLikesLabel }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -84,10 +84,10 @@ export default function PostDetailHighlightsSection( {
 				<div className="highlight-cards-list">
 					<PostStatsCard
 						heading={ translate( 'All-time stats' ) }
-						likeCount={ post?.like_count }
+						likeCount={ post?.like_count || 0 }
 						post={ postData }
 						viewCount={ viewCount }
-						commentCount={ post?.discussion?.comment_count }
+						commentCount={ post?.discussion?.comment_count || 0 }
 					/>
 
 					<Card className="highlight-card">

--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -95,9 +95,7 @@ export default function PostDetailHighlightsSection( {
 							<span>{ translate( 'Post likes' ) }</span>
 							<Count count={ post?.like_count || 0 } />
 						</div>
-						{ !! postId && (
-							<PostLikes siteId={ siteId } postId={ postId } postType={ post?.type } />
-						) }
+						<PostLikes siteId={ siteId } postId={ postId } postType={ post?.type } />
 					</Card>
 				</div>
 			</div>

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -132,8 +132,8 @@
 
 		.post-likes__count {
 			vertical-align: bottom;
-			margin: 0 0 7px 25px;
-			padding: 0;
+			margin: 0;
+			padding: 6px 16px;
 			border: 0;
 			color: var(--color-neutral-60);
 			font-size: $font-body-small;

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -114,6 +114,7 @@ class StatsPostDetail extends Component {
 			isRequestingStats,
 			countViews,
 			post,
+			postFallback,
 			postId,
 			siteId,
 			translate,
@@ -135,6 +136,12 @@ class StatsPostDetail extends Component {
 			noViewsLabel = translate( 'Your post has not received any views yet!' );
 		}
 
+		// Make title to PostStatsCard for Homepage
+		const passedPost = post ||
+			postFallback || {
+				title: this.getTitle(),
+			};
+
 		return (
 			<Main fullWidthLayout>
 				<PageViewTracker
@@ -155,7 +162,7 @@ class StatsPostDetail extends Component {
 						) }
 					</FixedNavigationHeader>
 
-					<PostDetailHighlightsSection siteId={ siteId } postId={ postId } post={ post } />
+					<PostDetailHighlightsSection siteId={ siteId } postId={ postId } post={ passedPost } />
 
 					<StatsPlaceholder isLoading={ isLoading } />
 

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -16,12 +16,7 @@ import WebPreview from 'calypso/components/web-preview';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { getSitePost, getPostPreviewUrl } from 'calypso/state/posts/selectors';
-import {
-	getSiteOption,
-	getSiteSlug,
-	isJetpackSite,
-	isSitePreviewable,
-} from 'calypso/state/sites/selectors';
+import { getSiteSlug, isJetpackSite, isSitePreviewable } from 'calypso/state/sites/selectors';
 import { getPostStat, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PostDetailHighlightsSection from '../post-detail-highlights-section';
@@ -91,9 +86,9 @@ class StatsPostDetail extends Component {
 	};
 
 	getTitle() {
-		const { isLatestPostsHomepage, post, postFallback, translate } = this.props;
+		const { isPostHomepage, post, postFallback, translate } = this.props;
 
-		if ( isLatestPostsHomepage ) {
+		if ( isPostHomepage ) {
 			return translate( 'Home page / Archives' );
 		}
 
@@ -110,7 +105,7 @@ class StatsPostDetail extends Component {
 
 	render() {
 		const {
-			isLatestPostsHomepage,
+			isPostHomepage,
 			isRequestingStats,
 			countViews,
 			post,
@@ -148,7 +143,7 @@ class StatsPostDetail extends Component {
 					path={ `/stats/${ postType }/:post_id/:site` }
 					title={ `Stats > Single ${ titlecase( postType ) }` }
 				/>
-				{ siteId && ! isLatestPostsHomepage && <QueryPosts siteId={ siteId } postId={ postId } /> }
+				{ siteId && ! isPostHomepage && <QueryPosts siteId={ siteId } postId={ postId } /> }
 				{ siteId && <QueryPostStats siteId={ siteId } postId={ postId } /> }
 
 				<div className="stats has-fixed-nav">
@@ -206,18 +201,17 @@ const connectComponent = connect( ( state, { postId } ) => {
 	const siteId = getSelectedSiteId( state );
 	const isJetpack = isJetpackSite( state, siteId );
 	const isPreviewable = isSitePreviewable( state, siteId );
-	const isLatestPostsHomepage =
-		getSiteOption( state, siteId, 'show_on_front' ) === 'posts' && postId === 0;
+	const isPostHomepage = postId === 0;
 
 	return {
 		post: getSitePost( state, siteId, postId ),
 		// NOTE: Post object from the stats response does not conform to the data structure returned by getSitePost!
 		postFallback: getPostStat( state, siteId, postId, 'post' ),
-		isLatestPostsHomepage,
+		isPostHomepage,
 		countViews: getPostStat( state, siteId, postId, 'views' ),
 		isRequestingStats: isRequestingPostStats( state, siteId, postId ),
 		siteSlug: getSiteSlug( state, siteId ),
-		showViewLink: ! isJetpack && ! isLatestPostsHomepage && isPreviewable,
+		showViewLink: ! isJetpack && ! isPostHomepage && isPreviewable,
 		previewUrl: getPostPreviewUrl( state, siteId, postId ),
 		siteId,
 	};

--- a/client/my-sites/stats/stats-post-likes/index.jsx
+++ b/client/my-sites/stats/stats-post-likes/index.jsx
@@ -13,7 +13,8 @@ import './style.scss';
 
 export const StatsPostLikes = ( props ) => {
 	const { countLikes, postId, postType, siteId } = props;
-	const isLoading = countLikes === null;
+	// Prevent loading for postId `0`
+	const isLoading = !! postId && countLikes === null;
 	const classes = {
 		'is-loading': isLoading,
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73251 

## Proposed Changes

* Show the post title as `Home page / Archives` when the post id is 0.
* Show both the like count and comment count as `0` when the post id is 0.
* Show the copy `There are no likes on this post yet` when the post id is 0.
* Update the [isLatestPostsHomepage checking](https://github.com/Automattic/wp-calypso/pull/64492/files#diff-5ca74c1f7635e327c6900ec02ba954dc366bfcf053dc5ea2cd2e74219a5ad3b7R205) to `isPostHomepage` since the accessible post id is not relevant to the customized `Homepage Settings`.

> About the isLatestPostsHomepage checking, we can still access the post details page of the Homepage (postId = 0) even if we change the Homepage settings `Your homepage displays` to the option `A static page`.
<img width="465" alt="截圖 2023-02-17 上午6 10 56" src="https://user-images.githubusercontent.com/6869813/219499020-3ba5203a-d295-43fa-b890-9ac2c0a3943d.png">
 
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Post Detail` page (`/stats/post/${post-id}/${site-slug}`).
* Ensure the page works as previously.
* Navigate to the Stats `Post Detail` page for the Homepage (`/stats/post/0/${site-slug}`).
* Ensure the page shows the title and `empty` statistic data excluding the `Views`.

|Before|After|
|-|-|
|<img width="1271" alt="截圖 2023-02-17 上午5 46 44" src="https://user-images.githubusercontent.com/6869813/219494295-16b7b71d-4e52-4400-bdbc-82f70898e768.png">|<img width="1264" alt="截圖 2023-02-17 上午5 23 24" src="https://user-images.githubusercontent.com/6869813/219494349-e46f5190-3754-4ca2-b553-c044ddb06308.png">|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
