### PR TITLE
Launchpad: Add Unit Tests for all flows's domain checklist task

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -78,9 +78,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 	const currentTask = getTasksProgress( enhancedTasks );
 	const launchTask = enhancedTasks?.find( ( task ) => task.isLaunchTask === true );
 
-	// Free, Write, Build, Link in Bio, & Newsletter flows - remove domain_upsell task if
-	// user is on paid plan
-	enhancedTasks = filterDomainUpsellTask( flow, enhancedTasks, site );
+	enhancedTasks = filterDomainUpsellTask( enhancedTasks, site );
 
 	const showLaunchTitle = launchTask && ! launchTask.disabled;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -4,17 +4,6 @@ import {
 	PLAN_PREMIUM,
 	FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
 } from '@automattic/calypso-products';
-import {
-	FREE_FLOW,
-	BUILD_FLOW,
-	WRITE_FLOW,
-	LINK_IN_BIO_FLOW,
-	LINK_IN_BIO_TLD_FLOW,
-	NEWSLETTER_FLOW,
-	isFreeFlow,
-	isBuildFlow,
-	isWriteFlow,
-} from '@automattic/onboarding';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -363,22 +352,9 @@ export function getArrayOfFilteredTasks( tasks: Task[], flow: string | null ) {
 	);
 }
 
-// Returns enhanced task list with domain_upsell task removed
-// Only applies to Free, Write, Build, Link in Bio, & Newsletter flow sites with paid plan
-export function filterDomainUpsellTask(
-	flow: string | null,
-	enhancedTasks: Task[] | null,
-	site: SiteDetails | null
-) {
-	const flowsAffected = [
-		FREE_FLOW,
-		BUILD_FLOW,
-		WRITE_FLOW,
-		LINK_IN_BIO_FLOW,
-		LINK_IN_BIO_TLD_FLOW,
-		NEWSLETTER_FLOW,
-	];
-	if ( flow && flowsAffected.includes( flow ) && enhancedTasks && ! site?.plan?.is_free ) {
+// Filter out the domain_upsell task from the enhanced task list when the user is not on a free plan anymore
+export function filterDomainUpsellTask( enhancedTasks: Task[] | null, site: SiteDetails | null ) {
+	if ( enhancedTasks && ! site?.plan?.is_free ) {
 		return enhancedTasks?.filter( ( task ) => {
 			return task.id !== 'domain_upsell';
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -4,6 +4,7 @@ import {
 	PLAN_PREMIUM,
 	FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
 } from '@automattic/calypso-products';
+import { isFreeFlow, isBuildFlow, isWriteFlow } from '@automattic/onboarding';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -9,6 +9,7 @@ import {
 	WRITE_FLOW,
 	BUILD_FLOW,
 	NEWSLETTER_FLOW,
+	VIDEOPRESS_FLOW,
 } from './../../../../../../../../packages/onboarding/src/utils/flows';
 import { buildTask, buildSiteDetails, defaultSiteDetails } from './lib/fixtures';
 
@@ -99,7 +100,7 @@ describe( 'Task Helpers', () => {
 	} );
 
 	describe( 'filterDomainUpsellTask', () => {
-		describe( 'when site plan is free and affected flow (free, build, write)', () => {
+		describe( 'when site plan is free and affected flow (free, build, write, link-in-bio, newsletter)', () => {
 			it( 'return original enhanceTasks', () => {
 				const task = buildTask( {
 					id: 'domain_upsell',
@@ -113,9 +114,13 @@ describe( 'Task Helpers', () => {
 				const freeFlow = FREE_FLOW;
 				const writeFlow = WRITE_FLOW;
 				const buildFlow = BUILD_FLOW;
+				const linkInBioFlow = LINK_IN_BIO_FLOW;
+				const newsletterFlow = NEWSLETTER_FLOW;
 				expect( filterDomainUpsellTask( freeFlow, tasks, site ) ).toBe( tasks );
 				expect( filterDomainUpsellTask( writeFlow, tasks, site ) ).toBe( tasks );
 				expect( filterDomainUpsellTask( buildFlow, tasks, site ) ).toBe( tasks );
+				expect( filterDomainUpsellTask( linkInBioFlow, tasks, site ) ).toBe( tasks );
+				expect( filterDomainUpsellTask( newsletterFlow, tasks, site ) ).toBe( tasks );
 			} );
 		} );
 
@@ -130,12 +135,12 @@ describe( 'Task Helpers', () => {
 				} );
 				const tasks = [ task ];
 				const site = defaultSiteDetails;
-				const newsletterFlow = NEWSLETTER_FLOW;
-				expect( filterDomainUpsellTask( newsletterFlow, tasks, site ) ).toBe( tasks );
+				const videopressFlow = VIDEOPRESS_FLOW;
+				expect( filterDomainUpsellTask( videopressFlow, tasks, site ) ).toBe( tasks );
 			} );
 		} );
 
-		describe( 'when site plan is not free and affected flow (free, build, write)', () => {
+		describe( 'when site plan is not free and affected flow (free, build, write, link-in-bio, newsletter)', () => {
 			it( 'return enhanceTask array with domain_upsell task removed', () => {
 				const task = buildTask( {
 					id: 'domain_upsell',
@@ -150,9 +155,13 @@ describe( 'Task Helpers', () => {
 				const freeFlow = FREE_FLOW;
 				const writeFlow = WRITE_FLOW;
 				const buildFlow = BUILD_FLOW;
+				const linkInBioFlow = LINK_IN_BIO_FLOW;
+				const newsletterFlow = NEWSLETTER_FLOW;
 				expect( filterDomainUpsellTask( freeFlow, tasks, site ) ).toHaveLength( 0 );
 				expect( filterDomainUpsellTask( writeFlow, tasks, site ) ).toHaveLength( 0 );
 				expect( filterDomainUpsellTask( buildFlow, tasks, site ) ).toHaveLength( 0 );
+				expect( filterDomainUpsellTask( linkInBioFlow, tasks, site ) ).toHaveLength( 0 );
+				expect( filterDomainUpsellTask( newsletterFlow, tasks, site ) ).toHaveLength( 0 );
 			} );
 		} );
 
@@ -166,10 +175,8 @@ describe( 'Task Helpers', () => {
 					title: 'domain upsell task',
 				} );
 				const site = buildSiteDetails( {} );
-				const newsletterFlow = NEWSLETTER_FLOW;
-				const linkInBioFlow = LINK_IN_BIO_FLOW;
-				expect( filterDomainUpsellTask( newsletterFlow, tasks, site ) ).toBe( tasks );
-				expect( filterDomainUpsellTask( linkInBioFlow, tasks, site ) ).toBe( tasks );
+				const videopressFlow = VIDEOPRESS_FLOW;
+				expect( filterDomainUpsellTask( videopressFlow, tasks, site ) ).toBe( tasks );
 			} );
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -3,15 +3,7 @@
  */
 import { filterDomainUpsellTask, getArrayOfFilteredTasks, getEnhancedTasks } from '../task-helper';
 import { tasks, launchpadFlowTasks } from '../tasks';
-import {
-	LINK_IN_BIO_FLOW,
-	FREE_FLOW,
-	WRITE_FLOW,
-	BUILD_FLOW,
-	NEWSLETTER_FLOW,
-	VIDEOPRESS_FLOW,
-} from './../../../../../../../../packages/onboarding/src/utils/flows';
-import { buildTask, buildSiteDetails, defaultSiteDetails } from './lib/fixtures';
+import { buildTask, buildSiteDetails } from './lib/fixtures';
 
 describe( 'Task Helpers', () => {
 	describe( 'getEnhancedTasks', () => {
@@ -100,8 +92,8 @@ describe( 'Task Helpers', () => {
 	} );
 
 	describe( 'filterDomainUpsellTask', () => {
-		describe( 'when site plan is free and affected flow (free, build, write, link-in-bio, newsletter)', () => {
-			it( 'return original enhanceTasks', () => {
+		describe( 'when site plan is free', () => {
+			it( 'return original enchanceTasks', () => {
 				const task = buildTask( {
 					id: 'domain_upsell',
 					completed: false,
@@ -110,38 +102,17 @@ describe( 'Task Helpers', () => {
 					title: 'domain upsell task',
 				} );
 				const tasks = [ task ];
-				const site = defaultSiteDetails;
-				const freeFlow = FREE_FLOW;
-				const writeFlow = WRITE_FLOW;
-				const buildFlow = BUILD_FLOW;
-				const linkInBioFlow = LINK_IN_BIO_FLOW;
-				const newsletterFlow = NEWSLETTER_FLOW;
-				expect( filterDomainUpsellTask( freeFlow, tasks, site ) ).toBe( tasks );
-				expect( filterDomainUpsellTask( writeFlow, tasks, site ) ).toBe( tasks );
-				expect( filterDomainUpsellTask( buildFlow, tasks, site ) ).toBe( tasks );
-				expect( filterDomainUpsellTask( linkInBioFlow, tasks, site ) ).toBe( tasks );
-				expect( filterDomainUpsellTask( newsletterFlow, tasks, site ) ).toBe( tasks );
+				const site = buildSiteDetails( { plan: { is_free: true } } );
+				// domain_upsell is still in the array
+				expect(
+					filterDomainUpsellTask( tasks, site )?.findIndex(
+						( task ) => ( task.id = 'domain_upsell' )
+					)
+				).toBe( 0 );
 			} );
 		} );
-
-		describe( 'when unaffected flow', () => {
-			it( 'return original enhanceTasks', () => {
-				const task = buildTask( {
-					id: 'domain_upsell',
-					completed: false,
-					disabled: true,
-					taskType: 'blog',
-					title: 'domain upsell task',
-				} );
-				const tasks = [ task ];
-				const site = defaultSiteDetails;
-				const videopressFlow = VIDEOPRESS_FLOW;
-				expect( filterDomainUpsellTask( videopressFlow, tasks, site ) ).toBe( tasks );
-			} );
-		} );
-
-		describe( 'when site plan is not free and affected flow (free, build, write, link-in-bio, newsletter)', () => {
-			it( 'return enhanceTask array with domain_upsell task removed', () => {
+		describe( 'when site plan is not free', () => {
+			it( 'filters out the domain_upsell task', () => {
 				const task = buildTask( {
 					id: 'domain_upsell',
 					completed: false,
@@ -151,32 +122,12 @@ describe( 'Task Helpers', () => {
 				} );
 				const tasks = [ task ];
 				const site = buildSiteDetails( { plan: { is_free: false } } );
-
-				const freeFlow = FREE_FLOW;
-				const writeFlow = WRITE_FLOW;
-				const buildFlow = BUILD_FLOW;
-				const linkInBioFlow = LINK_IN_BIO_FLOW;
-				const newsletterFlow = NEWSLETTER_FLOW;
-				expect( filterDomainUpsellTask( freeFlow, tasks, site ) ).toHaveLength( 0 );
-				expect( filterDomainUpsellTask( writeFlow, tasks, site ) ).toHaveLength( 0 );
-				expect( filterDomainUpsellTask( buildFlow, tasks, site ) ).toHaveLength( 0 );
-				expect( filterDomainUpsellTask( linkInBioFlow, tasks, site ) ).toHaveLength( 0 );
-				expect( filterDomainUpsellTask( newsletterFlow, tasks, site ) ).toHaveLength( 0 );
-			} );
-		} );
-
-		describe( 'when site plan is not free and not affected flow', () => {
-			it( 'return enhanceTask array with domain_upsell task removed', () => {
-				const tasks = buildTask( {
-					id: 'domain_upsell',
-					completed: false,
-					disabled: true,
-					taskType: 'blog',
-					title: 'domain upsell task',
-				} );
-				const site = buildSiteDetails( {} );
-				const videopressFlow = VIDEOPRESS_FLOW;
-				expect( filterDomainUpsellTask( videopressFlow, tasks, site ) ).toBe( tasks );
+				// domain_upsell is NOT in the array
+				expect(
+					filterDomainUpsellTask( tasks, site )?.findIndex(
+						( task ) => ( task.id = 'domain_upsell' )
+					)
+				).toBe( -1 );
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Time Estimate
Review: Short
Test: Short

### Proposed Changes
This is a follow-up PR to add unit tests for the `newsletter` and `link-in-bio` flows https://github.com/Automattic/wp-calypso/pull/73548 and https://github.com/Automattic/wp-calypso/pull/73550

### Testing Instructions
1. Checkout this branch
2. Run `yarn test-client launchpad`
3. Confirm all tests are passing