### PR TITLE
Add migration plugin check to signup url

### DIFF
--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -50,6 +50,7 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 	const redirectTo = get( currentQuery, 'redirect_to', '' );
 	const signupFlow = get( currentQuery, 'signup_flow' );
 	const wccomFrom = get( currentQuery, 'wccom-from' );
+	const isFromMigrationPlugin = includes( redirectTo, 'wpcom-migration' );
 
 	if (
 		// Match locales like `/log-in/jetpack/es`
@@ -116,7 +117,10 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 		signupUrl = `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
 	}
 
-	if ( includes( redirectTo, 'action=jetpack-sso' ) && includes( redirectTo, 'sso_nonce=' ) ) {
+	if (
+		isFromMigrationPlugin ||
+		( includes( redirectTo, 'action=jetpack-sso' ) && includes( redirectTo, 'sso_nonce=' ) )
+	) {
 		const params = new URLSearchParams( {
 			redirect_to: redirectTo,
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73719 

## Proposed Changes

* Following up from pdtkmj-1ay-p2#comment-2126 when a user coming from the migration plugin on a log-in page, but click create a new account, the redirect_to params is not carried over to the signup page. This PR adds a check to see if a user is coming from the migration plugin, if so, we add them to the signup URL.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a JN site with the [Migration plugin](https://jurassic.ninja/create/?jetpack-beta&branches.wpcom-migration=master&wp-debug-log)
* Navigate to `Move to WordPress.com` and click `Get started`
* See if you are on the log-in page
* Replace `wordpress.com` with `calypso.localhost:3000`
* Click `Create a new account` button
* See if you can create an account then continue on the migration process.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?