### PR TITLE
Theme Showcase: Remove the Support menu option from the theme card

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { mapValues, pickBy, flowRight as compose } from 'lodash';
 import { connect } from 'react-redux';
@@ -273,7 +274,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 		signup,
 		separator,
 		info,
-		help,
+		...( ! isEnabled( 'themes/showcase-i4/details-and-preview' ) && { help } ),
 	};
 }
 


### PR DESCRIPTION
## Proposed Changes

As discussed in pbxlJb-3ra-p2#comment-2362, the new Theme Detail page design removes section tabs and instead renders all sections as one. As a result, there is no longer a need to have both "Info" and "Support" in the theme card menu options, since they lead to the same section. In this PR, we propose to remove the "Support" menu option.

| Before | After |
| --- | --- |
| ![Screenshot 2023-02-20 at 5 19 28 PM](https://user-images.githubusercontent.com/797888/220064151-c1876b91-f097-4dec-8840-c0ec2e8ac393.png) | ![Screenshot 2023-02-20 at 5 19 18 PM](https://user-images.githubusercontent.com/797888/220064210-49559ceb-38ba-48f7-85c8-0474082a01bc.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Ensure that the "Support" menu has been removed.
* Ensure that the "Support" menu is still present when disabling the feature flag `themes/showcase-i4/details-and-preview`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?