### PR TITLE
Flaky E2E: avoid using the sidebar to insert Paragraph and Image blocks in certain specs.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -304,11 +304,14 @@ export class EditorPage {
 	 */
 	async addBlockFromSidebar(
 		blockName: string,
-		blockEditorSelector: string
+		blockEditorSelector: string,
+		{ noSearch }: { noSearch?: boolean } = {}
 	): Promise< ElementHandle > {
 		await this.editorGutenbergComponent.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
-		await this.addBlockFromInserter( blockName, this.editorSidebarBlockInserterComponent );
+		await this.addBlockFromInserter( blockName, this.editorSidebarBlockInserterComponent, {
+			noSearch: noSearch,
+		} );
 
 		const blockHandle = await this.editorGutenbergComponent.getSelectedBlockElementHandle(
 			blockEditorSelector
@@ -377,9 +380,12 @@ export class EditorPage {
 	 */
 	private async addBlockFromInserter(
 		blockName: string,
-		inserter: BlockInserter
+		inserter: BlockInserter,
+		{ noSearch }: { noSearch?: boolean } = {}
 	): Promise< void > {
-		await inserter.searchBlockInserter( blockName );
+		if ( ! noSearch ) {
+			await inserter.searchBlockInserter( blockName );
+		}
 		await inserter.selectBlockInserterResult( blockName );
 	}
 

--- a/test/e2e/specs/blocks/blocks__media.ts
+++ b/test/e2e/specs/blocks/blocks__media.ts
@@ -63,7 +63,8 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		it( `${ ImageBlock.blockName } block: upload image file with reserved URL characters`, async function () {
 			const blockHandle = await editorPage.addBlockFromSidebar(
 				ImageBlock.blockName,
-				ImageBlock.blockEditorSelector
+				ImageBlock.blockEditorSelector,
+				{ noSearch: true }
 			);
 			const imageBlock = new ImageBlock( blockHandle );
 			await imageBlock.upload( testFiles.imageReservedName.fullpath );
@@ -72,7 +73,8 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		it( `${ ImageBlock.blockName } block: upload image file using Calypso media modal `, async function () {
 			const blockHandle = await editorPage.addBlockFromSidebar(
 				ImageBlock.blockName,
-				ImageBlock.blockEditorSelector
+				ImageBlock.blockEditorSelector,
+				{ noSearch: true }
 			);
 			const imageBlock = new ImageBlock( blockHandle );
 			await imageBlock.uploadThroughMediaLibrary( testFiles.image.fullpath );
@@ -81,7 +83,8 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		it( `${ AudioBlock.blockName } block: upload audio file`, async function () {
 			const blockHandle = await editorPage.addBlockFromSidebar(
 				AudioBlock.blockName,
-				AudioBlock.blockEditorSelector
+				AudioBlock.blockEditorSelector,
+				{ noSearch: true }
 			);
 			const audioBlock = new AudioBlock( blockHandle );
 			await audioBlock.upload( testFiles.audio.fullpath );
@@ -90,7 +93,8 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 		it( `${ FileBlock.blockName } block: upload audio file`, async function () {
 			const blockHandle = await editorPage.addBlockFromSidebar(
 				FileBlock.blockName,
-				FileBlock.blockEditorSelector
+				FileBlock.blockEditorSelector,
+				{ noSearch: true }
 			);
 			const fileBlock = new FileBlock( blockHandle );
 			await fileBlock.upload( testFiles.audio.fullpath );

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -58,7 +58,8 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 		it( 'Enter post content', async function () {
 			const blockHandle = await editorPage.addBlockFromSidebar(
 				ParagraphBlock.blockName,
-				ParagraphBlock.blockEditorSelector
+				ParagraphBlock.blockEditorSelector,
+				{ noSearch: true }
 			);
 			paragraphBlock = new ParagraphBlock( blockHandle );
 			await paragraphBlock.enterParagraph( originalContent );
@@ -97,7 +98,8 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 		it( 'Append additional content', async function () {
 			const blockHandle = await editorPage.addBlockFromSidebar(
 				ParagraphBlock.blockName,
-				ParagraphBlock.blockEditorSelector
+				ParagraphBlock.blockEditorSelector,
+				{ noSearch: true }
 			);
 			paragraphBlock = new ParagraphBlock( blockHandle );
 			await paragraphBlock.enterParagraph( additionalContent );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72298

## Proposed Changes

This PR works around the pre-existing but exacerbated with Gutenberg 15.1.x issue of slow loading times for page templates, when the block inserter sidebar search is used.

For a demonstration of the issue, please see https://github.com/WordPress/gutenberg/pull/48085.

Key changes:
- add an optional param `noSearch` in order to not use the sidebar search to filter out blocks. This is to work around the slow loading of blocks and patterns caused by Gutenberg 15.1.x.
- update insertion of ParagraphBlock to bypass the search.

## Testing Instructions

Ensure the following build configurations are passing reliably. Trigger multiple times as required:
  - [ ] Gutenberg E2E (desktop)
  - [ ] Gutenberg E2E (mobile)
  - [ ] Calypso E2E (desktop)
  - [ ] Calypso E2E (mobile)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
