### PR TITLE
GitHub integration: grab deployment logs as blob and open them in a new tab

### DIFF
--- a/client/my-sites/hosting/github/deployment-card/deployment-status-explanation.tsx
+++ b/client/my-sites/hosting/github/deployment-card/deployment-status-explanation.tsx
@@ -2,26 +2,40 @@ import { Gridicon } from '@automattic/components';
 import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { ReactChild } from 'react';
+import { useDeploymentLogsURL } from './use-deployment-logs-url';
 
 interface DeploymentStatusBadgeProps {
 	status: string;
 	totalFailures: number;
+	connectionId: number;
+	deploymentTimestamp: number;
 }
 
 export const DeploymentStatusExplanation = ( {
 	status,
 	totalFailures,
+	connectionId,
+	deploymentTimestamp,
 }: DeploymentStatusBadgeProps ) => {
+	const deploymentLogsUrl = useDeploymentLogsURL( {
+		connectionId,
+		deploymentTimestamp,
+	} );
+
 	const translate = useTranslate();
 
 	let message: ReactChild = '';
+
+	if ( ! deploymentLogsUrl ) {
+		return null;
+	}
 
 	if ( status === 'failed' ) {
 		message = translate(
 			'Failed to build. Please {{a}}check the logs{{/a}} for more information.',
 			{
 				components: {
-					a: <ExternalLink href="#" />,
+					a: <ExternalLink href={ deploymentLogsUrl } />,
 				},
 			}
 		);
@@ -35,7 +49,7 @@ export const DeploymentStatusExplanation = ( {
 					totalFailures,
 				},
 				components: {
-					a: <ExternalLink href="#" />,
+					a: <ExternalLink href={ deploymentLogsUrl } />,
 				},
 			}
 		);

--- a/client/my-sites/hosting/github/deployment-card/index.tsx
+++ b/client/my-sites/hosting/github/deployment-card/index.tsx
@@ -115,6 +115,8 @@ export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardPr
 							<DeploymentStatusExplanation
 								status={ deployment.status }
 								totalFailures={ totalFailures }
+								connectionId={ connectionId }
+								deploymentTimestamp={ deployment.last_deployment_timestamp }
 							/>
 						) }
 					</div>

--- a/client/my-sites/hosting/github/deployment-card/use-deployment-logs-url.ts
+++ b/client/my-sites/hosting/github/deployment-card/use-deployment-logs-url.ts
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+import { useQuery } from 'react-query';
+import { useSelector } from 'react-redux';
+import wp from 'calypso/lib/wp';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { GITHUB_INTEGRATION_QUERY_KEY } from '../constants';
+
+interface DeploymentLogsData {
+	text: string;
+}
+
+interface UseDeploymentLogsURLArguments {
+	connectionId: number;
+	deploymentTimestamp: number;
+}
+
+export const useDeploymentLogsURL = ( {
+	connectionId,
+	deploymentTimestamp,
+}: UseDeploymentLogsURLArguments ) => {
+	const siteId = useSelector( getSelectedSiteId );
+
+	const { data } = useQuery< DeploymentLogsData >(
+		[ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId, 'deployment-logs', deploymentTimestamp ],
+		() =>
+			wp.req.get( {
+				path: `/sites/${ siteId }/hosting/github/deployment-logs`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		{
+			enabled: !! siteId,
+		}
+	);
+
+	const logsBlobUrl = useMemo( () => {
+		if ( ! data ) {
+			return null;
+		}
+
+		return URL.createObjectURL( new Blob( [ data.text ], { type: 'text/plain' } ) );
+	}, [ data ] );
+
+	return logsBlobUrl;
+};


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/73475.

## Proposed Changes

Moves logging fetching from exposing a file directly to streaming the contents and storing them in a blob that the user can click and open in a new tab.

## Testing Instructions

1. Deploy with warnings -- try to override a `wpcomsh` file for example (or hardcode `totalFailures` to some value other than zero after a successful deployment. Shh);
2. Click the `check the logs` link;
3. Check that the logs open in a new file as a blob.