### PR TITLE
VideoPress Tailored Onboarding: Override default color vars for the VideoPress flow.

### DIFF
--- a/client/signup/videopress-step-wrapper/style.scss
+++ b/client/signup/videopress-step-wrapper/style.scss
@@ -42,6 +42,14 @@
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
+
+	--color-text: var(--videopress-color-text);
+	--color-accent: var(--videopress-color-link);
+	--color-text-inverted: var(--videopress-color-background-dark);
+	--color-text-subtle: var(--videopress-color-text-dark);
+	--color-link: var(--videopress-color-link);
+	--color-link-dark: var(--videopress-color-link-dark);
+	--color-accent-60: var(--videopress-color-link-dark);
 }
 
 .videopress-step-wrapper__top {


### PR DESCRIPTION
This PR fixes an issue with a view of the onboarding flow that was displaying poorly. I've added some overrides for some default color vars, which should help future-proof it as well (We should have done this from the start, maybe?)

Before
<img width="1271" alt="218872129-f8dfe2e6-8034-4a22-be6a-0963d24f54a1" src="https://user-images.githubusercontent.com/789137/219814716-0757d9e4-b412-4bec-b640-dce9d86dcd32.png">

After
<img width="676" alt="Screenshot 2023-02-17 at 4 21 23 PM" src="https://user-images.githubusercontent.com/789137/219815503-7c245565-df56-4b03-9b60-d8f2e9e591ba.png">

Related to https://github.com/Automattic/greenhouse/issues/1589

## Testing Instructions

* Visit `/setup/videopress` when signed out.
* Proceed to create a user account. After creating it press the browser's back button.
* You should arrive at the `Let's get you signed up` view. It should match the video theme.
* Visit another flow like `setup/link-in-bio` and verify that the CSS styles are not changed there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
