### PR TITLE
Stats: Update contrast color on subscriber links

### DIFF
--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -542,9 +542,12 @@ ul.module-content-list-item-action-submenu {
 	}
 
 	// Color follow action when already following
-	.module-content-list-item-action-wrapper.following .module-content-list-item-action-label,
-	.module-content-list-item-action-wrapper.following .module-content-list-item-action-label:hover {
+	.module-content-list-item-action-wrapper.following .module-content-list-item-action-label {
 		color: var(--studio-white);
+		
+		&:hover {
+		  color: var(--studio-white);
+		}
 	}
 
 	// Display hidden label and change icon for Unfollow action

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -544,9 +544,9 @@ ul.module-content-list-item-action-submenu {
 	// Color follow action when already following
 	.module-content-list-item-action-wrapper.following .module-content-list-item-action-label {
 		color: var(--studio-white);
-		
+
 		&:hover {
-		  color: var(--studio-white);
+			color: var(--studio-white);
 		}
 	}
 

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -542,7 +542,8 @@ ul.module-content-list-item-action-submenu {
 	}
 
 	// Color follow action when already following
-	.module-content-list-item-action-wrapper.following .module-content-list-item-action-label, .module-content-list-item-action-wrapper.following .module-content-list-item-action-label:hover {
+	.module-content-list-item-action-wrapper.following .module-content-list-item-action-label,
+	.module-content-list-item-action-wrapper.following .module-content-list-item-action-label:hover {
 		color: var(--studio-white);
 	}
 

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -542,8 +542,8 @@ ul.module-content-list-item-action-submenu {
 	}
 
 	// Color follow action when already following
-	.module-content-list-item-action-wrapper.following .module-content-list-item-action-label {
-		color: var(--color-success);
+	.module-content-list-item-action-wrapper.following .module-content-list-item-action-label, .module-content-list-item-action-wrapper.following .module-content-list-item-action-label:hover {
+		color: var(--studio-white);
 	}
 
 	// Display hidden label and change icon for Unfollow action
@@ -551,7 +551,6 @@ ul.module-content-list-item-action-submenu {
 	.module-content-list-item-action-wrapper.following:hover {
 		.module-content-list-item-action-label {
 			display: none;
-			color: var(--color-link-dark);
 		}
 
 		.module-content-list-item-action-label.unfollow {


### PR DESCRIPTION
Related to #73675 

## Proposed Changes

* Fixes the color of the links on hover for subscribed subscriber item. Previously the contrast was off and they did not look right. Now they are white like the rest of the unsubscribed subscriber items are on hover. 

Note: currently, the hover state is *not* underlined. This is how it was previously. Do we want to keep it as-is, or add an underline to the hover text also?

## Testing Instructions

* Using the Calypso Live Branch, navigate to the stats insights page at `/stats/insights/{site URL}`
* Scroll down to find the `Subscribers` panel
* If you are not subscribed to any subscribers on the site, click the subscribe link to do so
* Confirm that the `following` and `unfollow` (on hover) links are displayed in white

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/30754158/221033662-fd245a87-ee5d-4c62-8558-fa75b6737026.png)  | ![image](https://user-images.githubusercontent.com/30754158/221034994-6319fe5b-f848-4f93-9649-e3370f0beab7.png)  |
| ![image](https://user-images.githubusercontent.com/30754158/221033728-14e53a1d-f45a-401f-8392-91a5de98b737.png)  | ![image](https://user-images.githubusercontent.com/30754158/221035134-a963efa0-86a0-4440-b747-3c6ffd77af43.png)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
