### PR TITLE
Fix author mapping for jetpack and atomic sites

### DIFF
--- a/client/blocks/author-selector/index.jsx
+++ b/client/blocks/author-selector/index.jsx
@@ -25,7 +25,7 @@ const AuthorSelector = ( {
 		}
 	}
 
-	const fetchOptions = { number: 50 };
+	const fetchOptions = { number: 50, authors_only: 1 };
 	const trimmedSearch = search.trim?.();
 
 	if ( trimmedSearch ) {

--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -106,7 +106,7 @@ const withUsers = createHigherOrderComponent(
 
 		return <Component users={ users } { ...props } />;
 	},
-	'withTotalUsers'
+	'withUsers'
 );
 
 export default localize( withUsers( ImporterAuthorMapping ) );

--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -100,7 +100,9 @@ class ImporterAuthorMapping extends PureComponent {
 const withUsers = createHigherOrderComponent(
 	( Component ) => ( props ) => {
 		const { siteId } = props;
-		const { data } = useUsersQuery( siteId );
+		const { data } = useUsersQuery( siteId, {
+			authors_only: 1,
+		} );
 
 		const users = data?.users ?? [];
 

--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -170,7 +170,9 @@ class AuthorMappingPane extends PureComponent {
 const withTotalUsers = createHigherOrderComponent(
 	( Component ) => ( props ) => {
 		const { siteId } = props;
-		const { data } = useUsersQuery( siteId );
+		const { data } = useUsersQuery( siteId, {
+			authors_only: 1,
+		} );
 
 		const totalUsers = data?.total ?? 0;
 

--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -15,7 +15,6 @@ class AuthorMappingPane extends PureComponent {
 	static displayName = 'AuthorMappingPane';
 
 	static propTypes = {
-		hasSingleAuthor: PropTypes.bool.isRequired,
 		onMap: PropTypes.func,
 		onStartImport: PropTypes.func,
 		siteId: PropTypes.number.isRequired,
@@ -118,7 +117,6 @@ class AuthorMappingPane extends PureComponent {
 
 	render() {
 		const {
-			hasSingleAuthor,
 			sourceAuthors,
 			sourceTitle,
 			targetTitle,
@@ -130,6 +128,8 @@ class AuthorMappingPane extends PureComponent {
 			site,
 			totalUsers,
 		} = this.props;
+
+		const hasSingleAuthor = totalUsers === 1;
 		const canStartImport = hasSingleAuthor || sourceAuthors.every( ( author ) => author.mappedTo );
 		const mappingDescription = this.getMappingDescription(
 			sourceAuthors.length,

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -212,7 +212,7 @@ export class ImportingPane extends PureComponent {
 	render() {
 		const {
 			importerStatus,
-			site: { ID: siteId, name: siteName, single_user_site: hasSingleAuthor },
+			site: { ID: siteId, name: siteName },
 			sourceType,
 			site,
 		} = this.props;
@@ -250,7 +250,6 @@ export class ImportingPane extends PureComponent {
 				{ this.isProcessing() && <p>{ this.getHeadingTextProcessing() }</p> }
 				{ this.isMapping() && (
 					<AuthorMappingPane
-						hasSingleAuthor={ hasSingleAuthor }
 						onMap={ this.handleOnMap }
 						onStartImport={ () => this.props.startImporting( this.props.importerStatus ) }
 						siteId={ siteId }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR fixes an issue with showing author mapping in the import UI. For Jetpack and Atomic sites, we are not showing the correct users. Instead, we are showing the wpcom user that is linked to the remote user.

* Use the useUserQuery output to decide if we display the authorSelect or a pre-selected author. 
* If the site has only 1 author, we don't display a author select dropdown but show the pre-selected author. This selection can not be changed.
* If the site has more than 1 user, show the author select dropdown in the mapping UI.

## Testing Instructions

Test imports (`Tools -> Imports`) for Simple, Jetpack, and Atomic sites. Ideally, the target site (the site you want to import content to) should be tested with 1 user and 2 (or more) users to make sure both scenarios work properly.

* Start an import to a Jetpack/Simple/Atomic site that has 1 user. The author mapping UI should not allow you to select the user to map the site to. The user should be mapped to the only user that is available on the Jetpack site.
<img width="762" alt="Screenshot 2566-02-23 at 19 59 56" src="https://user-images.githubusercontent.com/10244734/220913355-67b18d95-eeed-490d-80c2-b1fcf84dbdb1.png">

* Start an import to a Jetpack/Simple/Atomic site that has more than 1 user. The author mapping UI should allow you to choose which user to map to. 
<img width="782" alt="Screenshot 2566-02-23 at 19 58 30" src="https://user-images.githubusercontent.com/10244734/220913008-d86cde3f-ff85-4d09-9f43-8f0dc9d14ac2.png">

* Verify that the user mapping is successful on the imported content of the target site.

Repeat the above for each type of site (Jetpack, Atomic, Simple)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
