### PR TITLE
Reader: make case consistent for tag header follow button

### DIFF
--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -96,7 +96,7 @@ class TagStreamHeader extends Component {
 				<div className="tag-stream__header-follow">
 					{ showFollow && (
 						<FollowButton
-							followLabel={ translate( 'Follow Tag' ) }
+							followLabel={ translate( 'Follow tag' ) }
 							followingLabel={ translate( 'Following tag' ) }
 							iconSize={ 24 }
 							following={ following }


### PR DESCRIPTION
In the Reader tag stream, the follow button currently has inconsistent capitalization. It's "Follow Tag" and then "Following tag" once you're following:

<img width="141" alt="Screenshot 2023-02-24 at 14 56 45" src="https://user-images.githubusercontent.com/17325/221078571-e44db920-f01a-4d3f-b6a6-24c433104ceb.png">
<img width="154" alt="Screenshot 2023-02-24 at 14 56 35" src="https://user-images.githubusercontent.com/17325/221078575-a887edcd-ba52-4a4f-81b6-705c54b7b0c0.png">

This PR standardizes on sentence case, so the labels become "Follow tag" and "Following tag" for consistency.

### Testing instructions
After switching to the PR's branch or visiting the calypso.live link:

1. Visit the Reader tag stream for a tag you do not follow (e.g. /tag/mountains)
2. Verify that the follow button label is "Follow tag"
3. Click on the follow button to follow the tag
4. Verify that the follow button label is "Following tag"