### PR TITLE
Shows the 2023 Plans Grid in selected pages

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -1,4 +1,4 @@
-import { is2023PricingGridEnabled } from '@automattic/calypso-products';
+import { is2023PricingGridActivePage } from '@automattic/calypso-products';
 import { StepContainer } from '@automattic/onboarding';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import PlansWrapper from './plans-wrapper';
@@ -10,14 +10,14 @@ const plans: Step = function plans( { navigation, flow } ) {
 	const handleSubmit = () => {
 		submit?.();
 	};
-	const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
+	const is2023PricingGridVisible = is2023PricingGridActivePage( window );
 	return (
 		<StepContainer
 			stepName="plans"
 			goBack={ goBack }
 			isHorizontalLayout={ false }
-			isWideLayout={ ! is2023OnboardingPricingGrid }
-			isFullLayout={ is2023OnboardingPricingGrid }
+			isWideLayout={ ! is2023PricingGridVisible }
+			isFullLayout={ is2023PricingGridVisible }
 			hideFormattedHeader={ true }
 			isLargeSkipLayout={ false }
 			hideBack={ true }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -1,5 +1,5 @@
 // import { subscribeIsDesktop } from '@automattic/viewport';
-import { getPlan, PLAN_FREE, is2023PricingGridEnabled } from '@automattic/calypso-products';
+import { getPlan, PLAN_FREE, is2023PricingGridActivePage } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
 import { NEWSLETTER_FLOW } from '@automattic/onboarding';
@@ -159,7 +159,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					{ components: { link: freePlanButton } }
 			  );
 	};
-	const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
+	const is2023PricingGridVisible = is2023PricingGridActivePage( window );
 
 	const plansFeaturesSelection = () => {
 		const { flowName } = props;
@@ -177,8 +177,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					shouldHideNavButtons={ true }
 					fallbackHeaderText={ fallbackHeaderText }
 					fallbackSubHeaderText={ fallbackSubHeaderText }
-					isWideLayout={ ! is2023OnboardingPricingGrid }
-					isExtraWideLayout={ is2023OnboardingPricingGrid }
+					isWideLayout={ ! is2023PricingGridVisible }
+					isExtraWideLayout={ is2023PricingGridVisible }
 					stepContent={ plansFeaturesList() }
 					allowBackFirstStep={ false }
 				/>
@@ -189,8 +189,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	const classes = classNames( 'plans-step', {
 		'in-vertically-scrolled-plans-experiment': isInVerticalScrollingPlansExperiment,
 		'has-no-sidebar': true,
-		'is-wide-layout': ! is2023OnboardingPricingGrid,
-		'is-extra-wide-layout': is2023OnboardingPricingGrid,
+		'is-wide-layout': ! is2023PricingGridVisible,
+		'is-extra-wide-layout': is2023PricingGridVisible,
 	} );
 
 	return (

--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -1,10 +1,10 @@
 import {
-	is2023PricingGridEnabled,
 	getPlanClass,
 	isMonthly,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_P2_FREE,
 	isFreePlan,
+	is2023PricingGridActivePage,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
@@ -204,9 +204,9 @@ const LoggedInPlansFeatureActionButton = ( {
 		);
 	}
 
-	const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
+	const is2023PricingGridVisible = is2023PricingGridActivePage( window );
 	if ( ! availableForPurchase ) {
-		if ( is2023OnboardingPricingGrid ) {
+		if ( is2023PricingGridVisible ) {
 			return (
 				<Plans2023Tooltip text={ translate( 'Please contact support to downgrade your plan.' ) }>
 					<DummyDisabledButton>

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -28,7 +28,7 @@ import {
 	PLAN_PERSONAL,
 	TITAN_MAIL_MONTHLY_SLUG,
 	PLAN_FREE,
-	is2023PricingGridEnabled,
+	is2023PricingGridActivePage,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { isNewsletterOrLinkInBioFlow } from '@automattic/onboarding';
@@ -123,7 +123,7 @@ export class PlansFeaturesMain extends Component {
 			isReskinned,
 			isFAQCondensedExperiment,
 			isPlansInsideStepper,
-			is2023OnboardingPricingGrid,
+			is2023PricingGridVisible,
 			intervalType,
 			planTypeSelectorProps,
 			busyOnUpgradeClick,
@@ -132,7 +132,7 @@ export class PlansFeaturesMain extends Component {
 		const plans = this.getPlansForPlanFeatures();
 		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
 
-		if ( is2023OnboardingPricingGrid ) {
+		if ( is2023PricingGridVisible ) {
 			const asyncProps = {
 				basePlansPath,
 				domainName,
@@ -358,7 +358,7 @@ export class PlansFeaturesMain extends Component {
 			sitePlanSlug,
 			showTreatmentPlansReorderTest,
 			flowName,
-			is2023OnboardingPricingGrid,
+			is2023PricingGridVisible,
 		} = this.props;
 
 		const hideBloggerPlan = ! isBloggerPlan( selectedPlan ) && ! isBloggerPlan( sitePlanSlug );
@@ -370,7 +370,7 @@ export class PlansFeaturesMain extends Component {
 			plans = plansFromProps;
 		} else {
 			const isBloggerPlanVisible = hideBloggerPlan === true ? false : true;
-			const isEnterprisePlanVisible = is2023OnboardingPricingGrid;
+			const isEnterprisePlanVisible = is2023PricingGridVisible;
 			plans = [
 				findPlansKeys( { group: GROUP_WPCOM, type: TYPE_FREE } )[ 0 ],
 				isBloggerPlanVisible &&
@@ -445,7 +445,7 @@ export class PlansFeaturesMain extends Component {
 			isAllPaidPlansShown,
 			isInMarketplace,
 			sitePlanSlug,
-			is2023OnboardingPricingGrid,
+			is2023PricingGridVisible,
 		} = this.props;
 
 		const isPlanOneOfType = ( plan, types ) =>
@@ -465,7 +465,7 @@ export class PlansFeaturesMain extends Component {
 			  } )
 			: availablePlans;
 
-		if ( is2023OnboardingPricingGrid ) {
+		if ( is2023PricingGridVisible ) {
 			return plans.filter( ( plan ) =>
 				isPlanOneOfType( plan, [
 					TYPE_FREE,
@@ -570,9 +570,9 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	renderPlansGrid() {
-		const { shouldShowPlansFeatureComparison, is2023OnboardingPricingGrid } = this.props;
+		const { shouldShowPlansFeatureComparison, is2023PricingGridVisible } = this.props;
 
-		if ( is2023OnboardingPricingGrid ) {
+		if ( is2023PricingGridVisible ) {
 			return this.show2023OnboardingPricingGrid();
 		}
 
@@ -586,7 +586,7 @@ export class PlansFeaturesMain extends Component {
 			siteId,
 			redirectToAddDomainFlow,
 			domainAndPlanPackage,
-			is2023OnboardingPricingGrid,
+			is2023PricingGridVisible,
 			planTypeSelectorProps,
 		} = this.props;
 
@@ -607,7 +607,7 @@ export class PlansFeaturesMain extends Component {
 		return (
 			<div
 				className={ classNames( 'plans-features-main', {
-					'is-pricing-grid-2023-plans-features-main ': is2023OnboardingPricingGrid,
+					'is-pricing-grid-2023-plans-features-main ': is2023PricingGridVisible,
 				} ) }
 			>
 				<QueryPlans />
@@ -714,7 +714,7 @@ export default connect(
 		) {
 			customerType = 'business';
 		}
-		const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
+		const is2023PricingGridVisible = is2023PricingGridActivePage( window );
 		const planTypeSelectorProps = {
 			basePlansPath: props.basePlansPath,
 			isInSignup: props.isInSignup,
@@ -740,8 +740,8 @@ export default connect(
 			sitePlanSlug,
 			eligibleForWpcomMonthlyPlans,
 			titanMonthlyRenewalCost,
-			is2023OnboardingPricingGrid,
-			showFAQ: !! props.showFAQ && ! is2023OnboardingPricingGrid,
+			is2023PricingGridVisible,
+			showFAQ: !! props.showFAQ && ! is2023PricingGridVisible,
 			planTypeSelectorProps,
 		};
 	},

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -6,7 +6,7 @@ import {
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	isFreePlan,
 } from '@automattic/calypso-products';
-import { is2023PricingGridEnabled } from '@automattic/calypso-products/src/plans-utilities';
+import { is2023PricingGridActivePage } from '@automattic/calypso-products/src/plans-utilities';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { addQueryArgs } from '@wordpress/url';
@@ -229,7 +229,7 @@ class Plans extends Component {
 			);
 		}
 
-		const hideFreePlan = ! is2023PricingGridEnabled();
+		const hideFreePlan = ! is2023PricingGridActivePage( window );
 		if ( this.props.domainSidebarExperimentUser && this.props.domainAndPlanPackage ) {
 			return (
 				<CalypsoShoppingCartProvider>
@@ -280,7 +280,7 @@ class Plans extends Component {
 			canAccessPlans,
 			currentPlan,
 			domainAndPlanPackage,
-			is2023OnboardingPricingGrid,
+			is2023PricingGridVisible,
 			domainSidebarExperimentUser,
 			isJetpackNotAtomic,
 		} = this.props;
@@ -344,8 +344,8 @@ class Plans extends Component {
 						<div id="plans" className="plans plans__has-sidebar">
 							<PlansNavigation path={ this.props.context.path } />
 							<Main
-								fullWidthLayout={ is2023OnboardingPricingGrid && ! isEcommerceTrial }
-								wideLayout={ ! is2023OnboardingPricingGrid || isEcommerceTrial }
+								fullWidthLayout={ is2023PricingGridVisible && ! isEcommerceTrial }
+								wideLayout={ ! is2023PricingGridVisible || isEcommerceTrial }
 							>
 								{ ! domainSidebarExperimentUser && domainAndPlanPackage && (
 									<DomainAndPlanUpsellNotice />
@@ -374,7 +374,7 @@ const ConnectedPlans = connect( ( state ) => {
 	const currentPlanIntervalType = getIntervalTypeForTerm(
 		getPlan( currentPlan?.productSlug )?.term
 	);
-	const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
+	const is2023PricingGridVisible = is2023PricingGridActivePage( window );
 
 	return {
 		currentPlan,
@@ -386,7 +386,7 @@ const ConnectedPlans = connect( ( state ) => {
 		isSiteEligibleForMonthlyPlan: isEligibleForWpComMonthlyPlan( state, selectedSiteId ),
 		showTreatmentPlansReorderTest: isTreatmentPlansReorderTest( state ),
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
-		is2023OnboardingPricingGrid,
+		is2023PricingGridVisible,
 		domainSidebarExperimentUser: isDomainSidebarExperimentUser( state ),
 		isJetpackNotAtomic: isJetpackSite( state, selectedSiteId, { treatAtomicAsJetpackSite: false } ),
 	};

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -3,7 +3,7 @@ import {
 	isDomainRegistration,
 	isDomainTransfer,
 	isDomainMapping,
-	is2023PricingGridEnabled,
+	is2023PricingGridActivePage,
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
 import { isNewsletterOrLinkInBioFlow, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
@@ -775,7 +775,7 @@ class Signup extends Component {
 		// If there is any condition upon which the free plan should be hidden these issues need to be resolved.
 		// For now we always show the free plan for the 2023-pricing-grid
 		// More Context : Automattic/martech#1464
-		const hideFreePlan = is2023PricingGridEnabled()
+		const hideFreePlan = is2023PricingGridActivePage( window )
 			? false
 			: planWithDomain || this.props.isDomainOnlySite || selectedHideFreePlan;
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -1,10 +1,10 @@
 import {
-	is2023PricingGridEnabled,
 	planHasFeature,
 	FEATURE_UPLOAD_THEMES_PLUGINS,
 	getPlan,
 	PLAN_FREE,
 	isEcommerce,
+	is2023PricingGridActivePage,
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
@@ -274,7 +274,7 @@ export class PlansStep extends Component {
 	}
 
 	getHeaderText() {
-		const { headerText, translate, eligibleForProPlan, locale, isOnboarding2023PricingGrid } =
+		const { headerText, translate, eligibleForProPlan, locale, is2023PricingGridVisible } =
 			this.props;
 
 		if ( headerText ) {
@@ -287,7 +287,7 @@ export class PlansStep extends Component {
 				: translate( 'Choose the plan that’s right for you' );
 		}
 
-		if ( isOnboarding2023PricingGrid ) {
+		if ( is2023PricingGridVisible ) {
 			return translate( 'Choose your flavor of WordPress' );
 		}
 
@@ -306,7 +306,7 @@ export class PlansStep extends Component {
 			locale,
 			translate,
 			useEmailOnboardingSubheader,
-			isOnboarding2023PricingGrid,
+			is2023PricingGridVisible,
 		} = this.props;
 
 		const freePlanButton = <Button onClick={ this.handleFreePlanButtonClick } borderless />;
@@ -351,7 +351,7 @@ export class PlansStep extends Component {
 			);
 		}
 
-		if ( isOnboarding2023PricingGrid ) {
+		if ( is2023PricingGridVisible ) {
 			return;
 		}
 
@@ -384,7 +384,7 @@ export class PlansStep extends Component {
 			translate,
 			hasInitializedSitesBackUrl,
 			steps,
-			isOnboarding2023PricingGrid,
+			is2023PricingGridVisible,
 		} = this.props;
 
 		const headerText = this.getHeaderText();
@@ -427,8 +427,8 @@ export class PlansStep extends Component {
 					fallbackHeaderText={ fallbackHeaderText }
 					subHeaderText={ subHeaderText }
 					fallbackSubHeaderText={ fallbackSubHeaderText }
-					isWideLayout={ ! isOnboarding2023PricingGrid }
-					isExtraWideLayout={ isOnboarding2023PricingGrid }
+					isWideLayout={ ! is2023PricingGridVisible }
+					isExtraWideLayout={ is2023PricingGridVisible }
 					stepContent={ this.plansFeaturesList() }
 					allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 					backUrl={ backUrl }
@@ -440,14 +440,12 @@ export class PlansStep extends Component {
 	}
 
 	render() {
-		const is2023OnboardingPricingGrid = is2023PricingGridEnabled();
-
 		const classes = classNames( 'plans plans-step', {
 			'in-vertically-scrolled-plans-experiment':
-				! this.props.isOnboarding2023PricingGrid && this.props.isInVerticalScrollingPlansExperiment,
+				! this.props.is2023PricingGridVisible && this.props.isInVerticalScrollingPlansExperiment,
 			'has-no-sidebar': true,
-			'is-wide-layout': ! is2023OnboardingPricingGrid,
-			'is-extra-wide-layout': is2023OnboardingPricingGrid,
+			'is-wide-layout': ! this.props.is2023PricingGridVisible,
+			'is-extra-wide-layout': this.props.is2023PricingGridVisible,
 		} );
 
 		return (
@@ -515,7 +513,7 @@ export default connect(
 		isInVerticalScrollingPlansExperiment: true,
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
 		eligibleForProPlan: isEligibleForProPlan( state, getSiteBySlug( state, siteSlug )?.ID ),
-		isOnboarding2023PricingGrid: is2023PricingGridEnabled(),
+		is2023PricingGridVisible: is2023PricingGridActivePage( window ),
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep, errorNotice }
 )( localize( PlansStep ) );

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -48,7 +48,8 @@ export function getTermDuration( term: string ): number | undefined {
 export const redirectCheckoutToWpAdmin = (): boolean => !! JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN;
 
 /**
- * Returns if the 2023 Pricing grid optimized design should be visible or not
+ * Returns if the 2023 Pricing grid feature has been enabled.
+ * Currently this depends on the feature flag and on the locale the user is on
  *
  */
 export const is2023PricingGridEnabled = (): boolean => {
@@ -59,22 +60,31 @@ export const is2023PricingGridEnabled = (): boolean => {
 		return supportedLocales.includes( getLocaleSlug() ?? '' );
 	};
 
-	const isActivePage = (): boolean => {
-		let currentRoutePath = '';
-		currentRoutePath = window.location?.pathname ?? '';
+	return isFeatureFlagEnabled() && isLocaleSupported();
+};
 
-		// Is this the internal plans page /plans/<site-slug> ?
-		if ( currentRoutePath.startsWith( '/plans' ) ) {
-			return true;
-		}
+/**
+ * This function specifically checks if a given route path will display the pricing grid or not.
+ * However the pricing grid needs to be enabled in the first place for this function to return true.
+ *
+ * @param browserWindow Current browser window
+ * @returns true if the pricing grid maybe shown in a given page
+ */
+export const is2023PricingGridActivePage = (
+	browserWindow: Window & typeof globalThis
+): boolean => {
+	const currentRoutePath = browserWindow.location.pathname ?? '';
+	const isPricingGridEnabled = is2023PricingGridEnabled();
 
-		// Is this the onboarding flow?
-		if ( currentRoutePath.startsWith( '/start/plans' ) ) {
-			return true;
-		}
+	// Is this the internal plans page /plans/<site-slug> ?
+	if ( currentRoutePath.startsWith( '/plans' ) ) {
+		return isPricingGridEnabled;
+	}
 
-		return false;
-	};
+	// Is this the onboarding flow?
+	if ( currentRoutePath.startsWith( '/start/plans' ) ) {
+		return isPricingGridEnabled;
+	}
 
-	return isFeatureFlagEnabled() && isLocaleSupported() && isActivePage();
+	return false;
 };

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -55,21 +55,15 @@ export const is2023PricingGridEnabled = (): boolean => {
 
 	const isActivePage = (): boolean => {
 		let currentRoutePath = '';
-		if ( typeof window === 'object' && window.location ) {
-			currentRoutePath = window.location.pathname;
-		}
-
-		const [ firstPathPart, secondPathPart ] = ( currentRoutePath || '' )
-			.split( '/' )
-			.filter( ( i ) => i );
+		currentRoutePath = globalThis.location?.pathname ?? '';
 
 		// Is this the internal plans page /plans/<site-slug> ?
-		if ( firstPathPart === 'plans' ) {
+		if ( currentRoutePath.startsWith( '/plans' ) ) {
 			return true;
 		}
 
-		// Is this the onboarding flow /start/plans?
-		if ( firstPathPart === 'start' && secondPathPart === 'plans' ) {
+		// Is this the onboarding flow?
+		if ( currentRoutePath.startsWith( '/start/plans' ) ) {
 			return true;
 		}
 

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -13,6 +13,12 @@ import {
 	PLAN_TRIENNIAL_PERIOD,
 } from './constants';
 
+declare global {
+	interface Window {
+		location: Location;
+	}
+}
+
 export function isBestValue( plan: string ): boolean {
 	return ( BEST_VALUE_PLANS as ReadonlyArray< string > ).includes( plan );
 }
@@ -55,7 +61,7 @@ export const is2023PricingGridEnabled = (): boolean => {
 
 	const isActivePage = (): boolean => {
 		let currentRoutePath = '';
-		currentRoutePath = globalThis.location?.pathname ?? '';
+		currentRoutePath = window.location?.pathname ?? '';
 
 		// Is this the internal plans page /plans/<site-slug> ?
 		if ( currentRoutePath.startsWith( '/plans' ) ) {

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -41,10 +41,15 @@ export function getTermDuration( term: string ): number | undefined {
 
 export const redirectCheckoutToWpAdmin = (): boolean => !! JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN;
 
-export const is2023PricingGridEnabled = () => {
-	const supportedLocales = [ 'en', 'en-gb', 'es' ];
+export const is2023PricingGridEnabled = (): boolean => {
+	const isFeatureFlagEnabled = (): boolean => isEnabled( 'onboarding/2023-pricing-grid' );
 
-	const isPlans2023ActivePage = () => {
+	const isLocaleSupported = (): boolean => {
+		const supportedLocales = [ 'en', 'en-gb', 'es' ];
+		return supportedLocales.includes( getLocaleSlug() ?? '' );
+	};
+
+	const isActivePage = (): boolean => {
 		const currentRoutePath = window.location.pathname;
 
 		// Is this the internal plans page /plans/<site-slug> ?
@@ -64,9 +69,5 @@ export const is2023PricingGridEnabled = () => {
 		return false;
 	};
 
-	return (
-		isEnabled( 'onboarding/2023-pricing-grid' ) &&
-		supportedLocales.includes( getLocaleSlug() ?? '' ) &&
-		isPlans2023ActivePage()
-	);
+	return isFeatureFlagEnabled() && isLocaleSupported() && isActivePage();
 };

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -43,8 +43,30 @@ export const redirectCheckoutToWpAdmin = (): boolean => !! JETPACK_REDIRECT_CHEC
 
 export const is2023PricingGridEnabled = () => {
 	const supportedLocales = [ 'en', 'en-gb', 'es' ];
+
+	const isPlans2023ActivePage = () => {
+		const currentRoutePath = window.location.pathname;
+
+		// Is this the internal plans page /plans/<site-slug> ?
+		if (
+			currentRoutePath.includes( 'plans' ) &&
+			! currentRoutePath.includes( 'start' ) &&
+			! currentRoutePath.includes( 'setup' )
+		) {
+			return true;
+		}
+
+		// Is this the onboarding flow ?
+		if ( currentRoutePath.includes( '/start/plans' ) ) {
+			return true;
+		}
+
+		return false;
+	};
+
 	return (
 		isEnabled( 'onboarding/2023-pricing-grid' ) &&
-		supportedLocales.includes( getLocaleSlug() ?? '' )
+		supportedLocales.includes( getLocaleSlug() ?? '' ) &&
+		isPlans2023ActivePage()
 	);
 };

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -13,12 +13,6 @@ import {
 	PLAN_TRIENNIAL_PERIOD,
 } from './constants';
 
-declare global {
-	interface Window {
-		location: Location;
-	}
-}
-
 export function isBestValue( plan: string ): boolean {
 	return ( BEST_VALUE_PLANS as ReadonlyArray< string > ).includes( plan );
 }

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -41,6 +41,10 @@ export function getTermDuration( term: string ): number | undefined {
 
 export const redirectCheckoutToWpAdmin = (): boolean => !! JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN;
 
+/**
+ * Returns if the 2023 Pricing grid optimized design should be visible or not
+ *
+ */
 export const is2023PricingGridEnabled = (): boolean => {
 	const isFeatureFlagEnabled = (): boolean => isEnabled( 'onboarding/2023-pricing-grid' );
 
@@ -50,19 +54,22 @@ export const is2023PricingGridEnabled = (): boolean => {
 	};
 
 	const isActivePage = (): boolean => {
-		const currentRoutePath = window.location.pathname;
+		let currentRoutePath = '';
+		if ( typeof window === 'object' && window.location ) {
+			currentRoutePath = window.location.pathname;
+		}
+
+		const [ firstPathPart, secondPathPart ] = ( currentRoutePath || '' )
+			.split( '/' )
+			.filter( ( i ) => i );
 
 		// Is this the internal plans page /plans/<site-slug> ?
-		if (
-			currentRoutePath.includes( 'plans' ) &&
-			! currentRoutePath.includes( 'start' ) &&
-			! currentRoutePath.includes( 'setup' )
-		) {
+		if ( firstPathPart === 'plans' ) {
 			return true;
 		}
 
-		// Is this the onboarding flow ?
-		if ( currentRoutePath.includes( '/start/plans' ) ) {
+		// Is this the onboarding flow /start/plans?
+		if ( firstPathPart === 'start' && secondPathPart === 'plans' ) {
 			return true;
 		}
 


### PR DESCRIPTION
Fixes Automattic/martech#1523

### Show 2023 Plans on only
- Internal plans page `/plans/<site-slug>`
- Onboarding flow `/start/plans`

---

### Should not show the 2023 plans pages on any other flows or pages.

Eg: `/start/hosting/plans` should have the previous pricing grid

<img width="600" alt="image" src="https://user-images.githubusercontent.com/3422709/219646547-a8bda46e-ed80-44e1-944e-a3e7ccd8d60f.png">


## Testing Instructions
* Try the  Internal plans page `/plans/<site-slug>`, Onboarding flow `/start/plans` and make sure the new plans grid is visible
* Try any other flow that includes the plans step and make sure they remain unchanged. i.e. `/start/hosting/`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

