### PR TITLE
Bug Fix: Wrap checkForWoo request in a try/catch

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/check-for-woo/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/check-for-woo/index.tsx
@@ -15,14 +15,21 @@ const CheckForWoo: Step = function CheckForWoo( { navigation } ) {
 		}
 
 		const checkForWoo = async () => {
-			const response: PluginsResponse = await wpcomRequest( {
-				path: `/sites/${ site?.ID }/plugins`,
-				apiVersion: '1.1',
-			} );
+			let hasWooCommerce;
 
-			const hasWooCommerce =
-				response?.plugins.find( ( plugin: { slug: string } ) => plugin.slug === 'woocommerce' ) !==
-				undefined;
+			try {
+				const response: PluginsResponse = await wpcomRequest( {
+					path: `/sites/${ site?.ID }/plugins`,
+					apiVersion: '1.1',
+				} );
+
+				hasWooCommerce =
+					response?.plugins.find(
+						( plugin: { slug: string } ) => plugin.slug === 'woocommerce'
+					) !== undefined;
+			} catch ( error ) {
+				hasWooCommerce = false;
+			}
 
 			submit?.( { hasWooCommerce } );
 		};


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

Previously, any errors were unhandled and caused the step to hang.

## Testing Instructions

Prior to applying this branch, on a Business site, the plugin-bundle flow will hang at the `checkForWoo` step with an `UnauthorizedError: This endpoint is only available for Jetpack powered Sites` in the console.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch.
* Go to `http://calypso.localhost:3000/themes/:siteSlug?s=tazza` for a site with a Business plan. You may need to create one first.
* Activate Tazza.
* You should go through the plugin-bundle flow and up back at the dashboard.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
