### PR TITLE
Fixed typo at /advertising banner

### DIFF
--- a/client/my-sites/promote-post/components/posts-list-banner/index.tsx
+++ b/client/my-sites/promote-post/components/posts-list-banner/index.tsx
@@ -23,7 +23,7 @@ export default function PostsListBanner() {
 				</div>
 				<div className="posts-list-banner__description">
 					{ translate(
-						'Reach more people promoting your work to the larger WordPress.com community of blogs and sites.'
+						'Reach more people by promoting your work to the larger WordPress.com community of blogs and sites.'
 					) }
 				</div>
 				<Button compact className="posts-list-banner__learn-more">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1677168458492679-slack-CKZHG0QCR

## Proposed Changes

* Fixed typo at /advertising banner

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the /advertising banner doesn't have any typo
