### PR TITLE
Stats: Create summary page for Tags & categories

### DIFF
--- a/apps/odyssey-stats/src/routes.js
+++ b/apps/odyssey-stats/src/routes.js
@@ -38,7 +38,6 @@ export default function ( pageBase = '/' ) {
 		'clicks',
 		'countryviews',
 		'authors',
-		'tags-categories',
 		'videoplays',
 		'videodetails',
 		'filedownloads',

--- a/apps/odyssey-stats/src/routes.js
+++ b/apps/odyssey-stats/src/routes.js
@@ -38,6 +38,7 @@ export default function ( pageBase = '/' ) {
 		'clicks',
 		'countryviews',
 		'authors',
+		'tags-categories',
 		'videoplays',
 		'videodetails',
 		'filedownloads',

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -343,6 +343,7 @@ export function summary( context, next ) {
 		'referrers',
 		'clicks',
 		'countryviews',
+		'tags-categories',
 		'authors',
 		'videoplays',
 		'videodetails',

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -34,6 +34,7 @@ export default function () {
 		'referrers',
 		'clicks',
 		'countryviews',
+		'tags-categories',
 		'authors',
 		'videoplays',
 		'videodetails',

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -72,7 +72,7 @@ const StatsInsights = ( props ) => {
 							path="tags-categories"
 							moduleStrings={ moduleStrings.tags }
 							statType="statsTags"
-							hideSummaryLink
+							showSummaryLink
 							//hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
 						/>
 						<Comments path="comments" />
@@ -97,8 +97,8 @@ const StatsInsights = ( props ) => {
 									path="tags-categories"
 									moduleStrings={ moduleStrings.tags }
 									statType="statsTags"
-									hideSummaryLink
-									hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
+									// hideSummaryLink
+									// hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
 								/>
 								{ /** TODO: The feature depends on Jetpack Sharing module and is disabled for Odyssey for now. */ }
 								{ ! isOdysseyStats && <StatShares siteId={ siteId } /> }

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -299,13 +299,13 @@ class StatsModule extends Component {
 						</Card>
 						{ isAllTime && (
 							<div className="stats-module__footer-actions">
-								<DownloadCsv
+								{ /* <DownloadCsv
 									statType={ statType }
 									query={ query }
 									path={ path }
 									borderless
 									period={ period }
-								/>
+								/> */ }
 							</div>
 						) }
 					</div>

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -115,6 +115,7 @@ class StatsModule extends Component {
 			'statsReferrers',
 			'statsEmailsOpen',
 			'statsEmailsClick',
+			'statsTags',
 		];
 		return summary && includes( summarizedTypes, statType );
 	}

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -122,7 +122,7 @@ class StatsSummary extends Component {
 						path="tags-categories"
 						moduleStrings={ StatsStrings.tags }
 						period={ this.props.period }
-						query={ query }
+						query={ merge( {}, statsQueryOptions, query ) }
 						statType="statsTags"
 						summary
 					/>

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -114,6 +114,21 @@ class StatsSummary extends Component {
 				);
 				break;
 
+			case 'tagscategories':
+				title = translate( 'Tags & categories' );
+				summaryView = (
+					<StatsModule
+						key="tags-categories"
+						path="referrers"
+						moduleStrings={ StatsStrings.tags }
+						period={ this.props.period }
+						query={ merge( {}, statsQueryOptions, query ) }
+						statType="statsTags"
+						summary
+					/>
+				);
+				break;
+
 			case 'authors':
 				title = translate( 'Authors' );
 				// TODO: should be refactored so that className doesn't have to be passed in

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -114,15 +114,15 @@ class StatsSummary extends Component {
 				);
 				break;
 
-			case 'tagscategories':
+			case 'tags-categories':
 				title = translate( 'Tags & categories' );
 				summaryView = (
 					<StatsModule
-						key="tags-categories"
+						key="tags-categories-summary"
 						path="tags-categories"
 						moduleStrings={ StatsStrings.tags }
 						period={ this.props.period }
-						query={ merge( {}, statsQueryOptions, query ) }
+						query={ query }
 						statType="statsTags"
 						summary
 					/>

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -119,7 +119,7 @@ class StatsSummary extends Component {
 				summaryView = (
 					<StatsModule
 						key="tags-categories"
-						path="referrers"
+						path="tags-categories"
 						moduleStrings={ StatsStrings.tags }
 						period={ this.props.period }
 						query={ merge( {}, statsQueryOptions, query ) }


### PR DESCRIPTION
TBC

Related to #72132

## Proposed Changes

*  Create summary page for Tags & categories

## Testing Instructions

* TBC

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
