### PR TITLE
localizeUrl: Allow localization of Spanish Go blog post URLs

### DIFF
--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -115,7 +115,15 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 	'wordpress.com/support/': prefixLocalizedUrlPath( supportSiteLocales ),
 	'wordpress.com/forums/': prefixLocalizedUrlPath( forumLocales ),
 	'wordpress.com/blog/': prefixLocalizedUrlPath( localesWithBlog, /^\/blog\/?$/ ),
-	'wordpress.com/go/': prefixLocalizedUrlPath( localesWithGoBlog, /^\/go\/?$/ ),
+	'wordpress.com/go/': ( url: URL, localeSlug: Locale ): URL => {
+		// Rewrite non-home URLs (e.g. posts) only for Spanish, because that's
+		// the only language into which we're currently translating content.
+		const isHome = [ '/go/', '/go' ].includes( url.pathname );
+		if ( ! isHome && 'es' !== localeSlug ) {
+			return url;
+		}
+		return prefixLocalizedUrlPath( localesWithGoBlog )( url, localeSlug );
+	},
 	'wordpress.com/tos/': prefixLocalizedUrlPath( magnificentNonEnLocales ),
 	'wordpress.com/wp-admin/': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),
 	'wordpress.com/wp-login.php': setLocalizedUrlHost( 'wordpress.com', magnificentNonEnLocales ),

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -197,9 +197,15 @@ describe( '#localizeUrl', () => {
 		expect( localizeUrl( 'https://wordpress.com/go/', 'es' ) ).toEqual(
 			'https://wordpress.com/es/go/'
 		);
-		// Don't rewrite specific posts.
-		expect( localizeUrl( 'https://wordpress.com/go/category/test/', 'pt-br' ) ).toEqual(
-			'https://wordpress.com/go/category/test/'
+		// Rewrite specific posts only for Spanish.
+		expect( localizeUrl( 'https://wordpress.com/go/category/a-post/', 'pt-br' ) ).toEqual(
+			'https://wordpress.com/go/category/a-post/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/go/category/a-post/', 'pl' ) ).toEqual(
+			'https://wordpress.com/go/category/a-post/'
+		);
+		expect( localizeUrl( 'https://wordpress.com/go/category/a-post/', 'es' ) ).toEqual(
+			'https://wordpress.com/es/go/category/a-post/'
 		);
 	} );
 


### PR DESCRIPTION
Related to 536-gh-Automattic/i18n-issues.

## Proposed Changes

Since #71763, Go blog post URLs aren't localized anymore because Go posts are not regularly translated. The same approach was used for /blog posts in #43610. However, with the recent marketing efforts for Spain, Go blog posts will be translated into Spanish regularly. 

Case in point: at the bottom of the logged-in `/plugins` page, there are three links to Go blog posts, the first two of which are already translated into Spanish, and the third will soon follow:
<img width="1102" alt="image" src="https://user-images.githubusercontent.com/75777864/220441126-15adb8e3-2a5b-4cc4-9bda-8f25e907cec3.png">

Because of this, it makes sense to allow the localization of Go blog post URLs for Spanish, as it will improve the Spanish user experience.

This PR:

* Enables Go blog post URL localization for Spanish only.
* Updates the corresponding tests to reflect the change.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Code review.
2. Verify that the tests for `localizeUrl` pass by running `yarn test-packages -- packages/i18n-utils/src/test/localize-url.js`.
3. Verify that the localization of the post links on the logged-in `/plugins` page is correct:
    1. Change your UI language to Spanish.
    2. Visit `/plugins` while logged in and verify that the post links at the bottom (see screenshot above) are localized.
    3. Click the links and verify that the first two go to the Spanish posts, and the last one 404s.
    4. Change your UI language to any other non-English locale.
    5. Visit `/plugins` again, verify that the links are not localized, and that they lead to the English posts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
