### PR TITLE
GitHub integration: rework data fetching to use cache invalidation techniques

### DIFF
--- a/client/my-sites/hosting/github/constants.ts
+++ b/client/my-sites/hosting/github/constants.ts
@@ -1,0 +1,1 @@
+export const GITHUB_INTEGRATION_QUERY_KEY = 'github-integration';

--- a/client/my-sites/hosting/github/deployment-card/index.tsx
+++ b/client/my-sites/hosting/github/deployment-card/index.tsx
@@ -6,21 +6,22 @@ import SocialLogo from 'calypso/components/social-logo';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { DeploymentStatusBadge } from './deployment-status-badge';
 import { DeploymentStatusExplanation } from './deployment-status-explanation';
-import { useDeploymentStatus } from './use-deployment-status';
+import { useDeploymentStatusQuery } from './use-deployment-status-query';
 
 import './style.scss';
 
 type DeploymentCardProps = {
 	repo: string;
 	branch: string;
+	connectionId: number;
 };
-export const DeploymentCard = ( { repo, branch }: DeploymentCardProps ) => {
+export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardProps ) => {
 	let deploymentTime = '';
 	let totalFailures = 0;
 
 	const siteId = useSelector( getSelectedSiteId );
 
-	const { data: deployment, isLoading } = useDeploymentStatus( siteId );
+	const { data: deployment, isLoading } = useDeploymentStatusQuery( siteId, connectionId );
 	const translate = useTranslate();
 
 	if ( deployment ) {

--- a/client/my-sites/hosting/github/deployment-card/use-deployment-status-query.ts
+++ b/client/my-sites/hosting/github/deployment-card/use-deployment-status-query.ts
@@ -1,5 +1,6 @@
 import { useQuery, UseQueryOptions } from 'react-query';
 import wp from 'calypso/lib/wp';
+import { GITHUB_INTEGRATION_QUERY_KEY } from '../constants';
 
 export type DeploymentData = {
 	status: 'failed' | 'running' | 'success';
@@ -10,14 +11,13 @@ export type DeploymentData = {
 	last_deployment_sha: string;
 };
 
-const USE_DEPLOYMENT_STATUS_QUERY_KEY = 'deployment-status-query-key';
-
-export const useDeploymentStatus = (
+export const useDeploymentStatusQuery = (
 	siteId: number | null,
+	connectionId: number,
 	options?: UseQueryOptions< DeploymentData >
 ) => {
 	return useQuery< DeploymentData >(
-		[ USE_DEPLOYMENT_STATUS_QUERY_KEY, siteId ],
+		[ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId, 'deployment-status' ],
 		(): DeploymentData =>
 			wp.req.get( {
 				path: `/sites/${ siteId }/hosting/github/deployment-status`,

--- a/client/my-sites/hosting/github/disconnect-github-button/index.tsx
+++ b/client/my-sites/hosting/github/disconnect-github-button/index.tsx
@@ -1,9 +1,12 @@
 import { Button } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { useMutation } from 'react-query';
-import { useDispatch } from 'react-redux';
+import { useMutation, useQueryClient } from 'react-query';
+import { useDispatch, useSelector } from 'react-redux';
 import { deleteStoredKeyringConnection } from 'calypso/state/sharing/keyring/actions';
 import './style.scss';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { GITHUB_INTEGRATION_QUERY_KEY } from '../constants';
+import { GITHUB_CONNECTION_QUERY_KEY } from '../use-github-connection-query';
 
 type Connection = Parameters< typeof deleteStoredKeyringConnection >[ 0 ];
 
@@ -12,12 +15,19 @@ interface DisconnectGitHubButtonProps {
 }
 
 export function DisconnectGitHubButton( { connection }: DisconnectGitHubButtonProps ) {
+	const queryClient = useQueryClient();
+	const siteId = useSelector( getSelectedSiteId );
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	// Using ReactQuery to manage `isDisconnecting` state because it's not exposed from the Redux store.
-	const mutation = useMutation< unknown, unknown, Connection >(
-		async ( c ) => await dispatch( deleteStoredKeyringConnection( c ) )
-	);
+	const mutation = useMutation< unknown, unknown, Connection >( async ( c ) => {
+		await dispatch( deleteStoredKeyringConnection( c ) );
+		await queryClient.invalidateQueries( [
+			GITHUB_INTEGRATION_QUERY_KEY,
+			siteId,
+			GITHUB_CONNECTION_QUERY_KEY,
+		] );
+	} );
 	const { mutate: disconnect, isLoading: isDisconnecting } = mutation;
 
 	return (

--- a/client/my-sites/hosting/github/github-authorize-card/index.tsx
+++ b/client/my-sites/hosting/github/github-authorize-card/index.tsx
@@ -1,20 +1,24 @@
 import { Button, Card } from '@automattic/components';
 import requestExternalAccess from '@automattic/request-external-access';
 import { translate } from 'i18n-calypso';
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 import { useSelector, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import SocialLogo from 'calypso/components/social-logo';
 import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
 import { getKeyringServiceByName } from 'calypso/state/sharing/services/selectors';
-
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import '../style.scss';
+import { GITHUB_INTEGRATION_QUERY_KEY } from '../constants';
+import { GITHUB_CONNECTION_QUERY_KEY } from '../use-github-connection-query';
 
 type Service = {
 	connect_URL: string;
 };
 
 export const GithubAuthorizeCard = () => {
+	const queryClient = useQueryClient();
+	const siteId = useSelector( getSelectedSiteId );
 	const dispatch = useDispatch();
 	const github = useSelector( ( state ) =>
 		getKeyringServiceByName( state, 'github-deploy' )
@@ -24,6 +28,15 @@ export const GithubAuthorizeCard = () => {
 		async ( connectURL ) => {
 			await new Promise( ( resolve ) => requestExternalAccess( connectURL, resolve ) );
 			await dispatch( requestKeyringConnections() );
+		},
+		{
+			onSuccess: async () => {
+				await queryClient.invalidateQueries( [
+					GITHUB_INTEGRATION_QUERY_KEY,
+					siteId,
+					GITHUB_CONNECTION_QUERY_KEY,
+				] );
+			},
 		}
 	);
 

--- a/client/my-sites/hosting/github/github-connect-card/index.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/index.tsx
@@ -15,7 +15,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { DisconnectGitHubButton } from '../disconnect-github-button';
 import { SearchBranches } from './search-branches';
 import { SearchRepos } from './search-repos';
-import { useGithubConnectMutation } from './use-github-connect';
+import { useGithubConnectMutation } from './use-github-connect-mutation';
 
 import './style.scss';
 
@@ -99,6 +99,7 @@ export const GithubConnectCard = ( { connection }: GithubConnectCardProps ) => {
 						<FormLabel htmlFor="repository">{ __( 'Repository' ) }</FormLabel>
 						<SearchRepos
 							siteId={ siteId }
+							connectionId={ connection.ID }
 							onSelect={ handleRepoSelect }
 							onChange={ resetRepoSelection }
 						/>
@@ -107,6 +108,7 @@ export const GithubConnectCard = ( { connection }: GithubConnectCardProps ) => {
 						<FormLabel htmlFor="branch">{ __( 'Branch' ) }</FormLabel>
 						<SearchBranches
 							siteId={ siteId }
+							connectionId={ connection.ID }
 							repoName={ selectedRepo }
 							onSelect={ handleBranchSelect }
 							selectedBranch={ selectedBranch }

--- a/client/my-sites/hosting/github/github-connect-card/search-branches.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/search-branches.tsx
@@ -3,10 +3,11 @@ import { useI18n } from '@wordpress/react-i18n';
 import { ChangeEvent } from 'react';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import { useGithubBranches } from './use-github-branches';
+import { useGithubBranchesQuery } from './use-github-branches-query';
 
 interface SearchBranchesProps {
 	siteId: number | null;
+	connectionId: number;
 	onSelect( repo: string ): void;
 	repoName?: string;
 	selectedBranch?: string;
@@ -14,19 +15,25 @@ interface SearchBranchesProps {
 
 export const SearchBranches = ( {
 	siteId,
+	connectionId,
 	onSelect,
 	repoName,
 	selectedBranch,
 }: SearchBranchesProps ) => {
 	const { __ } = useI18n();
 
-	const { data: branches, isLoading: isLoading } = useGithubBranches( siteId, repoName, {
-		onSuccess( branches ) {
-			if ( branches.length < 30 ) {
-				onSelect( branches[ 0 ] );
-			}
-		},
-	} );
+	const { data: branches, isLoading: isLoading } = useGithubBranchesQuery(
+		siteId,
+		repoName,
+		connectionId,
+		{
+			onSuccess( branches ) {
+				if ( branches.length < 30 ) {
+					onSelect( branches[ 0 ] );
+				}
+			},
+		}
+	);
 
 	if ( branches && branches.length < 30 ) {
 		return (

--- a/client/my-sites/hosting/github/github-connect-card/search-repos.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/search-repos.tsx
@@ -2,20 +2,21 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 import { useDebounce } from 'use-debounce';
 import { Search } from './search';
-import { useGithubRepos } from './use-github-repos';
+import { useGithubReposQuery } from './use-github-repos-query';
 
 interface SearchReposProps {
 	siteId: number | null;
+	connectionId: number;
 	onSelect( repo: string ): void;
 	onChange?( query: string ): void;
 }
 
-export const SearchRepos = ( { siteId, onSelect, onChange }: SearchReposProps ) => {
+export const SearchRepos = ( { siteId, connectionId, onSelect, onChange }: SearchReposProps ) => {
 	const { __ } = useI18n();
 	const [ query, setQuery ] = useState( '' );
 	const [ debouncedQuery ] = useDebounce( query, 500 );
 
-	const { data: repos, isLoading } = useGithubRepos( siteId, debouncedQuery );
+	const { data: repos, isLoading } = useGithubReposQuery( siteId, debouncedQuery, connectionId );
 
 	return (
 		<Search

--- a/client/my-sites/hosting/github/github-connect-card/use-github-branches-query.ts
+++ b/client/my-sites/hosting/github/github-connect-card/use-github-branches-query.ts
@@ -1,7 +1,7 @@
 import { useQuery, UseQueryOptions } from 'react-query';
 import wp from 'calypso/lib/wp';
+import { GITHUB_INTEGRATION_QUERY_KEY } from '../constants';
 
-const USE_GITHUB_BRANCHES_QUERY_KEY = 'github-branches-query-key';
 const CACHE_TIME = 1000 * 60 * 5; // 5 mins
 
 const sortBranches = ( a: string, b: string ): number => {
@@ -13,13 +13,14 @@ const sortBranches = ( a: string, b: string ): number => {
 	return a.localeCompare( b );
 };
 
-export const useGithubBranches = (
+export const useGithubBranchesQuery = (
 	siteId: number | null,
 	repoName: string | undefined,
+	connectionId: number,
 	options?: UseQueryOptions< string[] >
 ) => {
 	return useQuery< string[] >(
-		[ USE_GITHUB_BRANCHES_QUERY_KEY, repoName, siteId ],
+		[ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId, 'branches', repoName ],
 		(): string[] =>
 			wp.req.get( {
 				path: `/sites/${ siteId }/hosting/github/branches?repo=${ repoName }`,

--- a/client/my-sites/hosting/github/github-connect-card/use-github-connect-mutation.ts
+++ b/client/my-sites/hosting/github/github-connect-card/use-github-connect-mutation.ts
@@ -1,9 +1,8 @@
 import { useCallback } from 'react';
 import { useMutation, UseMutationOptions, useQueryClient } from 'react-query';
 import wp from 'calypso/lib/wp';
-import { USE_GITHUB_CONNECTION_QUERY_KEY } from '../use-github-connection';
-
-export const USE_GITHUB_CONNECT_QUERY_KEY = 'github-connect-query-key';
+import { GITHUB_INTEGRATION_QUERY_KEY } from '../constants';
+import { GITHUB_CONNECTION_QUERY_KEY } from '../use-github-connection-query';
 
 interface MutationVariables {
 	repoName: string | undefined;
@@ -38,7 +37,11 @@ export const useGithubConnectMutation = (
 		{
 			...options,
 			onSuccess: async ( ...args ) => {
-				await queryClient.invalidateQueries( [ USE_GITHUB_CONNECTION_QUERY_KEY, siteId ] );
+				await queryClient.invalidateQueries( [
+					GITHUB_INTEGRATION_QUERY_KEY,
+					siteId,
+					GITHUB_CONNECTION_QUERY_KEY,
+				] );
 				options.onSuccess?.( ...args );
 			},
 		}

--- a/client/my-sites/hosting/github/github-connect-card/use-github-repos-query.ts
+++ b/client/my-sites/hosting/github/github-connect-card/use-github-repos-query.ts
@@ -1,16 +1,16 @@
 import { useQuery, UseQueryOptions } from 'react-query';
 import { addQueryArgs } from 'calypso/lib/url';
 import wp from 'calypso/lib/wp';
+import { GITHUB_INTEGRATION_QUERY_KEY } from '../constants';
 
-const USE_GITHUB_REPOS_QUERY_KEY = 'github-repos-query-key';
-
-export const useGithubRepos = (
+export const useGithubReposQuery = (
 	siteId: number | null,
 	query: string,
+	connectionId: number,
 	options?: UseQueryOptions< string[] >
 ) => {
 	return useQuery< string[] >(
-		[ USE_GITHUB_REPOS_QUERY_KEY, siteId, query ],
+		[ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId, 'repos', query ],
 		(): string[] =>
 			wp.req.get( {
 				path: addQueryArgs( { query }, `/sites/${ siteId }/hosting/github/repos` ),

--- a/client/my-sites/hosting/github/index.tsx
+++ b/client/my-sites/hosting/github/index.tsx
@@ -4,17 +4,24 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { DeploymentCard } from './deployment-card';
 import { GithubConnectCard } from './github-connect-card';
 import { GitHubPlaceholderCard } from './github-placeholder-card';
-import { useGithubConnection } from './use-github-connection';
+import { useGithubConnectionQuery } from './use-github-connection-query';
 
 export const GitHubCard = () => {
 	const siteId = useSelector( getSelectedSiteId );
-	const { data: connection, isLoading: isFetching } = useGithubConnection( siteId );
+	const { data: connection, isLoading: isFetching } = useGithubConnectionQuery( siteId );
+
 	if ( isFetching || ! connection ) {
 		return <GitHubPlaceholderCard />;
 	}
 
 	if ( connection.repo ) {
-		return <DeploymentCard repo={ connection.repo } branch={ connection.branch } />;
+		return (
+			<DeploymentCard
+				repo={ connection.repo }
+				branch={ connection.branch }
+				connectionId={ connection.ID }
+			/>
+		);
 	}
 
 	if ( ! connection.repo && connection.connected ) {

--- a/client/my-sites/hosting/github/use-github-connection-query.ts
+++ b/client/my-sites/hosting/github/use-github-connection-query.ts
@@ -1,7 +1,9 @@
 import { useQuery, UseQueryOptions } from 'react-query';
 import wp from 'calypso/lib/wp';
+import { GITHUB_INTEGRATION_QUERY_KEY } from './constants';
 
-export const USE_GITHUB_CONNECTION_QUERY_KEY = 'github-connection-query-key';
+export const GITHUB_CONNECTION_QUERY_KEY = 'github-connection';
+
 type GithubConnectionData = {
 	ID: number;
 	connected: boolean;
@@ -12,12 +14,12 @@ type GithubConnectionData = {
 	label: string;
 	external_name: string;
 };
-export const useGithubConnection = (
+export const useGithubConnectionQuery = (
 	siteId: number | null,
 	options?: UseQueryOptions< GithubConnectionData >
 ) => {
 	return useQuery< GithubConnectionData >(
-		[ USE_GITHUB_CONNECTION_QUERY_KEY, siteId ],
+		[ GITHUB_INTEGRATION_QUERY_KEY, siteId, GITHUB_CONNECTION_QUERY_KEY ],
 		(): GithubConnectionData =>
 			wp.req.get( {
 				path: `/sites/${ siteId }/hosting/github/connection`,


### PR DESCRIPTION
Supersedes https://github.com/Automattic/wp-calypso/pull/73587.

## Proposed Changes

This PR performs some code clean-up and introduces file name and query key patterns that are considered best practices when using `react-query`.

We're adding the `connection.ID` parameter to connection-related queries (I.e. status fetching, repository searching) so that when the user disconnects and reconnects with another account the data is invalidated properly.

## Test instructions

You shouldn't need to refresh the page after syncing these code changes in Calypso

1. Apply this branch to your Calypso installation
2. Apply D102269-code to your sandbox
3. Dispatch a `DELETE https://public-api.wordpress.com/wpcom/v2/sites/<site-id>/hosting/github/connection` request to remove the current connection
4. Focus the window and check that the repository connection is gone
5. Disconnect the GitHub installation
6. Check that it's reflected in the UI
7. Authorize again
8. Check that it's reflected in the UI
9. Search for a repository
10. Check that it's reflected in the UI
11. Connect the repository
12. Check that you now see the connected repository UI
13. Dispatch the `DELETE` request from step 3 again
14. Check that you see the repository connection UI

