### PR TITLE
BackupRetention: Update link to retention setting page

### DIFF
--- a/client/components/backup-storage-space/hooks.tsx
+++ b/client/components/backup-storage-space/hooks.tsx
@@ -1,5 +1,8 @@
+import { Gridicon } from '@automattic/components';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { useMemo } from 'react';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { settingsPath } from 'calypso/lib/jetpack/paths';
 
 export enum StorageUnits {
 	Gigabyte = 2 ** 30,
@@ -96,16 +99,19 @@ export const useDaysOfBackupsSavedText = (
 			return null;
 		}
 
-		const daysOfBackupsSavedLinkTarget = `/activity-log/${ siteSlug }?group=rewind`;
+		const daysOfBackupsSavedLinkTarget = isJetpackCloud()
+			? settingsPath( siteSlug )
+			: `/activity-log/${ siteSlug }?group=rewind`;
 
 		return translate(
-			'{{a}}%(daysOfBackupsSaved)d day of backups saved{{/a}}',
-			'{{a}}%(daysOfBackupsSaved)d days of backups saved{{/a}}',
+			'{{a}}%(daysOfBackupsSaved)d day of backups saved {{icon/}}{{/a}}',
+			'{{a}}%(daysOfBackupsSaved)d days of backups saved {{icon/}}{{/a}}',
 			{
 				count: daysOfBackupsSaved,
 				args: { daysOfBackupsSaved },
 				components: {
 					a: <a href={ daysOfBackupsSavedLinkTarget } />,
+					icon: isJetpackCloud() ? <Gridicon icon="cog" size={ 16 } /> : <></>,
 				},
 			}
 		);

--- a/client/components/backup-storage-space/style.scss
+++ b/client/components/backup-storage-space/style.scss
@@ -113,6 +113,12 @@
 
 	a {
 		text-decoration: underline;
+		display: inline-flex;
+		align-items: center;
+
+		svg.gridicon {
+			margin-left: 6px;
+		}
 	}
 }
 

--- a/client/components/backup-storage-space/test/hooks.js
+++ b/client/components/backup-storage-space/test/hooks.js
@@ -131,7 +131,7 @@ describe( 'useDaysOfBackupsSavedText', () => {
 		expect( link ).toHaveTextContent( '7 days of backups saved' );
 	} );
 
-	test( 'renders `7 days of backups saved` with link to activity log with site-slug in Jetpack Cloud', () => {
+	test( 'renders `7 days of backups saved` with link to settings page with site-slug in Jetpack Cloud', () => {
 		isJetpackCloud.mockImplementation( () => true );
 		const text = renderDaysOfBackupsSavedText( 7, 'site-slug' );
 		const link = text.childNodes[ 0 ];

--- a/client/components/backup-storage-space/test/hooks.js
+++ b/client/components/backup-storage-space/test/hooks.js
@@ -124,11 +124,19 @@ describe( 'useDaysOfBackupsSavedText', () => {
 		expect( text ).toHaveTextContent( '7 days of backups saved' );
 	} );
 
-	test( 'renders `7 days of backups saved` with link to activity log with site-slug', () => {
+	test( 'renders `7 days of backups saved` with link to activity log with site-slug in Calypso Blue', () => {
 		const text = renderDaysOfBackupsSavedText( 7, 'site-slug' );
-		expect( text.childNodes[ 0 ] ).toContainHTML(
-			'<a href="/activity-log/site-slug?group=rewind">7 days of backups saved</a>'
-		);
+		const link = text.childNodes[ 0 ];
+		expect( link ).toHaveAttribute( 'href', '/activity-log/site-slug?group=rewind' );
+		expect( link ).toHaveTextContent( '7 days of backups saved' );
+	} );
+
+	test( 'renders `7 days of backups saved` with link to activity log with site-slug in Jetpack Cloud', () => {
+		isJetpackCloud.mockImplementation( () => true );
+		const text = renderDaysOfBackupsSavedText( 7, 'site-slug' );
+		const link = text.childNodes[ 0 ];
+		expect( link ).toHaveAttribute( 'href', '/settings/site-slug' );
+		expect( link ).toHaveTextContent( '7 days of backups saved' );
 	} );
 } );
 


### PR DESCRIPTION
## Proposed Changes

* Update link on `X days of backups saved` to point to Jetpack Cloud settings page with a `cog` icon.
* Refactored existing unit tests to consider this new scenario

## Screenshots

| Environment | Description | Screenshot |
|---|---|---|
| Jetpack Cloud | It should include the `cog` gridicon and point to `https://cloud.jetpack.com/settings/:site` | ![screenshot-jetpack cloud localhost_3000-2023 02 20-23_25_40](https://user-images.githubusercontent.com/1488641/220247560-3d731695-9d0c-40b8-8177-b62c9559e3f7.png) |
| Calypso Blue | This backup retention setting is not yet available in Calypso Blue. | ![image](https://user-images.githubusercontent.com/1488641/220249031-8b4ff085-802e-47b0-ba35-54b66037a929.png) | 


## Testing Instructions
* **Jetpack Cloud**
  * Start a Jetpack Cloud live branch with a site that has a backup plan with storage limit (like Jetpack Backup 10 GB)
  * Navigate to `VaultPress Backup` section
  * You should see the `Cloud storage space` section and in the down-right corner the `X days of backups saved` label.
  * Ensure it has the cog/gear icon and that it should redirect you to the Settings page when clicking on it.
* **Calypso Blue**
  * Start a Jetpack Cloud live branch with a site that has a backup plan with storage limit (like Jetpack Backup 10 GB)
  * Navigate to `Jetpack` > `VaultPress Backup` section
  * You should see the `Cloud storage space` section and in the down-right corner the `X days of backups saved` label.
  * Ensure it does not have the cog/gear icon and that it should redirect you to the Activity Log in Calypso blue when clicking on it.
    * Given that we don't have this setting available on Jetpack Cloud yet, we couldn't include this link here yet.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
