### PR TITLE
VAT: Change instances of 'VAT' to generic 'Business Tax ID' in Calypso

### DIFF
--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -32,8 +32,8 @@ export function BillingHistoryContent( {
 function BillingHistory() {
 	const translate = useTranslate();
 	const { vatDetails } = useVatDetails();
-	const editVatText = translate( 'Edit VAT details (for Europe only)' );
-	const addVatText = translate( 'Add VAT details (for Europe only)' );
+	const editVatText = translate( 'Edit Business Tax ID details' );
+	const addVatText = translate( 'Add Business Tax ID details' );
 	const vatText = vatDetails.id ? editVatText : addVatText;
 
 	return (

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -56,7 +56,7 @@ Object.defineProperties( titles, {
 		get: () => i18n.translate( 'Payment Methods' ),
 	},
 	vatDetails: {
-		get: () => i18n.translate( 'VAT Details' ),
+		get: () => i18n.translate( 'Business Purchase ID Details' ),
 	},
 } );
 

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -56,7 +56,7 @@ Object.defineProperties( titles, {
 		get: () => i18n.translate( 'Payment Methods' ),
 	},
 	vatDetails: {
-		get: () => i18n.translate( 'Business Purchase ID Details' ),
+		get: () => i18n.translate( 'Business Tax ID details' ),
 	},
 } );
 

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -28,7 +28,9 @@ export default function VatInfoPage() {
 	if ( fetchError ) {
 		return (
 			<div className="vat-info">
-				<CompactCard>{ translate( 'An error occurred while fetching VAT details.' ) }</CompactCard>
+				<CompactCard>
+					{ translate( 'An error occurred while fetching Business Tax ID details.' ) }
+				</CompactCard>
 			</div>
 		);
 	}
@@ -44,11 +46,11 @@ export default function VatInfoPage() {
 			<Column type="sidebar">
 				<Card className="vat-info__sidebar-card">
 					<CardHeading tagName="h1" size={ 16 } isBold={ true } className="vat-info__sidebar-title">
-						{ translate( 'VAT Information' ) }
+						{ translate( 'Business Tax ID Information' ) }
 					</CardHeading>
 					<p className="vat-info__sidebar-paragraph">
 						{ translate(
-							"We currently only provide VAT invoices to users who are properly listed in the VIES (VAT Information Exchange System) or the UK VAT databases. VAT information saved on this page will be applied to all of your account's receipts."
+							"We currently only provide Business Tax ID invoices to users who are properly listed in Business Tax ID databases. Business Tax ID information saved on this page will be applied to all of your account's receipts."
 						) }
 					</p>
 				</Card>
@@ -104,7 +106,7 @@ function VatForm() {
 				{ isVatAlreadySet && (
 					<FormSettingExplanation>
 						{ translate(
-							'To change your VAT number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+							'To change your Business Tax ID number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
 							{
 								components: {
 									contactSupportLink: (
@@ -236,7 +238,9 @@ function useDisplayVatNotices( {
 			reduxDispatch( removeNotice( 'vat_info_notice' ) );
 			reduxDispatch(
 				errorNotice(
-					translate( 'Your VAT details are not valid. Please check each field and try again.' ),
+					translate(
+						'Your Business Tax ID details are not valid. Please check each field and try again.'
+					),
 					{ id: 'vat_info_notice' }
 				)
 			);
@@ -248,7 +252,7 @@ function useDisplayVatNotices( {
 			reduxDispatch(
 				errorNotice(
 					translate(
-						'An error occurred while updating your VAT details. Please try again or contact support.'
+						'An error occurred while updating your Business Tax ID details. Please try again or contact support.'
 					),
 					{
 						id: 'vat_info_notice',
@@ -261,7 +265,7 @@ function useDisplayVatNotices( {
 		if ( success ) {
 			reduxDispatch( removeNotice( 'vat_info_notice' ) );
 			reduxDispatch(
-				successNotice( translate( 'Your VAT details have been updated!' ), {
+				successNotice( translate( 'Your Business Tax ID details have been updated!' ), {
 					id: 'vat_info_notice',
 				} )
 			);

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -46,7 +46,7 @@ export default function VatInfoPage() {
 			<Column type="sidebar">
 				<Card className="vat-info__sidebar-card">
 					<CardHeading tagName="h1" size={ 16 } isBold={ true } className="vat-info__sidebar-title">
-						{ translate( 'Business Tax ID Information' ) }
+						{ translate( 'Business Tax ID details' ) }
 					</CardHeading>
 					<p className="vat-info__sidebar-paragraph">
 						{ translate(

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -50,7 +50,7 @@ export default function VatInfoPage() {
 					</CardHeading>
 					<p className="vat-info__sidebar-paragraph">
 						{ translate(
-							"We currently only provide Business Tax ID invoices to users who are properly listed in Business Tax ID databases. Business Tax ID information saved on this page will be applied to all of your account's receipts."
+							"We currently only provide Business Tax ID invoices to users who are properly registered. Business Tax ID information saved on this page will be applied to all of your account's receipts."
 						) }
 					</p>
 				</Card>

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -94,7 +94,7 @@ function VatForm() {
 				/>
 			</FormFieldset>
 			<FormFieldset className="vat-info__vat-field">
-				<FormLabel htmlFor="vat">{ translate( 'VAT Number' ) }</FormLabel>
+				<FormLabel htmlFor="vat">{ translate( 'Business Tax ID Number' ) }</FormLabel>
 				<FormTextInput
 					name="vat"
 					disabled={ isUpdating || isVatAlreadySet }

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -190,7 +190,7 @@ export function VatForm( {
 					className="vat-form__expand-button"
 					checked={ isFormActive }
 					onChange={ toggleVatForm }
-					label={ translate( 'Add VAT details' ) }
+					label={ translate( 'Add Business Tax ID details' ) }
 					disabled={ isDisabled }
 				/>
 			</div>
@@ -204,7 +204,7 @@ export function VatForm( {
 					className="vat-form__expand-button"
 					checked={ isFormActive }
 					onChange={ toggleVatForm }
-					label={ translate( 'Add VAT details' ) }
+					label={ translate( 'Add Business Tax ID details' ) }
 					disabled={ isDisabled || Boolean( vatDetailsFromServer.id ) }
 				/>
 				{ countryCode === 'GB' && (
@@ -212,7 +212,7 @@ export function VatForm( {
 						className="vat-form__expand-button"
 						checked={ vatDetailsInForm.country === 'XI' }
 						onChange={ toggleNorthernIreland }
-						label={ translate( 'Is the VAT for Northern Ireland?' ) }
+						label={ translate( 'Is the Business Tax ID for Northern Ireland?' ) }
 						disabled={ isDisabled }
 					/>
 				) }
@@ -221,7 +221,7 @@ export function VatForm( {
 				<Field
 					id={ section + '-vat-organization' }
 					type="text"
-					label={ String( translate( 'Organization for VAT' ) ) }
+					label={ String( translate( 'Organization for Business Tax ID' ) ) }
 					value={ vatDetailsInForm.name ?? '' }
 					disabled={ isDisabled }
 					onChange={ ( newValue: string ) => {
@@ -234,7 +234,7 @@ export function VatForm( {
 				<Field
 					id={ section + '-vat-id' }
 					type="text"
-					label={ String( translate( 'VAT Number' ) ) }
+					label={ String( translate( 'Business Tax ID Number' ) ) }
 					value={ vatDetailsInForm.id ?? '' }
 					disabled={ isDisabled || Boolean( vatDetailsFromServer.id ) }
 					onChange={ ( newValue: string ) => {
@@ -249,7 +249,7 @@ export function VatForm( {
 				<Field
 					id={ section + '-vat-address' }
 					type="text"
-					label={ String( translate( 'Address for VAT' ) ) }
+					label={ String( translate( 'Address for Business Tax ID' ) ) }
 					value={ vatDetailsInForm.address ?? '' }
 					autoComplete="address"
 					disabled={ isDisabled }
@@ -265,7 +265,7 @@ export function VatForm( {
 				<div>
 					<FormSettingExplanation>
 						{ translate(
-							'To change your VAT number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+							'To change your Business Tax ID number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
 							{
 								components: {
 									contactSupportLink: (

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -212,7 +212,7 @@ export function VatForm( {
 						className="vat-form__expand-button"
 						checked={ vatDetailsInForm.country === 'XI' }
 						onChange={ toggleNorthernIreland }
-						label={ translate( 'Is the Business Tax ID for Northern Ireland?' ) }
+						label={ translate( 'Is the tax ID for Northern Ireland?' ) }
 						disabled={ isDisabled }
 					/>
 				) }
@@ -221,7 +221,7 @@ export function VatForm( {
 				<Field
 					id={ section + '-vat-organization' }
 					type="text"
-					label={ String( translate( 'Organization for Business Tax ID' ) ) }
+					label={ String( translate( 'Organization for tax ID' ) ) }
 					value={ vatDetailsInForm.name ?? '' }
 					disabled={ isDisabled }
 					onChange={ ( newValue: string ) => {
@@ -249,7 +249,7 @@ export function VatForm( {
 				<Field
 					id={ section + '-vat-address' }
 					type="text"
-					label={ String( translate( 'Address for Business Tax ID' ) ) }
+					label={ String( translate( 'Address for tax ID' ) ) }
 					value={ vatDetailsInForm.address ?? '' }
 					autoComplete="address"
 					disabled={ isDisabled }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -395,7 +395,7 @@ export default function WPCheckout( {
 									reduxDispatch(
 										errorNotice(
 											translate(
-												'Your VAT details are not valid. Please check each field and try again.'
+												'Your Business Tax ID details are not valid. Please check each field and try again.'
 											),
 											{ id: 'vat_info_notice' }
 										)

--- a/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
@@ -69,7 +69,7 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'US' );
-		expect( screen.queryByLabelText( 'Add VAT details' ) ).not.toBeInTheDocument();
+		expect( screen.queryByLabelText( 'Add Business Tax ID details' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the VAT field checkbox if the selected country does support VAT', async () => {
@@ -77,7 +77,7 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
-		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeInTheDocument();
+		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).toBeInTheDocument();
 	} );
 
 	it( 'does not render the VAT fields if the checkbox is not checked', async () => {
@@ -85,8 +85,8 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
-		expect( await screen.findByLabelText( 'Add VAT details' ) ).not.toBeChecked();
-		expect( screen.queryByLabelText( 'VAT Number' ) ).not.toBeInTheDocument();
+		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).not.toBeChecked();
+		expect( screen.queryByLabelText( 'Business Tax ID Number' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the VAT fields if the checkbox is checked', async () => {
@@ -94,9 +94,9 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
-		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
-		expect( await screen.findByLabelText( 'VAT Number' ) ).toBeInTheDocument();
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).toBeChecked();
+		expect( await screen.findByLabelText( 'Business Tax ID Number' ) ).toBeInTheDocument();
 	} );
 
 	it( 'does not render the Northern Ireland checkbox is if the VAT checkbox is checked and the country is EU', async () => {
@@ -104,8 +104,10 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'ES' );
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
-		expect( screen.queryByLabelText( 'Is the VAT for Northern Ireland?' ) ).not.toBeInTheDocument();
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		expect(
+			screen.queryByLabelText( 'Is the tax ID for Northern Ireland?' )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the Northern Ireland checkbox is if the VAT checkbox is checked and the country is GB', async () => {
@@ -113,9 +115,9 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
 		expect(
-			await screen.findByLabelText( 'Is the VAT for Northern Ireland?' )
+			await screen.findByLabelText( 'Is the tax ID for Northern Ireland?' )
 		).toBeInTheDocument();
 	} );
 
@@ -124,12 +126,14 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
 		expect(
-			await screen.findByLabelText( 'Is the VAT for Northern Ireland?' )
+			await screen.findByLabelText( 'Is the tax ID for Northern Ireland?' )
 		).toBeInTheDocument();
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'ES' );
-		expect( screen.queryByLabelText( 'Is the VAT for Northern Ireland?' ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByLabelText( 'Is the tax ID for Northern Ireland?' )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the VAT fields and checks the box on load if the VAT endpoint returns data', async () => {
@@ -153,8 +157,8 @@ describe( 'Checkout contact step', () => {
 		const countryField = await screen.findByLabelText( 'Country' );
 
 		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
-		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
-		expect( await screen.findByLabelText( 'VAT Number' ) ).toBeInTheDocument();
+		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).toBeChecked();
+		expect( await screen.findByLabelText( 'Business Tax ID Number' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the VAT fields pre-filled if the VAT endpoint returns data', async () => {
@@ -178,9 +182,11 @@ describe( 'Checkout contact step', () => {
 		const countryField = await screen.findByLabelText( 'Country' );
 
 		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
-		expect( await screen.findByLabelText( 'VAT Number' ) ).toHaveValue( '12345' );
-		expect( await screen.findByLabelText( 'Organization for VAT' ) ).toHaveValue( 'Test company' );
-		expect( await screen.findByLabelText( 'Address for VAT' ) ).toHaveValue( '123 Main Street' );
+		expect( await screen.findByLabelText( 'Business Tax ID Number' ) ).toHaveValue( '12345' );
+		expect( await screen.findByLabelText( 'Organization for tax ID' ) ).toHaveValue(
+			'Test company'
+		);
+		expect( await screen.findByLabelText( 'Address for tax ID' ) ).toHaveValue( '123 Main Street' );
 	} );
 
 	it( 'does not allow unchecking the VAT details checkbox if the VAT fields are pre-filled', async () => {
@@ -205,13 +211,13 @@ describe( 'Checkout contact step', () => {
 		const countryField = await screen.findByLabelText( 'Country' );
 
 		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
-		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
-		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeDisabled();
+		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).toBeChecked();
+		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).toBeDisabled();
 
 		// Try to click it anyway and make sure it does not change.
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
-		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
-		expect( await screen.findByLabelText( 'VAT Number' ) ).toBeInTheDocument();
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).toBeChecked();
+		expect( await screen.findByLabelText( 'Business Tax ID Number' ) ).toBeInTheDocument();
 	} );
 
 	it( 'sends data to the VAT endpoint when completing the step if the box is checked', async () => {
@@ -229,10 +235,10 @@ describe( 'Checkout contact step', () => {
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
-		await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
-		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
@@ -271,10 +277,10 @@ describe( 'Checkout contact step', () => {
 
 		// Make sure the form has the autocompleted data.
 		expect( countryField.selectedOptions[ 0 ].value ).toBe( cachedContactCountry );
-		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
-		expect( await screen.findByLabelText( 'VAT Number' ) ).toHaveValue( vatId );
-		expect( await screen.findByLabelText( 'Organization for VAT' ) ).toHaveValue( vatName );
-		expect( await screen.findByLabelText( 'Address for VAT' ) ).toHaveValue( vatAddress );
+		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).toBeChecked();
+		expect( await screen.findByLabelText( 'Business Tax ID Number' ) ).toHaveValue( vatId );
+		expect( await screen.findByLabelText( 'Organization for tax ID' ) ).toHaveValue( vatName );
+		expect( await screen.findByLabelText( 'Address for tax ID' ) ).toHaveValue( vatAddress );
 
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
 		const mockVatEndpoint = mockSetVatInfoEndpoint();
@@ -302,11 +308,11 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
-		await user.click( await screen.findByLabelText( 'Is the VAT for Northern Ireland?' ) );
-		await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
-		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.click( await screen.findByLabelText( 'Is the tax ID for Northern Ireland?' ) );
+		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
@@ -329,15 +335,15 @@ describe( 'Checkout contact step', () => {
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		// Check the box
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
 
 		// Fill in the details
-		await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
-		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
+		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 
 		// Uncheck the box
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
 
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
@@ -367,12 +373,12 @@ describe( 'Checkout contact step', () => {
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.type( await screen.findByLabelText( 'Postal code' ), postalCode );
 		// Check the box
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
 
 		// Fill in the details
-		await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
-		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
+		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
@@ -419,15 +425,15 @@ describe( 'Checkout contact step', () => {
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.type( await screen.findByLabelText( 'Postal code' ), postalCode );
 		// Check the box
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
 
 		// Fill in the details
-		await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
-		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
+		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 
 		// Uncheck the box
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
 
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
@@ -468,12 +474,12 @@ describe( 'Checkout contact step', () => {
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.type( await screen.findByLabelText( 'Postal code' ), postalCode );
 		// Check the box
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
 
 		// Fill in the details
-		await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
-		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
+		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 
 		// Change the country to one that does not support VAT
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), nonVatCountryCode );
@@ -504,10 +510,10 @@ describe( 'Checkout contact step', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
-		await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
-		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
 	} );
@@ -672,14 +678,14 @@ describe( 'Checkout contact step', () => {
 			await user.type( await screen.findByLabelText( 'Organization' ), 'Contact Organization' );
 
 			// Check the box
-			await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+			await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
 
 			// Fill in the details
-			await user.type( await screen.findByLabelText( 'VAT Number' ), vatId );
+			await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
 			if ( vatOrganization === 'with' ) {
-				await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+				await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
 			}
-			await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
+			await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 
 			await user.click( screen.getByText( 'Continue' ) );
 			expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();


### PR DESCRIPTION
## Proposed Changes

This is part one of fixing [this issue](https://github.com/Automattic/payments-shilling/issues/1400).

Since we are going to dynamically load B2B tax names depending on the customer's locale, the first step is to set up the fallback version of these tax names instead of defaulting to 'VAT'.

This series of changes aims to cover the cases noted by @michaeldcain in the link above.

Related to https://github.com/Automattic/payments-shilling/issues/1400

## Testing Instructions
Checkout up this branch and go to:
- http://calypso.localhost:3000/me/purchases/billing
- http://calypso.localhost:3000/me/purchases/vat-details
- http://calypso.localhost:3000/checkout/[YOUR SITE NAME]

Please cross reference the screenshots shown in the issue linked above and verify that the 'VAT' text is replaced with 'Business Tax ID'.

**Notes**
In some cases, Business Tax ID is a bit wordy and awkward, so not sure if we should use a truncated version (or if this presents perhaps legal greyarea), for instance:

> "We currently only provide Business Tax ID invoices to users who are properly listed in **Business Tax ID databases**. **Business Tax ID information** saved on this page will be applied to all of your account's receipts."

Could be:

> "We currently only provide Business Tax ID invoices to users who are properly listed in _tax ID databases_. _Tax ID information_ saved on this page will be applied to all of your account's receipts."

Also, not exactly sure how to handle the VAT text in checkout line items:

![image](https://user-images.githubusercontent.com/16580129/220761031-2c450932-1cd4-4e58-a8bf-bbbd316da401.png)
