### PR TITLE
Update: Cancellation flow upgrade solution

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -113,7 +113,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 	const happyChat = useHappyChat();
 	const numberOfPluginsThemes = numberFormat( 50000, 0 );
 	const discountRate = '25%';
-	const couponCode = 'BIZC25';
+	const couponCode = 'BIZWPC25';
 	const builtByURL =
 		'https://builtbywp.com/get-started/?utm_medium=automattic_referred&utm_source=WordPresscom&utm_campaign=cancel-flow';
 	const { refundAmount } = props;


### PR DESCRIPTION
Small PR to update the upgrade code offered in a Cancellation flow solution.


 <!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1677096446621289-slack-C042CJ2NH

**Proposed Changes**

* Cycling upgrade code to a new one.

**Testing Instructions**

- Spin up this PR with the Calypso Live link below.
- With a Personal or Premium plan, go to the Cancelation flow. 
- Select "Can't use a plugin" and/or "Can't use a theme" as the cancelation reason.
- Verify the code offered to upgrade to Business matches the one used in this PR.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Pre-merge Checklist**

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?