### PR TITLE
Blaze: Add uploadImageLebel

### DIFF
--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -1,7 +1,9 @@
 import config from '@automattic/calypso-config';
 import { loadScript } from '@automattic/load-script';
+import { __ } from '@wordpress/i18n';
 import { useSelector } from 'react-redux';
 import request, { requestAllBlogsAccess } from 'wpcom-proxy-request';
+import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
@@ -23,6 +25,7 @@ declare global {
 				translateFn?: ( value: string, options?: any ) => string;
 				showDialog?: boolean;
 				setShowCancelButton?: ( show: boolean ) => void;
+				uploadImageLabel?: string;
 			} ) => void;
 			strings: any;
 		};
@@ -70,6 +73,7 @@ export async function showDSP(
 				translateFn: translateFn,
 				urn: `urn:wpcom:post:${ siteId }:${ postId || 0 }`,
 				setShowCancelButton: setShowCancelButton,
+				uploadImageLabel: isWpMobileApp() ? __( 'Tap to add image' ) : undefined,
 			} );
 		} else {
 			reject( false );


### PR DESCRIPTION
Related pe7hp4-aM-p2 

## Proposed Changes

* Adds `uploadImageLabel` prompt to Blaze widget.

Before:
<img width="300" src="https://user-images.githubusercontent.com/115071/220789500-f1e0955d-5a14-4f6a-b0f5-5ab12ff4c714.png" />

After:
<img width="300" src="https://user-images.githubusercontent.com/115071/220789509-82246ad5-78d0-4cfb-8fba-c187f27e3c7d.png" />


## Testing Instructions

* See the related tumblr PR. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?