### PR TITLE
Plugin Bundle Flow: Redirect back to the activated theme page

### DIFF
--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -78,6 +78,7 @@ const pluginBundleFlow: Flow = {
 		const { setPendingAction, setStepProgress, resetOnboardStoreWithSkipFlags } =
 			useDispatch( ONBOARD_STORE );
 		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite } = useDispatch( SITE_STORE );
+		const siteDetails = useSelect( ( select ) => site && select( SITE_STORE ).getSite( site.ID ) );
 		const dispatch = reduxDispatch();
 
 		// Since we're mimicking a subset of the site-setup-flow, we're safe to use the siteSetupProgress.
@@ -129,11 +130,16 @@ const pluginBundleFlow: Flow = {
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
 			recordSubmitStep( providedDependencies, intent, flowName, currentStep );
 
+			const defaultExitDest = siteDetails?.options
+				? `/theme/${ siteDetails?.options.theme_slug }/${ siteSlug }`
+				: `/home/${ siteSlug }`;
+
 			switch ( currentStep ) {
 				case 'checkForWoo':
 					// If WooCommerce is already installed, we should exit the flow.
 					if ( providedDependencies?.hasWooCommerce ) {
-						return exitFlow( `/home/${ siteSlug }` );
+						// If we have the theme for the site, redirect to the theme page. Otherwise redirect to /home.
+						return exitFlow( defaultExitDest );
 					}
 
 					// Otherwise, we should continue to the next step.
@@ -188,7 +194,7 @@ const pluginBundleFlow: Flow = {
 						return exitFlow( `${ adminUrl }admin.php?page=wc-admin` );
 					}
 
-					return exitFlow( `/home/${ siteSlug }` );
+					return exitFlow( defaultExitDest );
 				}
 
 				case 'wooTransfer':

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -130,7 +130,7 @@ const pluginBundleFlow: Flow = {
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
 			recordSubmitStep( providedDependencies, intent, flowName, currentStep );
 
-			const defaultExitDest = siteDetails?.options
+			const defaultExitDest = siteDetails?.options?.theme_slug
 				? `/theme/${ siteDetails?.options.theme_slug }/${ siteSlug }`
 				: `/home/${ siteSlug }`;
 


### PR DESCRIPTION
Fixes #73661

Redirect to the theme page from the plugin-bundle flow

When exiting the plugin-bundle flow, we now redirect back to the theme page for the theme that was just activated. Previously we redirected to `/home`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### WooExpress Trial

* Apply this branch.
* Visit http://calypso.localhost:3000/setup/wooexpress/ to create a new WooExpress trial site.
* After the trial site has been created, visit `http://calypso.localhost:3000/themes/:siteSlug?s=tazza`.
* Activate the Tazza theme.
* You should briefly enter the plugin-bundle flow but then exit without having to enter any information.
* After exiting the plugin-bundle flow, you should be redirected to the Tazza page.

### Business Site

* Apply this branch.
* Create a new site with a Business plan or use an existing one.
* Visit `http://calypso.localhost:3000/themes/:siteSlug?s=tazza`.
* Activate the Tazza theme.
* You should go through the plugin-bundle flow.
* After exiting the plugin-bundle flow, you should be redirected to the Tazza page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
