### PR TITLE
Odyssey: use page base from current page url

### DIFF
--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -47,7 +47,7 @@ async function AppBoot() {
 	if ( ! window.location?.hash ) {
 		window.location.hash = `#!/stats/day/${ siteId }`;
 	}
-	registerStatsPages( config( 'admin_page_base' ) );
+	registerStatsPages( window.location.pathname + window.location.search );
 }
 
 AppBoot();


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack/issues/28142

## Proposed Changes

If page base is not the same as the current URL, `page.js` couldn't route pages correctly.  The PR proposes to  `pathname` + `search` from the current URL as page base, which should be working in all scenarios.

Thanks for reporting @brbrr  and thanks for bringing this to attention @lakellie.

## Testing Instructions

* Use Option 2 in PejTkB-3E-p2 to test (replace the branch with `fix/base-path-for-customized-wp-installations`)
* Use a Pressable test site - please contact @kangzj if you don't have one
* Ensure all routes work, including switching to Insights page, switching periods etc

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?