### PR TITLE
Theme Showcase: Style variation upsell banner and tagline in detail page

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -45,7 +45,7 @@ body.is-section-theme-i4 {
 			grid-area: header;
 
 			h2 {
-				margin: 0 0 12px 0;
+				margin: 0;
 			}
 		}
 
@@ -252,8 +252,27 @@ body.is-section-theme-i4 {
 		padding: 12px 2px;
 	}
 
-	.premium-badge {
-		-webkit-font-smoothing: antialiased;
+	.theme__sheet-style-variations-header {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+
+		p {
+			color: var(--color-neutral-60);
+			font-size: $font-body-small;
+			letter-spacing: -0.15px;
+			line-height: 20px;
+			margin: 0;
+
+			a {
+				color: var(--color-neutral-60);
+				text-decoration: underline;
+			}
+		}
+
+		.premium-badge {
+			-webkit-font-smoothing: antialiased;
+		}
 	}
 
 	.design-preview__style-variation-wrapper {
@@ -349,8 +368,8 @@ body.is-section-theme-i4 {
 		color: var(--color-neutral-60);
 		font-size: $font-body;
 		font-weight: 400;
+		letter-spacing: -0.32px;
 		line-height: 24px;
-		-webkit-font-smoothing: antialiased;
 	}
 }
 

--- a/packages/design-picker/src/components/premium-badge/index.tsx
+++ b/packages/design-picker/src/components/premium-badge/index.tsx
@@ -12,6 +12,7 @@ interface Props {
 	tooltipClassName?: string;
 	tooltipPosition?: string;
 	isPremiumThemeAvailable?: boolean;
+	shouldHideTooltip?: boolean;
 	focusOnShow?: boolean;
 }
 
@@ -22,6 +23,7 @@ const PremiumBadge: FunctionComponent< Props > = ( {
 	tooltipClassName,
 	tooltipPosition = 'bottom left',
 	isPremiumThemeAvailable,
+	shouldHideTooltip,
 	focusOnShow,
 } ) => {
 	const { __ } = useI18n();
@@ -48,15 +50,17 @@ const PremiumBadge: FunctionComponent< Props > = ( {
 			{ /*  eslint-disable-next-line wpcalypso/jsx-gridicon-size */ }
 			<Gridicon className="premium-badge__logo" icon="star" size={ 14 } />
 			<span>{ labelText || __( 'Premium' ) }</span>
-			<Popover
-				className={ classNames( 'premium-badge__popover', tooltipClassName ) }
-				context={ divRef.current }
-				isVisible={ isPopoverVisible }
-				position={ tooltipPosition }
-				focusOnShow={ focusOnShow }
-			>
-				{ tooltipContent || tooltipText }
-			</Popover>
+			{ ! shouldHideTooltip && (
+				<Popover
+					className={ classNames( 'premium-badge__popover', tooltipClassName ) }
+					context={ divRef.current }
+					isVisible={ isPopoverVisible }
+					position={ tooltipPosition }
+					focusOnShow={ focusOnShow }
+				>
+					{ tooltipContent || tooltipText }
+				</Popover>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
## Proposed Changes

This PR adds style variation upsell banner and tagline in the theme detail page as follows:

**Banner**
A banner will be shown to users that have a free active theme on a free plan. The banner communicates that they can unlock theme customization options by upgrading to the Premium plan.

![Screenshot 2023-02-20 at 9 52 57 AM](https://user-images.githubusercontent.com/797888/219991317-027762e7-0c89-4497-b320-2e7b9d61159a.png)

**Tagline**
1) Active theme, without global style gating:
![Screenshot 2023-02-20 at 9 57 05 AM](https://user-images.githubusercontent.com/797888/219991757-eb8fb3a2-b1aa-4be3-88ac-31f28a2b2683.png)

2) Inactive first-party theme, user on the Free plan:
![Screenshot 2023-02-20 at 9 54 54 AM](https://user-images.githubusercontent.com/797888/219991656-50889bdc-a03b-450e-b0e5-ef54a9b40279.png)

3) Inactive third-party theme, user on the Free plan:
![Screenshot 2023-02-20 at 9 59 23 AM](https://user-images.githubusercontent.com/797888/219991936-789e50d3-f28d-4c92-b022-42626898593c.png)

4) Inactive theme, without global style gating:
![Screenshot 2023-02-20 at 9 59 49 AM](https://user-images.githubusercontent.com/797888/219992006-b09c29bf-3b47-4c0c-89ad-a624ec2c103a.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Using a site with Free plan, ensure that for themes with style variations:
  * The banner shows up for the active theme.
  * The tagline shows up "Additional styles require the Premium plan or higher." for inactive themes.
* Using a site with Premium plan, ensure that for themes with style variations:
  * The banner doesn't show up for the active theme.
  * No tagline shows up for inactive themes.

Note: Third-party themes don't seem to have style variations available in the Theme Showcase yet (see Oaknut: https://wordpress.org/themes/oaknut/). Let's follow up on that in a separate PR.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
