### PR TITLE
GitHub integration: use correct URI to the create connection resource

### DIFF
--- a/client/my-sites/hosting/github/github-connect-card/use-github-connect.ts
+++ b/client/my-sites/hosting/github/github-connect-card/use-github-connect.ts
@@ -29,7 +29,7 @@ export const useGithubConnectMutation = (
 		async ( { repoName, branchName, basePath }: MutationVariables ) =>
 			wp.req.post(
 				{
-					path: `/sites/${ siteId }/hosting/github/connect`,
+					path: `/sites/${ siteId }/hosting/github/connection`,
 					apiNamespace: 'wpcom/v2',
 				},
 				{ repo: repoName, branch: branchName, base_path: basePath }


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/1716.

## Proposed changes

Explained in https://github.com/Automattic/dotcom-forge/issues/1716.

## Testing instructions

1. Remove your connection to GitHub;
2. Try reconnecting.

It should connect successfully.