### PR TITLE
Launchpad: Ensure Select Design task maintains flow

### DIFF
--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -53,7 +53,7 @@ const updateDesign: Flow = {
 							) }?redirect_to=${ returnUrl }&signup=1`
 						);
 					}
-					return navigate( `processing?siteSlug=${ siteSlug }` );
+					return navigate( `processing?siteSlug=${ siteSlug }&flowToReturnTo=${ flowToReturnTo }` );
 			}
 		}
 


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/73401

### Proposed Changes

We recently enabled the Select a Design task on Launchpad. Before this PR, if you click that task, select a design, and navigate back to Launchpad, the flow in the URL always gets updated to 'free' regardless of which flow you were in when you started. After this PR, you'll always be redirected back to launchpad inside the same flow you started with.

### Testing Instructions

**Review Time: Short**
**Testing Time: Short**

Testing: 
1. Checkout this branch and run yarn and yarn start if needed. 
2. Create a new free site starting at http://calypso.localhost:3000/setup/free/intro and navigate to Launchpad.
3. TEST FREE FLOW: Click `Select a Design`, choose a new design, navigate back to Launchpad, and confirm that the URL still shows you are in the free flow (ie, you should see .../setup/FREE/...). 
3. TEST BUILD FLOW: Update the flow in the URL from 'free' to 'build' (ie, .../setup/BUILD/...). Again, click `Select a Design`, choose a new design, navigate back to Launchpad, and confirm that the URL still shows you are in the build flow. 
4. TEST WRITE FLOW: Update the flow in the URL from 'build' to 'write' (ie, .../setup/WRITE/...). Again, click `Select a Design`, choose a new design, navigate back to Launchpad, and confirm that the URL still shows you are in the write flow. 

