### PR TITLE
Premium Global Styles: Only Enqueue Front End Assets When Necessary

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -144,9 +144,9 @@ add_action( 'enqueue_block_editor_assets', 'wpcom_global_styles_enqueue_block_ed
  */
 function wpcom_global_styles_enqueue_assets() {
 	if (
+		! wpcom_global_styles_current_user_can_edit_wp_global_styles() ||
 		! wpcom_should_limit_global_styles() ||
-		! wpcom_global_styles_in_use() ||
-		! wpcom_global_styles_current_user_can_edit_wp_global_styles()
+		! wpcom_global_styles_in_use()
 	) {
 		return;
 	}


### PR DESCRIPTION
## Proposed Changes

* Only enqueue front end assets when necessary.

We incorrectly enqueued all front end assets for the Premium Global Styles notice on all gated sites, even if they were not used (for example if the site is not using Global Styles, or if the current user cannot edit the site's Global Styles).

This was not a big deal until the recent change where we extended the gating mechanism to all sites (https://github.com/Automattic/wp-calypso/pull/73428), instead of just those created after 15 Dec 2022.

While the Premium Global Styles front end assets are very lean, they import a library that uses Lodash, which was suddenly loaded everywhere, significantly increasing the page size.

With this change, we are only enqueuing the Premium Global Styles front end assets to gated sites with Global Styles in use, and only if the current user can edit Global Styles.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test sites:
  * Site A: Gated sites with GS in use.
  * Site B: Gated sites with GS not in use.
  * Site C: Non-gated site (e.g. Premium+).
* With an admin user, open the front end for each site:
  * Site A: should load the `wpcom-global-styles` assets.
  * Site B and C: should not load them.
* In incognito, open the front end for each site:
  * All sites: should not load the assets.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
