### PR TITLE
Pattern Assembler - Hardcode block-gap and background-color in large preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -15,6 +15,17 @@
 	margin: 0;
 	list-style-type: none;
 	overflow: auto;
+	// Expected to be changed by using the theme setting "styles.color.background"
+	background: var(--studio-white);
+
+	> li {
+		// Expected to be changed by using the theme setting "styles.spacing.blockGap"
+		margin-block-start: 1.5rem;
+
+		&:first-child {
+			margin-block-start: unset;
+		}
+	}
 }
 
 .pattern-large-preview__placeholder {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -15,16 +15,15 @@
 	margin: 0;
 	list-style-type: none;
 	overflow: auto;
-	// Expected to be changed by using the theme setting "styles.color.background"
+	// @TODO: Use theme setting "styles.color.background"
 	background: var(--studio-white);
 
-	> li {
-		// Expected to be changed by using the theme setting "styles.spacing.blockGap"
+	// @TODO: Use theme setting "styles.spacing.blockGap"
+	.pattern-large-preview__pattern-header {
+		margin-block-end: 1.5rem;
+	}
+	.pattern-large-preview__pattern-footer {
 		margin-block-start: 1.5rem;
-
-		&:first-child {
-			margin-block-start: unset;
-		}
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -26,7 +26,7 @@ const PatternLargePreview = ( { header, sections, footer, activePosition }: Prop
 	const [ viewportHeight, setViewportHeight ] = useState< number | undefined >( 0 );
 
 	const renderPattern = ( key: string, pattern: Pattern ) => (
-		<li key={ key }>
+		<li key={ key } className={ `pattern-large-preview__pattern-${ key }` }>
 			<PatternRenderer
 				patternId={ encodePatternId( pattern.id ) }
 				viewportHeight={ viewportHeight || frameRef.current?.clientHeight }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/73072

## Proposed Changes

* Use a white background `--studio-white` for the large preview. 
  - The value is hardcoded for now until we fetch it from the BC theme.json [styles.color.background](https://github.com/Automattic/themes/blob/trunk/blank-canvas-3/theme.json#L202)
* Use a gap of `1.5rem` between patterns in the large preview. 
  - The value is hardcoded for now until we fetch it from the BC theme.json [styles.spacing.blockGap](https://github.com/Automattic/themes/blob/trunk/blank-canvas-3/theme.json#L277)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to`/setup?siteSlug=<your_site>`
* Continue until you land on the Design Picker
* Click "Start designing" at the bottom of the Design Picker
* Add a header, multiple sections, and a footer. Choose patterns **with a dark background color**.
* In the large preview, verify that you see **a white gap** after the header and before the footer but not between sections.
* Click "Continue" and verify that you see the same gap in the editor and the front of the site

**Before** 
|Assembler|Editor|Front|
|-----------|------|-----|
|<img width="1211" alt="Screenshot 2566-02-22 at 14 36 48" src="https://user-images.githubusercontent.com/1881481/220554094-d14d65e5-3316-4ab8-93db-3f4da2b50cf4.png">|<img width="1209" alt="Screenshot 2566-02-22 at 14 38 05" src="https://user-images.githubusercontent.com/1881481/220554114-c8a081ba-f6e4-487d-af07-7f1f6f1ed922.png">|<img width="1209" alt="Screenshot 2566-02-22 at 14 38 46" src="https://user-images.githubusercontent.com/1881481/220554138-0be92acc-95f6-440a-9fae-1ffde1d62469.png">|

**After** 
|Assembler|Editor|Front|
|-----------|------|-----|
|<img width="1212" alt="Screenshot 2566-02-22 at 14 28 07" src="https://user-images.githubusercontent.com/1881481/220554332-0bd29885-4f5a-472a-a281-6c445fefa54a.png">|<img width="1210" alt="Screenshot 2566-02-22 at 14 29 06" src="https://user-images.githubusercontent.com/1881481/220554350-04e4acb5-465e-4d10-a9ff-b72bec6f4ebd.png">|<img width="1209" alt="Screenshot 2566-02-22 at 14 29 20" src="https://user-images.githubusercontent.com/1881481/220554468-fffa35cb-d379-45b8-b86e-97f8cfd70973.png">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
