### PR TITLE
Jetpack Cloud: Update presales chat widget to only appear during specified times.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -9,9 +9,18 @@ import type { ConfigData } from '@automattic/create-calypso-config';
 
 const isWithinAvailableChatDays = ( currentTime: Date ) => {
 	const [ SUNDAY, SATURDAY ] = [ 0, 6 ];
+	//open and close hours, currently 09:00 - 19:00 UTC
+	const [ OPEN_HOUR, CLOSE_HOUR ] = [ 9, 19 ];
+	const utcHour = currentTime.getUTCHours();
 	const utcWeekDay = currentTime.getUTCDay();
 
-	return utcWeekDay !== SUNDAY && utcWeekDay !== SATURDAY;
+	//if current hour is within open and close hour range and day is not saturday or sunday, return true
+	return (
+		utcHour >= OPEN_HOUR &&
+		utcHour <= CLOSE_HOUR &&
+		utcWeekDay !== SUNDAY &&
+		utcWeekDay !== SATURDAY
+	);
 };
 
 const isWithinShutdownDates = ( currentTime: Date ) => {

--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -16,10 +16,7 @@ const isWithinAvailableChatDays = ( currentTime: Date ) => {
 
 	//if current hour is within open and close hour range and day is not saturday or sunday, return true
 	return (
-		utcHour >= OPEN_HOUR &&
-		utcHour <= CLOSE_HOUR &&
-		utcWeekDay !== SUNDAY &&
-		utcWeekDay !== SATURDAY
+		utcHour >= OPEN_HOUR && utcHour < CLOSE_HOUR && utcWeekDay !== SUNDAY && utcWeekDay !== SATURDAY
 	);
 };
 


### PR DESCRIPTION
## Proposed Changes

* Per a request from JPOP happy 1202858161751496-as-1204016034524978/f
* P2 p8wKgj-3Fh-p2
* The hours logic was removed when we switched to 24/5.  I've put the logic back and set it to the currently requested hours (9 - 19 utc)

## Testing Instructions

* There's not a great way to test this, load the jetpack cloud live link and go to the pricing page.  Verify that you either do or don't see the chat bubble according to the time.
* For something more precise, you can load this branch locally and run yarn start-jetpack-cloud then check your browser.  
* Then, change the hours in the file and save, and check the local site again to see if the chat bubble now disappears.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?