### PR TITLE
Theme Showcase: Theme detail page Tracks events

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -194,7 +194,7 @@ class ThemeSheet extends Component {
 
 	onStyleVariationClick = ( variation ) => {
 		this.props.recordTracksEvent( 'calypso_theme_sheet_style_variation_click', {
-			theme: this.props.themeId,
+			theme_name: this.props.themeId,
 			style_variation: variation.slug,
 		} );
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -139,7 +139,8 @@ body.is-section-theme-i4 {
 			margin: 0;
 			text-align: left;
 
-			a {
+			a,
+			span {
 				background-color: var(--color-neutral-5);
 				border-radius: 4px;
 				color: var(--color-neutral-80);
@@ -717,7 +718,8 @@ body.is-section-theme-i4 {
 	margin: -10px;
 	padding: 0;
 
-	a {
+	a,
+	span {
 		display: inline-block;
 		position: relative;
 		background: var(--color-neutral-0);

--- a/client/my-sites/theme/theme-features-card.js
+++ b/client/my-sites/theme/theme-features-card.js
@@ -24,7 +24,7 @@ const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onCli
 							onClick={ () => onClick?.( slug ) }
 						>
 							{ ! isWpcomTheme ? (
-								<span href="">{ name }</span>
+								<span>{ name }</span>
 							) : (
 								<a href={ `/themes/filter/${ term }/${ siteSlug || '' }` }>{ name }</a>
 							) }

--- a/client/my-sites/theme/theme-features-card.js
+++ b/client/my-sites/theme/theme-features-card.js
@@ -6,7 +6,7 @@ import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
 import SectionHeader from 'calypso/components/section-header';
 import { isValidThemeFilterTerm } from 'calypso/state/themes/selectors';
 
-const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate } ) => {
+const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onClick } ) => {
 	if ( isEmpty( features ) ) {
 		return null;
 	}
@@ -18,9 +18,13 @@ const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate } ) =>
 			<Card>
 				<ul className="theme__sheet-features-list">
 					{ features.map( ( { name, slug, term } ) => (
-						<li key={ 'theme-features-item-' + slug }>
+						<li
+							key={ 'theme-features-item-' + slug }
+							role="presentation"
+							onClick={ () => onClick?.( slug ) }
+						>
 							{ ! isWpcomTheme ? (
-								<a>{ name }</a>
+								<span href="">{ name }</span>
 							) : (
 								<a href={ `/themes/filter/${ term }/${ siteSlug || '' }` }>{ name }</a>
 							) }
@@ -33,6 +37,7 @@ const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate } ) =>
 };
 
 export default connect( ( state, { taxonomies } ) => {
+	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 	const features = get( taxonomies, 'theme_feature', [] ).map( ( { name, slug } ) => {
 		const term = isValidThemeFilterTerm( state, slug ) ? slug : `feature:${ slug }`;
 		return { name, slug, term };


### PR DESCRIPTION
## Proposed Change

This PR implements Tracks events as defined in pbxlJb-3ra-p2. The list of Tracks events added is as follows:

| Event name | Description |
| --- | --- |
| calypso_theme_sheet_back_click | User clicks on the "Back to themes" button. |
| calypso_theme_sheet_feature_click | User clicks on one of the tags in the Features section. |
| calypso_theme_sheet_style_variation_click | User clicks on a style variation. |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase and ensure the Tracks events trigger as intended. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?