### PR TITLE
Stats: Release new Insights grid

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -114,7 +114,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/horizontal-bars-everywhere": true,
-		"stats/insights-page-grid": false,
+		"stats/insights-page-grid": true,
 		"stats/latest-post-stats": true,
 		"stats/most-popular-post": false,
 		"stats/new-video-summary": false,

--- a/config/production.json
+++ b/config/production.json
@@ -134,7 +134,7 @@
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
 		"stats/horizontal-bars-everywhere": true,
-		"stats/insights-page-grid": false,
+		"stats/insights-page-grid": true,
 		"stats/latest-post-stats": true,
 		"stats/most-popular-post": false,
 		"stats/new-video-summary": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -131,7 +131,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/horizontal-bars-everywhere": true,
-		"stats/insights-page-grid": false,
+		"stats/insights-page-grid": true,
 		"stats/latest-post-stats": true,
 		"stats/most-popular-post": false,
 		"stats/new-video-summary": false,

--- a/config/test.json
+++ b/config/test.json
@@ -94,7 +94,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/horizontal-bars-everywhere": true,
-		"stats/insights-page-grid": false,
+		"stats/insights-page-grid": true,
 		"stats/latest-post-stats": true,
 		"stats/most-popular-post": false,
 		"stats/new-video-summary": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -143,7 +143,7 @@
 		"site-indicator": true,
 		"ssr/prefetch-timebox": true,
 		"stats/horizontal-bars-everywhere": true,
-		"stats/insights-page-grid": false,
+		"stats/insights-page-grid": true,
 		"stats/latest-post-stats": true,
 		"stats/most-popular-post": false,
 		"stats/new-video-summary": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72038

## Proposed Changes

* enable `insights-page-grid` feature flag in production to show the new grid and modernised components at the bottom part of the `Insights` Stats page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* smoke test the entire `Insights` page
* verify that the `Traffic` page looks the same

| Before | After |
| --- | --- |
| ![SCR-20230221-omh](https://user-images.githubusercontent.com/112354940/220250313-1b79ae6f-d1e3-4f8f-ac3c-2b285cdc128d.png) | ![SCR-20230221-ooi](https://user-images.githubusercontent.com/112354940/220250342-b2f8bcc6-8a41-4e33-a088-7191a70336d4.png) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
