### PR TITLE
WooExpress: Move plugin check types to internals/types.ts

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
@@ -5,21 +5,7 @@ import wpcomRequest from 'wpcom-proxy-request';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { ONBOARD_STORE } from '../../../../stores';
-import type { Step } from '../../types';
-
-export interface Plugin {
-	slug: string;
-}
-
-export interface PluginsResponse {
-	plugins: Plugin[];
-}
-
-export interface FailureInfo {
-	type: string;
-	code: number | string;
-	error: string;
-}
+import type { Step, PluginsResponse, FailureInfo } from '../../types';
 
 export const installedStates = {
 	PENDING: 'pending',

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -104,3 +104,17 @@ export type AssertConditionResult = {
 	state: AssertConditionState;
 	message?: string;
 };
+
+export interface Plugin {
+	slug: string;
+}
+
+export interface PluginsResponse {
+	plugins: Plugin[];
+}
+
+export interface FailureInfo {
+	type: string;
+	code: number | string;
+	error: string;
+}


### PR DESCRIPTION
We had several types in the `waitForPluginInstall` step related to checking a site's installed plugins. This moves those types into the main stepper types file so we can use them in other places more easily

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit http://calypso.localhost:3000/setup/wooexpress/ and verify that the site is created properly and you end up on the WooCommerce launch checklist.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
