### PR TITLE
GitHub integration: soft release it for Automatticians

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -7,6 +7,7 @@ import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
+import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
 import FeatureExample from 'calypso/components/feature-example';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Layout from 'calypso/components/layout';
@@ -71,7 +72,7 @@ class Hosting extends Component {
 
 	render() {
 		const {
-			isGithubIntegrationEnabled,
+			teams,
 			clickActivate,
 			hasSftpFeature,
 			isDisabled,
@@ -166,6 +167,7 @@ class Hosting extends Component {
 		};
 
 		const getContent = () => {
+			const isGithubIntegrationEnabled = isAutomatticTeamMember( teams );
 			const WrapperComponent = isDisabled || isTransferring ? FeatureExample : Fragment;
 
 			return (
@@ -193,6 +195,7 @@ class Hosting extends Component {
 							</Column>
 						</Layout>
 					</WrapperComponent>
+					{ ! teams && <QueryReaderTeams /> }
 				</>
 			);
 		};
@@ -225,7 +228,7 @@ export default connect(
 		const hasSftpFeature = siteHasFeature( state, siteId, FEATURE_SFTP );
 
 		return {
-			isGithubIntegrationEnabled: isAutomatticTeamMember( getReaderTeams( state ) ),
+			teams: getReaderTeams( state ),
 			isECommerceTrial: isSiteOnECommerceTrial( state, siteId ),
 			transferState: getAutomatedTransferStatus( state, siteId ),
 			isTransferring: isAutomatedTransferActive( state, siteId ),

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -213,7 +213,7 @@ class Hosting extends Component {
 				/>
 				{ hasSftpFeature ? getAtomicActivationNotice() : getUpgradeBanner() }
 				{ getContent() }
-				{ ! teams && <QueryReaderTeams /> }
+				<QueryReaderTeams />
 			</Main>
 		);
 	}

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_SFTP, FEATURE_SFTP_DATABASE } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
@@ -19,6 +18,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import { GitHubCard } from 'calypso/my-sites/hosting/github';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
@@ -30,6 +30,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
 import { isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import CacheCard from './cache-card';
 import { HostingUpsellNudge } from './hosting-upsell-nudge';
@@ -40,7 +41,6 @@ import SiteBackupCard from './site-backup-card';
 import SupportCard from './support-card';
 import WebServerLogsCard from './web-server-logs-card';
 import WebServerSettingsCard from './web-server-settings-card';
-
 import './style.scss';
 
 class Hosting extends Component {
@@ -71,6 +71,7 @@ class Hosting extends Component {
 
 	render() {
 		const {
+			isGithubIntegrationEnabled,
 			clickActivate,
 			hasSftpFeature,
 			isDisabled,
@@ -166,11 +167,10 @@ class Hosting extends Component {
 
 		const getContent = () => {
 			const WrapperComponent = isDisabled || isTransferring ? FeatureExample : Fragment;
-			const isGitHubEnabled = isEnabled( 'hosting/github-integration' );
 
 			return (
 				<>
-					{ isGitHubEnabled && (
+					{ isGithubIntegrationEnabled && (
 						<>
 							<QueryKeyringServices />
 							<QueryKeyringConnections />
@@ -181,7 +181,7 @@ class Hosting extends Component {
 							<Column type="main" className="hosting__main-layout-col">
 								<SFTPCard disabled={ isDisabled } />
 								<PhpMyAdminCard disabled={ isDisabled } />
-								{ isGitHubEnabled && <GitHubCard /> }
+								{ isGithubIntegrationEnabled && <GitHubCard /> }
 								<WebServerSettingsCard disabled={ isDisabled } />
 								<RestorePlanSoftwareCard disabled={ isDisabled } />
 								<CacheCard disabled={ isDisabled } />
@@ -225,6 +225,7 @@ export default connect(
 		const hasSftpFeature = siteHasFeature( state, siteId, FEATURE_SFTP );
 
 		return {
+			isGithubIntegrationEnabled: isAutomatticTeamMember( getReaderTeams( state ) ),
 			isECommerceTrial: isSiteOnECommerceTrial( state, siteId ),
 			transferState: getAutomatedTransferStatus( state, siteId ),
 			isTransferring: isAutomatedTransferActive( state, siteId ),

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -195,7 +195,6 @@ class Hosting extends Component {
 							</Column>
 						</Layout>
 					</WrapperComponent>
-					{ ! teams && <QueryReaderTeams /> }
 				</>
 			);
 		};
@@ -214,6 +213,7 @@ class Hosting extends Component {
 				/>
 				{ hasSftpFeature ? getAtomicActivationNotice() : getUpgradeBanner() }
 				{ getContent() }
+				{ ! teams && <QueryReaderTeams /> }
 			</Main>
 		);
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -67,7 +67,6 @@
 		"gutenboarding/alpha-templates": false,
 		"happychat": true,
 		"help": true,
-		"hosting/github-integration": true,
 		"home/layout-dev": true,
 		"hosting/datacenter-picker": true,
 		"i18n/community-translator": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,7 +41,6 @@
 		"google-my-business": true,
 		"happychat": true,
 		"help": true,
-		"hosting/github-integration": true,
 		"i18n/empathy-mode": true,
 		"inline-help": true,
 		"jetpack/agency-dashboard": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -49,7 +49,6 @@
 		"gutenboarding/alpha-templates": false,
 		"happychat": true,
 		"help": true,
-		"hosting/github-integration": true,
 		"home/layout-dev": true,
 		"hosting/datacenter-picker": true,
 		"i18n/translation-scanner": true,


### PR DESCRIPTION
## Proposed Changes

As part of this first iteration, let's soft-release the feature.

The idea is to gather feedback on the CfT, and usage from within Automattic, including Team 51, then use the feedback to hone the experience and functionalities. Once we achieve that state, we can release it to a wider public (a.k.a. everyone).

## Testing Instructions

Check that the feature shows up in WPCOM if you're logged in with your A8C WPCOM account.

Check that it doesn't show up if you log in with a different account that is not related to Automattic.