### PR TITLE
Updating focus styles on domain step of onboarding flow

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -462,6 +462,11 @@ body.is-section-signup.is-white-signup {
 					padding: 0.65em 2.8em;
 					width: auto;
 				}
+
+				&:focus {
+					border-color: var(--color-primary);
+					box-shadow: 0 0 0 2px var(--color-primary-light);
+				}
 			}
 
 			&.domain-transfer-suggestion {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -209,6 +209,11 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 			margin-top: 0;
 			padding: 0.65em 2.8em;
 		}
+
+		&:focus {
+			border-color: var(--color-primary);
+			box-shadow: 0 0 0 2px var(--color-primary-light);
+		}
 	}
 
 	.domain-registration-suggestion__domain-title {

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -271,6 +271,11 @@ body.is-section-signup.is-white-signup {
 			@include break-mobile {
 				padding: 0.65em 2.8em;
 			}
+
+			&:focus {
+				border-color: var(--color-primary);
+				box-shadow: 0 0 0 2px var(--color-primary-light);
+			}
 		}
 	}
 }

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -111,14 +111,13 @@ class ReskinSideExplainer extends Component {
 				</div>
 				{ ctaText && (
 					<div className="reskin-side-explainer__cta">
-						<span
+						<button
 							className="reskin-side-explainer__cta-text"
-							role="button"
 							onClick={ this.props.onClick }
 							tabIndex="0"
 						>
 							{ ctaText }
-						</span>
+						</button>
 					</div>
 				) }
 			</div>

--- a/client/components/domains/reskin-side-explainer/style.scss
+++ b/client/components/domains/reskin-side-explainer/style.scss
@@ -36,6 +36,11 @@
 			text-decoration: underline;
 			cursor: pointer;
 			font-weight: 500;
+
+			&:focus {
+				border-color: var(--color-primary);
+				box-shadow: 0 0 0 2px var(--color-primary-light);
+			}
 		}
 	}
 	.is-loading {

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -201,7 +201,7 @@ body.is-section-signup.is-white-signup {
 		}
 
 		.search-component__icon-navigation.components-button:focus:not(:disabled) {
-			box-shadow: 0 0 0 1px var(--color-neutral-60);
+			box-shadow: 0 0 0 1px var(--color-primary);
 		}
 
 		.search-component__icon-search {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -890,6 +890,11 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 	button.is-borderless {
 		box-shadow: none;
 		border: 0;
+
+		&:focus {
+			border-color: var(--color-primary);
+			box-shadow: 0 0 0 2px var(--color-primary-light);
+		}
 	}
 
 	.inline-help {

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-domain-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-domain-page.ts
@@ -20,9 +20,7 @@ export class SignupDomainPage {
 	 * Skips the domain selection screen.
 	 */
 	async skipDomainSelection(): Promise< void > {
-		const locator = this.page.locator(
-			'span[role="button"]:has-text("Choose my domain later"):visible'
-		);
+		const locator = this.page.locator( 'button:has-text("Choose my domain later"):visible' );
 		await locator.click();
 	}
 }


### PR DESCRIPTION
## Description

The domain step within the onboarding flow is not great for keyboard navigation. Some focus styles are just completely missing.

### Before

![domains-before](https://user-images.githubusercontent.com/5634774/220118763-40e87a80-ef64-4476-b4b3-6da52f634aee.gif)

This example is a little hard to tell, but I'm tabbing around and the focus disappears completely from the page.

### After

https://user-images.githubusercontent.com/5634774/220118493-1088c09f-4d10-4c6b-b5cb-28a2f73c0813.mp4

## How to reproduce

- Go to create a new site
- On /start/domains tab around the page

## Previously deployed

This PR was previously deployed in #73540 and reverted in #73554 when it was discovered that these changes broke unit tests.