### PR TITLE
Stats: expand child to parent level if there is only one item in a group for Referrers

### DIFF
--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -813,7 +813,7 @@ export const normalizers = {
 
 		// If there's only one item in a group, then we expand the children to the parent level.
 		statsData = statsData.map( ( item ) => {
-			if ( item.results.length === 1 ) {
+			if ( item.results?.length === 1 ) {
 				return {
 					...item.results[ 0 ],
 					group: item.results[ 0 ].name,

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -788,7 +788,7 @@ export const normalizers = {
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
 		const dataPath = query.summarize ? [ 'summary', 'groups' ] : [ 'days', startOf, 'groups' ];
-		const statsData = get( data, dataPath, [] );
+		let statsData = get( data, dataPath, [] );
 
 		const parseItem = ( item ) => {
 			let children;
@@ -810,6 +810,17 @@ export const normalizers = {
 
 			return record;
 		};
+
+		// If there's only one group, then we expand the children to the top level.
+		if ( 1 === statsData.length ) {
+			statsData = statsData[ 0 ].results.map( ( child ) => {
+				return {
+					...child,
+					group: child.name,
+					total: child.views,
+				};
+			} );
+		}
 
 		return statsData.map( ( item ) => {
 			let actions = [];

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -811,8 +811,20 @@ export const normalizers = {
 			return record;
 		};
 
+		// If there's only one item in a group, then we expand the children to the top level.
+		statsData = statsData.map( ( item ) => {
+			if ( item.results.length === 1 ) {
+				return {
+					...item.results[ 0 ],
+					group: item.results[ 0 ].name,
+					total: item.results[ 0 ].views,
+				};
+			}
+			return item;
+		} );
+
 		// If there's only one group, then we expand the children to the top level.
-		if ( 1 === statsData.length ) {
+		if ( 1 === statsData.length && statsData[ 0 ].results ) {
 			statsData = statsData[ 0 ].results.map( ( child ) => {
 				return {
 					...child,

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -813,7 +813,7 @@ export const normalizers = {
 
 		// If there's only one item in a group, then we expand the children to the top level.
 		statsData = statsData.map( ( item ) => {
-			if ( item.results.length === 1 ) {
+			if ( item.results.length === 1 || ( statsData.length === 1 && item.results?.length > 0 ) ) {
 				return {
 					...item.results[ 0 ],
 					group: item.results[ 0 ].name,
@@ -822,17 +822,6 @@ export const normalizers = {
 			}
 			return item;
 		} );
-
-		// If there's only one group, then we expand the children to the top level.
-		if ( 1 === statsData.length && statsData[ 0 ].results ) {
-			statsData = statsData[ 0 ].results.map( ( child ) => {
-				return {
-					...child,
-					group: child.name,
-					total: child.views,
-				};
-			} );
-		}
 
 		return statsData.map( ( item ) => {
 			let actions = [];

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -811,7 +811,7 @@ export const normalizers = {
 			return record;
 		};
 
-		// If there's only one item in a group, then we expand the children to the top level.
+		// Expand the children to the parent level, if there's only one group or only one item in a group.
 		statsData = statsData.map( ( item ) => {
 			if ( item.results.length === 1 || ( statsData.length === 1 && item.results?.length > 0 ) ) {
 				return {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -811,9 +811,9 @@ export const normalizers = {
 			return record;
 		};
 
-		// Expand the children to the parent level, if there's only one group or only one item in a group.
+		// If there's only one item in a group, then we expand the children to the parent level.
 		statsData = statsData.map( ( item ) => {
-			if ( item.results.length === 1 || ( statsData.length === 1 && item.results?.length > 0 ) ) {
+			if ( item.results.length === 1 ) {
 				return {
 					...item.results[ 0 ],
 					group: item.results[ 0 ].name,


### PR DESCRIPTION
Related to #70260 

## Proposed Changes

The PR propose to expand the children to the top level if there's only one item in a group.

## Testing Instructions

* Navigate to  `Referrers` card on the Traffic page
* Ensure child is elevated to the parent level if only one item is in a group


<img width="396" alt="image" src="https://user-images.githubusercontent.com/1425433/219503537-80d62251-eaac-4d8f-a4d2-903a9adf18ac.png">

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
