### PR TITLE
chore: update Playwright to 1.30.x.

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -43,7 +43,7 @@
 		"electron-rebuild": "^2.3.5",
 		"jest": "^27.3.1",
 		"lodash": "^4.17.21",
-		"playwright": "^1.28",
+		"playwright": "^1.30",
 		"postcss": "^8.4.5",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -23,7 +23,7 @@
 		"jest-docblock": "^27",
 		"mailosaur": "^8.4.0",
 		"nock": "^12.0.3",
-		"playwright": "^1.28",
+		"playwright": "^1.30",
 		"totp-generator": "^0.0.12"
 	},
 	"devDependencies": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -55,7 +55,7 @@
 		"lodash": "^4.17.20",
 		"mailosaur": "^8.4.0",
 		"node-fetch": "^2.6.1",
-		"playwright": "^1.28",
+		"playwright": "^1.30",
 		"postcss": "^8.3.11"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,7 +276,7 @@ __metadata:
     mailosaur: ^8.4.0
     nock: ^12.0.3
     node-fetch: ^2.6.7
-    playwright: ^1.28
+    playwright: ^1.30
     totp-generator: ^0.0.12
     typescript: ^4.7.4
   languageName: unknown
@@ -9467,7 +9467,7 @@ __metadata:
     keytar: ^7.7.0
     lodash: ^4.17.21
     make-dir: ^3.1.0
-    playwright: ^1.28
+    playwright: ^1.30
     postcss: ^8.4.5
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -25692,23 +25692,23 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.28.1":
-  version: 1.28.1
-  resolution: "playwright-core@npm:1.28.1"
+"playwright-core@npm:1.30.0":
+  version: 1.30.0
+  resolution: "playwright-core@npm:1.30.0"
   bin:
     playwright: cli.js
-  checksum: ad6dcdd57b1be811443a352eab3ce7b6adb06204a784a76dfa5b41c15e84d96c0bfff931573da2d04f15f4a4f3dd26995afbe84c2cb377576de84168f51c3723
+  checksum: cad74ca8ff028f4e65336323f7eec54497e344810c2f2e9c1ffaf836dcc20eb15c073aae6c5e994eaf800b75ea0f0817ffb60ff7ecaadc59229df54779d5f429
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.28":
-  version: 1.28.1
-  resolution: "playwright@npm:1.28.1"
+"playwright@npm:^1.30":
+  version: 1.30.0
+  resolution: "playwright@npm:1.30.0"
   dependencies:
-    playwright-core: 1.28.1
+    playwright-core: 1.30.0
   bin:
     playwright: cli.js
-  checksum: 308a6053de7de012141bbdedeb3fb28dc6dcce0fa5bd4879da42a77d9b6f445495c6717783854ada8184585c9b0650e012a103e0fa70b3e164a3f358c638866f
+  checksum: 49bbae502f45cdc7d5977d073080b6eb1aa871a14fa1aab23a23f331bdbc95bcc5a0dac00c01c4589231a8bb3fd4b7c154bfc1a47d80ea82c6aeb155275760be
   languageName: node
   linkType: hard
 
@@ -34265,7 +34265,7 @@ resolve@^2.0.0-next.3:
     lodash: ^4.17.20
     mailosaur: ^8.4.0
     node-fetch: ^2.6.1
-    playwright: ^1.28
+    playwright: ^1.30
     postcss: ^8.3.11
     webpack: ^5.63.0
   languageName: unknown


### PR DESCRIPTION
## Proposed Changes

This PR updates Playwright to 1.30.x from 1.28.x.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
