### PR TITLE
Enable the new pricing page in horizon, staging, and production.

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -79,6 +79,7 @@
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"onboarding/import-light-url-screen": true,
+		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/client-side-render": true,
 		"pattern-assembler/logged-out-showcase": true,

--- a/config/production.json
+++ b/config/production.json
@@ -93,6 +93,7 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redirect-to-themes": true,
+		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/client-side-render": true,
 		"pattern-assembler/logged-out-showcase": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -91,6 +91,7 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-light-url-screen": true,
 		"onboarding/import-redirect-to-themes": true,
+		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/client-side-render": true,


### PR DESCRIPTION
## Proposed Changes

This PR enables the new pricing grid to all the production environment, including horizon, staging, and the production.

## Testing Instructions
Mainly code review and E2E tests to make sure nothing obviously broken. It's possible to mimic the production environment by running a docker container and pointing wpcom domain to it, but the effort would arguably outweigh the gain in this case.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
