### PR TITLE
GitHub integration: add basic empty state after connecting a repository

### DIFF
--- a/client/my-sites/hosting/github/deployment-card/empty-deployments.tsx
+++ b/client/my-sites/hosting/github/deployment-card/empty-deployments.tsx
@@ -7,7 +7,7 @@ export const EmptyDeployments = () => {
 		<div className="deployment-card__empty-deployments">
 			<p>
 				{ translate(
-					'Pushing to the connected branch will trigger a deployment. {{a}}Learn more{{/a}}',
+					'Push to the connected branch to trigger a deployment. {{a}}Learn more{{/a}}',
 					{
 						components: {
 							a: <ExternalLink href="#" />,

--- a/client/my-sites/hosting/github/deployment-card/empty-deployments.tsx
+++ b/client/my-sites/hosting/github/deployment-card/empty-deployments.tsx
@@ -1,0 +1,20 @@
+import { ExternalLink } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+
+export const EmptyDeployments = () => {
+	const translate = useTranslate();
+	return (
+		<div className="deployment-card__empty-deployments">
+			<p>
+				{ translate(
+					'Pushing to the connected branch will trigger a deployment. {{a}}Learn more{{/a}}',
+					{
+						components: {
+							a: <ExternalLink href="#" />,
+						},
+					}
+				) }
+			</p>
+		</div>
+	);
+};

--- a/client/my-sites/hosting/github/deployment-card/index.tsx
+++ b/client/my-sites/hosting/github/deployment-card/index.tsx
@@ -35,7 +35,9 @@ export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardPr
 		connectionId,
 		{
 			onSuccess: () => {
-				dispatch( successNotice( translate( 'Disconnected from repository successfully' ) ) );
+				dispatch(
+					successNotice( translate( 'Disconnected from repository successfully' ), noticeOptions )
+				);
 			},
 			onError: ( error ) => {
 				dispatch(

--- a/client/my-sites/hosting/github/deployment-card/index.tsx
+++ b/client/my-sites/hosting/github/deployment-card/index.tsx
@@ -30,22 +30,26 @@ export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardPr
 
 	const dispatch = useDispatch();
 
-	const { disconnectRepo, isLoading: isDisconnecting } = useGithubDisconnectRepoMutation( siteId, {
-		onSuccess: () => {
-			dispatch( successNotice( translate( 'Disconnected from repository successfully' ) ) );
-		},
-		onError: ( error ) => {
-			dispatch(
-				errorNotice(
-					// translators: "reason" is why disconnecting the branch failed.
-					sprintf( translate( 'Failed to disconnect: %(reason)s' ), { reason: error.message } ),
-					{
-						...noticeOptions,
-					}
-				)
-			);
-		},
-	} );
+	const { disconnectRepo, isLoading: isDisconnecting } = useGithubDisconnectRepoMutation(
+		siteId,
+		connectionId,
+		{
+			onSuccess: () => {
+				dispatch( successNotice( translate( 'Disconnected from repository successfully' ) ) );
+			},
+			onError: ( error ) => {
+				dispatch(
+					errorNotice(
+						// translators: "reason" is why disconnecting the branch failed.
+						sprintf( translate( 'Failed to disconnect: %(reason)s' ), { reason: error.message } ),
+						{
+							...noticeOptions,
+						}
+					)
+				);
+			},
+		}
+	);
 
 	return (
 		<Card>

--- a/client/my-sites/hosting/github/deployment-card/index.tsx
+++ b/client/my-sites/hosting/github/deployment-card/index.tsx
@@ -6,6 +6,7 @@ import CardHeading from 'calypso/components/card-heading';
 import SocialLogo from 'calypso/components/social-logo';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { EmptyDeployments } from './empty-deployments';
 import { LastDeploymentInformation } from './last-deployment-information';
 import { useDeploymentStatusQuery } from './use-deployment-status-query';
 import { useGithubDisconnectRepoMutation } from './use-disconnect-repo';
@@ -72,13 +73,14 @@ export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardPr
 			</div>
 			<div>
 				{ isLoading && <Spinner /> }
-				{ deployment && (
+				{ ! isLoading && deployment && (
 					<LastDeploymentInformation
 						deployment={ deployment }
 						connectedRepo={ repo }
 						connectionId={ connectionId }
 					/>
 				) }
+				{ ! isLoading && ! deployment && <EmptyDeployments /> }
 			</div>
 			<Button primary busy={ isDisconnecting } onClick={ () => disconnectRepo( siteId ) }>
 				<span>{ translate( 'Disconnect repository' ) }</span>

--- a/client/my-sites/hosting/github/deployment-card/use-disconnect-repo.ts
+++ b/client/my-sites/hosting/github/deployment-card/use-disconnect-repo.ts
@@ -11,6 +11,7 @@ interface MutationError {
 
 export const useGithubDisconnectRepoMutation = (
 	siteId: number | null,
+	connectionId: number,
 	options: UseMutationOptions< unknown, MutationError, unknown > = {}
 ) => {
 	const queryClient = useQueryClient();
@@ -24,10 +25,13 @@ export const useGithubDisconnectRepoMutation = (
 		{
 			...options,
 			onSuccess: async ( ...args ) => {
-				await queryClient.invalidateQueries( [
-					GITHUB_INTEGRATION_QUERY_KEY,
-					siteId,
-					GITHUB_CONNECTION_QUERY_KEY,
+				await Promise.all( [
+					queryClient.invalidateQueries( [ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId ] ),
+					queryClient.invalidateQueries( [
+						GITHUB_INTEGRATION_QUERY_KEY,
+						siteId,
+						GITHUB_CONNECTION_QUERY_KEY,
+					] ),
 				] );
 				options.onSuccess?.( ...args );
 			},


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/1750.

## Proposed Changes

Let's explain what happens and add a link to the support page as the empty state after connecting a repository.

<img width="749" alt="CleanShot 2023-02-23 at 14 56 02@2x" src="https://user-images.githubusercontent.com/1500769/220805053-2eb226ab-9803-43bf-b848-b697a901429c.png">


## Testing Instructions

1. Open the Hosting Configuration page for an Atomic site that has no GH deployments;
2. Connect any repository;
3. Check that the empty state appears.