### PR TITLE
Bypass limited global styles when fetching accent colour

### DIFF
--- a/client/landing/stepper/hooks/use-accent-color.ts
+++ b/client/landing/stepper/hooks/use-accent-color.ts
@@ -9,7 +9,7 @@ const useAccentColor = () => {
 	if ( ID ) {
 		wpcom.req
 			.get( {
-				path: `/sites/${ ID }/global-styles-variation/site-accent-color`,
+				path: `/sites/${ ID }/global-styles-variation/site-accent-color?preview-global-styles=true`,
 				apiNamespace: 'wpcom/v2',
 			} )
 			.then( ( color: string ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/73339

## Proposed Changes

The global-styles-variation/site-accent-color API end point is used to fetch the accent colour set by the user during the newsletter setup. If the site has limited global styles then it will always return the theme default colour, rather than the one set by the user.

The implication is that if the user chooses a non-default colour, they cannot later change their mind and revert back to the default colour during the newsletter set-up process.

This has been addressed by always setting the preview-global-styles GET var when calling the endpoint so that it returns the set value and not the limited value.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



1. Create a free site in the newsletter flow - wordpress.com/setup/newsletter
2. Select a non-default "favorite color" (like vivid red) in the first setup step.
3. Continue through onboarding to the launchpad and notice the "choose a plan" task showed up due to our selection
4. Click on "Personalize Newsletter" to revisit the setup step.
5. Check that the Favorite color is set to the non-default color you selected before
6. Change the Favourite color to the default color, press Continue
7. Check that the preview shows the Favorite color last selected.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
