### PR TITLE
Stored Payments/Checkout: Increase coverage of new tax fields in Calypso

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -4,6 +4,7 @@ import {
 	makeSuccessResponse,
 	makeErrorResponse,
 } from '@automattic/composite-checkout';
+import { ManagedContactDetails } from '@automattic/wpcom-checkout';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import wp from 'calypso/lib/wp';
@@ -76,9 +77,10 @@ export async function assignNewCardProcessor(
 			throw new Error( 'Cannot assign payment method if there is no card number' );
 		}
 
-		const { name, countryCode, postalCode, useForAllSubscriptions } = submitData;
+		const { name, countryCode, postalCode, state, city, organization, useForAllSubscriptions } =
+			submitData;
 
-		const contactValidationResponse = await getTaxValidationResult( {
+		const contactInfo: ManagedContactDetails = {
 			countryCode: {
 				value: countryCode,
 				isTouched: true,
@@ -89,7 +91,29 @@ export async function assignNewCardProcessor(
 				isTouched: true,
 				errors: [],
 			},
-		} );
+		};
+		if ( state ) {
+			contactInfo.state = {
+				value: state,
+				isTouched: true,
+				errors: [],
+			};
+		}
+		if ( city ) {
+			contactInfo.city = {
+				value: city,
+				isTouched: true,
+				errors: [],
+			};
+		}
+		if ( organization ) {
+			contactInfo.organization = {
+				value: organization,
+				isTouched: true,
+				errors: [],
+			};
+		}
+		const contactValidationResponse = await getTaxValidationResult( contactInfo );
 		if ( ! contactValidationResponse.success ) {
 			const errorMessage =
 				contactValidationResponse.messages_simple.length > 0
@@ -130,6 +154,9 @@ export async function assignNewCardProcessor(
 				eventSource,
 				postalCode,
 				countryCode,
+				state,
+				city,
+				organization,
 			} );
 
 			return makeSuccessResponse( result );
@@ -142,6 +169,9 @@ export async function assignNewCardProcessor(
 			eventSource,
 			postalCode,
 			countryCode,
+			state,
+			city,
+			organization,
 		} );
 
 		return makeSuccessResponse( result );
@@ -188,6 +218,9 @@ interface NewCardSubmitData {
 	name?: string;
 	countryCode: string;
 	postalCode?: string;
+	state?: string;
+	city?: string;
+	organization?: string;
 	useForAllSubscriptions: boolean;
 }
 

--- a/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
@@ -12,6 +12,9 @@ export async function saveCreditCard( {
 	eventSource,
 	postalCode,
 	countryCode,
+	state,
+	city,
+	organization,
 }: {
 	token: string;
 	stripeConfiguration: StripeConfiguration;
@@ -19,6 +22,9 @@ export async function saveCreditCard( {
 	eventSource?: string;
 	postalCode?: string;
 	countryCode: string;
+	state?: string;
+	city?: string;
+	organization?: string;
 } ): Promise< StoredCardEndpointResponse > {
 	const additionalData = getParamsForApi( {
 		cardToken: token,
@@ -27,6 +33,9 @@ export async function saveCreditCard( {
 		eventSource,
 		postalCode,
 		countryCode,
+		state,
+		city,
+		organization,
 	} );
 	const response = await wp.req.post(
 		{
@@ -54,6 +63,9 @@ export async function updateCreditCard( {
 	useForAllSubscriptions,
 	eventSource,
 	postalCode,
+	state,
+	city,
+	organization,
 	countryCode,
 }: {
 	purchase: Purchase;
@@ -62,6 +74,9 @@ export async function updateCreditCard( {
 	useForAllSubscriptions: boolean;
 	eventSource?: string;
 	postalCode?: string;
+	state?: string;
+	city?: string;
+	organization?: string;
 	countryCode: string;
 } ): Promise< StoredCardEndpointResponse > {
 	const {
@@ -72,6 +87,9 @@ export async function updateCreditCard( {
 		event_source,
 		postal_code,
 		country_code,
+		tax_subdivision_code,
+		tax_city,
+		tax_organization,
 	} = getParamsForApi( {
 		cardToken: token,
 		stripeConfiguration,
@@ -80,6 +98,9 @@ export async function updateCreditCard( {
 		eventSource,
 		postalCode,
 		countryCode,
+		state,
+		city,
+		organization,
 	} );
 	const response = await wp.req.post(
 		{
@@ -93,6 +114,9 @@ export async function updateCreditCard( {
 			event_source,
 			postal_code,
 			country_code,
+			tax_subdivision_code,
+			tax_city,
+			tax_organization,
 		}
 	);
 	if ( response.error ) {
@@ -111,6 +135,9 @@ function getParamsForApi( {
 	eventSource,
 	postalCode,
 	countryCode,
+	state,
+	city,
+	organization,
 }: {
 	cardToken: string;
 	stripeConfiguration: StripeConfiguration;
@@ -119,6 +146,9 @@ function getParamsForApi( {
 	eventSource?: string;
 	postalCode: string | undefined;
 	countryCode: string;
+	state?: string;
+	city?: string;
+	organization?: string;
 } ) {
 	return {
 		payment_partner: stripeConfiguration ? stripeConfiguration.processor_id : '',
@@ -129,5 +159,8 @@ function getParamsForApi( {
 		...( eventSource ? { event_source: eventSource } : {} ),
 		postal_code: postalCode ?? '',
 		country_code: countryCode,
+		tax_subdivision_code: state,
+		tax_city: city,
+		tax_organization: organization,
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/payment-method-tax-info.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/payment-method-tax-info.tsx
@@ -103,7 +103,7 @@ function joinNonEmptyValues( joinString: string, ...values: ( string | undefined
 }
 
 function contactDetailsToTaxInfo( info?: TaxInfo ): ManagedContactDetails {
-	return {
+	const taxInfo: ManagedContactDetails = {
 		countryCode: {
 			value: info?.tax_country_code ?? '',
 			isTouched: true,
@@ -115,6 +115,28 @@ function contactDetailsToTaxInfo( info?: TaxInfo ): ManagedContactDetails {
 			errors: [],
 		},
 	};
+	if ( info?.tax_subdivision_code ) {
+		taxInfo.state = {
+			value: info.tax_subdivision_code,
+			isTouched: true,
+			errors: [],
+		};
+	}
+	if ( info?.tax_city ) {
+		taxInfo.city = {
+			value: info.tax_city,
+			isTouched: true,
+			errors: [],
+		};
+	}
+	if ( info?.tax_organization ) {
+		taxInfo.organization = {
+			value: info.tax_organization,
+			isTouched: true,
+			errors: [],
+		};
+	}
+	return taxInfo;
 }
 
 export function TaxInfoArea( {
@@ -165,6 +187,9 @@ export function TaxInfoArea( {
 		setTaxInfo( {
 			tax_country_code: inputValues?.countryCode?.value ?? '',
 			tax_postal_code: inputValues?.postalCode?.value ?? '',
+			tax_subdivision_code: inputValues?.state?.value,
+			tax_city: inputValues?.city?.value,
+			tax_organization: inputValues?.organization?.value,
 		} )
 			.then( closeDialog )
 			.catch( setUpdateError );

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/types.ts
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/types.ts
@@ -1,6 +1,9 @@
 export interface TaxInfo {
 	tax_postal_code: string;
 	tax_country_code: string;
+	tax_subdivision_code?: string;
+	tax_city?: string;
+	tax_organization?: string;
 }
 
 export interface TaxGetInfo extends TaxInfo {

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/use-payment-method-tax-info.ts
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/use-payment-method-tax-info.ts
@@ -7,17 +7,10 @@ async function fetchTaxInfoFromServer( storedDetailsId: string ): Promise< TaxGe
 	return await wpcom.req.get( `/me/payment-methods/${ storedDetailsId }/tax-location` );
 }
 
-async function setTaxInfoOnServer(
-	storedDetailsId: string,
-	taxPostalCode: string,
-	taxCountryCode: string
-): Promise< TaxInfo > {
+async function setTaxInfoOnServer( storedDetailsId: string, taxInfo: TaxInfo ): Promise< TaxInfo > {
 	return await wpcom.req.post( {
 		path: `/me/payment-methods/${ storedDetailsId }/tax-location`,
-		body: {
-			tax_country_code: taxCountryCode,
-			tax_postal_code: taxPostalCode,
-		},
+		body: taxInfo,
 	} );
 }
 
@@ -37,17 +30,11 @@ export function usePaymentMethodTaxInfo( storedDetailsId: string ): {
 	);
 
 	const mutation = useMutation(
-		( mutationInputValues: TaxInfo ) =>
-			setTaxInfoOnServer(
-				storedDetailsId,
-				mutationInputValues.tax_postal_code,
-				mutationInputValues.tax_country_code
-			),
+		( mutationInputValues: TaxInfo ) => setTaxInfoOnServer( storedDetailsId, mutationInputValues ),
 		{
 			onSuccess: ( onSuccessInputValues: TaxInfo ) => {
 				queryClient.setQueryData( queryKey, {
-					tax_postal_code: onSuccessInputValues.tax_postal_code,
-					tax_country_code: onSuccessInputValues.tax_country_code,
+					...onSuccessInputValues,
 					is_tax_info_set: true,
 				} );
 			},

--- a/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/tax-fields.tsx
@@ -63,10 +63,7 @@ export default function TaxFields( {
 		countriesList.length && countryCode?.value
 			? getCountryPostalCodeSupport( countriesList, countryCode.value )
 			: false;
-	const taxRequirements =
-		countriesList.length && countryCode?.value
-			? getCountryTaxRequirements( countriesList, countryCode.value )
-			: {};
+	const taxRequirements = getCountryTaxRequirements( countriesList, countryCode?.value );
 	const isVatSupported = config.isEnabled( 'checkout/vat-form' ) && allowVat;
 
 	const fields: JSX.Element[] = [

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.tsx
@@ -24,9 +24,15 @@ export default function ContactFields( {
 	const onChangeContactInfo = ( newInfo: {
 		countryCode?: { value?: string };
 		postalCode?: { value?: string };
+		state?: { value?: string };
+		city?: { value?: string };
+		organization?: { value?: string };
 	} ) => {
 		setFieldValue( 'countryCode', newInfo.countryCode?.value ?? '' );
 		setFieldValue( 'postalCode', newInfo.postalCode?.value ?? '' );
+		setFieldValue( 'state', newInfo.state?.value ?? '' );
+		setFieldValue( 'city', newInfo.city?.value ?? '' );
+		setFieldValue( 'organization', newInfo.organization?.value ?? '' );
 	};
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -62,6 +62,9 @@ export default function CreditCardPayButton( {
 							paymentPartner,
 							countryCode: fields?.countryCode?.value ?? '',
 							postalCode: fields?.postalCode?.value ?? '',
+							state: fields?.state?.value,
+							city: fields?.city?.value,
+							organization: fields?.organization?.value,
 							useForAllSubscriptions,
 							eventSource: 'checkout',
 						} );

--- a/packages/wpcom-checkout/src/get-country-tax-requirements.ts
+++ b/packages/wpcom-checkout/src/get-country-tax-requirements.ts
@@ -14,8 +14,8 @@ export interface CountryTaxRequirements {
  * before calling this.
  */
 export function getCountryTaxRequirements(
-	countries: CountryListItem[],
-	countryCode: string
+	countries: CountryListItem[] | undefined,
+	countryCode: string | undefined
 ): CountryTaxRequirements {
 	if ( ! countryCode ) {
 		return {};


### PR DESCRIPTION
The tax fields component is used in many areas of Calypso for validating, storing, adding, and updating stored payments. Each use requires state management, passing the new fields for validation, and passing the new fields to perform the related action.

Related to 1388-gh-Automattic/payments-shilling

## Proposed Changes

* Adds state management and event information to modal popup used in Change Payment Method and Manage Your Payment Methods
* Adds event information to the checkout submit button
* Adds event information to `ContactFields` when adding a new card
* Adds properties to stored details and validation APIs

## Testing Instructions

* Apply D102477-code
* Run this test in store sandbox (PCYsg-IA-p2)
* Considering running some of the tests outlined in #73121 to test for regressions
* Test with a country with no validation like United States
* Test with a country that has a required tax field (like Norway)
* Test with a country that has all required tax fields (like Canada)
* In Calypso => Upgrades => Purchases, select your current plan
* Click "Change payment method"
* Add a credit card using a [Stripe test card](https://stripe.com/docs/testing)
* <img width="898" alt="image" src="https://user-images.githubusercontent.com/38750/220765518-d6209885-e7f9-4dd1-b2b2-28c55fa4fac2.png">
* Click on the link with the billing information for the added card
* <img width="890" alt="image" src="https://user-images.githubusercontent.com/38750/220765959-a791b098-62a4-455e-8e39-556dcc9b7eb6.png">
* Confirm the tax fields used when creating the card are all present and match
* Change to another country and Save
* <img width="605" alt="image" src="https://user-images.githubusercontent.com/38750/220766114-a535ad00-9d0d-4e84-8410-6d969cd8e8e6.png">
* Click on the link again and verify changes
* Reload the page
* Click on the link again and verify changes
* Add a new Paypal account using a test account (PCYsg-IA-p2#creating-a-paypal-test-account)
* <img width="889" alt="image" src="https://user-images.githubusercontent.com/38750/220771008-cffa1d33-8d46-45ea-86d9-f59de366ba48.png">
* Switch to Upgrades => Purchases => Payment Methods
* Confirm the Paypal tax fields match
* Edit the billing information of a saved credit card as described above, confirming, reloading, and re-confirming
* Click "Add payment method" and add a card using a Stripe test card
* Confirm the tax fields used when creating the card are all present and match
* Return to Calypso => Upgrades => Purchases, select your current plan, and click "Renew now" to add it to checkout
* Click "Edit" in "Billing information" to change the tax fields and click "Continue"
* <img width="562" alt="image" src="https://user-images.githubusercontent.com/38750/220771744-61da9571-c74d-4082-a010-1c20c71c15fc.png">
* Check out with a new credit card as described above
* Check out with a Paypal account as described above
* Verify the tax fields for the new stored payments in Upgrades => Purchases => Payment Methods
* Return to Calypso => Upgrades => Purchases, select your current plan, and click "Renew now" to add it to checkout
* Click "Edit" in "Billing information" to change the tax fields
* Check out with an existing stored payment
* Verify the tax fields were changed in Upgrades => Purchases => Payment Methods

## Confirm Coverage

* Are there any other areas in Calypso that allow the addition or updating of stored payments?