### PR TITLE
Design picker: Fix selected disc style for Safari

### DIFF
--- a/packages/design-picker/src/components/style-variation-badges/style.scss
+++ b/packages/design-picker/src/components/style-variation-badges/style.scss
@@ -47,7 +47,9 @@
 .style-variation__badge-is-selected {
 	> * {
 		cursor: default;
-		outline: 2px solid var(--studio-blue-30);
+		box-shadow:
+			inset 0 0 0 1px rgb(0 0 0 / 20%),
+			0 0 0 2px var(--studio-blue-30);
 
 		&:hover {
 			&::after {


### PR DESCRIPTION
## Proposed Changes

Looks like Safari cannot have an element with both `border-radius` and `outline`, which was causing the selected variation disc on the Design picker to have a square border.

This PR fixes that by implementing a workaround that uses `box-shadow`.

Before | After
--- | ---
<img width="421" alt="Screenshot 2023-02-22 at 17 12 53" src="https://user-images.githubusercontent.com/1233880/220688239-a31ad89e-9961-4a39-8a81-f9874d185a06.png"> | <img width="415" alt="Screenshot 2023-02-22 at 17 13 16" src="https://user-images.githubusercontent.com/1233880/220688409-49e0ffb5-ccab-433a-9339-ed06f83ccfa6.png">
## Testing Instructions

- In Safari, go to the Calypso live link
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>`
- Make sure the selected variation discs have a rounded blue border