### PR TITLE
Update initiateTransfer action with API accepted parameters

### DIFF
--- a/client/state/atomic/transfers/actions.ts
+++ b/client/state/atomic/transfers/actions.ts
@@ -24,22 +24,26 @@ export interface AtomicTransferError {
 	code: string; // "no_transfer_record"
 }
 
+export interface InitiateTransfer {
+	softwareSet?: string | 'woo-on-plans';
+	themeSlug?: string;
+	pluginSlug?: string;
+	pluginFile?: File;
+	themeFile?: File;
+}
+
 /**
  * Initiate Atomic transfer, optionally with software set install.
  *
  * @param {string} siteId Site ID.
- * @param {Object} options Transfer options.
- * @param {string} options.softwareSet Software set to install.
+ * @param {InitiateTransfer} initiateTransfer The InitiateTransfer parameters.
  * @returns {Object} An action object.
  */
-export const initiateAtomicTransfer = (
-	siteId: number,
-	{ softwareSet }: { softwareSet: string }
-) =>
+export const initiateAtomicTransfer = ( siteId: number, initiateTransfer: InitiateTransfer ) =>
 	( {
 		type: ATOMIC_TRANSFER_INITIATE_TRANSFER,
 		siteId,
-		softwareSet,
+		...initiateTransfer,
 	} as const );
 
 /**

--- a/client/state/data-layer/wpcom/sites/atomic/test/transfers/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/test/transfers/index.js
@@ -1,0 +1,21 @@
+import { mapToRequestBody } from 'state/data-layer/wpcom/sites/atomic/transfers';
+
+describe( 'AtomicTransfers', () => {
+	test( 'Should map the InitiateTransfer to request body', () => {
+		const initiateTransferWithSoftwareSet = {
+			softwareSet: 'woo-on-all-plans',
+		};
+
+		expect( mapToRequestBody( initiateTransferWithSoftwareSet ) ).toEqual( {
+			software_set: 'woo-on-all-plans',
+		} );
+
+		const initiateTransferWithThemeSlug = {
+			themeSlug: 'foo',
+		};
+
+		expect( mapToRequestBody( initiateTransferWithThemeSlug ) ).toEqual( {
+			theme_slug: 'foo',
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
@@ -8,6 +8,32 @@ import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 
+export const mapToRequestBody = ( action ) => {
+	const requestBody = {};
+
+	if ( action.softwareSet ) {
+		requestBody.software_set = action.softwareSet;
+	}
+
+	if ( action.themeSlug ) {
+		requestBody.theme_slug = action.themeSlug;
+	}
+
+	if ( action.pluginSlug ) {
+		requestBody.plugin_slug = action.pluginSlug;
+	}
+
+	if ( action.themeFile ) {
+		requestBody.theme_file = action.themeFile;
+	}
+
+	if ( action.pluginFile ) {
+		requestBody.plugin_file = action.pluginFile;
+	}
+
+	return requestBody;
+};
+
 const initiateAtomicTransfer = ( action ) =>
 	http(
 		{
@@ -16,9 +42,7 @@ const initiateAtomicTransfer = ( action ) =>
 			path: `/sites/${ action.siteId }/atomic/transfers/`,
 			...( action.softwareSet
 				? {
-						body: {
-							software_set: action.softwareSet,
-						},
+						body: mapToRequestBody( action ),
 				  }
 				: {} ),
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
