### PR TITLE
Site Assembler: Handle submit selected patterns with color variation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -46,7 +46,8 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 	const incrementIndexRef = useRef( 0 );
 	const [ activePosition, setActivePosition ] = useState( -1 );
 	const { goBack, goNext, submit } = navigation;
-	const { setThemeOnSite, runThemeSetupOnSite, createCustomTemplate, setGlobalStyles } = useDispatch( SITE_STORE );
+	const { setThemeOnSite, runThemeSetupOnSite, createCustomTemplate, setGlobalStyles } =
+		useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { useSyncGlobalStyles } from '@automattic/global-styles';
+import { useSyncGlobalStylesUserConfig } from '@automattic/global-styles';
 import { StepContainer, WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import {
 	__experimentalNavigatorProvider as NavigatorProvider,
@@ -46,7 +46,7 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 	const incrementIndexRef = useRef( 0 );
 	const [ activePosition, setActivePosition ] = useState( -1 );
 	const { goBack, goNext, submit } = navigation;
-	const { setThemeOnSite, runThemeSetupOnSite, createCustomTemplate } = useDispatch( SITE_STORE );
+	const { setThemeOnSite, runThemeSetupOnSite, createCustomTemplate, setGlobalStyles } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
@@ -75,6 +75,11 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 		[ selectedColorPaletteVariation ]
 	);
 
+	const syncedGlobalStylesUserConfig = useSyncGlobalStylesUserConfig(
+		selectedVariations,
+		isEnabledColorAndFonts
+	);
+
 	const largePreviewProps = {
 		placeholder: null,
 		header,
@@ -87,8 +92,6 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 		title: site?.name,
 		tagline: site?.description || SITE_TAGLINE,
 	};
-
-	useSyncGlobalStyles( selectedVariations, isEnabledColorAndFonts );
 
 	const getPatterns = ( patternType?: string | null ) => {
 		let patterns = [ header, ...sections, footer ];
@@ -279,6 +282,11 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 			// the slug of newly created Home template if the current activated theme has
 			// modified Home template.
 			setThemeOnSite( siteSlugOrId, theme, undefined, false )
+				.then( () => {
+					if ( isEnabledColorAndFonts ) {
+						return setGlobalStyles( siteSlugOrId, stylesheet, syncedGlobalStylesUserConfig );
+					}
+				} )
 				.then( () =>
 					createCustomTemplate(
 						siteSlugOrId,

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -218,9 +218,11 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 
 	function* setGlobalStyles(
 		siteIdOrSlug: number | string,
-		globalStylesId: number,
+		stylesheet: string,
 		globalStyles: GlobalStyles
 	) {
+		const globalStylesId: number = yield getGlobalStylesId( siteIdOrSlug, stylesheet );
+
 		const updatedGlobalStyles: GlobalStyles = yield wpcomRequest( {
 			path: `/sites/${ encodeURIComponent( siteIdOrSlug ) }/global-styles/${ globalStylesId }`,
 			apiNamespace: 'wp/v2',
@@ -379,11 +381,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			);
 
 			if ( currentVariation ) {
-				const globalStylesId: number = yield getGlobalStylesId(
-					siteSlug,
-					activatedTheme.stylesheet
-				);
-				yield setGlobalStyles( siteSlug, globalStylesId, currentVariation );
+				yield setGlobalStyles( siteSlug, activatedTheme.stylesheet, currentVariation );
 			}
 		}
 	}
@@ -698,6 +696,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		getCart,
 		setCart,
 		getGlobalStyles,
+		setGlobalStyles,
 		receiveSiteGlobalStyles,
 		setSiteSetupError,
 		clearSiteSetupError,

--- a/packages/global-styles/src/hooks/index.ts
+++ b/packages/global-styles/src/hooks/index.ts
@@ -1,3 +1,3 @@
 export { default as useColorPaletteVariations } from './use-color-palette-variations';
 export { default as useGetGlobalStylesBaseConfig } from './use-get-global-styles-base-config';
-export { default as useSyncGlobalStyles } from './use-sync-global-styles';
+export { default as useSyncGlobalStylesUserConfig } from './use-sync-global-styles-user-config';

--- a/packages/global-styles/src/hooks/use-sync-global-styles-user-config.ts
+++ b/packages/global-styles/src/hooks/use-sync-global-styles-user-config.ts
@@ -3,8 +3,8 @@ import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/compo
 import { useContext, useEffect } from 'react';
 import type { GlobalStylesObject } from '../types';
 
-const useSyncGlobalStyles = ( globalStyles: GlobalStylesObject[], enabled: boolean ) => {
-	const { setUserConfig } = useContext( GlobalStylesContext );
+const useSyncGlobalStylesUserConfig = ( globalStyles: GlobalStylesObject[], enabled: boolean ) => {
+	const { user, setUserConfig } = useContext( GlobalStylesContext );
 
 	useEffect( () => {
 		if ( ! enabled ) {
@@ -17,6 +17,8 @@ const useSyncGlobalStyles = ( globalStyles: GlobalStylesObject[], enabled: boole
 				.reduce( ( prev, current ) => mergeBaseAndUserConfigs( prev, current ), {} )
 		);
 	}, [ globalStyles, enabled ] );
+
+	return user;
 };
 
-export default useSyncGlobalStyles;
+export default useSyncGlobalStylesUserConfig;

--- a/packages/global-styles/src/index.tsx
+++ b/packages/global-styles/src/index.tsx
@@ -1,3 +1,3 @@
 export * from './components';
-export { useSyncGlobalStyles } from './hooks';
+export { useSyncGlobalStylesUserConfig } from './hooks';
 export * from './types';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71979

## Proposed Changes

This PR is focusing on applying the selected color variation to your site when you finish the Pattern Assembler step
* Return the user styles from the `useSyncGlobalStylesUserConfig` hook
* Apply the user styles by the `setGlobalStyles` action

https://user-images.githubusercontent.com/13596067/220568613-2d45f4e6-dbdd-40a0-b426-5eee8522d5c3.mov

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/sidebar-revamp,pattern-assembler/color-and-fonts`
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Pick any patterns
  * Submit the selected patterns and color
* On the site editor, verify the colors still works there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
