### PR TITLE
WooExpress: Added trial upgrade confirmation page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/controlller.jsx
+++ b/client/my-sites/plans/ecommerce-trial/controlller.jsx
@@ -1,0 +1,6 @@
+import TrialUpgradeConfirmation from './upgrade-confirmation';
+
+export function trialUpgradeConfirmation( context, next ) {
+	context.primary = <TrialUpgradeConfirmation />;
+	next();
+}

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/index.tsx
@@ -1,5 +1,5 @@
 import { Card } from '@automattic/components';
-import { TranslateResult } from 'i18n-calypso';
+import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
 

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/index.tsx
@@ -1,10 +1,11 @@
 import { Card } from '@automattic/components';
+import { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
 
 interface ConfirmationTaskProps {
-	title: string;
-	subtitle: string;
+	title: TranslateResult;
+	subtitle: TranslateResult;
 	illustration: string;
 }
 

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/index.tsx
@@ -1,0 +1,23 @@
+import { Card } from '@automattic/components';
+
+import './style.scss';
+
+interface ConfirmationTaskProps {
+	title: string;
+	subtitle: string;
+	illustration: string;
+}
+
+const ConfirmationTask = ( props: ConfirmationTaskProps ) => {
+	const { title, subtitle } = props;
+
+	return (
+		<Card className="confirmation-task__card">
+			<span>{ title }</span>
+			<br />
+			<span>{ subtitle }</span>
+		</Card>
+	);
+};
+
+export default ConfirmationTask;

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/style.scss
@@ -1,0 +1,4 @@
+.confirmation-task__card {
+	margin: 0;
+	padding: 40px 25px;
+}

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-tasks.ts
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-tasks.ts
@@ -1,0 +1,44 @@
+import { translate as i18nTranslate } from 'i18n-calypso';
+
+type ConfirmationTasksProps = {
+	translate: typeof i18nTranslate;
+};
+
+export const getConfirmationTasks = ( { translate }: ConfirmationTasksProps ) => {
+	return [
+		{
+			illustration: 'TODO',
+			title: translate( 'Select your custom domain' ),
+			subtitle: translate(
+				'Enhance your brand and make your store more professional with a custom domain.'
+			),
+		},
+		{
+			illustration: 'TODO',
+			title: translate( 'Promote your products' ),
+			subtitle: translate( 'Grow your customer base by reaching millions of engaged shoppers.' ),
+		},
+		{
+			illustration: 'TODO',
+			title: translate( 'Provide a way to pay ' ),
+			subtitle: translate(
+				'Set up one or more payment methods to make it easy for your customers to pay.'
+			),
+		},
+		{
+			illustration: 'TODO',
+			title: translate( 'Create a marketing campaign' ),
+			subtitle: translate( 'Drive sales and build loyalty through automated marketing messages.' ),
+		},
+		{
+			illustration: 'TODO',
+			title: translate( 'Make your store stand out' ),
+			subtitle: translate( 'Keep customizing your store appearance and make it stand out.' ),
+		},
+		{
+			illustration: 'TODO',
+			title: translate( 'Manage your store on the go' ),
+			subtitle: translate( 'Manage your store anywhere with the free WooCommerce Mobile App.' ),
+		},
+	];
+};

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -1,0 +1,33 @@
+import { useTranslate } from 'i18n-calypso';
+import Main from 'calypso/components/main';
+import './style.scss';
+import ConfirmationTask from './confirmation-task';
+import { getConfirmationTasks } from './confirmation-tasks';
+
+const TrialUpgradeConfirmation = () => {
+	const translate = useTranslate();
+
+	const tasks = getConfirmationTasks( { translate } );
+
+	return (
+		<Main wideLayout>
+			<div className="trial-upgrade-confirmation__header">
+				<h1 className="trial-upgrade-confirmation__title">
+					{ translate( 'Woo! Welcome to eCommerce' ) }
+				</h1>
+				<div className="trial-upgrade-confirmation__subtitle">
+					{ translate( 'Your purchase has been completed and you’re on the Commerce plan.' ) }
+					<br />
+					{ translate( "Now it's time to get creative. What would you like to do next?" ) }
+				</div>
+			</div>
+			<div className="trial-upgrade-confirmation__tasks">
+				{ tasks.map( ( task ) => (
+					<ConfirmationTask { ...task } />
+				) ) }
+			</div>
+		</Main>
+	);
+};
+
+export default TrialUpgradeConfirmation;

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -13,7 +13,7 @@ const TrialUpgradeConfirmation = () => {
 
 	return (
 		<>
-			<BodySectionCssClass bodyClass={ [ 'trial-upgraded' ] } />
+			<BodySectionCssClass bodyClass={ [ 'ecommerce-trial-upgraded' ] } />
 			<Main wideLayout>
 				<div className="trial-upgrade-confirmation__header">
 					<h1 className="trial-upgrade-confirmation__title">

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -17,10 +17,12 @@ const TrialUpgradeConfirmation = () => {
 			<Main wideLayout>
 				<div className="trial-upgrade-confirmation__header">
 					<h1 className="trial-upgrade-confirmation__title">
-						{ translate( 'Woo! Welcome to eCommerce' ) }
+						{ translate( 'Woo! Welcome to Commerce' ) }
 					</h1>
 					<div className="trial-upgrade-confirmation__subtitle">
-						{ translate( 'Your purchase has been completed and you’re on the Commerce plan.' ) }
+						{ translate( "Your purchase has been completed and you're on the %(planName)s plan.", {
+							args: { planName: 'Commerce' },
+						} ) }
 						<br />
 						{ translate( "Now it's time to get creative. What would you like to do next?" ) }
 					</div>

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -1,8 +1,10 @@
 import { useTranslate } from 'i18n-calypso';
 import Main from 'calypso/components/main';
-import './style.scss';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import ConfirmationTask from './confirmation-task';
 import { getConfirmationTasks } from './confirmation-tasks';
+
+import './style.scss';
 
 const TrialUpgradeConfirmation = () => {
 	const translate = useTranslate();
@@ -10,23 +12,26 @@ const TrialUpgradeConfirmation = () => {
 	const tasks = getConfirmationTasks( { translate } );
 
 	return (
-		<Main wideLayout>
-			<div className="trial-upgrade-confirmation__header">
-				<h1 className="trial-upgrade-confirmation__title">
-					{ translate( 'Woo! Welcome to eCommerce' ) }
-				</h1>
-				<div className="trial-upgrade-confirmation__subtitle">
-					{ translate( 'Your purchase has been completed and you’re on the Commerce plan.' ) }
-					<br />
-					{ translate( "Now it's time to get creative. What would you like to do next?" ) }
+		<>
+			<BodySectionCssClass bodyClass={ [ 'trial-upgraded' ] } />
+			<Main wideLayout>
+				<div className="trial-upgrade-confirmation__header">
+					<h1 className="trial-upgrade-confirmation__title">
+						{ translate( 'Woo! Welcome to eCommerce' ) }
+					</h1>
+					<div className="trial-upgrade-confirmation__subtitle">
+						{ translate( 'Your purchase has been completed and you’re on the Commerce plan.' ) }
+						<br />
+						{ translate( "Now it's time to get creative. What would you like to do next?" ) }
+					</div>
 				</div>
-			</div>
-			<div className="trial-upgrade-confirmation__tasks">
-				{ tasks.map( ( task ) => (
-					<ConfirmationTask { ...task } />
-				) ) }
-			</div>
-		</Main>
+				<div className="trial-upgrade-confirmation__tasks">
+					{ tasks.map( ( task ) => (
+						<ConfirmationTask key={ task.title } { ...task } />
+					) ) }
+				</div>
+			</Main>
+		</>
 	);
 };
 

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
@@ -1,0 +1,25 @@
+body {
+	background-color: var(--color-surface);
+
+	.trial-upgrade-confirmation__header {
+		text-align: center;
+		padding: 20px 0;
+
+		.trial-upgrade-confirmation__title {
+			font-size: $font-title-large;
+			padding: 20px;
+		}
+
+		.trial-upgrade-confirmation__subtitle {
+			font-size: $font-body;
+		}
+	}
+
+	.trial-upgrade-confirmation__tasks {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		grid-column-gap: 32px;
+		grid-row-gap: 32px;
+		margin-top: 35px;
+	}
+}

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
@@ -1,5 +1,6 @@
 body.trial-upgraded {
 	background-color: var(--color-surface);
+	font-family: "SF Pro Text", $sans;
 
 	.trial-upgrade-confirmation__header {
 		text-align: center;

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
@@ -1,6 +1,8 @@
-body.trial-upgraded {
+@import "@automattic/components/src/styles/typography";
+
+body.ecommerce-trial-upgraded {
 	background-color: var(--color-surface);
-	font-family: "SF Pro Text", $sans;
+	font-family: $font-sf-pro-text;
 
 	.trial-upgrade-confirmation__header {
 		text-align: center;

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
@@ -1,4 +1,4 @@
-body {
+body.trial-upgraded {
 	background-color: var(--color-surface);
 
 	.trial-upgrade-confirmation__header {

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -74,11 +74,7 @@ export default function () {
 		p2RedirectToHubPlans,
 		currentPlan
 	);
-	trackedPage(
-		'/plans/my-plan/trial-upgrade-confirmation/:domain',
-		siteSelection,
-		trialUpgradeConfirmation
-	);
+	trackedPage( '/plans/my-plan/trial-upgraded/:domain', siteSelection, trialUpgradeConfirmation );
 	trackedPage(
 		'/plans/my-plan/:site',
 		siteSelection,

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -18,6 +18,7 @@ import {
 	redirectToPlansIfNotJetpack,
 } from './controller';
 import { currentPlan } from './current-plan/controller';
+import { trialUpgradeConfirmation } from './ecommerce-trial/controlller';
 
 const trackedPage = ( url, ...rest ) => {
 	page( url, ...rest, makeLayout, clientRender );
@@ -72,6 +73,11 @@ export default function () {
 		navigation,
 		p2RedirectToHubPlans,
 		currentPlan
+	);
+	trackedPage(
+		'/plans/my-plan/trial-upgrade-confirmation/:domain',
+		siteSelection,
+		trialUpgradeConfirmation
 	);
 	trackedPage(
 		'/plans/my-plan/:site',


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/73500

## Proposed Changes

Figma: jBwlERMS350NqhJNHZzAVF-fi-98%3A33334

* Added a new route to place the confirmation page.
* Created a new component: `<TrialUpgradeConfirmation />` 
* Created a getter to hold the task data (copy from the designs): `upgrade-confirmation/confirmation-tasks.ts`
* Created basic structure/placeholders for the page content, including `<ConfirmationTask />`

## Outside of this PR's scope
* Full style definitions
* Mobile version
* Dynamic plan information
* Animations/confetti
* Illustrations

## Testing Instructions

* Using calypso-live, access `plans/my-plan/trial-upgraded/<site-slug>`
   * The site slug is not being validated yet
* Please confirm that the approach to creating the new route (and the route name/path) is sensible.
* Note that the font family doesn't match the one from the designs. I'm not sure if we should change it.
   * The font used in the design is "SF Pro Text", but it's not currently loaded in the browser. Is this expected or do we need to load the font file dynamically?

![image](https://user-images.githubusercontent.com/3801502/220496149-8645076a-0bfb-4338-80ca-2f82e17e20a9.png)
