### PR TITLE
Load translations for happy blocks

### DIFF
--- a/apps/happy-blocks/index.php
+++ b/apps/happy-blocks/index.php
@@ -97,6 +97,9 @@ function a8c_happyblocks_view_assets() {
 		$assets['version'],
 		true
 	);
+	if ( function_exists( 'wp_set_script_translations' ) ) {
+		wp_set_script_translations( 'a8c-happyblock-view-js', 'happy-blocks' );
+	}
 }
 add_action( 'enqueue_block_editor_assets', 'a8c_happyblocks_edit_assets' );
 add_action( 'wp_enqueue_scripts', 'a8c_happyblocks_view_assets' );

--- a/apps/happy-blocks/src/pricing-plans/hooks/pricing-plans.ts
+++ b/apps/happy-blocks/src/pricing-plans/hooks/pricing-plans.ts
@@ -37,7 +37,7 @@ const parsePlans = ( data: ApiPricingPlan[] ): BlockPlan[] => {
 					) ?? '',
 				upgradeLabel: sprintf(
 					// translators: %s is the plan name
-					__( 'Upgrade to %s', 'happy-tools' ),
+					__( 'Upgrade to %s', 'happy-blocks' ),
 					plan.getTitle()
 				),
 			};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to D101407-code

## Proposed Changes

* Load the translations for happy blocks from the JSON files

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `install-plugin.sh happy-blocks add/load-happy-blocks-translations` on your sandbox
* Point `wordpress.com` and `br.forums.wordpress.com` to your sandbox
* Open https://br.forums.wordpress.com/?p=54514 in an incognito window and confirm that the `monthly` / `yearly` / `Upgrade to` labels are translated. Translations for the plan title/description would be added in another PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
