### PR TITLE
Add skipCta params after checkout page to kick off migration

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/confirm.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm.tsx
@@ -3,6 +3,7 @@ import { Title, SubTitle, NextButton, Notice } from '@automattic/onboarding';
 import { sprintf } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import { getQueryArg } from '@wordpress/url';
 import classnames from 'classnames';
 import React, { useState, useEffect } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
@@ -23,6 +24,7 @@ interface Props {
 	isTargetSitePlanCompatible: boolean;
 	showConfirmDialog: boolean;
 	startImport: () => void;
+	isMigrateFromWp: boolean;
 }
 
 export const Confirm: React.FunctionComponent< Props > = ( props ) => {
@@ -40,6 +42,7 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 		isTargetSitePlanCompatible,
 		showConfirmDialog,
 		startImport,
+		isMigrateFromWp,
 	} = props;
 	const [ isModalDetailsOpen, setIsModalDetailsOpen ] = useState( false );
 	const [ showUpgradePlanScreen, setShowUpgradePlanScreen ] = useState( false );
@@ -48,7 +51,11 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 	 ↓ Effects
 	 */
 	useEffect( () => {
+		const skipCta = getQueryArg( window.location.href, 'skipCta' );
 		recordTracksEvent( 'calypso_site_importer_migration_confirmation' );
+		if ( isTargetSitePlanCompatible && isMigrateFromWp && skipCta ) {
+			startImportCta();
+		}
 	}, [] );
 
 	/**
@@ -60,6 +67,14 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 		} else {
 			startImport();
 		}
+	}
+	function startImportCta() {
+		recordTracksEvent( 'calypso_signup_step_start', {
+			flow: 'importer',
+			step: 'importerWordpress',
+			action: 'startImport',
+		} );
+		showConfirmDialogOrStartImport();
 	}
 
 	return (
@@ -143,18 +158,7 @@ export const Confirm: React.FunctionComponent< Props > = ( props ) => {
 						) }
 
 						{ isTargetSitePlanCompatible && (
-							<NextButton
-								onClick={ () => {
-									recordTracksEvent( 'calypso_signup_step_start', {
-										flow: 'importer',
-										step: 'importerWordpress',
-										action: 'startImport',
-									} );
-									showConfirmDialogOrStartImport();
-								} }
-							>
-								{ __( 'Start import' ) }
-							</NextButton>
+							<NextButton onClick={ startImportCta }>{ __( 'Start import' ) }</NextButton>
 						) }
 					</>
 				) }

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -40,6 +40,11 @@ interface State {
 	migrationStatus: string;
 	percent: number | null;
 }
+
+type ExtraParams = {
+	[ key: string ]: any;
+};
+
 export class ImportEverything extends SectionMigrate {
 	componentDidUpdate( prevProps: any, prevState: State ) {
 		super.componentDidUpdate( prevProps, prevState );
@@ -47,9 +52,12 @@ export class ImportEverything extends SectionMigrate {
 	}
 
 	goToCart = () => {
-		const { stepNavigator } = this.props;
-
-		stepNavigator?.goToCheckoutPage();
+		const { stepNavigator, isMigrateFromWp } = this.props;
+		const extraParamsArg: ExtraParams = {};
+		if ( isMigrateFromWp ) {
+			extraParamsArg[ 'skipCta' ] = true;
+		}
+		stepNavigator?.goToCheckoutPage( extraParamsArg );
 	};
 
 	resetMigration = () => {
@@ -130,12 +138,14 @@ export class ImportEverything extends SectionMigrate {
 			isTargetSitePlanCompatible,
 			stepNavigator,
 			showConfirmDialog = true,
+			isMigrateFromWp,
 		} = this.props;
 
 		if ( sourceSite ) {
 			return (
 				<Confirm
 					startImport={ this.startMigration }
+					isMigrateFromWp={ isMigrateFromWp }
 					isTargetSitePlanCompatible={ isTargetSitePlanCompatible }
 					targetSite={ targetSite }
 					targetSiteSlug={ targetSiteSlug }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
@@ -36,10 +36,10 @@ export function useStepNavigator(
 		} );
 	}
 
-	function goToCheckoutPage() {
+	function goToCheckoutPage( extraArgs = {} ) {
 		navigation.submit?.( {
 			type: 'redirect',
-			url: getCheckoutUrl(),
+			url: getCheckoutUrl( extraArgs ),
 		} );
 	}
 
@@ -60,21 +60,22 @@ export function useStepNavigator(
 		} );
 	}
 
-	function getWordpressImportEverythingUrl(): string {
+	function getWordpressImportEverythingUrl( extraArgs = {} ): string {
 		const queryParams = {
 			siteSlug: siteSlug,
 			from: fromSite,
 			option: WPImportOption.EVERYTHING,
 			run: true,
+			...extraArgs,
 		};
 
 		return addQueryArgs( queryParams, `/${ BASE_STEPPER_ROUTE }/${ flow }/importerWordpress` );
 	}
 
-	function getCheckoutUrl() {
+	function getCheckoutUrl( extraArgs = {} ) {
 		const path = checkoutUrl;
 		const queryParams = {
-			redirect_to: getWordpressImportEverythingUrl(),
+			redirect_to: getWordpressImportEverythingUrl( extraArgs ),
 			cancel_to: getWordpressImportEverythingUrl(),
 		};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73330 

## Proposed Changes

* We're trying to reduce the steps for users when they come from the migration plugin. In this PR, we've introduced an extra param called `skipCta`, if a user comes from the migration plugin and purchases the plan, they'll start importing directly after the checkout is finished. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a JN site with [the migration plugin](https://href.li/?https://jurassic.ninja/create/?jetpack-beta&branches.wpcom-migration=master&wp-debug-log)
* Once it redirects to `wordpress.com`, replace it with `calypso.localhost:3000`.
* Go through the migration process and purchase the plan.
* See if the migration starts directly after the checkout is finished. ( Originally you'll need to click start import after the checkout)
* Test with another site that's already an atomic site, since you didn't see the plans page, you will still need to click "Start import" in this case.
* This change should only affect the users who see the plans page during the migration flow from the plugin.


https://user-images.githubusercontent.com/4074459/221114152-66b1269b-a535-4557-8d06-55ed28dbb0a2.mov



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
