### PR TITLE
Jetpack App: update the advertising views to work in Jetpack app

### DIFF
--- a/client/my-sites/promote-post/components/post-item/index.tsx
+++ b/client/my-sites/promote-post/components/post-item/index.tsx
@@ -65,7 +65,7 @@ export default function PostItem( { post }: Props ) {
 						) }
 					</span>
 					<span className="post-item__post-type">{ getPostType( post.type ) }</span>
-					<span className="post-item__post-type">
+					<span className="post-item__link">
 						<a href={ post.URL } className="post-item__title-view">
 							{ __( 'View' ) }{ ' ' }
 							<Gridicon icon="external" size={ 12 } className="post-item__external-icon" />

--- a/client/my-sites/promote-post/components/post-item/style.scss
+++ b/client/my-sites/promote-post/components/post-item/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 $post-item-background-color: var(--color-surface);
 
 .promote-post {
@@ -20,17 +23,25 @@ $post-item-background-color: var(--color-surface);
 	}
 
 	.post-item__meta,
-	.post-item__post-type {
+	.post-item__post-type,
+	.post-item__link {
 		font-size: $font-body-extra-small;
 		color: var(--color-text-subtle);
 	}
 
 	.post-item__meta-time-status {
 		display: inline-block;
-		margin-right: 16px;
+		margin-right: 0;
+		width: 100%;
+
+		@include break-mobile {
+			margin-right: 16px;
+			width: auto;
+		}
 	}
 
-	.post-item__post-type {
+	.post-item__post-type,
+	.post-item__link {
 		margin-right: 16px;
 	}
 

--- a/client/my-sites/promote-post/style.scss
+++ b/client/my-sites/promote-post/style.scss
@@ -33,3 +33,19 @@
 		font-size: $font-body;
 	}
 }
+
+.is-mobile-app-view {
+	.advertising__page-header,
+	.promote-post .posts-list-banner__container,
+	.promote-post .section-nav,
+	.promote-post .post-item__link {
+		display: none;
+	}
+	.layout.has-no-masterbar.is-group-sites.is-section-promote-post .layout__content {
+		padding-top: 0;
+	}
+
+	.layout__primary .main {
+		padding-bottom: 0;
+	}
+}


### PR DESCRIPTION
This PR updates the look and feel of the advertising and Campain page to work well in the WebView context. 

Related: PT pcdRpT-1LY-p2 - Design: pcdRpT-1QG-p2

## Proposed Changes

1. Removes the Heading, 
2. Removes the Tabs. (in page navigation)
3. Removes the Banner.
4. Removes the permalink. 
5. Removed the top and bottom padding. 

It updates the post lists so that the post type always shows up in a consistent way. 

### Before:
/ Advertising
<img width="300" src="https://user-images.githubusercontent.com/115071/220461095-cd372a8c-e590-417a-91d6-bea3ff00a8d8.png" />


/ Advertising/campaigns
<img width="300" src="https://user-images.githubusercontent.com/115071/220460903-c5b8b0ac-6584-41db-8b9d-120c227533b5.png" />

### After:
/ Advertising

<img width="300" src="https://user-images.githubusercontent.com/115071/220461444-29b09922-40e1-44fd-94d3-ba7b2754f994.png" />

/ Advertising/campaigns

<img width="300" src="https://user-images.githubusercontent.com/115071/220681646-382e57fd-1e42-4a0a-83d7-a4ba4175be45.png" />


## Testing Instructions
1. Load this PR. (Using calypso live links) 
2. Using the `Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 wp-android` UA header. You can change it in the developer tools preview

<img width="300" alt="Screenshot 2023-02-21 at 1 25 44 PM" src="https://user-images.githubusercontent.com/115071/220462021-f946e255-23ce-450f-acd2-229dc9e311a2.png">

3. Load the view as a regular user and notice that there are no visible changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
