### PR TITLE
Add isRequesting* selectors to selectors-ts.

### DIFF
--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -6,7 +6,6 @@ import {
 	isJetpackSite,
 	isJetpackSiteSecondaryNetworkSite,
 } from 'calypso/state/sites/selectors';
-import { isRequesting, isRequestingForAllSites } from './selectors';
 import type {
 	InstalledPlugins,
 	InstalledPluginData,

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -30,6 +30,30 @@ const getSortCompareNumber = ( a: string, b: string ) => {
 	return 0;
 };
 
+export function isEqualSlugOrId( pluginSlug: string, plugin: Plugin ) {
+	return plugin.slug === pluginSlug || plugin?.id?.split( '/' ).shift() === pluginSlug;
+}
+
+export function isRequesting( state: AppState, siteId: number ) {
+	if ( typeof state.plugins.installed.isRequesting[ siteId ] === 'undefined' ) {
+		return false;
+	}
+	return state.plugins.installed.isRequesting[ siteId ];
+}
+
+export function isRequestingForSites( state: AppState, sites: number[] ) {
+	// As long as any sites have isRequesting true, we consider this group requesting
+	return sites.some( ( siteId ) => isRequesting( state, siteId ) );
+}
+
+export function isRequestingForAllSites( state: AppState ) {
+	return state.plugins.installed.isRequestingAll;
+}
+
+export function requestPluginsError( state: AppState ) {
+	return state.plugins.installed.requestError;
+}
+
 const getSiteIdsThatHavePlugins = createSelector(
 	( state: AppState ) => {
 		return Object.keys( state.plugins.installed.plugins ).map( ( siteId ) => Number( siteId ) );

--- a/client/state/plugins/installed/test/selectors-ts.ts
+++ b/client/state/plugins/installed/test/selectors-ts.ts
@@ -17,6 +17,8 @@ import {
 	getSiteObjectsWithPlugin,
 	getSitesWithPlugin,
 	getSitesWithoutPlugin,
+	isRequesting,
+	isRequestingForSites,
 } from '../selectors-ts';
 import { akismet, helloDolly, jetpack } from './fixtures/plugins';
 
@@ -167,6 +169,38 @@ const helloDollyWithSites = deepFreeze( {
 			autoupdate: true,
 		},
 	},
+} );
+
+describe( 'isRequesting', () => {
+	test( 'Should get `false` if this site is not in the current state', () => {
+		expect( isRequesting( state, nonExistingSiteId1 ) ).toBe( false );
+	} );
+
+	test( 'Should get `false` if this site is not being fetched', () => {
+		expect( isRequesting( state, siteOneId ) ).toBe( false );
+	} );
+
+	test( 'Should get `true` if this site is being fetched', () => {
+		expect( isRequesting( state, siteThreeId ) ).toBe( true );
+	} );
+} );
+
+describe( 'isRequestingForSites', () => {
+	test( 'Should get `false` if no sites are being fetched', () => {
+		expect( isRequestingForSites( state, [ siteOneId, siteTwoId ] ) ).toBe( false );
+	} );
+
+	test( 'Should get `true` if any site is being fetched', () => {
+		expect( isRequestingForSites( state, [ siteOneId, siteThreeId ] ) ).toBe( true );
+	} );
+
+	test( 'Should get `true` if any site is being fetched, even if one is not in the current state', () => {
+		expect( isRequestingForSites( state, [ nonExistingSiteId1, siteThreeId ] ) ).toBe( true );
+	} );
+
+	test( 'Should get `false` if sites are not being fetched, including a site not in the current state', () => {
+		expect( isRequestingForSites( state, [ nonExistingSiteId1, siteTwoId ] ) ).toBe( false );
+	} );
 } );
 
 describe( 'getAllPluginsIndexedByPluginSlug', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR adds the selectors related to plugin requests to selectors-ts, along with the function for comparing plugins by ID an slug. It is a part of the ongoing improvements to the plugin selectors which began in https://github.com/Automattic/wp-calypso/pull/72363.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Review the code and tests, and ensure the tests pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
