### PR TITLE
Header Footer: move WordPress.com header and footer to package

### DIFF
--- a/packages/wpcom-template-parts/package.json
+++ b/packages/wpcom-template-parts/package.json
@@ -32,6 +32,7 @@
 	"dependencies": {
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
+		"@wordpress/url": "^3.28.0",
 		"i18n-calypso": "workspace:^",
 		"social-logos": "^2.5.2"
 	},

--- a/packages/wpcom-template-parts/package.json
+++ b/packages/wpcom-template-parts/package.json
@@ -1,0 +1,48 @@
+{
+	"name": "@automattic/wpcom-template-parts",
+	"version": "1.0.0",
+	"description": "WordPress.com template parts to be used everywhere",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.ts",
+	"sideEffects": [
+		"*.css",
+		"*.scss"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/wpcom-template-parts"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"private": true,
+	"bugs": "https://github.com/Automattic/wp-calypso/issues",
+	"types": "dist/types",
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch"
+	},
+	"dependencies": {
+		"@automattic/components": "workspace:^",
+		"@automattic/i18n-utils": "workspace:^",
+		"i18n-calypso": "workspace:^",
+		"social-logos": "^2.5.2"
+	},
+	"devDependencies": {
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"@types/social-logos": "^2.3.1",
+		"typescript": "^4.7.4"
+	},
+	"peerDependencies": {
+		"@wordpress/data": "^6.1.5",
+		"react": "^17.0.2",
+		"react-dom": "^17.0.2"
+	}
+}

--- a/packages/wpcom-template-parts/src/hooks/use-automattic-branding-noun.ts
+++ b/packages/wpcom-template-parts/src/hooks/use-automattic-branding-noun.ts
@@ -1,0 +1,27 @@
+import { useTranslate } from 'i18n-calypso';
+
+const useAutomatticBrandingNoun = () => {
+	const translate = useTranslate();
+	const automatticRoger = [
+		translate( 'An Automattic brainchild' ),
+		translate( 'An Automattic contraption' ),
+		translate( 'An Automattic creation' ),
+		translate( 'An Automattic experiment' ),
+		translate( 'An Automattic invention' ),
+		translate( 'An Automattic joint' ),
+		translate( 'An Automattic medley' ),
+		translate( 'An Automattic opus' ),
+		translate( 'An Automattic production' ),
+		translate( 'An Automattic ruckus' ),
+		translate( 'An Automattic thingamajig' ),
+	];
+
+	const branding = automatticRoger[ Math.floor( Math.random() * ( 10 - 0 + 1 ) + 0 ) ];
+
+	return {
+		article: branding.split( 'Automattic' )[ 0 ],
+		noun: branding.split( 'Automattic' )[ 1 ],
+	};
+};
+
+export default useAutomatticBrandingNoun;

--- a/packages/wpcom-template-parts/src/index.ts
+++ b/packages/wpcom-template-parts/src/index.ts
@@ -1,0 +1,2 @@
+export { default as UniversalNavbarFooter } from './universal-footer-navigation';
+export { default as UniversalNavbarHeader } from './universal-header-navigation';

--- a/packages/wpcom-template-parts/src/types.ts
+++ b/packages/wpcom-template-parts/src/types.ts
@@ -1,12 +1,13 @@
 export interface HeaderProps {
 	isLoggedIn: boolean;
-	sectionName: string;
+	sectionName?: string;
 }
 
 export interface FooterProps {
+	onLanguageChange: React.ChangeEventHandler< HTMLSelectElement >;
 	isLoggedIn: boolean;
 	currentRoute: string;
-	additonalFooterLinks: any;
+	additonalCompanyLinks?: HTMLLIElement;
 }
 
 export interface MenuItemProps {

--- a/packages/wpcom-template-parts/src/types.ts
+++ b/packages/wpcom-template-parts/src/types.ts
@@ -1,0 +1,23 @@
+export interface HeaderProps {
+	isLoggedIn: boolean;
+	sectionName: string;
+}
+
+export interface FooterProps {
+	isLoggedIn: boolean;
+	currentRoute: string;
+	additonalFooterLinks: any;
+}
+
+export interface MenuItemProps {
+	content: string;
+	className?: string;
+}
+
+export interface ClickableItemProps extends MenuItemProps {
+	titleValue: string;
+	urlValue: string;
+	type: string;
+	typeClassName?: string;
+	target?: string;
+}

--- a/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
@@ -1,0 +1,461 @@
+/* eslint-disable no-restricted-imports */
+import {
+	useLocalizeUrl,
+	removeLocaleFromPathLocaleInFront,
+	useIsEnglishLocale,
+} from '@automattic/i18n-utils';
+import { useTranslate, getLocaleSlug } from 'i18n-calypso';
+import page from 'page';
+import SocialLogo from 'social-logos';
+import useAutomatticBrandingNoun from '../hooks/use-automattic-branding-noun';
+import { FooterProps } from '../types';
+
+import './style.scss';
+
+const UniversalNavbarFooter = ( {
+	isLoggedIn = false,
+	currentRoute,
+	additonalFooterLinks,
+}: FooterProps ) => {
+	const translate = useTranslate();
+	const localizeUrl = useLocalizeUrl();
+	const locale = getLocaleSlug() ?? undefined;
+	const isEnglishLocale = useIsEnglishLocale();
+	const pathNameWithoutLocale = removeLocaleFromPathLocaleInFront( currentRoute ).slice( 1 );
+	const automatticBranding = useAutomatticBrandingNoun();
+
+	return (
+		<>
+			<section
+				id="lpc-footer-nav"
+				data-vars-ev-id="lpc-footer-nav"
+				className="lpc lpc-footer-nav"
+				data-vars-ev-classname="lpc lpc-footer-nav"
+			>
+				<h2 className="lp-hidden">WordPress.com</h2>
+				<div className="lpc-footer-nav-wrapper">
+					<div className="lpc-footer-nav-container">
+						<div>
+							<h3>{ translate( 'Products' ) }</h3>
+							<ul>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/hosting/' ) } target="_self">
+										{ translate( 'WordPress Hosting' ) }
+									</a>
+								</li>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/domains/' ) } target="_self">
+										{ translate( 'Domain Names' ) }
+									</a>
+								</li>
+								<li>
+									<a
+										href={ localizeUrl( 'https://wordpress.com/website-builder/' ) }
+										target="_self"
+									>
+										{ translate( 'Website Builder' ) }
+									</a>
+								</li>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/create-blog/' ) } target="_self">
+										{ translate( 'Create a Blog' ) }
+									</a>
+								</li>
+								<li>
+									<a
+										href={ localizeUrl( 'https://wordpress.com/professional-email/' ) }
+										target="_self"
+									>
+										{ translate( 'Professional Email' ) }
+									</a>
+								</li>
+								<li>
+									<a
+										href={ localizeUrl( 'https://wordpress.com/p2/?ref=wpcom-product-menu' ) }
+										target="_self"
+									>
+										{ translate( 'P2: WordPress for Teams' ) }
+									</a>
+								</li>
+								<li>
+									<a href="https://wpvip.com/" data-is_external="1" target="_self">
+										{ translate( 'Enterprise' ) }{ ' ' }
+										<span className="lp-link-chevron-external">{ translate( 'Solutions' ) }</span>
+									</a>
+								</li>
+								<li>
+									<a
+										href={ localizeUrl( 'https://wordpress.com/do-it-for-me/?ref=footer_pricing' ) }
+										title="WordPress Website Building Service"
+										target="_self"
+									>
+										{ translate( 'Built by WordPress.com' ) }
+									</a>
+								</li>
+							</ul>
+						</div>
+						<div>
+							<h3>{ translate( 'Features' ) }</h3>
+							<ul>
+								<li>
+									<a
+										href={ localizeUrl( 'https://wordpress.com/features/' ) }
+										title="WordPress.com Features"
+										target="_self"
+									>
+										{ translate( 'Overview' ) }
+									</a>
+								</li>
+								<li>
+									<a
+										href={ localizeUrl( 'https://wordpress.com/themes', locale, isLoggedIn ) }
+										target="_self"
+									>
+										{ translate( 'WordPress Themes' ) }
+									</a>
+								</li>
+								<li>
+									<a
+										href={ localizeUrl( 'https://wordpress.com/plugins/', locale, isLoggedIn ) }
+										target="_self"
+									>
+										{ translate( 'WordPress Plugins' ) }
+									</a>
+								</li>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/google/' ) } target="_self">
+										{ translate( 'Google Apps' ) }
+									</a>
+								</li>
+							</ul>
+						</div>
+						<div>
+							<h3>{ translate( 'Resources' ) }</h3>
+							<ul>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/support/' ) } target="_self">
+										{ translate( 'WordPress.com Support' ) }
+									</a>
+								</li>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/forums/' ) } target="_self">
+										{ translate( 'WordPress Forums' ) }
+									</a>
+								</li>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/blog/' ) } target="_self">
+										{ translate( 'WordPress News' ) }
+									</a>
+								</li>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/go/' ) } target="_self">
+										{ translate( 'Website Building Tips' ) }
+									</a>
+								</li>
+								<li>
+									<a
+										href={ localizeUrl( 'https://wordpress.com/business-name-generator/' ) }
+										target="_self"
+									>
+										{ translate( 'Business Name Generator' ) }
+									</a>
+								</li>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/logo-maker/' ) } target="_self">
+										{ translate( 'Logo Maker' ) }
+									</a>
+								</li>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/webinars/' ) } target="_self">
+										{ translate( 'Daily Webinars' ) }
+									</a>
+								</li>
+								<li>
+									{ isEnglishLocale && (
+										<a href={ localizeUrl( 'https://wordpress.com/learn/' ) } target="_self">
+											{ translate( 'Learn WordPress' ) }
+										</a>
+									) }
+								</li>
+								<li>
+									<a
+										href={ localizeUrl( 'https://developer.wordpress.com/' ) }
+										data-is_external="1"
+									>
+										{ translate( 'Developer' ) }{ ' ' }
+										<span className="lp-link-chevron-external">{ translate( 'Resources' ) }</span>
+									</a>
+								</li>
+							</ul>
+						</div>
+						<div>
+							<h3>{ translate( 'Company' ) }</h3>
+							<ul>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/about/' ) } target="_self">
+										{ translate( 'About' ) }
+									</a>
+								</li>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/partners/' ) } target="_self">
+										{ translate( 'Partners' ) }
+									</a>
+								</li>
+								<li>
+									<a href="https://automattic.com/press/" data-is_external="1">
+										<span className="lp-link-chevron-external">{ translate( 'Press' ) }</span>
+									</a>
+								</li>
+								<li>
+									<a href={ localizeUrl( 'https://wordpress.com/tos/' ) } target="_self">
+										{ translate( 'Terms of Service' ) }
+									</a>
+								</li>
+								<li>
+									<a href="https://automattic.com/privacy/" data-is_external="1">
+										{ translate( 'Privacy' ) }{ ' ' }
+										<span className="lp-link-chevron-external">{ translate( 'Policy' ) }</span>
+									</a>
+								</li>
+								{ additonalFooterLinks }
+							</ul>
+						</div>
+					</div>
+					<div className="lpc-footer-subnav-container">
+						<div className="lp-footer-language">
+							<h2 className="lp-hidden">{ translate( 'Language' ) }</h2>
+							<div className="lp-language-picker">
+								<div className="lp-language-picker__icon"></div>
+								<div className="lp-language-picker__chevron"></div>
+								<select
+									className="lp-language-picker__content"
+									title={ translate( 'Change Language' ) }
+									onChange={ ( e ) => {
+										page.show( e.target.value );
+										window.location.reload();
+									} }
+									defaultValue={ currentRoute }
+								>
+									<option>{ translate( 'Change Language' ) }</option>
+									<option lang="es" value={ `/es/${ pathNameWithoutLocale }` }>
+										Español
+									</option>
+									<option lang="pt-br" value={ `/pt-br/${ pathNameWithoutLocale }` }>
+										Português do Brasil
+									</option>
+									<option lang="de" value={ `/de/${ pathNameWithoutLocale }` }>
+										Deutsch
+									</option>
+									<option lang="fr" value={ `/fr/${ pathNameWithoutLocale }` }>
+										Français
+									</option>
+									<option lang="he" value={ `/he/${ pathNameWithoutLocale }` }>
+										עִבְרִית
+									</option>
+									<option lang="ja" value={ `/ja/${ pathNameWithoutLocale }` }>
+										日本語
+									</option>
+									<option lang="it" value={ `/it/${ pathNameWithoutLocale }` }>
+										Italiano
+									</option>
+									<option lang="nl" value={ `/nl/${ pathNameWithoutLocale }` }>
+										Nederlands
+									</option>
+									<option lang="ru" value={ `/ru/${ pathNameWithoutLocale }` }>
+										Русский
+									</option>
+									<option lang="tr" value={ `/tr/${ pathNameWithoutLocale }` }>
+										Türkçe
+									</option>
+									<option lang="id" value={ `/id/${ pathNameWithoutLocale }` }>
+										Bahasa Indonesia
+									</option>
+									<option lang="zh-cn" value={ `/zh-cn/${ pathNameWithoutLocale }` }>
+										简体中文
+									</option>
+									<option lang="zh-tw" value={ `/zh-tw/${ pathNameWithoutLocale }` }>
+										繁體中文
+									</option>
+									<option lang="ko" value={ `/ko/${ pathNameWithoutLocale }` }>
+										한국어
+									</option>
+									<option lang="ar" value={ `/ar/${ pathNameWithoutLocale }` }>
+										العربية
+									</option>
+									<option lang="sv" value={ `/sv/${ pathNameWithoutLocale }` }>
+										Svenska
+									</option>
+									<option lang="el" value={ `/el/${ pathNameWithoutLocale }` }>
+										Ελληνικά
+									</option>
+									<option lang="en" value={ `/${ pathNameWithoutLocale }` }>
+										English
+									</option>
+									<option lang="ro" value={ `/ro/${ pathNameWithoutLocale }` }>
+										Română
+									</option>
+								</select>
+							</div>
+						</div>
+						<div className="lpc-footer-mobile-apps">
+							<h2 className="lp-hidden">{ translate( 'Mobile Apps' ) }</h2>
+							<ul className="lp-footer-mobile-icons">
+								<li>
+									<a
+										className="lp-app-button lp-app-button--type-google-play"
+										href="https://play.google.com/store/apps/details?id=org.wordpress.android"
+									>
+										<span className="lp-app-button__content">
+											<svg
+												className="lp-app-button__content--icon"
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 23 25"
+												aria-hidden="true"
+											>
+												<defs>
+													<linearGradient id="lp-gp-a" x1="50%" x2="40%" y1="25%" y2="50%">
+														<stop offset="0%" stopColor="#00c4ff"></stop>
+														<stop offset="100%" stopColor="#00e3ff"></stop>
+													</linearGradient>
+													<linearGradient id="lp-gp-b" x1="0%" x2="100%" y1="50%" y2="50%">
+														<stop offset="0%" stopColor="#fb0"></stop>
+														<stop offset="100%" stopColor="#fd0"></stop>
+													</linearGradient>
+													<linearGradient id="lp-gp-c" x1="100%" x2="0%" y1="20%" y2="80%">
+														<stop offset="0%" stopColor="#df2454"></stop>
+														<stop offset="100%" stopColor="#ff3a44"></stop>
+													</linearGradient>
+													<linearGradient id="lp-gp-d" x1="0%" x2="100%" y1="20%" y2="80%">
+														<stop offset="0%" stopColor="#13d375"></stop>
+														<stop offset="100%" stopColor="#00f076"></stop>
+													</linearGradient>
+												</defs>
+												<path
+													fill="url(#lp-gp-a)"
+													d="M.44.38C.16.68 0 1.15 0 1.75v21.48c0 .6.16 1.07.45 1.36l.08.07 12.03-12.04v-.26L.52.32.44.38z"
+												></path>
+												<path
+													fill="url(#lp-gp-b)"
+													d="m16.57 16.65-4.02-4.02v-.28l4.02-4.01.08.05 4.75 2.7c1.36.77 1.36 2.03 0 2.8l-4.74 2.7-.1.06z"
+												></path>
+												<path
+													fill="url(#lp-gp-c)"
+													d="m16.66 16.6-4.1-4.1L.43 24.6c.45.48 1.19.53 2.02.07l14.2-8.08"
+												></path>
+												<path
+													fill="url(#lp-gp-d)"
+													d="M16.66 8.4 2.46.32C1.63-.15.88-.08.44.4l12.11 12.1 4.1-4.1z"
+												></path>
+											</svg>
+											<span className="lp-app-button__content--label">
+												<span className="lp-app-button__line lp-app-button__line--top">
+													{ translate( 'Get it on' ) }
+												</span>
+												<span className="lp-app-button__line lp-app-button__line--bottom">
+													Google Play
+												</span>
+											</span>
+										</span>
+									</a>
+								</li>
+								<li>
+									<a
+										className="lp-app-button lp-app-button--type-app-store"
+										href="https://apps.apple.com/us/app/wordpress/id335703880"
+									>
+										<span className="lp-app-button__content">
+											<svg
+												className="lp-app-button__content--icon"
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 18 23"
+												aria-hidden="true"
+											>
+												<path
+													fill="#fff"
+													d="m12.88 5.97.28.02c1.6.05 3.08.85 4 2.16a4.95 4.95 0 0 0-2.36 4.15 4.78 4.78 0 0 0 2.92 4.4 10.96 10.96 0 0 1-1.52 3.1c-.9 1.33-1.83 2.64-3.32 2.66-1.45.04-1.94-.85-3.6-.85-1.67 0-2.19.83-3.57.89-1.42.05-2.5-1.43-3.43-2.76-1.85-2.7-3.3-7.63-1.36-10.97a5.32 5.32 0 0 1 4.47-2.73C6.81 6 8.13 7 9 7c.86 0 2.48-1.18 4.16-1zm.3-5.25a4.87 4.87 0 0 1-1.11 3.49 4.1 4.1 0 0 1-3.24 1.53 4.64 4.64 0 0 1 1.14-3.36A4.96 4.96 0 0 1 13.18.72z"
+												></path>
+											</svg>
+											<span className="lp-app-button__content--label">
+												<span className="lp-app-button__line lp-app-button__line--top">
+													{ translate( 'Download on the' ) }
+												</span>
+												<span className="lp-app-button__line lp-app-button__line--bottom">
+													App Store
+												</span>
+											</span>
+										</span>
+									</a>
+								</li>
+							</ul>
+						</div>
+
+						<div className="lp-footer-social-media">
+							<h2 className="lp-hidden">{ translate( 'Social Media' ) }</h2>
+							<ul className="lp-footer-social-icons">
+								<li>
+									<a href="https://twitter.com/wordpressdotcom" title="WordPress.com on Twitter">
+										<span className="lp-hidden">{ translate( 'WordPress.com on Twitter' ) }</span>
+										<SocialLogo size={ 24 } icon="twitter-alt" className="lp-icon" />
+									</a>
+								</li>
+								<li>
+									<a
+										href="https://www.facebook.com/WordPresscom/"
+										title="WordPress.com on Facebook"
+									>
+										<span className="lp-hidden">{ translate( 'WordPress.com on Facebook' ) }</span>
+										<SocialLogo size={ 24 } icon="facebook" className="lp-icon" />
+									</a>
+								</li>
+								<li>
+									<a
+										href="https://www.instagram.com/wordpressdotcom/"
+										title="WordPress.com on Instagram"
+									>
+										<span className="lp-hidden">{ translate( 'WordPress.com on Instagram' ) }</span>
+										<SocialLogo size={ 24 } icon="instagram" className="lp-icon" />
+									</a>
+								</li>
+								<li>
+									<a
+										href="https://www.youtube.com/WordPressdotcom"
+										title="WordPress.com on YouTube"
+									>
+										<span className="lp-hidden">{ translate( 'WordPress.com on YouTube' ) }</span>
+										<SocialLogo size={ 24 } icon="youtube" className="lp-icon" />
+									</a>
+								</li>
+							</ul>
+						</div>
+					</div>
+				</div>
+			</section>
+			<div className="lpc-footer-automattic-nav">
+				<div className="lpc-footer-automattic-nav-wrapper">
+					<a className="lp-logo-label" href="https://automattic.com/">
+						{ automatticBranding.article }
+						<span className="lp-hidden">Automattic</span>
+						<svg
+							className="lp-icon lp-icon--custom-automattic-footer"
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 126 11"
+							aria-hidden="true"
+						>
+							<path d="M121 .68c1.9 0 3.62.82 4.55 1.86l-1.05 1.1c-.81-.77-2-1.5-3.6-1.5-2.4 0-3.75 1.71-3.75 3.48v.19c0 1.76 1.36 3.4 3.87 3.4 1.5 0 2.74-.74 3.52-1.5l1.01 1.11a6.58 6.58 0 0 1-4.64 1.86c-3.4 0-5.46-2.29-5.46-4.8v-.31c0-2.52 2.25-4.89 5.54-4.89zm-104.64.34v5.46c0 1.71 1.09 2.73 3.17 2.73 2.13 0 3-1.02 3-2.73V1.02h1.69v5.43c0 2.3-1.43 4.23-4.82 4.23-3.22 0-4.72-1.82-4.72-4.23V1h1.68zM45.88.68c3.2 0 5.25 2.33 5.25 4.85v.3c0 2.48-2.06 4.85-5.26 4.85-3.18 0-5.24-2.37-5.24-4.85v-.3C40.63 3 42.69.68 45.88.68zm-8.35.34v1.45H33.6v7.85h-1.68V2.47h-3.93V1.02h9.54zm20.12 0 3.54 6.38.42.78.42-.78 3.5-6.4h2.31v9.3h-1.68V2.97l-.45.8-3.76 6.56h-.82L57.4 3.77l-.45-.81v7.36h-1.64v-9.3h2.33zm35.47 0v1.45h-3.93v7.85h-1.68V2.47h-3.93V1.02h9.54zm12.36 0v1.45h-3.92v7.85h-1.69V2.47h-3.92V1.02h9.53zm5.82 0v9.3h-1.66V1.89c.67 0 .94-.37.94-.88h.72zm-104.5 0 4.94 9.3h-1.8l-1.19-2.3H3.48l-1.15 2.3H.55l4.86-9.3h1.4zm70.66 0 4.93 9.3h-1.8l-1.19-2.3h-5.27l-1.15 2.3H71.2l4.86-9.3h1.4zM45.88 2.15c-2.3 0-3.55 1.6-3.55 3.4v.23c0 1.8 1.25 3.43 3.55 3.43 2.29 0 3.56-1.63 3.56-3.43v-.23c0-1.8-1.27-3.4-3.56-3.4zm1.1 1.77a.7.7 0 0 1 .2.94l-1.54 2.46a.64.64 0 0 1-.9.2.7.7 0 0 1-.2-.93l1.54-2.47a.64.64 0 0 1 .9-.2zM6.08 2.83 4.1 6.74h3.98l-2.02-3.9zm70.65 0-1.96 3.91h3.98l-2.02-3.9z"></path>
+						</svg>
+						{ automatticBranding.noun }
+					</a>
+					<div className="lp-logo-label-spacer"></div>
+					<a className="lp-link-work" href="https://automattic.com/work-with-us/">
+						<span className="lp-link-chevron-external">{ translate( 'Work With Us' ) }</span>
+					</a>
+				</div>
+				<a className="lp-link-work-m" href="https://automattic.com/work-with-us/">
+					<span className="lp-link-chevron-external">{ translate( 'Work With Us' ) }</span>
+				</a>
+			</div>
+		</>
+	);
+};
+
+export default UniversalNavbarFooter;

--- a/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
@@ -5,7 +5,6 @@ import {
 	useIsEnglishLocale,
 } from '@automattic/i18n-utils';
 import { useTranslate, getLocaleSlug } from 'i18n-calypso';
-import page from 'page';
 import SocialLogo from 'social-logos';
 import useAutomatticBrandingNoun from '../hooks/use-automattic-branding-noun';
 import { FooterProps } from '../types';
@@ -15,7 +14,8 @@ import './style.scss';
 const UniversalNavbarFooter = ( {
 	isLoggedIn = false,
 	currentRoute,
-	additonalFooterLinks,
+	additonalCompanyLinks,
+	onLanguageChange,
 }: FooterProps ) => {
 	const translate = useTranslate();
 	const localizeUrl = useLocalizeUrl();
@@ -217,7 +217,7 @@ const UniversalNavbarFooter = ( {
 										<span className="lp-link-chevron-external">{ translate( 'Policy' ) }</span>
 									</a>
 								</li>
-								{ additonalFooterLinks }
+								{ additonalCompanyLinks }
 							</ul>
 						</div>
 					</div>
@@ -230,10 +230,7 @@ const UniversalNavbarFooter = ( {
 								<select
 									className="lp-language-picker__content"
 									title={ translate( 'Change Language' ) }
-									onChange={ ( e ) => {
-										page.show( e.target.value );
-										window.location.reload();
-									} }
+									onChange={ onLanguageChange }
 									defaultValue={ currentRoute }
 								>
 									<option>{ translate( 'Change Language' ) }</option>

--- a/packages/wpcom-template-parts/src/universal-footer-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/style.scss
@@ -1,0 +1,565 @@
+$wpc-gray-150: #141517;
+$lp-font-stack-emoji: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+$lp-font-stack-default: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica", "Arial", sans-serif, $lp-font-stack-emoji;
+
+@function static-url($path: "") {
+	@return "//s1.wp.com/wp-content/themes/h4/landing/marketing/" + $path;
+}
+
+$breakpoints: 320px, 360px, 480px, 660px, 782px, 960px, 1140px, 1366px, 1440px, 1600px; // Think very carefully before adding a new breakpoint
+
+@mixin breakpoint( $size ) {
+	@if type-of($size) == string {
+		$approved-value: 0;
+		@each $breakpoint in $breakpoints {
+			$and-larger: ">" + $breakpoint;
+			$and-smaller: "<" + $breakpoint;
+
+			@if $size == $and-smaller {
+				$approved-value: 1;
+				@media ( max-width: $breakpoint ) {
+					@content;
+				}
+			}
+			@else {
+				@if $size == $and-larger {
+					$approved-value: 2;
+					@media ( min-width: $breakpoint + 1 ) {
+						@content;
+					}
+				}
+				@else {
+					@each $breakpoint-end in $breakpoints {
+						$range: $breakpoint + "-" + $breakpoint-end;
+						@if $size == $range {
+							$approved-value: 3;
+							@media ( min-width: $breakpoint + 1 ) and ( max-width: $breakpoint-end ) {
+								@content;
+							}
+						}
+					}
+				}
+			}
+		}
+		@if $approved-value == 0 {
+			$sizes: "";
+			@each $breakpoint in $breakpoints {
+				$sizes: $sizes + " " + $breakpoint;
+			}
+			// TODO - change this to use @error, when it is supported by node-sass
+			@warn "ERROR in breakpoint( #{ $size } ): You can only use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
+		}
+	}
+	@else {
+		$sizes: "";
+		@each $breakpoint in $breakpoints {
+			$sizes: $sizes + " " + $breakpoint;
+		}
+		// TODO - change this to use @error, when it is supported by node-sass
+		@warn "ERROR in breakpoint( #{ $size } ): Please wrap the breakpoint $size in parenthesis. You can use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
+	}
+}
+
+.lpc-footer-nav {
+	font-size: 1rem;
+	line-height: 36px;
+	font-family: $lp-font-stack-default;
+	background: #141517;
+	padding: 25px 20px 80px;
+
+	ul {
+		margin: 0;
+		padding: 0;
+	}
+}
+
+.lpc-footer-automattic-nav {
+	padding: 1rem 7%;
+	font-size: 1rem;
+	line-height: 36px;
+	font-family: $lp-font-stack-default;
+	background: #fff;
+}
+
+.lpc-footer-nav-wrapper,
+.lpc-footer-automattic-nav-wrapper {
+	max-width: 1056px;
+	margin: 0 auto;
+}
+
+.lpc-footer-automattic-nav-wrapper {
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	color: #2c3338;
+
+	a {
+		display: block;
+		padding: 5px 0;
+		text-decoration: underline;
+		color: inherit;
+	}
+
+	.lp-logo-label-spacer {
+		grid-column: span 2;
+	}
+
+	.lp-logo-label {
+		white-space: nowrap;
+		text-decoration: none;
+		margin-right: 18px;
+		color: #0675c4;
+	}
+}
+
+.lpc-footer-nav-container {
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	justify-content: space-between;
+	margin-bottom: 52px;
+	position: relative;
+	column-gap: 18px;
+
+	& > div {
+		margin: 20px 0;
+		flex-shrink: 1;
+	}
+
+	h3 {
+		color: #fff;
+		font-weight: 600;
+		font-size: 1rem;
+	}
+
+	ul {
+		margin-top: 10px;
+		list-style: none;
+	}
+
+	li {
+		list-style: none;
+	}
+
+	a,
+	button {
+		text-align: left;
+		text-decoration: underline;
+		display: block;
+		padding: 0;
+		color: #c3c4c7;
+		transition: opacity 0.15s ease-out;
+		font-size: 1rem;
+		line-height: inherit;
+		cursor: pointer;
+
+		&:hover {
+			opacity: 0.85;
+		}
+	}
+}
+
+.lpc-footer-subnav-container {
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	justify-content: space-between;
+	align-items: center;
+
+	ul {
+		list-style: none;
+	}
+}
+
+
+.lpc-footer-mobile-apps {
+	display: flex;
+	flex: 1;
+	grid-column: span 2;
+	grid-row: span 2;
+
+	li:first-child {
+		padding-right: 10px;
+	}
+}
+
+.lp-footer-mobile-icons {
+	display: flex;
+	justify-content: center;
+}
+
+/*
+ * App Button styles
+ *
+ * 1. Used by the default link and button styles.
+ */
+
+.lp-app-button {
+	position: relative;
+	display: inline-block;
+	vertical-align: top;
+	padding: 0.5em 0.65em calc(0.5em - 1px);
+	font-weight: 600;
+	line-height: 1.1;
+	text-align: left;
+	white-space: nowrap;
+	text-decoration: none;
+	// prettier-ignore
+	font-size: 1.25rem;
+
+	&:link,
+	&:visited {
+		color: #fff;
+	}
+
+	&:hover,
+	&:active {
+		opacity: 1; /* 1 */
+		text-decoration: none;
+	}
+
+	&:active {
+		opacity: 0.85; /* 1 */
+	}
+
+
+	&::before {
+		content: "";
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		border: 1px solid #50575e;
+		border-radius: 4px;
+		background: #000;
+	}
+}
+
+.lp-app-button__content {
+	position: relative;
+	display: flex;
+	align-items: center;
+}
+
+.lp-app-button__content--icon {
+	width: 1em;
+	margin-right: 0.5em;
+	fill: rgb(195, 196, 199);
+
+	.lp-app-button--type-app-store & {
+		position: relative;
+		top: -1px;
+	}
+
+	.lp-app-button--type-google-play & {
+		width: 1.1em;
+		margin-right: 0.4em;
+	}
+}
+
+.lp-footer-social-media {
+	order: 1;
+}
+.lp-footer-social-icons {
+	display: flex;
+	justify-content: flex-start;
+	margin: 0 18px;
+
+	a {
+		display: block;
+		padding: 12px 9px;
+	}
+
+	.lp-icon {
+		width: 24px;
+		height: 24px;
+		background-size: 24px;
+	}
+}
+
+.lp-icon {
+	display: block;
+	fill: rgb(195, 196, 199);
+}
+
+/*
+ * App Button labels
+ */
+
+.lp-app-button__line {
+	display: block;
+}
+
+.lp-app-button__line--top {
+	padding-bottom: 1px;
+	// prettier-ignore
+	font-size: 0.75rem;
+	font-weight: 500;
+}
+
+.lp-app-button__line--bottom {
+	.lp-app-button:hover &,
+	.lp-app-button:active & {
+		text-decoration: underline;
+	}
+}
+
+/*
+ * Language Picker styles
+ *
+ * 1. Explicitely show the element when masks are supported in order to avoid
+ *    a flash of full-bleed color fill.
+ */
+
+.lp-icon--custom-automattic-footer {
+	display: inline-block;
+	height: 12px;
+	margin: 0 0.15em 0 0.1em;
+	position: relative;
+	top: 1px;
+	vertical-align: baseline;
+	width: 143px;
+	fill: inherit;
+}
+
+.lp-language-picker {
+	position: relative;
+
+	&::before {
+		background: #1d2327;
+		border: 1px solid #3c434a;
+		border-radius: 4px;
+		bottom: 0;
+		content: "";
+		left: 0;
+		pointer-events: none;
+		position: absolute;
+		right: 0;
+		top: 0;
+	}
+}
+
+.lp-footer-language {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	order: 2;
+	flex-wrap: nowrap;
+	color: #a7aaad;
+	text-align: center;
+}
+
+%lp-language-picker__icon {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	width: 16px;
+	background: currentColor;
+	pointer-events: none;
+	margin-right: 5px;
+}
+
+.lp-language-picker__icon {
+	@extend %lp-language-picker__icon;
+
+	-webkit-mask: url(static-url("pages/_common/components/footer-nav/media/icon-language.svg")) center center no-repeat;
+	-webkit-mask-size: contain;
+	left: 0.85em;
+}
+
+.lp-language-picker__chevron {
+	@extend %lp-language-picker__icon;
+
+	-webkit-mask: url(static-url("pages/_common/components/footer-nav/media/icon-chevron-down.svg")) center center no-repeat;
+	-webkit-mask-size: contain;
+	right: 0.65em;
+}
+
+.lp-language-picker__content {
+	border: none;
+	color: #c3c4c7;
+	cursor: pointer;
+	display: block;
+	font-family: inherit;
+	font-weight: 600;
+	padding: 16px 45px;
+	position: relative;
+	text-overflow: ellipsis;
+	width: 100%;
+	appearance: none;
+	-webkit-appearance: none;
+	background: none;
+
+	&:hover {
+		text-decoration: underline;
+	}
+}
+
+.lp-link-chevron-external {
+	white-space: nowrap;
+
+	&::after {
+		content: "\00a0\2197";
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+		display: inline-block;
+		font-weight: 600;
+		left: 0.165em;
+		margin-right: -0.095em;
+		top: 0.055em;
+		transform: scale(0.55, 0.55);
+		transform-origin: 0 0;
+		transition: transform 0.15s ease-out 0s;
+	}
+
+	&:hover,
+	&:active {
+		&::after {
+			transform: scale(0.55, 0.55) translate(0.15em, -0.065em);
+		}
+	}
+}
+
+.lp-hidden {
+	display: none;
+}
+
+/**
+ * Automattic Branding Bar
+ */
+.lp-icon__custom-automattic-footer {
+	display: inline-block;
+	margin: 0 0.15em 0 0.1em;
+	position: relative;
+	top: 1px;
+	vertical-align: text-bottom;
+}
+
+.lp-link-work-m {
+	display: none;
+	color: #2c3338;
+	text-decoration: underline;
+}
+
+@include breakpoint( "<1140px" ) {
+	.lpc-footer-automattic-nav {
+		padding-left: 20px;
+		padding-right: 20px;
+		margin-left: 0 !important;
+		margin-right: 0 !important;
+	}
+}
+
+@include breakpoint( "<960px" ) {
+	.lp-footer-mobile-icons {
+		flex-direction: column;
+	}
+
+	.lp-footer-mobile-icons li {
+		padding-bottom: 10px;
+	}
+
+	.lpc-footer-nav .lp-footer-social-icons {
+		padding: 10px 0;
+	}
+
+	.lp-footer-social-media,
+	.lp-footer-language {
+		grid-column: span 2;
+		order: 1;
+	}
+
+	.lpc-footer-automattic-nav-wrapper {
+		grid-template-columns: 1fr 1fr;
+	}
+
+	.lpc-footer-automattic-nav {
+		padding-top: 24px;
+		padding-bottom: 24px;
+	}
+}
+
+@include breakpoint("<782px") {
+	.lpc-footer-nav-container {
+		right: auto;
+		grid-template-columns: 1fr 1fr;
+		margin-bottom: 20px;
+	}
+
+	.lp-app-button__line--bottom {
+		font-size: 1rem;
+	}
+
+	.lp-language-picker__content {
+		font-size: 0.875rem;
+		padding-top: 15px;
+		padding-bottom: 15px;
+	}
+
+	.lpc-footer-nav,
+	.lpc-footer-automattic-nav {
+		font-size: 0.875rem;
+		line-height: 30px;
+	}
+
+	.lpc-footer-automattic-nav {
+		padding-top: 16px;
+		padding-bottom: 16px;
+	}
+}
+
+@include breakpoint("<660px") {
+	.lpc-footer-nav {
+		padding: 0 16px;
+	}
+
+	.lpc-footer-automattic-nav {
+		margin: auto !important;
+	}
+}
+
+@include breakpoint("<480px") {
+	.lpc-footer-nav-container,
+	.lpc-footer-subnav-container,
+	.lpc-footer-automattic-nav-wrapper {
+		grid-template-columns: 1fr;
+	}
+
+	.lpc-footer-nav-container {
+		ul {
+			margin-top: 6px;
+		}
+
+		& > div {
+			margin: 10px 0;
+		}
+	}
+
+	.lp-footer-language {
+		order: 0;
+		display: block;
+	}
+
+	.lpc-footer-nav .lp-footer-mobile-icons {
+		flex-direction: row;
+		padding-top: 20px;
+	}
+
+	.lpc-footer-mobile-apps {
+		justify-content: center;
+	}
+
+	.lpc-footer-nav .lp-footer-social-icons {
+		justify-content: center;
+		padding: 0;
+	}
+
+	.lp-link-work {
+		display: none !important;
+	}
+
+	.lp-link-work-m {
+		display: block !important;
+	}
+
+	.lp-footer-social-media {
+		margin-bottom: 36px;
+	}
+}

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-imports */
+import { WordPressWordmark } from '@automattic/components';
 import { useLocalizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { useState } from 'react';
@@ -40,7 +41,10 @@ const UniversalNavbarHeader = ( { isLoggedIn = false, sectionName }: HeaderProps
 											href={ localizeUrl( '//wordpress.com' ) }
 											target="_self"
 										>
-											{ /* <WordPressWordmark className="x-icon x-icon__logo" /> */ }
+											<WordPressWordmark
+												className="x-icon x-icon__logo"
+												color="var(--studio-blue-50)"
+											/>
 											<span className="x-hidden">WordPress.com</span>
 										</a>
 									</li>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable no-restricted-imports */
 import { WordPressWordmark } from '@automattic/components';
 import { useLocalizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { useState } from 'react';
-import { addQueryArgs } from 'calypso/lib/route';
 import { HeaderProps } from '../types';
 import { NonClickableItem, ClickableItem } from './menu-items';
 
@@ -17,12 +17,16 @@ const UniversalNavbarHeader = ( { isLoggedIn = false, sectionName }: HeaderProps
 	const isEnglishLocale = useIsEnglishLocale();
 
 	const startUrl = addQueryArgs(
-		{
-			ref: sectionName + '-lp',
-		},
+		// url
 		sectionName === 'plugins'
 			? localizeUrl( '//wordpress.com/start/business', locale, isLoggedIn )
-			: localizeUrl( '//wordpress.com/start', locale, isLoggedIn )
+			: localizeUrl( '//wordpress.com/start', locale, isLoggedIn ),
+		// query
+		sectionName
+			? {
+					ref: sectionName + '-lp',
+			  }
+			: {}
 	);
 
 	return (

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -1,0 +1,443 @@
+/* eslint-disable no-restricted-imports */
+import { useLocalizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { useTranslate, getLocaleSlug } from 'i18n-calypso';
+import { useState } from 'react';
+import { addQueryArgs } from 'calypso/lib/route';
+import { HeaderProps } from '../types';
+import { NonClickableItem, ClickableItem } from './menu-items';
+
+import './style.scss';
+
+const UniversalNavbarHeader = ( { isLoggedIn = false, sectionName }: HeaderProps ) => {
+	const translate = useTranslate();
+	const localizeUrl = useLocalizeUrl();
+	const locale = getLocaleSlug() ?? undefined;
+	const [ isMobileMenuOpen, setMobileMenuOpen ] = useState( false );
+	const isEnglishLocale = useIsEnglishLocale();
+
+	const startUrl = addQueryArgs(
+		{
+			ref: sectionName + '-lp',
+		},
+		sectionName === 'plugins'
+			? localizeUrl( '//wordpress.com/start/business', locale, isLoggedIn )
+			: localizeUrl( '//wordpress.com/start', locale, isLoggedIn )
+	);
+
+	return (
+		<div>
+			<div className="x-root lpc-header-nav-wrapper">
+				<div className="lpc-header-nav-container">
+					{ /*<!-- Nav bar starts here. -->*/ }
+					<div className="masterbar-menu">
+						<div className="masterbar">
+							<nav className="x-nav" aria-label="WordPress.com">
+								<ul className="x-nav-list x-nav-list__left">
+									<li className="x-nav-item">
+										<a
+											role="menuitem"
+											className="x-nav-link x-nav-link__logo x-link"
+											href={ localizeUrl( '//wordpress.com' ) }
+											target="_self"
+										>
+											{ /* <WordPressWordmark className="x-icon x-icon__logo" /> */ }
+											<span className="x-hidden">WordPress.com</span>
+										</a>
+									</li>
+									<li className="x-nav-item x-nav-item__wide">
+										<NonClickableItem
+											className="x-nav-link x-link"
+											content={ translate( 'Products' ) }
+										/>
+										<div
+											className="x-dropdown-content"
+											data-dropdown-name="products"
+											role="menu"
+											aria-label={ translate( 'Products' ) }
+											aria-hidden="true"
+										>
+											<ul>
+												<ClickableItem
+													titleValue={ translate( 'WordPress Hosting' ) }
+													content={ translate( 'WordPress Hosting' ) }
+													urlValue={ localizeUrl( '//wordpress.com/hosting/' ) }
+													type="dropdown"
+													target="_self"
+												/>
+												<ClickableItem
+													titleValue={ translate( 'Domain Names' ) }
+													content={ translate( 'Domain Names' ) }
+													urlValue={ localizeUrl( '//wordpress.com/domains/' ) }
+													type="dropdown"
+													target="_self"
+												/>
+												<ClickableItem
+													titleValue={ translate( 'Website Builder' ) }
+													content={ translate( 'Website Builder' ) }
+													urlValue={ localizeUrl( '//wordpress.com/website-builder/' ) }
+													type="dropdown"
+													target="_self"
+												/>
+												<ClickableItem
+													titleValue={ translate( 'Create a Blog' ) }
+													content={ translate( 'Create a Blog' ) }
+													urlValue={ localizeUrl( '//wordpress.com/create-blog/' ) }
+													type="dropdown"
+													target="_self"
+												/>
+												<ClickableItem
+													titleValue={ translate( 'Professional Email' ) }
+													content={ translate( 'Professional Email' ) }
+													urlValue={ localizeUrl( '//wordpress.com/professional-email/' ) }
+													type="dropdown"
+													target="_self"
+												/>
+											</ul>
+											<div className="x-dropdown-content-separator"></div>
+											<ul>
+												<ClickableItem
+													titleValue={ translate( 'Enterprise' ) }
+													content={ translate( 'Enterprise' ) }
+													urlValue="https://wpvip.com/?utm_source=WordPresscom&utm_medium=automattic_referral&utm_campaign=top_nav"
+													type="dropdown"
+												/>
+											</ul>
+										</div>
+									</li>
+									<li className="x-nav-item x-nav-item__wide">
+										<NonClickableItem
+											className="x-nav-link x-link"
+											content={ translate( 'Features' ) }
+										/>
+										<div
+											className="x-dropdown-content"
+											data-dropdown-name="features"
+											role="menu"
+											aria-label={ translate( 'Features' ) }
+											aria-hidden="true"
+										>
+											<ul>
+												<ClickableItem
+													titleValue={ translate( 'Features' ) }
+													content={ translate( 'Overview' ) }
+													urlValue={ localizeUrl( '//wordpress.com/features/' ) }
+													type="dropdown"
+													target="_self"
+												/>
+											</ul>
+											<div className="x-dropdown-content-separator"></div>
+											<ul>
+												<ClickableItem
+													titleValue={ translate( 'WordPress Themes' ) }
+													content={ translate( 'WordPress Themes' ) }
+													urlValue={ localizeUrl( '//wordpress.com/themes', locale, isLoggedIn ) }
+													type="dropdown"
+												/>
+												<ClickableItem
+													titleValue={ translate( 'WordPress Plugins' ) }
+													content={ translate( 'WordPress Plugins' ) }
+													urlValue={ localizeUrl( '//wordpress.com/plugins', locale, isLoggedIn ) }
+													type="dropdown"
+												/>
+												<ClickableItem
+													titleValue={ translate( 'Google Apps' ) }
+													content={ translate( 'Google Apps' ) }
+													urlValue={ localizeUrl( '//wordpress.com/google/' ) }
+													type="dropdown"
+													target="_self"
+												/>
+											</ul>
+										</div>
+									</li>
+									<li className="x-nav-item x-nav-item__wide">
+										<NonClickableItem
+											className="x-nav-link x-link"
+											content={ translate( 'Resources' ) }
+										/>
+										<div
+											className="x-dropdown-content"
+											data-dropdown-name="resources"
+											role="menu"
+											aria-label={ translate( 'Resources' ) }
+											aria-hidden="true"
+										>
+											<ul>
+												<ClickableItem
+													titleValue={ translate( 'Support' ) }
+													content={ translate( 'WordPress.com Support' ) }
+													urlValue={ localizeUrl( '//wordpress.com/support/' ) }
+													type="dropdown"
+												/>
+												<ClickableItem
+													titleValue={ translate( 'News' ) }
+													content={ translate( 'News' ) }
+													urlValue={ localizeUrl( '//wordpress.com/blog/' ) }
+													type="dropdown"
+													target="_self"
+												/>
+												<ClickableItem
+													titleValue={ translate( 'Website Building Tips' ) }
+													content={ translate( 'Website Building Tips' ) }
+													urlValue={ localizeUrl( '//wordpress.com/go/' ) }
+													type="dropdown"
+													target="_self"
+												/>
+												<ClickableItem
+													titleValue={ translate( 'Business Name Generator' ) }
+													content={ translate( 'Business Name Generator' ) }
+													urlValue={ localizeUrl( '//wordpress.com/business-name-generator/' ) }
+													type="dropdown"
+													target="_self"
+												/>
+												<ClickableItem
+													titleValue={ translate( 'Logo Maker' ) }
+													content={ translate( 'Logo Maker' ) }
+													urlValue={ localizeUrl( '//wordpress.com/logo-maker/' ) }
+													type="dropdown"
+													target="_self"
+												/>
+												<ClickableItem
+													titleValue={ translate( 'Daily Webinars' ) }
+													content={ translate( 'Daily Webinars' ) }
+													urlValue={ localizeUrl( '//wordpress.com/webinars/' ) }
+													type="dropdown"
+													target="_self"
+												/>
+												{ isEnglishLocale && (
+													<ClickableItem
+														titleValue={ translate( 'Learn WordPress' ) }
+														content={ translate( 'Learn WordPress' ) }
+														urlValue={ localizeUrl( '//wordpress.com/learn/' ) }
+														type="dropdown"
+														target="_self"
+													/>
+												) }
+											</ul>
+										</div>
+									</li>
+									<ClickableItem
+										className="x-nav-item x-nav-item__wide"
+										titleValue={ translate( 'Plans & Pricing' ) }
+										content={ translate( 'Plans & Pricing' ) }
+										urlValue={ localizeUrl( '//wordpress.com/pricing/' ) }
+										type="nav"
+										target="_self"
+									/>
+								</ul>
+								<ul className="x-nav-list x-nav-list__right">
+									<ClickableItem
+										className="x-nav-item x-nav-item__wide"
+										titleValue={ translate( 'Log In' ) }
+										content={ translate( 'Log In' ) }
+										urlValue={ localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn ) }
+										type="nav"
+									/>
+									<ClickableItem
+										className="x-nav-item x-nav-item__wide"
+										titleValue={ translate( 'Get Started' ) }
+										content={ translate( 'Get Started' ) }
+										urlValue={ startUrl }
+										type="nav"
+										typeClassName="x-nav-link x-nav-link__primary x-link cta-btn-nav"
+									/>
+									<li className="x-nav-item x-nav-item__narrow">
+										<button
+											role="menuitem"
+											className="x-nav-link x-nav-link__menu x-link"
+											aria-haspopup="true"
+											aria-expanded="false"
+											onClick={ () => setMobileMenuOpen( true ) }
+										>
+											<span className="x-hidden">{ translate( 'Menu' ) }</span>
+											<span className="x-icon x-icon__menu">
+												<span></span>
+												<span></span>
+												<span></span>
+											</span>
+										</button>
+									</li>
+								</ul>
+							</nav>
+						</div>
+					</div>
+					{ /*<!-- Nav bar ends here. -->*/ }
+
+					{ /*<!-- Mobile menu starts here. -->*/ }
+					<div
+						className={ isMobileMenuOpen ? 'x-menu x-menu__active x-menu__open' : 'x-menu' }
+						role="menu"
+						aria-label={ translate( 'WordPress.com Navigation Menu' ) }
+						aria-hidden="true"
+					>
+						<div className="x-menu-overlay"></div>
+						<div className="x-menu-content">
+							<button
+								className="x-menu-button x-link"
+								onClick={ () => setMobileMenuOpen( false ) }
+								tabIndex={ -1 }
+							>
+								<span className="x-hidden">{ translate( 'Close the navigation menu' ) }</span>
+								<span className="x-icon x-icon__close">
+									<span></span>
+									<span></span>
+								</span>
+							</button>
+							<div className="x-menu-list">
+								<div className="x-menu-list-title">{ translate( 'Get Started' ) }</div>
+								<ul className="x-menu-grid">
+									<ClickableItem
+										titleValue={ translate( 'Sign Up' ) }
+										content={ translate( 'Sign Up' ) }
+										urlValue={ startUrl }
+										type="menu"
+									/>
+									<ClickableItem
+										titleValue={ translate( 'Log In' ) }
+										content={ translate( 'Log In' ) }
+										urlValue={ localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn ) }
+										type="menu"
+									/>
+								</ul>
+							</div>
+							<div className="x-menu-list">
+								<div className="x-hidden">{ translate( 'About' ) }</div>
+								<ul className="x-menu-grid">
+									<ClickableItem
+										titleValue={ translate( 'Plans & Pricing' ) }
+										content={ translate( 'Plans & Pricing' ) }
+										urlValue={ localizeUrl( '//wordpress.com/pricing/' ) }
+										type="menu"
+									/>
+								</ul>
+							</div>
+							<div className="x-menu-list">
+								<div className="x-menu-list-title">{ translate( 'Products' ) }</div>
+								<ul className="x-menu-grid">
+									<ClickableItem
+										titleValue={ translate( 'WordPress Hosting' ) }
+										content={ translate( 'WordPress Hosting' ) }
+										urlValue={ localizeUrl( '//wordpress.com/hosting/' ) }
+										type="menu"
+									/>
+									<ClickableItem
+										titleValue={ translate( 'Domain Names' ) }
+										content={ translate( 'Domain Names' ) }
+										urlValue={ localizeUrl( '//wordpress.com/domains/' ) }
+										type="menu"
+									/>
+									<ClickableItem
+										titleValue={ translate( 'Website Builder' ) }
+										content={ translate( 'Website Builder' ) }
+										urlValue={ localizeUrl( '//wordpress.com/website-builder/' ) }
+										type="menu"
+									/>
+									<ClickableItem
+										titleValue={ translate( 'Create a Blog' ) }
+										content={ translate( 'Create a Blog' ) }
+										urlValue={ localizeUrl( '//wordpress.com/create-blog/' ) }
+										type="menu"
+									/>
+									<ClickableItem
+										titleValue={ translate( 'Professional Email' ) }
+										content={ translate( 'Professional Email' ) }
+										urlValue={ localizeUrl( '//wordpress.com/professional-email/' ) }
+										type="menu"
+									/>
+									<ClickableItem
+										titleValue={ translate( 'Enterprise' ) }
+										content={ translate( 'Enterprise' ) }
+										urlValue="https://wpvip.com/?utm_source=WordPresscom&utm_medium=automattic_referral&utm_campaign=top_nav"
+										type="menu"
+									/>
+								</ul>
+							</div>
+							<div className="x-menu-list">
+								<div className="x-menu-list-title">{ translate( 'Features' ) }</div>
+								<ul className="x-menu-grid">
+									<ClickableItem
+										titleValue={ translate( 'Features' ) }
+										content={ translate( 'Overview' ) }
+										urlValue={ localizeUrl( '//wordpress.com/features/' ) }
+										type="menu"
+									/>
+								</ul>
+								<ul className="x-menu-grid">
+									<ClickableItem
+										titleValue={ translate( 'WordPress Themes' ) }
+										content={ translate( 'WordPress Themes' ) }
+										urlValue={ localizeUrl( '//wordpress.com/themes', locale, isLoggedIn ) }
+										type="menu"
+									/>
+									<ClickableItem
+										titleValue={ translate( 'WordPress Plugins' ) }
+										content={ translate( 'WordPress Plugins' ) }
+										urlValue={ localizeUrl( '//wordpress.com/plugins', locale, isLoggedIn ) }
+										type="menu"
+									/>
+									<ClickableItem
+										titleValue={ translate( 'Google Apps' ) }
+										content={ translate( 'Google Apps' ) }
+										urlValue={ localizeUrl( '//wordpress.com/google/' ) }
+										type="menu"
+									/>
+								</ul>
+							</div>
+							<div className="x-menu-list">
+								<div className="x-menu-list-title">{ translate( 'Resources' ) }</div>
+								<ul className="x-menu-grid">
+									<ClickableItem
+										titleValue={ translate( 'Support' ) }
+										content={ translate( 'WordPress.com Support' ) }
+										urlValue={ localizeUrl( '//wordpress.com/support/' ) }
+										type="menu"
+									/>
+									<ClickableItem
+										titleValue={ translate( 'News' ) }
+										content={ translate( 'News' ) }
+										urlValue={ localizeUrl( '//wordpress.com/blog/' ) }
+										type="menu"
+									/>
+									<ClickableItem
+										titleValue={ translate( 'Website Building Tips' ) }
+										content={ translate( 'Website Building Tips' ) }
+										urlValue={ localizeUrl( '//wordpress.com/go/' ) }
+										type="menu"
+									/>
+									<ClickableItem
+										titleValue={ translate( 'Business Name Generator' ) }
+										content={ translate( 'Business Name Generator' ) }
+										urlValue={ localizeUrl( '//wordpress.com/business-name-generator/' ) }
+										type="menu"
+									/>
+									<ClickableItem
+										titleValue={ translate( 'Logo Maker' ) }
+										content={ translate( 'Logo Maker' ) }
+										urlValue={ localizeUrl( '//wordpress.com/logo-maker/' ) }
+										type="menu"
+									/>
+									<ClickableItem
+										titleValue={ translate( 'Daily Webinars' ) }
+										content={ translate( 'Daily Webinars' ) }
+										urlValue={ localizeUrl( '//wordpress.com/webinars/' ) }
+										type="menu"
+									/>
+									{ isEnglishLocale && (
+										<ClickableItem
+											titleValue={ translate( 'Learn WordPress' ) }
+											content={ translate( 'Learn WordPress' ) }
+											urlValue={ localizeUrl( '//wordpress.com/learn/' ) }
+											type="menu"
+										/>
+									) }
+								</ul>
+							</div>
+						</div>
+					</div>
+					{ /*<!-- Mobile menu ends here. -->*/ }
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default UniversalNavbarHeader;

--- a/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
@@ -1,0 +1,41 @@
+import { ClickableItemProps, MenuItemProps } from '../types';
+
+export const NonClickableItem = ( { content, className }: MenuItemProps ) => {
+	return (
+		<button role="menuitem" className={ className }>
+			{ content } <span className="x-nav-link-chevron" aria-hidden="true"></span>
+		</button>
+	);
+};
+
+export const ClickableItem = ( {
+	titleValue,
+	content,
+	urlValue,
+	className,
+	type,
+	typeClassName,
+	target,
+}: ClickableItemProps ) => {
+	let liClassName = '';
+	if ( type === 'menu' ) {
+		liClassName = liClassName + ' x-menu-grid-item';
+	}
+	if ( className ) {
+		liClassName = liClassName + ' ' + className;
+	}
+	return (
+		<li className={ liClassName }>
+			<a
+				role="menuitem"
+				className={ typeClassName ? typeClassName : `x-${ type }-link x-link` }
+				href={ urlValue }
+				title={ titleValue }
+				tabIndex={ -1 }
+				target={ target }
+			>
+				{ content }
+			</a>
+		</li>
+	);
+};

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1,0 +1,783 @@
+$studio-blue-15: #e5f4ff;
+$studio-blue-30: #0675c4;
+
+.x-hidden {
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+}
+
+.is-section-plugins.has-no-sidebar {
+	.masterbar {
+		height: 56px;
+		position: relative;
+		background: $studio-blue-15;
+		border-bottom: 1px solid $studio-blue-15;
+	}
+	.fixed-navigation-header__header {
+		position: absolute;
+		top: 0;
+	}
+	.search-box-header.fixed-top .search-box-header__search {
+		margin-top: -32px;
+	}
+}
+
+.is-section-themes,
+.is-section-theme {
+	&.has-no-sidebar {
+		.masterbar {
+			height: 56px;
+			position: relative;
+			background: $studio-blue-15;
+			border-bottom: 1px solid $studio-blue-15;
+			.x-nav {
+				height: 56px;
+			}
+		}
+		.layout__content {
+			overflow: visible;
+		}
+	}
+}
+
+%x-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	font: inherit;
+
+	li {
+		margin: 0;
+	}
+}
+
+.x-icon__logo {
+	left: -1px;
+}
+
+.x-icon__close {
+	width: 36px;
+	cursor: pointer;
+
+	span {
+		position: absolute;
+		top: 17px;
+		left: 11px;
+		height: 2px;
+		width: 14px;
+		transform: rotate(45deg);
+	}
+}
+
+.x-icon__close span + span {
+	transform: rotate(-45deg);
+}
+
+.x-icon__menu {
+	width: 26px;
+	padding-top: 10px;
+}
+
+.x-icon,
+.x-icon span {
+	color: inherit;
+	display: block;
+}
+.x-icon {
+	fill: currentcolor;
+	box-sizing: border-box;
+	height: 36px;
+	overflow: hidden;
+	position: relative;
+
+	g {
+		fill: $studio-blue-30;
+	}
+}
+.x-icon span {
+	display: block;
+	height: 2px;
+	background: currentcolor;
+	color: inherit;
+	margin-bottom: 6px;
+}
+
+/**
+ * Content area
+ */
+
+$lp-content-width-center-minus: 480px;
+$lp-content-width-center: 576px;
+$lp-content-width-center-plus: 672px;
+$lp-content-width-wide-minus: 960px;
+$lp-content-width-wide: 1056px;
+
+/**
+ * Responsive web design
+ */
+
+$lp-breakpoint-S: $lp-content-width-center-minus;
+$lp-breakpoint-M: 768px;
+$lp-breakpoint-L: $lp-content-width-wide;
+
+$x-nav-breakpoint-small: $lp-breakpoint-S;
+$x-nav-breakpoint-medium: $lp-breakpoint-M;
+$x-nav-breakpoint-medium-wide: 864px;
+$x-nav-breakpoint-wide: $lp-breakpoint-L;
+
+$studio-pink-50-rgb: 201, 53, 110;
+$studio-white: #fff;
+$studio-gray-100: #101517;
+$studio-gray-5: #dcdcde;
+$studio-blue-60: #055d9c;
+$studio-blue-0: #e9f0f5;
+$studio-blue-5: #bbe0fa;
+$studio-blue-70: #044b7a;
+$studio-blue-90: #01283d;
+$x-color-link-active: $studio-blue-90;
+$x-color-link-background-active: $studio-blue-5;
+$x-color-link-hover: $studio-blue-70;
+$x-color-link-background-hover: $studio-blue-0;
+$x-color-link: $studio-blue-60;
+$x-color-content-separator: rgba($studio-gray-5, 0.85);
+$studio-white-rgb: 255, 255, 255;
+$x-content-min-z-index: 801;
+$lp-font-weight-bold: 600;
+$lp-font-weight-semi-bold: 400;
+$lp-chevron-content-right: "\203A";
+$lp-chevron-content-down: "\25BE";
+$x-nav-breakpoint-small: $lp-breakpoint-S;
+
+$x-nav-padding-top: 9px;
+$x-nav-padding-x-narrow: 18px;
+$x-nav-padding-x-wide: 24px;
+
+$x-nav-item-padding-x-narrow: 9px;
+$x-nav-item-padding-x-wide: 12px;
+$x-nav-item-height: 36px;
+$x-nav-item-default-color: $studio-white-rgb;
+$x-nav-item-font-size: 14px;
+$x-nav-item-line-height: $x-nav-item-font-size;
+
+$x-nav-height: $x-nav-padding-top + $x-nav-item-height + $x-nav-item-padding-x-wide;
+
+.x-nav {
+	position: absolute;
+	z-index: $x-content-min-z-index;
+	top: 0;
+	right: 0;
+	left: 0;
+	display: flex;
+	justify-content: space-between;
+	height: $x-nav-height;
+	padding: 0;
+	color: unquote("rgb(var(--lp-color-primary, #{$x-nav-item-default-color}))"); /* 1 */
+}
+
+.x-nav-list {
+	display: flex;
+	margin: 0;
+}
+
+.x-nav-item {
+	display: block;
+	color: $studio-blue-90;
+
+	.cta-btn-nav {
+		padding: 10px 24px 10px 24px !important;
+		border-radius: 4px;
+		background: $studio-blue-30 !important;
+		margin: 11px 14px 0 8px;
+		text-decoration: none !important;
+	}
+}
+
+.x-nav-item__wide {
+	display: none;
+	position: relative;
+
+	&:hover > .x-dropdown-content {
+		opacity: 1;
+		pointer-events: all;
+		transform: translateY(0) scale(1);
+		transition: all 450ms cubic-bezier(0.5, 1, 0.89, 1);
+	}
+}
+
+button.x-nav-link.x-link {
+	cursor: pointer;
+}
+
+.x-nav-link {
+	$offset-bottom: round(( $x-nav-item-height - $x-nav-item-line-height ) * 0.5);
+	$offset-top: $x-nav-padding-top + ( $x-nav-item-height - $x-nav-item-line-height - $offset-bottom );
+	position: relative;
+	display: block;
+	padding: $offset-top $x-nav-item-padding-x-narrow $offset-bottom;
+	color: inherit !important; /* 2 */
+	font-size: $x-nav-item-font-size;
+	font-weight: $lp-font-weight-semi-bold !important;
+	line-height: $x-nav-item-line-height;
+	white-space: nowrap;
+
+	&.x-nav-link { /* 2 */
+		border: none;
+		background: none;
+		box-shadow: none;
+		overflow: unset;
+	}
+
+	&:focus {
+		outline: none;
+	}
+
+	&::before {
+		position: absolute;
+		top: $x-nav-padding-top + 1px;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		border-radius: var(--lp-control-border-radius, 0.25em);
+		opacity: 0.35;
+	}
+
+	&:not(:active):focus::before {
+		content: "";
+		opacity: 1;
+	}
+}
+
+.x-nav-link__logo {
+	padding: $x-nav-padding-top $x-nav-padding-x-wide 0 $x-nav-padding-x-narrow;
+
+	&::before {
+		top: $x-nav-padding-top - 1px;
+		right: $x-nav-padding-x-wide - $x-nav-item-padding-x-narrow;
+		left: $x-nav-padding-x-narrow - $x-nav-item-padding-x-narrow;
+	}
+}
+
+.x-nav-link__primary {
+	padding-right: $x-nav-item-padding-x-narrow + $x-nav-padding-x-narrow;
+	padding-left: $x-nav-item-padding-x-narrow * 2;
+	color: unquote("rgb( var( --lp-color-nav-item-primary, var(--lp-color-primary, #{$x-nav-item-default-color} ) ) )") !important; /* 1, 2 */
+
+	&:hover,
+	&:active {
+		text-decoration: underline;
+		opacity: 1;
+	}
+
+	&:active {
+		opacity: 0.85;
+	}
+
+	&::before {
+		content: "";
+		right: $x-nav-padding-x-narrow;
+		left: $x-nav-item-padding-x-narrow;
+	}
+}
+
+.x-nav-link__menu {
+	padding: $x-nav-padding-top $x-nav-padding-x-narrow 0 $x-nav-padding-x-wide;
+
+	&::before {
+		top: $x-nav-padding-top - 1px;
+		right: $x-nav-padding-x-narrow - $x-nav-item-padding-x-narrow;
+		left: $x-nav-padding-x-wide - $x-nav-item-padding-x-narrow;
+	}
+}
+
+.x-nav-link__chevron::after, /* 3 */
+.x-nav-link-chevron {
+	position: relative;
+	left: 1px;
+	margin-right: -1px;
+	color: inherit;
+	opacity: 0.65;
+}
+
+.x-nav-link__chevron::after, /* 3 */
+.x-nav-link-chevron::before {
+	content: $lp-chevron-content-down;
+	color: $studio-blue-90;
+}
+
+.x-nav-link-suffix {
+	display: block;
+	height: 0;
+
+	/* rtl:ignore */
+	text-align: right;
+	white-space: nowrap;
+	transform: translate(-1px, -10px) scale(0.65); /* 4 */
+	transform-origin: 100% 0;
+}
+
+/*
+ * Dropdown
+ */
+
+$x-dropdown-attachment-x: 0;
+$x-dropdown-attachment-y: 45px;
+
+$x-dropdown-background-color: $studio-white;
+$x-dropdown-background-width: 216px;
+$x-dropdown-background-offset-y: 9px;
+
+$x-dropdown-shadow-x: 0;
+$x-dropdown-shadow-y: 9px;
+$x-dropdown-shadow-blur: 48px;
+$x-dropdown-shadow-color: rgba($studio-gray-100, 0.25);
+
+$x-dropdown-item-font-size: 13px;
+$x-dropdown-item-line-height: 19px;
+
+.x-dropdown {
+	position: absolute;
+	z-index: $x-content-min-z-index + 1;
+	top: $x-dropdown-attachment-y;
+	bottom: 0;
+
+	/* rtl:ignore */
+	left: $x-dropdown-attachment-x;
+	width: $x-dropdown-background-width + 2 * $x-dropdown-shadow-blur;
+	opacity: 0;
+	transform-origin: 50% 0;
+}
+
+/*
+ * Dropdown background
+ *
+ * 1. The background element is split into 3 parts: top, middle, bottom. The top
+ *    one contains the pointer.
+ * 2. The middle part covers the rounding error gap that might appear when
+ *    dropdown transforms are in place.
+ * 3. The bottom part contains the very background that will be animated using
+ *    negative translation. Its height will set programatically.
+ */
+
+%x-dropdown-background-container {
+	position: absolute;
+	right: 0;
+	left: 0;
+	padding: 0 $x-dropdown-shadow-blur;
+	overflow: hidden;
+}
+
+.x-dropdown-top { /* 1 */
+	@extend %x-dropdown-background-container;
+	box-sizing: border-box;
+	top: -1 * $x-dropdown-shadow-blur;
+	height: 2 * $x-dropdown-shadow-blur;
+	padding-top: $x-dropdown-shadow-blur + $x-dropdown-background-offset-y;
+}
+
+.x-dropdown-middle { /* 2 */
+	position: absolute;
+	z-index: 1;
+	top: $x-dropdown-shadow-blur - 1px;
+	right: $x-dropdown-shadow-blur;
+	left: $x-dropdown-shadow-blur;
+	height: 2px;
+	background: $x-dropdown-background-color;
+}
+
+.x-dropdown-bottom { /* 3 */
+	@extend %x-dropdown-background-container;
+	top: $x-dropdown-shadow-blur;
+	height: 0; /* 3 */
+}
+
+%x-dropdown-background-fill {
+	position: relative;
+	border-radius: 4px;
+	background: $x-dropdown-background-color;
+	box-shadow: $x-dropdown-shadow-x $x-dropdown-shadow-y $x-dropdown-shadow-blur $x-dropdown-shadow-color;
+}
+
+.x-dropdown-top-fill {
+	@extend %x-dropdown-background-fill;
+	height: 2 * $x-dropdown-shadow-blur;
+
+	&::before { /* 1 */
+		content: "";
+		position: absolute;
+		top: 0;
+		left: round(( $x-dropdown-background-width - 36px ) * 0.5);
+		border-radius: 2px;
+		background: inherit;
+		width: 36px;
+		height: 36px;
+		transform: rotate(45deg);
+	}
+}
+
+.x-dropdown-bottom-fill {
+	@extend %x-dropdown-background-fill;
+	top: -1 * $x-dropdown-shadow-blur;
+	height: 0; /* 3 */
+}
+
+/*
+ * Dropdown content
+ */
+
+.x-dropdown-content {
+	z-index: 901;
+	position: absolute; /* 1 */
+	top: 55px; /* 1 */
+	padding: 12px 0;
+	opacity: 0;
+	left: -60px;
+	background: #fff;
+	border-radius: 4px;
+	box-shadow: 0 9px 48px rgb(16 21 23 / 25%);
+	width: 210px;
+	pointer-events: none;
+	transition: all 150ms cubic-bezier(0.1, 0.6, 0.2, 1);
+	transform: translateY(-6px) scale(0.9);
+	transform-origin: 29px 0;
+
+	&[aria-hidden="false"] { /* 2 */
+		z-index: 1;
+	}
+
+	ul {
+		@extend %x-list;
+	}
+
+	&::before {
+		background: inherit;
+		border-radius: 2px;
+		content: "";
+		height: 36px;
+		left: 90px;
+		position: absolute;
+		top: -2px;
+		transform: rotate(45deg);
+		width: 36px;
+		z-index: -1;
+	}
+}
+
+.x-dropdown-content-separator {
+	height: 1px;
+	background: $x-color-content-separator;
+	margin: 9px 0 12px;
+}
+
+.x-dropdown-link.x-dropdown-link { /* 3 */
+	display: block;
+	padding: 6px 12px 6px 24px;
+	font-size: $x-dropdown-item-font-size;
+	font-weight: $lp-font-weight-bold;
+	line-height: $x-dropdown-item-line-height;
+	color: $x-color-link;
+
+	&:hover,
+	&:active,
+	&:focus {
+		background: $x-color-link-background-hover;
+		color: $x-color-link-hover;
+		opacity: 1;
+		transition-property: background, color;
+	}
+
+	&:active {
+		background: $x-color-link-background-active;
+		color: $x-color-link-active;
+	}
+}
+
+
+/*
+ * Mobile menu
+ *
+ * 1. The line height values are determined based on the `__lp-line-height`
+ *    helper function found in Landpack.
+ * 2. The transform origin is set approximately to the middle of the menu icon.
+ * 3. Increase the specificity due to side effects on older landing pages.
+ * 4. The equivalent of 13px/18px without Dynamic Type on.
+ * 5. Due to the way Dynamic Type is defined in CSS, some of the properties
+ *    have to be overriden by repetition.
+ */
+
+$lp-font-stack-emoji: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+$lp-font-stack-default: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica", "Arial", sans-serif, $lp-font-stack-emoji;
+$x-content-font-stack: $lp-font-stack-default;
+
+%x-text {
+	font-family: $x-content-font-stack;
+	text-rendering: optimizelegibility;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+$lp-transition-properties: 0.15s ease-out;
+$lp-chevron-transform-right: translate3d(0.15em, 0, 0);
+$studio-gray-50: #646970;
+$studio-gray-30: #8c8f94;
+$x-color-content-icon: $studio-gray-30;
+$x-color-content-heading: $studio-gray-50;
+
+$x-menu-width-narrow: 408px;
+$x-menu-width-wide: 480px;
+
+$x-menu-outer-offset: 12px;
+$x-menu-border-radius: 4px;
+
+$x-menu-item-font-size-narrow: 13px;
+$x-menu-item-font-size-wide: 14px;
+$x-menu-item-line-height-narrow: $x-menu-item-font-size-narrow + 7px; /* 1 */
+$x-menu-item-line-height-wide: $x-menu-item-font-size-wide + 7px; /* 1 */
+
+$x-menu-heading-font-size-small: 12px;
+$x-menu-heading-font-size-wide: 13px;
+$x-menu-heading-line-height-small: $x-menu-heading-font-size-small + 6px; /* 1 */
+$x-menu-heading-line-height-wide: $x-menu-heading-font-size-wide + 7px; /* 1 */
+
+.x-menu {
+	@extend %x-text;
+	position: absolute;
+	z-index: $x-content-min-z-index + 2;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	display: none;
+}
+
+.x-menu__active {
+	display: block;
+}
+
+.x-menu-overlay {
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	background: rgba($studio-gray-100, 0.65);
+	opacity: 0;
+
+	.x-menu__active & {
+		transition: opacity 0.25s ease-out;
+	}
+
+	.x-menu__open & {
+		opacity: 1;
+		transition-timing-function: ease-in-out;
+		z-index: 12;
+	}
+}
+
+.x-menu-content {
+	position: fixed;
+	top: $x-menu-outer-offset;
+	right: $x-menu-outer-offset;
+	left: $x-menu-outer-offset;
+	border-radius: $x-menu-border-radius;
+	background: $studio-white;
+	font-size: $x-menu-item-font-size-narrow;
+	line-height: $x-menu-item-line-height-narrow;
+	transform: scale(0);
+	transform-origin: 100% 0;
+	transform-origin: calc(100% - 19px) 15px; /* 2 */
+
+	@media ( min-width: $x-nav-breakpoint-small ) {
+		left: auto;
+		width: $x-menu-width-narrow;
+	}
+
+	@media ( min-width: $x-nav-breakpoint-medium ) {
+		width: $x-menu-width-wide;
+		font-size: $x-menu-item-font-size-wide;
+		line-height: $x-menu-item-line-height-wide;
+	}
+
+	.x-menu__active & {
+		transition: transform 0.25s ease-in-out;
+	}
+
+	.x-menu__open & {
+		transform: scale(1);
+		transition-duration: 0.35s;
+		transition-timing-function: cubic-bezier(0.1, 0.6, 0.2, 1);
+		z-index: 850;
+	}
+}
+
+@media (min-width: 480px) {
+	.x-menu-content {
+		left: auto;
+		width: 408px;
+	}
+}
+
+.x-menu-button {
+	box-sizing: border-box;
+	position: absolute;
+	z-index: 1;
+	top: -1 * $x-menu-outer-offset;
+	right: -1 * $x-menu-outer-offset;
+	width: $x-menu-outer-offset + 36px;
+	height: $x-menu-outer-offset + 36px;
+	padding-top: $x-menu-outer-offset;
+	color: $x-color-content-icon;
+
+	&.x-menu-button { /* 3 */
+		border: none;
+		background: none;
+		box-shadow: none;
+	}
+}
+
+.x-menu-list {
+	padding: 12px;
+
+	&:last-of-type {
+		padding-bottom: 18px;
+	}
+
+	@media ( min-width: $x-nav-breakpoint-medium ) {
+		padding: 18px;
+
+		&:last-of-type {
+			padding-bottom: 24px;
+		}
+	}
+
+	& + & {
+		border-top: 1px solid $x-color-content-separator;
+	}
+}
+
+.x-menu-list-title {
+	position: relative;
+	top: 1px;
+	padding: 6px 6px 3px;
+	color: $x-color-content-heading;
+	font-size: $x-menu-heading-font-size-small;
+	font-weight: 400;
+	line-height: $x-menu-heading-line-height-small;
+	text-transform: uppercase;
+
+	@media ( min-width: $x-nav-breakpoint-medium ) {
+		top: -2px;
+		padding-bottom: 0;
+		font-size: $x-menu-heading-font-size-wide;
+		line-height: $x-menu-heading-line-height-wide;
+	}
+}
+
+.x-menu-grid {
+	@extend %x-list;
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+
+	:not(.x-menu-list-title) ~ & {
+		margin-top: -3px;
+	}
+}
+
+.x-menu-link.x-menu-link { /* 3 */
+	display: block;
+	padding: 6px 6px 3px;
+	color: $x-color-link;
+	font-size: inherit;
+	font-weight: $lp-font-weight-bold;
+	line-height: inherit;
+}
+
+.x-menu-link-chevron {
+	display: inline-block;
+	color: inherit;
+	font-weight: 400;
+	transition: transform $lp-transition-properties;
+
+	&::before {
+		content: $lp-chevron-content-right;
+	}
+
+	.x-menu-link:hover &,
+	.x-menu-link:active & {
+		transform: $lp-chevron-transform-right;
+	}
+}
+
+@media ( min-width: $x-nav-breakpoint-small ) {
+	.x-nav-link__logo {
+		padding-left: $x-nav-padding-x-wide;
+
+		&::before {
+			left: $x-nav-padding-x-wide - $x-nav-item-padding-x-narrow;
+		}
+	}
+
+	.x-nav-link__menu {
+		padding-right: $x-nav-padding-x-wide;
+
+		&::before {
+			right: $x-nav-padding-x-wide - $x-nav-item-padding-x-narrow;
+		}
+	}
+}
+
+@media ( min-width: $x-nav-breakpoint-medium-wide ) {
+	.x-nav-item__narrow {
+		display: none;
+	}
+
+	.x-nav-item__wide {
+		display: block;
+	}
+
+	.x-nav-item:not(:only-child) .x-nav-link__logo { /* 5 */
+		padding-right: $x-nav-item-padding-x-wide;
+
+		&::before {
+			right: $x-nav-item-padding-x-wide - $x-nav-item-padding-x-narrow;
+		}
+	}
+}
+
+@media ( min-width: $x-nav-breakpoint-wide ) {
+	.x-nav-link:not(.x-nav-link__logo):not(.x-nav-link__menu) {
+		padding-right: $x-nav-item-padding-x-wide;
+		padding-left: $x-nav-item-padding-x-wide;
+	}
+
+	.x-nav-link__logo {
+		padding-left: $x-nav-padding-x-wide;
+
+		&::before {
+			left: $x-nav-padding-x-wide - $x-nav-item-padding-x-wide;
+		}
+
+		.x-nav-item:not(:only-child) & { /* 5 */
+			padding-right: $x-nav-item-padding-x-wide * 1.5;
+
+			&::before {
+				left: $x-nav-padding-x-wide - $x-nav-item-padding-x-wide;
+			}
+		}
+	}
+
+	.x-nav-link.x-nav-link.x-nav-link__primary { /* 6 */
+		padding-right: $x-nav-item-padding-x-wide + $x-nav-padding-x-wide;
+		padding-left: $x-nav-item-padding-x-wide * 2;
+
+		&::before {
+			right: $x-nav-padding-x-wide;
+			left: $x-nav-item-padding-x-wide;
+		}
+	}
+}

--- a/packages/wpcom-template-parts/tsconfig.json
+++ b/packages/wpcom-template-parts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src"
+	},
+	"include": [ "src" ],
+	"exclude": [ "**/test/*" ]
+}

--- a/packages/wpcom-template-parts/tsconfig.json
+++ b/packages/wpcom-template-parts/tsconfig.json
@@ -6,5 +6,6 @@
 		"rootDir": "src"
 	},
 	"include": [ "src" ],
-	"exclude": [ "**/test/*" ]
+	"exclude": [ "**/test/*" ],
+	"references": [ { "path": "../components" }, { "path": "../i18n-utils" } ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1881,6 +1881,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/wpcom-template-parts@workspace:packages/wpcom-template-parts":
+  version: 0.0.0-use.local
+  resolution: "@automattic/wpcom-template-parts@workspace:packages/wpcom-template-parts"
+  dependencies:
+    "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/components": "workspace:^"
+    "@automattic/i18n-utils": "workspace:^"
+    "@types/social-logos": ^2.3.1
+    i18n-calypso: "workspace:^"
+    social-logos: ^2.5.2
+    typescript: ^4.7.4
+  peerDependencies:
+    "@wordpress/data": ^6.1.5
+    react: ^17.0.2
+    react-dom: ^17.0.2
+  languageName: unknown
+  linkType: soft
+
 "@babel/cli@npm:^7.17.6":
   version: 7.17.6
   resolution: "@babel/cli@npm:7.17.6"
@@ -7171,6 +7189,15 @@ __metadata:
     "@types/mime": ^1
     "@types/node": "*"
   checksum: 7f3de245cbb11f3a9d7977b6e763585c6022ebfc079fa746f8d824411bb6b343521c1cff5407edc0d5196f4b7d6fea431fb36455843f4a6717d295c235065cf2
+  languageName: node
+  linkType: hard
+
+"@types/social-logos@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "@types/social-logos@npm:2.3.1"
+  dependencies:
+    "@types/react": "*"
+  checksum: 1cbeae892b0e6bd770f2aa74dc5d72320e20ecb4125899f1cda5c17cb2d5863c02adc157fc7a1acb8e961814bdb973134bf56c61c3f1c8ffa4f2bbb67c517210
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,6 +1889,7 @@ __metadata:
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@types/social-logos": ^2.3.1
+    "@wordpress/url": ^3.28.0
     i18n-calypso: "workspace:^"
     social-logos: ^2.5.2
     typescript: ^4.7.4
@@ -9399,13 +9400,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/url@npm:^3.10.0, @wordpress/url@npm:^3.3.1":
-  version: 3.10.0
-  resolution: "@wordpress/url@npm:3.10.0"
+"@wordpress/url@npm:^3.10.0, @wordpress/url@npm:^3.28.0, @wordpress/url@npm:^3.3.1":
+  version: 3.28.0
+  resolution: "@wordpress/url@npm:3.28.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    lodash: ^4.17.21
-  checksum: 90ef36047c92f9035792604662e118b9c88de503781cd4519adf85f1ca32a482fce5cb00f0a71de96516e7124ccdc025d40a025921202cc3841ab6b89687592e
+    remove-accents: ^0.4.2
+  checksum: b8ee3809bd27a4c6d698ea73848f2466ada531fbe843dc79cda784970d30c8422a5fc8e4b5c554d7a2ff7219c23f8e6269a157c142e69863d024ca64a51011a0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

With the recent projects to unify our WordPress.com sites such as /support, /forums, and /learn we are lacking a unified approach to loading the constants like the header and footer. Both of these components have existed inside Calypso for the logged-out view of themes and plugins.

This PR creates a new package `packages/wpcom-template-parts` with to components inside, the header and footer. The goal from after this is to use them inside a block found in `apps/happy-blocks`. This PR depends on a separate PR to move the WordPressWatermark to components #73583

<img width="1906" alt="Markup 2023-02-20 at 17 44 41" src="https://user-images.githubusercontent.com/33258733/220162505-1e1c7eec-42b8-416b-b53d-55685266a937.png">

<img width="1897" alt="Markup 2023-02-20 at 17 45 01" src="https://user-images.githubusercontent.com/33258733/220162528-e1d025a0-b747-4d54-a02f-c9c145ac6036.png">

## Testing Instructions

This only adds a new package so there is no place to see it working yet. Please read through the code and look for errors. There will be a following PR to implement this.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
