### PR TITLE
Launchpad: Track domain_upsell task completion status

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -12,7 +12,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import Checklist from './checklist';
-import { filterDomainUpsellTask, getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
+import { getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
 import { tasks } from './tasks';
 import { getLaunchpadTranslations } from './translations';
 import { Task } from './types';
@@ -63,7 +63,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 
 	const { flowName, title, launchTitle, subtitle } = getLaunchpadTranslations( flow );
 	const arrayOfFilteredTasks: Task[] | null = getArrayOfFilteredTasks( tasks, flow );
-	let enhancedTasks =
+	const enhancedTasks =
 		site &&
 		getEnhancedTasks(
 			arrayOfFilteredTasks,
@@ -77,8 +77,6 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 
 	const currentTask = getTasksProgress( enhancedTasks );
 	const launchTask = enhancedTasks?.find( ( task ) => task.isLaunchTask === true );
-
-	enhancedTasks = filterDomainUpsellTask( enhancedTasks, site );
 
 	const showLaunchTitle = launchTask && ! launchTask.disabled;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -315,12 +315,14 @@ export function getEnhancedTasks(
 					taskData = {
 						title: translate( 'Choose a domain' ),
 						completed: chooseDomainCompleted,
-						disabled: chooseDomainCompleted,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, chooseDomainCompleted, task.id );
-							window.location.assign( `/domains/add/${ siteSlug }?domainAndPlanPackage=true` );
+							const redirectURL = chooseDomainCompleted
+								? `/domains/manage/${ siteSlug }`
+								: `/domains/add/${ siteSlug }?domainAndPlanPackage=true`;
+							window.location.assign( redirectURL );
 						},
-						badgeText: translate( 'Upgrade plan' ),
+						badgeText: ! chooseDomainCompleted ? translate( 'Upgrade plan' ) : null,
 					};
 					break;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -36,6 +36,9 @@ export function getEnhancedTasks(
 
 	const siteEditCompleted = site?.options?.launchpad_checklist_tasks_statuses?.site_edited || false;
 
+	const chooseDomainCompleted =
+		site?.options?.launchpad_checklist_tasks_statuses?.domain_upsell || false;
+
 	const siteLaunchCompleted =
 		site?.options?.launchpad_checklist_tasks_statuses?.site_launched || false;
 
@@ -311,8 +314,10 @@ export function getEnhancedTasks(
 				case 'domain_upsell':
 					taskData = {
 						title: translate( 'Choose a domain' ),
+						completed: chooseDomainCompleted,
+						disabled: chooseDomainCompleted,
 						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
+							recordTaskClickTracksEvent( flow, chooseDomainCompleted, task.id );
 							window.location.assign( `/domains/add/${ siteSlug }?domainAndPlanPackage=true` );
 						},
 						badgeText: translate( 'Upgrade plan' ),
@@ -351,14 +356,4 @@ export function getArrayOfFilteredTasks( tasks: Task[], flow: string | null ) {
 			return accumulator;
 		}, [] as Task[] )
 	);
-}
-
-// Filter out the domain_upsell task from the enhanced task list when the user is not on a free plan anymore
-export function filterDomainUpsellTask( enhancedTasks: Task[] | null, site: SiteDetails | null ) {
-	if ( enhancedTasks && ! site?.plan?.is_free ) {
-		return enhancedTasks?.filter( ( task ) => {
-			return task.id !== 'domain_upsell';
-		} );
-	}
-	return enhancedTasks;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -1,9 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { filterDomainUpsellTask, getArrayOfFilteredTasks, getEnhancedTasks } from '../task-helper';
+import { getArrayOfFilteredTasks, getEnhancedTasks } from '../task-helper';
 import { tasks, launchpadFlowTasks } from '../tasks';
-import { buildTask, buildSiteDetails } from './lib/fixtures';
+import { buildTask } from './lib/fixtures';
 
 describe( 'Task Helpers', () => {
 	describe( 'getEnhancedTasks', () => {
@@ -87,47 +87,6 @@ describe( 'Task Helpers', () => {
 						.sort( ( a, b ) => ( a.id < b.id ? -1 : 1 ) )
 						.filter( ( task ) => launchpadFlowTasks[ 'newsletter' ].includes( task.id ) )
 				);
-			} );
-		} );
-	} );
-
-	describe( 'filterDomainUpsellTask', () => {
-		describe( 'when site plan is free', () => {
-			it( 'return original enchanceTasks', () => {
-				const task = buildTask( {
-					id: 'domain_upsell',
-					completed: false,
-					disabled: true,
-					taskType: 'blog',
-					title: 'domain upsell task',
-				} );
-				const tasks = [ task ];
-				const site = buildSiteDetails( { plan: { is_free: true } } );
-				// domain_upsell is still in the array
-				expect(
-					filterDomainUpsellTask( tasks, site )?.findIndex(
-						( task ) => ( task.id = 'domain_upsell' )
-					)
-				).toBe( 0 );
-			} );
-		} );
-		describe( 'when site plan is not free', () => {
-			it( 'filters out the domain_upsell task', () => {
-				const task = buildTask( {
-					id: 'domain_upsell',
-					completed: false,
-					disabled: true,
-					taskType: 'blog',
-					title: 'domain upsell task',
-				} );
-				const tasks = [ task ];
-				const site = buildSiteDetails( { plan: { is_free: false } } );
-				// domain_upsell is NOT in the array
-				expect(
-					filterDomainUpsellTask( tasks, site )?.findIndex(
-						( task ) => ( task.id = 'domain_upsell' )
-					)
-				).toBe( -1 );
 			} );
 		} );
 	} );

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -464,6 +464,7 @@ export interface LaunchPadCheckListTasksStatuses {
 	site_edited?: boolean;
 	video_uploaded?: boolean;
 	publish_first_course?: boolean;
+	domain_upsell?: boolean;
 }
 
 export interface ThemeSetupOptions {


### PR DESCRIPTION
### Time Estimate
Review: Short
Test: Med

### Proposed Changes
This PR (Along with this BE DIff D102510-code) adds status completion tracking for the `domain_upsell` task. Instead of removing the task, this allows us to keep it in the Launchpad with a completed style (crossed out).

![image](https://user-images.githubusercontent.com/20927667/220796466-3ee4ce82-fda5-4680-9543-20098fa626d6.png)

### Testing
1. Checkout this branch
2. Apply this Diff D102510-code to your sandbox
3. Create a new Launchpad site
• Newsletter: http://calypso.localhost:3000/setup/newsletter/intro
• Link-in-Bio: http://calypso.localhost:3000/setup/link-in-bio/intro
• Free: http://calypso.localhost:3000/setup/free/intro
• General: http://calypso.localhost:3000/start
4. Sandbox your site
5. Once you arrive at Launchpad you should see the "Choose a domain" task is active and not completed. Copy the URL so you can go back easily
6. Click the task and go through the flow to buy a plan
7. Go back to Launchpad (Paste the URL you've copied)
8. Verify the "Choose a domain" task is still there but it's disabled and completed (crossed out)


https://user-images.githubusercontent.com/20927667/220803172-7a08f74d-2270-4527-88cc-d0e1e29f1a97.mov

