### PR TITLE
Virtual themes i1: Fix variation button click event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -241,9 +241,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		};
 	}
 
-	function previewDesign( design: Design, _styleVariation?: StyleVariation ) {
-		const styleVariation = _styleVariation ?? design.preselected_style_variation;
-
+	function previewDesign( design: Design, styleVariation?: StyleVariation ) {
 		recordPreviewedDesign( { flow, intent, design, styleVariation } );
 
 		if ( ! design.is_virtual ) {
@@ -257,6 +255,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 		if ( styleVariation ) {
 			setSelectedStyleVariation( styleVariation );
+		} else if ( design.preselected_style_variation ) {
+			setSelectedStyleVariation( design.preselected_style_variation );
 		}
 
 		setIsPreviewingDesign( true );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -241,7 +241,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		};
 	}
 
-	function previewDesign( design: Design, styleVariation?: StyleVariation ) {
+	function previewDesign( design: Design, _styleVariation?: StyleVariation ) {
+		const styleVariation = _styleVariation ?? design.preselected_style_variation;
+
 		recordPreviewedDesign( { flow, intent, design, styleVariation } );
 
 		if ( ! design.is_virtual ) {
@@ -254,16 +256,17 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		}
 
 		if ( styleVariation ) {
-			recordTracksEvent( 'calypso_signup_design_picker_style_variation_button_click', {
-				...getEventPropsByDesign( design, styleVariation ),
-				...getVirtualDesignProps( design, styleVariation ),
-			} );
 			setSelectedStyleVariation( styleVariation );
-		} else if ( design.preselected_style_variation ) {
-			setSelectedStyleVariation( design.preselected_style_variation );
 		}
 
 		setIsPreviewingDesign( true );
+	}
+
+	function onChangeVariation( design: Design, styleVariation?: StyleVariation ) {
+		recordTracksEvent( 'calypso_signup_design_picker_style_variation_button_click', {
+			...getEventPropsByDesign( design, styleVariation ),
+			...getVirtualDesignProps( design, styleVariation ),
+		} );
 	}
 
 	function trackAllDesignsView() {
@@ -711,6 +714,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			onSelect={ pickDesign }
 			onSelectBlankCanvas={ pickBlankCanvasDesign }
 			onPreview={ previewDesign }
+			onChangeVariation={ onChangeVariation }
 			onViewAllDesigns={ trackAllDesignsView }
 			onCheckout={ goToCheckout }
 			heading={ heading }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -153,6 +153,7 @@ interface DesignButtonProps {
 	locale: string;
 	onSelect: ( design: Design ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
+	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	isPremiumThemeAvailable?: boolean;
 	hasPurchasedTheme?: boolean;
 	onCheckout?: any;
@@ -164,6 +165,7 @@ interface DesignButtonProps {
 const DesignButton: React.FC< DesignButtonProps > = ( {
 	locale,
 	onPreview,
+	onChangeVariation,
 	design,
 	isPremiumThemeAvailable = false,
 	hasPurchasedTheme = false,
@@ -265,7 +267,10 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 						<div className="design-picker__options-style-variations">
 							<StyleVariationBadges
 								variations={ style_variations }
-								onClick={ ( variation ) => setSelectedStyleVariation( variation ) }
+								onClick={ ( variation ) => {
+									onChangeVariation( design, variation );
+									setSelectedStyleVariation( variation );
+								} }
 								selectedVariation={ selectedStyleVariation }
 								firstVariation={ preselected_style_variation }
 								onMoreClick={ () => onPreview( design ) }
@@ -402,6 +407,7 @@ interface DesignPickerProps {
 	onSelect: ( design: Design ) => void;
 	onSelectBlankCanvas: ( design: Design, shouldGoToAssemblerStep: boolean ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
+	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	staticDesigns: Design[];
 	generatedDesigns: Design[];
 	categorization?: Categorization;
@@ -417,6 +423,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	onSelect,
 	onSelectBlankCanvas,
 	onPreview,
+	onChangeVariation,
 	staticDesigns,
 	generatedDesigns,
 	categorization,
@@ -455,6 +462,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						onSelect={ onSelect }
 						onSelectBlankCanvas={ onSelectBlankCanvas }
 						onPreview={ onPreview }
+						onChangeVariation={ onChangeVariation }
 						isPremiumThemeAvailable={ isPremiumThemeAvailable }
 						onCheckout={ onCheckout }
 						verticalId={ verticalId }
@@ -485,6 +493,7 @@ export interface UnifiedDesignPickerProps {
 	onSelect: ( design: Design ) => void;
 	onSelectBlankCanvas: ( design: Design, shouldGoToAssemblerStep: boolean ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
+	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
 	onViewAllDesigns: () => void;
 	generatedDesigns: Design[];
 	staticDesigns: Design[];
@@ -502,6 +511,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	onSelect,
 	onSelectBlankCanvas,
 	onPreview,
+	onChangeVariation,
 	onViewAllDesigns,
 	verticalId,
 	staticDesigns,
@@ -541,6 +551,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					onSelect={ onSelect }
 					onSelectBlankCanvas={ onSelectBlankCanvas }
 					onPreview={ onPreview }
+					onChangeVariation={ onChangeVariation }
 					staticDesigns={ staticDesigns }
 					generatedDesigns={ generatedDesigns }
 					categorization={ categorization }


### PR DESCRIPTION
## Proposed Changes

Fixes a regression introduced in https://github.com/Automattic/wp-calypso/pull/73476 which prevents the `calypso_signup_design_picker_style_variation_button_click` event from being tracked when changing the style variation using the discs.

## Testing Instructions

- Use the Calypso live link below
- Open the Networks tab of your browser devtools
- Observe the `t.gif` requests
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>`
- Use the discs to change the style variation of a design
- Make sure the `calypso_signup_design_picker_style_variation_button_click` event is tracked correctly
