### PR TITLE
Design setup: Add "is_style_variation" property to Tracks events

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -91,15 +91,19 @@ export function getDesignEventProps( {
 }
 
 export function getVirtualDesignProps( design: Design, styleVariation?: StyleVariation ) {
+	let is_style_variation = false;
 	let variationSlugSuffix = '';
 	if ( styleVariation && styleVariation.slug !== 'default' ) {
+		is_style_variation = true;
 		variationSlugSuffix = `-${ styleVariation.slug }`;
 	} else if ( ! styleVariation && design.preselected_style_variation ) {
+		is_style_variation = true;
 		variationSlugSuffix = `-${ design.preselected_style_variation.slug }`;
 	}
 
 	return {
 		slug: design.slug + variationSlugSuffix,
 		is_virtual: design.is_virtual,
+		is_style_variation: is_style_variation,
 	};
 }

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -73,8 +73,8 @@ export function getDesignEventProps( {
 	design: Design;
 	styleVariation?: StyleVariation;
 } ) {
-	const variationSlugSuffix =
-		styleVariation && styleVariation.slug !== 'default' ? `-${ styleVariation.slug }` : '';
+	const is_style_variation = styleVariation && styleVariation.slug !== 'default';
+	const variationSlugSuffix = is_style_variation ? `-${ styleVariation.slug }` : '';
 
 	return {
 		flow,
@@ -86,6 +86,7 @@ export function getDesignEventProps( {
 		design_type: design.design_type,
 		is_premium: design.is_premium,
 		has_style_variations: ( design.style_variations || [] ).length > 0,
+		is_style_variation: is_style_variation,
 	};
 }
 


### PR DESCRIPTION
## Proposed Changes

In order to A/B test the style variations as separate theme cards (https://github.com/Automattic/dotcom-forge/issues/1655), ExPlat needs a new metric to measure the number of designs with a style variation that have been selected.

The ExPlat metric can be configured to use any of the design setup Tracks events such as `calypso_signup_select_design`. However, these events don't indicate clearly whether a style variation is involved, since that information is encoded in the `slug` property (e.g. `slug: 'upsidedown-noir'` which refers to the Upsidedown theme and the Noir variation).

Since the ExPlat metrics can only perform an exact match of properties, this PR adds a new `is_style_variation` property so the metric can be built as `calypso_signup_select_design` events with `is_style_variation: true`.

## Testing Instructions

- Use the Calypso live link below
- Open the Network tab in the browser devtools
- Observe the `t.gif` requests
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>`
- Perform some actions such as:
  - Preview a design (with a default style variation)
  - Preview a style variation
  - Select a design (with a default style variation)
  - Select a style variation (after choosing the "Try out" option in the GS gating modal)
- Make sure the tracked events include a new `is_style_variation` property

