### PR TITLE
Launchpad: Add domain upsell task for Link in Bio

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -78,7 +78,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 	const currentTask = getTasksProgress( enhancedTasks );
 	const launchTask = enhancedTasks?.find( ( task ) => task.isLaunchTask === true );
 
-	// Free, Write & Build flows - remove domain_upsell task if user is on paid plan
+	// Free, Write, Build, Link in Bio flows - remove domain_upsell task if user is on paid plan
 	enhancedTasks = filterDomainUpsellTask( flow, enhancedTasks, site );
 
 	const showLaunchTitle = launchTask && ! launchTask.disabled;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -4,7 +4,13 @@ import {
 	PLAN_PREMIUM,
 	FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
 } from '@automattic/calypso-products';
-import { FREE_FLOW, BUILD_FLOW, WRITE_FLOW } from '@automattic/onboarding';
+import {
+	FREE_FLOW,
+	BUILD_FLOW,
+	WRITE_FLOW,
+	LINK_IN_BIO_FLOW,
+	LINK_IN_BIO_TLD_FLOW,
+} from '@automattic/onboarding';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -350,13 +356,19 @@ export function getArrayOfFilteredTasks( tasks: Task[], flow: string | null ) {
 }
 
 // Returns enhanced task list with domain_upsell task removed
-// Only applies to Free, Write & Build flow sites with paid plan
+// Only applies to Free, Write, Build, Link in Bio flow sites with paid plan
 export function filterDomainUpsellTask(
 	flow: string | null,
 	enhancedTasks: Task[] | null,
 	site: SiteDetails | null
 ) {
-	const flowsAffected = [ FREE_FLOW, BUILD_FLOW, WRITE_FLOW ];
+	const flowsAffected = [
+		FREE_FLOW,
+		BUILD_FLOW,
+		WRITE_FLOW,
+		LINK_IN_BIO_FLOW,
+		LINK_IN_BIO_TLD_FLOW,
+	];
 	if ( flow && flowsAffected.includes( flow ) && enhancedTasks && ! site?.plan?.is_free ) {
 		return enhancedTasks?.filter( ( task ) => {
 			return task.id !== 'domain_upsell';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -120,6 +120,7 @@ export const tasks: Task[] = [
 
 const linkInBioTaskList = [
 	'design_selected',
+	'domain_upsell',
 	'setup_link_in_bio',
 	'plan_selected',
 	'links_added',


### PR DESCRIPTION
### Estimate
Review: Short
Testing: Short

### Proposed Changes
This PR is a follow up to https://github.com/Automattic/wp-calypso/pull/73440 adding the domain upsell task to the Link in Bio flow

![lib](https://user-images.githubusercontent.com/20927667/220181218-61656fff-c2f8-46a3-9b62-eaa71be374b1.png)


### Testing
* Checkout this branch
* Create a new `link-in-bio` flow site https://wordpress.com/setup/link-in-bio/intro, select a free domain and free plan.
* Navigate to the launchpad and confirm that the `Choose a domain` task is visible in the task checklist.
* Click the task and confirm that it navigates to `domains/add/{siteSlug}?domainAndPlanPackage=true`
* Select a new domain and paid plan.
* Navigate back to the launchpad and confirm the `Choose a domain` task is no longer visible
* Confirm the launchpad test cases are still passing: `npm run test-client client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test`