### PR TITLE
update tours in functional component with intent property

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -86,6 +86,7 @@ function WelcomeTour() {
 				is_gutenboarding: isGutenboarding,
 				slide_number: currentStepIndex + 1,
 				action: source,
+				intent: intent,
 			} );
 			setShowWelcomeGuide( false, { openedManually: false } );
 		},
@@ -103,6 +104,7 @@ function WelcomeTour() {
 					recordTracksEvent( 'calypso_editor_wpcom_tour_rate', {
 						thumbs_up: rating === 'thumbs-up',
 						is_gutenboarding: false,
+						intent: intent,
 					} );
 				},
 			},
@@ -111,12 +113,14 @@ function WelcomeTour() {
 					recordTracksEvent( 'calypso_editor_wpcom_tour_minimize', {
 						is_gutenboarding: isGutenboarding,
 						slide_number: currentStepIndex + 1,
+						intent: intent,
 					} );
 				},
 				onMaximize: ( currentStepIndex ) => {
 					recordTracksEvent( 'calypso_editor_wpcom_tour_maximize', {
 						is_gutenboarding: isGutenboarding,
 						slide_number: currentStepIndex + 1,
+						intent: intent,
 					} );
 				},
 				onStepViewOnce: ( currentStepIndex ) => {
@@ -128,6 +132,7 @@ function WelcomeTour() {
 						is_last_slide: currentStepIndex === lastStepIndex,
 						slide_heading: heading,
 						is_gutenboarding: isGutenboarding,
+						intent: intent,
 					} );
 				},
 			},


### PR DESCRIPTION
 <!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/73142

## Proposed Changes

* In the WelcomeTour() functional component found in tour-launch.tsx, there are calypso_editor_wpcom_tour events that need the intent property. The intent property is obtained from useSiteIntent(). 
* For this first PR, I am merging in the intent field for the tours that are in a functional component because the useSiteIntent() hook can easily retrieve the values. 
* The second PR will add the intent property for tours that are not in a functional component: 
* The third PR will add the editor_type properties to all the tours 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
