### PR TITLE
WooExpress: Changed section item title on trial sites

### DIFF
--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -1,3 +1,4 @@
+import { PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { isMobile } from '@automattic/viewport';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -40,6 +41,9 @@ class PlansNavigation extends Component {
 		const path = sectionify( this.props.path );
 		const sectionTitle = this.getSectionTitle( path );
 		const hasPinnedItems = Boolean( site ) && isMobile();
+		const currentPlanSlug = site?.plan?.product_slug;
+		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
+		const myPlanItemTitle = isEcommerceTrial ? translate( 'Free trial' ) : translate( 'My Plan' );
 
 		return (
 			site &&
@@ -51,7 +55,7 @@ class PlansNavigation extends Component {
 								path={ `/plans/my-plan/${ site.slug }` }
 								selected={ path === '/plans/my-plan' }
 							>
-								{ translate( 'My Plan' ) }
+								{ myPlanItemTitle }
 							</NavItem>
 							<NavItem
 								path={ `/plans/${ site.slug }` }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/73320

## Proposed Changes

* For eCommerce trial sites, change the section tag to 'Free trial' instead of 'My Plan'.

## Testing Instructions

* Using calypso-live, access the My Plan page of an eCommerce trial site (`/plans/my-plan/<site-slug>`)
* Check if the section title says "Free trial"

Before:
![image](https://user-images.githubusercontent.com/3801502/219785909-91d09285-cbf9-4c66-8cb6-e7e6f0445696.png)

After:
![image](https://user-images.githubusercontent.com/3801502/219786066-0d52428f-c858-4726-8631-82409ab252a1.png)
