### PR TITLE
Marketplace: uses PluginIcon component in plugin details page.

### DIFF
--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -4,6 +4,7 @@ import Badge from 'calypso/components/badge';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import { preventWidows } from 'calypso/lib/formatting';
+import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -23,7 +24,7 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder, isJetpackCloud } ) => {
 	return (
 		<div className="plugin-details-header__container">
 			<div className="plugin-details-header__main-info">
-				<img className="plugin-details-header__icon" src={ plugin.icon } alt="" />
+				<PluginIcon className="plugin-details-header__icon" image={ plugin.icon } />
 				<div className="plugin-details-header__title-container">
 					<h1 className="plugin-details-header__name">{ plugin.name }</h1>
 					<div className="plugin-details-header__subtitle">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #73359

## Proposed Changes

* uses PluginIcon component in plugin details page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The problem has surfaced cause some plugins didn't have an icon in shadow DB.
Since the data problem is fixed now, testing this will require you to pass `null` in `image` prop in the code https://github.com/Automattic/wp-calypso/blob/08ba02904b808f94ce1ec6b46bf9816e01e4d2e5/client/my-sites/plugins/plugin-details-header/index.jsx#L27

and load `http://calypso.localhost:3000/plugins/woocommerce-product-recommendations`

|Before | After|
|-------|------|
|<img width="720" alt="CleanShot 2023-02-21 at 20 10 11@2x" src="https://user-images.githubusercontent.com/12430020/220425562-d0f6812b-dce0-4a5d-8459-910bf4468e19.png">|<img width="611" alt="CleanShot 2023-02-21 at 20 10 50@2x" src="https://user-images.githubusercontent.com/12430020/220425687-2d063322-e633-4e28-bff4-9ac0e87b0725.png">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
