### PR TITLE
Launchpad: Update launchpad site editor links with canvas query param

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -815,7 +815,7 @@ const mapStateToProps = (
 		...pressThisData,
 		answer_prompt: getQueryArg( window.location.href, 'answer_prompt' ),
 		completedFlow,
-		canvas: 'edit', // Load side editor in edit mode instead of displaying sidebar by default (Gutenberg v15.0.0)
+		canvas: getQueryArg( window.location.href, 'canvas' ), // Site editor can initially load with or without nav sidebar (Gutenberg v15.0.0)
 	} );
 
 	// needed for loading the editor in SU sessions

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -49,7 +49,7 @@ export function getEnhancedTasks(
 	// send user to Home page editor, fallback to FSE if page id is not known
 	const launchpadUploadVideoLink = homePageId
 		? `/page/${ siteSlug }/${ homePageId }`
-		: `/site-editor/${ siteSlug }`;
+		: `/site-editor/${ siteSlug }?canvas=edit`;
 
 	let planWarningText = displayGlobalStylesWarning
 		? translate(
@@ -110,7 +110,7 @@ export function getEnhancedTasks(
 						completed: siteEditCompleted,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, siteEditCompleted, task.id );
-							window.location.assign( `/site-editor/${ siteSlug }` );
+							window.location.assign( `/site-editor/${ siteSlug }?canvas=edit` );
 						},
 					};
 					break;
@@ -183,7 +183,7 @@ export function getEnhancedTasks(
 						completed: linkInBioLinksEditCompleted,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, linkInBioLinksEditCompleted, task.id );
-							window.location.assign( `/site-editor/${ siteSlug }` );
+							window.location.assign( `/site-editor/${ siteSlug }?canvas=edit` );
 						},
 					};
 					break;

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -394,7 +394,7 @@ export class FullSiteEditorPage {
 	 */
 	async openNavSidebar(): Promise< void > {
 		const openButton = this.editor.locator( 'button[aria-label="Open Navigation Sidebar"]' );
-		const closeButton = this.editor.locator( 'button.edit-site-site-hub__edit-button' );
+		const closeButton = this.editor.locator( '.edit-site-site-hub button.is-primary' );
 
 		await Promise.race( [ closeButton.waitFor(), openButton.click() ] );
 	}
@@ -404,7 +404,7 @@ export class FullSiteEditorPage {
 	 */
 	async closeNavSidebar(): Promise< void > {
 		const openButton = this.editor.locator( 'button[aria-label="Open Navigation Sidebar"]' );
-		const closeButton = this.editor.locator( 'button.edit-site-site-hub__edit-button' );
+		const closeButton = this.editor.locator( '.edit-site-site-hub button.is-primary' );
 
 		await Promise.race( [ openButton.waitFor(), closeButton.click() ] );
 	}

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -394,7 +394,7 @@ export class FullSiteEditorPage {
 	 */
 	async openNavSidebar(): Promise< void > {
 		const openButton = this.editor.locator( 'button[aria-label="Open Navigation Sidebar"]' );
-		const closeButton = this.editor.locator( 'button[aria-label="Open the editor"]' );
+		const closeButton = this.editor.locator( 'button.edit-site-site-hub__edit-button' );
 
 		await Promise.race( [ closeButton.waitFor(), openButton.click() ] );
 	}
@@ -404,7 +404,7 @@ export class FullSiteEditorPage {
 	 */
 	async closeNavSidebar(): Promise< void > {
 		const openButton = this.editor.locator( 'button[aria-label="Open Navigation Sidebar"]' );
-		const closeButton = this.editor.locator( 'button[aria-label="Open the editor"]' );
+		const closeButton = this.editor.locator( 'button.edit-site-site-hub__edit-button' );
 
 		await Promise.race( [ openButton.waitFor(), closeButton.click() ] );
 	}

--- a/test/e2e/specs/fse/fse__limited-global-styles.ts
+++ b/test/e2e/specs/fse/fse__limited-global-styles.ts
@@ -30,6 +30,7 @@ describe( DataHelper.createSuiteTitle( 'Site Editor: Limited Global Styles' ), f
 	it( 'Visit the site editor', async function () {
 		await fullSiteEditorPage.visit( siteSlug );
 		await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
+		await fullSiteEditorPage.closeNavSidebar();
 	} );
 
 	it( 'Open site styles', async function () {

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -49,6 +49,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 	it( 'Editor canvas loads', async function () {
 		fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+		// The site editor navigation sidebar opens by default, so we close it
+		await fullSiteEditorPage.closeNavSidebar();
 		await fullSiteEditorPage.waitUntilLoaded();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Estimated Time to Test / Review:
- Test -> Short
- Review -> Short

## Proposed Changes

Currently, we always open the site editor in `edit` mode. Because there is value in defaulting to `view` mode ( which keeps the navigation sidebar open by default ) we're only defaulting to edit mode when certain query params are passed through, which are now scoped to launchpad site editor links.

## GIFs

### Before
![2023-02-16 16 57 38](https://user-images.githubusercontent.com/5414230/219522320-163a4180-12c4-47be-95ed-ad300aeb9630.gif)

### After
![2023-02-16 16 56 24](https://user-images.githubusercontent.com/5414230/219522152-5b2655a3-149d-48da-b389-96cac89ce75d.gif)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Check out this branch and run yarn and yarn start if needed. 
2) Go to http://calypso.localhost:3000/setup/free/intro and start a free site. 
3) Go all the way through to Launchpad.
4) Confirm that the `Edit site design` task opens up the site editor in edit mode by default ( **without** the nav sidebar open )
5) Navigate to the site editor through Appearance > Editor
6) Confirm that the site editor opens in view mode by default ( **with** the nav sidebar open )

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
