### PR TITLE
Revert "Purchase Management: Add early return to block loading of '/cancel' endpoint"

### DIFF
--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -90,13 +90,9 @@ class CancelPurchase extends Component {
 			return true;
 		}
 
-		const { purchase, site } = props;
+		const { purchase } = props;
 
 		if ( ! purchase ) {
-			return false;
-		}
-
-		if ( ! site ) {
 			return false;
 		}
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#72697

Issue: https://github.com/Automattic/payments-shilling/issues/1405