### PR TITLE
Stats: fix translations on the StatsEmptyState component

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -113,7 +113,7 @@ class StatModuleChartTabs extends Component {
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
 				<Chart barClick={ this.props.barClick } data={ this.props.chartData } minBarWidth={ 35 }>
-					<StatsEmptyState stateType={ this.props.activeTab && this.props.activeTab.label } />
+					<StatsEmptyState />
 				</Chart>
 				<StatTabs
 					data={ this.props.counts }

--- a/client/my-sites/stats/stats-empty-state/index.tsx
+++ b/client/my-sites/stats/stats-empty-state/index.tsx
@@ -3,28 +3,16 @@ import { useTranslate } from 'i18n-calypso';
 
 import './style.scss';
 
-interface Props {
-	stateType: string;
-}
-
-export default function StatsEmptyState( { stateType }: Props ) {
-	const _stateType = String( stateType ).toLowerCase().trim();
+export default function StatsEmptyState() {
 	const translate = useTranslate();
 
 	return (
 		<div className="stats__empty-state">
 			<Card className="empty-state-card">
-				<div className="empty-state-card-heading">
-					{ translate( 'No %(_stateType)s in this period', {
-						args: { _stateType },
-					} ) }
-				</div>
+				<div className="empty-state-card-heading">{ translate( 'No data in this period' ) }</div>
 				<p className="empty-state-card-info">
 					{ translate(
-						'There were no %(_stateType)s recorded during the selected time period. Try selecting a different time range.',
-						{
-							args: { _stateType },
-						}
+						'There was no data recorded during the selected time period. Try selecting a different time range.'
 					) }
 				</p>
 			</Card>

--- a/client/my-sites/stats/stats-summary/index.jsx
+++ b/client/my-sites/stats/stats-summary/index.jsx
@@ -67,7 +67,7 @@ class StatsSummaryChart extends Component {
 	}
 
 	renderEmptyState() {
-		return <StatsEmptyState stateType={ this.props.tabLabel } />;
+		return <StatsEmptyState />;
 	}
 
 	buildChartData() {

--- a/client/my-sites/stats/wordads-chart-tabs/index.jsx
+++ b/client/my-sites/stats/wordads-chart-tabs/index.jsx
@@ -132,7 +132,7 @@ class WordAdsChartTabs extends Component {
 	}
 
 	render() {
-		const { siteId, query, isDataLoading, activeTab } = this.props;
+		const { siteId, query, isDataLoading } = this.props;
 		const classes = [
 			'is-chart-tabs',
 			{
@@ -148,7 +148,7 @@ class WordAdsChartTabs extends Component {
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 					<StatsModulePlaceholder className="is-chart" isLoading={ isDataLoading } />
 					<Chart barClick={ this.props.barClick } data={ this.buildChartData() } minBarWidth={ 35 }>
-						<StatsEmptyState stateType={ activeTab && activeTab.label } />
+						<StatsEmptyState />
 					</Chart>
 					<StatTabs
 						data={ this.props.data }

--- a/client/my-sites/store/app/store-stats/store-stats-chart/index.js
+++ b/client/my-sites/store/app/store-stats/store-stats-chart/index.js
@@ -167,7 +167,7 @@ class StoreStatsChart extends Component {
 					barClick={ this.barClick }
 					minBarWidth={ 35 }
 				>
-					<StatsEmptyState stateType={ selectedTab.label } />
+					<StatsEmptyState />
 				</ElementChart>
 				{ ! isLoading &&
 					renderTabs( {


### PR DESCRIPTION
Related to #72178 

## Proposed Changes

The PR proposes not show what exact type of data is empty, so that the translations would be easier.

I tried to add what's suggested [here](https://github.com/Automattic/wp-calypso/pull/71745#issuecomment-1383476120), but the strings seem endless:

```JavaScript
const getTranslationForStateType = ( stateType: string ) => {
		switch ( stateType ) {
			case 'view':
				return translate( 'No views in this period' );
			case 'like':
				return translate( 'No likes in this period' );
			case 'comment':
				return translate( 'No comments in this period' );
			case 'order':
				return translate( 'No orders in this period' );
			case 'revenue':
				return translate( 'No revenue in this period' );
			case 'average cpm':
				return translate( 'No average CPM in this period' );
			case 'ads served':
				return translate( 'No Ads served in this period' );
                       more...

			default:
				return translate( 'No data in this period' );
		}
	};
```

And we'll need to do the same for the descriptions as well, so it doesn't seem viable to me. And IMO, there's no data, there isn't much to tell the user anyway.

## Testing Instructions

* Open Calypso Live branch
* Choose a period without any data
* Ensure the message shows up in the chart

<img width="870" alt="image" src="https://user-images.githubusercontent.com/1425433/219542888-0b44c70e-ccc4-4c56-ba78-6cd120d58af6.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
