### PR TITLE
Onboarding - Remove progress bar from /site-setup flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -151,6 +151,8 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 									<VideoPressIntroBackground />
 								) }
 								{ flow.name !== SITE_SETUP_FLOW && (
+									// The progress bar is removed from the site-setup due to its fragility.
+									// See https://github.com/Automattic/wp-calypso/pull/73653
 									<ProgressBar
 										// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 										className="flow-progress"

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -1,5 +1,9 @@
 import { ProgressBar } from '@automattic/components';
-import { isNewsletterOrLinkInBioFlow, isWooExpressFlow } from '@automattic/onboarding';
+import {
+	isNewsletterOrLinkInBioFlow,
+	isWooExpressFlow,
+	SITE_SETUP_FLOW,
+} from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import { useEffect, useState } from 'react';
@@ -146,14 +150,15 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 								{ 'videopress' === flow.name && 'intro' === step.slug && (
 									<VideoPressIntroBackground />
 								) }
-								<ProgressBar
-									// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-									className="flow-progress"
-									value={ progressValue * 100 }
-									total={ 100 }
-									style={ progressBarExtraStyle }
-								/>
-
+								{ flow.name !== SITE_SETUP_FLOW && (
+									<ProgressBar
+										// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+										className="flow-progress"
+										value={ progressValue * 100 }
+										total={ 100 }
+										style={ progressBarExtraStyle }
+									/>
+								) }
 								<SignupHeader pageTitle={ flow.title } showWooLogo={ getShowWooLogo() } />
 								{ renderStep( step ) }
 							</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/73036 https://github.com/Automattic/wp-calypso/issues/72071 https://github.com/Automattic/wp-calypso/issues/70205 https://github.com/Automattic/wp-calypso/issues/72073
Close https://github.com/Automattic/wp-calypso/issues/73036 https://github.com/Automattic/wp-calypso/issues/70205

## Proposed Changes

* Remove the progress bar from the general onboarding flows in `/setup/site-setup`

Due to the fragility of the progress bar, we are removing it from the `site-setup` flow until we have a more maintainable version. See pbxlJb-3wV-p2

See how the progress of the bar is handled in [use-site-setup-flow-progress.ts](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/hooks/use-site-setup-flow-progress.ts) and the steps in the [site-setup-flow.ts](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/site-setup-flow.ts#L68).

**Why only from `site-setup` flow?**

Because there are many different flows and URLs, see them in [/stepper/declarative-flow](https://github.com/Automattic/wp-calypso/tree/trunk/client/landing/stepper/declarative-flow), I'd like to reduce the impact of the changes and start by removing the progress bar only from the `site-setup`. 

Let me know if this should be done otherwise or if there are other considerations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site from the dashboard or `/start`
* Continue until the goals screen (this is the first screen of the general onboarding flows)
* Mark different goals and continue
* Verify that the progress bar doesn't appear on any screen other after the goals screen


|Before|After|
|------|-----|
|**No goal selected**<img width="1209" alt="Screenshot 2566-02-22 at 14 59 09" src="https://user-images.githubusercontent.com/1881481/220558993-6faf2e17-589c-480f-910c-d921eeb67af7.png">**Write and publish**<img width="1210" alt="Screenshot 2566-02-22 at 14 59 24" src="https://user-images.githubusercontent.com/1881481/220559072-5cb3854c-14d4-48d0-a09b-82dbf2d0513b.png">**Sell online**<img width="1210" alt="Screenshot 2566-02-22 at 14 59 35" src="https://user-images.githubusercontent.com/1881481/220559231-a9a22eef-9294-43b1-a995-d916e000c3ca.png">**Promote myself or business**<img width="1210" alt="Screenshot 2566-02-22 at 14 59 49" src="https://user-images.githubusercontent.com/1881481/220559470-da0f9418-8a7f-4e01-8084-aeba2d948578.png">**Get a website quickly [Premium]**<img width="1212" alt="Screenshot 2566-02-22 at 15 00 04" src="https://user-images.githubusercontent.com/1881481/220559592-b7e90cae-d321-449b-b83e-f0f7a5462acf.png">**Import my existing website content**<img width="1210" alt="Screenshot 2566-02-22 at 15 00 13" src="https://user-images.githubusercontent.com/1881481/220559692-8e774e4f-97d4-4ef3-bf7f-069a524fa3fc.png">**Other**<img width="1210" alt="Screenshot 2566-02-22 at 15 00 24" src="https://user-images.githubusercontent.com/1881481/220559725-7ee72d37-b012-4e2e-850b-b173a3466f2d.png">|**No goal selected**<img width="1210" alt="Screenshot 2566-02-22 at 15 08 15" src="https://user-images.githubusercontent.com/1881481/220560212-e3a39064-c0d9-43d0-9e1a-129f9e4ab661.png">**Write and publish**<img width="1210" alt="Screenshot 2566-02-22 at 15 08 15" src="https://user-images.githubusercontent.com/1881481/220560212-e3a39064-c0d9-43d0-9e1a-129f9e4ab661.png">**Sell online**<img width="1210" alt="Screenshot 2566-02-22 at 15 08 15" src="https://user-images.githubusercontent.com/1881481/220560212-e3a39064-c0d9-43d0-9e1a-129f9e4ab661.png">**Promote myself or business**<img width="1210" alt="Screenshot 2566-02-22 at 15 08 15" src="https://user-images.githubusercontent.com/1881481/220560212-e3a39064-c0d9-43d0-9e1a-129f9e4ab661.png">**Get a website quickly [Premium]**<img width="1212" alt="Screenshot 2566-02-22 at 15 00 04" src="https://user-images.githubusercontent.com/1881481/220559592-b7e90cae-d321-449b-b83e-f0f7a5462acf.png">**Import my existing website content**<img width="1209" alt="Screenshot 2566-02-22 at 15 10 39" src="https://user-images.githubusercontent.com/1881481/220560839-b60f8b6a-1b5f-4b2f-a549-593a5b76f8b4.png">**Other**<img width="1210" alt="Screenshot 2566-02-22 at 15 08 15" src="https://user-images.githubusercontent.com/1881481/220560212-e3a39064-c0d9-43d0-9e1a-129f9e4ab661.png">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?