### PR TITLE
Stats: Fix labels (x-axis) offsets related to bar charts

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -98,7 +98,7 @@ function Chart( {
 				return prevSizing;
 			} );
 		},
-		[ yAxisSize ]
+		[ yAxisRef, yAxisSize.clientWidth ]
 	);
 
 	// Subscribe to changes to element size and position.
@@ -134,15 +134,8 @@ function Chart( {
 			isEmptyChart: Boolean( ! nextVals.some( ( a ) => a > 0 ) ),
 			yMax: getYAxisMax( nextVals ),
 		};
-	}, [ data, maxBars, hasResized, sliceFromBeginning ] );
+	}, [ data, maxBars, sliceFromBeginning ] );
 
-	// Recover the chart with data even if no sizing is updated on the first loading.
-	// If we don't have any sizing info yet, render an empty chart with the ref.
-	// if ( ! hasResized ) {
-	// 	return <div ref={ resizeRef } className="chart" />;
-	// }
-
-	// Otherwise, render full chart.
 	const { isTooltipVisible, tooltipContext, tooltipPosition, tooltipData } = tooltip;
 
 	return (

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -71,7 +71,6 @@ function Chart( {
 		}
 	}, [] );
 
-	// Prevent using `useCallback` to keep the Y-Axis refresh via useEffect of `useWindowResizeCallback` with re-rendering.
 	const handleYAxisSizeChange = ( contentRect ) => {
 		setYAxisSize( ( prevSizing ) => {
 			const clientWidth = contentRect.width;

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -60,7 +60,6 @@ function Chart( {
 	const [ tooltip, setTooltip ] = useState( { isTooltipVisible: false } );
 	const [ sizing, setSizing ] = useState( { clientWidth: 650, hasResized: false } );
 	const [ yAxisSize, setYAxisSize ] = useState( { clientWidth: 0, hasResized: false } );
-	const { hasResized } = sizing;
 
 	// Callback to handle tooltip changes.
 	// Needs to be memoized to avoid assigning children a new function every render.

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -72,7 +72,8 @@ function Chart( {
 		}
 	}, [] );
 
-	const handleYAxisSizeChange = useCallback( ( contentRect ) => {
+	// Prevent using `useCallback` to keep the Y-Axis refresh via useEffect of `useWindowResizeCallback` with re-rendering.
+	const handleYAxisSizeChange = ( contentRect ) => {
 		setYAxisSize( ( prevSizing ) => {
 			const clientWidth = contentRect.width;
 			if ( ! prevSizing.hasResized || clientWidth !== prevSizing.clientWidth ) {
@@ -80,7 +81,7 @@ function Chart( {
 			}
 			return prevSizing;
 		} );
-	}, [] );
+	};
 
 	const yAxisRef = useWindowResizeCallback( handleYAxisSizeChange );
 

--- a/client/lib/track-element-size/index.ts
+++ b/client/lib/track-element-size/index.ts
@@ -86,7 +86,7 @@ export function useWindowResizeCallback(
 			window.removeEventListener( 'resize', throttledMeasureElement );
 			throttledMeasureElement.cancel();
 		};
-	}, [ callback ] );
+	}, [ elementRef.current, callback ] );
 
 	return elementRef;
 }

--- a/client/lib/track-element-size/index.ts
+++ b/client/lib/track-element-size/index.ts
@@ -86,7 +86,7 @@ export function useWindowResizeCallback(
 			window.removeEventListener( 'resize', throttledMeasureElement );
 			throttledMeasureElement.cancel();
 		};
-	}, [ elementRef.current, callback ] );
+	}, [ callback ] );
 
 	return elementRef;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73589

## Proposed Changes

* Remove the usage of `useCallback` on `handleYAxisSizeChange` to keep the y-axis refreshed with the chart re-rendering, which prevents stopping updating states for drawing the chart.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Traffic` page.
* Change the date period to `Years`.
* Ensure the chart x-axis labels are aligned with corresponding bar charts.
* Reload the page plenty of times to ensure the x-axis offsets no longer appear.

|Before (intermittently)|After|
|-|-|
|<img width="1301" alt="截圖 2023-02-22 下午11 08 39" src="https://user-images.githubusercontent.com/6869813/220663999-b0cc260e-9fb2-4aa2-afaf-8760e160095d.png">|<img width="1284" alt="截圖 2023-02-22 下午11 10 55" src="https://user-images.githubusercontent.com/6869813/220664429-8f5ec1e4-9964-4412-bc13-508fb30d0eed.png">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
