### PR TITLE
Update WebPreview edit overlay text

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -468,7 +468,7 @@ export default class WebPreviewContent extends Component {
 										onFocus={ () => this.setState( { showIFrameOverlay: true } ) }
 										onBlur={ () => this.setState( { showIFrameOverlay: false } ) }
 									>
-										{ translate( 'Edit' ) }
+										{ translate( 'Edit design' ) }
 									</button>
 								</div>
 							) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
## Testing / Review time

Test: short
Review: short

## Proposed Changes

* Update `<WebPreviewContent/>` component edit overlay text from `Edit` to `Edit design`
<img width="670" alt="CleanShot 2023-02-23 at 14 54 13@2x" src="https://user-images.githubusercontent.com/10482592/221015653-4db3442f-3e8e-49ba-9384-5a94746b6be6.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch (or use calypso.live link)
* Create a launchpad enabled site or use an existing site
* Navigate to the launchpad
* Hover over the site preview and confirm the site preview overlay button text displays `Edit design`.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
