### PR TITLE
Add/all jetpack product benefits in checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -313,11 +313,11 @@ function CheckoutSummaryFeaturesList( props: {
 	const plans = responseCart.products.filter( ( product ) => isPlan( product ) );
 	const hasPlanInCart = plans.length > 0;
 
-	const jetpackProducts = responseCart.products.filter( isJetpackProduct );
-	const hasJetpackProduct = jetpackProducts.length > 0;
+	const jetpackPlansAndProducts = responseCart.products.filter( ( product ) => {
+		return isJetpackProduct( product ) || isJetpackPlan( product );
+	} );
 
-	const jetpackPlans = responseCart.products.filter( isJetpackPlan );
-	const hasJetpackPlan = jetpackPlans.length > 0;
+	const hasJetpackProductOrPlan = jetpackPlansAndProducts.length > 0;
 
 	const hasSingleProduct = responseCart.products.length === 1;
 
@@ -332,10 +332,8 @@ function CheckoutSummaryFeaturesList( props: {
 					return <CheckoutSummaryFeaturesListDomainItem domain={ domain } key={ domain.uuid } />;
 				} ) }
 
-			{ hasSingleProduct && ( hasJetpackProduct || hasJetpackPlan ) && (
-				<CheckoutSummaryJetpackProductFeatures
-					product={ hasJetpackProduct ? jetpackProducts[ 0 ] : jetpackPlans[ 0 ] }
-				/>
+			{ hasSingleProduct && hasJetpackProductOrPlan && (
+				<CheckoutSummaryJetpackProductFeatures product={ jetpackPlansAndProducts[ 0 ] } />
 			) }
 
 			{ hasPlanInCart && (

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -12,6 +12,7 @@ import {
 	isWpComPlan,
 	isWpComPremiumPlan,
 	isJetpackProduct,
+	isJetpackPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import {
@@ -314,6 +315,10 @@ function CheckoutSummaryFeaturesList( props: {
 
 	const jetpackProducts = responseCart.products.filter( isJetpackProduct );
 	const hasJetpackProduct = jetpackProducts.length > 0;
+
+	const jetpackPlans = responseCart.products.filter( isJetpackPlan );
+	const hasJetpackPlan = jetpackPlans.length > 0;
+
 	const hasSingleProduct = responseCart.products.length === 1;
 
 	const translate = useTranslate();
@@ -327,8 +332,10 @@ function CheckoutSummaryFeaturesList( props: {
 					return <CheckoutSummaryFeaturesListDomainItem domain={ domain } key={ domain.uuid } />;
 				} ) }
 
-			{ hasSingleProduct && hasJetpackProduct && (
-				<CheckoutSummaryJetpackProductFeatures product={ jetpackProducts[ 0 ] } />
+			{ hasSingleProduct && ( hasJetpackProduct || hasJetpackPlan ) && (
+				<CheckoutSummaryJetpackProductFeatures
+					product={ hasJetpackProduct ? jetpackProducts[ 0 ] : jetpackPlans[ 0 ] }
+				/>
 			) }
 
 			{ hasPlanInCart && (

--- a/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
@@ -1,7 +1,10 @@
 import {
+	isJetpackAntiSpamSlug,
 	isJetpackBackupT1Slug,
+	isJetpackBoostSlug,
 	isJetpackScanSlug,
 	isJetpackSearchSlug,
+	isJetpackSecuritySlug,
 	isJetpackSocialBasicSlug,
 	isJetpackSocialAdvancedSlug,
 	isJetpackVideoPressSlug,
@@ -14,11 +17,25 @@ export default function getJetpackProductFeatures(
 	translate: ReturnType< typeof useTranslate >
 ): string[] {
 	const productFeatureStrings = {
+		antiSpam: [
+			translate( 'Comment and form spam protection' ),
+			translate( '10K API calls per month' ),
+			translate( 'Akismet technology' ),
+			translate( 'Flexible API' ),
+		],
 		backupT1: [
 			translate( 'Real-time cloud backups' ),
 			translate( '10GB of backup storage' ),
 			translate( '30-day archive & activity log' ),
 			translate( 'One-click restores' ),
+		],
+		boost: [
+			translate( 'Automated critical CSS' ),
+			translate( 'Site performance scores' ),
+			translate( 'One-click optimization' ),
+			translate( 'Deferred non-essential JavaScript' ),
+			translate( 'Optimized CSS loading' ),
+			translate( 'Lazy image loading' ),
 		],
 		scan: [
 			translate( 'Website firewall (WAF beta)' ),
@@ -34,10 +51,10 @@ export default function getJetpackProductFeatures(
 		],
 		socialBasic: [
 			translate( 'Automatically share your posts' ),
-			translate( 'Post to multiple channels at once' ),
-			translate( 'Schedule your posts' ),
-			translate( 'Share to Twitter, Facebook, LinkedIn, and Tumblr' ),
-			translate( 'Recycle content' ),
+			translate( 'Posting to multiple channels at once' ),
+			translate( 'Scheduled posts' ),
+			translate( 'Sharing to Twitter, Facebook, LinkedIn, and Tumblr' ),
+			translate( 'Content recycling' ),
 		],
 		socialAdvanced: [ translate( 'Engagement Optimizer' ) ],
 		support: [ translate( 'Priority support' ) ],
@@ -52,8 +69,16 @@ export default function getJetpackProductFeatures(
 		],
 	};
 
+	if ( isJetpackAntiSpamSlug( product.product_slug ) ) {
+		return productFeatureStrings.antiSpam;
+	}
+
 	if ( isJetpackBackupT1Slug( product.product_slug ) ) {
 		return [ ...productFeatureStrings.backupT1, ...productFeatureStrings.support ];
+	}
+
+	if ( isJetpackBoostSlug( product.product_slug ) ) {
+		return productFeatureStrings.boost;
 	}
 
 	if ( isJetpackScanSlug( product.product_slug ) ) {
@@ -62,6 +87,15 @@ export default function getJetpackProductFeatures(
 
 	if ( isJetpackSearchSlug( product.product_slug ) ) {
 		return productFeatureStrings.search;
+	}
+
+	if ( isJetpackSecuritySlug( product.product_slug ) ) {
+		return [
+			...productFeatureStrings.antiSpam,
+			...productFeatureStrings.backupT1,
+			...productFeatureStrings.scan,
+			...productFeatureStrings.support,
+		];
 	}
 
 	if ( isJetpackSocialBasicSlug( product.product_slug ) ) {

--- a/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
@@ -5,7 +5,7 @@ import {
 	isJetpackCompleteSlug,
 	isJetpackScanSlug,
 	isJetpackSearchSlug,
-	isJetpackSecuritySlug,
+	isJetpackSecurityT1Slug,
 	isJetpackSocialBasicSlug,
 	isJetpackSocialAdvancedSlug,
 	isJetpackVideoPressSlug,
@@ -142,7 +142,7 @@ export default function getJetpackProductFeatures(
 		return getFeatureStrings( 'search', translate );
 	}
 
-	if ( isJetpackSecuritySlug( product.product_slug ) ) {
+	if ( isJetpackSecurityT1Slug( product.product_slug ) ) {
 		// Filter out these strings for Security to avoid clutter
 		const securityExcludes = [
 			translate( '10K API calls per month' ),

--- a/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
@@ -12,102 +12,138 @@ import {
 import { useTranslate } from 'i18n-calypso';
 import type { WithSnakeCaseSlug } from '@automattic/calypso-products';
 
+type productString =
+	| 'anti-spam'
+	| 'backup-t1'
+	| 'boost'
+	| 'scan'
+	| 'search'
+	| 'social-basic'
+	| 'social-advanced'
+	| 'support'
+	| 'videopress';
+
+function getFeatureStrings(
+	feature: productString,
+	translate: ReturnType< typeof useTranslate >
+): string[] {
+	switch ( feature ) {
+		case 'anti-spam':
+			return [
+				translate( 'Comment and form spam protection' ),
+				translate( '10K API calls per month' ),
+				translate( 'Akismet technology' ),
+				translate( 'Flexible API' ),
+			];
+		case 'backup-t1':
+			return [
+				translate( 'Real-time cloud backups' ),
+				translate( '10GB of backup storage' ),
+				translate( '30-day archive & activity log' ),
+				translate( 'One-click restores' ),
+			];
+		case 'boost':
+			return [
+				translate( 'Automated critical CSS' ),
+				translate( 'Site performance scores' ),
+				translate( 'One-click optimization' ),
+				translate( 'Deferred non-essential JavaScript' ),
+				translate( 'Optimized CSS loading' ),
+				translate( 'Lazy image loading' ),
+			];
+		case 'scan':
+			return [
+				translate( 'Website firewall (WAF beta)' ),
+				translate( 'Automated daily scanning' ),
+				translate( 'One-click fixes for most issues' ),
+				translate( 'Instant email threat notifications' ),
+			];
+		case 'search':
+			return [
+				translate( 'Instant search, filtering, and indexing' ),
+				translate( 'Highly relevant search results' ),
+				translate( 'Quick and accurate spelling correction' ),
+				translate( 'Support for 38 languages' ),
+			];
+		case 'social-basic':
+			return [
+				translate( 'Automatically share your posts' ),
+				translate( 'Posting to multiple channels at once' ),
+				translate( 'Scheduled posts' ),
+				translate( 'Sharing to Twitter, Facebook, LinkedIn, and Tumblr' ),
+				translate( 'Content recycling' ),
+			];
+		case 'social-advanced':
+			return [ translate( 'Engagement Optimizer' ) ];
+		case 'support':
+			return [ translate( 'Priority support' ) ];
+		case 'videopress':
+			return [
+				translate( '1TB of cloud-hosted video' ),
+				translate( 'Customizable video player' ),
+				translate( 'Fast-motion video' ),
+				translate( 'Global CDN' ),
+				translate( 'Powerful and reliable hosting infrastructure' ),
+				translate( 'Video and story blocks' ),
+				translate( 'Unlimited logins for team members' ),
+			];
+		default:
+			return [];
+	}
+}
+
 export default function getJetpackProductFeatures(
 	product: WithSnakeCaseSlug,
 	translate: ReturnType< typeof useTranslate >
 ): string[] {
-	const productFeatureStrings = {
-		antiSpam: [
-			translate( 'Comment and form spam protection' ),
-			translate( '10K API calls per month' ),
-			translate( 'Akismet technology' ),
-			translate( 'Flexible API' ),
-		],
-		backupT1: [
-			translate( 'Real-time cloud backups' ),
-			translate( '10GB of backup storage' ),
-			translate( '30-day archive & activity log' ),
-			translate( 'One-click restores' ),
-		],
-		boost: [
-			translate( 'Automated critical CSS' ),
-			translate( 'Site performance scores' ),
-			translate( 'One-click optimization' ),
-			translate( 'Deferred non-essential JavaScript' ),
-			translate( 'Optimized CSS loading' ),
-			translate( 'Lazy image loading' ),
-		],
-		scan: [
-			translate( 'Website firewall (WAF beta)' ),
-			translate( 'Automated daily scanning' ),
-			translate( 'One-click fixes for most issues' ),
-			translate( 'Instant email threat notifications' ),
-		],
-		search: [
-			translate( 'Instant search, filtering, and indexing' ),
-			translate( 'Highly relevant search results' ),
-			translate( 'Quick and accurate spelling correction' ),
-			translate( 'Support for 38 languages' ),
-		],
-		socialBasic: [
-			translate( 'Automatically share your posts' ),
-			translate( 'Posting to multiple channels at once' ),
-			translate( 'Scheduled posts' ),
-			translate( 'Sharing to Twitter, Facebook, LinkedIn, and Tumblr' ),
-			translate( 'Content recycling' ),
-		],
-		socialAdvanced: [ translate( 'Engagement Optimizer' ) ],
-		support: [ translate( 'Priority support' ) ],
-		videopress: [
-			translate( '1TB of cloud-hosted video' ),
-			translate( 'Customizable video player' ),
-			translate( 'Fast-motion video' ),
-			translate( 'Global CDN' ),
-			translate( 'Powerful and reliable hosting infrastructure' ),
-			translate( 'Video and story blocks' ),
-			translate( 'Unlimited logins for team members' ),
-		],
-	};
-
 	if ( isJetpackAntiSpamSlug( product.product_slug ) ) {
-		return productFeatureStrings.antiSpam;
+		return getFeatureStrings( 'anti-spam', translate );
 	}
 
 	if ( isJetpackBackupT1Slug( product.product_slug ) ) {
-		return [ ...productFeatureStrings.backupT1, ...productFeatureStrings.support ];
+		return [
+			...getFeatureStrings( 'backup-t1', translate ),
+			...getFeatureStrings( 'support', translate ),
+		];
 	}
 
 	if ( isJetpackBoostSlug( product.product_slug ) ) {
-		return productFeatureStrings.boost;
+		return getFeatureStrings( 'boost', translate );
 	}
 
 	if ( isJetpackScanSlug( product.product_slug ) ) {
-		return [ ...productFeatureStrings.scan, ...productFeatureStrings.support ];
+		return [
+			...getFeatureStrings( 'scan', translate ),
+			...getFeatureStrings( 'support', translate ),
+		];
 	}
 
 	if ( isJetpackSearchSlug( product.product_slug ) ) {
-		return productFeatureStrings.search;
+		return getFeatureStrings( 'search', translate );
 	}
 
 	if ( isJetpackSecuritySlug( product.product_slug ) ) {
 		return [
-			...productFeatureStrings.antiSpam,
-			...productFeatureStrings.backupT1,
-			...productFeatureStrings.scan,
-			...productFeatureStrings.support,
+			...getFeatureStrings( 'anti-spam', translate ),
+			...getFeatureStrings( 'backup-t1', translate ),
+			...getFeatureStrings( 'scan', translate ),
+			...getFeatureStrings( 'support', translate ),
 		];
 	}
 
 	if ( isJetpackSocialBasicSlug( product.product_slug ) ) {
-		return productFeatureStrings.socialBasic;
+		return getFeatureStrings( 'social-basic', translate );
 	}
 
 	if ( isJetpackSocialAdvancedSlug( product.product_slug ) ) {
-		return [ ...productFeatureStrings.socialBasic, ...productFeatureStrings.socialAdvanced ];
+		return [
+			...getFeatureStrings( 'social-basic', translate ),
+			...getFeatureStrings( 'social-advanced', translate ),
+		];
 	}
 
 	if ( isJetpackVideoPressSlug( product.product_slug ) ) {
-		return productFeatureStrings.videopress;
+		return getFeatureStrings( 'videopress', translate );
 	}
 
 	return [];

--- a/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
@@ -1,5 +1,7 @@
 import {
 	isJetpackBackupT1Slug,
+	isJetpackScanSlug,
+	isJetpackSearchSlug,
 	isJetpackSocialBasicSlug,
 	isJetpackSocialAdvancedSlug,
 } from '@automattic/calypso-products';
@@ -17,6 +19,18 @@ export default function getJetpackProductFeatures(
 			translate( '30-day archive & activity log' ),
 			translate( 'One-click restores' ),
 		],
+		scan: [
+			translate( 'Website firewall (WAF beta)' ),
+			translate( 'Automated daily scanning' ),
+			translate( 'One-click fixes for most issues' ),
+			translate( 'Instant email threat notifications' ),
+		],
+		search: [
+			translate( 'Instant search, filtering, and indexing' ),
+			translate( 'Highly relevant search results' ),
+			translate( 'Quick and accurate spelling correction' ),
+			translate( 'Support for 38 languages' ),
+		],
 		socialBasic: [
 			translate( 'Automatically share your posts' ),
 			translate( 'Post to multiple channels at once' ),
@@ -30,6 +44,14 @@ export default function getJetpackProductFeatures(
 
 	if ( isJetpackBackupT1Slug( product.product_slug ) ) {
 		return [ ...productFeatureStrings.backupT1, ...productFeatureStrings.support ];
+	}
+
+	if ( isJetpackScanSlug( product.product_slug ) ) {
+		return [ ...productFeatureStrings.scan, ...productFeatureStrings.support ];
+	}
+
+	if ( isJetpackSearchSlug( product.product_slug ) ) {
+		return productFeatureStrings.search;
 	}
 
 	if ( isJetpackSocialBasicSlug( product.product_slug ) ) {

--- a/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
@@ -2,6 +2,7 @@ import {
 	isJetpackAntiSpamSlug,
 	isJetpackBackupT1Slug,
 	isJetpackBoostSlug,
+	isJetpackCompleteSlug,
 	isJetpackScanSlug,
 	isJetpackSearchSlug,
 	isJetpackSecuritySlug,
@@ -12,7 +13,7 @@ import {
 import { useTranslate } from 'i18n-calypso';
 import type { WithSnakeCaseSlug } from '@automattic/calypso-products';
 
-type productString =
+type featureString =
 	| 'anti-spam'
 	| 'backup-t1'
 	| 'boost'
@@ -21,10 +22,11 @@ type productString =
 	| 'social-basic'
 	| 'social-advanced'
 	| 'support'
-	| 'videopress';
+	| 'videopress'
+	| 'complete';
 
 function getFeatureStrings(
-	feature: productString,
+	feature: featureString,
 	translate: ReturnType< typeof useTranslate >
 ): string[] {
 	switch ( feature ) {
@@ -51,6 +53,17 @@ function getFeatureStrings(
 				translate( 'Optimized CSS loading' ),
 				translate( 'Lazy image loading' ),
 			];
+		case 'complete':
+			return [
+				translate( 'Akismet Anti-spam' ),
+				translate( 'VaultPress Backup' ),
+				translate( 'Site Search' ),
+				translate( 'Social' ),
+				translate( 'Scan' ),
+				translate( 'VideoPress' ),
+				translate( 'Boost' ),
+				translate( 'CRM Entrepreneur' ),
+			];
 		case 'scan':
 			return [
 				translate( 'Website firewall (WAF beta)' ),
@@ -65,6 +78,8 @@ function getFeatureStrings(
 				translate( 'Quick and accurate spelling correction' ),
 				translate( 'Support for 38 languages' ),
 			];
+		case 'social-advanced':
+			return [ translate( 'Engagement Optimizer' ) ];
 		case 'social-basic':
 			return [
 				translate( 'Automatically share your posts' ),
@@ -73,8 +88,6 @@ function getFeatureStrings(
 				translate( 'Sharing to Twitter, Facebook, LinkedIn, and Tumblr' ),
 				translate( 'Content recycling' ),
 			];
-		case 'social-advanced':
-			return [ translate( 'Engagement Optimizer' ) ];
 		case 'support':
 			return [ translate( 'Priority support' ) ];
 		case 'videopress':
@@ -111,6 +124,13 @@ export default function getJetpackProductFeatures(
 		return getFeatureStrings( 'boost', translate );
 	}
 
+	if ( isJetpackCompleteSlug( product.product_slug ) ) {
+		return [
+			...getFeatureStrings( 'complete', translate ),
+			...getFeatureStrings( 'support', translate ),
+		];
+	}
+
 	if ( isJetpackScanSlug( product.product_slug ) ) {
 		return [
 			...getFeatureStrings( 'scan', translate ),
@@ -123,12 +143,21 @@ export default function getJetpackProductFeatures(
 	}
 
 	if ( isJetpackSecuritySlug( product.product_slug ) ) {
+		// Filter out these strings for Security to avoid clutter
+		const securityExcludes = [
+			translate( '10K API calls per month' ),
+			translate( 'Akismet technology' ),
+			translate( 'Flexible API' ),
+		];
+
 		return [
 			...getFeatureStrings( 'anti-spam', translate ),
 			...getFeatureStrings( 'backup-t1', translate ),
 			...getFeatureStrings( 'scan', translate ),
 			...getFeatureStrings( 'support', translate ),
-		];
+		].filter( ( productFeature ) => {
+			return ! securityExcludes.includes( productFeature );
+		} );
 	}
 
 	if ( isJetpackSocialBasicSlug( product.product_slug ) ) {

--- a/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
@@ -1,4 +1,8 @@
-import { isJetpackBackupT1Slug } from '@automattic/calypso-products';
+import {
+	isJetpackBackupT1Slug,
+	isJetpackSocialBasicSlug,
+	isJetpackSocialAdvancedSlug,
+} from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import type { WithSnakeCaseSlug } from '@automattic/calypso-products';
 
@@ -6,14 +10,34 @@ export default function getJetpackProductFeatures(
 	product: WithSnakeCaseSlug,
 	translate: ReturnType< typeof useTranslate >
 ): string[] {
-	if ( isJetpackBackupT1Slug( product.product_slug ) ) {
-		return [
+	const productFeatureStrings = {
+		backupT1: [
 			translate( 'Real-time cloud backups' ),
 			translate( '10GB of backup storage' ),
 			translate( '30-day archive & activity log' ),
 			translate( 'One-click restores' ),
-			translate( 'Priority support' ),
-		];
+		],
+		socialBasic: [
+			translate( 'Automatically share your posts' ),
+			translate( 'Post to multiple channels at once' ),
+			translate( 'Schedule your posts' ),
+			translate( 'Share to Twitter, Facebook, LinkedIn, and Tumblr' ),
+			translate( 'Recycle content' ),
+		],
+		socialAdvanced: [ translate( 'Engagement Optimizer' ) ],
+		support: [ translate( 'Priority support' ) ],
+	};
+
+	if ( isJetpackBackupT1Slug( product.product_slug ) ) {
+		return [ ...productFeatureStrings.backupT1, ...productFeatureStrings.support ];
+	}
+
+	if ( isJetpackSocialBasicSlug( product.product_slug ) ) {
+		return productFeatureStrings.socialBasic;
+	}
+
+	if ( isJetpackSocialAdvancedSlug( product.product_slug ) ) {
+		return [ ...productFeatureStrings.socialBasic, ...productFeatureStrings.socialAdvanced ];
 	}
 
 	return [];

--- a/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
@@ -4,6 +4,7 @@ import {
 	isJetpackSearchSlug,
 	isJetpackSocialBasicSlug,
 	isJetpackSocialAdvancedSlug,
+	isJetpackVideoPressSlug,
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import type { WithSnakeCaseSlug } from '@automattic/calypso-products';
@@ -40,6 +41,15 @@ export default function getJetpackProductFeatures(
 		],
 		socialAdvanced: [ translate( 'Engagement Optimizer' ) ],
 		support: [ translate( 'Priority support' ) ],
+		videopress: [
+			translate( '1TB of cloud-hosted video' ),
+			translate( 'Customizable video player' ),
+			translate( 'Fast-motion video' ),
+			translate( 'Global CDN' ),
+			translate( 'Powerful and reliable hosting infrastructure' ),
+			translate( 'Video and story blocks' ),
+			translate( 'Unlimited logins for team members' ),
+		],
 	};
 
 	if ( isJetpackBackupT1Slug( product.product_slug ) ) {
@@ -60,6 +70,10 @@ export default function getJetpackProductFeatures(
 
 	if ( isJetpackSocialAdvancedSlug( product.product_slug ) ) {
 		return [ ...productFeatureStrings.socialBasic, ...productFeatureStrings.socialAdvanced ];
+	}
+
+	if ( isJetpackVideoPressSlug( product.product_slug ) ) {
+		return productFeatureStrings.videopress;
 	}
 
 	return [];

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -357,22 +357,94 @@ export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
 	};
 }
 
-export function convertProductSlugToResponseProduct( productSlug: string ) {
+export function convertProductSlugToResponseProduct( productSlug: string ): ResponseCartProduct {
 	switch ( productSlug ) {
+		case 'jetpack_anti_spam_monthly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2111,
+				product_name: 'Jetpack Akismet Anti-spam',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_anti_spam':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2110,
+				product_name: 'Jetpack Akismet Anti-spam',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
 		case 'jetpack_backup_t1_monthly':
 			return {
 				...getEmptyResponseCartProduct(),
-				product_id: 2100,
+				product_id: 2113,
 				product_name: 'Jetpack VaultPress Backup (10GB)',
-				product_slug: 'jetpack_backup_t1_monthly',
+				product_slug: productSlug,
 				currency: 'USD',
 			};
 		case 'jetpack_backup_t1_yearly':
 			return {
 				...getEmptyResponseCartProduct(),
-				product_id: 2100,
+				product_id: 2112,
 				product_name: 'Jetpack VaultPress Backup (10GB)',
-				product_slug: 'jetpack_backup_t1_yearly',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_backup_t2_monthly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2115,
+				product_name: 'Jetpack VaultPress Backup (1TB)',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_backup_t2_yearly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2114,
+				product_name: 'Jetpack VaultPress Backup (1TB)',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_boost_monthly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2400,
+				product_name: 'Jetpack Boost',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_boost_yearly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2401,
+				product_name: 'Jetpack Boost',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_complete_monthly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2015,
+				product_name: 'Jetpack Complete',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_complete':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2014,
+				product_name: 'Jetpack Complete',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_scan_monthly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2107,
+				product_name: 'Jetpack Scan',
+				product_slug: productSlug,
 				currency: 'USD',
 			};
 		case 'jetpack_scan':
@@ -380,7 +452,103 @@ export function convertProductSlugToResponseProduct( productSlug: string ) {
 				...getEmptyResponseCartProduct(),
 				product_id: 2106,
 				product_name: 'Jetpack Scan Daily',
-				product_slug: 'jetpack_scan',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_search_monthly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2105,
+				product_name: 'Jetpack Search',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_search':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2104,
+				product_name: 'Jetpack Search',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_security_t1_monthly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2017,
+				product_name: 'Jetpack Security T1',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_security_t1_yearly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2016,
+				product_name: 'Jetpack Security T1',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_security_t2_monthly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2020,
+				product_name: 'Jetpack Security T2',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_security_t2_yearly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2019,
+				product_name: 'Jetpack Security T2',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_social_basic_monthly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2504,
+				product_name: 'Jetpack Social Basic',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_social_basic_yearly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2503,
+				product_name: 'Jetpack Social Basic',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_social_advanced_monthly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2603,
+				product_name: 'Jetpack Social Advanced',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_social_advanced_yearly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2602,
+				product_name: 'Jetpack Social Advanced',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_videopress_monthly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2117,
+				product_name: 'Jetpack VideoPress',
+				product_slug: productSlug,
+				currency: 'USD',
+			};
+		case 'jetpack_videopress_yearly':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2116,
+				product_name: 'Jetpack VideoPress',
+				product_slug: productSlug,
 				currency: 'USD',
 			};
 		default:

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -365,6 +365,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2111,
 				product_name: 'Jetpack Akismet Anti-spam',
 				product_slug: productSlug,
+				bill_period: 'monthly',
 				currency: 'USD',
 			};
 		case 'jetpack_anti_spam':
@@ -373,6 +374,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2110,
 				product_name: 'Jetpack Akismet Anti-spam',
 				product_slug: productSlug,
+				bill_period: 'yearly',
 				currency: 'USD',
 			};
 		case 'jetpack_backup_t1_monthly':
@@ -381,6 +383,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2113,
 				product_name: 'Jetpack VaultPress Backup (10GB)',
 				product_slug: productSlug,
+				bill_period: 'monthly',
 				currency: 'USD',
 			};
 		case 'jetpack_backup_t1_yearly':
@@ -389,6 +392,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2112,
 				product_name: 'Jetpack VaultPress Backup (10GB)',
 				product_slug: productSlug,
+				bill_period: 'yearly',
 				currency: 'USD',
 			};
 		case 'jetpack_backup_t2_monthly':
@@ -397,6 +401,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2115,
 				product_name: 'Jetpack VaultPress Backup (1TB)',
 				product_slug: productSlug,
+				bill_period: 'monthly',
 				currency: 'USD',
 			};
 		case 'jetpack_backup_t2_yearly':
@@ -405,6 +410,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2114,
 				product_name: 'Jetpack VaultPress Backup (1TB)',
 				product_slug: productSlug,
+				bill_period: 'yearly',
 				currency: 'USD',
 			};
 		case 'jetpack_boost_monthly':
@@ -413,6 +419,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2400,
 				product_name: 'Jetpack Boost',
 				product_slug: productSlug,
+				bill_period: 'monthly',
 				currency: 'USD',
 			};
 		case 'jetpack_boost_yearly':
@@ -421,6 +428,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2401,
 				product_name: 'Jetpack Boost',
 				product_slug: productSlug,
+				bill_period: 'yearly',
 				currency: 'USD',
 			};
 		case 'jetpack_complete_monthly':
@@ -429,6 +437,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2015,
 				product_name: 'Jetpack Complete',
 				product_slug: productSlug,
+				bill_period: 'monthly',
 				currency: 'USD',
 			};
 		case 'jetpack_complete':
@@ -437,6 +446,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2014,
 				product_name: 'Jetpack Complete',
 				product_slug: productSlug,
+				bill_period: 'yearly',
 				currency: 'USD',
 			};
 		case 'jetpack_scan_monthly':
@@ -445,6 +455,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2107,
 				product_name: 'Jetpack Scan',
 				product_slug: productSlug,
+				bill_period: 'monthly',
 				currency: 'USD',
 			};
 		case 'jetpack_scan':
@@ -453,6 +464,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2106,
 				product_name: 'Jetpack Scan Daily',
 				product_slug: productSlug,
+				bill_period: 'yearly',
 				currency: 'USD',
 			};
 		case 'jetpack_search_monthly':
@@ -461,6 +473,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2105,
 				product_name: 'Jetpack Search',
 				product_slug: productSlug,
+				bill_period: 'monthly',
 				currency: 'USD',
 			};
 		case 'jetpack_search':
@@ -469,6 +482,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2104,
 				product_name: 'Jetpack Search',
 				product_slug: productSlug,
+				bill_period: 'yearly',
 				currency: 'USD',
 			};
 		case 'jetpack_security_t1_monthly':
@@ -477,6 +491,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2017,
 				product_name: 'Jetpack Security T1',
 				product_slug: productSlug,
+				bill_period: 'monthly',
 				currency: 'USD',
 			};
 		case 'jetpack_security_t1_yearly':
@@ -485,6 +500,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2016,
 				product_name: 'Jetpack Security T1',
 				product_slug: productSlug,
+				bill_period: 'yearly',
 				currency: 'USD',
 			};
 		case 'jetpack_security_t2_monthly':
@@ -493,6 +509,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2020,
 				product_name: 'Jetpack Security T2',
 				product_slug: productSlug,
+				bill_period: 'monthly',
 				currency: 'USD',
 			};
 		case 'jetpack_security_t2_yearly':
@@ -501,6 +518,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2019,
 				product_name: 'Jetpack Security T2',
 				product_slug: productSlug,
+				bill_period: 'yearly',
 				currency: 'USD',
 			};
 		case 'jetpack_social_basic_monthly':
@@ -509,6 +527,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2504,
 				product_name: 'Jetpack Social Basic',
 				product_slug: productSlug,
+				bill_period: 'monthly',
 				currency: 'USD',
 			};
 		case 'jetpack_social_basic_yearly':
@@ -517,6 +536,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2503,
 				product_name: 'Jetpack Social Basic',
 				product_slug: productSlug,
+				bill_period: 'yearly',
 				currency: 'USD',
 			};
 		case 'jetpack_social_advanced_monthly':
@@ -525,6 +545,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2603,
 				product_name: 'Jetpack Social Advanced',
 				product_slug: productSlug,
+				bill_period: 'monthly',
 				currency: 'USD',
 			};
 		case 'jetpack_social_advanced_yearly':
@@ -533,6 +554,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2602,
 				product_name: 'Jetpack Social Advanced',
 				product_slug: productSlug,
+				bill_period: 'yearly',
 				currency: 'USD',
 			};
 		case 'jetpack_videopress_monthly':
@@ -541,6 +563,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2117,
 				product_name: 'Jetpack VideoPress',
 				product_slug: productSlug,
+				bill_period: 'monthly',
 				currency: 'USD',
 			};
 		case 'jetpack_videopress_yearly':
@@ -549,6 +572,7 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				product_id: 2116,
 				product_name: 'Jetpack VideoPress',
 				product_slug: productSlug,
+				bill_period: 'yearly',
 				currency: 'USD',
 			};
 		default:

--- a/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
@@ -89,6 +89,22 @@ const nonFeatureListProductMap = [
 	[ 'Security T2', 'yearly', PLAN_JETPACK_SECURITY_T2_YEARLY ],
 ];
 
+const allProducts = productMap.reduce( ( productList: ResponseCartProduct[], currentProduct ) => {
+	productList.push( convertProductSlugToResponseProduct( currentProduct[ 2 ] ) );
+	return productList;
+}, [] );
+
+// Converting to Set to remove duplicate strings to avoid unnecessary loops
+const allFeatures = new Set(
+	allProducts.reduce( ( featureList: string[], currentProduct ) => {
+		const currentProductFeatures = getJetpackProductFeatures(
+			currentProduct,
+			identity as translateType
+		);
+		return [ ...featureList, ...currentProductFeatures ];
+	}, [] )
+);
+
 describe( 'WPCheckoutOrderSummary', () => {
 	let container: HTMLDivElement | null;
 	let MyCheckoutSummary: FC< { cartChanges: Partial< ResponseCart > } >;
@@ -170,25 +186,6 @@ describe( 'WPCheckoutOrderSummary', () => {
 		} );
 
 		test( 'No feature list items show up if there are multiple items in the cart', async () => {
-			const allProducts = productMap.reduce(
-				( productList: ResponseCartProduct[], currentProduct ) => {
-					productList.push( convertProductSlugToResponseProduct( currentProduct[ 2 ] ) );
-					return productList;
-				},
-				[]
-			);
-
-			// Converting to Set to remove duplicate strings to avoid unnecessary loops
-			const allFeatures = new Set(
-				allProducts.reduce( ( featureList: string[], currentProduct ) => {
-					const currentProductFeatures = getJetpackProductFeatures(
-						currentProduct,
-						identity as translateType
-					);
-					return [ ...featureList, ...currentProductFeatures ];
-				}, [] )
-			);
-
 			const cartChanges = {
 				products: allProducts,
 			};
@@ -203,25 +200,6 @@ describe( 'WPCheckoutOrderSummary', () => {
 		} );
 
 		test( 'No feature list items show up if the cart is empty', async () => {
-			const allProducts = productMap.reduce(
-				( productList: ResponseCartProduct[], currentProduct ) => {
-					productList.push( convertProductSlugToResponseProduct( currentProduct[ 2 ] ) );
-					return productList;
-				},
-				[]
-			);
-
-			// Converting to Set to remove duplicate strings to avoid unnecessary loops
-			const allFeatures = new Set(
-				allProducts.reduce( ( featureList: string[], currentProduct ) => {
-					const currentProductFeatures = getJetpackProductFeatures(
-						currentProduct,
-						identity as translateType
-					);
-					return [ ...featureList, ...currentProductFeatures ];
-				}, [] )
-			);
-
 			const cartChanges = { products: [] };
 
 			render( <MyCheckoutSummary cartChanges={ cartChanges } /> );

--- a/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
@@ -48,14 +48,16 @@ import {
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 import type { FC } from 'react';
 
+type translateType = ReturnType< typeof useTranslate >;
+
+const identity = ( x: string ) => x;
+
 const mockConfig = config as unknown as { isEnabled: jest.Mock };
 jest.mock( '@automattic/calypso-config', () => {
 	const mock = () => '';
 	mock.isEnabled = jest.fn();
 	return mock;
 } );
-
-const identity = ( x: string ) => x;
 
 const productMap = [
 	[ 'Akismet Anti-spam', 'monthly', PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ],
@@ -140,10 +142,7 @@ describe( 'WPCheckoutOrderSummary', () => {
 
 			test( `${ productName } feature list shows up if ${ productName } ${ billingTerm } is in the cart`, async () => {
 				const product = convertProductSlugToResponseProduct( productSlug );
-				const productFeatures = getJetpackProductFeatures(
-					product,
-					identity as ReturnType< typeof useTranslate >
-				);
+				const productFeatures = getJetpackProductFeatures( product, identity as translateType );
 				const cartChanges = {
 					products: [ product ],
 				};
@@ -164,10 +163,7 @@ describe( 'WPCheckoutOrderSummary', () => {
 
 			test( `Deprecated T2 plan ${ productName } ${ billingTerm } does not show feature list`, async () => {
 				const product = convertProductSlugToResponseProduct( productSlug );
-				const productFeatures = getJetpackProductFeatures(
-					product,
-					identity as ReturnType< typeof useTranslate >
-				);
+				const productFeatures = getJetpackProductFeatures( product, identity as translateType );
 
 				expect( productFeatures.length ).toEqual( 0 );
 			} );
@@ -187,7 +183,7 @@ describe( 'WPCheckoutOrderSummary', () => {
 				allProducts.reduce( ( featureList: string[], currentProduct ) => {
 					const currentProductFeatures = getJetpackProductFeatures(
 						currentProduct,
-						identity as ReturnType< typeof useTranslate >
+						identity as translateType
 					);
 					return [ ...featureList, ...currentProductFeatures ];
 				}, [] )
@@ -220,7 +216,7 @@ describe( 'WPCheckoutOrderSummary', () => {
 				allProducts.reduce( ( featureList: string[], currentProduct ) => {
 					const currentProductFeatures = getJetpackProductFeatures(
 						currentProduct,
-						identity as ReturnType< typeof useTranslate >
+						identity as translateType
 					);
 					return [ ...featureList, ...currentProductFeatures ];
 				}, [] )

--- a/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
@@ -59,7 +59,7 @@ jest.mock( '@automattic/calypso-config', () => {
 	return mock;
 } );
 
-const productMap = [
+const productSlugs = [
 	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
 	PRODUCT_JETPACK_ANTI_SPAM,
 	PRODUCT_JETPACK_BACKUP_T1_MONTHLY,
@@ -82,19 +82,19 @@ const productMap = [
 	PRODUCT_JETPACK_VIDEOPRESS,
 ];
 
-const nonFeatureListProductMap = [
+const nonFeatureListProductSlugs = [
 	PRODUCT_JETPACK_BACKUP_T2_MONTHLY,
 	PRODUCT_JETPACK_BACKUP_T2_YEARLY,
 	PLAN_JETPACK_SECURITY_T2_MONTHLY,
 	PLAN_JETPACK_SECURITY_T2_YEARLY,
 ];
 
-const allProducts = productMap.reduce( ( productList: ResponseCartProduct[], currentProduct ) => {
+const allProducts = productSlugs.reduce( ( productList: ResponseCartProduct[], currentProduct ) => {
 	productList.push( convertProductSlugToResponseProduct( currentProduct ) );
 	return productList;
 }, [] );
 
-const allNonFeatureListProducts = nonFeatureListProductMap.reduce(
+const allNonFeatureListProducts = nonFeatureListProductSlugs.reduce(
 	( productList: ResponseCartProduct[], currentProduct ) => {
 		productList.push( convertProductSlugToResponseProduct( currentProduct ) );
 		return productList;

--- a/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
@@ -45,7 +45,7 @@ import {
 	getBasicCart,
 	convertProductSlugToResponseProduct,
 } from './util';
-import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
+import type { ResponseCart } from '@automattic/shopping-cart';
 import type { FC } from 'react';
 
 type translateType = ReturnType< typeof useTranslate >;
@@ -89,18 +89,12 @@ const nonFeatureListProductSlugs = [
 	PLAN_JETPACK_SECURITY_T2_YEARLY,
 ];
 
-const allProducts = productSlugs.reduce( ( productList: ResponseCartProduct[], currentProduct ) => {
-	productList.push( convertProductSlugToResponseProduct( currentProduct ) );
-	return productList;
-}, [] );
-
-const allNonFeatureListProducts = nonFeatureListProductSlugs.reduce(
-	( productList: ResponseCartProduct[], currentProduct ) => {
-		productList.push( convertProductSlugToResponseProduct( currentProduct ) );
-		return productList;
-	},
-	[]
-);
+const allProducts = productSlugs.map( ( currentProduct ) => {
+	return convertProductSlugToResponseProduct( currentProduct );
+} );
+const allNonFeatureListProducts = nonFeatureListProductSlugs.map( ( currentProduct ) => {
+	return convertProductSlugToResponseProduct( currentProduct );
+} );
 
 // Converting to Set to remove duplicate strings to avoid unnecessary loops
 const allFeatures = new Set(

--- a/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/wp-checkout-order-summary.tsx
@@ -60,39 +60,47 @@ jest.mock( '@automattic/calypso-config', () => {
 } );
 
 const productMap = [
-	[ 'Akismet Anti-spam', 'monthly', PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ],
-	[ 'Akismet Anti-spam', 'yearly', PRODUCT_JETPACK_ANTI_SPAM ],
-	[ 'VaultPress Backup T1', 'monthly', PRODUCT_JETPACK_BACKUP_T1_MONTHLY ],
-	[ 'VaultPress Backup T1', 'yearly', PRODUCT_JETPACK_BACKUP_T1_YEARLY ],
-	[ 'Boost', 'yearly', PRODUCT_JETPACK_BOOST_MONTHLY ],
-	[ 'Boost', 'monthly', PRODUCT_JETPACK_BOOST ],
-	[ 'Complete', 'monthly', PLAN_JETPACK_COMPLETE_MONTHLY ],
-	[ 'Complete', 'yearly', PLAN_JETPACK_COMPLETE ],
-	[ 'Scan', 'monthly', PRODUCT_JETPACK_SCAN_MONTHLY ],
-	[ 'Scan', 'yearly', PRODUCT_JETPACK_SCAN ],
-	[ 'Search', 'monthly', PRODUCT_JETPACK_SEARCH_MONTHLY ],
-	[ 'Search', 'yearly', PRODUCT_JETPACK_SEARCH ],
-	[ 'Security T1', 'monthly', PLAN_JETPACK_SECURITY_T1_MONTHLY ],
-	[ 'Security T1', 'yearly', PLAN_JETPACK_SECURITY_T1_YEARLY ],
-	[ 'Social Basic', 'monthly', PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY ],
-	[ 'Social Basic', 'yearly', PRODUCT_JETPACK_SOCIAL_BASIC ],
-	[ 'Social Advanced', 'monthly', PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY ],
-	[ 'Social Advanced', 'yearly', PRODUCT_JETPACK_SOCIAL_ADVANCED ],
-	[ 'VideoPress', 'monthly', PRODUCT_JETPACK_VIDEOPRESS_MONTHLY ],
-	[ 'VideoPress', 'yearly', PRODUCT_JETPACK_VIDEOPRESS ],
+	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
+	PRODUCT_JETPACK_ANTI_SPAM,
+	PRODUCT_JETPACK_BACKUP_T1_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_T1_YEARLY,
+	PRODUCT_JETPACK_BOOST_MONTHLY,
+	PRODUCT_JETPACK_BOOST,
+	PLAN_JETPACK_COMPLETE_MONTHLY,
+	PLAN_JETPACK_COMPLETE,
+	PRODUCT_JETPACK_SCAN_MONTHLY,
+	PRODUCT_JETPACK_SCAN,
+	PRODUCT_JETPACK_SEARCH_MONTHLY,
+	PRODUCT_JETPACK_SEARCH,
+	PLAN_JETPACK_SECURITY_T1_MONTHLY,
+	PLAN_JETPACK_SECURITY_T1_YEARLY,
+	PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY,
+	PRODUCT_JETPACK_SOCIAL_BASIC,
+	PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY,
+	PRODUCT_JETPACK_SOCIAL_ADVANCED,
+	PRODUCT_JETPACK_VIDEOPRESS_MONTHLY,
+	PRODUCT_JETPACK_VIDEOPRESS,
 ];
 
 const nonFeatureListProductMap = [
-	[ 'Backup T2', 'monthly', PRODUCT_JETPACK_BACKUP_T2_MONTHLY ],
-	[ 'Backup T2', 'yearly', PRODUCT_JETPACK_BACKUP_T2_YEARLY ],
-	[ 'Security T2', 'monthly', PLAN_JETPACK_SECURITY_T2_MONTHLY ],
-	[ 'Security T2', 'yearly', PLAN_JETPACK_SECURITY_T2_YEARLY ],
+	PRODUCT_JETPACK_BACKUP_T2_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_T2_YEARLY,
+	PLAN_JETPACK_SECURITY_T2_MONTHLY,
+	PLAN_JETPACK_SECURITY_T2_YEARLY,
 ];
 
 const allProducts = productMap.reduce( ( productList: ResponseCartProduct[], currentProduct ) => {
-	productList.push( convertProductSlugToResponseProduct( currentProduct[ 2 ] ) );
+	productList.push( convertProductSlugToResponseProduct( currentProduct ) );
 	return productList;
 }, [] );
+
+const allNonFeatureListProducts = nonFeatureListProductMap.reduce(
+	( productList: ResponseCartProduct[], currentProduct ) => {
+		productList.push( convertProductSlugToResponseProduct( currentProduct ) );
+		return productList;
+	},
+	[]
+);
 
 // Converting to Set to remove duplicate strings to avoid unnecessary loops
 const allFeatures = new Set(
@@ -153,11 +161,11 @@ describe( 'WPCheckoutOrderSummary', () => {
 
 	describe( 'CheckoutSummaryJetpackProductFeatures', () => {
 		// Loop through adding all products to cart, and ensuring their respective feature lists are shown
-		productMap.forEach( ( product ) => {
-			const [ productName, billingTerm, productSlug ] = product;
+		allProducts.forEach( ( product ) => {
+			const { product_name, bill_period, product_slug } = product;
 
-			test( `${ productName } feature list shows up if ${ productName } ${ billingTerm } is in the cart`, async () => {
-				const product = convertProductSlugToResponseProduct( productSlug );
+			test( `${ product_name } feature list shows up if ${ product_name } ${ bill_period } is in the cart`, async () => {
+				const product = convertProductSlugToResponseProduct( product_slug );
 				const productFeatures = getJetpackProductFeatures( product, identity as translateType );
 				const cartChanges = {
 					products: [ product ],
@@ -174,11 +182,11 @@ describe( 'WPCheckoutOrderSummary', () => {
 		} );
 
 		// Ensure deprecated Security T2 and Backup T2 plans do not show a feature list
-		nonFeatureListProductMap.forEach( ( product ) => {
-			const [ productName, billingTerm, productSlug ] = product;
+		allNonFeatureListProducts.forEach( ( product ) => {
+			const { product_name, bill_period, product_slug } = product;
 
-			test( `Deprecated T2 plan ${ productName } ${ billingTerm } does not show feature list`, async () => {
-				const product = convertProductSlugToResponseProduct( productSlug );
+			test( `Deprecated T2 plan ${ product_name } ${ bill_period } does not show feature list`, async () => {
+				const product = convertProductSlugToResponseProduct( product_slug );
 				const productFeatures = getJetpackProductFeatures( product, identity as translateType );
 
 				expect( productFeatures.length ).toEqual( 0 );

--- a/packages/calypso-products/src/is-jetpack-complete-slug.ts
+++ b/packages/calypso-products/src/is-jetpack-complete-slug.ts
@@ -1,0 +1,5 @@
+import { JETPACK_COMPLETE_PLANS } from './constants';
+
+export function isJetpackCompleteSlug( productSlug: string ): boolean {
+	return ( JETPACK_COMPLETE_PLANS as ReadonlyArray< string > ).includes( productSlug );
+}

--- a/packages/calypso-products/src/is-jetpack-security-t1-slug.ts
+++ b/packages/calypso-products/src/is-jetpack-security-t1-slug.ts
@@ -1,0 +1,5 @@
+import { JETPACK_SECURITY_T1_PLANS } from './constants';
+
+export function isJetpackSecurityT1Slug( productSlug: string ): boolean {
+	return ( JETPACK_SECURITY_T1_PLANS as ReadonlyArray< string > ).includes( productSlug );
+}

--- a/packages/calypso-products/src/is-jetpack-social-advanced-slug.ts
+++ b/packages/calypso-products/src/is-jetpack-social-advanced-slug.ts
@@ -1,0 +1,5 @@
+import { JETPACK_SOCIAL_ADVANCED_PRODUCTS } from './constants';
+
+export function isJetpackSocialAdvancedSlug( productSlug: string ) {
+	return ( JETPACK_SOCIAL_ADVANCED_PRODUCTS as ReadonlyArray< string > ).includes( productSlug );
+}

--- a/packages/calypso-products/src/is-jetpack-social-basic-slug.ts
+++ b/packages/calypso-products/src/is-jetpack-social-basic-slug.ts
@@ -1,0 +1,5 @@
+import { JETPACK_SOCIAL_BASIC_PRODUCTS } from './constants';
+
+export function isJetpackSocialBasicSlug( productSlug: string ) {
+	return ( JETPACK_SOCIAL_BASIC_PRODUCTS as ReadonlyArray< string > ).includes( productSlug );
+}

--- a/packages/calypso-products/src/is-jetpack-videopress-slug.ts
+++ b/packages/calypso-products/src/is-jetpack-videopress-slug.ts
@@ -1,0 +1,5 @@
+import { JETPACK_VIDEOPRESS_PRODUCTS } from './constants';
+
+export function isJetpackVideoPressSlug( productSlug: string ): boolean {
+	return ( JETPACK_VIDEOPRESS_PRODUCTS as ReadonlyArray< string > ).includes( productSlug );
+}

--- a/packages/calypso-products/src/is-jetpack-videopress.ts
+++ b/packages/calypso-products/src/is-jetpack-videopress.ts
@@ -1,8 +1,7 @@
 import { camelOrSnakeSlug } from './camel-or-snake-slug';
-import { JETPACK_VIDEOPRESS_PRODUCTS } from './constants';
+import { isJetpackVideoPressSlug } from './is-jetpack-videopress-slug';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
 export function isJetpackVideoPress( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
-	const products = JETPACK_VIDEOPRESS_PRODUCTS as ReadonlyArray< string >;
-	return products.includes( camelOrSnakeSlug( product ) );
+	return isJetpackVideoPressSlug( camelOrSnakeSlug( product ) );
 }

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -74,6 +74,8 @@ export { isJetpackScanSlug } from './is-jetpack-scan-slug';
 export { isJetpackSearch } from './is-jetpack-search';
 export { isJetpackSearchSlug } from './is-jetpack-search-slug';
 export { isJetpackSearchFree } from './is-jetpack-search-free';
+export { isJetpackSocialAdvancedSlug } from './is-jetpack-social-advanced-slug';
+export { isJetpackSocialBasicSlug } from './is-jetpack-social-basic-slug';
 export { isJetpackVideoPress } from './is-jetpack-videopress';
 export { isJetpackBoostSlug } from './is-jetpack-boost-slug';
 export { default as isJetpackLegacyItem } from './is-jetpack-legacy-item';

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -95,6 +95,7 @@ export { isSecurityRealTime } from './is-security-realtime';
 export { isSecurityT1 } from './is-security-t1';
 export { isSecurityT2 } from './is-security-t2';
 export { isJetpackSecuritySlug } from './is-jetpack-security-slug';
+export { isJetpackSecurityT1Slug } from './is-jetpack-security-t1-slug';
 export { isThemePurchase } from './is-theme-purchase';
 export { isTitanMail } from './is-titan-mail';
 export { isTitanMailMonthly } from './is-titan-mail-monthly';

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -78,6 +78,7 @@ export { isJetpackSocialAdvancedSlug } from './is-jetpack-social-advanced-slug';
 export { isJetpackSocialBasicSlug } from './is-jetpack-social-basic-slug';
 export { isJetpackVideoPress } from './is-jetpack-videopress';
 export { isJetpackBoostSlug } from './is-jetpack-boost-slug';
+export { isJetpackVideoPressSlug } from './is-jetpack-videopress-slug';
 export { default as isJetpackLegacyItem } from './is-jetpack-legacy-item';
 export { default as isJetpackPurchasableItem } from './is-jetpack-purchasable-item';
 export * from './is-monthly';

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -64,6 +64,7 @@ export { isJetpackBackupSlug } from './is-jetpack-backup-slug';
 export { isJetpackBackupT1Slug } from './is-jetpack-backup-t1-slug';
 export { isJetpackBusiness } from './is-jetpack-business';
 export { isJetpackCloudProductSlug } from './is-jetpack-cloud-product-slug';
+export { isJetpackCompleteSlug } from './is-jetpack-complete-slug';
 export { isJetpackPlan } from './is-jetpack-plan';
 export { isJetpackPlanSlug } from './is-jetpack-plan-slug';
 export { isJetpackPremium } from './is-jetpack-premium';


### PR DESCRIPTION
Adds a product features list to checkout for all Jetpack products when a single product is in the cart. No list will show if there are more than one item in the cart

NOTE: These lists were pulled from the pricing page and edited slightly to fit the context. For the Security bundles, a few items were removed to make the list shorter and make sense, and for Complete, only the list of products is shown. For more context, see this post: pbNhbs-5vs-p2

Related to #

## Proposed Changes

* Add more product lists for the rest of the Jetpack products that will be shown in the order summary in checkout
* Update tests to be more dynamic

## Testing Instructions

1. Check out these changes
2. Start your local environment with `yarn start`
3. Go to http://calypso.localhost:3000/checkout/jetpack/jetpack_boost_monthly and ensure the product feature list shows up
4. Go to http://calypso.localhost:3000/checkout/jetpack/jetpack_backup_t2_yearly and ensure the product feature list does NOT show up
5. Try out some other products with the URL format of http://calypso.localhost:3000/checkout/jetpack/{product_slug}. I'd recommending also checking out `jetpack_complete` and `jetpack_security_t1_yearly` (or monthly, idc). See the reference below for the product slugs
6. Make sure new tests are passing, and that they make sense as far as what to test

NOTE: No feature list should show if multiple products are in the cart

Product slugs that should show a feature list in the order summary:

* jetpack_boost_yearly
* jetpack_boost_monthly
* jetpack_backup_t1_yearly
* jetpack_backup_t1_monthly
* jetpack_scan
* jetpack_scan_monthly
* jetpack_anti_spam
* jetpack_anti_spam_monthly
* jetpack_search
* jetpack_search_monthly
* jetpack_videopress
* jetpack_videopress_monthly
* jetpack_social_basic_yearly
* jetpack_social_basic_monthly
* jetpack_social_advanced_yearly
* jetpack_social_advanced_monthly
* jetpack_security_t1_yearly
* jetpack_security_t1_monthly
* jetpack_complete
* jetpack_complete_monthly

Product slugs that should NOT show a feature list in the order summary

* jetpack_backup_t2_yearly
* jetpack_backup_t2_monthly
* jetpack_security_t2_yearly
* jetpack_security_t2_monthly
* Anything else

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?