### PR TITLE
Launchpad: Only enabled Select a Design task for some flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -11,6 +11,9 @@ import {
 	LINK_IN_BIO_FLOW,
 	LINK_IN_BIO_TLD_FLOW,
 	NEWSLETTER_FLOW,
+	isFreeFlow,
+	isBuildFlow,
+	isWriteFlow,
 } from '@automattic/onboarding';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -51,6 +54,9 @@ export function getEnhancedTasks(
 
 	const videoPressUploadCompleted =
 		site?.options?.launchpad_checklist_tasks_statuses?.video_uploaded || false;
+
+	const allowUpdateDesign =
+		flow && ( isFreeFlow( flow ) || isBuildFlow( flow ) || isWriteFlow( flow ) );
 
 	const homePageId = site?.options?.page_on_front;
 	// send user to Home page editor, fallback to FSE if page id is not known
@@ -171,6 +177,7 @@ export function getEnhancedTasks(
 				case 'design_selected':
 					taskData = {
 						title: translate( 'Select a design' ),
+						disabled: ! allowUpdateDesign,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -23,13 +23,13 @@ export const tasks: Task[] = [
 	{
 		id: 'first_post_published',
 		completed: false,
-		disabled: true,
+		disabled: false,
 		taskType: 'blog',
 	},
 	{
 		id: 'design_selected',
 		completed: true,
-		disabled: false,
+		disabled: true,
 		taskType: 'blog',
 	},
 	{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -23,7 +23,7 @@ export const tasks: Task[] = [
 	{
 		id: 'first_post_published',
 		completed: false,
-		disabled: false,
+		disabled: true,
 		taskType: 'blog',
 	},
 	{

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -74,6 +74,10 @@ export const isBuildFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ BUILD_FLOW ].includes( flowName ) );
 };
 
+export const isWriteFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ WRITE_FLOW ].includes( flowName ) );
+};
+
 export const isUpdateDesignFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ UPDATE_DESIGN_FLOW ].includes( flowName ) );
 };


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/73401

### Proposed Changes

We recently enabled the Select a Design task on Launchpad, but it is now enabled for flows (like Link in Bio) where it should not be. This PR ensures that this task is only enabled for relevant flows: Free, Write, and Build. 

### Testing Instructions

**Review Time: Short**
**Testing Time: Short**

**Known Issue:** If you click `Select a Design`, choose a new design, and navigate back to Launchpad, the flow in the URL will always update to Free. I am fixing that in a separate PR. For this PR, just ensure we only show/enable that link for the correct flows. 

Testing: 
1. Checkout this branch and run yarn and yarn start if needed. 
2. Create a new free site starting at http://calypso.localhost:3000/setup/free/intro
3. TEST: When you get to Launchpad, confirm that `Select a Design` task is enabled/clickable. 
4. Test other flows. You can do this efficiently. Starting from the Launchpad screen in Step 3 (`http://calypso.localhost:3000/setup/free/launchpad?siteSlug=YOURSITESLUG`) simply change the word `free` in the URL to different flow names and confirm each time if the `Select a Design` task appears  and/or is enabled.  
   - Write Flow: Change 'free' in URL to 'write', and confirm `Select a Design` shows and is enabled/clickable.
   - Build Flow: Change 'free' in URL to 'build', and confirm `Select a Design` shows and is enabled/clickable.
   - Build Flow: Change 'free' in URL to 'link-in-bio', and confirm `Select a Design` shows and is NOT enabled/clickable.
   - Build Flow: Change 'free' in URL to 'newsletter', and confirm `Select a Design` does NOT show.
   - Build Flow: Change 'videopress' in URL to 'build', and confirm `Select a Design` does NOT show.

