### PR TITLE
Support user: pass correct args to localStorageBypass

### DIFF
--- a/client/lib/local-storage-bypass/index.js
+++ b/client/lib/local-storage-bypass/index.js
@@ -22,7 +22,7 @@ export const key = ( memoryStore ) => {
 
 export const setItem = ( memoryStore, allowedKeys, original ) => {
 	return ( _key, value ) => {
-		if ( original && allowedKeys.indexOf( _key ) > -1 ) {
+		if ( original && allowedKeys.includes( _key ) ) {
 			original( _key, value );
 			return;
 		}
@@ -34,7 +34,7 @@ export const setItem = ( memoryStore, allowedKeys, original ) => {
 
 export const getItem = ( memoryStore, allowedKeys, original ) => {
 	return ( _key ) => {
-		if ( original && allowedKeys.indexOf( _key ) > -1 ) {
+		if ( original && allowedKeys.includes( _key ) ) {
 			return original( _key );
 		}
 
@@ -45,7 +45,7 @@ export const getItem = ( memoryStore, allowedKeys, original ) => {
 
 export const removeItem = ( memoryStore, allowedKeys, original ) => {
 	return ( _key ) => {
-		if ( original && allowedKeys.indexOf( _key ) > -1 ) {
+		if ( original && allowedKeys.includes( _key ) ) {
 			original( _key );
 			return;
 		}
@@ -76,7 +76,7 @@ export const clear = ( memoryStore ) => {
  * @param {Object}   [args.root]       Allow alternate "window" object to support tests in non-browser environments
  * @param {string[]} [args.allowedKeys] An array of localStorage keys that are proxied to the real localStorage
  */
-export default function ( {
+export default function localStorageBypass( {
 	root = typeof window === 'undefined' ? undefined : window,
 	allowedKeys = [],
 } = {} ) {

--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -92,7 +92,7 @@ export async function supportUserBoot() {
 	// The following keys will not be bypassed as
 	// they are safe to share across user sessions.
 	const allowedKeys = [ STORAGE_KEY, 'debug' ];
-	localStorageBypass( allowedKeys );
+	localStorageBypass( { allowedKeys } );
 
 	wpcom.setSupportUserToken( user, token, onTokenError );
 
@@ -110,7 +110,7 @@ export async function supportNextBoot() {
 	// The following keys will not be bypassed as
 	// they are safe to share across user sessions.
 	const allowedKeys = [ 'debug' ];
-	localStorageBypass( allowedKeys );
+	localStorageBypass( { allowedKeys } );
 
 	// This needs to be a dynamic import in order to avoid boot race conditions.
 	const { supportSessionActivate } = await import( 'calypso/state/support/actions' );


### PR DESCRIPTION
While reviewing #73525 I looked at the `local-storage-bypass` module and noticed that the `support-user-interop` module has been calling its initialization function wrong, for 4 years, since #30569. Instead of passing the `allowedKeys` option, it's been passing effectively nothing, and the allowed keys (`boot_support_user` and `debug`) were not passed through to the native storage implementation.

This PR fixes that. Also does a drive-by modifications from `.indexOf` to `includes`, and gives a name to the default export of `local-storage-bypass`. That makes the function easier to grep.