### PR TITLE
Jetpack Pro Dashboard: implement expandable block

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -1,0 +1,15 @@
+import type { SiteData } from '../types';
+
+import './style.scss';
+
+interface Props {
+	site: SiteData;
+}
+
+export const SiteExpandedContent = ( { site }: Props ) => {
+	return (
+		<div className="site-expanded-content">
+			Expanded content for { site.value.blog_id } | { site.value.url }
+		</div>
+	);
+};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -1,9 +1,9 @@
-import type { SiteData } from '../types';
+import type { SiteNode } from '../types';
 
 import './style.scss';
 
 interface Props {
-	site: SiteData;
+	site: SiteNode;
 }
 
 export const SiteExpandedContent = ( { site }: Props ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -1,0 +1,3 @@
+.site-expanded-content {
+	padding-inline-start: 54px;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
@@ -45,6 +45,13 @@ td.site-table__actions {
 	width: 50px;
 }
 
-td.site-table__td-with-error {
+td.site-table__td-without-border-bottom {
 	border-bottom: none;
+}
+
+.site-table__expandable-button {
+	display: flex;
+	position: relative;
+	right: 0;
+	top: 2px;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -1,6 +1,7 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Icon, starFilled } from '@wordpress/icons';
 import classNames from 'classnames';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import './style.scss';
 import EditButton from '../../dashboard-bulk-actions/edit-button';
@@ -17,6 +18,12 @@ interface Props {
 
 export default function SiteTable( { isLoading, columns, items }: Props ) {
 	const { isBulkManagementActive } = useContext( SitesOverviewContext );
+
+	const [ expandedRow, setExpandedRow ] = useState< number | null >( null );
+
+	const setExpanded = ( blogId: number ) => {
+		setExpandedRow( expandedRow === blogId ? null : blogId );
+	};
 
 	return (
 		<table className="site-table__table">
@@ -39,7 +46,7 @@ export default function SiteTable( { isLoading, columns, items }: Props ) {
 									</span>
 								</th>
 							) ) }
-							<th>
+							<th colSpan={ isEnabled( 'jetpack/pro-dashboard-expandable-block' ) ? 2 : 1 }>
 								<div className="plugin-common-table__bulk-actions">
 									<EditButton isLargeScreen sites={ items } />
 								</div>
@@ -65,7 +72,13 @@ export default function SiteTable( { isLoading, columns, items }: Props ) {
 						const blogId = item.site.value.blog_id;
 
 						return (
-							<SiteTableRow item={ item } columns={ columns } key={ `table-row-${ blogId }` } />
+							<SiteTableRow
+								item={ item }
+								columns={ columns }
+								key={ `table-row-${ blogId }` }
+								isExpanded={ expandedRow === blogId }
+								setExpanded={ () => setExpanded( blogId ) }
+							/>
 						);
 					} )
 				) }


### PR DESCRIPTION
#### Proposed Changes

This PR implements an expandable block in the Jetpack Agency Dashboard.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_** The expanded content is dummy content and will be replaced with the actual content later. Also, these changes are behind a feature flag.

**Instructions**

1. Run `git checkout add/implement-expand-site-content` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify you can see the `chevron-down` icon next to actions on each site row.

<img width="1646" alt="Screenshot 2023-02-17 at 12 18 58 PM" src="https://user-images.githubusercontent.com/10586875/219581443-77cf7806-f2bf-4845-a561-3cbd4bce533c.png">

4. Verify that clicking on the `chevron-down` expands the row, and you can see the UI below. Make sure you can now see the `chevron-up` icon, and clicking that closes the expanded row.

<img width="1646" alt="Screenshot 2023-02-17 at 12 20 25 PM" src="https://user-images.githubusercontent.com/10586875/219581500-178e2ba5-867b-42dc-b267-80343dd65705.png">

5. Clicking on any other block should close the already opened block and open the newly clicked one.
6. Open the Jetpack Cloud live link and verify these changes are not visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related to 1203940061556608-as-1203942568420848