### PR TITLE
GitHub Integration: Tracks for auth/connect/disconnect flows

### DIFF
--- a/client/my-sites/hosting/github/deployment-card/index.tsx
+++ b/client/my-sites/hosting/github/deployment-card/index.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import SocialLogo from 'calypso/components/social-logo';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { EmptyDeployments } from './empty-deployments';
@@ -50,6 +51,13 @@ export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardPr
 					)
 				);
 			},
+			onSettled: ( _, error ) => {
+				dispatch(
+					recordTracksEvent( 'calypso_hosting_github_disconnect_complete', {
+						disconnected: ! error,
+					} )
+				);
+			},
 		}
 	);
 
@@ -88,7 +96,14 @@ export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardPr
 				) }
 				{ ! isLoading && ! deployment && <EmptyDeployments /> }
 			</div>
-			<Button primary busy={ isDisconnecting } onClick={ () => disconnectRepo( siteId ) }>
+			<Button
+				primary
+				busy={ isDisconnecting }
+				onClick={ () => {
+					dispatch( recordTracksEvent( 'calypso_hosting_github_disconnect_click' ) );
+					disconnectRepo( siteId );
+				} }
+			>
 				<span>{ translate( 'Disconnect repository' ) }</span>
 			</Button>
 		</Card>

--- a/client/my-sites/hosting/github/disconnect-github-button/index.tsx
+++ b/client/my-sites/hosting/github/disconnect-github-button/index.tsx
@@ -2,11 +2,12 @@ import { Button } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMutation, useQueryClient } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { deleteStoredKeyringConnection } from 'calypso/state/sharing/keyring/actions';
-import './style.scss';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { GITHUB_INTEGRATION_QUERY_KEY } from '../constants';
 import { GITHUB_CONNECTION_QUERY_KEY } from '../use-github-connection-query';
+import './style.scss';
 
 type Connection = Parameters< typeof deleteStoredKeyringConnection >[ 0 ];
 
@@ -21,6 +22,7 @@ export function DisconnectGitHubButton( { connection }: DisconnectGitHubButtonPr
 	const dispatch = useDispatch();
 	// Using ReactQuery to manage `isDisconnecting` state because it's not exposed from the Redux store.
 	const mutation = useMutation< unknown, unknown, Connection >( async ( c ) => {
+		dispatch( recordTracksEvent( 'calypso_hosting_github_unauthorize_click' ) );
 		await dispatch( deleteStoredKeyringConnection( c ) );
 		await queryClient.invalidateQueries( [
 			GITHUB_INTEGRATION_QUERY_KEY,

--- a/client/my-sites/hosting/github/github-connect-card/index.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/index.tsx
@@ -10,6 +10,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import Image from 'calypso/components/image';
 import SocialLogo from 'calypso/components/social-logo';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { DisconnectGitHubButton } from '../disconnect-github-button';
@@ -46,6 +47,11 @@ export const GithubConnectCard = ( { connection }: GithubConnectCardProps ) => {
 						...noticeOptions,
 					}
 				)
+			);
+		},
+		onSettled: ( _, error ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_hosting_github_connect_complete', { connected: ! error } )
 			);
 		},
 	} );
@@ -124,6 +130,7 @@ export const GithubConnectCard = ( { connection }: GithubConnectCardProps ) => {
 				<Button
 					primary
 					onClick={ () => {
+						dispatch( recordTracksEvent( 'calypso_hosting_github_connect_click' ) );
 						connectBranch( {
 							repoName: selectedRepo,
 							branchName: selectedBranch,

--- a/client/my-sites/hosting/github/index.tsx
+++ b/client/my-sites/hosting/github/index.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
-import { GithubAuthorizeCard } from 'calypso/my-sites/hosting/github/github-authorize-card';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { DeploymentCard } from './deployment-card';
+import { GithubAuthorizeCard } from './github-authorize-card';
 import { GithubConnectCard } from './github-connect-card';
 import { GitHubPlaceholderCard } from './github-placeholder-card';
 import { useGithubConnectionQuery } from './use-github-connection-query';

--- a/client/my-sites/hosting/github/use-github-connection-query.ts
+++ b/client/my-sites/hosting/github/use-github-connection-query.ts
@@ -4,7 +4,7 @@ import { GITHUB_INTEGRATION_QUERY_KEY } from './constants';
 
 export const GITHUB_CONNECTION_QUERY_KEY = 'github-connection';
 
-type GithubConnectionData = {
+export interface GithubConnectionData {
 	ID: number;
 	connected: boolean;
 	external_profile_picture: string;
@@ -13,7 +13,8 @@ type GithubConnectionData = {
 	base_path: string;
 	label: string;
 	external_name: string;
-};
+}
+
 export const useGithubConnectionQuery = (
 	siteId: number | null,
 	options?: UseQueryOptions< GithubConnectionData >


### PR DESCRIPTION
Part of #70383

## Proposed Changes

Adds the following tracks events to the GitHub interface in `/hosting-config`

| Event Name | Prop | Notes |
| --- | --- | --- |
| `calypso_hosting_github_authorize_click` | | |
| `calypso_hosting_github_authorize_complete` | `authorized: true \| false` | Prop records whether user bailed in the middle of the auth flow |
| `calypso_hosting_github_connect_click` | | |
| `calypso_hosting_github_connect_complete` | `connected: true \| false` | Prop records success or failure |
| `calypso_hosting_github_disconnect_click` | | |
| `calypso_hosting_github_disconnect_complete` | `disconnected: true \| false` | Prop records success or failure |
| `calypso_hosting_github_unauthorize_click` | | |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Watch tracks event in dev tools (I watch for `t.gif` in the network tab)
* Fully disconnect/reconnect to view all events
