### PR TITLE
Button: fix dashicon specificity

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -36,6 +36,12 @@ class Help_Center {
 	 * Help_Center constructor.
 	 */
 	public function __construct() {
+		global $wp_customize;
+
+		if ( isset( $wp_customize ) ) {
+			return;
+		}
+
 		$this->asset_file = include plugin_dir_path( __FILE__ ) . 'dist/help-center.asset.php';
 		$this->version    = $this->asset_file['version'];
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -24,6 +24,7 @@
 	padding: 8px 14px;
 	appearance: none;
 
+
 	.rtl & {
 		font-family: $a8c-font-family-sans-rtl;
 	}
@@ -113,6 +114,11 @@
 		animation: button__busy-animation 3000ms infinite linear;
 		background-size: 120px 100%;
 		background-image: linear-gradient(-45deg, var(--color-neutral-0) 28%, var(--color-surface) 28%, var(--color-surface) 72%, var(--color-neutral-0) 72%);
+	}
+
+	&.dashicons {
+		/* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
+		font-family: dashicons;
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

The button component that is in `/packages/components` had very greedy selectors that were overriding the font for `dashicons`. This issue could specifically be seen in the customizer when you make changes. There should be a gear icon next to the save button. Read more about the issue here ⇢ p1676387672739839-slack-CNA89KY6M

This adds a new style specifically for `dashicon` situations of the button.

| Before | After |
| - | - |
| <img width="406" alt="Markup 2023-02-17 at 15 40 23" src="https://user-images.githubusercontent.com/33258733/219691791-505e7487-4696-471e-ad12-feeaa83155c1.png"> |  <img width="430" alt="Markup 2023-02-17 at 15 44 19" src="https://user-images.githubusercontent.com/33258733/219691659-47320fec-d31c-4e8f-8476-2048c3ee00bc.png"> |


## Testing Instructions

1. Pull branch and `cd apps/editing-toolkit/ && yarn dev --sync`
2. Sandbox a simple site and go to Appearance ⇢ Customize
3. Make a change to anything in the customizer to see the `SAVE` button enabled.
4. The icon next to the button should be a gear.