### PR TITLE
Update Boost description on pricing page lightbox

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-included-product-description-map.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-included-product-description-map.tsx
@@ -66,7 +66,7 @@ export const useIncludedProductDescriptionMap = ( productSlug: string ) => {
 
 			...setTranslation(
 				JETPACK_BOOST_PRODUCTS,
-				translate( 'Speed up your site and improve SEO with automatic Critical CSS generation.' )
+				translate( 'Speed up your site and improve SEO with automatic critical CSS generation.' )
 			),
 
 			...setTranslation(

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-included-product-description-map.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-included-product-description-map.tsx
@@ -64,7 +64,10 @@ export const useIncludedProductDescriptionMap = ( productSlug: string ) => {
 				translate( '1TB of ad-free video hosting.' )
 			),
 
-			...setTranslation( JETPACK_BOOST_PRODUCTS, translate( 'Automatic CSS generation.' ) ),
+			...setTranslation(
+				JETPACK_BOOST_PRODUCTS,
+				translate( 'Speed up your site and improve SEO with automatic Critical CSS generation.' )
+			),
 
 			...setTranslation(
 				JETPACK_SEARCH_PRODUCTS,


### PR DESCRIPTION
Revised the description of Boost in the Complete's lightbox because it wasn't conveying the product benefit.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1198218726984184-as-1204004381422738/f

## Proposed Changes

Changing the text to convey product benefits

- **Current text:**  "Automatic CSS generation."
- **New text:**  "Speed up your site and improve SEO with automatic Critical CSS generation."


## Testing Instructions

* Patch the changes
* Check if the text has changed and there is no Grammatical Errors
* Before:
<img width="1440" alt="Screen Shot 2023-02-21 at 13 26 10" src="https://user-images.githubusercontent.com/82706809/220264454-fdec43f0-f322-4812-a038-36d3f018080d.png">

- After:

<img width="1440" alt="Screen Shot 2023-02-21 at 13 26 47" src="https://user-images.githubusercontent.com/82706809/220264559-e5f1d382-e0c0-4536-9b5b-484e803e15d6.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?