### PR TITLE
Adding 2023 pricing grid to launch site flow

### DIFF
--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -80,5 +80,10 @@ export const is2023PricingGridActivePage = (
 		return isPricingGridEnabled;
 	}
 
+	// Is this the launch site flow?
+	if ( currentRoutePath.startsWith( '/start/launch-site/plans-launch' ) ) {
+		return isPricingGridEnabled;
+	}
+
 	return false;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1548

## Proposed Changes

* The pricing grid should be visible in the launch site flow

## Testing Instructions

* Create a new site
* Click on the button to launch it
* Make sure on the launch site flow, plans step the Plans2023 grid should be visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
