### PR TITLE
Design Picker: Fix PremiumGlobalStylesUpgradeModal is always loading

### DIFF
--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -3,6 +3,7 @@ import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/componen
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 
@@ -26,76 +27,83 @@ export default function PremiumGlobalStylesUpgradeModal( {
 	const isLoading = ! premiumPlanProduct;
 
 	return (
-		<Dialog
-			className={ classNames( 'upgrade-modal', { loading: isLoading } ) }
-			isFullScreen
-			isVisible={ isOpen }
-			onClose={ () => closeModal() }
-		>
-			{ isLoading && <LoadingEllipsis /> }
-			{ ! isLoading && (
-				<>
-					<div className="upgrade-modal__col">
-						<h1 className="upgrade-modal__heading">{ translate( 'Unlock this style' ) }</h1>
-						<p>
-							{ translate(
-								'Get access to all theme styles, fonts, colors, and tons of other features by upgrading to {{strong}}%s{{/strong}}.',
-								{
-									components: {
-										strong: <strong />,
-									},
-									args: premiumPlanProduct?.product_name,
-									comment:
-										'The variable is the plan name: "...by upgrading to WordPress.com Premium."',
-								}
-							) }
-						</p>
-						<div className="upgrade-modal__actions bundle">
-							<Button className="upgrade-modal__cancel" onClick={ () => tryStyle() }>
-								{ translate( 'Try it out first' ) }
-							</Button>
-							<Button className="upgrade-modal__upgrade-plan" primary onClick={ () => checkout() }>
-								{ translate( 'Upgrade plan' ) }
-							</Button>
+		<>
+			<QueryProductsList />
+			<Dialog
+				className={ classNames( 'upgrade-modal', { loading: isLoading } ) }
+				isFullScreen
+				isVisible={ isOpen }
+				onClose={ () => closeModal() }
+			>
+				{ isLoading && <LoadingEllipsis /> }
+				{ ! isLoading && (
+					<>
+						<div className="upgrade-modal__col">
+							<h1 className="upgrade-modal__heading">{ translate( 'Unlock this style' ) }</h1>
+							<p>
+								{ translate(
+									'Get access to all theme styles, fonts, colors, and tons of other features by upgrading to {{strong}}%s{{/strong}}.',
+									{
+										components: {
+											strong: <strong />,
+										},
+										args: premiumPlanProduct?.product_name,
+										comment:
+											'The variable is the plan name: "...by upgrading to WordPress.com Premium."',
+									}
+								) }
+							</p>
+							<div className="upgrade-modal__actions bundle">
+								<Button className="upgrade-modal__cancel" onClick={ () => tryStyle() }>
+									{ translate( 'Try it out first' ) }
+								</Button>
+								<Button
+									className="upgrade-modal__upgrade-plan"
+									primary
+									onClick={ () => checkout() }
+								>
+									{ translate( 'Upgrade plan' ) }
+								</Button>
+							</div>
 						</div>
-					</div>
-					<div className="upgrade-modal__col">
-						<div className="upgrade-modal__included">
-							<h2>{ translate( 'Included with your purchase' ) }</h2>
-							<ul>
-								<li className="upgrade-modal__included-item">
-									<Gridicon icon="checkmark" size={ 16 } />
-									<strong>{ translate( 'Access all theme styles' ) }</strong>
-								</li>
-								<li className="upgrade-modal__included-item">
-									<Gridicon icon="checkmark" size={ 16 } />
-									<strong>{ translate( 'Change fonts, colors, and more sitewide' ) }</strong>
-								</li>
-								<li className="upgrade-modal__included-item">
-									<Gridicon icon="checkmark" size={ 16 } />
-									{ translate( 'Unlimited customer support via email' ) }
-								</li>
-								<li className="upgrade-modal__included-item">
-									<Gridicon icon="checkmark" size={ 16 } />
-									{ translate( 'Remove WordPress.com Ads' ) }
-								</li>
-								<li className="upgrade-modal__included-item">
-									<Gridicon icon="checkmark" size={ 16 } />
-									{ translate( 'Collect payments' ) }
-								</li>
-								<li className="upgrade-modal__included-item">
-									<Gridicon icon="checkmark" size={ 16 } />
-									{ translate( 'Best-in-class hosting' ) }
-								</li>
-							</ul>
+						<div className="upgrade-modal__col">
+							<div className="upgrade-modal__included">
+								<h2>{ translate( 'Included with your purchase' ) }</h2>
+								<ul>
+									<li className="upgrade-modal__included-item">
+										<Gridicon icon="checkmark" size={ 16 } />
+										<strong>{ translate( 'Access all theme styles' ) }</strong>
+									</li>
+									<li className="upgrade-modal__included-item">
+										<Gridicon icon="checkmark" size={ 16 } />
+										<strong>{ translate( 'Change fonts, colors, and more sitewide' ) }</strong>
+									</li>
+									<li className="upgrade-modal__included-item">
+										<Gridicon icon="checkmark" size={ 16 } />
+										{ translate( 'Unlimited customer support via email' ) }
+									</li>
+									<li className="upgrade-modal__included-item">
+										<Gridicon icon="checkmark" size={ 16 } />
+										{ translate( 'Remove WordPress.com Ads' ) }
+									</li>
+									<li className="upgrade-modal__included-item">
+										<Gridicon icon="checkmark" size={ 16 } />
+										{ translate( 'Collect payments' ) }
+									</li>
+									<li className="upgrade-modal__included-item">
+										<Gridicon icon="checkmark" size={ 16 } />
+										{ translate( 'Best-in-class hosting' ) }
+									</li>
+								</ul>
+							</div>
 						</div>
-					</div>
-					<Button className="upgrade-modal__close" borderless onClick={ () => closeModal() }>
-						<Gridicon icon="cross" size={ 12 } />
-						<ScreenReaderText>{ translate( 'Close modal' ) }</ScreenReaderText>
-					</Button>
-				</>
-			) }
-		</Dialog>
+						<Button className="upgrade-modal__close" borderless onClick={ () => closeModal() }>
+							<Gridicon icon="cross" size={ 12 } />
+							<ScreenReaderText>{ translate( 'Close modal' ) }</ScreenReaderText>
+						</Button>
+					</>
+				) }
+			</Dialog>
+		</>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

If you land on the setup flow directly, the `PremiumGlobalStylesUpgradeModal` modal is always loading since the product list from `calypso/state/products-list` is never loaded during the onboarding flow

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/220843397-e1dda72f-92b9-41be-b121-a5eb6b083755.png) | ![image](https://user-images.githubusercontent.com/13596067/220843459-75f305c5-e4ee-46a5-8dc5-caa478c6e3f5.png) |

Note that I found we have 2 places to store the product list as followed, and we might need to centralize them 🤔
* `client/state/products-list`
* `@automattic/data-stores/src/products-list`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=your_site` where the site is a free site
* Continue until you land on the Design Picker
* Select a design with styles variations, e.g. TT3
* Select a style variation
* Click on "Unlock this style" button
* Ensure the modal will show

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
