### PR TITLE
Add fallback to phone number country guessing

### DIFF
--- a/client/components/phone-input/index.tsx
+++ b/client/components/phone-input/index.tsx
@@ -339,7 +339,7 @@ function guessCountryFromValueOrGetSelected(
 	freezeSelection: boolean
 ) {
 	if ( shouldGuessCountry( value, fallbackCountryCode, freezeSelection ) ) {
-		return findCountryFromNumber( value ) || getCountry( 'world' );
+		return findCountryFromNumber( value, fallbackCountryCode ) || getCountry( 'world' );
 	}
 
 	return getCountry( fallbackCountryCode );

--- a/client/components/phone-input/phone-number.ts
+++ b/client/components/phone-input/phone-number.ts
@@ -32,7 +32,7 @@ function prefixSearch( prefixQuery: string ) {
 		.flat();
 }
 
-export function findCountryFromNumber( inputNumber: string ) {
+export function findCountryFromNumber( inputNumber: string, fallbackCountry?: string ) {
 	let lastExactMatch;
 
 	for ( let i = 1; i <= 6; i++ ) {
@@ -57,6 +57,15 @@ export function findCountryFromNumber( inputNumber: string ) {
 		if ( prefixMatch.length === 1 ) {
 			// not an exact match, but there is only one option with this prefix
 			return countries[ prefixMatch[ 0 ] as keyof typeof countries ];
+		}
+	}
+
+	if ( fallbackCountry && lastExactMatch ) {
+		const fallbackCountryData = lastExactMatch.find(
+			( countryCode ) => fallbackCountry === countryCode
+		);
+		if ( fallbackCountryData ) {
+			return countries[ fallbackCountryData ];
 		}
 	}
 

--- a/client/components/phone-input/test/phone-number__find-country-from-number.test.ts
+++ b/client/components/phone-input/test/phone-number__find-country-from-number.test.ts
@@ -42,4 +42,21 @@ describe( 'Phone Number: findCountyFromNumber', () => {
 		const result = findCountryFromNumber( number ).isoCode;
 		expect( result ).toEqual( expected );
 	} );
+
+	test.each( [
+		{ number: '+1 ', fallback: 'CA', expected: 'CA' },
+		{ number: '+1 ', expected: 'US' },
+		{ number: '+1 20', fallback: 'CA', expected: 'CA' },
+		{ number: '+1 20', expected: 'US' },
+		{ number: '+1 204', expected: 'CA' },
+		{ number: '+551204', fallback: 'CA', expected: 'BR' },
+		{ number: '+551204', fallback: 'US', expected: 'BR' },
+		{ number: '+551204', expected: 'BR' },
+	] )(
+		`Fallback to $fallback if prefix matches - else returns a country as soon as possible from "$number"`,
+		function ( { number, fallback, expected } ) {
+			const result = findCountryFromNumber( number, fallback ).isoCode;
+			expect( result ).toEqual( expected );
+		}
+	);
 } );


### PR DESCRIPTION
## Proposed Changes
When entering your contact information on checkout, if you set the flag to Canada and then type `+1 `, the form switches to the US flag. 
Since the flag was passed as Canada, we shouldn't try to "guess" it and switch to the US flag. This PR fixes it. 

## Testing Instructions
- Try selecting the Canada flag and typing `+1 2`: the form shouldn't switch the flag in this case.
- Try selecting a country with a different country code than `+1` - e.g Brazil:
  - Select its flag;
  - Type `+1 2`;
  - Ensure it guesses the country as the US - same as before.
- Also please ensure that all tests are still passing 😬 

### Changes:
#### Before:
https://user-images.githubusercontent.com/18705930/219797841-3cdcb177-cc74-467d-ae97-9295f02eb678.mov

#### After:
##### Shouldn't guess US - Canada was selected:
https://user-images.githubusercontent.com/18705930/219798197-b9bda6f2-0c19-47cf-9052-7a41198719cd.mov

##### Should guess US - Brazil was selected, but US number (`+1`) was typed:
https://user-images.githubusercontent.com/18705930/219798541-d6b1a359-d1f7-45cb-86ba-b4fcc7f1dc9b.mov

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] (N/A) Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] (N/A) Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] (N/A) Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] (N/A) For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
