### PR TITLE
Theme Showcase: Collapsible style variation previews

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -6,11 +6,7 @@ import {
 	WPCOM_FEATURES_PREMIUM_THEMES,
 } from '@automattic/calypso-products';
 import { Button, Card, Gridicon } from '@automattic/components';
-import {
-	getDesignPreviewUrl,
-	PremiumBadge,
-	ThemePreview as ThemeWebPreview,
-} from '@automattic/design-picker';
+import { getDesignPreviewUrl, ThemePreview as ThemeWebPreview } from '@automattic/design-picker';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import classNames from 'classnames';
@@ -85,6 +81,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ThemeDownloadCard from './theme-download-card';
 import ThemeFeaturesCard from './theme-features-card';
 import ThemeNotFoundError from './theme-not-found-error';
+import ThemeStyleVariations from './theme-style-variations';
 
 import './style.scss';
 
@@ -566,28 +563,16 @@ class ThemeSheet extends Component {
 	};
 
 	renderStyleVariations = () => {
-		const { styleVariations, translate } = this.props;
+		const { styleVariations } = this.props;
 
 		return (
 			styleVariations.length > 0 && (
-				<div className="theme__sheet-style-variations">
-					<div className="theme__sheet-style-variations-header">
-						<h2>
-							{ translate( 'Styles' ) }
-							<PremiumBadge shouldHideTooltip />
-						</h2>
-						<p>{ this.getStyleVariationDescription() }</p>
-					</div>
-					<div className="theme__sheet-style-variations-previews">
-						<AsyncLoad
-							require="@automattic/design-preview/src/components/style-variation"
-							placeholder={ null }
-							selectedVariation={ this.getSelectedStyleVariation() }
-							variations={ styleVariations }
-							onClick={ this.onStyleVariationClick }
-						/>
-					</div>
-				</div>
+				<ThemeStyleVariations
+					description={ this.getStyleVariationDescription() }
+					selectedVariation={ this.getSelectedStyleVariation() }
+					variations={ styleVariations }
+					onClick={ this.onStyleVariationClick }
+				/>
 			)
 		);
 	};

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -7,6 +7,11 @@ body.is-section-theme-i4 {
 
 	.layout:not(.has-no-sidebar) .layout__content {
 		padding-top: var(--masterbar-height);
+
+		@include breakpoint-deprecated( "<960px" ) {
+			padding-left: 0;
+			padding-right: 0;
+		}
 	}
 
 	.layout__primary .main {
@@ -231,56 +236,6 @@ body.is-section-theme-i4 {
 
 		svg {
 			top: 2px;
-		}
-	}
-}
-
-.theme__sheet-style-variations {
-	@include breakpoint-deprecated( "<960px" ) {
-		margin-bottom: -16px;
-		padding: 0 0 0 24px;
-
-		.theme__sheet-style-variations-previews {
-			padding: 2px 24px 16px 2px;
-		}
-	}
-
-	&-previews {
-		display: flex;
-		gap: 8px;
-		overflow: scroll;
-		padding: 12px 2px;
-	}
-
-	.theme__sheet-style-variations-header {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-
-		p {
-			color: var(--color-neutral-60);
-			font-size: $font-body-small;
-			letter-spacing: -0.15px;
-			line-height: 20px;
-			margin: 0;
-
-			a {
-				color: var(--color-neutral-60);
-				text-decoration: underline;
-			}
-		}
-
-		.premium-badge {
-			-webkit-font-smoothing: antialiased;
-		}
-	}
-
-	.design-preview__style-variation-wrapper {
-		flex-basis: 100px;
-		flex-shrink: 0;
-
-		@include breakpoint-deprecated( ">1024px" ) {
-			flex-basis: 120px;
 		}
 	}
 }

--- a/client/my-sites/theme/theme-style-variations/index.tsx
+++ b/client/my-sites/theme/theme-style-variations/index.tsx
@@ -26,6 +26,7 @@ const ThemeStyleVariations = ( {
 	const [ collapsibleMaxHeight, setCollapsibleMaxHeight ] = useState< number | undefined >();
 	const [ isCollapsible, setIsCollapsible ] = useState< boolean >( false );
 	const [ isCollapsed, setIsCollapsed ] = useState< boolean >( false );
+	const isCollapsibleRef = useRef( false );
 
 	useLayoutEffect( () => {
 		if ( ! observerRef.current ) {
@@ -42,9 +43,11 @@ const ThemeStyleVariations = ( {
 
 			// Detect flex wrap.
 			const currentIsCollapsible = nodeLastChild.offsetTop > nodeFirstChild.offsetTop;
-			const shouldCollapse = isCollapsible !== currentIsCollapsible || isCollapsed;
+			const shouldCollapse = isCollapsibleRef.current !== currentIsCollapsible || isCollapsed;
 
 			setIsCollapsible( currentIsCollapsible );
+			isCollapsibleRef.current = currentIsCollapsible;
+
 			setIsCollapsed( shouldCollapse );
 			setCollapsibleMaxHeight( shouldCollapse ? nodeFirstChild.offsetHeight : node.scrollHeight );
 		} );
@@ -53,7 +56,7 @@ const ThemeStyleVariations = ( {
 		return () => {
 			resizeObserver.disconnect();
 		};
-	}, [ isCollapsible, isCollapsed ] );
+	}, [ isCollapsed ] );
 
 	const handleCollapseButtonClick = () => {
 		setIsCollapsed( ! isCollapsed );

--- a/client/my-sites/theme/theme-style-variations/index.tsx
+++ b/client/my-sites/theme/theme-style-variations/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { PremiumBadge } from '@automattic/design-picker';
-import { useEffect, useLayoutEffect, useRef, useState } from '@wordpress/element';
+import { useLayoutEffect, useRef, useState } from '@wordpress/element';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
@@ -41,20 +41,19 @@ const ThemeStyleVariations = ( {
 			}
 
 			// Detect flex wrap.
-			setIsCollapsible( nodeFirstChildRect.top !== nodeLastChildRect.top );
-			setCollapsibleMaxHeight( isCollapsed ? nodeFirstChildRect.height : node.scrollHeight );
+			const currentIsCollapsible = nodeFirstChildRect.top !== nodeLastChildRect.top;
+			const shouldCollapse = isCollapsible !== currentIsCollapsible || isCollapsed;
+
+			setIsCollapsible( currentIsCollapsible );
+			setIsCollapsed( shouldCollapse );
+			setCollapsibleMaxHeight( shouldCollapse ? nodeFirstChildRect.height : node.scrollHeight );
 		} );
 
 		resizeObserver.observe( observerRef.current );
 		return () => {
 			resizeObserver.disconnect();
 		};
-	}, [ isCollapsed ] );
-
-	// Ensure to start collapsed when collapsible, and vice-versa.
-	useEffect( () => {
-		setIsCollapsed( isCollapsible );
-	}, [ isCollapsible ] );
+	}, [ isCollapsible, isCollapsed ] );
 
 	const handleCollapseButtonClick = () => {
 		setIsCollapsed( ! isCollapsed );
@@ -89,6 +88,7 @@ const ThemeStyleVariations = ( {
 					placeholder={ null }
 					selectedVariation={ selectedVariation }
 					variations={ variations }
+					showOnlyHoverViewDefaultVariation
 					onClick={ onClick }
 				/>
 			</div>

--- a/client/my-sites/theme/theme-style-variations/index.tsx
+++ b/client/my-sites/theme/theme-style-variations/index.tsx
@@ -34,7 +34,7 @@ const ThemeStyleVariations = ( {
 
 	const updateCollapsibleMaxHeight = ( shouldCollapse: boolean ) => {
 		const node = observerRef.current;
-		const nodeFirstChild = node.firstChild as HTMLElement;
+		const nodeFirstChild = node?.firstChild as HTMLElement;
 		if ( ! node || ! nodeFirstChild ) {
 			return null;
 		}

--- a/client/my-sites/theme/theme-style-variations/index.tsx
+++ b/client/my-sites/theme/theme-style-variations/index.tsx
@@ -23,7 +23,7 @@ const ThemeStyleVariations = ( {
 	onClick,
 }: ThemeStyleVariationsProps ) => {
 	const observerRef = useRef< HTMLDivElement | null >( null );
-	const [ collapsibleMaxHeight, setCollapsibleMaxHeight ] = useState< number | null >( null );
+	const [ collapsibleMaxHeight, setCollapsibleMaxHeight ] = useState< number | undefined >();
 	const [ isCollapsible, setIsCollapsible ] = useState< boolean >( false );
 	const [ isCollapsed, setIsCollapsed ] = useState< boolean >( false );
 
@@ -76,6 +76,7 @@ const ThemeStyleVariations = ( {
 			</div>
 			<div
 				className={ classNames( 'theme__sheet-style-variations-previews', {
+					'theme__sheet-style-variations-previews--is-collapsible': isCollapsible,
 					'theme__sheet-style-variations-previews--is-collapsed': isCollapsed,
 				} ) }
 				style={ {

--- a/client/my-sites/theme/theme-style-variations/index.tsx
+++ b/client/my-sites/theme/theme-style-variations/index.tsx
@@ -27,6 +27,20 @@ const ThemeStyleVariations = ( {
 	const [ isCollapsible, setIsCollapsible ] = useState< boolean >( false );
 	const [ isCollapsed, setIsCollapsed ] = useState< boolean >( false );
 	const isCollapsibleRef = useRef( false );
+	const isCollapsedRef = useRef( false );
+
+	isCollapsibleRef.current = isCollapsible;
+	isCollapsedRef.current = isCollapsed;
+
+	const updateCollapsibleMaxHeight = ( shouldCollapse: boolean ) => {
+		const node = observerRef.current;
+		const nodeFirstChild = node.firstChild as HTMLElement;
+		if ( ! node || ! nodeFirstChild ) {
+			return null;
+		}
+
+		setCollapsibleMaxHeight( shouldCollapse ? nodeFirstChild.offsetHeight : node.scrollHeight );
+	};
 
 	useLayoutEffect( () => {
 		if ( ! observerRef.current ) {
@@ -43,23 +57,25 @@ const ThemeStyleVariations = ( {
 
 			// Detect flex wrap.
 			const currentIsCollapsible = nodeLastChild.offsetTop > nodeFirstChild.offsetTop;
-			const shouldCollapse = isCollapsibleRef.current !== currentIsCollapsible || isCollapsed;
+			const shouldCollapse =
+				isCollapsibleRef.current !== currentIsCollapsible || isCollapsedRef.current;
 
 			setIsCollapsible( currentIsCollapsible );
-			isCollapsibleRef.current = currentIsCollapsible;
-
 			setIsCollapsed( shouldCollapse );
-			setCollapsibleMaxHeight( shouldCollapse ? nodeFirstChild.offsetHeight : node.scrollHeight );
+			updateCollapsibleMaxHeight( shouldCollapse );
 		} );
 
 		resizeObserver.observe( observerRef.current );
 		return () => {
 			resizeObserver.disconnect();
 		};
-	}, [ isCollapsed ] );
+	}, [] );
 
 	const handleCollapseButtonClick = () => {
-		setIsCollapsed( ! isCollapsed );
+		const shouldCollapse = ! isCollapsed;
+
+		setIsCollapsed( shouldCollapse );
+		updateCollapsibleMaxHeight( shouldCollapse );
 	};
 
 	return (

--- a/client/my-sites/theme/theme-style-variations/index.tsx
+++ b/client/my-sites/theme/theme-style-variations/index.tsx
@@ -34,19 +34,19 @@ const ThemeStyleVariations = ( {
 
 		const resizeObserver = new ResizeObserver( ( [ observerNode ] ) => {
 			const node = observerNode.target;
-			const nodeFirstChildRect = ( node.firstChild as HTMLElement )?.getBoundingClientRect();
-			const nodeLastChildRect = ( node.lastChild as HTMLElement )?.getBoundingClientRect();
-			if ( ! nodeFirstChildRect || ! nodeLastChildRect ) {
+			const nodeFirstChild = node.firstChild as HTMLElement;
+			const nodeLastChild = node.lastChild as HTMLElement;
+			if ( ! nodeFirstChild || ! nodeLastChild ) {
 				return;
 			}
 
 			// Detect flex wrap.
-			const currentIsCollapsible = nodeFirstChildRect.top !== nodeLastChildRect.top;
+			const currentIsCollapsible = nodeLastChild.offsetTop > nodeFirstChild.offsetTop;
 			const shouldCollapse = isCollapsible !== currentIsCollapsible || isCollapsed;
 
 			setIsCollapsible( currentIsCollapsible );
 			setIsCollapsed( shouldCollapse );
-			setCollapsibleMaxHeight( shouldCollapse ? nodeFirstChildRect.height : node.scrollHeight );
+			setCollapsibleMaxHeight( shouldCollapse ? nodeFirstChild.offsetHeight : node.scrollHeight );
 		} );
 
 		resizeObserver.observe( observerRef.current );

--- a/client/my-sites/theme/theme-style-variations/index.tsx
+++ b/client/my-sites/theme/theme-style-variations/index.tsx
@@ -1,0 +1,98 @@
+import { Button } from '@automattic/components';
+import { PremiumBadge } from '@automattic/design-picker';
+import { useEffect, useLayoutEffect, useRef, useState } from '@wordpress/element';
+import classNames from 'classnames';
+import { translate } from 'i18n-calypso';
+import AsyncLoad from 'calypso/components/async-load';
+import type { StyleVariation } from '@automattic/design-picker/src/types';
+import type { TranslateResult } from 'i18n-calypso';
+
+import './style.scss';
+
+interface ThemeStyleVariationsProps {
+	description: TranslateResult;
+	selectedVariation: StyleVariation;
+	variations: StyleVariation[];
+	onClick: ( variation: StyleVariation ) => void;
+}
+
+const ThemeStyleVariations = ( {
+	description,
+	selectedVariation,
+	variations,
+	onClick,
+}: ThemeStyleVariationsProps ) => {
+	const observerRef = useRef< HTMLDivElement | null >( null );
+	const [ collapsibleMaxHeight, setCollapsibleMaxHeight ] = useState< number | null >( null );
+	const [ isCollapsible, setIsCollapsible ] = useState< boolean >( false );
+	const [ isCollapsed, setIsCollapsed ] = useState< boolean >( false );
+
+	useLayoutEffect( () => {
+		if ( ! observerRef.current ) {
+			return;
+		}
+
+		const resizeObserver = new ResizeObserver( ( [ observerNode ] ) => {
+			const node = observerNode.target;
+			const nodeFirstChildRect = ( node.firstChild as HTMLElement )?.getBoundingClientRect();
+			const nodeLastChildRect = ( node.lastChild as HTMLElement )?.getBoundingClientRect();
+			if ( ! nodeFirstChildRect || ! nodeLastChildRect ) {
+				return;
+			}
+
+			// Detect flex wrap.
+			setIsCollapsible( nodeFirstChildRect.top !== nodeLastChildRect.top );
+			setCollapsibleMaxHeight( isCollapsed ? nodeFirstChildRect.height : node.scrollHeight );
+		} );
+
+		resizeObserver.observe( observerRef.current );
+		return () => {
+			resizeObserver.disconnect();
+		};
+	}, [ isCollapsed ] );
+
+	// Ensure to start collapsed when collapsible, and vice-versa.
+	useEffect( () => {
+		setIsCollapsed( isCollapsible );
+	}, [ isCollapsible ] );
+
+	const handleCollapseButtonClick = () => {
+		setIsCollapsed( ! isCollapsed );
+	};
+
+	return (
+		<div className="theme__sheet-style-variations">
+			<div className="theme__sheet-style-variations-header">
+				<h2>
+					{ translate( 'Styles' ) }
+					<PremiumBadge shouldHideTooltip />
+					{ isCollapsible && (
+						<Button borderless onClick={ handleCollapseButtonClick }>
+							{ isCollapsed ? translate( 'Show all' ) : translate( 'Show less' ) }
+						</Button>
+					) }
+				</h2>
+				<p>{ description }</p>
+			</div>
+			<div
+				className={ classNames( 'theme__sheet-style-variations-previews', {
+					'theme__sheet-style-variations-previews--is-collapsed': isCollapsed,
+				} ) }
+				style={ {
+					...( isCollapsible && { maxHeight: collapsibleMaxHeight } ),
+				} }
+				ref={ observerRef }
+			>
+				<AsyncLoad
+					require="@automattic/design-preview/src/components/style-variation"
+					placeholder={ null }
+					selectedVariation={ selectedVariation }
+					variations={ variations }
+					onClick={ onClick }
+				/>
+			</div>
+		</div>
+	);
+};
+
+export default ThemeStyleVariations;

--- a/client/my-sites/theme/theme-style-variations/style.scss
+++ b/client/my-sites/theme/theme-style-variations/style.scss
@@ -19,14 +19,6 @@
 		overflow: scroll;
 		padding: 12px 2px;
 
-		@include breakpoint-deprecated( "<960px" ) {
-			flex-wrap: nowrap;
-
-			&--is-collapsed {
-				padding-bottom: 12px;
-			}
-		}
-
 		&--is-collapsible {
 			transition: max-height 0.2s ease-in-out;
 		}
@@ -34,6 +26,15 @@
 		&--is-collapsed {
 			overflow: hidden;
 			padding-bottom: 3px;
+		}
+
+		@include breakpoint-deprecated( "<960px" ) {
+			flex-wrap: nowrap;
+
+			&--is-collapsed {
+				overflow: scroll;
+				padding-bottom: 12px;
+			}
 		}
 	}
 

--- a/client/my-sites/theme/theme-style-variations/style.scss
+++ b/client/my-sites/theme/theme-style-variations/style.scss
@@ -18,7 +18,6 @@
 		gap: 8px;
 		overflow: scroll;
 		padding: 12px 2px;
-		transition: max-height 0.2s ease-in-out;
 
 		@include breakpoint-deprecated( "<960px" ) {
 			flex-wrap: nowrap;
@@ -26,6 +25,10 @@
 			&--is-collapsed {
 				padding-bottom: 12px;
 			}
+		}
+
+		&--is-collapsible {
+			transition: max-height 0.2s ease-in-out;
 		}
 
 		&--is-collapsed {

--- a/client/my-sites/theme/theme-style-variations/style.scss
+++ b/client/my-sites/theme/theme-style-variations/style.scss
@@ -1,0 +1,86 @@
+@import "@automattic/onboarding/styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.theme__sheet-style-variations {
+	@include breakpoint-deprecated( "<960px" ) {
+		margin-bottom: -16px;
+		padding: 0 0 0 24px;
+
+		.theme__sheet-style-variations-previews {
+			padding: 2px 24px 16px 2px;
+		}
+	}
+
+	&-previews {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+		overflow: scroll;
+		padding: 12px 2px;
+		transition: max-height 0.2s ease-in-out;
+
+		@include breakpoint-deprecated( "<960px" ) {
+			flex-wrap: nowrap;
+
+			&--is-collapsed {
+				padding-bottom: 12px;
+			}
+		}
+
+		&--is-collapsed {
+			overflow: hidden;
+			padding-bottom: 3px;
+		}
+	}
+
+	.theme__sheet-style-variations-header {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+
+		@include breakpoint-deprecated( "<960px" ) {
+			button {
+				display: none;
+			}
+		}
+
+		button {
+			color: var(--color-link);
+			float: right;
+			padding: 0;
+
+			&:active,
+			&:focus,
+			&:hover {
+				color: var(--color-link-dark);
+			}
+		}
+
+		p {
+			color: var(--color-neutral-60);
+			font-size: $font-body-small;
+			letter-spacing: -0.15px;
+			line-height: 20px;
+			margin: 0;
+
+			a {
+				color: var(--color-neutral-60);
+				text-decoration: underline;
+			}
+		}
+
+		.premium-badge {
+			-webkit-font-smoothing: antialiased;
+		}
+	}
+
+	.design-preview__style-variation-wrapper {
+		flex-basis: 100px;
+		flex-shrink: 0;
+
+		@include break-xlarge {
+			flex-basis: 120px;
+		}
+	}
+}

--- a/packages/design-preview/src/components/style-variation.tsx
+++ b/packages/design-preview/src/components/style-variation.tsx
@@ -18,6 +18,7 @@ interface StyleVariationPreviewProps {
 	isPremium: boolean;
 	onClick: ( variation: StyleVariation ) => void;
 	showGlobalStylesPremiumBadge: boolean;
+	showOnlyHoverView: boolean;
 }
 
 const StyleVariationPreview: React.FC< StyleVariationPreviewProps > = ( {
@@ -27,6 +28,7 @@ const StyleVariationPreview: React.FC< StyleVariationPreviewProps > = ( {
 	isPremium,
 	onClick,
 	showGlobalStylesPremiumBadge,
+	showOnlyHoverView,
 } ) => {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const context = useMemo( () => {
@@ -72,7 +74,11 @@ const StyleVariationPreview: React.FC< StyleVariationPreviewProps > = ( {
 					/>
 				) }
 				<GlobalStylesContext.Provider value={ context }>
-					<Preview label={ variation.title } isFocused={ isFocused } withHoverView />
+					<Preview
+						label={ variation.title }
+						isFocused={ isFocused || showOnlyHoverView }
+						withHoverView
+					/>
 				</GlobalStylesContext.Provider>
 			</div>
 		</div>
@@ -84,6 +90,7 @@ interface StyleVariationPreviewsProps {
 	selectedVariation?: StyleVariation;
 	onClick: ( variation: StyleVariation ) => void;
 	showGlobalStylesPremiumBadge: boolean;
+	showOnlyHoverViewDefaultVariation: boolean;
 }
 
 const StyleVariationPreviews: React.FC< StyleVariationPreviewsProps > = ( {
@@ -91,6 +98,7 @@ const StyleVariationPreviews: React.FC< StyleVariationPreviewsProps > = ( {
 	selectedVariation,
 	onClick,
 	showGlobalStylesPremiumBadge,
+	showOnlyHoverViewDefaultVariation,
 } ) => {
 	const selectedVariationSlug = selectedVariation?.slug ?? DEFAULT_VARIATION_SLUG;
 	const base = useMemo(
@@ -109,6 +117,9 @@ const StyleVariationPreviews: React.FC< StyleVariationPreviewsProps > = ( {
 					isPremium={ variation.slug !== DEFAULT_VARIATION_SLUG }
 					onClick={ onClick }
 					showGlobalStylesPremiumBadge={ showGlobalStylesPremiumBadge }
+					showOnlyHoverView={
+						showOnlyHoverViewDefaultVariation && variation.slug === DEFAULT_VARIATION_SLUG
+					}
 				/>
 			) ) }
 		</>

--- a/packages/design-preview/src/components/style-variation.tsx
+++ b/packages/design-preview/src/components/style-variation.tsx
@@ -18,7 +18,7 @@ interface StyleVariationPreviewProps {
 	isPremium: boolean;
 	onClick: ( variation: StyleVariation ) => void;
 	showGlobalStylesPremiumBadge: boolean;
-	showOnlyHoverView: boolean;
+	showOnlyHoverView?: boolean;
 }
 
 const StyleVariationPreview: React.FC< StyleVariationPreviewProps > = ( {

--- a/packages/design-preview/src/components/style-variation.tsx
+++ b/packages/design-preview/src/components/style-variation.tsx
@@ -90,7 +90,7 @@ interface StyleVariationPreviewsProps {
 	selectedVariation?: StyleVariation;
 	onClick: ( variation: StyleVariation ) => void;
 	showGlobalStylesPremiumBadge: boolean;
-	showOnlyHoverViewDefaultVariation: boolean;
+	showOnlyHoverViewDefaultVariation?: boolean;
 }
 
 const StyleVariationPreviews: React.FC< StyleVariationPreviewsProps > = ( {


### PR DESCRIPTION
## Proposed Changes

As per the design spec in 0EogtxvlmxMGcnEEaMVECv-fi-2412%3A63031, and Slack thread p1676665429018439-slack-CRWCHQGUB, we want to improve the style variation preview UX in the Theme Detail page.

![Screenshot 2023-02-22 at 4 14 35 PM](https://user-images.githubusercontent.com/797888/220561528-df9b1eaf-cd67-4193-aacf-5553444057a9.png)

This PR implements the following behaviors:
- Always show "Default" for the default style variation.
- In mobile view, style variation previews scroll horizontally.
- In tablet/desktop view, style variation previews should be collapsible via a "Show all" button if they overflow the container width.
  - Show the first row of style variation previews by default.
  - Clicking the "Show all" button will expand to show all the remaining style variation previews.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Ensure that the style preview layout is as described above.
* Ensure that the "Show all" button works as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?