### PR TITLE
Jetpack Cloud, Social: Add default landing page for Social subscribers

### DIFF
--- a/client/jetpack-cloud/sections/landing/selectors.ts
+++ b/client/jetpack-cloud/sections/landing/selectors.ts
@@ -1,4 +1,5 @@
 import {
+	FEATURE_SOCIAL_SHARES_1000,
 	WPCOM_FEATURES_BACKUPS,
 	WPCOM_FEATURES_INSTANT_SEARCH,
 	WPCOM_FEATURES_SCAN,
@@ -47,6 +48,11 @@ export const getLandingPath = ( state: AppState, siteId: number | null ) => {
 	const hasSearch = siteHasFeature( state, siteId, WPCOM_FEATURES_INSTANT_SEARCH );
 	if ( hasSearch ) {
 		return `/jetpack-search/${ siteSlug }`;
+	}
+
+	const hasSocial = siteHasFeature( state, siteId, FEATURE_SOCIAL_SHARES_1000 );
+	if ( hasSocial ) {
+		return `/jetpack-social/${ siteSlug }`;
 	}
 
 	// For sites with no eligible capabilities, or in situations where

--- a/client/jetpack-cloud/sections/landing/test/selectors.js
+++ b/client/jetpack-cloud/sections/landing/test/selectors.js
@@ -1,5 +1,6 @@
 // Test resources
 import {
+	FEATURE_SOCIAL_SHARES_1000,
 	WPCOM_FEATURES_AKISMET,
 	WPCOM_FEATURES_BACKUPS,
 	WPCOM_FEATURES_CDN,
@@ -67,7 +68,8 @@ describe( 'getLandingPath', () => {
 	it.each( [
 		[ WPCOM_FEATURES_SCAN ],
 		[ WPCOM_FEATURES_INSTANT_SEARCH ],
-		[ WPCOM_FEATURES_SCAN, WPCOM_FEATURES_INSTANT_SEARCH ],
+		[ FEATURE_SOCIAL_SHARES_1000 ],
+		[ WPCOM_FEATURES_SCAN, WPCOM_FEATURES_INSTANT_SEARCH, FEATURE_SOCIAL_SHARES_1000 ],
 	] )(
 		'should return /backup/<site> for eligible sites with Backup and other features',
 		( otherFeatures ) => {
@@ -91,7 +93,11 @@ describe( 'getLandingPath', () => {
 		expect( landingPath ).toEqual( `/scan/${ FAKE_SITE_SLUG }` );
 	} );
 
-	it.each( [ [ WPCOM_FEATURES_INSTANT_SEARCH ] ] )(
+	it.each( [
+		[ WPCOM_FEATURES_INSTANT_SEARCH ],
+		[ FEATURE_SOCIAL_SHARES_1000 ],
+		[ WPCOM_FEATURES_INSTANT_SEARCH, FEATURE_SOCIAL_SHARES_1000 ],
+	] )(
 		'should return /scan/<site> for eligible sites with Scan and other non-Backup features',
 		( otherFeatures ) => {
 			isJetpackSite.mockReturnValue( true );
@@ -113,6 +119,27 @@ describe( 'getLandingPath', () => {
 		const landingPath = getLandingPath( {}, 0 );
 		expect( landingPath ).toEqual( `/jetpack-search/${ FAKE_SITE_SLUG }` );
 	} );
+
+	it( 'should return /jetpack-search/<site> for sites with Search and Social', () => {
+		isJetpackSite.mockReturnValue( true );
+		getSiteSlug.mockReturnValue( FAKE_SITE_SLUG );
+		siteHasFeature.mockImplementation(
+			mockSiteFeatures( WPCOM_FEATURES_INSTANT_SEARCH, FEATURE_SOCIAL_SHARES_1000 )
+		);
+
+		const landingPath = getLandingPath( {}, 0 );
+		expect( landingPath ).toEqual( `/jetpack-search/${ FAKE_SITE_SLUG }` );
+	} );
+
+	it( 'should return /jetpack-social/<site> for sites with Social but not Backup, Scan, or Search', () => {
+		isJetpackSite.mockReturnValue( true );
+		getSiteSlug.mockReturnValue( FAKE_SITE_SLUG );
+		siteHasFeature.mockImplementation( mockSiteFeatures( FEATURE_SOCIAL_SHARES_1000 ) );
+
+		const landingPath = getLandingPath( {}, 0 );
+		expect( landingPath ).toEqual( `/jetpack-social/${ FAKE_SITE_SLUG }` );
+	} );
+
 	it.each( [ [ WPCOM_FEATURES_AKISMET ], [ WPCOM_FEATURES_VIDEOPRESS ], [ WPCOM_FEATURES_CDN ] ] )(
 		'should return /backup/<site> for sites with any other feature set',
 		( featureSet ) => {
@@ -124,6 +151,7 @@ describe( 'getLandingPath', () => {
 			expect( landingPath ).toEqual( `/backup/${ FAKE_SITE_SLUG }` );
 		}
 	);
+
 	it( 'should return /backup/<site> when site features are unavailable', () => {
 		isJetpackSite.mockReturnValue( true );
 		getSiteSlug.mockReturnValue( FAKE_SITE_SLUG );


### PR DESCRIPTION
Jetpack Cloud has a page for Social, but people who purchase it for their sites aren't sent there by default when they log in; rather, they're sent to `/backup/:site`. This PR fixes that issue and adds tests to assert the correct behavior.

Resolves `1202858161751496-as-1203937561792507`.

## Proposed Changes

* Modify and add unit test cases to account for Jetpack Social as a possible default landing page.
* Add a new conditional expression to `jetpack-cloud/sections/landing/selectors.ts` to check whether or not a site has the `FEATURE_SOCIAL_SHARES_1000` feature, indicating a paid subscription to Jetpack Social.

## Testing Instructions

_(Very similar to the testing instructions for #73124.)_

1. Find the site slug for a self-hosted Jetpack site with an active paid subscription to Jetpack Social.
2. Navigate to `/landing/:site`, where `:site` is your site slug.
3. Verify your browser redirects to the Social landing page at `/jetpack-social/:site`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203937561792507