### PR TITLE
Import flow: Fix minor styling issues

### DIFF
--- a/client/blocks/importer/wordpress/content-chooser/style.scss
+++ b/client/blocks/importer/wordpress/content-chooser/style.scss
@@ -21,6 +21,7 @@
 	}
 
 	.card.list__importer-option {
+		background: transparent;
 		box-shadow: none;
 		padding: 0;
 		margin: 1.25rem 0;

--- a/client/blocks/importer/wordpress/import-everything/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/style.scss
@@ -94,6 +94,7 @@
 .import__upgrade-plan {
 	p {
 		color: var(--studio-gray-40);
+		margin-bottom: 1em;
 	}
 
 	.import__upgrade-plan-container {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/73667
Closes https://github.com/Automattic/wp-calypso/issues/73669

## Proposed Changes

Fixed minor style issues on the import flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused/import?siteSlug={SIMPLE_SITE}`
* Enter self-hosted website URL
* Check if options **Everything** and **Content only** cards has transparency background
* Select **Everything** option
* Press the "See plans" button
* Check if the paragraph above the Business plan info has margin spacing between

For the screenshots, see mentioned related tickets.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
