### PR TITLE
WooExpress: Check for WooCommerce at the beginning of the plugin-bundle flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/check-for-woo/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/check-for-woo/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { useEffect } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/check-for-woo/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/check-for-woo/index.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable no-console */
+import { useEffect } from 'react';
+import wpcomRequest from 'wpcom-proxy-request';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import type { Step, PluginsResponse } from '../../types';
+import './styles.scss';
+
+const CheckForWoo: Step = function CheckForWoo( { navigation } ) {
+	const { submit } = navigation;
+	const site = useSite();
+
+	useEffect( () => {
+		if ( ! site ) {
+			return;
+		}
+
+		const checkForWoo = async () => {
+			const response: PluginsResponse = await wpcomRequest( {
+				path: `/sites/${ site?.ID }/plugins`,
+				apiVersion: '1.1',
+			} );
+
+			const hasWooCommerce =
+				response?.plugins.find( ( plugin: { slug: string } ) => plugin.slug === 'woocommerce' ) !==
+				undefined;
+
+			submit?.( { hasWooCommerce } );
+		};
+
+		checkForWoo();
+
+		// We don't need to include `submit` in the dependency array.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ site ] );
+
+	return (
+		<div className="step-container">
+			<div className="step-container__content">
+				<LoadingEllipsis />
+			</div>
+		</div>
+	);
+};
+
+export default CheckForWoo;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/check-for-woo/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/check-for-woo/styles.scss
@@ -1,0 +1,20 @@
+.plugin-bundle.check-for-woo {
+	padding: 1.5em;
+	max-width: 540px;
+	text-align: center;
+	margin: 0 auto;
+
+	.step-container {
+		display: flex;
+	}
+
+	.step-container__content {
+		width: 100%;
+		margin-top: 16vh;
+	}
+
+	.wpcom__loading-ellipsis {
+		display: block;
+		margin: 0 auto;
+	}
+}

--- a/client/landing/stepper/declarative-flow/plugin-bundle-data.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-data.ts
@@ -1,4 +1,5 @@
 import BusinessInfo from './internals/steps-repository/business-info';
+import CheckForWoo from './internals/steps-repository/check-for-woo';
 import ProcessingStep from './internals/steps-repository/processing-step';
 import StoreAddress from './internals/steps-repository/store-address';
 import WooConfirm from './internals/steps-repository/woo-confirm';
@@ -8,6 +9,7 @@ import { StepperStep } from './internals/types';
 
 const pluginBundleSteps: Record< string, StepperStep[] > = {
 	'woo-on-plans': [
+		{ slug: 'checkForWoo', component: CheckForWoo },
 		{ slug: 'storeAddress', component: StoreAddress },
 		{ slug: 'businessInfo', component: BusinessInfo },
 		{ slug: 'wooConfirm', component: WooConfirm },

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -130,6 +130,15 @@ const pluginBundleFlow: Flow = {
 			recordSubmitStep( providedDependencies, intent, flowName, currentStep );
 
 			switch ( currentStep ) {
+				case 'checkForWoo':
+					// If WooCommerce is already installed, we should exit the flow.
+					if ( providedDependencies?.hasWooCommerce ) {
+						return exitFlow( `/home/${ siteSlug }` );
+					}
+
+					// Otherwise, we should continue to the next step.
+					return navigate( 'storeAddress' );
+
 				case 'storeAddress':
 					return navigate( 'businessInfo' );
 
@@ -198,7 +207,7 @@ const pluginBundleFlow: Flow = {
 					return navigate( 'businessInfo' );
 
 				default:
-					return navigate( 'storeAddress' );
+					return navigate( 'checkForWoo' );
 			}
 		};
 
@@ -206,7 +215,7 @@ const pluginBundleFlow: Flow = {
 			switch ( currentStep ) {
 				// TODO - Do we need anything here?
 				default:
-					return navigate( 'storeAddress' );
+					return navigate( 'checkForWoo' );
 			}
 		};
 


### PR DESCRIPTION
Closes #71215

## Proposed Changes

When we start the plugin-bundle flow, we check to see if WooCommerce is already installed. If it is, we exit the flow early.

The normal behavior for themes with bundled plugins is that they return to `/home` after the plugin-bundle flow. In our case, we'll actually end up on the WooCommerce launch checklist which is the correct behavior for WooExpress trial sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch.
* Start with an existing trial site or create a new one by visiting http://calypso.localhost:3000/setup/wooexpress/.
* Once the trial site is complete visit, `http://calypso.localhost:3000/themes/:siteSlug?s=tazza`.
* Activate the Tazza theme.
* You should briefly enter the plugin-bundle flow but will return to the dashboard after the `checkForWoo` step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
