### PR TITLE
Launchpad: Change Header text for General Onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/translations.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/translations.ts
@@ -27,7 +27,7 @@ describe( 'Translations', () => {
 		describe( 'when no flow is specified', () => {
 			it( 'provides generic text', () => {
 				const translations = getLaunchpadTranslations( null );
-				expect( translations.flowName ).toEqual( 'WordPress' );
+				expect( translations.flowName ).toEqual( 'WordPress.com' );
 				expect( translations.title ).toEqual( 'Your website is ready!' );
 				expect( translations.subtitle ).toEqual( 'Keep up the momentum with these final steps.' );
 			} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -11,7 +11,7 @@ import { TranslatedLaunchpadStrings } from './types';
 
 export function getLaunchpadTranslations( flow: string | null ): TranslatedLaunchpadStrings {
 	const translatedStrings: TranslatedLaunchpadStrings = {
-		flowName: translate( 'WordPress' ),
+		flowName: translate( 'WordPress.com' ),
 		title: translate( 'Your website is ready!' ),
 		subtitle: translate( 'Keep up the momentum with these final steps.' ),
 	};


### PR DESCRIPTION
### Time Estimate
Review: Short
Testing: Short

### Proposed changes
Change the header text from "WordPress" to "WordPress.com" on general onboarding flows
<img width="842" alt="image" src="https://user-images.githubusercontent.com/20927667/220741679-5638651c-33c4-4db2-8c49-01deeab4ae74.png">

### Testing
1. Checkout this branch
2. Create a new general onboarding site http://calypso.localhost:3000/start
3. Once you arrive at Launchpad, confirm that the header text is "WordPress.com"