### PR TITLE
WIP: Enable reader pages for logged out users

### DIFF
--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -1,5 +1,5 @@
 import page from 'page';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'calypso/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 import { updateLastRoute, unmountSidebar, blogDiscoveryByFeedId } from 'calypso/reader/controller';
 import { blogPost, feedPost } from './controller';
 
@@ -8,7 +8,6 @@ export default function () {
 	page(
 		'/read/feeds/:feed/posts/:post',
 		blogDiscoveryByFeedId,
-		redirectLoggedOut,
 		updateLastRoute,
 		unmountSidebar,
 		feedPost,
@@ -19,7 +18,6 @@ export default function () {
 	// Blog full post
 	page(
 		'/read/blogs/:blog/posts/:post',
-		redirectLoggedOut,
 		updateLastRoute,
 		unmountSidebar,
 		blogPost,

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -62,7 +62,6 @@ export default async function () {
 		page(
 			'/read/feeds/:feed_id',
 			blogDiscoveryByFeedId,
-			redirectLoggedOut,
 			updateLastRoute,
 			prettyRedirects,
 			sidebar,
@@ -77,7 +76,6 @@ export default async function () {
 		page( '/read/blogs/:blog_id/posts', incompleteUrlRedirects );
 		page(
 			'/read/blogs/:blog_id',
-			redirectLoggedOut,
 			updateLastRoute,
 			prettyRedirects,
 			sidebar,

--- a/client/sections.js
+++ b/client/sections.js
@@ -354,6 +354,7 @@ const sections = [
 		paths: [ '/read/search', '/recommendations' ],
 		module: 'calypso/reader/search',
 		group: 'reader',
+		enableLoggedOut: true,
 		trackLoadPerformance: true,
 	},
 	{

--- a/client/sections.js
+++ b/client/sections.js
@@ -339,6 +339,7 @@ const sections = [
 		paths: [ '/tags', '/tag' ],
 		module: 'calypso/reader/tag-stream',
 		group: 'reader',
+		enableLoggedOut: true,
 		trackLoadPerformance: true,
 	},
 	{


### PR DESCRIPTION
A spike to see what would be required to make a public version of reader. Enables the tag, search, feed, and full post pages.

### Current issues
* We are currently working on design for the sidebar, most of the links are only suitable for logged in users
* Liking, commenting, following and other actions cause errors to be thrown.

### Discussion
#### Slack
p1676939188765189-slack-C03NLNTPZ2T, p1676939366551039-slack-C03NLNTPZ2T, p1676940274929589-slack-C03NLNTPZ2T

#### P2
pe7F0s-A6-p2

### Test instructions
as a logged out user start from /tag/dailyprompt or similar, view posts and also the search page.