### PR TITLE
Site Assembler: Fix the animation of section list broken due to scrollable container

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -135,12 +135,12 @@ const PatternLayout = ( {
 	}
 
 	return (
-		<div className="pattern-layout">
-			{ sections.length > 0 && (
-				<ul className="pattern-layout__list">
-					<AsyncLoad require="./animate-list" featureName="domMax" placeholder={ <div /> }>
-						{ ( m: any ) =>
-							sections.map( ( { category, key }: Pattern, index ) => {
+		<AsyncLoad require="./animate-list" featureName="domMax" placeholder={ <div /> }>
+			{ ( m: any ) => (
+				<m.div className="pattern-layout" layoutScroll>
+					{ sections.length > 0 && (
+						<ul className="pattern-layout__list">
+							{ sections.map( ( { category, key }: Pattern, index ) => {
 								return (
 									<m.li
 										key={ key }
@@ -163,31 +163,31 @@ const PatternLayout = ( {
 										/>
 									</m.li>
 								);
-							} )
-						}
-					</AsyncLoad>
-				</ul>
+							} ) }
+						</ul>
+					) }
+					<div
+						className="pattern-layout__add-button-container"
+						ref={ addButtonContainerRef }
+						onMouseEnter={ () => setIsPopoverVisible( true ) }
+						onMouseLeave={ () => setIsPopoverVisible( false ) }
+					>
+						<Button className="pattern-layout__add-button" onClick={ () => onAddSection() }>
+							<Icon icon={ plus } size={ 32 } />
+						</Button>
+						<Popover
+							className="pattern-layout__add-button-popover"
+							context={ addButtonContainerRef.current }
+							isVisible={ isPopoverVisible }
+							position="right"
+							focusOnShow
+						>
+							{ translate( 'Add your next pattern' ) }
+						</Popover>
+					</div>
+				</m.div>
 			) }
-			<div
-				className="pattern-layout__add-button-container"
-				ref={ addButtonContainerRef }
-				onMouseEnter={ () => setIsPopoverVisible( true ) }
-				onMouseLeave={ () => setIsPopoverVisible( false ) }
-			>
-				<Button className="pattern-layout__add-button" onClick={ () => onAddSection() }>
-					<Icon icon={ plus } size={ 32 } />
-				</Button>
-				<Popover
-					className="pattern-layout__add-button-popover"
-					context={ addButtonContainerRef.current }
-					isVisible={ isPopoverVisible }
-					position="right"
-					focusOnShow
-				>
-					{ translate( 'Add your next pattern' ) }
-				</Popover>
-			</div>
-		</div>
+		</AsyncLoad>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -50,31 +50,34 @@ const PatternLayout = ( {
 
 	if ( ! isSidebarRevampEnabled ) {
 		return (
-			<div className="pattern-layout">
-				<ul className="pattern-layout__list">
-					{ selectedHeader ? (
-						<li className="pattern-layout__list-item">
-							<Icon className="pattern-layout__icon" icon={ header } size={ 24 } />
-							<span className="pattern-layout__list-item-text" title={ selectedHeader.category }>
-								{ selectedHeader.category }
-							</span>
-							<PatternActionBar
-								patternType="header"
-								onReplace={ onReplaceHeader }
-								onDelete={ onDeleteHeader }
-							/>
-						</li>
-					) : (
-						<li className="pattern-layout__list-item">
-							<Button className="pattern-layout__add-button" onClick={ onAddHeader }>
-								<span className="pattern-layout__add-button-icon">+</span>
-								{ translate( 'Add a header' ) }
-							</Button>
-						</li>
-					) }
-					{ sections.length > 0 && (
-						<AsyncLoad require="./animate-list" featureName="domMax" placeholder={ <div /> }>
-							{ ( m: any ) =>
+			<AsyncLoad require="./animate-list" featureName="domMax" placeholder={ <div /> }>
+				{ ( m: any ) => (
+					<m.div className="pattern-layout" layoutScroll>
+						<ul className="pattern-layout__list">
+							{ selectedHeader ? (
+								<li className="pattern-layout__list-item">
+									<Icon className="pattern-layout__icon" icon={ header } size={ 24 } />
+									<span
+										className="pattern-layout__list-item-text"
+										title={ selectedHeader.category }
+									>
+										{ selectedHeader.category }
+									</span>
+									<PatternActionBar
+										patternType="header"
+										onReplace={ onReplaceHeader }
+										onDelete={ onDeleteHeader }
+									/>
+								</li>
+							) : (
+								<li className="pattern-layout__list-item">
+									<Button className="pattern-layout__add-button" onClick={ onAddHeader }>
+										<span className="pattern-layout__add-button-icon">+</span>
+										{ translate( 'Add a header' ) }
+									</Button>
+								</li>
+							) }
+							{ sections.length > 0 &&
 								sections.map( ( { category, key }: Pattern, index ) => {
 									return (
 										<m.li
@@ -99,38 +102,40 @@ const PatternLayout = ( {
 											/>
 										</m.li>
 									);
-								} )
-							}
-						</AsyncLoad>
-					) }
-					<li className="pattern-layout__list-item">
-						<Button className="pattern-layout__add-button" onClick={ () => onAddSection() }>
-							<span className="pattern-layout__add-button-icon">+</span>
-							{ translate( 'Add sections' ) }
-						</Button>
-					</li>
-					{ selectedFooter ? (
-						<li className="pattern-layout__list-item">
-							<Icon className="pattern-layout__icon" icon={ footer } size={ 24 } />
-							<span className="pattern-layout__list-item-text" title={ selectedFooter.category }>
-								{ selectedFooter.category }
-							</span>
-							<PatternActionBar
-								patternType="footer"
-								onReplace={ onReplaceFooter }
-								onDelete={ onDeleteFooter }
-							/>
-						</li>
-					) : (
-						<li className="pattern-layout__list-item">
-							<Button className="pattern-layout__add-button" onClick={ onAddFooter }>
-								<span className="pattern-layout__add-button-icon">+</span>
-								{ translate( 'Add a footer' ) }
-							</Button>
-						</li>
-					) }
-				</ul>
-			</div>
+								} ) }
+							<li className="pattern-layout__list-item">
+								<Button className="pattern-layout__add-button" onClick={ () => onAddSection() }>
+									<span className="pattern-layout__add-button-icon">+</span>
+									{ translate( 'Add sections' ) }
+								</Button>
+							</li>
+							{ selectedFooter ? (
+								<li className="pattern-layout__list-item">
+									<Icon className="pattern-layout__icon" icon={ footer } size={ 24 } />
+									<span
+										className="pattern-layout__list-item-text"
+										title={ selectedFooter.category }
+									>
+										{ selectedFooter.category }
+									</span>
+									<PatternActionBar
+										patternType="footer"
+										onReplace={ onReplaceFooter }
+										onDelete={ onDeleteFooter }
+									/>
+								</li>
+							) : (
+								<li className="pattern-layout__list-item">
+									<Button className="pattern-layout__add-button" onClick={ onAddFooter }>
+										<span className="pattern-layout__add-button-icon">+</span>
+										{ translate( 'Add a footer' ) }
+									</Button>
+								</li>
+							) }
+						</ul>
+					</m.div>
+				) }
+			</AsyncLoad>
 		);
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -50,10 +50,10 @@ const PatternLayout = ( {
 
 	if ( ! isSidebarRevampEnabled ) {
 		return (
-			<AsyncLoad require="./animate-list" featureName="domMax" placeholder={ <div /> }>
-				{ ( m: any ) => (
-					<m.div className="pattern-layout" layoutScroll>
-						<ul className="pattern-layout__list">
+			<div className="pattern-layout">
+				<AsyncLoad require="./animate-list" featureName="domMax" placeholder={ <div /> }>
+					{ ( m: any ) => (
+						<m.ul className="pattern-layout__list" layoutScroll>
 							{ selectedHeader ? (
 								<li className="pattern-layout__list-item">
 									<Icon className="pattern-layout__icon" icon={ header } size={ 24 } />
@@ -132,19 +132,19 @@ const PatternLayout = ( {
 									</Button>
 								</li>
 							) }
-						</ul>
-					</m.div>
-				) }
-			</AsyncLoad>
+						</m.ul>
+					) }
+				</AsyncLoad>
+			</div>
 		);
 	}
 
 	return (
-		<AsyncLoad require="./animate-list" featureName="domMax" placeholder={ <div /> }>
-			{ ( m: any ) => (
-				<m.div className="pattern-layout" layoutScroll>
-					{ sections.length > 0 && (
-						<ul className="pattern-layout__list">
+		<div className="pattern-layout">
+			{ sections.length > 0 && (
+				<AsyncLoad require="./animate-list" featureName="domMax" placeholder={ <div /> }>
+					{ ( m: any ) => (
+						<m.ul className="pattern-layout__list" layoutScroll>
 							{ sections.map( ( { category, key }: Pattern, index ) => {
 								return (
 									<m.li
@@ -169,30 +169,30 @@ const PatternLayout = ( {
 									</m.li>
 								);
 							} ) }
-						</ul>
+						</m.ul>
 					) }
-					<div
-						className="pattern-layout__add-button-container"
-						ref={ addButtonContainerRef }
-						onMouseEnter={ () => setIsPopoverVisible( true ) }
-						onMouseLeave={ () => setIsPopoverVisible( false ) }
-					>
-						<Button className="pattern-layout__add-button" onClick={ () => onAddSection() }>
-							<Icon icon={ plus } size={ 32 } />
-						</Button>
-						<Popover
-							className="pattern-layout__add-button-popover"
-							context={ addButtonContainerRef.current }
-							isVisible={ isPopoverVisible }
-							position="right"
-							focusOnShow
-						>
-							{ translate( 'Add your next pattern' ) }
-						</Popover>
-					</div>
-				</m.div>
+				</AsyncLoad>
 			) }
-		</AsyncLoad>
+			<div
+				className="pattern-layout__add-button-container"
+				ref={ addButtonContainerRef }
+				onMouseEnter={ () => setIsPopoverVisible( true ) }
+				onMouseLeave={ () => setIsPopoverVisible( false ) }
+			>
+				<Button className="pattern-layout__add-button" onClick={ () => onAddSection() }>
+					<Icon icon={ plus } size={ 32 } />
+				</Button>
+				<Popover
+					className="pattern-layout__add-button-popover"
+					context={ addButtonContainerRef.current }
+					isVisible={ isPopoverVisible }
+					position="right"
+					focusOnShow
+				>
+					{ translate( 'Add your next pattern' ) }
+				</Popover>
+			</div>
+		</div>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -52,6 +52,7 @@ $font-family: "SF Pro Text", $sans;
 		height: 100%;
 		width: 100%;
 		margin: 0;
+		overflow-y: auto;
 
 		button {
 			display: flex;
@@ -360,7 +361,6 @@ $font-family: "SF Pro Text", $sans;
  */
 .pattern-assembler.pattern-assembler__sidebar-revamp {
 	.pattern-layout {
-		overflow-y: auto;
 		margin-bottom: 32px;
 
 		.pattern-action-bar {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -362,5 +362,9 @@ $font-family: "SF Pro Text", $sans;
 	.pattern-layout {
 		overflow-y: auto;
 		margin-bottom: 32px;
+
+		.pattern-action-bar {
+			right: 2px;
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -52,7 +52,6 @@ $font-family: "SF Pro Text", $sans;
 		height: 100%;
 		width: 100%;
 		margin: 0;
-		overflow-y: auto;
 
 		button {
 			display: flex;
@@ -118,6 +117,7 @@ $font-family: "SF Pro Text", $sans;
 			color: #101517;
 			letter-spacing: -0.24px;
 			user-select: none;
+			overflow-y: auto;
 		}
 
 		.pattern-layout__list-item {
@@ -170,6 +170,7 @@ $font-family: "SF Pro Text", $sans;
 		.pattern-layout__add-button-container {
 			position: relative;
 			margin-right: auto;
+			margin-bottom: 32px;
 		}
 
 		.pattern-layout__icon {
@@ -361,7 +362,9 @@ $font-family: "SF Pro Text", $sans;
  */
 .pattern-assembler.pattern-assembler__sidebar-revamp {
 	.pattern-layout {
-		margin-bottom: 32px;
+		.pattern-layout__list {
+			margin: 0 0 16px;
+		}
 
 		.pattern-action-bar {
 			right: 2px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/72144#pullrequestreview-1310882153

## Proposed Changes

* Referring to [Animating within scroll containers](https://www.framer.com/motion/layout-animations/##animating-within-scroll-containers), we have to give the `layoutScroll` prop to the scroll container so that Framer Motion is able to account for this element's scroll offset when measuring children.

https://user-images.githubusercontent.com/13596067/221090135-07d4dd55-b182-49b4-a765-769b0d75fb43.mov

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /setup?flags=pattern-assembler/sidebar-revamp&siteSlug=<your_site>
- Click the "Continue" button until you land on the Design Picker step
- Scroll to the bottom and select the Blank Canvas CTA
- When you're in the Pattern Assembler step, click on the "Design your homepage"
- Add patterns to make the list scrollable
- Scroll down and reorder the bottom patterns.
- Scroll up to remove the top-most pattern.
- Scroll down and reorder the bottom patterns again, and ensure the animation still works well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
