### PR TITLE
GitHub integration: Add logic to disconnect from repo using the endpoint

### DIFF
--- a/client/my-sites/hosting/github/deployment-card/index.tsx
+++ b/client/my-sites/hosting/github/deployment-card/index.tsx
@@ -47,8 +47,8 @@ export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardPr
 		onError: ( error ) => {
 			dispatch(
 				errorNotice(
-					// translators: "reason" is why connecting the branch failed.
-					sprintf( translate( 'Failed to connect: %(reason)s' ), { reason: error.message } ),
+					// translators: "reason" is why disconnecting the branch failed.
+					sprintf( translate( 'Failed to disconnect: %(reason)s' ), { reason: error.message } ),
 					{
 						...noticeOptions,
 					}

--- a/client/my-sites/hosting/github/deployment-card/index.tsx
+++ b/client/my-sites/hosting/github/deployment-card/index.tsx
@@ -1,13 +1,15 @@
 import { Button, Card, Spinner } from '@automattic/components';
+import { sprintf } from '@wordpress/i18n';
 import i18n, { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import SocialLogo from 'calypso/components/social-logo';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { DeploymentStatusBadge } from './deployment-status-badge';
 import { DeploymentStatusExplanation } from './deployment-status-explanation';
 import { useDeploymentStatusQuery } from './use-deployment-status-query';
-
+import { useGithubDisconnectRepoMutation } from './use-disconnect-repo';
 import './style.scss';
 
 type DeploymentCardProps = {
@@ -15,6 +17,10 @@ type DeploymentCardProps = {
 	branch: string;
 	connectionId: number;
 };
+const noticeOptions = {
+	duration: 3000,
+};
+
 export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardProps ) => {
 	let deploymentTime = '';
 	let totalFailures = 0;
@@ -31,6 +37,25 @@ export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardPr
 			timeStyle: 'short',
 		} ).format( new Date( deployment.last_deployment_timestamp * 1000 ) );
 	}
+
+	const dispatch = useDispatch();
+
+	const { disconnectRepo, isLoading: isDisconnecting } = useGithubDisconnectRepoMutation( siteId, {
+		onSuccess: () => {
+			dispatch( successNotice( translate( 'Disconnected from repository successfully' ) ) );
+		},
+		onError: ( error ) => {
+			dispatch(
+				errorNotice(
+					// translators: "reason" is why connecting the branch failed.
+					sprintf( translate( 'Failed to connect: %(reason)s' ), { reason: error.message } ),
+					{
+						...noticeOptions,
+					}
+				)
+			);
+		},
+	} );
 
 	return (
 		<Card>
@@ -95,7 +120,7 @@ export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardPr
 					</div>
 				) }
 			</div>
-			<Button primary>
+			<Button primary busy={ isDisconnecting } onClick={ () => disconnectRepo( siteId ) }>
 				<span>{ translate( 'Disconnect repository' ) }</span>
 			</Button>
 		</Card>

--- a/client/my-sites/hosting/github/deployment-card/use-disconnect-repo.ts
+++ b/client/my-sites/hosting/github/deployment-card/use-disconnect-repo.ts
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
+import wp from 'calypso/lib/wp';
+
+const USE_GITHUB_DISCONNECT_REPO_QUERY_KEY = 'github-disconnect-repo-query-key';
+
+interface MutationError {
+	code: string;
+	message: string;
+}
+
+export const useGithubDisconnectRepoMutation = (
+	siteId: number | null,
+	options: UseMutationOptions< unknown, MutationError, unknown > = {}
+) => {
+	const queryClient = useQueryClient();
+	const mutation = useMutation(
+		async () =>
+			wp.req.post( {
+				method: 'DELETE',
+				path: `/sites/${ siteId }/hosting/github/connection`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		{
+			...options,
+			onSuccess: async ( ...args ) => {
+				await queryClient.invalidateQueries( [ USE_GITHUB_DISCONNECT_REPO_QUERY_KEY, siteId ] );
+				options.onSuccess?.( ...args );
+			},
+		}
+	);
+
+	const { mutate, isLoading } = mutation;
+
+	const disconnectRepo = useCallback( ( args ) => mutate( args ), [ mutate ] );
+
+	return { disconnectRepo, isLoading };
+};

--- a/client/my-sites/hosting/github/deployment-card/use-disconnect-repo.ts
+++ b/client/my-sites/hosting/github/deployment-card/use-disconnect-repo.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
 import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
 import wp from 'calypso/lib/wp';
-
-const USE_GITHUB_DISCONNECT_REPO_QUERY_KEY = 'github-disconnect-repo-query-key';
+import { GITHUB_INTEGRATION_QUERY_KEY } from '../constants';
+import { GITHUB_CONNECTION_QUERY_KEY } from '../use-github-connection-query';
 
 interface MutationError {
 	code: string;
@@ -24,7 +24,11 @@ export const useGithubDisconnectRepoMutation = (
 		{
 			...options,
 			onSuccess: async ( ...args ) => {
-				await queryClient.invalidateQueries( [ USE_GITHUB_DISCONNECT_REPO_QUERY_KEY, siteId ] );
+				await queryClient.invalidateQueries( [
+					GITHUB_INTEGRATION_QUERY_KEY,
+					siteId,
+					GITHUB_CONNECTION_QUERY_KEY,
+				] );
 				options.onSuccess?.( ...args );
 			},
 		}


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/1713.

## Proposed Changes

*Add hook to disconnect from repository

## Testing Instructions\

- Connect to Github and connect to a repository
- Disconnect from the Repository
- Verify the repo is disconnected and your taken to the `ConnectBranchCard`

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*
![image](https://user-images.githubusercontent.com/47489215/220467212-cca873b4-3f80-4ecd-8c4f-131c4d664f77.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
