### PR TITLE
Plans 2023: Fix borders in comparison grid after removing commerce plan highlight

### DIFF
--- a/client/my-sites/plan-features-2023-grid/hooks/use-highlight-adjacency-matrix.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-highlight-adjacency-matrix.ts
@@ -1,4 +1,4 @@
-import { isBusinessPlan, isPremiumPlan, isEcommercePlan } from '@automattic/calypso-products';
+import { isBusinessPlan, isPremiumPlan } from '@automattic/calypso-products';
 import { useMemo } from '@wordpress/element';
 import type { PlanProperties } from '../types';
 
@@ -14,8 +14,7 @@ const useHighlightAdjacencyMatrix = ( visiblePlans: PlanProperties[] ) => {
 	return useMemo( () => {
 		const adjacencyMatrix: HighlightAdjacencyMatrix = {};
 		const highlightIndices = visiblePlans.reduce< number[] >( ( acc, { planName }, index ) => {
-			const isHighlight =
-				isBusinessPlan( planName ) || isPremiumPlan( planName ) || isEcommercePlan( planName );
+			const isHighlight = isBusinessPlan( planName ) || isPremiumPlan( planName );
 
 			if ( isHighlight ) {
 				acc.push( index );

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -481,8 +481,7 @@ export class PlanFeatures2023Grid extends Component<
 				getPlanClass( planName )
 			);
 			const tableItemClasses = classNames( 'plan-features-2023-grid__table-item', {
-				'popular-plan-parent-class':
-					isBusinessPlan( planName ) || isEcommercePlan( planName ) || isPremiumPlan( planName ),
+				'popular-plan-parent-class': isBusinessPlan( planName ) || isPremiumPlan( planName ),
 			} );
 
 			const popularBadgeClasses = classNames( {

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -9,7 +9,6 @@ import {
 	getPlanFeaturesGrouped,
 	PLAN_ENTERPRISE_GRID_WPCOM,
 	isPremiumPlan,
-	isEcommercePlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { css } from '@emotion/react';
@@ -315,8 +314,7 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 			{ visiblePlansProperties.map( ( planProperties, index ) => {
 				const { planName, planConstantObj, availableForPurchase, current, ...planPropertiesObj } =
 					planProperties;
-				const isHighlight =
-					isBusinessPlan( planName ) || isPremiumPlan( planName ) || isEcommercePlan( planName );
+				const isHighlight = isBusinessPlan( planName ) || isPremiumPlan( planName );
 
 				const headerClasses = classNames(
 					'plan-comparison-grid__header-cell',
@@ -644,10 +642,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 										{ ( visiblePlansProperties ?? [] ).map( ( { planName } ) => {
 											const hasFeature =
 												restructuredFeatures.featureMap[ planName ].has( featureSlug );
-											const isHighlight =
-												isBusinessPlan( planName ) ||
-												isPremiumPlan( planName ) ||
-												isEcommercePlan( planName );
+											const isHighlight = isBusinessPlan( planName ) || isPremiumPlan( planName );
 											const cellClasses = classNames(
 												'plan-comparison-grid__plan',
 												getPlanClass( planName ),
@@ -709,10 +704,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 									{ ( visiblePlansProperties ?? [] ).map( ( { planName } ) => {
 										const storageFeature = restructuredFeatures.planStorageOptionsMap[ planName ];
 										const [ featureObject ] = getPlanFeaturesObject( [ storageFeature ] );
-										const isHighlight =
-											isBusinessPlan( planName ) ||
-											isPremiumPlan( planName ) ||
-											isEcommercePlan( planName );
+										const isHighlight = isBusinessPlan( planName ) || isPremiumPlan( planName );
 										const cellClasses = classNames(
 											'plan-comparison-grid__plan',
 											'has-feature',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/73681 https://github.com/Automattic/wp-calypso/pull/73689

## Proposed Changes

Follow-up to https://github.com/Automattic/wp-calypso/pull/73681 and https://github.com/Automattic/wp-calypso/pull/73689, where the borders for the comparison grid weren't updated accordingly.

## Media

### Before

<img width="700" alt="Screenshot 2023-02-23 at 12 55 29 PM" src="https://user-images.githubusercontent.com/1705499/220887631-077e8e13-7873-4fbc-b1dd-f5cebe0db8fb.png">

<img width="700" alt="Screenshot 2023-02-23 at 12 56 13 PM" src="https://user-images.githubusercontent.com/1705499/220887648-283a8d24-8b74-417b-bd72-1d1cef2cff55.png">

### After

<img width="700" alt="Screenshot 2023-02-23 at 12 57 17 PM" src="https://user-images.githubusercontent.com/1705499/220887695-396ccf31-dd03-4937-9648-53b7ee43e28e.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /start/, choose domain, and verify borders are not visible around the commerce plan (media)
- Go to /plans/$site_slug and verify the same

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
