### PR TITLE
Theme Showcase: Open the theme detail page when clicking on a style variation disc

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -173,7 +173,17 @@ class ThemeSheet extends Component {
 		!! this.props.taxonomies?.theme_status?.find( ( status ) => status.slug === 'removed' );
 
 	onButtonClick = () => {
-		const { defaultOption, themeId } = this.props;
+		const { defaultOption, secondaryOption, themeId } = this.props;
+		const selectedStyleVariation = this.getSelectedStyleVariation();
+		if ( selectedStyleVariation ) {
+			this.props.setThemePreviewOptions(
+				themeId,
+				defaultOption,
+				secondaryOption,
+				selectedStyleVariation
+			);
+		}
+
 		defaultOption.action && defaultOption.action( themeId );
 	};
 
@@ -183,9 +193,6 @@ class ThemeSheet extends Component {
 	};
 
 	onStyleVariationClick = ( variation ) => {
-		const { themeId, primary, secondary } = this.props.themeOptions;
-		this.props.setThemePreviewOptions( themeId, primary, secondary, variation );
-
 		if ( typeof window !== 'undefined' ) {
 			const params = new URLSearchParams( window.location.search );
 			if ( variation?.inline_css !== '' ) {
@@ -399,7 +406,7 @@ class ThemeSheet extends Component {
 	}
 
 	renderWebPreview = () => {
-		const { locale, stylesheet, themeId, themeOptions } = this.props;
+		const { locale, stylesheet, themeId } = this.props;
 		const url = getDesignPreviewUrl(
 			{ slug: themeId, recipe: { stylesheet } },
 			{ language: locale }
@@ -409,7 +416,7 @@ class ThemeSheet extends Component {
 			<div className="theme__sheet-web-preview">
 				<ThemeWebPreview
 					url={ url }
-					inlineCss={ themeOptions?.styleVariation?.inline_css }
+					inlineCss={ this.getSelectedStyleVariation()?.inline_css }
 					isShowFrameBorder={ false }
 					isShowDeviceSwitcher={ false }
 				/>
@@ -552,11 +559,7 @@ class ThemeSheet extends Component {
 	};
 
 	renderStyleVariations = () => {
-		const { selectedVariationSlug, shouldLimitGlobalStyles, styleVariations, translate } =
-			this.props;
-		const selectedVariation = styleVariations.find(
-			( variation ) => variation.slug === selectedVariationSlug
-		);
+		const { shouldLimitGlobalStyles, styleVariations, translate } = this.props;
 
 		return (
 			styleVariations.length > 0 && (
@@ -573,7 +576,7 @@ class ThemeSheet extends Component {
 						<AsyncLoad
 							require="@automattic/design-preview/src/components/style-variation"
 							placeholder={ null }
-							selectedVariation={ selectedVariation }
+							selectedVariation={ this.getSelectedStyleVariation() }
 							variations={ styleVariations }
 							onClick={ this.onStyleVariationClick }
 							showGlobalStylesPremiumBadge={ shouldLimitGlobalStyles }
@@ -896,6 +899,11 @@ class ThemeSheet extends Component {
 				) }
 			</Button>
 		);
+	};
+
+	getSelectedStyleVariation = () => {
+		const { selectedStyleVariationSlug, styleVariations } = this.props;
+		return styleVariations.find( ( variation ) => variation.slug === selectedStyleVariationSlug );
 	};
 
 	goBack = () => {
@@ -1309,7 +1317,7 @@ export default connect(
 			isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
 			softLaunched: theme?.soft_launched,
 			styleVariations: theme?.style_variations || [],
-			selectedVariationSlug: getCurrentQueryArguments( state )?.style_variation,
+			selectedStyleVariationSlug: getCurrentQueryArguments( state )?.style_variation,
 			isExternallyManagedTheme,
 			isSiteEligibleForManagedExternalThemes: getIsSiteEligibleForManagedExternalThemes(
 				state,

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -1,5 +1,6 @@
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { compact, property, snakeCase } from 'lodash';
+import { default as pageRouter } from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import * as React from 'react';
@@ -15,6 +16,7 @@ import { setThemePreviewOptions } from 'calypso/state/themes/actions';
 import {
 	arePremiumThemesEnabled,
 	getPremiumThemePrice,
+	getThemeDetailsUrl,
 	getThemesForQueryIgnoringPage,
 	getThemesFoundForQuery,
 	isRequestingThemesForQuery,
@@ -43,6 +45,7 @@ class ThemesSelection extends Component {
 			PropTypes.shape( { current: PropTypes.any } ),
 		] ),
 		getPremiumThemePrice: PropTypes.func,
+		getThemeDetailsUrl: PropTypes.func,
 		isInstallingTheme: PropTypes.func,
 		isLastPage: PropTypes.bool,
 		isRequesting: PropTypes.bool,
@@ -135,15 +138,8 @@ class ThemesSelection extends Component {
 			);
 		}
 
-		const options = this.getOptions(
-			themeId,
-			variation,
-			`style variation: ${ variation ? variation.slug : 'show more' }`
-		);
-
-		if ( options && options.preview ) {
-			options.preview.action( themeId );
-		}
+		this.props.setThemePreviewOptions( themeId, null, null, variation );
+		pageRouter( this.props.getThemeDetailsUrl( themeId ) );
 	};
 
 	onMoreButtonItemClick = ( themeId, resultsRank, key ) => {
@@ -207,12 +203,7 @@ class ThemesSelection extends Component {
 				} else {
 					defaultOption = options.activate;
 				}
-				this.props.setThemePreviewOptions(
-					themeId,
-					defaultOption,
-					secondaryOption,
-					styleVariation
-				);
+				this.props.setThemePreviewOptions( themeId, defaultOption, secondaryOption, null );
 				return action( t, context );
 			};
 		};
@@ -279,6 +270,10 @@ function bindIsInstallingTheme( state, siteId ) {
 
 function bindGetPremiumThemePrice( state, siteId ) {
 	return ( themeId ) => getPremiumThemePrice( state, themeId, siteId );
+}
+
+function bindGetThemeDetailsUrl( state, siteId ) {
+	return ( themeId ) => getThemeDetailsUrl( state, themeId, siteId );
 }
 
 // Exporting this for use in customized themes lists (recommended-themes.jsx, etc.)
@@ -356,6 +351,7 @@ export const ConnectedThemesSelection = connect(
 			// provides caching, and both are already being rendered by a parent component. So to avoid
 			// redundant AJAX requests, we're not rendering these query components locally.
 			getPremiumThemePrice: bindGetPremiumThemePrice( state, siteId ),
+			getThemeDetailsUrl: bindGetThemeDetailsUrl( state, siteId ),
 			filterString: prependThemeFilterKeys( state, query.filter ),
 			wpOrgThemes,
 		};

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -138,8 +138,17 @@ class ThemesSelection extends Component {
 			);
 		}
 
-		this.props.setThemePreviewOptions( themeId, null, null, variation );
-		pageRouter( this.props.getThemeDetailsUrl( themeId ) );
+		const url = this.props.getThemeDetailsUrl( themeId );
+		if ( url ) {
+			const [ urlBase, urlQuery ] = url.split( '?' );
+			const params = new URLSearchParams( urlQuery );
+			if ( variation ) {
+				params.set( 'style_variation', variation.slug );
+			}
+
+			const paramsString = params.toString().length ? `?${ params.toString() }` : '';
+			pageRouter( `${ urlBase }${ paramsString }` );
+		}
 	};
 
 	onMoreButtonItemClick = ( themeId, resultsRank, key ) => {


### PR DESCRIPTION
## Proposed Changes

This PR changes the behavior so that clicking on style variation discs in the theme card will show the theme detail page instead of the theme preview. The style variation selection will carry over to the theme detail page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Ensure that clicking on a style variation disc will take users to the theme detail page.
* Ensure that the style variation selection carries over to the theme detail page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
