### PR TITLE
Flaky E2E: extend timeout for Home dashboard to load in FTME: Sell flow.

### DIFF
--- a/test/e2e/specs/onboarding/ftme__sell.ts
+++ b/test/e2e/specs/onboarding/ftme__sell.ts
@@ -183,7 +183,8 @@ describe( DataHelper.createSuiteTitle( 'FTME: Sell' ), function () {
 
 		it( 'Land in Home dashboard', async function () {
 			await page.waitForURL(
-				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.site_slug }` )
+				DataHelper.getCalypsoURL( `/home/${ newSiteDetails.blog_details.site_slug }` ),
+				{ timeout: 20 * 1000 }
 			);
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #73677.

## Proposed Changes

This PR extends the timeout for FTME: Sell flow for the step `Land in Home dashboard`.


## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Pre-Release E2E


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
