### PR TITLE
VAT Info: Add CH to VatInfoPage country selector

### DIFF
--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -166,6 +166,7 @@ function CountryCodeInput( {
 		'AT',
 		'BE',
 		'BG',
+		'CH',
 		'CY',
 		'CZ',
 		'DE',
@@ -175,6 +176,7 @@ function CountryCodeInput( {
 		'ES',
 		'FI',
 		'FR',
+		'GB',
 		'HR',
 		'HU',
 		'IE',
@@ -190,7 +192,6 @@ function CountryCodeInput( {
 		'SE',
 		'SI',
 		'SK',
-		'GB',
 		'XI',
 	];
 


### PR DESCRIPTION
## Proposed Changes

As part of enabling VAT collection for Switzerland (see https://github.com/Automattic/payments-shilling/issues/1395), this PR adds `CH` to the list of countries available in the VAT form in the user's purchase history pages.

<img width="1082" alt="Screenshot 2023-02-21 at 1 08 20 PM" src="https://user-images.githubusercontent.com/2036909/220425198-2a5e60af-a693-449f-b648-70dd8a5f6894.png">

## Testing Instructions

- Visit `/me/purchases/vat-details`.
- Verify that `CH` is listed as an option.