### PR TITLE
WPCOM + GitHub: Rework frontend to make use of new endpoint /hosting/github/connection

### DIFF
--- a/client/my-sites/hosting/github/disconnect-github-button/index.tsx
+++ b/client/my-sites/hosting/github/disconnect-github-button/index.tsx
@@ -1,23 +1,29 @@
 import { Button } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 import { useDispatch } from 'react-redux';
+import {
+	GitHubConnection,
+	USE_GITHUB_REPOS_QUERY_KEY,
+} from 'calypso/my-sites/hosting/github/use-github-connection';
 import { deleteStoredKeyringConnection } from 'calypso/state/sharing/keyring/actions';
+
 import './style.scss';
 
-type Connection = Parameters< typeof deleteStoredKeyringConnection >[ 0 ];
-
 interface DisconnectGitHubButtonProps {
-	connection: Connection;
+	connection: GitHubConnection;
 }
 
 export function DisconnectGitHubButton( { connection }: DisconnectGitHubButtonProps ) {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
+	const queryClient = useQueryClient();
+
 	// Using ReactQuery to manage `isDisconnecting` state because it's not exposed from the Redux store.
-	const mutation = useMutation< unknown, unknown, Connection >(
-		async ( c ) => await dispatch( deleteStoredKeyringConnection( c ) )
-	);
+	const mutation = useMutation< unknown, unknown, GitHubConnection >( async ( c ) => {
+		await dispatch( deleteStoredKeyringConnection( c ) );
+		await queryClient.invalidateQueries( { queryKey: [ USE_GITHUB_REPOS_QUERY_KEY ] } );
+	} );
 	const { mutate: disconnect, isLoading: isDisconnecting } = mutation;
 
 	return (

--- a/client/my-sites/hosting/github/github-authorize-card/index.tsx
+++ b/client/my-sites/hosting/github/github-authorize-card/index.tsx
@@ -1,10 +1,11 @@
 import { Button, Card } from '@automattic/components';
 import requestExternalAccess from '@automattic/request-external-access';
 import { translate } from 'i18n-calypso';
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 import { useSelector, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import SocialLogo from 'calypso/components/social-logo';
+import { USE_GITHUB_REPOS_QUERY_KEY } from 'calypso/my-sites/hosting/github/use-github-connection';
 import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
 import { getKeyringServiceByName } from 'calypso/state/sharing/services/selectors';
 
@@ -19,11 +20,13 @@ export const GithubAuthorizeCard = () => {
 	const github = useSelector( ( state ) =>
 		getKeyringServiceByName( state, 'github-deploy' )
 	) as Service;
+	const queryClient = useQueryClient();
 
 	const { mutate: authorize, isLoading: isAuthorizing } = useMutation< void, unknown, string >(
 		async ( connectURL ) => {
 			await new Promise( ( resolve ) => requestExternalAccess( connectURL, resolve ) );
 			await dispatch( requestKeyringConnections() );
+			await queryClient.invalidateQueries( { queryKey: [ USE_GITHUB_REPOS_QUERY_KEY ] } );
 		}
 	);
 

--- a/client/my-sites/hosting/github/github-connect-card/index.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/index.tsx
@@ -2,7 +2,7 @@ import { Button, Card } from '@automattic/components';
 import { ExternalLink } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import classNames from 'classnames';
-import { ComponentProps, useState } from 'react';
+import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -10,6 +10,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import Image from 'calypso/components/image';
 import SocialLogo from 'calypso/components/social-logo';
+import { GitHubConnection } from 'calypso/my-sites/hosting/github/use-github-connection';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { DisconnectGitHubButton } from '../disconnect-github-button';
@@ -20,7 +21,7 @@ import { useGithubConnectMutation } from './use-github-connect';
 import './style.scss';
 
 interface GithubConnectCardProps {
-	connection: ComponentProps< typeof DisconnectGitHubButton >[ 'connection' ];
+	connection: GitHubConnection;
 }
 const noticeOptions = {
 	duration: 3000,

--- a/client/my-sites/hosting/github/index.tsx
+++ b/client/my-sites/hosting/github/index.tsx
@@ -1,24 +1,20 @@
 import { useSelector } from 'react-redux';
 import { GithubAuthorizeCard } from 'calypso/my-sites/hosting/github/github-authorize-card';
 import { GithubConnectCard } from 'calypso/my-sites/hosting/github/github-connect-card';
-import {
-	getKeyringConnections,
-	isKeyringConnectionsFetching,
-} from 'calypso/state/sharing/keyring/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors/index';
 import { GitHubPlaceholderCard } from './github-placeholder-card';
+import { useGithubConnection } from './use-github-connection';
 
 export const GitHubCard = () => {
-	const isFetching = useSelector( isKeyringConnectionsFetching );
-	const connections = useSelector( getKeyringConnections );
+	const siteId = useSelector( getSelectedSiteId );
+	const { data: connection, isLoading } = useGithubConnection( siteId );
 
-	if ( isFetching ) {
+	if ( isLoading ) {
 		return <GitHubPlaceholderCard />;
 	}
 
-	const gitHub = connections.find( ( connection ) => connection.service === 'github-deploy' );
-
-	if ( gitHub ) {
-		return <GithubConnectCard connection={ gitHub } />;
+	if ( connection?.connected ) {
+		return <GithubConnectCard connection={ connection } />;
 	}
 
 	return <GithubAuthorizeCard />;

--- a/client/my-sites/hosting/github/use-github-connection.ts
+++ b/client/my-sites/hosting/github/use-github-connection.ts
@@ -1,0 +1,40 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+import wp from 'calypso/lib/wp';
+
+export const USE_GITHUB_REPOS_QUERY_KEY = 'github-connection-query-key';
+
+export type InactiveGitHubConnection = {
+	connected: boolean;
+};
+
+export type GitHubConnection = {
+	ID: number;
+	base_path: string;
+	repo: string;
+	branch: string;
+	external_profile_picture: string;
+	external_name: string;
+	label: string;
+} & InactiveGitHubConnection;
+
+export const useGithubConnection = (
+	siteId: number | null,
+	options?: UseQueryOptions< GitHubConnection >
+) => {
+	return useQuery< GitHubConnection >(
+		[ USE_GITHUB_REPOS_QUERY_KEY, siteId ],
+		(): GitHubConnection =>
+			wp.req.get( {
+				path: `/sites/${ siteId }/hosting/github/connection`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		{
+			enabled: !! siteId,
+			meta: {
+				persist: true,
+			},
+			refetchOnWindowFocus: false,
+			...options,
+		}
+	);
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1704
D102157-code


## Proposed Changes

* Since D102157-code we will deliver connection info via a new endpoint: `/hosting/github/connection`. This is frontend PR to connect to that new endpoint. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You should be able to connect and disconnect to GH as before. 
* The problem described in https://github.com/Automattic/dotcom-forge/issues/1704 should also be fixed. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?