### PR TITLE
Flaky E2E: disable shared memory on Chromium.

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -112,9 +112,10 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 		);
 		const logFilePath = path.join( this.testArtifactsPath, `${ this.testFilename }.log` );
 
-		// Start the browser.
+		// Start the browser and sets launch options.
 		const browser = await browserType.launch( {
 			...config.launchOptions,
+			args: [ browserType.name() === 'chromium' ? '--disable-dev-shm-usage' : '' ],
 			logger: {
 				log: async ( name: string, severity: string, message: string ) => {
 					await fs.appendFile(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/70674.

## Proposed Changes

This PR opts to disable the usage of shared memory for Chromium entirely.

Despite multiple attempts to eliminate the page crashing from occurring on some suites (documented in https://github.com/Automattic/wp-calypso/issues/70674), this issue persists.

![image](https://user-images.githubusercontent.com/6549265/219779013-5cfcc51b-e4e3-436e-9d5b-f41887e660f0.png)

On upstream repo, it appears most hits for the query `shm` comes from the `--disable-dev-shm-usage` flag as part of the user's command. Seeing how prevalent it is, I think it's time for us to go back to not using shared memory in the first place to see if this has a positive impact on browser crash rates.

## Testing Instructions

Any E2E build should run and pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
