### PR TITLE
Jetpack Pro Dashboard: update sites table and column design

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -176,11 +176,7 @@ export default function SiteStatusContent( {
 
 	switch ( status ) {
 		case 'failed': {
-			content = (
-				<Badge className="sites-overview__badge" type="error">
-					{ value }
-				</Badge>
-			);
+			content = <div className="sites-overview__failed">{ value }</div>;
 			break;
 		}
 		case 'warning': {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -184,11 +184,7 @@ export default function SiteStatusContent( {
 			break;
 		}
 		case 'warning': {
-			content = (
-				<Badge className="sites-overview__badge" type="warning">
-					{ value }
-				</Badge>
-			);
+			content = <div className="sites-overview__warning">{ value }</div>;
 			break;
 		}
 		case 'success': {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
@@ -5,6 +6,7 @@ import { translate } from 'i18n-calypso';
 import page from 'page';
 import { useRef, useState, useMemo, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import Badge from 'calypso/components/badge';
 import Tooltip from 'calypso/components/tooltip';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectLicense, unselectLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
@@ -43,6 +45,7 @@ export default function SiteStatusContent( {
 	} = getRowMetaData( rows, type, isLargeScreen );
 
 	const { isBulkManagementActive } = useContext( SitesOverviewContext );
+	const isExpandedBlockEnabled = isEnabled( 'jetpack/pro-dashboard-expandable-block' );
 
 	const siteId = rows.site.value.blog_id;
 	const siteUrl = rows.site.value.url;
@@ -179,11 +182,23 @@ export default function SiteStatusContent( {
 			break;
 		}
 		case 'failed': {
-			content = <div className="sites-overview__failed">{ value }</div>;
+			content = isExpandedBlockEnabled ? (
+				<div className="sites-overview__failed">{ value }</div>
+			) : (
+				<Badge className="sites-overview__badge" type="error">
+					{ value }
+				</Badge>
+			);
 			break;
 		}
 		case 'warning': {
-			content = <div className="sites-overview__warning">{ value }</div>;
+			content = isExpandedBlockEnabled ? (
+				<div className="sites-overview__warning">{ value }</div>
+			) : (
+				<Badge className="sites-overview__badge" type="warning">
+					{ value }
+				</Badge>
+			);
 			break;
 		}
 		case 'success': {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -5,7 +5,6 @@ import { translate } from 'i18n-calypso';
 import page from 'page';
 import { useRef, useState, useMemo, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import Badge from 'calypso/components/badge';
 import Tooltip from 'calypso/components/tooltip';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectLicense, unselectLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
@@ -175,6 +174,10 @@ export default function SiteStatusContent( {
 	let content;
 
 	switch ( status ) {
+		case 'critical': {
+			content = <div className="sites-overview__critical">{ value }</div>;
+			break;
+		}
 		case 'failed': {
 			content = <div className="sites-overview__failed">{ value }</div>;
 			break;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -104,6 +104,7 @@ export default function SiteTableRow( { columns, item, setExpanded, isExpanded }
 					<td
 						className={ classNames( 'site-table__error', {
 							'site-table__td-without-border-bottom': isExpanded,
+							'padding-0': isExpandedContentEnabled,
 						} ) }
 						// If there is an error, we need to span the whole row because we don't show any column.
 						colSpan={ columns.length - 1 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -79,11 +79,13 @@ export default function SiteTableRow( { columns, item, setExpanded, isExpanded }
 					if ( hasSiteError && column.key !== 'site' ) {
 						return null;
 					}
+					const isCritical = 'critical' === row.status;
 					if ( row.type ) {
 						return (
 							<td
 								className={ classNames( column.className, {
 									'site-table__td-without-border-bottom': isExpanded,
+									'site-table__td-critical': isCritical,
 								} ) }
 								key={ `table-data-${ row.type }-${ blogId }` }
 							>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -54,6 +54,8 @@ export default function SiteTableRow( { columns, item, setExpanded, isExpanded }
 
 	const isExpandedContentEnabled = isEnabled( 'jetpack/pro-dashboard-expandable-block' );
 
+	const isExpandedBlockEnabled = isEnabled( 'jetpack/pro-dashboard-expandable-block' );
+
 	return (
 		<Fragment>
 			<tr
@@ -110,6 +112,7 @@ export default function SiteTableRow( { columns, item, setExpanded, isExpanded }
 				<td
 					className={ classNames( 'site-table__actions', {
 						'site-table__td-without-border-bottom': isExpanded,
+						'site-table__actions-button': isExpandedBlockEnabled,
 					} ) }
 					// If there is an error, we need to span the whole row because we don't show the expand buttons.
 					colSpan={ hasSiteError && isExpandedContentEnabled ? 2 : 1 }
@@ -119,7 +122,7 @@ export default function SiteTableRow( { columns, item, setExpanded, isExpanded }
 				{ /* Show expand buttons only when the feature is enabled and there is no site error. */ }
 				{ ! hasSiteError && isExpandedContentEnabled && (
 					<td
-						className={ classNames( 'site-table__actions', {
+						className={ classNames( 'site-table__actions site-table__expand-row', {
 							'site-table__td-without-border-bottom': isExpanded,
 						} ) }
 					>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
@@ -69,3 +69,13 @@ tr.site-table__table-row-site-error {
 	}
 }
 
+
+td.site-table__td-critical {
+	background: var(--studio-red-50);
+	padding: 0;
+	margin: 16px;
+
+	.sites-overview__row-status {
+		max-width: none;
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
@@ -56,6 +56,7 @@ td.site-table__td-without-border-bottom {
 	right: -10px;
 	top: 2px;
 }
+
 td.site-table__error {
 	padding: 0 16px;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
@@ -35,6 +35,17 @@ td.site-table__actions {
 	width: 50px;
 }
 
+td.site-table__actions-button {
+	border-right: none;
+	button {
+		margin-inline-end: 15px;
+	}
+}
+
+td.site-table__expand-row {
+	border-left: none;
+}
+
 td.site-table__td-without-border-bottom {
 	border-bottom: none;
 }
@@ -42,7 +53,7 @@ td.site-table__td-without-border-bottom {
 .site-table__expandable-button {
 	display: flex;
 	position: relative;
-	right: 0;
+	right: -10px;
 	top: 2px;
 }
 td.site-table__error {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -25,8 +25,14 @@ export default function SiteTable( { isLoading, columns, items }: Props ) {
 		setExpandedRow( expandedRow === blogId ? null : blogId );
 	};
 
+	const isExpandedBlockEnabled = isEnabled( 'jetpack/pro-dashboard-expandable-block' );
+
 	return (
-		<table className="site-table__table">
+		<table
+			className={ classNames( 'site-table__table', {
+				'site-table__table-v2': isExpandedBlockEnabled,
+			} ) }
+		>
 			<thead>
 				<tr>
 					{ isBulkManagementActive ? (
@@ -46,7 +52,7 @@ export default function SiteTable( { isLoading, columns, items }: Props ) {
 									</span>
 								</th>
 							) ) }
-							<th colSpan={ isEnabled( 'jetpack/pro-dashboard-expandable-block' ) ? 2 : 1 }>
+							<th colSpan={ isExpandedBlockEnabled ? 2 : 1 }>
 								<div className="plugin-common-table__bulk-actions">
 									<EditButton isLargeScreen sites={ items } />
 								</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
@@ -1,6 +1,13 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.site-table__table-v2 {
+	td,
+	th {
+		border: 1px solid rgba(220, 220, 222, 0.5);
+	}
+}
+
 .site-table__table {
 	border: 1px solid var(--studio-gray-5);
 	border-collapse: collapse;
@@ -48,7 +55,7 @@
 
 	td,
 	th {
-		border: 1px solid rgba(220, 220, 222, 0.5);
+		border-bottom: 1px solid var(--studio-gray-5);
 		text-align: left;
 		border-collapse: collapse;
 		vertical-align: middle;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
@@ -48,7 +48,7 @@
 
 	td,
 	th {
-		border-bottom: 1px solid var(--studio-gray-5);
+		border: 1px solid rgba(220, 220, 222, 0.5);
 		text-align: left;
 		border-collapse: collapse;
 		vertical-align: middle;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -390,6 +390,10 @@
 
 .sites-overview__critical {
 	@extend .sites-overview__column-content;
-	color: var(--studio-white);
 	padding: 15px;
+	color: var(--studio-red-50);
+
+	@include break-xlarge {
+		color: var(--studio-white);
+	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -388,3 +388,8 @@
 	color: var(--studio-red-50);
 }
 
+.sites-overview__critical {
+	@extend .sites-overview__column-content;
+	color: var(--studio-white);
+	padding: 15px;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -363,3 +363,22 @@
 		padding: 0.5rem;
 	}
 }
+
+.sites-overview__column-content {
+	font-size: 0.75rem !important;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	vertical-align: middle;
+	@include break-xlarge {
+		max-width: 70px;
+	}
+	@include break-wide() {
+		max-width: fit-content;
+	}
+}
+
+.sites-overview__warning {
+	@extend .sites-overview__column-content;
+	color: var(--color-warning-50);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -382,3 +382,9 @@
 	@extend .sites-overview__column-content;
 	color: var(--color-warning-50);
 }
+
+.sites-overview__failed {
+	@extend .sites-overview__column-content;
+	color: var(--studio-red-50);
+}
+

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -16,7 +16,8 @@ export type AllowedStatusTypes =
 	| 'failed'
 	| 'warning'
 	| 'success'
-	| 'disabled';
+	| 'disabled'
+	| 'critical';
 
 export interface MonitorSettings {
 	monitor_active: boolean;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -165,7 +165,7 @@ const getRowEventName = (
 
 const backupTooltips: StatusTooltip = {
 	critical: translate( 'Latest backup failed' ),
-	failed: translate( 'Running out of backup storage' ),
+	failed: translate( 'Latest backup failed' ),
 	warning: translate( 'Latest backup completed with warnings' ),
 	inactive: translate( 'Add Jetpack VaultPress Backup to this site' ),
 	progress: translate( 'Backup in progress' ),

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -38,7 +38,7 @@ export const siteColumns = [
 	},
 	{
 		key: 'plugin',
-		title: translate( 'Plugin Updates' ),
+		title: translate( 'Plugins' ),
 	},
 ];
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -297,6 +297,7 @@ export const getRowMetaData = (
 };
 
 const formatBackupData = ( site: Site ) => {
+	const isExpandedBlockEnabled = config.isEnabled( 'jetpack/pro-dashboard-expandable-block' );
 	const backup: BackupNode = {
 		value: '',
 		status: '',
@@ -313,7 +314,7 @@ const formatBackupData = ( site: Site ) => {
 			break;
 		case 'rewind_backup_error':
 		case 'backup_only_error':
-			backup.status = 'critical';
+			backup.status = isExpandedBlockEnabled ? 'critical' : 'failed';
 			backup.value = translate( 'Failed' );
 			break;
 		case 'rewind_backup_complete_warning':

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -164,7 +164,8 @@ const getRowEventName = (
 };
 
 const backupTooltips: StatusTooltip = {
-	failed: translate( 'Latest backup failed' ),
+	critical: translate( 'Latest backup failed' ),
+	failed: translate( 'Running out of backup storage' ),
 	warning: translate( 'Latest backup completed with warnings' ),
 	inactive: translate( 'Add Jetpack VaultPress Backup to this site' ),
 	progress: translate( 'Backup in progress' ),
@@ -312,7 +313,7 @@ const formatBackupData = ( site: Site ) => {
 			break;
 		case 'rewind_backup_error':
 		case 'backup_only_error':
-			backup.status = 'failed';
+			backup.status = 'critical';
 			backup.value = translate( 'Failed' );
 			break;
 		case 'rewind_backup_complete_warning':

--- a/client/jetpack-cloud/sections/agency-dashboard/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/style.scss
@@ -144,3 +144,7 @@
 		}
 	}
 }
+
+.padding-0 {
+	padding: 0 !important;
+}


### PR DESCRIPTION
#### Proposed Changes

This PR updates the table and column design according to the new proposed design.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_** These changes are behind a feature flag and will not be effective in production immediately after merging. The only change that will be visible in production is the title change from `Plugin Updates` to `Plugins`. Please open the live link below and verify that this change is not affected and is still under the feature flag.

**Instructions**

1. Run `git checkout update/new-design-for-pro-dashboard` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that the table design is as shown below

<img width="1624" alt="Screenshot 2023-02-21 at 10 49 28 AM" src="https://user-images.githubusercontent.com/10586875/220256122-a59914c8-d3f5-4ff2-8ae9-43cf818ffb1b.png">

<img width="1421" alt="Screenshot 2023-02-22 at 11 00 20 AM" src="https://user-images.githubusercontent.com/10586875/220531462-39341881-f986-44e0-a6a0-1e7cb33dfda1.png">


4. Verify the `warning`& `failed` designs as shown below

<img width="194" alt="Screenshot 2023-02-21 at 10 50 36 AM" src="https://user-images.githubusercontent.com/10586875/220256224-c6ae870c-3c7b-4e91-a269-657aaf11c19b.png">

<img width="285" alt="Screenshot 2023-02-21 at 11 11 14 AM" src="https://user-images.githubusercontent.com/10586875/220257473-4fcbc47e-f79f-488d-a439-9ac8587a7ce4.png">

<img width="170" alt="Screenshot 2023-02-21 at 10 49 45 AM" src="https://user-images.githubusercontent.com/10586875/220256220-bc80ae6a-04e2-42ff-b0fb-b9644654cd78.png">

<img width="287" alt="Screenshot 2023-02-21 at 11 11 02 AM" src="https://user-images.githubusercontent.com/10586875/220257493-ce0ff2bc-06d6-48c6-9a96-7b4afbde4fa5.png">

5. Verify the `critical` design is as shown below. This is only applicable to failed backups.

<img width="209" alt="Screenshot 2023-02-21 at 10 49 52 AM" src="https://user-images.githubusercontent.com/10586875/220256426-86ea642c-1080-42d6-8d46-3fb918e56282.png">

<img width="286" alt="Screenshot 2023-02-21 at 11 10 56 AM" src="https://user-images.githubusercontent.com/10586875/220257429-352723b9-a1b2-4461-823e-1720e876d4d4.png">

<img width="222" alt="Screenshot 2023-02-21 at 11 25 26 AM" src="https://user-images.githubusercontent.com/10586875/220259475-be732c44-22a2-40b6-b917-19ecec117438.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Related to 1203940061556608-as-1203964949843534