### PR TITLE
Checkout: Allow CH to see checkout VAT form

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -15,6 +15,7 @@ const countriesSupportingVat = [
 	'AT',
 	'BE',
 	'BG',
+	'CH',
 	'CY',
 	'CZ',
 	'DE',
@@ -24,6 +25,7 @@ const countriesSupportingVat = [
 	'ES',
 	'FI',
 	'FR',
+	'GB',
 	'HR',
 	'HU',
 	'IE',
@@ -39,7 +41,6 @@ const countriesSupportingVat = [
 	'SE',
 	'SI',
 	'SK',
-	'GB',
 	'XI',
 ];
 


### PR DESCRIPTION
## Proposed Changes

As part of enabling VAT collection for Switzerland (see https://github.com/Automattic/payments-shilling/issues/1395), this PR adds `CH` to the list of countries that will see the "Add VAT details" checkbox and the VAT form in checkout.

<img width="578" alt="Screenshot 2023-02-21 at 12 49 16 PM" src="https://user-images.githubusercontent.com/2036909/220421540-b1ce8786-3655-496d-af7a-70d12bda9607.png">


## Testing Instructions

- Add a product to your cart and visit checkout.
- Select "Switzerland" from the county selector (you may need to click "Edit" first if the step is not active).
- Verify that you see the "Add VAT details" checkbox appear.
- Check the checkbox and verify that the VAT form appears.