### PR TITLE
ETK: Add next steps button to first post published modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-first-post-published-modal-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-first-post-published-modal-controller.php
@@ -17,6 +17,24 @@ class WP_REST_WPCOM_Block_Editor_First_Post_Published_Modal_Controller extends \
 	public function __construct() {
 		$this->namespace = 'wpcom/v2';
 		$this->rest_base = 'block-editor/should-show-first-post-published-modal';
+
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_script' ), 100 );
+	}
+
+	/**
+	 * Enqueue Launchpad options.
+	 */
+	public function enqueue_script() {
+		$launchpad_options = array(
+			'launchpadScreenOption' => get_option( 'launchpad_screen' ),
+			'siteUrlOption'         => get_option( 'siteurl' ),
+		);
+
+		wp_add_inline_script(
+			'jetpack-blocks-editor',
+			'var launchpadOptions = ' . wp_json_encode( $launchpad_options, JSON_HEX_TAG | JSON_HEX_AMP ) . ';',
+			'before'
+		);
 	}
 
 	/**

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-first-post-published-modal-controller.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-first-post-published-modal-controller.php
@@ -28,6 +28,7 @@ class WP_REST_WPCOM_Block_Editor_First_Post_Published_Modal_Controller extends \
 		$launchpad_options = array(
 			'launchpadScreenOption' => get_option( 'launchpad_screen' ),
 			'siteUrlOption'         => get_option( 'siteurl' ),
+			'siteIntentOption'      => get_option( 'site_intent' ),
 		);
 
 		wp_add_inline_script(

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
@@ -47,6 +47,9 @@ const PostPublishedModal: React.FC = () => {
 	const { fetchShouldShowFirstPostPublishedModal, setShouldShowFirstPostPublishedModal } =
 		useDispatch( 'automattic/wpcom-welcome-guide' );
 
+	const { siteUrlOption, launchpadScreenOption } = window?.launchpadOptions || {};
+	const siteUrl = siteUrlOption.replace( 'http://', '' );
+
 	useEffect( () => {
 		fetchShouldShowFirstPostPublishedModal();
 	}, [ fetchShouldShowFirstPostPublishedModal ] );
@@ -76,9 +79,16 @@ const PostPublishedModal: React.FC = () => {
 		setShouldShowFirstPostPublishedModal,
 	] );
 
-	const handleClick = ( event: React.MouseEvent ) => {
+	const handleViewPostClick = ( event: React.MouseEvent ) => {
 		event.preventDefault();
 		( window.top as Window ).location.href = link;
+	};
+
+	const handleNextStepsClick = ( event: React.MouseEvent ) => {
+		event.preventDefault();
+		(
+			window.top as Window
+		 ).location.href = `https://wordpress.com/setup/write/launchpad?siteSlug=${ siteUrl }`;
 	};
 
 	return (
@@ -92,9 +102,16 @@ const PostPublishedModal: React.FC = () => {
 			) }
 			imageSrc={ postPublishedImage }
 			actionButtons={
-				<Button isPrimary onClick={ handleClick }>
-					{ __( 'View Post', 'full-site-editing' ) }
-				</Button>
+				<>
+					<Button isPrimary onClick={ handleViewPostClick }>
+						{ __( 'View Post', 'full-site-editing' ) }
+					</Button>
+					{ launchpadScreenOption === 'full' && (
+						<Button isSecondary onClick={ handleNextStepsClick }>
+							{ __( 'Next Steps', 'full-site-editing' ) }
+						</Button>
+					) }
+				</>
 			}
 			onRequestClose={ closeModal }
 			onOpen={ () => recordTracksEvent( 'calypso_editor_wpcom_first_post_published_modal_show' ) }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
@@ -52,6 +52,7 @@ const PostPublishedModal: React.FC = () => {
 
 	let siteUrl = '';
 	if ( isURL( siteUrlOption ) ) {
+		// https://mysite.wordpress.com/path becomes mysite.wordpress.com
 		siteUrl = new URL( siteUrlOption ).hostname;
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
@@ -47,8 +47,8 @@ const PostPublishedModal: React.FC = () => {
 	const { fetchShouldShowFirstPostPublishedModal, setShouldShowFirstPostPublishedModal } =
 		useDispatch( 'automattic/wpcom-welcome-guide' );
 
-	const { siteUrlOption, launchpadScreenOption } = window?.launchpadOptions || {};
-	const siteUrl = siteUrlOption.replace( 'http://', '' );
+	const { siteUrlOption, launchpadScreenOption, siteIntentOption } = window?.launchpadOptions || {};
+	const siteUrl = siteUrlOption.replace( /^https?:\/\//, '' );
 
 	useEffect( () => {
 		fetchShouldShowFirstPostPublishedModal();
@@ -106,7 +106,7 @@ const PostPublishedModal: React.FC = () => {
 					<Button isPrimary onClick={ handleViewPostClick }>
 						{ __( 'View Post', 'full-site-editing' ) }
 					</Button>
-					{ launchpadScreenOption === 'full' && (
+					{ launchpadScreenOption === 'full' && siteIntentOption === 'write' && (
 						<Button isSecondary onClick={ handleNextStepsClick }>
 							{ __( 'Next Steps', 'full-site-editing' ) }
 						</Button>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/post-published-modal/index.tsx
@@ -3,6 +3,7 @@ import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { isURL } from '@wordpress/url';
 import React from 'react';
 import NuxModal from '../nux-modal';
 import { selectors as wpcomWelcomeGuideSelectors } from '../store';
@@ -48,7 +49,11 @@ const PostPublishedModal: React.FC = () => {
 		useDispatch( 'automattic/wpcom-welcome-guide' );
 
 	const { siteUrlOption, launchpadScreenOption, siteIntentOption } = window?.launchpadOptions || {};
-	const siteUrl = siteUrlOption.replace( /^https?:\/\//, '' );
+
+	let siteUrl = '';
+	if ( isURL( siteUrlOption ) ) {
+		siteUrl = new URL( siteUrlOption ).hostname;
+	}
 
 	useEffect( () => {
 		fetchShouldShowFirstPostPublishedModal();

--- a/apps/editing-toolkit/typings/index.d.ts
+++ b/apps/editing-toolkit/typings/index.d.ts
@@ -26,5 +26,10 @@ declare global {
 			closeButtonLabel?: string;
 			manageReusableBlocksUrl?: string;
 		};
+		launchpadOptions: {
+			siteUrlOption: string;
+			launchpadScreenOption: 'full' | 'off' | 'minimized';
+			siteIntentOption: string;
+		};
 	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/72803

### Time Estimate
Review: Med
Test: Med

### Proposed Changes
Add Next Steps button redirecting to Launchpad when Launchpad is enabled

<img width="679" alt="image" src="https://user-images.githubusercontent.com/20927667/220527780-ef5e5161-0a04-45fa-b412-8d61492d720a.png">

### Testing
1. Checkout this branch
2. Run `cd apps/editing-toolkit` from calypso root
3. Run `yarn dev --sync`
4. Create a new site using the write flow from https://wordpress.com/start
5. Sandbox your site
6. Once you arrive at Launchpad, click on "Write your first post task"
7. Make a change and save
8. You should see the first post published modal displayed with a "Next Steps" button that redirects back to Launchpad