### PR TITLE
Update tour events to include intent

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-intent/use-site-intent.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-intent/use-site-intent.js
@@ -2,17 +2,24 @@ import apiFetch from '@wordpress/api-fetch';
 import { useState, useEffect, useCallback } from '@wordpress/element';
 
 const useSiteIntent = () => {
-	const [ siteIntent, setSiteIntent ] = useState( '' );
+	const [ siteIntent, setSiteIntent ] = useState( undefined );
+	const [ siteIntentFetched, setSiteIntentFetched ] = useState( false );
 
 	const fetchSiteIntent = useCallback( () => {
 		apiFetch( { path: '/wpcom/v2/site-intent' } )
-			.then( ( result ) => setSiteIntent( result.site_intent ) )
-			.catch( () => setSiteIntent( '' ) );
+			.then( ( result ) => {
+				setSiteIntent( result.site_intent );
+				setSiteIntentFetched( true );
+			} )
+			.catch( () => {
+				setSiteIntent( undefined );
+				setSiteIntentFetched( true );
+			} );
 	}, [] );
 
 	useEffect( () => {
 		fetchSiteIntent();
 	}, [ fetchSiteIntent ] );
-	return siteIntent;
+	return { siteIntent, siteIntentFetched };
 };
 export default useSiteIntent;

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-intent/use-site-intent.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-intent/use-site-intent.js
@@ -1,6 +1,8 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useState, useEffect, useCallback } from '@wordpress/element';
 
+// FIXME: We can use `useSiteIntent` from `@automattic/data-stores` and remove this.
+// https://github.com/Automattic/wp-calypso/pull/73565#discussion_r1113839120
 const useSiteIntent = () => {
 	const [ siteIntent, setSiteIntent ] = useState( undefined );
 	const [ siteIntentFetched, setSiteIntentFetched ] = useState( false );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/seller-celebration-modal/index.jsx
@@ -103,7 +103,7 @@ const SellerCelebrationModalInner = () => {
 		};
 	} );
 
-	const intent = useSiteIntent();
+	const { siteIntent: intent } = useSiteIntent();
 
 	useEffect( () => {
 		if (
@@ -160,7 +160,7 @@ const SellerCelebrationModalInner = () => {
 };
 
 const SellerCelebrationModal = () => {
-	const intent = useSiteIntent();
+	const { siteIntent: intent } = useSiteIntent();
 	if ( intent === 'sell' ) {
 		return <SellerCelebrationModalInner />;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/index.jsx
@@ -47,7 +47,7 @@ const VideoCelebrationModalInner = () => {
 		};
 	} );
 
-	const intent = useSiteIntent();
+	const { siteIntent: intent } = useSiteIntent();
 
 	useEffect( () => {
 		const maybeRenderVideoCelebrationModal = async () => {
@@ -117,7 +117,7 @@ const VideoCelebrationModalInner = () => {
 };
 
 const VideoCelebrationModal = () => {
-	const intent = useSiteIntent();
+	const { siteIntent: intent } = useSiteIntent();
 	if ( 'videopress' === intent ) {
 		return <VideoCelebrationModalInner />;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -63,7 +63,8 @@ function getTourSteps(
 	localeSlug: string,
 	referencePositioning = false,
 	isSiteEditor = false,
-	themeName: string | null = null
+	themeName: string | null = null,
+	siteIntent: string | undefined
 ): WpcomStep[] {
 	const completedFlow = getQueryArg( window.location.href, 'completedFlow' );
 	const isVideoMaker = 'videomaker' === ( themeName ?? '' );
@@ -72,6 +73,7 @@ function getTourSteps(
 	const onSiteEditorCourseLinkClick = () => {
 		recordTracksEvent( 'calypso_editor_wpcom_tour_site_editor_course_link_click', {
 			is_pattern_assembler: isPatternAssemblerFlow,
+			intent: siteIntent,
 		} );
 	};
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -64,7 +64,7 @@ function getTourSteps(
 	referencePositioning = false,
 	isSiteEditor = false,
 	themeName: string | null = null,
-	siteIntent: string | undefined
+	siteIntent: string | undefined = undefined
 ): WpcomStep[] {
 	const completedFlow = getQueryArg( window.location.href, 'completedFlow' );
 	const isVideoMaker = 'videomaker' === ( themeName ?? '' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
Related to #

-->


## Proposed Changes

Update tour events in the editor to include `intent`.

Because there are future analyses we can do where we know a user interacts more with Tour in certain cases, in the case of write flow or using the Assembler.

Part of https://github.com/Automattic/wp-calypso/issues/73142

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/site-editor/<your-site>`
- Open `Welcome Guide`
- Verify events with [Tracks Vigilante Chrome Extension](https://github.com/Automattic/tracks-chrome-extension)

<img width="755" alt="Screen Shot 2023-02-22 at 10 38 47" src="https://user-images.githubusercontent.com/5287479/220499347-c633d19b-d577-44a0-ad62-0a29ca5379c2.png">
<img width="751" alt="Screen Shot 2023-02-22 at 10 39 05" src="https://user-images.githubusercontent.com/5287479/220499350-d68bd92b-a67b-40bd-80e7-4f88c4651d0b.png">
<img width="755" alt="Screen Shot 2023-02-22 at 10 39 37" src="https://user-images.githubusercontent.com/5287479/220499353-29caea61-3134-4d03-8de1-2cf462739507.png">
<img width="751" alt="Screen Shot 2023-02-22 at 10 39 44" src="https://user-images.githubusercontent.com/5287479/220499355-cd8abc92-8e59-4454-81f3-cd4465228e66.png">
<img width="757" alt="Screen Shot 2023-02-22 at 10 40 24" src="https://user-images.githubusercontent.com/5287479/220499362-61388a61-8300-44b7-b63e-95929a720ec5.png">
<img width="757" alt="Screen Shot 2023-02-22 at 10 40 48" src="https://user-images.githubusercontent.com/5287479/220499368-79f15dca-7e72-4c24-b660-a1b02088c5b7.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
	- No, but can be done with mocking `recordTracksEvent`
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
	- Tested on Simple site
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
