### PR TITLE
GitHub integration: highlight that a different repo was connected when last deployed

### DIFF
--- a/client/my-sites/hosting/github/deployment-card/index.tsx
+++ b/client/my-sites/hosting/github/deployment-card/index.tsx
@@ -1,15 +1,15 @@
 import { Button, Card, Spinner } from '@automattic/components';
 import { sprintf } from '@wordpress/i18n';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import SocialLogo from 'calypso/components/social-logo';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { DeploymentStatusBadge } from './deployment-status-badge';
-import { DeploymentStatusExplanation } from './deployment-status-explanation';
+import { LastDeploymentInformation } from './last-deployment-information';
 import { useDeploymentStatusQuery } from './use-deployment-status-query';
 import { useGithubDisconnectRepoMutation } from './use-disconnect-repo';
+
 import './style.scss';
 
 type DeploymentCardProps = {
@@ -22,21 +22,10 @@ const noticeOptions = {
 };
 
 export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardProps ) => {
-	let deploymentTime = '';
-	let totalFailures = 0;
-
 	const siteId = useSelector( getSelectedSiteId );
 
 	const { data: deployment, isLoading } = useDeploymentStatusQuery( siteId, connectionId );
 	const translate = useTranslate();
-
-	if ( deployment ) {
-		totalFailures = deployment.move_failures.length + deployment.remove_failures.length;
-		deploymentTime = new Intl.DateTimeFormat( i18n.getLocaleSlug() ?? 'en', {
-			dateStyle: 'medium',
-			timeStyle: 'short',
-		} ).format( new Date( deployment.last_deployment_timestamp * 1000 ) );
-	}
 
 	const dispatch = useDispatch();
 
@@ -84,42 +73,11 @@ export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardPr
 			<div>
 				{ isLoading && <Spinner /> }
 				{ deployment && (
-					<div style={ { marginBottom: '24px' } }>
-						<strong style={ { display: 'block', marginBottom: '8px' } }>
-							{ translate( 'Last deployment' ) }
-						</strong>
-						<div className="deployment-card__row">
-							<div className="deployment-card__column">
-								<span>{ deploymentTime }</span>
-							</div>
-							<div className="deployment-card__column">
-								<a
-									target="_blank"
-									href={ `https://github.com/${ repo }/commit/${ deployment.last_deployment_sha }` }
-									rel="noreferrer"
-								>
-									{ deployment.last_deployment_sha.substring( 0, 7 ) }
-								</a>
-							</div>
-							<div
-								className="deployment-card__column"
-								style={ { flexDirection: 'row', gap: '8px' } }
-							>
-								<DeploymentStatusBadge
-									status={ deployment.status }
-									totalFailures={ totalFailures }
-								/>
-							</div>
-						</div>
-						{ ( deployment.status === 'failed' || totalFailures > 0 ) && (
-							<DeploymentStatusExplanation
-								status={ deployment.status }
-								totalFailures={ totalFailures }
-								connectionId={ connectionId }
-								deploymentTimestamp={ deployment.last_deployment_timestamp }
-							/>
-						) }
-					</div>
+					<LastDeploymentInformation
+						deployment={ deployment }
+						connectedRepo={ repo }
+						connectionId={ connectionId }
+					/>
 				) }
 			</div>
 			<Button primary busy={ isDisconnecting } onClick={ () => disconnectRepo( siteId ) }>

--- a/client/my-sites/hosting/github/deployment-card/last-deployment-information.tsx
+++ b/client/my-sites/hosting/github/deployment-card/last-deployment-information.tsx
@@ -1,0 +1,81 @@
+import i18n, { useTranslate } from 'i18n-calypso';
+import { DeploymentStatusBadge } from './deployment-status-badge';
+import { DeploymentStatusExplanation } from './deployment-status-explanation';
+import { DeploymentData } from './use-deployment-status-query';
+
+import './style.scss';
+
+interface LastDeploymentInformationProps {
+	deployment: DeploymentData;
+	connectedRepo: string;
+	connectionId: number;
+}
+
+export const LastDeploymentInformation = ( {
+	deployment,
+	connectedRepo,
+	connectionId,
+}: LastDeploymentInformationProps ) => {
+	const translate = useTranslate();
+
+	const totalFailures = deployment.move_failures.length + deployment.remove_failures.length;
+	const deploymentTime = new Intl.DateTimeFormat( i18n.getLocaleSlug() ?? 'en', {
+		dateStyle: 'medium',
+		timeStyle: 'short',
+	} ).format( new Date( deployment.last_deployment_timestamp * 1000 ) );
+
+	const deploymentRepo = deployment.last_deployment_repo;
+	const deploymentRepoLink = `https://github.com/${ deploymentRepo }`;
+
+	return (
+		<div style={ { marginBottom: '24px' } }>
+			<strong style={ { display: 'block', marginBottom: '8px' } }>
+				{ translate( 'Last deployment' ) }
+			</strong>
+			<div className="deployment-card__row">
+				<div className="deployment-card__column">
+					<span>{ deploymentTime }</span>
+				</div>
+				<div className="deployment-card__column">
+					<a
+						target="_blank"
+						href={ `${ deploymentRepoLink }/commit/${ deployment.last_deployment_sha }` }
+						rel="noreferrer"
+					>
+						{ deployment.last_deployment_sha.substring( 0, 7 ) }
+					</a>
+				</div>
+				<div className="deployment-card__column" style={ { flexDirection: 'row', gap: '8px' } }>
+					<DeploymentStatusBadge status={ deployment.status } totalFailures={ totalFailures } />
+				</div>
+			</div>
+			{ deploymentRepo !== connectedRepo && (
+				<div className="deployment-card__row">
+					<div className="deployment-card__column">
+						<span className="deployment-card__different-repo-notice">
+							{ translate(
+								'This commit belongs to a different repository: {{repoLink}}%(deploymentRepo)s{{/repoLink}}',
+								{
+									args: {
+										deploymentRepo,
+									},
+									components: {
+										repoLink: <a href={ deploymentRepoLink } />,
+									},
+								}
+							) }
+						</span>
+					</div>
+				</div>
+			) }
+			{ ( deployment.status === 'failed' || totalFailures > 0 ) && (
+				<DeploymentStatusExplanation
+					status={ deployment.status }
+					totalFailures={ totalFailures }
+					connectionId={ connectionId }
+					deploymentTimestamp={ deployment.last_deployment_timestamp }
+				/>
+			) }
+		</div>
+	);
+};

--- a/client/my-sites/hosting/github/deployment-card/style.scss
+++ b/client/my-sites/hosting/github/deployment-card/style.scss
@@ -10,3 +10,8 @@
 	display: flex;
 	flex-direction: column;
 }
+
+.deployment-card__different-repo-notice {
+	color: var(--color-text-subtle);
+	font-size: $font-body-small;
+}

--- a/client/my-sites/hosting/github/deployment-card/use-deployment-status-query.ts
+++ b/client/my-sites/hosting/github/deployment-card/use-deployment-status-query.ts
@@ -8,6 +8,7 @@ export type DeploymentData = {
 	remove_failures: string[];
 	log_file_url: string;
 	last_deployment_timestamp: number;
+	last_deployment_repo: string;
 	last_deployment_sha: string;
 };
 


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/1755.

## Proposed Changes

As it's possible to switch repositories in the UI by disconnecting and reconnecting, we should indicate whether that's the case for the last deployment.

When the last deployment is from the...

| Same repository | Different repository |
| ----------------- | ------------------- |
| ![image](https://user-images.githubusercontent.com/26530524/220744009-f2b1dad3-47ba-4aa7-92ed-9204ec798df2.png) | ![image](https://user-images.githubusercontent.com/26530524/220744145-7558f10f-16e7-48af-b40c-35f7aefc5072.png) |

## Testing Instructions

1. Connect a repository in Calypso;
2. Sync it to Atomic by pushing a commit;
3. Disconnect the repository in Calypso;
4. Connect to a different repository;
5. Check that the message shows up.