### PR TITLE
Virtual themes i1: Implement A/B test

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -22,6 +22,7 @@ import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-s
 import WebPreview from 'calypso/components/web-preview/content';
 import { useSiteVerticalQueryById } from 'calypso/data/site-verticals';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useExperiment } from 'calypso/lib/explat';
 import { urlToSlug } from 'calypso/lib/url';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import { requestActiveTheme } from 'calypso/state/themes/actions';
@@ -120,16 +121,20 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		return allDesigns;
 	};
 
+	const [ isLoadingVirtualThemesExperiment, virtualThemesExperiment ] = useExperiment(
+		'calypso_signup_design_picker_virtual_themes_v1'
+	);
+
 	const { data: allDesigns, isLoading: isLoadingDesigns } = useStarterDesignsQuery(
 		{
 			vertical_id: siteVerticalId,
 			intent,
 			seed: siteSlugOrId || undefined,
 			_locale: locale,
-			include_virtual_designs: isEnabled( 'virtual-themes/onboarding' ),
+			include_virtual_designs: virtualThemesExperiment?.variationName === 'treatment',
 		},
 		{
-			enabled: true,
+			enabled: ! isLoadingVirtualThemesExperiment,
 			select: selectStarterDesigns,
 			shouldLimitGlobalStyles,
 		}

--- a/config/development.json
+++ b/config/development.json
@@ -192,7 +192,6 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"user-management-revamp": true,
-		"virtual-themes/onboarding": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,


### PR DESCRIPTION
Part of https://github.com/Automattic/dotcom-forge/issues/1655
See pbxNRc-2n5-p2.

## Proposed Changes

Implements the logic to handle the Abacus experiment that will A/B test the virtual themes i1.

## Testing Instructions

- Go to the experiment details in Abacus (find a link in pbxNRc-2n5-p2) and click on the Overview tab.
- Navigate to the Audience section and hover over the `control` assignment group.
- Upon mouse hover, click on the link to be assigned that assignment group.
- Wait a minute for the changes to be applied.
- Use the Calypso live link below.
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>`.
- Make sure the virtual themes are not displayed.
- Now assign yourself to the `treatment` group.
- Wait a minute for the changes to be applied.
- Reload `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>`.
- Make sure the virtual themes are displayed now.