### PR TITLE
Update Post Purchase Upsell discount with experiment

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { isMonthly, getPlanByPathSlug, TERM_MONTHLY } from '@automattic/calypso-products';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CompactCard, Gridicon } from '@automattic/components';
@@ -15,6 +14,7 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
 import QueryStoredCards from 'calypso/components/data/query-stored-cards';
 import Main from 'calypso/components/main';
+import { Experiment } from 'calypso/lib/explat';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import { TITAN_MAIL_MONTHLY_SLUG, TITAN_MAIL_YEARLY_SLUG } from 'calypso/lib/titan/constants';
 import {
@@ -294,35 +294,37 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 				);
 
 			case BUSINESS_PLAN_UPGRADE_UPSELL:
-				if ( config.isEnabled( 'upsell/post-purchase-treatment' ) ) {
-					return isLoading ? (
-						this.renderGenericPlaceholder()
-					) : (
-						<BusinessPlanUpgradeUpsellTreatment
-							currencyCode={ currencyCode }
-							planRawPrice={ planRawPrice }
-							planDiscountedRawPrice={ planDiscountedRawPrice }
-							receiptId={ receiptId }
-							translate={ translate }
-							handleClickAccept={ this.handleClickAccept }
-							handleClickDecline={ this.handleClickDecline }
-							hasSevenDayRefundPeriod={ hasSevenDayRefundPeriod }
-							currentPlan={ currentPlan }
-						/>
-					);
-				}
 				return isLoading ? (
 					this.renderGenericPlaceholder()
 				) : (
-					<BusinessPlanUpgradeUpsell
-						currencyCode={ currencyCode }
-						planRawPrice={ planRawPrice }
-						planDiscountedRawPrice={ planDiscountedRawPrice }
-						receiptId={ receiptId }
-						translate={ translate }
-						handleClickAccept={ this.handleClickAccept }
-						handleClickDecline={ this.handleClickDecline }
-						hasSevenDayRefundPeriod={ hasSevenDayRefundPeriod }
+					<Experiment
+						name="calypso_postpurchase_upsell_countdown_timer"
+						defaultExperience={
+							<BusinessPlanUpgradeUpsell
+								currencyCode={ currencyCode }
+								planRawPrice={ planRawPrice }
+								planDiscountedRawPrice={ planDiscountedRawPrice }
+								receiptId={ receiptId }
+								translate={ translate }
+								handleClickAccept={ this.handleClickAccept }
+								handleClickDecline={ this.handleClickDecline }
+								hasSevenDayRefundPeriod={ hasSevenDayRefundPeriod }
+							/>
+						}
+						treatmentExperience={
+							<BusinessPlanUpgradeUpsellTreatment
+								currencyCode={ currencyCode }
+								planRawPrice={ planRawPrice }
+								planDiscountedRawPrice={ planDiscountedRawPrice }
+								receiptId={ receiptId }
+								translate={ translate }
+								handleClickAccept={ this.handleClickAccept }
+								handleClickDecline={ this.handleClickDecline }
+								hasSevenDayRefundPeriod={ hasSevenDayRefundPeriod }
+								currentPlan={ currentPlan }
+							/>
+						}
+						loadingExperience={ null }
 					/>
 				);
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/1605

## Proposed Changes

Following [this](https://github.com/Automattic/wp-calypso/pull/73402), we show the post-purchase upsell with the discount countdown time with the experiment `treatment` instead of a flag.
Experiment: 21081-explat-experiment

Control | Treatment
--|--
![countdown-before](https://user-images.githubusercontent.com/140841/219508109-ea1c284f-72cc-41cc-bf8c-1ae5c8417837.png)  | ![countdown-after](https://user-images.githubusercontent.com/140841/219508084-30db3830-ad79-4f6e-93de-1a8474a1289d.png)

## Testing Instructions
* Load this PR
* Purchase a Premium plan. You should see the same upsell that we currently have in production.
* If the countdown is showing, you are on the `treatment` variation of the experiment.
* If the countdown is not showing, you are on the `control` variation of the experiment.
* You can change between `treatment` and `control` using the bookmarklets on the Experiment page. (remember to clean the Local Storage of the experiment before reloading the page)
* Switch the variation and refresh the page.
* Continue to checkout and make sure the discount matches the preview screen.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~