### PR TITLE
Try parallel app processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ cached-requests.json
 /build-tools/dist/
 /apps/*/.cache/
 /desktop/.cache/
+/apps/*/release-files/
 
 # webpack assets
 /assets*.json

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -92,9 +92,6 @@ object CalypsoApps: BuildType({
 
 				# Install dependencies
 				yarn
-
-				# Set execution permission for additional scripts.
-				chmod +x .teamcity/scripts/WPComPlugins/
 			"""
 		}
 
@@ -104,6 +101,24 @@ object CalypsoApps: BuildType({
 				# Run `yarn build-ci` script for the plugins specified in the glob.
 				# `build-ci` is a specialized build for CI environment.
 				yarn workspaces foreach --verbose --parallel --include '{happy-blocks,@automattic/notifications}' run build-ci
+			"""
+		}
+
+		bashNodeScript {
+			name = "Process artifact"
+			scriptContent = """
+				export tc_auth="%system.teamcity.auth.userId%:%system.teamcity.auth.password%"
+				export git_branch="%teamcity.build.branch%"
+				export build_id="%teamcity.build.id%"
+				export GH_TOKEN="%matticbot_oauth_token%"
+				export is_default_branch="%teamcity.build.branch.is_default%"
+				export skip_build_diff="%skip_release_diff%"
+				export mc_auth_secret="%mc_auth_secret%"
+				export commit_sha="%build.vcs.number%"
+				export mc_post_root="%mc_post_root%"
+				export tc_sever_url="%teamcity.serverUrl%"
+
+				node ./bin/process-calypso-app-artifacts.mjs
 			"""
 		}
 	}

--- a/apps/happy-blocks/.gitignore
+++ b/apps/happy-blocks/.gitignore
@@ -1,4 +1,3 @@
 /dist
 /block-library/*/build
-/release-files
 translations-manifest.json

--- a/apps/happy-blocks/bin/prepArtifactForCI.sh
+++ b/apps/happy-blocks/bin/prepArtifactForCI.sh
@@ -4,15 +4,15 @@ set -o nounset
 set -o pipefail
 
 # Copy build directories to the release directory.
-find ./block-library/* -type d -name "*" -prune |\
+find ./block-library/* -type d -name "*" -prune ! -name "shared" |\
 while read -r block;
 do
-	mkdir -p ./release-files/${block//\.\.\//}; 
-	cp -r $block/build/* ./release-files/${block//\.\.\//}/; 
+	mkdir -p "./release-files/${block//\.\.\//}"; 
+	cp -r $block/build/* "./release-files/${block//\.\.\//}/"; 
 done
 
 # Add the index.php file
-cp ./index.php ./README.md ./dist/* ./release-files/
+cp ./index.php ./README.md ./release-files/
 cp ./translations-manifest.json ./release-files/
 
 printf "Finished configuration of the @automattic/happy-blocks plugin artifacts directory.\n"

--- a/apps/happy-blocks/bin/prepArtifactForCI.sh
+++ b/apps/happy-blocks/bin/prepArtifactForCI.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-
-set -x
+set -o errexit
+set -o nounset
+set -o pipefail
 
 # Copy build directories to the release directory.
 find ./block-library/* -type d -name "*" -prune |\

--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -10,14 +10,14 @@
 		"directory": "packages/happy-blocks"
 	},
 	"scripts": {
-		"build": "NODE_ENV=production yarn dev && yarn run build-translations-manifest",
+		"build": "NODE_ENV=production yarn dev",
 		"build-ci": "yarn build && ./bin/prepArtifactForCI.sh",
 		"build-calypso-strings": "wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base '../../' --dir 'dist/strings' --output './dist/calypso-strings.pot' && rm -rf dist/strings",
 		"build:pricing-plans": "calypso-build --env block='pricing-plans'",
 		"build:universal-header": "calypso-build --env block='universal-header'",
 		"build:universal-footer": "calypso-build --env block='universal-footer'",
 		"build-translations-manifest": "yarn run build-calypso-strings && node bin/build-translations-manifest.js",
-		"clean": "rm -rf dist block-library/*/build || true",
+		"clean": "rm -r release-files block-library/*/build || true",
 		"dev": "yarn run calypso-apps-builder --localPath / --remotePath /home/wpcom/public_html/wp-content/a8c-plugins/happy-blocks"
 	},
 	"dependencies": {

--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -10,7 +10,7 @@
 		"directory": "packages/happy-blocks"
 	},
 	"scripts": {
-		"build": "NODE_ENV=production yarn dev",
+		"build": "NODE_ENV=production yarn dev && yarn run build-translations-manifest",
 		"build-ci": "yarn build && ./bin/prepArtifactForCI.sh",
 		"build-calypso-strings": "wp-babel-makepot '../../{client,packages,apps}/**/*.{js,jsx,ts,tsx}' --ignore '**/node_modules/**,**/test/**,**/*.d.ts' --base '../../' --dir 'dist/strings' --output './dist/calypso-strings.pot' && rm -rf dist/strings",
 		"build:pricing-plans": "calypso-build --env block='pricing-plans'",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -22,7 +22,7 @@
 		"start": "yarn run clean && yarn run build:notifications && yarn run dev-server",
 		"dev": "yarn run calypso-apps-builder --localPath dist --remotePath /home/wpcom/public_html/widgets.wp.com/notifications",
 		"build": "NODE_ENV=production yarn dev",
-		"build-ci": "yarn build && ./bin/prepArtifactForCI.sh"
+		"build-ci": "yarn build"
 	},
 	"dependencies": {
 		"@automattic/calypso-color-schemes": "workspace:^",

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -41,9 +41,10 @@ const excludedPackages = [
 ];
 
 const excludedPackagePlugins = excludedPackages.map(
-	( package ) =>
+	// Note: apparently the word "package" is a reserved keyword here for some reason
+	( pkg ) =>
 		new webpack.NormalModuleReplacementPlugin(
-			package,
+			pkg,
 			path.resolve( __dirname, 'src/components/nothing' )
 		)
 );

--- a/bin/did-calypso-app-change.mjs
+++ b/bin/did-calypso-app-change.mjs
@@ -1,0 +1,45 @@
+import { exec as _exec } from 'node:child_process';
+import { createWriteStream } from 'node:fs';
+import { Readable } from 'node:stream';
+import { finished } from 'node:stream/promises';
+import util from 'node:util';
+const exec = util.promisify( _exec );
+
+export default async function didCalypsoAppChange( { slug, dir, newReleaseDir, customNormalize } ) {
+	await downloadPrevBuild( slug, dir );
+	await customNormalize?.();
+	try {
+		await exec(
+			`diff -rq --exclude="*.js.map" --exclude="*.asset.php" --exclude="build_meta.json" --exclude="README.md" ${ newReleaseDir } ${ dir }/prev-release/`,
+			{ encoding: 'UTF-8', cwd: dir, stdio: 'inherit' }
+		);
+		return false;
+	} catch ( { code, stdout, stderr } ) {
+		if ( code === 1 ) {
+			console.info( `The build for ${ slug } changed. Cause:` );
+			console.info( stdout );
+			return true;
+		}
+		throw new Error( `Unexpected error code ${ code } while diffing ${ slug } build: ${ stderr }` );
+	}
+}
+
+async function downloadPrevBuild( appSlug, dir ) {
+	const prevBuildZip = `${ dir }/prev-archive-download.zip`;
+	const stream = createWriteStream( prevBuildZip );
+
+	const prevBuildUrl = `${ process.env.tc_sever_url }/repository/download/calypso_calypso_WPComPlugins_Build_Plugins/${ appSlug }-release-build.tcbuildtag/${ appSlug }.zip?guest=1&branch=try-parallel-app-processing`;
+	console.info( `Fetching previous release build for ${ appSlug } from ${ prevBuildUrl }` );
+
+	const { body, status } = await fetch( prevBuildUrl );
+	if ( status !== 200 ) {
+		throw new Error( `Could not fetch previous build! Response code ${ status }.` );
+	}
+
+	console.info( `Extracting downloaded archive for ${ appSlug }...` );
+	await finished( Readable.fromWeb( body ).pipe( stream ) );
+	await exec( `unzip -q ${ prevBuildZip } -d ${ dir }/prev-release`, {
+		encoding: 'UTF-8',
+		stdio: 'inherit',
+	} );
+}

--- a/bin/process-calypso-app-artifacts.mjs
+++ b/bin/process-calypso-app-artifacts.mjs
@@ -1,0 +1,165 @@
+import { exec as _exec } from 'node:child_process';
+import { createHmac } from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import util from 'node:util';
+import didCalypsoAppChange from './did-calypso-app-change.mjs';
+
+checkEnvVars();
+
+const exec = util.promisify( _exec );
+const SKIP_BUILD_DIFF = process.env.skip_build_diff === 'true';
+const IS_DEFAULT_BRANCH = process.env.is_default_branch === 'true';
+const dirname = fileURLToPath( new URL( '.', import.meta.url ) );
+const appRoot = path.resolve( dirname, '../apps' );
+
+const apps = [
+	{
+		slug: 'happy-blocks',
+		dir: path.resolve( appRoot, 'happy-blocks' ),
+		newReleaseDir: path.resolve( appRoot, 'happy-blocks/release-files' ),
+		slackNotify: true,
+	},
+];
+
+// STEP 1: Check if any apps have changed. If skipping the diff, continue as if all apps have changed.
+const changedApps = SKIP_BUILD_DIFF
+	? apps
+	: (
+			await Promise.all(
+				apps.map( async ( app ) => ( ( await didCalypsoAppChange( app ) ) ? app : null ) )
+			)
+	   ).filter( Boolean );
+
+if ( changedApps.length ) {
+	console.info(
+		'The following apps changed: ',
+		changedApps.map( ( { slug } ) => slug ).join( ', ' )
+	);
+} else {
+	console.info( 'No apps changed.' );
+}
+
+// STEP 2: Tag the build in TeamCity. This will let future builds identify the previous release.
+const finalTasks = [];
+if ( changedApps.length ) {
+	console.info( 'Tagging build...' );
+	finalTasks.push( tagBuild( changedApps ) );
+}
+
+// STEP 3: Notify the author. On trunk, send a Slack notification. On a PR, a GitHub commnent.
+if ( ! IS_DEFAULT_BRANCH ) {
+	console.info( 'Running GitHub comment...' );
+	finalTasks.push( addGitHubComment( changedApps ) );
+} else {
+	console.info( 'Running Slack notification...' );
+	finalTasks.push( sendSlackNotification( changedApps ) );
+}
+
+await Promise.all( finalTasks );
+console.log( 'Success!' );
+
+async function tagBuild( _changedApps ) {
+	const tags = _changedApps.map( ( app ) => `${ app.slug }-release-build` );
+
+	const tagurl = `https://teamcity.a8c.com/httpAuth/app/rest/builds/id:${ process.env.build_id }/tags/`;
+	console.info( `Adding tags (${ tags }) to current build at URL ${ tagurl }` );
+
+	const jsonTags = JSON.stringify( {
+		count: tags.length,
+		tag: tags.map( ( tag ) => ( {
+			name: tag,
+		} ) ),
+	} );
+
+	const res = await fetch( tagurl, {
+		method: 'POST',
+		headers: new Headers( {
+			'Content-Type': 'application/json',
+			Authorization: `Basic ${ Buffer.from( process.env.tc_auth ).toString( 'base64' ) }`,
+		} ),
+		body: jsonTags,
+	} );
+	if ( res.status !== 200 ) {
+		console.error( 'Tagging the build failed!' );
+	}
+}
+
+async function addGitHubComment( _changedApps ) {
+	const notifyApps = _changedApps.filter( ( { ghNotify = true } ) => ghNotify );
+
+	const commentWatermark = 'calypso-app-artifacts';
+	const ghCommentCmd = `./bin/add-pr-comment.sh ${ process.env.git_branch } ${ commentWatermark }`;
+
+	if ( ! notifyApps.length ) {
+		console.info( 'No apps to notify about. Deleting existing comment if exists.' );
+		// Delete the existing comment, since there are no apps to notify about.
+		return await exec( `${ ghCommentCmd } delete <<< "" || true`, {
+			encoding: 'UTF-8',
+			stdio: 'inherit',
+		} );
+	}
+
+	const header = '**This PR modifies the release build for the following Calypso Apps:**';
+	const docsMsg = '_For info about this notification, see here: PCYsg-OT6-p2_';
+	const changedAppsMsg = notifyApps.map( ( { slug } ) => `* ${ slug }` ).join( '\n' );
+	const testMsg = `To test WordPress.com changes, run "install-plugin.sh $pluginSlug ${ process.env.git_branch }" on your sandbox.`;
+
+	const appMsg = `${ header }\n\n${ docsMsg }\n\n${ changedAppsMsg }\n\n${ testMsg }`;
+
+	await exec( `${ ghCommentCmd } <<- EOF || true\n${ appMsg }\nEOF`, {
+		encoding: 'UTF-8',
+	} );
+}
+
+async function sendSlackNotification( _changedApps ) {
+	const notifyApps = _changedApps.filter( ( { slackNotify = false } ) => slackNotify );
+
+	if ( ! notifyApps.length ) {
+		console.info( 'No apps to notify about. Skipping Slack notification.' );
+		return;
+	}
+
+	// TODO: move from one to multiple plugins!
+	const body = `commit=${ process.env.commit_sha }&plugin=$pluginSlug`;
+
+	const signature = createHmac( 'sha256', process.env.mc_auth_secret )
+		.update( body )
+		.digest( 'hex' );
+
+	console.log( `Sending data to slack endpoint: ${ body }` );
+	const res = await fetch( `${ process.env.mc_post_root }?plugin-deploy-reminder`, {
+		method: 'POST',
+		headers: new Headers( {
+			'Content-Type': 'application/x-www-form-urlencoded',
+			'TEAMCITY-SIGNATURE': signature,
+		} ),
+		body,
+	} );
+	if ( res.status !== 200 ) {
+		console.error( 'Slack notification failed!' );
+		console.error( 'Details: ', await res.text() );
+	}
+}
+
+function checkEnvVars() {
+	const requiredVars = [
+		'tc_auth',
+		'git_branch',
+		'build_id',
+		'GH_TOKEN',
+		'is_default_branch',
+		'skip_build_diff',
+		'mc_auth_secret',
+		'commit_sha',
+		'mc_post_root',
+		'tc_sever_url',
+	];
+
+	// Undefined and empty strings will be detected.
+	const missingVars = requiredVars.filter( ( varName ) => ! process.env[ varName ] );
+	if ( missingVars.length > 0 ) {
+		console.error( `Missing required environment variables: ${ missingVars.join( ', ' ) }` );
+		process.exit( 1 );
+	}
+}


### PR DESCRIPTION
This PR creates an all-in-one Calypso app artifact processor. In the previous approach, with each app processed in an individual TeamCity build, the artifact process script only had to care about one app.

The major change here is to parallelize and combine in the following ways:

1. In parallel, download the artifact for each app and compare it to the release. This gives us a `Promise.all` over functions which return boolean, which in turn gives us a list of apps which are changing.
2. Update the tag logic to do multiple tags in a build, based on the changing apps.
3. Update the notification logic to handle multiple apps. Instead of one GH comment per app, we'll have one comment which lists the app. (The slack endpoint will ultimately have to be updated too, but it's currently unused.)

All of this is re-written in NodeJS to be (hopefully!) easier to read than bash script in kotlin string! It's also easier to manage data and parallelization.

I've tested the following parts:
1. Does it detect a changing app vs previous tagged build: ✅
2. Does it add and remove GH comment: ✅
3. Does it authenticate with the Slack endpoint: ✅
4. Does it add tags based on what changes: ✅

What's missing: the previous artifact processor added a build_meta.txt file. I'd like to deprecate that in favor of build_meta.json. Some builds generate that with webpack, but we need some way to get it in all builds.