### PR TITLE
Remove unnecessary @mixins for $break-xlarge

### DIFF
--- a/client/components/theme-preview-modal/style.scss
+++ b/client/components/theme-preview-modal/style.scss
@@ -2,12 +2,6 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
-@mixin break-design-preview() {
-	@media (min-width: #{ ($break-xlarge) }) {
-		@content;
-	}
-}
-
 .theme-preview-modal {
 	background-color: #fdfdfd;
 	bottom: 0;
@@ -20,7 +14,7 @@
 	z-index: z-index("root", ".theme-preview-modal");
 	-webkit-font-smoothing: antialiased;
 
-	@include break-design-preview {
+	@include break-xlarge {
 		padding-inline-start: 32px;
 		padding-inline-end: 32px;
 	}
@@ -42,7 +36,7 @@
 	justify-content: space-between;
 	z-index: z-index(".theme-preview-modal", ".theme-preview-modal__navigation");
 
-	@include break-design-preview {
+	@include break-xlarge {
 		gap: 24px;
 		position: absolute;
 		top: 8px;
@@ -61,7 +55,7 @@
 		fill: var(--color-text);
 		margin: 2px 0 0 0;
 
-		@include break-design-preview {
+		@include break-xlarge {
 			display: block;
 		}
 	}
@@ -83,7 +77,7 @@
 			width: 20px;
 		}
 
-		@include break-design-preview {
+		@include break-xlarge {
 			margin-top: 0;
 		}
 	}
@@ -112,7 +106,7 @@
 
 	&-title,
 	&-action {
-		@include break-design-preview {
+		@include break-xlarge {
 			display: none;
 		}
 	}
@@ -124,7 +118,7 @@
 	position: relative;
 	z-index: 1;
 
-	@include break-design-preview {
+	@include break-xlarge {
 		box-sizing: border-box;
 		height: calc(100vh - 24px);
 		margin-top: 24px;
@@ -140,7 +134,7 @@
 		height: calc(100vh - 156px);
 		margin-top: 96px;
 
-		@include break-design-preview {
+		@include break-xlarge {
 			height: calc(100vh - 24px);
 			margin-top: 24px;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -7,12 +7,6 @@ $gray-100: #101517;
 $gray-60: #50575e;
 $design-button-primary-color: rgb(17, 122, 201);
 
-@mixin break-design-preview() {
-	@media (min-width: #{ ($break-xlarge) }) {
-		@content;
-	}
-}
-
 .design-setup {
 	.step-container {
 		padding-inline-start: 20px;
@@ -583,7 +577,7 @@ $design-button-primary-color: rgb(17, 122, 201);
 			font-weight: 500;
 			line-height: 20px;
 
-			@include break-design-preview {
+			@include break-xlarge {
 				display: none;
 			}
 
@@ -612,7 +606,7 @@ $design-button-primary-color: rgb(17, 122, 201);
 					margin-top: -2px;
 				}
 
-				@include break-design-preview {
+				@include break-xlarge {
 					inset-inline-start: 72px;
 					inset-inline-end: 24px;
 					padding: 1px 0 0;
@@ -644,7 +638,7 @@ $design-button-primary-color: rgb(17, 122, 201);
 			z-index: 1;
 		}
 
-		@include break-design-preview {
+		@include break-xlarge {
 			max-width: none;
 			padding-inline-start: 32px;
 			padding-inline-end: 32px;

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -2,18 +2,12 @@
 @import "@wordpress/base-styles/mixins";
 @import "@automattic/typography/styles/fonts";
 
-@mixin break-design-preview() {
-	@media (min-width: #{ ($break-xlarge) }) {
-		@content;
-	}
-}
-
 .design-preview {
 	display: flex;
 	flex-direction: column;
 	height: 100%;
 
-	@include break-design-preview {
+	@include break-xlarge {
 		flex-direction: row;
 		margin: 0;
 		gap: 32px;
@@ -50,7 +44,7 @@
 			box-shadow: 0 1px 2px rgb(0 0 0 / 5%);
 		}
 
-		@include break-design-preview {
+		@include break-xlarge {
 			bottom: 8px;
 			display: flex;
 			flex-direction: column;
@@ -64,7 +58,7 @@
 		justify-content: center;
 	}
 
-	@include break-design-preview {
+	@include break-xlarge {
 		border: 0;
 		box-shadow: none;
 		display: block;
@@ -111,7 +105,7 @@
 			}
 		}
 
-		@include break-design-preview {
+		@include break-xlarge {
 			display: block;
 		}
 	}
@@ -120,7 +114,7 @@
 		display: none;
 		font-size: $font-body-small;
 
-		@include break-design-preview {
+		@include break-xlarge {
 			display: block;
 			margin-top: 0.25rem;
 		}
@@ -149,7 +143,7 @@
 			}
 		}
 
-		@include break-design-preview {
+		@include break-xlarge {
 			display: flex;
 			flex-wrap: wrap;
 			gap: 8px 4px;
@@ -179,13 +173,13 @@
 			}
 		}
 
-		@include break-design-preview {
+		@include break-xlarge {
 			display: block;
 			margin-top: 2rem;
 		}
 	}
 
-	@include break-design-preview {
+	@include break-xlarge {
 		h2 {
 			display: block;
 		}
@@ -217,7 +211,7 @@
 		}
 	}
 
-	@include break-design-preview {
+	@include break-xlarge {
 		margin: 2rem 0 0;
 
 		> p {
@@ -287,7 +281,7 @@
 		max-width: 100%;
 		overflow: hidden;
 
-		@include break-design-preview {
+		@include break-xlarge {
 			max-height: 77.2258px;
 		}
 	}
@@ -308,7 +302,7 @@
 	flex-grow: 1;
 	position: relative;
 
-	@include break-design-preview {
+	@include break-xlarge {
 		margin-bottom: 32px;
 	}
 
@@ -329,7 +323,7 @@
 		display: none;
 		margin-top: -11px;
 
-		@include break-design-preview {
+		@include break-xlarge {
 			display: block;
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

We removed a custom breakpoint of 1024px in https://github.com/Automattic/wp-calypso/pull/73413, but it's better to use `@mixin` provided by Gutenberg to eliminate unnecessary code. (see https://github.com/Automattic/wp-calypso/pull/73413#discussion_r1109339428 )

Close https://github.com/Automattic/wp-calypso/issues/73468

## Testing Instructions

Needs `themes/showcase-i4/details-and-preview` to be enabled for calypso.live.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

case 1

- Go to `Appearance > Themes`
- Preview theme with style variation, and click `Open live demo`
- Confirm that the style switches at 1080px screen width

case 2

- Click `Add new site` on the admin page
- Click `Continue` to the `Nice job! Now it’s time to get creative.` page, and click `View designs`
- Preview theme with style variation on the `Pick a design` page
- Confirm that the style switches at 1080px screen width

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
	- No, but fine for this PR
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
	- No, but fine for this PR
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
