### PR TITLE
BackupRetention: Add Tracks event on purchase CTA

### DIFF
--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -115,6 +115,12 @@ const BackupRetentionManagement: FunctionComponent< OwnProps > = ( { defaultRete
 	);
 
 	const goToCheckoutPage = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_storage_retention_purchase_click', {
+				retention_option: retentionSelected,
+			} )
+		);
+
 		// The idea is to redirect back to the setting page with the current selected retention period.
 		const redirectBackUrl = addQueryArgs( { retention: retentionSelected }, window.location.href );
 
@@ -131,7 +137,7 @@ const BackupRetentionManagement: FunctionComponent< OwnProps > = ( { defaultRete
 		} );
 
 		window.location.href = storageUpgradeUrl;
-	}, [ retentionSelected, siteSlug, upsellSlug.productSlug ] );
+	}, [ dispatch, retentionSelected, siteSlug, upsellSlug.productSlug ] );
 
 	// Set the retention period selected when the user selects a new option
 	const onRetentionSelectionChange = useCallback(


### PR DESCRIPTION
## Proposed Changes
* Add event `calypso_jetpack_backup_storage_retention_purchase_click` to track when user clicks on purchase button.

## Screenshots
<img width="550" alt="image" src="https://user-images.githubusercontent.com/1488641/219718018-3fb841c0-577a-4979-82a1-da2b545cb624.png">


## Testing Instructions
* Start a Jetpack Cloud live branch
* Select a site with a backup plan that has storage limit like Jetpack Backup 10 GB. 
* Navigate to Settings and wait for the new setting to render. It should render.
* Open developer console in Network tab and ensure `Preserve log` are ticked.
* Click on any retention option radio button that requires a storage upgrade.
* Click on `Purchase storage` button.
* You should see a `t.gif` call with the event `calypso_jetpack_backup_storage_retention_purchase_click` including the prop `retention_option` with the selected number of days.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related to #73357