### PR TITLE
Launchpad: Remove edit design task from write flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -158,7 +158,6 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 		'design_selected',
 		'domain_upsell',
 		'first_post_published',
-		'design_edited',
 		'site_launched',
 	],
 	videopress: [ 'videopress_setup', 'plan_selected', 'videopress_upload', 'videopress_launched' ],


### PR DESCRIPTION
### Proposed Changes

Very simple change in response to testing feedback. We're removing the Edit Design task from the write flow. 

### Testing Instructions

**Testing Time: Short**
**Review Time: Short**

1. Check out this branch and run yarn and yarn start if needed. 
2. Start a new site at http://calypso.localhost:3000/start
3. On goals page, choose 'Write & Publish'
4. TEST: When you get to Launchpad, confirm that Edit Design task no longer shows. 

<img width="790" alt="edit design 2" src="https://user-images.githubusercontent.com/21228350/221025212-441344d9-13bf-4902-ba52-8827b2d501ff.png">
