### PR TITLE
FSE Customizer notice link to wpcom

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/class-wpcom-documentation-links.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/class-wpcom-documentation-links.php
@@ -66,7 +66,7 @@ class WPCOM_Documentation_Links {
 			plugins_url( 'dist/', __FILE__ )
 		);
 
-		// This is a way to get the data from the customize-controls script and change the link to the wpcom support page
+		// This is a way to get the data from the customize-controls script and change the link to the wpcom support page.
 		global $wp_scripts;
 		$data = $wp_scripts->get_data( 'customize-controls', 'data' );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/class-wpcom-documentation-links.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-documentation-links/class-wpcom-documentation-links.php
@@ -65,6 +65,16 @@ class WPCOM_Documentation_Links {
 			'wpcomDocumentationLinksAssetsUrl',
 			plugins_url( 'dist/', __FILE__ )
 		);
+
+		// This is a way to get the data from the customize-controls script and change the link to the wpcom support page
+		global $wp_scripts;
+		$data = $wp_scripts->get_data( 'customize-controls', 'data' );
+
+		if ( $data ) {
+			$data = str_replace( 'https:\\/\\/wordpress.org\\/support\\/article\\/site-editor\\/\\', 'https:\\/\\/wordpress.com\\/support\\/site-editor\\/\\', $data );
+			$wp_scripts->registered['customize-controls']->extra['data'] = $data;
+		}
+
 		wp_localize_script(
 			'wpcom-documentation-links-script',
 			'wpcomDocumentationLinksLocale',


### PR DESCRIPTION
## Proposed Changes

In the Customizer for sites with a FSE theme, the link in the notice in the screenshot now brings users to https://wordpress.com/support/site-editor/ and not .org

<img width="365" alt="image" src="https://user-images.githubusercontent.com/52076348/220776016-8b01a6f4-25fe-4a3c-9b88-647410118208.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox a site with FSE theme
* Go to wp-admin, Appereance -> Customize
* Check the `Tell me more` link.


Fixes https://github.com/Automattic/wp-calypso/issues/63351