### PR TITLE
GH: Fetch github connection from new endpoint

### DIFF
--- a/client/my-sites/hosting/github/deployment-card/index.tsx
+++ b/client/my-sites/hosting/github/deployment-card/index.tsx
@@ -69,7 +69,7 @@ export const DeploymentCard = ( { repo, branch }: DeploymentCardProps ) => {
 							<div className="deployment-card__column">
 								<a
 									target="_blank"
-									href={ `https://github.com/${ repo }/${ deployment.last_deployment_sha }` }
+									href={ `https://github.com/${ repo }/commit/${ deployment.last_deployment_sha }` }
 									rel="noreferrer"
 								>
 									{ deployment.last_deployment_sha.substring( 0, 7 ) }

--- a/client/my-sites/hosting/github/deployment-card/use-deployment-status.ts
+++ b/client/my-sites/hosting/github/deployment-card/use-deployment-status.ts
@@ -28,7 +28,6 @@ export const useDeploymentStatus = (
 			meta: {
 				persist: false,
 			},
-			refetchOnWindowFocus: false,
 			...options,
 			refetchInterval: 5000,
 		}

--- a/client/my-sites/hosting/github/github-connect-card/use-github-connect.ts
+++ b/client/my-sites/hosting/github/github-connect-card/use-github-connect.ts
@@ -1,8 +1,9 @@
 import { useCallback } from 'react';
 import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
 import wp from 'calypso/lib/wp';
+import { USE_GITHUB_CONNECTION_QUERY_KEY } from '../use-github-connection';
 
-const USE_GITHUB_CONNECT_QUERY_KEY = 'github-connect-query-key';
+export const USE_GITHUB_CONNECT_QUERY_KEY = 'github-connect-query-key';
 
 interface MutationVariables {
 	repoName: string | undefined;
@@ -37,7 +38,7 @@ export const useGithubConnectMutation = (
 		{
 			...options,
 			onSuccess: async ( ...args ) => {
-				await queryClient.invalidateQueries( [ USE_GITHUB_CONNECT_QUERY_KEY, siteId ] );
+				await queryClient.invalidateQueries( [ USE_GITHUB_CONNECTION_QUERY_KEY, siteId ] );
 				options.onSuccess?.( ...args );
 			},
 		}

--- a/client/my-sites/hosting/github/index.tsx
+++ b/client/my-sites/hosting/github/index.tsx
@@ -1,24 +1,24 @@
 import { useSelector } from 'react-redux';
 import { GithubAuthorizeCard } from 'calypso/my-sites/hosting/github/github-authorize-card';
-import {
-	getKeyringConnections,
-	isKeyringConnectionsFetching,
-} from 'calypso/state/sharing/keyring/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { DeploymentCard } from './deployment-card';
+import { GithubConnectCard } from './github-connect-card';
 import { GitHubPlaceholderCard } from './github-placeholder-card';
+import { useGithubConnection } from './use-github-connection';
 
 export const GitHubCard = () => {
-	const isFetching = useSelector( isKeyringConnectionsFetching );
-	const connections = useSelector( getKeyringConnections );
-
+	const siteId = useSelector( getSelectedSiteId );
+	const { data: connection, isLoading: isFetching } = useGithubConnection( siteId );
 	if ( isFetching ) {
 		return <GitHubPlaceholderCard />;
 	}
 
-	const gitHub = connections.find( ( connection ) => connection.service === 'github-deploy' );
+	if ( connection && ! connection.repo ) {
+		return <GithubConnectCard connection={ connection } />;
+	}
 
-	if ( gitHub ) {
-		return <DeploymentCard repo="Automattic/testing" branch="main" />;
+	if ( connection && connection.repo ) {
+		return <DeploymentCard repo={ connection.repo } branch={ connection.branch } />;
 	}
 
 	return <GithubAuthorizeCard />;

--- a/client/my-sites/hosting/github/index.tsx
+++ b/client/my-sites/hosting/github/index.tsx
@@ -9,16 +9,16 @@ import { useGithubConnection } from './use-github-connection';
 export const GitHubCard = () => {
 	const siteId = useSelector( getSelectedSiteId );
 	const { data: connection, isLoading: isFetching } = useGithubConnection( siteId );
-	if ( isFetching ) {
+	if ( isFetching || ! connection ) {
 		return <GitHubPlaceholderCard />;
 	}
 
-	if ( connection && ! connection.repo ) {
-		return <GithubConnectCard connection={ connection } />;
+	if ( connection.repo ) {
+		return <DeploymentCard repo={ connection.repo } branch={ connection.branch } />;
 	}
 
-	if ( connection && connection.repo ) {
-		return <DeploymentCard repo={ connection.repo } branch={ connection.branch } />;
+	if ( ! connection.repo && connection.connected ) {
+		return <GithubConnectCard connection={ connection } />;
 	}
 
 	return <GithubAuthorizeCard />;

--- a/client/my-sites/hosting/github/use-github-connection.ts
+++ b/client/my-sites/hosting/github/use-github-connection.ts
@@ -1,7 +1,7 @@
 import { useQuery, UseQueryOptions } from 'react-query';
 import wp from 'calypso/lib/wp';
 
-const USE_GITHUB_CONNECTION_QUERY_KEY = 'github-connection-query-key';
+export const USE_GITHUB_CONNECTION_QUERY_KEY = 'github-connection-query-key';
 type GithubConnectionData = {
 	ID: number;
 	connected: boolean;

--- a/client/my-sites/hosting/github/use-github-connection.ts
+++ b/client/my-sites/hosting/github/use-github-connection.ts
@@ -1,0 +1,35 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+import wp from 'calypso/lib/wp';
+
+const USE_GITHUB_CONNECTION_QUERY_KEY = 'github-connection-query-key';
+type GithubConnectionData = {
+	ID: number;
+	connected: boolean;
+	external_profile_picture: string;
+	repo: string;
+	branch: string;
+	base_path: string;
+	label: string;
+	external_name: string;
+};
+export const useGithubConnection = (
+	siteId: number | null,
+	options?: UseQueryOptions< GithubConnectionData >
+) => {
+	return useQuery< GithubConnectionData >(
+		[ USE_GITHUB_CONNECTION_QUERY_KEY, siteId ],
+		(): GithubConnectionData =>
+			wp.req.get( {
+				path: `/sites/${ siteId }/hosting/github/connection`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		{
+			enabled: !! siteId,
+			meta: {
+				persist: false,
+			},
+			refetchOnWindowFocus: false,
+			...options,
+		}
+	);
+};

--- a/client/my-sites/hosting/github/use-github-connection.ts
+++ b/client/my-sites/hosting/github/use-github-connection.ts
@@ -28,7 +28,6 @@ export const useGithubConnection = (
 			meta: {
 				persist: false,
 			},
-			refetchOnWindowFocus: false,
 			...options,
 		}
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

- Add hook to fetch blog specific github connection
- Display `connect` or `deployment` card based on connection data

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Authorise to github
- Verify `GithubConnectCard` is shown when not connected to a repository
- Verify `DeploymentCard` is shown when connected to a repository

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
