### PR TITLE
Fix issue causing reader to be constantly re-rendered.

### DIFF
--- a/client/lib/with-dimensions/index.jsx
+++ b/client/lib/with-dimensions/index.jsx
@@ -39,7 +39,7 @@ export default ( EnhancedComponent ) =>
 			height: 0,
 		};
 
-		handleResize = afterLayoutFlush( () => {
+		handleResize = afterLayoutFlush( ( prevState ) => {
 			const domElement = this.props.domTarget || this.setRef || this.divRef;
 
 			if ( domElement ) {
@@ -51,7 +51,15 @@ export default ( EnhancedComponent ) =>
 				const { width, height } = dimensions;
 				const overflowX = domElement.scrollWidth > domElement.clientWidth + OVERFLOW_BUFFER;
 				const overflowY = domElement.scrollHeight > domElement.clientHeight + OVERFLOW_BUFFER;
-
+				if (
+					prevState &&
+					prevState.width === width &&
+					prevState.height === height &&
+					prevState.overflowX === overflowX &&
+					prevState.overflowY === overflowY
+				) {
+					return;
+				}
 				this.setState( { width, height, overflowX, overflowY } );
 			}
 		} );
@@ -64,8 +72,8 @@ export default ( EnhancedComponent ) =>
 			this.handleResize();
 		}
 
-		componentDidUpdate() {
-			this.handleResize();
+		componentDidUpdate( prevProps, prevState ) {
+			this.handleResize( prevState );
 		}
 
 		componentWillUnmount() {


### PR DESCRIPTION
I noticed this issue when putting a console.log() in the render method of [the reader-main component ](https://github.com/Automattic/wp-calypso/blob/trunk/client/reader/components/reader-main/index.jsx#L45) and found it was being continuously rendered.

This is wasting a lot of resources and is likely to cause performance issues, though I haven't noticed symptoms before myself.

The issue is caused by the "with-dimensions" component, which is calling setState with each componentDidUpdate, which in turn triggers another componentDidUpdate, and another setState, essentially in an infinite loop.

The fix simply performs a check on whether the dimensions have actually changed since the last update.

#### Testing instructions
You can add a console.log to [the reader-main component ](https://github.com/Automattic/wp-calypso/blob/trunk/client/reader/components/reader-main/index.jsx#L45) as I did. Or you can use the chrome performance tool.
Wait until the page has finished loading and record a ~3 second snapshot. You should see that there is constant activity before and basically no activity after this patch is applied.
Also test that the with-dimensions component still works as it should, infinite scroll still works and resizing the window still works as before.

##### Before
<img width="1728" alt="Screen Shot 2023-02-23 at 2 18 42 pm" src="https://user-images.githubusercontent.com/22446385/220820856-7ce8b944-0a85-45c7-99bf-f9d100e9b146.png">

##### After 
<img width="1728" alt="Screen Shot 2023-02-23 at 2 19 42 pm" src="https://user-images.githubusercontent.com/22446385/220820874-f7d3d9ca-aae0-4a05-86d4-0d2b37279abe.png">
