### PR TITLE
BackupRetention: Allow purchase when current plan requires upgrade

### DIFF
--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -151,23 +151,15 @@ const BackupRetentionManagement: FunctionComponent< OwnProps > = ( { defaultRete
 							retention_option: value,
 						} )
 					);
-
-					const selectedOption = retentionOptionsCards.find(
-						( option ) => option.id === value
-					) as RetentionOptionInput;
-
-					if ( selectedOption.upgradeRequired !== storageUpgradeRequired ) {
-						setStorageUpgradeRequired( selectedOption.upgradeRequired );
-					}
 				}
 			}
 		},
-		[ dispatch, retentionOptionsCards, retentionSelected, storageUpgradeRequired ]
+		[ dispatch, retentionSelected ]
 	);
 
 	const disableFormSubmission =
 		! retentionSelected ||
-		retentionSelected === currentRetentionPlan ||
+		( retentionSelected === currentRetentionPlan && ! storageUpgradeRequired ) ||
 		updateRetentionRequestStatus === BACKUP_RETENTION_UPDATE_REQUEST.PENDING;
 
 	const [ confirmationDialogVisible, setConfirmationDialogVisible ] = useState( false );
@@ -204,6 +196,17 @@ const BackupRetentionManagement: FunctionComponent< OwnProps > = ( { defaultRete
 			setRetentionSelected( currentRetentionPlan );
 		}
 	}, [ currentRetentionPlan, isFetching ] );
+
+	// Determinate if storage upgrade is required when the retention period selected changes
+	useEffect( () => {
+		const selectedOption = retentionOptionsCards.find(
+			( option ) => option.id === retentionSelected
+		) as RetentionOptionInput;
+
+		if ( selectedOption && selectedOption.upgradeRequired !== storageUpgradeRequired ) {
+			setStorageUpgradeRequired( selectedOption.upgradeRequired );
+		}
+	}, [ retentionOptionsCards, retentionSelected, storageUpgradeRequired ] );
 
 	useEffect( () => {
 		if (


### PR DESCRIPTION
Currently, when the current retention period requires an upgrade, the `Update settings` or `Purchase storage` button is disabled. With this PR, we are enabling the `Purchase storage` buttons on this scenario, so the customer can purchase the additional storage needed to keep this retention period.

## Proposed Changes
* Enable `Purchase storage` button when current plan requires an upgrade

## Screenshots
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/1488641/221050311-9c778b09-4c7e-41db-ae9d-4cb853630165.png) | ![image](https://user-images.githubusercontent.com/1488641/221050109-f78060a5-6172-4429-9cd8-fe2c31439b92.png) |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Grab a site with a 30-day retention period, 10 GB backup plan and set the last backup size to a higher size like 1 GB. Details on how to do it are available here: 1203596170892175-as-1204010089973353/f
* To test before the patch, you could use Jetpack Cloud in production.
  * When navigating to Jetpack Cloud > Settings, you should see the current plan saying `Upgrade required` and `Update settings` button disabled as the `Before` screenshot above.
* To test after the patch, you could use Jetpack Cloud live branch.
  * When navigating to Jetpack Cloud > Settings, you should see the current plan saying `Upgrade required` and `Purchase storage` button is now enabled as the `After` screenshot above.
  * Validate that the purchase storage button takes you to the checkout page. NOTE: you will not be able to test the checkout purchase because the redirect back is not working on Calypso Live, so if you want to test it, you could use your local environment. Either way, it is not necessary to test the checkout, as nothing is changing there on this PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?