### PR TITLE
Pricing Grid: Remove best for stores

### DIFF
--- a/client/my-sites/plan-features-2023-grid/hooks/use-highlight-label.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-highlight-label.ts
@@ -1,4 +1,4 @@
-import { isBusinessPlan, isEcommercePlan, isPremiumPlan } from '@automattic/calypso-products';
+import { isBusinessPlan, isPremiumPlan } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 
 const useHighlightLabel = ( planName: string ) => {
@@ -6,8 +6,6 @@ const useHighlightLabel = ( planName: string ) => {
 
 	if ( isBusinessPlan( planName ) ) {
 		return translate( 'Best for devs' );
-	} else if ( isEcommercePlan( planName ) ) {
-		return translate( 'Best for stores' );
 	} else if ( isPremiumPlan( planName ) ) {
 		return translate( 'Popular' );
 	}


### PR DESCRIPTION
See D102468-code for more context.

## Proposed Changes

* Remove best for stores and Commerce plan highlight.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/`, choose domain, and verify that pricing grid does not contain best for stores
* Go to `/plans/$site_slug` and verify that pricing grid does not contain best for stores

<img width="1629" alt="Screenshot 2023-02-22 at 2 04 58 PM" src="https://user-images.githubusercontent.com/1126811/220747454-abdd1657-30b3-4662-abad-18389e753a47.png">
<img width="1355" alt="Screenshot 2023-02-22 at 2 08 18 PM" src="https://user-images.githubusercontent.com/1126811/220747461-7d5eb5a8-2422-4517-b313-70ad8d0209ee.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
