### PR TITLE
Hosting Configuration: Add 'PHP error' log downloads

### DIFF
--- a/client/my-sites/hosting/web-server-logs-card/index.js
+++ b/client/my-sites/hosting/web-server-logs-card/index.js
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
+import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import MaterialIcon from 'calypso/components/material-icon';
 import wpcom from 'calypso/lib/wp';
@@ -34,6 +35,7 @@ const WebServerLogsCard = ( props ) => {
 	const dateTimeFormat = 'YYYY-MM-DD HH:mm:ss';
 	const [ startDateTime, setStartDateTime ] = useState( oneHourAgo.format( dateTimeFormat ) );
 	const [ endDateTime, setEndDateTime ] = useState( now.format( dateTimeFormat ) );
+	const [ logType, setLogType ] = useState( 'php' );
 	const [ downloading, setDownloading ] = useState( false );
 	const [ downloadErrorOccurred, setDownloadErrorOccurred ] = useState( false );
 	const [ progress, setProgress ] = useState( { recordsDownloaded: 0, totalRecordsAvailable: 0 } );
@@ -46,6 +48,17 @@ const WebServerLogsCard = ( props ) => {
 		isValid: true,
 		validationInfo: '',
 	} );
+
+	const logTypes = [
+		{
+			label: translate( 'PHP error' ),
+			value: 'php',
+		},
+		{
+			label: translate( 'Web request' ),
+			value: 'web',
+		},
+	];
 
 	useEffect( () => {
 		const startMoment = moment.utc( startDateTime );
@@ -103,6 +116,17 @@ const WebServerLogsCard = ( props ) => {
 		setProgress( { recordsDownloaded: 0, totalRecordsAvailable: 0 } );
 		setDownloadErrorOccurred( false );
 
+		let path = null;
+		if ( logType === 'php' ) {
+			path = `/sites/${ siteId }/hosting/error-logs`;
+		} else if ( logType === 'web' ) {
+			path = `/sites/${ siteId }/hosting/logs`;
+		} else {
+			downloadErrorNotice( translate( 'Invalid log type specified' ) );
+			setDownloadErrorOccurred( true );
+			return;
+		}
+
 		const startMoment = moment.utc( startDateTime );
 		const endMoment = moment.utc( endDateTime );
 
@@ -132,7 +156,7 @@ const WebServerLogsCard = ( props ) => {
 			await wpcom.req
 				.post(
 					{
-						path: `/sites/${ siteId }/hosting/logs`,
+						path,
 						apiNamespace: 'wpcom/v2',
 					},
 					{
@@ -243,6 +267,16 @@ const WebServerLogsCard = ( props ) => {
 						'To help troubleshoot or debug problems with your site, you may download web server logs between the following dates.'
 					) }
 				</p>
+				<div className="web-server-logs-card__type">
+					<FormFieldset>
+						<FormLabel>{ translate( 'Log type:' ) }</FormLabel>
+						<FormRadiosBar
+							items={ logTypes }
+							checked={ logType }
+							onChange={ ( event ) => setLogType( event.target.value ) }
+						/>
+					</FormFieldset>
+				</div>
 				<div className="web-server-logs-card__dates">
 					<div className="web-server-logs-card__start">
 						<FormFieldset>

--- a/client/my-sites/hosting/web-server-logs-card/index.js
+++ b/client/my-sites/hosting/web-server-logs-card/index.js
@@ -142,6 +142,7 @@ const WebServerLogsCard = ( props ) => {
 			site_id: siteId,
 			start_time: startMoment.format( dateTimeFormat ),
 			end_time: endMoment.format( dateTimeFormat ),
+			log_type: logType,
 		};
 
 		recordDownloadStarted( tracksProps );

--- a/client/my-sites/hosting/web-server-logs-card/index.js
+++ b/client/my-sites/hosting/web-server-logs-card/index.js
@@ -212,7 +212,8 @@ const WebServerLogsCard = ( props ) => {
 
 		const url = window.URL.createObjectURL( logFile );
 		const link = document.createElement( 'a' );
-		const downloadFilename = siteSlug + '-' + startString + '-' + endString + '.csv';
+		const downloadFilename =
+			siteSlug + '-' + logType + '-logs-' + startString + '-' + endString + '.csv';
 		link.href = url;
 		link.setAttribute( 'download', downloadFilename );
 		link.click();

--- a/client/my-sites/hosting/web-server-logs-card/index.js
+++ b/client/my-sites/hosting/web-server-logs-card/index.js
@@ -264,7 +264,7 @@ const WebServerLogsCard = ( props ) => {
 			<>
 				<p className="web-server-logs-card__info">
 					{ translate(
-						'To help troubleshoot or debug problems with your site, you may download web server logs between the following dates.'
+						'Download web server logs to troubleshoot or debug problems with your site.'
 					) }
 				</p>
 				<div className="web-server-logs-card__type">
@@ -319,7 +319,7 @@ const WebServerLogsCard = ( props ) => {
 						disabled={ downloading || ! startDateValidation.isValid || ! endDateValidation.isValid }
 						onClick={ downloadLogs }
 					>
-						Download Logs
+						{ translate( 'Download logs' ) }
 					</Button>
 				</div>
 			</>

--- a/client/my-sites/hosting/web-server-logs-card/index.js
+++ b/client/my-sites/hosting/web-server-logs-card/index.js
@@ -217,7 +217,7 @@ const WebServerLogsCard = ( props ) => {
 		link.click();
 		window.URL.revokeObjectURL( url );
 
-		downloadSuccessNotice( 'Logs downloaded successfully.' );
+		downloadSuccessNotice( translate( 'Logs downloaded.' ) );
 		recordDownloadCompleted( {
 			download_filename: downloadFilename,
 			total_log_records_downloaded: totalLogs,

--- a/client/my-sites/hosting/web-server-logs-card/index.js
+++ b/client/my-sites/hosting/web-server-logs-card/index.js
@@ -299,7 +299,7 @@ const WebServerLogsCard = ( props ) => {
 	return (
 		<Card className="web-server-logs-card">
 			<MaterialIcon icon="settings" size={ 32 } />
-			<CardHeading>{ translate( 'Download web server logs' ) }</CardHeading>
+			<CardHeading>{ translate( 'Web server logs' ) }</CardHeading>
 			{ getContent() }
 		</Card>
 	);

--- a/client/my-sites/hosting/web-server-logs-card/style.scss
+++ b/client/my-sites/hosting/web-server-logs-card/style.scss
@@ -2,6 +2,11 @@
 	color: var(--color-text-subtle);
 }
 
+.web-server-logs-card__type .form-radios-bar {
+	display: flex;
+	gap: 1em;
+}
+
 .web-server-logs-card__dates {
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/1702
Tracks changes: https://github.com/Automattic/tracks-events-registration/pull/1431

## Proposed Changes

Adds support for downloading 'PHP error' logs, as well as a variety of UX tweaks.

The date picker UX is still wonky. Not sure if I want to replace it with [`<DateRange>`](https://wpcalypso.wordpress.com/devdocs/design/date-range) in this PR or a follow-up one.

### After

<img width="748" alt="image" src="https://user-images.githubusercontent.com/36432/220497222-46362384-09f5-4594-aac9-fd6eda0c9aec.png">

### Before

<img width="748" alt="image" src="https://user-images.githubusercontent.com/36432/220497826-bcaa1562-328d-4053-b0ad-4a2b704f52f0.png">

## Testing Instructions

1. Apply D102134-code to your sandbox
2. Enable 'Atomic Site Logs' in your user's report card
3. Navigate to `/hosting-config`
4. Verify you can download the PHP error logs for your site.
5. Verify you can download the Web request logs for your site.