### PR TITLE
Launchpad: Truncate long domain text in the site launch celebration modal

### DIFF
--- a/client/my-sites/customer-home/components/celebrate-launch-modal.scss
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.scss
@@ -32,7 +32,12 @@
 	}
 
 	&-domain {
-		padding-left: 8px;
+		padding: 0 8px;
+
+		// prevent text overflow
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;
 	}
 
 	&-buttons {


### PR DESCRIPTION
### Time Estimate
Testing: Short
Review: Short

### Proposed Changes
Currently, a long domain name overflows on mobile inside the Launchpad launch celebration modal. Truncate the text on mobile similar to how we do it on the Launchpad screen

![domain](https://user-images.githubusercontent.com/20927667/220266463-3383c205-a2ac-4b62-8a3a-ea7e392dfa0b.png)

### Testing
1. Checkout this branch
2. Create a new free site `http://calypso.localhost:3000/setup/free/intro` and make sure to choose a long domain name
3. Arrive at the Launchpad screen and launch the site
4. You will be redirected to my home with the modal open. Verify the domain isn't overflowing the container on mobile