### PR TITLE
Marketplace: adds a title attribute to the categories html.

### DIFF
--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -58,7 +58,9 @@ const Categories = ( { selected, noSelection }: { selected?: string; noSelection
 			forceSwipe={ 'undefined' === typeof window }
 		>
 			{ categories.map( ( category ) => (
-				<span key={ `category-${ category.slug }` }>{ category.menu }</span>
+				<span key={ `category-${ category.slug }` } title={ category.menu }>
+					{ category.menu }
+				</span>
 			) ) }
 		</ResponsiveToolbarGroup>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdh6GB-2M1-p2#comment-3488

## Proposed Changes

*  adds a title attribute to each category in the categories menu of the Plugins List page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

![CleanShot 2023-02-22 at 15 31 24@2x](https://user-images.githubusercontent.com/12430020/220634735-e30cce8b-67f4-4551-a721-e04e2f65413c.png)

* Go to `/plugins` 
* Observe that hovering at a Category displays the title after a while.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?