### PR TITLE
Listing content on /advertising by number of views - POC 1

### DIFF
--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -243,16 +243,7 @@ export const getMostPopularDatetime = ( state, siteId, query ) => {
 	};
 };
 
-export const getTopPostAndPage = ( state, siteId, query ) => {
-	const data = getSiteStatsForQuery( state, siteId, 'statsTopPosts', query );
-
-	if ( ! data ) {
-		return {
-			post: null,
-			page: null,
-		};
-	}
-
+const getSortedPostsAndPages = ( data ) => {
 	const topPosts = {};
 
 	Object.values( data.days ).forEach( ( { postviews: posts } ) => {
@@ -275,6 +266,21 @@ export const getTopPostAndPage = ( state, siteId, query ) => {
 		return 0;
 	} );
 
+	return sortedTopPosts;
+};
+
+export const getTopPostAndPage = ( state, siteId, query ) => {
+	const data = getSiteStatsForQuery( state, siteId, 'statsTopPosts', query );
+
+	if ( ! data ) {
+		return {
+			post: null,
+			page: null,
+		};
+	}
+
+	const sortedTopPosts = getSortedPostsAndPages( data );
+
 	if ( ! sortedTopPosts.length ) {
 		return {
 			post: null,
@@ -286,4 +292,20 @@ export const getTopPostAndPage = ( state, siteId, query ) => {
 		post: sortedTopPosts.find( ( { type } ) => type === 'post' ),
 		page: sortedTopPosts.find( ( { type } ) => type === 'page' ),
 	};
+};
+
+export const getTopPostAndPages = ( state, siteId, query ) => {
+	const data = getSiteStatsForQuery( state, siteId, 'statsTopPosts', query );
+
+	if ( ! data ) {
+		return null;
+	}
+
+	const sortedTopPosts = getSortedPostsAndPages( data );
+
+	if ( ! sortedTopPosts.length ) {
+		return null;
+	}
+
+	return sortedTopPosts;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1693-gh-Automattic/dotcom-forge

## Proposed Changes

* Here we're showing /advertising posts/pages by their views numbers, then comments

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the Diff in your sandbox: D102272-code
* Access a popular site you have and make sure we're listing posts and pages by their views at the top of /advertising items
* Tip: Comment [these lines](https://github.com/Automattic/wp-calypso/blob/update/filter-advertising-by-views-v2/client/my-sites/promote-post/main.tsx#L122-L143) and access any private site from automattic that have more views, like the explorers p2.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?