### PR TITLE
Launchpad: Fix style bug on update design screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -282,7 +282,8 @@ button {
 }
 
 .free,
-.free-post-setup {
+.free-post-setup,
+.update-design {
 	.signup-header h1 {
 		display: none;
 	}


### PR DESCRIPTION
### Proposed Changes

This fixes a small style bug on the theme preview screen when updating your theme from Launchpad. 

<img width="1445" alt="style bug" src="https://user-images.githubusercontent.com/21228350/221006703-e903e91a-e91f-4dd7-bc39-b7f39ccde77a.png">

### Testing Instructions

**Review Time: Short**
**Testing Time: Short**

1. Check out branch and run yarn and yarn start if needed. 
2. Create a new free site at http://calypso.localhost:3000/setup/free/intro
3. Go through flow until Launchpad, then click Select a Design task.
4. Pick a new theme, which will take you to the single theme preview screen. 
5. Confirm the bug in the screenshot above if fixed. It should look like the 'after' screen.