### PR TITLE
Stats: Hide StatsDetailsNavigation on the post details page for Odyssey Stats

### DIFF
--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -5,6 +5,8 @@ import { useSelector } from 'react-redux';
 import Count from 'calypso/components/count';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getPostStat } from 'calypso/state/stats/posts/selectors';
 import StatsDetailsNavigation from '../stats-details-navigation';
 import PostLikes from '../stats-post-likes';
@@ -65,7 +67,13 @@ export default function PostDetailHighlightsSection( {
 		title: decodeEntities( stripHTML( textTruncator( post?.title, POST_STATS_CARD_TITLE_LIMIT ) ) ),
 	};
 
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+	const isJetpack = useSelector( ( state ) => siteId && isJetpackSite( state, siteId ) );
+	const isAtomic = useSelector( ( state ) => siteId && isSiteWpcomAtomic( state, siteId ) );
+	const isWPcomSite = ! isJetpack || isAtomic;
+
+	// postId > 0: Show the tabs for posts except for the Home Page (postId = 0).
+	// isWPcomSite: The Newsletter Stats is only covering `WPCOM sites` for now.
+	const isEmailTabsAvailable = config.isEnabled( 'newsletter/stats' ) && postId > 0 && isWPcomSite;
 
 	return (
 		<div className="stats__post-detail-highlights-section">
@@ -79,7 +87,7 @@ export default function PostDetailHighlightsSection( {
 			<div className="highlight-cards">
 				<h1 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h1>
 
-				{ config.isEnabled( 'newsletter/stats' ) && ! isOdysseyStats && (
+				{ isEmailTabsAvailable && (
 					<StatsDetailsNavigation postId={ postId } givenSiteId={ siteId } />
 				) }
 

--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -65,6 +65,8 @@ export default function PostDetailHighlightsSection( {
 		title: decodeEntities( stripHTML( textTruncator( post?.title, POST_STATS_CARD_TITLE_LIMIT ) ) ),
 	};
 
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+
 	return (
 		<div className="stats__post-detail-highlights-section">
 			{ siteId && (
@@ -77,7 +79,7 @@ export default function PostDetailHighlightsSection( {
 			<div className="highlight-cards">
 				<h1 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h1>
 
-				{ config.isEnabled( 'newsletter/stats' ) && (
+				{ config.isEnabled( 'newsletter/stats' ) && ! isOdysseyStats && (
 					<StatsDetailsNavigation postId={ postId } givenSiteId={ siteId } />
 				) }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/73459#pullrequestreview-1302404550, https://github.com/Automattic/wp-calypso/pull/73349#issue-1584954518

## Proposed Changes

* Hide the `StatsDetailsNavigation` that is presently behind the feature flag `newsletter/stats` on Odyssey Stats.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set `newsletter/stats` to `true` in `config/production.json` on the local dev environment.
* Verify Odyssey Stats with Option 1 in `PejTkB-3E-p2`
* Ensure the `StatsDetailsNavigation` section does not show on the `Post Details` page for Odyssey Stats.

|Before|After|
|-|-|
|<img width="1263" alt="截圖 2023-02-21 下午10 59 38" src="https://user-images.githubusercontent.com/6869813/220380362-dcd8c0fa-24b8-4f5a-9219-4bae3012af04.png">|<img width="1277" alt="截圖 2023-02-21 下午10 46 58" src="https://user-images.githubusercontent.com/6869813/220380419-65a98683-9db7-4938-b401-521b8a4e46c5.png">|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
