### PR TITLE
Sensei Tailored Flow: Fix styling issues

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/sensei-variables.scss
+++ b/client/landing/stepper/declarative-flow/internals/sensei-variables.scss
@@ -1,7 +1,34 @@
 $sensei-mobile-layout-width: 1200px;
-$sensei-color: #43af99;
+$sensei-green-50: #43af99;
+$sensei-green-60: #30968b;
+$sensei-green-80: #155e65;
 $sensei-purple-50: #26212e;
 $sensei-gray-100: #101517;
 $sensei-onboarding-color: #b7c9be;
 $breakpoint-mobile: 600px;
 $sensei-focus-color: #217d7c;
+
+@mixin sensei-button {
+	padding: 10px 20px;
+	font-size: $font-body-small;
+	line-height: 20px;
+	font-weight: 500;
+	border-radius: 4px;
+	cursor: pointer;
+
+	background-color: $sensei-green-50;
+	color: $sensei-purple-50;
+	border: none;
+	transition: ease 300ms;
+
+	&:hover:not(:disabled) {
+		background-color: $sensei-green-80;
+		color: #fff;
+	}
+
+	&:disabled {
+		background-color: #aaa;
+		color: #fff;
+		cursor: not-allowed;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/sensei.scss
+++ b/client/landing/stepper/declarative-flow/internals/sensei.scss
@@ -3,32 +3,11 @@
 @import "sensei-variables";
 
 .sensei .progress-bar__progress {
-	background-color: $sensei-color;
+	background-color: $sensei-green-50;
 }
 
 .sensei {
 	.sensei-button {
-		margin-top: 40px;
-		padding: 10px 80px;
-		font-size: $font-body-small;
-		line-height: 20px;
-		font-weight: 500;
-		border-radius: 4px;
-		cursor: pointer;
-
-		width: 100%;
-		background-color: $sensei-color;
-		color: $sensei-purple-50;
-		border: none;
-
-		&:hover:not(:disabled) {
-			background-color: darken($sensei-color, 10%);
-		}
-
-		&:disabled {
-			background-color: #aaa;
-			cursor: not-allowed;
-		}
+		@include sensei-button;
 	}
-
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/sensei-step-container/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/sensei-step-container/styles.scss
@@ -11,6 +11,10 @@
 		max-width: 100%;
 	}
 
+	.step-container__header {
+		margin: 24px;
+	}
+
 	.progress-bar {
 		position: absolute;
 		top: 0;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/sensei-step-progress/components.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/sensei-step-progress/components.ts
@@ -15,10 +15,10 @@ export const Container = styled.div`
 `;
 
 export const Content = styled.div`
-	max-width: 520px;
+	max-width: 560px;
 	width: 100%;
 	margin: auto 24px;
-	padding: 32px 0 60px;
+	padding: 32px 20px 60px;
 	flex: 0 0 auto;
 	position: relative;
 `;
@@ -39,9 +39,9 @@ export const Subtitle = styled.div`
 
 export const Progress = styled.div`
 	position: absolute;
-	right: 0;
+	right: 20px;
 	bottom: 32px;
-	left: 0;
+	left: 20px;
 	height: 4px;
 	background-color: #fff;
 `;
@@ -60,11 +60,13 @@ export const ProgressValue = styled.div< { progress: number } >`
 export const TopRightImg = styled.img`
 	width: 100%;
 	max-width: 237px;
-	margin-left: auto;
+	margin-left: max( calc( 100vw - 237px ), 22rem );
 	flex: 0 1 auto;
+	position: relative;
 
 	@media ( min-width: 700px ) {
 		max-width: 395px;
+		margin-left: auto;
 	}
 `;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/index.tsx
@@ -37,14 +37,16 @@ const SenseiDomain: Step = ( { navigation } ) => {
 	const domainSuggestion = domain?.domain_name ?? siteTitle;
 
 	return (
-		<SenseiStepContainer stepName="senseiDomain" recordTracksEvent={ recordTracksEvent }>
-			<CalypsoShoppingCartProvider>
+		<SenseiStepContainer
+			stepName="senseiDomain"
+			recordTracksEvent={ recordTracksEvent }
+			formattedHeader={
 				<FormattedHeader
 					id="choose-a-domain-header"
-					headerText="Choose a domain"
+					headerText={ __( 'Choose a domain' ) }
 					subHeaderText={
 						<>
-							{ __( 'Make your course site shine with a custom domain. Not sure yet ?' ) }
+							{ __( 'Make your course site shine with a custom domain. Not sure yet?' ) }{ ' ' }
 							<button
 								className="button navigation-link step-container__navigation-link has-underline is-borderless"
 								onClick={ onSkip }
@@ -55,6 +57,9 @@ const SenseiDomain: Step = ( { navigation } ) => {
 					}
 					align="center"
 				/>
+			}
+		>
+			<CalypsoShoppingCartProvider>
 				<div className="container domains__step-content domains__step-content-domain-step">
 					<RegisterDomainStep
 						vendor="sensei"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
@@ -4,6 +4,7 @@
 @import "../../sensei-variables";
 
 .sensei.sensei-domain {
+
 	.step-container__content > div {
 		height: auto;
 	}
@@ -12,11 +13,21 @@
 		max-width: 1160px;
 	}
 
+	.domain-search-results {
+		margin: 32px -24px;
+
+		@include break-large {
+			margin: 32px 0;
+		}
+
+	}
+
 	.domain-search-results__domain-suggestions {
 		.card {
 			box-shadow: none;
 			border-bottom: 1px solid var(--color-border-subtle);
 			border-top: 1px solid #fff;
+			transition: ease 300ms;
 			background: none;
 			margin: 0;
 
@@ -27,13 +38,17 @@
 		}
 	}
 	.domains__step-content {
-		display: flex;
-		margin-top: 50px;
+		margin: 0;
+		padding: 24px;
+		max-width: 100%;
+
+		@include break-large {
+			display: flex;
+		}
 
 		.domains__domain-side-content-container {
 			flex-direction: column;
 			margin-top: 40px;
-			display: none;
 
 			@include break-large {
 				width: 30vw;
@@ -82,14 +97,8 @@
 	}
 
 	.register-domain-step__search {
-		@media (min-width: $sensei-mobile-layout-width) {
-			padding-top: 8px;
-			padding-left: 0;
-			padding-right: 0;
-		}
-
-		padding: 20px;
-		padding-bottom: 24px;
+		margin: 0;
+		padding: 0;
 	}
 
 	.step-container__content {
@@ -161,22 +170,23 @@
 		}
 	}
 
-	.formatted-header__subtitle {
-		text-align: center !important;
-	}
-
-	.step-container__navigation-link {
-		font-size: 1rem;
-		line-height: 1.55;
-		margin-left: 5px;
-	}
-
 	.register-domain-step__search-card {
 		border-radius: 4px;
+		box-shadow: none;
+		border: 1px solid #a7aaad;
+		&:focus-within {
+			border-color: #646970;
+
+		}
 	}
 
 	.search-component {
 		box-shadow: none;
+		min-width: 0;
+
+		&.is-open.has-focus:hover {
+			box-shadow: unset;
+		}
 
 		button,
 		.components-button:focus:not(:disabled),
@@ -234,14 +244,8 @@
 		}
 
 		.domain-suggestion__action {
-			border: none;
-			border-radius: 4px;
-			background-color: $sensei-color;
-			color: #fff;
-
-			&:hover {
-				background: darken($sensei-color, 10%);
-			}
+			@include sensei-button;
+			padding: 0.25em 3em;
 		}
 	}
 
@@ -250,7 +254,7 @@
 	}
 
 	.domain-product-price .domain-product-price__free-price {
-		color: $sensei-color;
+		color: $sensei-green-60;
 	}
 
 	.register-domain-step__next-page {
@@ -273,10 +277,10 @@
 }
 .search-filters__popover {
 	.button.is-primary {
-		background: $sensei-color;
-		border-color: $sensei-color;
+		@include sensei-button;
 	}
+
 	.token-field__suggestion.is-selected {
-		background-color: darken($sensei-color, 10);
+		background-color: $sensei-green-60;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/components.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/components.ts
@@ -4,32 +4,8 @@ import {
 	PlansIntervalToggleProps,
 } from 'calypso/../packages/plans-grid/src';
 
-export const Title = styled.h1`
-	font-family: Recoleta, sans-serif;
-	font-size: 36px;
-	line-height: 40px;
-	text-align: center;
-	color: #101517;
-	margin-top: 16px;
-
-	@media ( min-width: 700px ) {
-		font-size: 44px;
-		line-height: 48px;
-		margin-top: 72px;
-	}
-`;
-
-export const Tagline = styled.p`
-	font-size: 16px;
-	line-height: 24px;
-	letter-spacing: 0.24px;
-	color: #50575e;
-	margin-top: 8px;
-	text-align: center;
-`;
-
 export const PlansIntervalToggle = styled(
 	UnstyledPlansIntervalToggle
 )< PlansIntervalToggleProps >`
-	margin-top: 40px;
+	margin-top: 32px;
 `;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/index.tsx
@@ -7,6 +7,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import formatCurrency from 'calypso/../packages/format-currency/src';
 import PlanItem from 'calypso/../packages/plans-grid/src/plans-table/plan-item';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
@@ -14,7 +15,7 @@ import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client
 import { SenseiStepContainer } from '../components/sensei-step-container';
 import { SenseiStepError } from '../components/sensei-step-error';
 import { SenseiStepProgress } from '../components/sensei-step-progress';
-import { PlansIntervalToggle, Tagline, Title } from './components';
+import { PlansIntervalToggle } from './components';
 import { features, Status } from './constants';
 import { useCreateSenseiSite } from './create-sensei-site';
 import { useBusinessPlanPricing, useSenseiProPricing } from './sensei-plan-products';
@@ -124,15 +125,23 @@ const SenseiPlan: Step = ( { flow, navigation: { submit } } ) => {
 	const title = __( 'Sensei Pro Bundle' );
 
 	return (
-		<SenseiStepContainer stepName="senseiPlan" recordTracksEvent={ recordTracksEvent }>
+		<SenseiStepContainer
+			stepName="senseiPlan"
+			recordTracksEvent={ recordTracksEvent }
+			formattedHeader={
+				status === Status.Initial && (
+					<FormattedHeader
+						headerText={ __( 'Choose Monthly or Annually' ) }
+						subHeaderText={ __(
+							'Sensei + WooCommerce + Jetpack + WordPress.com in the ultimate Course Bundle'
+						) }
+						align="center"
+					/>
+				)
+			}
+		>
 			{ status === Status.Initial && (
 				<>
-					<Title>{ __( 'Choose Monthly or Annually' ) }</Title>
-
-					<Tagline>
-						{ __( 'Sensei + WooCommerce + Jetpack + WordPress.com in the ultimate Course Bundle' ) }
-					</Tagline>
-
 					<PlansIntervalToggle
 						intervalType={ billingPeriod }
 						onChange={ setBillingPeriod }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/styles.scss
@@ -138,12 +138,15 @@
 
 	.plans-interval-toggle__popover:not(.plans-interval-toggle__popover--mobile) {
 		display: none;
-		@media ( min-width: 780px ) {
+		@media ( min-width: 782px ) {
 			display: block;
 		}
 	}
 
 	.plans-interval-toggle--monthly .segmented-control {
 		margin-bottom: 32px;
+		@media (min-width: 782px) {
+			margin-bottom: 0;
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/styles.scss
@@ -2,11 +2,27 @@
 @import "../../sensei-variables";
 
 .step-container.senseiPlan {
+
+	.plan-item:not(.is-open) .plan-item__summary .plan-item__price {
+		margin: 0;
+	}
+	.plan-item:not(.is-open) .plan-item__name {
+		font-weight: 700;
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		font-size: 18px;
+	}
+	.plan-item:not(.is-open) .plan-item__price-amount {
+		font-weight: 600;
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		font-size: 32px;
+	}
+
 	.plan-item {
 		margin-top: 0;
 
 		&__viewport {
 			border: none;
+			padding: 24px 0;
 		}
 
 		&__heading,
@@ -21,6 +37,11 @@
 			text-align: center;
 		}
 
+		&__price-discount {
+			margin-bottom: 0;
+			color: $sensei-green-60;
+		}
+
 		&__price-amount {
 			margin-top: 20px;
 			color: $black;
@@ -28,14 +49,8 @@
 
 		&__select-button {
 			width: 100%;
-			background-color: $sensei-color;
-			color: $sensei-purple-50;
-			border: none;
-			font-weight: 500;
-			&:hover:not(:disabled) {
-				background-color: darken($sensei-color, 10%);
-				color: $sensei-purple-50;
-			}
+			margin: 0;
+			@include sensei-button;
 		}
 
 		&__summary,
@@ -49,7 +64,7 @@
 			flex-direction: column;
 			justify-content: flex-end;
 			align-items: center;
-			margin-top: 48px;
+			margin-top: 40px;
 			flex: 0;
 
 			.plan-item {
@@ -79,7 +94,6 @@
 			}
 		}
 	}
-
 
 	.plans-feature-list {
 		&__item {
@@ -112,13 +126,24 @@
 				}
 			}
 		}
+
 	}
 
+	.plans-feature-list__item-content-wrapper--domain-button:not(.is-unavailable) .plans-feature-list__item-description {
+		color: $sensei-green-60;
+		&:hover {
+			color: $sensei-green-80;
+		}
+	}
 
 	.plans-interval-toggle__popover:not(.plans-interval-toggle__popover--mobile) {
 		display: none;
 		@media ( min-width: 780px ) {
 			display: block;
 		}
+	}
+
+	.plans-interval-toggle--monthly .segmented-control {
+		margin-bottom: 32px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/style.scss
@@ -108,5 +108,11 @@ $checked-color: #000;
 		opacity: 0.6;
 	}
 
+	&__actions .sensei-button {
+		margin: 40px 0;
+		padding: 10px;
+		width: 100%;
+	}
+
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/components.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/components.ts
@@ -28,20 +28,3 @@ export const Input = styled.input`
 		color: #909398;
 	}
 `;
-
-export const Button = styled.button`
-	margin-top: 40px;
-	padding: 10px 80px;
-	font-size: 14px;
-	line-height: 20px;
-	font-weight: 500;
-	background-color: #0675c4;
-	border-radius: 4px;
-	color: #fff;
-	cursor: pointer;
-
-	&:disabled {
-		background-color: #aaa;
-		cursor: not-allowed;
-	}
-`;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
@@ -7,9 +7,10 @@ import classnames from 'classnames';
 import { CSSProperties, useEffect } from 'react';
 import FormRadioWithThumbnail from 'calypso/components/forms/form-radio-with-thumbnail';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { preventWidows } from 'calypso/lib/formatting';
 import { ONBOARD_STORE } from '../../../../stores';
 import { SenseiStepContainer } from '../components/sensei-step-container';
-import { Title, Label, Input, Button, Hint } from './components';
+import { Title, Label, Input, Hint } from './components';
 import type { StyleVariation } from 'calypso/../packages/design-picker/src/types';
 import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import './style.scss';
@@ -90,7 +91,7 @@ const SenseiSetup: Step = ( { navigation } ) => {
 		<SenseiStepContainer stepName="senseiSetup" recordTracksEvent={ recordTracksEvent }>
 			<div className="sensei-start-row">
 				<div className="sensei-onboarding-main-content">
-					<Title>{ __( 'Set up your course site' ) }</Title>
+					<Title>{ preventWidows( __( 'Set up your course site' ) ) }</Title>
 					<Label htmlFor="sensei_site_title">{ __( 'Site name' ) }</Label>
 					<Input
 						id="sensei_site_title"
@@ -121,9 +122,9 @@ const SenseiSetup: Step = ( { navigation } ) => {
 						) ) }
 					</div>
 					{ ! isDesktop && preview }
-					<Button disabled={ ! siteTitle } onClick={ handleSubmit }>
+					<button className="sensei-button" disabled={ ! siteTitle } onClick={ handleSubmit }>
 						{ __( 'Continue' ) }
-					</Button>
+					</button>
 					<p className="sensei-style-notice">
 						<Gridicon icon="notice-outline" />
 						{ __( 'You can change all of this later, too.' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/style.scss
@@ -31,7 +31,7 @@
 		padding-top: 64px;
 		padding-right: 20px;
 		position: relative;
-		width: 415px;
+		width: 404px;
 
 		h1 {
 			width: 60%;
@@ -85,7 +85,7 @@
 	.sensei-theme-style-selector {
 		display: grid;
 		grid-template-columns: 1fr 1fr;
-		margin: 24px auto;
+		margin: 24px 0;
 		gap: 20px;
 
 		@media ( max-width: $break-large ) {
@@ -120,7 +120,7 @@
 	}
 
 	.form-radio-with-thumbnail__thumbnail {
-		width: 180px;
+		width: 100%;
 		height: 110px;
 		margin: 0;
 
@@ -146,7 +146,7 @@
 			margin: 10px auto 0 auto;
 			border-bottom: 0;
 			border-radius: 36px 36px 0 0; /* stylelint-disable-line scales/radii */
-			padding: 20px;
+			padding: 0 20px;
 		}
 		@media ( max-width: $break-mobile ) {
 			width: 90%;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/style.scss
@@ -85,8 +85,7 @@
 	.sensei-theme-style-selector {
 		display: grid;
 		grid-template-columns: 1fr 1fr;
-		margin-top: 24px;
-		margin-bottom: auto;
+		margin: 24px auto;
 		gap: 20px;
 
 		@media ( max-width: $break-large ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/style.scss
@@ -117,7 +117,7 @@
 	}
 
 	.form-radio-with-thumbnail__thumbnail.checked {
-		box-shadow: 0 0 0 2px $sensei-color, 0 1px 2px var(--color-neutral-0);
+		box-shadow: 0 0 0 1px #000, 0 1px 2px var(--color-neutral-0);
 	}
 
 	.form-radio-with-thumbnail__thumbnail {
@@ -262,7 +262,6 @@
 	}
 
 	button {
-		background-color: $sensei-color;
 
 		@media ( max-width: $break-large ) {
 			margin-top: 20px;


### PR DESCRIPTION
## Proposed Changes

* Fix spacing, typography and layout issues, mainly on mobile
* Update Sensei branded buttons, colors
* Fix missing domain screen sidebar on mobile
* Fix domain search input being broken on mobile
* Use `FormattedHeader` component on all screens for title and subtitle
* Fix missing i18n call for domain screen title

## Testing Instructions

* Go through the setup flow via `/setup/sensei` on mobile & desktop view, make sure everything looks right

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

## Screenshots

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/176949/219507539-fe5072ce-49df-47a2-9951-64ade855fd64.png">