### PR TITLE
Site Assembler: Prepare global-styles package

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -48,6 +48,10 @@ logFilters:
   - level: discard
     pattern: "@automattic/search@workspace:packages/search *provides react (*) with version 17.0.2, which doesn't satisfy what @wordpress/components and some of its descendants request"
   - level: discard
+    pattern: "happy-blocks@workspace:apps/happy-blocks provides react (*) with version 17.0.2, which doesn't satisfy what @wordpress/block-editor and some of its descendants request"
+  - level: discard
+    pattern: "happy-blocks@workspace:apps/happy-blocks provides react-dom (*) with version 17.0.2, which doesn't satisfy what @wordpress/block-editor and some of its descendants request"
+  - level: discard
     pattern: "happy-blocks@workspace:apps/happy-blocks provides react (*) with version 17.0.2, which doesn't satisfy what @wordpress/components and some of its descendants request"
   - level: discard
     pattern: "happy-blocks@workspace:apps/happy-blocks provides react-dom (*) with version 17.0.2, which doesn't satisfy what @wordpress/components and some of its descendants request"
@@ -69,6 +73,10 @@ logFilters:
     pattern: "@automattic/o2-blocks@workspace:apps/o2-blocks provides react-dom (*) with version 17.0.2, which doesn't satisfy what @wordpress/components and some of its descendants request"
   - level: discard
     pattern: "@automattic/onboarding@workspace:packages/onboarding *provides react-dom (*) with version 17.0.2, which doesn't satisfy what @wordpress/components and some of its descendants request"
+  - level: discard
+    pattern: "@automattic/page-pattern-modal@workspace:packages/page-pattern-modal *provides react (*) with version 17.0.2, which doesn't satisfy what @wordpress/block-editor and some of its descendants request"
+  - level: discard
+    pattern: "@automattic/page-pattern-modal@workspace:packages/page-pattern-modal *provides react-dom (*) with version 17.0.2, which doesn't satisfy what @wordpress/block-editor and some of its descendants request"
   - level: discard
     pattern: "@automattic/page-pattern-modal@workspace:packages/page-pattern-modal *provides react-dom (*) with version 17.0.2, which doesn't satisfy what @wordpress/components and some of its descendants request"
   - level: discard
@@ -95,6 +103,14 @@ logFilters:
     pattern: "wp-calypso@workspace:. provides eslint (p3918c) with version 8.6.0, which doesn't satisfy what @wordpress/eslint-plugin and some of its descendants request"
   - level: discard
     pattern: "@react-spring/core@npm:9.3.0 * lists build scripts, but its build has been explicitly disabled through configuration."
+  - level: discard
+    pattern: "@automattic/global-styles@workspace:packages/global-styles provides react (*) with version 17.0.2, which doesn't satisfy what @wordpress/block-editor and some of its descendants request"
+  - level: discard
+    pattern: "@automattic/global-styles@workspace:packages/global-styles provides react (*) with version 17.0.2, which doesn't satisfy what @wordpress/components and some of its descendants request"
+  - level: discard
+    pattern: "@automattic/global-styles@workspace:packages/global-styles provides react-dom (*) with version 17.0.2, which doesn't satisfy what @wordpress/block-editor and some of its descendants request"
+  - level: discard
+    pattern: "@automattic/global-styles@workspace:packages/global-styles provides react-dom (*) with version 17.0.2, which doesn't satisfy what @wordpress/components and some of its descendants request"
 
 nodeLinker: node-modules
 

--- a/client/package.json
+++ b/client/package.json
@@ -37,6 +37,7 @@
 		"@automattic/explat-client-react-helpers": "workspace:^",
 		"@automattic/format-currency": "workspace:^",
 		"@automattic/generate-password": "workspace:^",
+		"@automattic/global-styles": "workspace:^",
 		"@automattic/happychat-connection": "workspace:^",
 		"@automattic/help-center": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",

--- a/packages/global-styles/.eslintrc.js
+++ b/packages/global-styles/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+	overrides: [
+		{
+			files: [ '**/*.{js.jsx,ts,tsx}' ],
+			rules: {
+				'wpcalypso/no-unsafe-wp-apis': [
+					'error',
+					{
+						'@wordpress/block-editor': [ '__unstableIframe', '__unstableEditorStyles' ],
+						'@wordpress/components': [ '__experimentalHStack', '__experimentalVStack' ],
+					},
+				],
+			},
+		},
+	],
+};

--- a/packages/global-styles/README.md
+++ b/packages/global-styles/README.md
@@ -1,0 +1,3 @@
+# Global-Styles
+
+Wrap global styles related components from gutenberg

--- a/packages/global-styles/jest.config.js
+++ b/packages/global-styles/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+	testEnvironment: 'jsdom',
+	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
+	setupFilesAfterEnv: [ '@testing-library/jest-dom/extend-expect' ],
+	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
+};

--- a/packages/global-styles/package.json
+++ b/packages/global-styles/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "@automattic/global-styles",
+	"version": "1.0.0",
+	"description": "Wrap global-styles related components from Gutenberg",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.tsx",
+	"sideEffects": [
+		"*.css",
+		"*.scss"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/global-styles"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": "https://github.com/Automattic/wp-calypso/issues",
+	"types": "dist/types",
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch"
+	},
+	"dependencies": {
+		"@wordpress/block-editor": "^9.1.0",
+		"@wordpress/components": "^19.15.0",
+		"@wordpress/compose": "^5.7.0",
+		"@wordpress/edit-site": "^4.6.0",
+		"@wordpress/keycodes": "^3.9.0",
+		"classnames": "^2.3.1",
+		"react": "^17.0.2",
+		"react-dom": "^17.0.2",
+		"react-query": "^3.32.1",
+		"tslib": "^2.3.0",
+		"wpcom-proxy-request": "workspace:^"
+	},
+	"devDependencies": {
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"typescript": "^4.7.4"
+	},
+	"private": true
+}

--- a/packages/global-styles/src/global.d.ts
+++ b/packages/global-styles/src/global.d.ts
@@ -1,0 +1,23 @@
+declare module '@wordpress/block-editor' {
+	interface Props {
+		[ key: string ]: unknown;
+	}
+
+	export const __unstableIframe: React.ComponentType< Props >;
+	export const __unstableEditorStyles: React.ComponentType< Props >;
+}
+
+declare module '@wordpress/components' {
+	interface Props {
+		[ key: string ]: unknown;
+	}
+
+	export const __experimentalHStack: React.ComponentType< Props >;
+	export const __experimentalVStack: React.ComponentType< Props >;
+}
+
+declare module '@wordpress/edit-site/build-module/components/global-styles/context';
+declare module '@wordpress/edit-site/build-module/components/global-styles/global-styles-provider';
+declare module '@wordpress/edit-site/build-module/components/global-styles/hooks';
+declare module '@wordpress/edit-site/build-module/components/global-styles/preview';
+declare module '@wordpress/edit-site/build-module/components/global-styles/use-global-styles-output';

--- a/packages/global-styles/src/index.tsx
+++ b/packages/global-styles/src/index.tsx
@@ -1,0 +1,5 @@
+const GlobalStyles = () => {
+	return null;
+};
+
+export default GlobalStyles;

--- a/packages/global-styles/tsconfig-cjs.json
+++ b/packages/global-styles/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/global-styles/tsconfig.json
+++ b/packages/global-styles/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src",
+		"types": []
+	},
+	"include": [ "src", "src/*.json" ],
+	"exclude": [ "**/__tests__/*", "**/__mocks__/*" ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -791,6 +791,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/global-styles@workspace:^, @automattic/global-styles@workspace:packages/global-styles":
+  version: 0.0.0-use.local
+  resolution: "@automattic/global-styles@workspace:packages/global-styles"
+  dependencies:
+    "@automattic/calypso-typescript-config": "workspace:^"
+    "@wordpress/block-editor": ^9.1.0
+    "@wordpress/components": ^19.15.0
+    "@wordpress/compose": ^5.7.0
+    "@wordpress/edit-site": ^4.6.0
+    "@wordpress/keycodes": ^3.9.0
+    classnames: ^2.3.1
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    react-query: ^3.32.1
+    tslib: ^2.3.0
+    typescript: ^4.7.4
+    wpcom-proxy-request: "workspace:^"
+  languageName: unknown
+  linkType: soft
+
 "@automattic/happychat-app@workspace:apps/happychat":
   version: 0.0.0-use.local
   resolution: "@automattic/happychat-app@workspace:apps/happychat"
@@ -11757,6 +11777,7 @@ __metadata:
     "@automattic/explat-client-react-helpers": "workspace:^"
     "@automattic/format-currency": "workspace:^"
     "@automattic/generate-password": "workspace:^"
+    "@automattic/global-styles": "workspace:^"
     "@automattic/happychat-connection": "workspace:^"
     "@automattic/help-center": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/73073

## Proposed Changes

* Introduce a new package to handle the global styles in the site assembler and install required dependencies

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
