### PR TITLE
Plugins: Add Action and Status Selectors to selectors-ts.

### DIFF
--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -372,6 +372,7 @@ export function isPluginActionStatus(
 	state: AppState,
 	siteId: number,
 	pluginId: string,
+	// TODO: refactor to take only string and not string[] to reduce complexity.
 	action: string | string[],
 	status: string
 ) {
@@ -393,6 +394,7 @@ export function isPluginActionStatus(
  * @param  {string|Array} action   Action, or array of actions of interest
  * @returns {boolean}              True if one or more specified actions are in progress, false otherwise.
  */
+// TODO: remove isPluginActionInProgress and use isPluginActionStatus instead.
 export function isPluginActionInProgress(
 	state: AppState,
 	siteId: number,

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -351,8 +351,11 @@ export function getStatusForPlugin( state: AppState, siteId: number, pluginId: s
 		return undefined;
 	}
 
-	const status = state.plugins.installed.status[ siteId ][ pluginId ];
-	return Object.assign( {}, status, { siteId: siteId, pluginId: pluginId } );
+	return {
+		...state.plugins.installed.status[ siteId ][ pluginId ],
+		siteId,
+		pluginId,
+	};
 }
 
 /**

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -12,6 +12,7 @@ import type {
 	Plugin,
 	PluginFilter,
 	PluginSites,
+	PluginStatus,
 } from './types';
 import type { AppState } from 'calypso/types';
 
@@ -343,4 +344,90 @@ export const getSiteObjectsWithoutPlugin = createSelector(
 	},
 	( state: AppState ) => [ getAllPluginsIndexedByPluginSlug( state ), getSitesItems( state ) ],
 	( state: AppState, siteIds: number[], pluginSlug: string ) => [ pluginSlug, ...siteIds ].join()
+);
+
+export function getStatusForPlugin( state: AppState, siteId: number, pluginId: string ) {
+	if ( typeof state.plugins.installed.status[ siteId ] === 'undefined' ) {
+		return false;
+	}
+	if ( typeof state.plugins.installed.status[ siteId ][ pluginId ] === 'undefined' ) {
+		return false;
+	}
+	const status = state.plugins.installed.status[ siteId ][ pluginId ];
+	return Object.assign( {}, status, { siteId: siteId, pluginId: pluginId } );
+}
+
+/**
+ * Whether the plugin's status for one or more recent actions matches a specified status.
+ *
+ * @param  {Object}       state    Global state tree
+ * @param  {number}       siteId   ID of the site
+ * @param  {string}       pluginId ID of the plugin
+ * @param  {string|Array} action   Action, or array of actions of interest
+ * @param  {string}       status   Status to check against
+ * @returns {boolean}              True if status is the specified one for one or more actions, false otherwise.
+ */
+export function isPluginActionStatus(
+	state: AppState,
+	siteId: number,
+	pluginId: string,
+	action: string | string[],
+	status: string
+) {
+	const pluginStatus = getStatusForPlugin( state, siteId, pluginId );
+	if ( ! pluginStatus ) {
+		return false;
+	}
+
+	const actions = Array.isArray( action ) ? action : [ action ];
+	return actions.includes( pluginStatus.action ) && status === pluginStatus.status;
+}
+
+/**
+ * Whether the plugin's status for one or more recent actions is in progress.
+ *
+ * @param  {Object}       state    Global state tree
+ * @param  {number}       siteId   ID of the site
+ * @param  {string}       pluginId ID of the plugin
+ * @param  {string|Array} action   Action, or array of actions of interest
+ * @returns {boolean}              True if one or more specified actions are in progress, false otherwise.
+ */
+export function isPluginActionInProgress(
+	state: AppState,
+	siteId: number,
+	pluginId: string,
+	action: string
+) {
+	return isPluginActionStatus( state, siteId, pluginId, action, 'inProgress' );
+}
+
+/**
+ * Retrieve all plugin statuses of a certain type.
+ *
+ * @param  {Object} state    Global state tree
+ * @param  {string} status   Status of interest
+ * @returns {Array}          Array of plugin status objects
+ */
+export const getPluginStatusesByType = createSelector(
+	( state: AppState, status: string ) => {
+		const statuses: PluginStatus[] = [];
+
+		const pluginStatuses: { [ siteId: number ]: { [ pluginId: string ]: PluginStatus } } =
+			state.plugins.installed.status;
+
+		Object.entries( pluginStatuses ).map( ( [ siteId, siteStatuses ] ) => {
+			Object.entries( siteStatuses ).map( ( [ pluginId, pluginStatus ] ) => {
+				if ( pluginStatus.status === status ) {
+					statuses.push( {
+						...pluginStatus,
+						siteId: Number( siteId ),
+						pluginId,
+					} );
+				}
+			} );
+		} );
+
+		return statuses;
+	},
+	( state: AppState ) => state.plugins.installed.status
 );

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -347,12 +347,10 @@ export const getSiteObjectsWithoutPlugin = createSelector(
 );
 
 export function getStatusForPlugin( state: AppState, siteId: number, pluginId: string ) {
-	if ( typeof state.plugins.installed.status[ siteId ] === 'undefined' ) {
-		return false;
+	if ( typeof state.plugins.installed.status[ siteId ]?.[ pluginId ] === 'undefined' ) {
+		return undefined;
 	}
-	if ( typeof state.plugins.installed.status[ siteId ][ pluginId ] === 'undefined' ) {
-		return false;
-	}
+
 	const status = state.plugins.installed.status[ siteId ][ pluginId ];
 	return Object.assign( {}, status, { siteId: siteId, pluginId: pluginId } );
 }

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -193,10 +193,12 @@ export function getSiteObjectsWithoutPlugin( state, siteIds, pluginSlug ) {
 }
 
 export function getStatusForPlugin( state, siteId, pluginId ) {
-	if ( typeof state.plugins.installed.status[ siteId ]?.[ pluginId ] === 'undefined' ) {
-		return undefined;
+	if ( typeof state.plugins.installed.status[ siteId ] === 'undefined' ) {
+		return false;
 	}
-
+	if ( typeof state.plugins.installed.status[ siteId ][ pluginId ] === 'undefined' ) {
+		return false;
+	}
 	const status = state.plugins.installed.status[ siteId ][ pluginId ];
 	return Object.assign( {}, status, { siteId: siteId, pluginId: pluginId } );
 }

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -193,12 +193,10 @@ export function getSiteObjectsWithoutPlugin( state, siteIds, pluginSlug ) {
 }
 
 export function getStatusForPlugin( state, siteId, pluginId ) {
-	if ( typeof state.plugins.installed.status[ siteId ] === 'undefined' ) {
-		return false;
+	if ( typeof state.plugins.installed.status[ siteId ]?.[ pluginId ] === 'undefined' ) {
+		return undefined;
 	}
-	if ( typeof state.plugins.installed.status[ siteId ][ pluginId ] === 'undefined' ) {
-		return false;
-	}
+
 	const status = state.plugins.installed.status[ siteId ][ pluginId ];
 	return Object.assign( {}, status, { siteId: siteId, pluginId: pluginId } );
 }

--- a/client/state/plugins/installed/test/selectors-ts.ts
+++ b/client/state/plugins/installed/test/selectors-ts.ts
@@ -480,12 +480,12 @@ describe( 'getSitesWithoutPlugin', () => {
 } );
 
 describe( 'getStatusForPlugin', () => {
-	test( 'Should get `false` if the requested site is not in the current state', () => {
-		expect( getStatusForPlugin( state, nonExistingSiteId1, 'akismet/akismet' ) ).toBe( false );
+	test( 'Should get `undefined` if the requested site is not in the current state', () => {
+		expect( getStatusForPlugin( state, nonExistingSiteId1, 'akismet/akismet' ) ).toBe( undefined );
 	} );
 
-	test( 'Should get `false` if the requested plugin on this site is not in the current state', () => {
-		expect( getStatusForPlugin( state, siteOneId, 'hello-dolly/hello' ) ).toBe( false );
+	test( 'Should get `undefined` if the requested plugin on this site is not in the current state', () => {
+		expect( getStatusForPlugin( state, siteOneId, 'hello-dolly/hello' ) ).toBe( undefined );
 	} );
 
 	test( 'Should get the log if the requested site & plugin have logs', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR adds the selectors related to plugin actions and statuses to selectors-ts. It is a part of the ongoing improvements to the plugin selectors which began in https://github.com/Automattic/wp-calypso/pull/72363.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Review the code and tests, and ensure the tests pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
