### PR TITLE
Hooray screen: fix mobile size styles

### DIFF
--- a/packages/onboarding/src/hooray/style.scss
+++ b/packages/onboarding/src/hooray/style.scss
@@ -13,6 +13,10 @@
 		font-size: 3rem;
 		color: var(--studio-gray-100);
 		margin-bottom: 0.75rem;
+
+		@media ( max-width: 1080px ) {
+			line-height: 1;
+		}
 	}
 
 	.onboarding-subtitle {
@@ -20,19 +24,11 @@
 		margin-bottom: 1.5em;
 	}
 
-	.components-button.is-normal-width.action-buttons__next.is-primary {
+	.components-button.action-buttons__next {
 		min-width: 100px;
-		padding: 10px 24px;
-	}
-
-	.components-button.action-buttons__next.is-secondary {
-		min-width: 100px;
-		margin-left: 8px;
-		padding: 10px 24px;
-
-		@include break-mobile {
-			margin-left: 24px;
-		}
+		padding: 10px 24px !important;
+		margin: 0 0.75em 0.75em 0.75em;
+		border-radius: 4px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #73581

## Proposed Changes

* Fixed styling issue of the Hooray component for the mobile screens

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the migration process from the Jetpack migration plugin
* Wait to see the Hooray screen
* Check if title line height and space between buttons are ok

## Screenshots
<table>
  <tr>
    <td width="50%">
      <img width="386" alt="Screenshot 2023-02-21 at 15 17 09" src="https://user-images.githubusercontent.com/1241413/220373886-b4e1254f-9d8f-4948-a886-35d40719b51b.png">
    <td width="50%">
      <img width="387" alt="Screenshot 2023-02-21 at 15 17 19" src="https://user-images.githubusercontent.com/1241413/220374061-4d9e3639-f1e7-42b2-aabd-2ba2dd95f7d7.png">
</table>


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
