### PR TITLE
Fix the Jetpack E2E tests CI build id to be character safe

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -182,8 +182,9 @@ fun editorTrackingBuildType( targetDevice: String, buildUuid: String, atomic: Bo
 }
 
 fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpackTarget: String = "wpcom-production" ): E2EBuildType {
+	val idSafeJetpackTarget = jetpackTarget.replace( "-", "_" );
 	return E2EBuildType (
-		buildId = "WPComTests_jetpack_Playwright_${jetpackTarget}_$targetDevice",
+		buildId = "WPComTests_jetpack_Playwright_${idSafeJetpackTarget}_$targetDevice",
 		buildUuid = buildUuid,
 		buildName = "Jetpack E2E Tests [${jetpackTarget}] ($targetDevice)",
 		buildDescription = "Runs Jetpack E2E tests as $targetDevice against Jetpack install $jetpackTarget",


### PR DESCRIPTION
Related to #

## Proposed Changes

It's not a new TC build if you don't get to do it twice! 😒 

Apparently it's 1990 and hyphens aren't cool in TC build ids. This makes the ID safe by swapping them for underscores. This unfortunately before didn't trigger any errors until after trunk merge, and that might be the same here too.

Context: p1677004836819509-slack-CQD1HH4MA

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?