### PR TITLE
WooExpress: Added custom copy in plugins page for trial plan

### DIFF
--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -6,6 +6,8 @@ import {
 	isBlogger,
 	isPersonal,
 	isPremium,
+	PLAN_ECOMMERCE_MONTHLY,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	TYPE_BUSINESS,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
@@ -26,6 +28,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 const UpgradeNudge = ( { siteSlug, paidPlugins } ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
+	const isEcommerceTrial = sitePlan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 	const jetpackNonAtomic = useSelector(
 		( state ) =>
 			isJetpackSite( state, selectedSite?.ID ) && ! isAtomicSite( state, selectedSite?.ID )
@@ -114,6 +117,22 @@ const UpgradeNudge = ( { siteSlug, paidPlugins } ) => {
 		type: TYPE_BUSINESS,
 	} );
 
+	// This banner upsells the ability to install free and paid plugins on a eCommerce plan.
+	if ( isEcommerceTrial ) {
+		return (
+			<UpsellNudge
+				event="calypso_plugins_browser_upgrade_nudge"
+				className="plugins-discovery-page__upsell"
+				callToAction={ translate( 'Upgrade now' ) }
+				icon="notice-outline"
+				showIcon={ true }
+				href={ `/checkout/${ siteSlug }/${ PLAN_ECOMMERCE_MONTHLY }` }
+				feature={ FEATURE_INSTALL_PLUGINS }
+				plan={ plan }
+				title={ translate( 'To install additional plugins, please upgrade to a paid plan.' ) }
+			/>
+		);
+	}
 	// This banner upsells the ability to install free and paid plugins on a Pro plan.
 	const isLegacyPlan = isBlogger( sitePlan ) || isPersonal( sitePlan ) || isPremium( sitePlan );
 	const shouldUpsellProPlan = eligibleForProPlan && ! isLegacyPlan;

--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -128,7 +128,7 @@ const UpgradeNudge = ( { siteSlug, paidPlugins } ) => {
 				showIcon={ true }
 				href={ `/checkout/${ siteSlug }/${ PLAN_ECOMMERCE_MONTHLY }` }
 				feature={ FEATURE_INSTALL_PLUGINS }
-				plan={ plan }
+				plan={ PLAN_ECOMMERCE_MONTHLY }
 				title={ translate( 'To install additional plugins, please upgrade to a paid plan.' ) }
 			/>
 		);


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/73430

## Proposed Changes

* Changed Upgrade nudge copy for eCommerce trial plan sites
* Changed the cta to add the eCommerce plan to the cart.

## Testing Instructions

* Open the plugins page (`/plugins/<site-slug>`) of a trial site
* Check the banner copy
* Click on the CTA and confirm it adds the eCommerce monthly plan to the cart.

Before:

![image](https://user-images.githubusercontent.com/3801502/219876635-f85cd179-6f15-4dfc-b646-bc43dfc37a13.png)

After:

![image](https://user-images.githubusercontent.com/3801502/219876668-186a0ad5-c4ea-47d8-9a27-796bc32e669e.png)

