### PR TITLE
Site Assembler: Handle select color variation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -90,7 +90,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	// Retrieve any extra step data from the stepper-internal store. This will be passed as a prop to the current step.
 	const stepData = useSelect( ( select ) => select( STEPPER_INTERNAL_STORE ).getStepData() );
 
-	flow.useSideEffect?.( navigate );
+	flow.useSideEffect?.( currentStepRoute, navigate );
 
 	useEffect( () => {
 		window.scrollTo( 0, 0 );

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -69,28 +69,28 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		return false;
 	}, [ flow, stepProgress ] );
 
-	const stepNavigation = flow.useStepNavigation(
-		currentStepRoute,
-		async ( path, extraData = null ) => {
-			// If any extra data is passed to the navigate() function, store it to the stepper-internal store.
-			setStepData( {
-				path: path,
-				intent: intent,
-				...extraData,
-			} );
+	const navigate = async ( path: string, extraData = {} ) => {
+		// If any extra data is passed to the navigate() function, store it to the stepper-internal store.
+		setStepData( {
+			path: path,
+			intent: intent,
+			...extraData,
+		} );
 
-			const _path = path.includes( '?' ) // does path contain search params
-				? generatePath( `/${ flow.name }/${ path }` )
-				: generatePath( `/${ flow.name }/${ path }${ search }` );
+		const _path = path.includes( '?' ) // does path contain search params
+			? generatePath( `/${ flow.name }/${ path }` )
+			: generatePath( `/${ flow.name }/${ path }${ search }` );
 
-			history.push( _path, stepPaths );
-			setPreviousProgress( stepProgress?.progress ?? 0 );
-		}
-	);
+		history.push( _path, stepPaths );
+		setPreviousProgress( stepProgress?.progress ?? 0 );
+	};
+
+	const stepNavigation = flow.useStepNavigation( currentStepRoute, navigate );
+
 	// Retrieve any extra step data from the stepper-internal store. This will be passed as a prop to the current step.
 	const stepData = useSelect( ( select ) => select( STEPPER_INTERNAL_STORE ).getStepData() );
 
-	flow.useSideEffect?.();
+	flow.useSideEffect?.( navigate );
 
 	useEffect( () => {
 		window.scrollTo( 0, 0 );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -71,7 +71,7 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 		useState< GlobalStylesObject | null >( null );
 
 	const selectedVariations = useMemo(
-		() => [ selectedColorPaletteVariation ],
+		() => [ selectedColorPaletteVariation ].filter( Boolean ) as GlobalStylesObject[],
 		[ selectedColorPaletteVariation ]
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useSyncGlobalStyles } from '@automattic/global-styles';
-import { StepContainer, SITE_SETUP_FLOW, WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
+import { StepContainer, WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalNavigatorScreen as NavigatorScreen,
@@ -8,7 +8,7 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useRef, useEffect, useMemo } from 'react';
+import { useState, useRef, useMemo } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -45,7 +45,7 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
 	const incrementIndexRef = useRef( 0 );
 	const [ activePosition, setActivePosition ] = useState( -1 );
-	const { goBack, goNext, submit, goToStep } = navigation;
+	const { goBack, goNext, submit } = navigation;
 	const { setThemeOnSite, runThemeSetupOnSite, createCustomTemplate } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
@@ -87,13 +87,6 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 		title: site?.name,
 		tagline: site?.description || SITE_TAGLINE,
 	};
-
-	useEffect( () => {
-		// Require to start the flow from the first step
-		if ( ! selectedDesign && flow === SITE_SETUP_FLOW ) {
-			goToStep?.( 'goals' );
-		}
-	}, [] );
 
 	useSyncGlobalStyles( selectedVariations, isEnabledColorAndFonts );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
@@ -1,5 +1,4 @@
 import { BlockRendererProvider, PatternsRendererProvider } from '@automattic/block-renderer';
-import { GlobalStylesProvider } from '@automattic/global-styles';
 import { PLACEHOLDER_SITE_ID } from './constants';
 import type { SiteInfo } from '@automattic/block-renderer';
 
@@ -17,30 +16,20 @@ const PatternAssemblerContainer = ( {
 	patternIds,
 	children,
 	siteInfo,
-}: Props ) => {
-	const commonProps = {
-		siteId,
-		stylesheet,
-	};
-
-	// TODO: We might need to lazy load the GlobalStylesProvider
-	return (
-		<GlobalStylesProvider { ...commonProps }>
-			<BlockRendererProvider { ...commonProps }>
-				<PatternsRendererProvider
-					{ ...commonProps }
-					// Site used to render site-related things on the previews,
-					// such as the logo, title, and tagline.
-					siteId={ PLACEHOLDER_SITE_ID }
-					patternIds={ patternIds }
-					// Use siteInfo to overwrite site-related things such as title, and tagline.
-					siteInfo={ siteInfo }
-				>
-					{ children }
-				</PatternsRendererProvider>
-			</BlockRendererProvider>
-		</GlobalStylesProvider>
-	);
-};
+}: Props ) => (
+	<BlockRendererProvider siteId={ siteId } stylesheet={ stylesheet }>
+		<PatternsRendererProvider
+			// Site used to render site-related things on the previews,
+			// such as the logo, title, and tagline.
+			siteId={ PLACEHOLDER_SITE_ID }
+			stylesheet={ stylesheet }
+			patternIds={ patternIds }
+			// Use siteInfo to overwrite site-related things such as title, and tagline.
+			siteInfo={ siteInfo }
+		>
+			{ children }
+		</PatternsRendererProvider>
+	</BlockRendererProvider>
+);
 
 export default PatternAssemblerContainer;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
@@ -3,14 +3,23 @@ import { ColorPaletteVariations } from '@automattic/global-styles';
 import { __experimentalNavigatorBackButton as NavigatorBackButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import NavigatorHeader from './navigator-header';
+import type { GlobalStylesObject } from '@automattic/global-styles';
 
 interface Props {
 	siteId: number | string;
 	stylesheet: string;
+	selectedColorPaletteVariation: GlobalStylesObject | null;
+	onSelect: ( colorPaletteVariation: GlobalStylesObject ) => void;
 	onDoneClick: () => void;
 }
 
-const ScreenColorPalettes = ( { siteId, stylesheet, onDoneClick }: Props ) => {
+const ScreenColorPalettes = ( {
+	siteId,
+	stylesheet,
+	selectedColorPaletteVariation,
+	onSelect,
+	onDoneClick,
+}: Props ) => {
 	const translate = useTranslate();
 
 	return (
@@ -20,7 +29,12 @@ const ScreenColorPalettes = ( { siteId, stylesheet, onDoneClick }: Props ) => {
 				description={ translate( 'Foreground and background colours used throughout your site.' ) }
 			/>
 			<div className="screen-container__body">
-				<ColorPaletteVariations siteId={ siteId } stylesheet={ stylesheet } />
+				<ColorPaletteVariations
+					siteId={ siteId }
+					stylesheet={ stylesheet }
+					selectedColorPaletteVariation={ selectedColorPaletteVariation }
+					onSelect={ onSelect }
+				/>
 			</div>
 			<div className="screen-container__footer">
 				<NavigatorBackButton

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
@@ -9,7 +9,7 @@ interface Props {
 	siteId: number | string;
 	stylesheet: string;
 	selectedColorPaletteVariation: GlobalStylesObject | null;
-	onSelect: ( colorPaletteVariation: GlobalStylesObject ) => void;
+	onSelect: ( colorPaletteVariation: GlobalStylesObject | null ) => void;
 	onDoneClick: () => void;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/with-global-styles-provider.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/with-global-styles-provider.tsx
@@ -1,0 +1,35 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { GlobalStylesProvider } from '@automattic/global-styles';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
+import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
+import { ONBOARD_STORE } from '../../../../stores';
+
+const withGlobalStylesProvider = createHigherOrderComponent(
+	< OuterProps, >( InnerComponent: React.ComponentType< OuterProps > ) => {
+		return ( props: OuterProps ) => {
+			const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+			const siteSlug = useSiteSlugParam();
+			const siteId = useSiteIdParam();
+			const siteSlugOrId = siteSlug ? siteSlug : siteId;
+
+			if ( ! isEnabled( 'pattern-assembler/color-and-fonts' ) ) {
+				return <InnerComponent { ...props } />;
+			}
+
+			// TODO: We might need to lazy load the GlobalStylesProvider
+			return (
+				<GlobalStylesProvider
+					siteId={ siteSlugOrId }
+					stylesheet={ selectedDesign?.recipe?.stylesheet }
+				>
+					<InnerComponent { ...props } />
+				</GlobalStylesProvider>
+			);
+		};
+	},
+	'withGlobalStylesProvider'
+);
+
+export default withGlobalStylesProvider;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/with-global-styles-provider.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/with-global-styles-provider.tsx
@@ -13,6 +13,11 @@ const withGlobalStylesProvider = createHigherOrderComponent(
 			const siteSlug = useSiteSlugParam();
 			const siteId = useSiteIdParam();
 			const siteSlugOrId = siteSlug ? siteSlug : siteId;
+			const stylesheet = selectedDesign?.recipe?.stylesheet;
+
+			if ( ! siteSlugOrId || ! stylesheet ) {
+				return null;
+			}
 
 			if ( ! isEnabled( 'pattern-assembler/color-and-fonts' ) ) {
 				return <InnerComponent { ...props } />;
@@ -20,10 +25,7 @@ const withGlobalStylesProvider = createHigherOrderComponent(
 
 			// TODO: We might need to lazy load the GlobalStylesProvider
 			return (
-				<GlobalStylesProvider
-					siteId={ siteSlugOrId }
-					stylesheet={ selectedDesign?.recipe?.stylesheet }
-				>
+				<GlobalStylesProvider siteId={ siteSlugOrId } stylesheet={ stylesheet }>
 					<InnerComponent { ...props } />
 				</GlobalStylesProvider>
 			);

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -72,6 +72,11 @@ export type UseStepNavigationHook< FlowSteps extends StepperStep[] > = (
 
 export type UseAssertConditionsHook = () => AssertConditionResult;
 
+export type UseSideEffectHook< FlowSteps extends StepperStep[] > = (
+	currentStepSlug: FlowSteps[ number ][ 'slug' ],
+	navigate: Navigate< FlowSteps >
+) => void;
+
 export type Flow = {
 	name: string;
 	title?: string;
@@ -82,7 +87,7 @@ export type Flow = {
 	/**
 	 * A hook that is called in the flow's root at every render. You can use this hook to setup side-effects, call other hooks, etc..
 	 */
-	useSideEffect?: ( navigate: Navigate< ReturnType< Flow[ 'useSteps' ] > > ) => void;
+	useSideEffect?: UseSideEffectHook< ReturnType< Flow[ 'useSteps' ] > >;
 };
 
 export type StepProps = {

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -54,6 +54,11 @@ export type StepperStep = {
 	component: React.FC< StepProps >;
 };
 
+export type Navigate< FlowSteps extends StepperStep[] > = (
+	stepName: FlowSteps[ number ][ 'slug' ] | `${ FlowSteps[ number ][ 'slug' ] }?${ string }`,
+	extraData?: any
+) => void;
+
 /**
  * This is the return type of useSteps hook
  */
@@ -61,10 +66,7 @@ export type UseStepsHook = () => StepperStep[];
 
 export type UseStepNavigationHook< FlowSteps extends StepperStep[] > = (
 	currentStepSlug: FlowSteps[ number ][ 'slug' ],
-	navigate: (
-		stepName: FlowSteps[ number ][ 'slug' ] | `${ FlowSteps[ number ][ 'slug' ] }?${ string }`,
-		extraData?: any
-	) => void,
+	navigate: Navigate< FlowSteps >,
 	steps?: FlowSteps[ number ][ 'slug' ][]
 ) => NavigationControls;
 
@@ -80,7 +82,7 @@ export type Flow = {
 	/**
 	 * A hook that is called in the flow's root at every render. You can use this hook to setup side-effects, call other hooks, etc..
 	 */
-	useSideEffect?: () => void;
+	useSideEffect?: ( navigate: Navigate< ReturnType< Flow[ 'useSteps' ] > > ) => void;
 };
 
 export type StepProps = {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -2,6 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { Design, isBlankCanvasDesign } from '@automattic/design-picker';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
 import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
@@ -66,6 +67,17 @@ function isLaunchpadIntent( intent: string ) {
 
 const siteSetupFlow: Flow = {
 	name: 'site-setup',
+
+	useSideEffect( navigate ) {
+		const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
+
+		useEffect( () => {
+			// Require to start the flow from the first step
+			if ( ! selectedDesign ) {
+				navigate( 'goals' );
+			}
+		}, [] );
+	},
 
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -68,12 +68,12 @@ function isLaunchpadIntent( intent: string ) {
 const siteSetupFlow: Flow = {
 	name: 'site-setup',
 
-	useSideEffect( navigate ) {
+	useSideEffect( currentStep, navigate ) {
 		const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 
 		useEffect( () => {
 			// Require to start the flow from the first step
-			if ( ! selectedDesign ) {
+			if ( currentStep === 'patternAssembler' && ! selectedDesign ) {
 				navigate( 'goals' );
 			}
 		}, [] );

--- a/packages/block-renderer/package.json
+++ b/packages/block-renderer/package.json
@@ -31,6 +31,7 @@
 	"dependencies": {
 		"@wordpress/block-editor": "^9.1.0",
 		"@wordpress/compose": "^5.7.0",
+		"@wordpress/edit-site": "^4.6.0",
 		"classnames": "^2.3.1",
 		"react-query": "^3.32.1",
 		"tslib": "^2.3.0",

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -1,16 +1,15 @@
 // The idea of this file is from the Gutenberg file packages/block-editor/src/components/block-preview/auto.js (d50e613).
 import {
-	store as blockEditorStore,
 	__unstableIframe as Iframe,
 	__unstableEditorStyles as EditorStyles,
 	__unstablePresetDuotoneFilter as PresetDuotoneFilter,
 } from '@wordpress/block-editor';
 import { useResizeObserver, useRefEffect } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useContext } from 'react';
 import { BLOCK_MAX_HEIGHT } from '../constants';
 import useParsedAssets from '../hooks/use-parsed-assets';
 import loadStyles from '../utils/load-styles';
+import BlockRendererContext from './block-renderer-context';
 import type { RenderedStyle } from '../types';
 import './block-renderer-container.scss';
 
@@ -44,28 +43,20 @@ const ScaledBlockRendererContainer = ( {
 }: ScaledBlockRendererContainerProps ) => {
 	const [ isLoaded, setIsLoaded ] = useState( false );
 	const [ contentResizeListener, { height: contentHeight } ] = useResizeObserver();
-	const { styles, assets, duotone } = useSelect( ( select ) => {
-		// @ts-expect-error Type definition is outdated
-		const settings = select( blockEditorStore ).getSettings();
-		return {
+	const { settings } = useContext( BlockRendererContext );
+	const { styles, assets, duotone } = useMemo(
+		() => ( {
 			styles: settings.styles,
 			assets: settings.__unstableResolvedAssets,
 			duotone: settings.__experimentalFeatures?.color?.duotone,
-		};
-	}, [] );
+		} ),
+		[ settings ]
+	);
 
 	const styleAssets = useParsedAssets( assets?.styles ) as HTMLLinkElement[];
 
 	const editorStyles = useMemo( () => {
-		const mergedStyles = [
-			...( styles || [] ),
-			...( customStyles || [] ),
-			// Avoid scrollbars for pattern previews.
-			{
-				css: 'body{height:auto;overflow:hidden;}',
-				__unstableType: 'presets',
-			},
-		];
+		const mergedStyles = [ ...( styles || [] ), ...( customStyles || [] ) ];
 
 		if ( ! inlineCss ) {
 			return mergedStyles;

--- a/packages/block-renderer/src/components/block-renderer-context.tsx
+++ b/packages/block-renderer/src/components/block-renderer-context.tsx
@@ -1,0 +1,14 @@
+import { createContext } from '@wordpress/element';
+import type { BlockRendererSettings } from '../types';
+
+export interface BlockRendererContextValue {
+	isReady: boolean;
+	settings: BlockRendererSettings;
+}
+
+const BlockRendererContext = createContext< BlockRendererContextValue >( {
+	isReady: true,
+	settings: {},
+} );
+
+export default BlockRendererContext;

--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -3,7 +3,7 @@ import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/compo
 import { ENTER } from '@wordpress/keycodes';
 import classnames from 'classnames';
 import { translate } from 'i18n-calypso';
-import { useState, useMemo, useContext } from 'react';
+import { useMemo, useContext } from 'react';
 import { useColorPaletteVariations } from '../../hooks';
 import ColorPaletteVariationPreview from './preview';
 import type { GlobalStylesObject } from '../../types';
@@ -12,20 +12,20 @@ import './style.scss';
 interface ColorPaletteVariationProps {
 	colorPaletteVariation: GlobalStylesObject;
 	isActive: boolean;
-	selectColorPaletteVariation: () => void;
+	onSelect: () => void;
 }
 
 interface ColorPaletteVariationsProps {
 	siteId: number | string;
 	stylesheet: string;
+	selectedColorPaletteVariation: GlobalStylesObject | null;
+	onSelect: ( colorPaletteVariation: GlobalStylesObject | null ) => void;
 }
-
-const INITIAL_INDEX = -1;
 
 const ColorPaletteVariation = ( {
 	colorPaletteVariation,
 	isActive,
-	selectColorPaletteVariation,
+	onSelect,
 }: ColorPaletteVariationProps ) => {
 	const { base } = useContext( GlobalStylesContext );
 	const context = useMemo( () => {
@@ -39,7 +39,7 @@ const ColorPaletteVariation = ( {
 	const selectOnEnter = ( event: React.KeyboardEvent ) => {
 		if ( event.keyCode === ENTER ) {
 			event.preventDefault();
-			selectColorPaletteVariation();
+			onSelect();
 		}
 	};
 
@@ -49,7 +49,7 @@ const ColorPaletteVariation = ( {
 				'is-active': isActive,
 			} ) }
 			role="button"
-			onClick={ selectColorPaletteVariation }
+			onClick={ onSelect }
 			onKeyDown={ selectOnEnter }
 			tabIndex={ 0 }
 			aria-current={ isActive }
@@ -69,34 +69,29 @@ const ColorPaletteVariation = ( {
 	);
 };
 
-const ColorPaletteVariations = ( { siteId, stylesheet }: ColorPaletteVariationsProps ) => {
-	const [ selectedIndex, setSelectedIndex ] = useState( INITIAL_INDEX );
+const ColorPaletteVariations = ( {
+	siteId,
+	stylesheet,
+	selectedColorPaletteVariation,
+	onSelect,
+}: ColorPaletteVariationsProps ) => {
 	const { base } = useContext( GlobalStylesContext );
 	const colorPaletteVariations = useColorPaletteVariations( siteId, stylesheet ) ?? [];
-
-	const selectColorPaletteVariation = (
-		colorPaletteVariation: GlobalStylesObject,
-		index: number
-	) => {
-		setSelectedIndex( index );
-	};
 
 	return (
 		<div className="color-palette-variations">
 			<ColorPaletteVariation
 				key="base"
 				colorPaletteVariation={ base }
-				isActive={ selectedIndex === INITIAL_INDEX }
-				selectColorPaletteVariation={ () => selectColorPaletteVariation( base, INITIAL_INDEX ) }
+				isActive={ ! selectedColorPaletteVariation }
+				onSelect={ () => onSelect( null ) }
 			/>
 			{ colorPaletteVariations.map( ( colorPaletteVariation, index ) => (
 				<ColorPaletteVariation
 					key={ index }
 					colorPaletteVariation={ colorPaletteVariation }
-					isActive={ selectedIndex === index }
-					selectColorPaletteVariation={ () =>
-						selectColorPaletteVariation( colorPaletteVariation, index )
-					}
+					isActive={ colorPaletteVariation.title === selectedColorPaletteVariation?.title }
+					onSelect={ () => onSelect( colorPaletteVariation ) }
 				/>
 			) ) }
 		</div>

--- a/packages/global-styles/src/hooks/index.ts
+++ b/packages/global-styles/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { default as useColorPaletteVariations } from './use-color-palette-variations';
 export { default as useGetGlobalStylesBaseConfig } from './use-get-global-styles-base-config';
+export { default as useSyncGlobalStyles } from './use-sync-global-styles';

--- a/packages/global-styles/src/hooks/use-sync-global-styles.ts
+++ b/packages/global-styles/src/hooks/use-sync-global-styles.ts
@@ -1,0 +1,22 @@
+import { GlobalStylesContext } from '@wordpress/edit-site/build-module/components/global-styles/context';
+import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/components/global-styles/global-styles-provider';
+import { useContext, useEffect } from 'react';
+import type { GlobalStylesObject } from '../types';
+
+const useSyncGlobalStyles = ( globalStyles: GlobalStylesObject[], enabled: boolean ) => {
+	const { setUserConfig } = useContext( GlobalStylesContext );
+
+	useEffect( () => {
+		if ( ! enabled ) {
+			return;
+		}
+
+		setUserConfig( () =>
+			globalStyles
+				.filter( Boolean )
+				.reduce( ( prev, current ) => mergeBaseAndUserConfigs( prev, current ), {} )
+		);
+	}, [ globalStyles, enabled ] );
+};
+
+export default useSyncGlobalStyles;

--- a/packages/global-styles/src/index.tsx
+++ b/packages/global-styles/src/index.tsx
@@ -1,2 +1,3 @@
 export * from './components';
+export { useSyncGlobalStyles } from './hooks';
 export * from './types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -88,6 +88,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@wordpress/block-editor": ^9.1.0
     "@wordpress/compose": ^5.7.0
+    "@wordpress/edit-site": ^4.6.0
     classnames: ^2.3.1
     react: ^17.0.2
     react-dom: ^17.0.2


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71977, https://github.com/Automattic/wp-calypso/issues/71978

## Proposed Changes

This PR is focusing on applying the selected color variation to the patterns and the large preview, so you're able to preview the selected color variation
* Create `BlockRendererContext` to generate the output global styles on the provider once instead of every pattern
* Implement `useSyncGlobalStyles` to apply the global styles
* Move the redirection to the first step to the useSideEffect of the flow since the `<PatternAssembler />` is wrapped into `GlobalStylesProvider` and it won't render the children while the settings are not ready. Thus, we have to make redirection before fetching the settings.

https://user-images.githubusercontent.com/13596067/220564859-c0142bd8-2046-4906-b424-420b4962605e.mov

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/sidebar-revamp,pattern-assembler/color-and-fonts`
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Pick any patterns
  * Pick any color variation via "Change colours"
  * Verify the color styles are changed on the large preview
  * Pick any patterns again and verify the color styles also apply to the pattern selector

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
