### PR TITLE
Add site data-store item for retrieving the current theme

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -27,6 +27,7 @@ import type {
 	SiteSettings,
 	ThemeSetupOptions,
 	ActiveTheme,
+	CurrentTheme,
 } from './types';
 import type { WpcomClientCredentials } from '../shared-types';
 
@@ -168,6 +169,12 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		type: 'RECEIVE_SITE_DOMAINS' as const,
 		siteId,
 		domains,
+	} );
+
+	const receiveSiteTheme = ( siteId: number, theme: CurrentTheme ) => ( {
+		type: 'RECEIVE_SITE_THEME' as const,
+		siteId,
+		theme,
 	} );
 
 	const receiveSiteSettings = ( siteId: number, settings: SiteSettings ) => ( {
@@ -659,6 +666,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 	return {
 		receiveSiteDomains,
 		receiveSiteSettings,
+		receiveSiteTheme,
 		saveSiteTitle,
 		saveSiteSettings,
 		setIntentOnSite,
@@ -721,6 +729,7 @@ export type Action =
 			| ActionCreators[ 'fetchSite' ]
 			| ActionCreators[ 'receiveSiteDomains' ]
 			| ActionCreators[ 'receiveSiteSettings' ]
+			| ActionCreators[ 'receiveSiteTheme' ]
 			| ActionCreators[ 'receiveNewSite' ]
 			| ActionCreators[ 'receiveSiteTitle' ]
 			| ActionCreators[ 'receiveNewSiteFailed' ]

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -1,5 +1,6 @@
 import { combineReducers } from '@wordpress/data';
 import {
+	CurrentTheme,
 	NewSiteBlogDetails,
 	NewSiteErrorResponse,
 	SiteDetails,
@@ -161,6 +162,16 @@ export const sitesSettings: Reducer< { [ key: number ]: SiteSettings }, Action >
 				...action.settings,
 			},
 		};
+	}
+	return state;
+};
+
+export const siteTheme: Reducer< { [ key: number ]: CurrentTheme }, Action > = (
+	state = {},
+	action
+) => {
+	if ( action.type === 'RECEIVE_SITE_THEME' ) {
+		return { ...state, [ action.siteId ]: action.theme };
 	}
 	return state;
 };
@@ -421,6 +432,7 @@ const reducer = combineReducers( {
 	launchStatus,
 	sitesDomains,
 	sitesSettings,
+	siteTheme,
 	sitesGlobalStyles,
 	siteSetupErrors,
 	atomicTransferStatus,

--- a/packages/data-stores/src/site/resolvers.ts
+++ b/packages/data-stores/src/site/resolvers.ts
@@ -1,6 +1,13 @@
 // wpcomRequest is a temporary rename while we're working on migrating generators to thunks
 import wpcomRequest from 'wpcom-proxy-request';
-import type { SiteDetails, Domain, SiteSettings, Dispatch, NewSiteErrorResponse } from './types';
+import type {
+	CurrentTheme,
+	SiteDetails,
+	Domain,
+	SiteSettings,
+	Dispatch,
+	NewSiteErrorResponse,
+} from './types';
 
 /**
  * Attempt to find a site based on its id, and if not return undefined.
@@ -54,4 +61,20 @@ export const getSiteSettings =
 		} );
 
 		dispatch.receiveSiteSettings( siteId, result?.settings );
+	};
+
+/**
+ * Get current site theme
+ *
+ * @param siteId {number} The site id
+ */
+export const getSiteTheme =
+	( siteId: number ) =>
+	async ( { dispatch }: Dispatch ) => {
+		const theme: CurrentTheme = await wpcomRequest( {
+			path: '/sites/' + encodeURIComponent( siteId ) + '/themes/mine',
+			apiVersion: '1.1',
+		} );
+
+		dispatch.receiveSiteTheme( siteId, theme );
 	};

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -69,6 +69,10 @@ export const getSiteSettings = ( state: State, siteId: number ) => {
 	return state.sitesSettings[ siteId ];
 };
 
+export const getSiteTheme = ( state: State, siteId: number ) => {
+	return state.siteTheme[ siteId ];
+};
+
 export const getSiteGlobalStyles = ( state: State, siteId: number ) => {
 	return state.sitesGlobalStyles[ siteId ];
 };

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -40,6 +40,22 @@ describe( 'Site Actions', () => {
 			expect( setBundledPluginSlug( siteSlug, pluginSlug ) ).toEqual( expected );
 		} );
 	} );
+	describe( 'Site Theme Actions', () => {
+		it( 'should return a RECEIVE_SITE_THEME Action', () => {
+			const siteId = 12345;
+			const theme = {
+				id: 'tazza',
+			};
+			const { receiveSiteTheme } = createActions( mockedClientCredentials );
+			const expected = {
+				type: 'RECEIVE_SITE_THEME',
+				siteId,
+				theme,
+			};
+
+			expect( receiveSiteTheme( siteId, theme ) ).toEqual( expected );
+		} );
+	} );
 	describe( 'LAUNCH_SITE Actions', () => {
 		it( 'should return a LAUNCH_SITE_START Action', () => {
 			const { launchSiteStart } = createActions( mockedClientCredentials );

--- a/packages/data-stores/src/site/test/reducer.ts
+++ b/packages/data-stores/src/site/test/reducer.ts
@@ -7,8 +7,9 @@
  */
 
 import { createActions } from '../actions';
-import { sites, launchStatus, siteSetupErrors } from '../reducer';
+import { sites, siteTheme, launchStatus, siteSetupErrors } from '../reducer';
 import {
+	CurrentTheme,
 	SiteLaunchError,
 	SiteLaunchState,
 	SiteLaunchStatus,
@@ -170,6 +171,23 @@ describe( 'Site', () => {
 			const expected = {};
 
 			expect( siteSetupErrors( originalState, action ) ).toEqual( expected );
+		} );
+	} );
+} );
+
+describe( 'Site Theme', () => {
+	const siteThemeResponse: CurrentTheme = {
+		id: 'tazza',
+	};
+
+	it( 'returns site data keyed by id', () => {
+		const state = siteTheme( undefined, {
+			type: 'RECEIVE_SITE_THEME',
+			siteId: 12345,
+			theme: siteThemeResponse,
+		} );
+		expect( state ).toEqual( {
+			12345: siteThemeResponse,
 		} );
 	} );
 } );

--- a/packages/data-stores/src/site/test/selectors.ts
+++ b/packages/data-stores/src/site/test/selectors.ts
@@ -15,6 +15,7 @@ import {
 	getSiteOptions,
 	getSiteOption,
 	getBundledPluginSlug,
+	getSiteTheme,
 } from '../selectors';
 import { SiteDetails } from '../types';
 import type { State } from '../reducer';
@@ -48,6 +49,23 @@ describe( 'getBundledPluginSlug', () => {
 		};
 
 		expect( getBundledPluginSlug( state, siteSlug ) ).toEqual( pluginSlug );
+	} );
+} );
+
+describe( 'getSiteTheme', () => {
+	it( 'retrieves the site theme from the store', () => {
+		const siteId = 1234;
+		const themeSlug = 'tazza';
+
+		const state: State = {
+			siteTheme: {
+				[ siteId ]: {
+					id: themeSlug,
+				},
+			},
+		};
+
+		expect( getSiteTheme( state, siteId ).id ).toEqual( themeSlug );
 	} );
 } );
 

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -482,6 +482,10 @@ export interface ActiveTheme {
 	};
 }
 
+export interface CurrentTheme {
+	id: string;
+}
+
 export interface SourceSiteMigrationDetails {
 	status: string;
 	target_blog_id?: number;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73661

## Proposed Changes

As part of working on bundled theme activation in #73661, we experimented with using a call to `/v1.1/sites/:siteId/themes/mine`. That ended up not being necessary but it still seems worthwhile to have that capability as part of the `SITE_STORE`.

To that end, this adds the `getSiteTheme` resolver (and corresponding action/selector/reducer).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

```
yarn run test-packages packages/data-stores/src/site/test/
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
