### PR TITLE
Signup: Handle case where window.sessionStorage does not exist

### DIFF
--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -21,16 +21,16 @@ export const clearSignupDestinationCookie = () => {
 };
 
 export const getSignupCompleteSlug = () =>
-	sessionStorage.getItem( 'wpcom_signup_complete_site_slug' );
+	sessionStorage?.getItem( 'wpcom_signup_complete_site_slug' );
 export const setSignupCompleteSlug = ( value ) =>
-	sessionStorage.setItem( 'wpcom_signup_complete_site_slug', value );
+	sessionStorage?.setItem( 'wpcom_signup_complete_site_slug', value );
 export const wasSignupCheckoutPageUnloaded = () =>
-	sessionStorage.getItem( 'was_signup_checkout_page_unloaded' );
+	sessionStorage?.getItem( 'was_signup_checkout_page_unloaded' );
 export const setSignupCheckoutPageUnloaded = ( value ) =>
-	sessionStorage.setItem( 'was_signup_checkout_page_unloaded', value );
+	sessionStorage?.setItem( 'was_signup_checkout_page_unloaded', value );
 export const getSignupCompleteFlowName = () =>
-	sessionStorage.getItem( 'wpcom_signup_complete_flow_name' );
+	sessionStorage?.getItem( 'wpcom_signup_complete_flow_name' );
 export const setSignupCompleteFlowName = ( value ) =>
-	sessionStorage.setItem( 'wpcom_signup_complete_flow_name', value );
+	sessionStorage?.setItem( 'wpcom_signup_complete_flow_name', value );
 export const clearSignupCompleteFlowName = () =>
-	sessionStorage.removeItem( 'wpcom_signup_complete_flow_name' );
+	sessionStorage?.removeItem( 'wpcom_signup_complete_flow_name' );


### PR DESCRIPTION
In checkout's review step (added in https://github.com/Automattic/wp-calypso/pull/72523), and many other places, there is code that calls a series of functions in the `client/signup` library like `getSignupCompleteFlowName()`. These functions (from https://github.com/Automattic/wp-calypso/pull/45040) all access `window.sessionStorage`. However, there are cases where that global object will not exist (I'm not 100% sure what those are but based on the errors it seems to be related to Safari). If this occurs, these functions throw a fatal error. 

This was noticed in checkout because we have more advanced error logging and reporting there, but it's likely causing crashes in other parts of calypso too.

Here's an example of the error: 

```
null is not an object (evaluating 'sessionStorage.getItem'); Stack: d@https:\/\/wordpress.com\/calypso\/evergreen\/90798.0e53b958e45ce8df970f.min.js:339:87368\nIo@https:\/\/wordpress.com\/calypso\/evergreen\/90798.0e53b958e45ce8df970f.min.js:106:3895\nai@https:\/\/wordpress.com\/calypso\/evergreen\/89564.0db68a9a80fa90a7f77c.min.js:2:168083...
```

For the alert, see p1676742304987539-slack-C096PD42U and p1676396706072749-slack-C096PD42U

## Proposed Changes

In this PR we use optional chaining to modify all the `window.sessionStorage` functions in the signup library so that they can be safely called when `window.sessionStorage` does not exist.

## Testing Instructions

None should be needed.