### PR TITLE
Move features as required

### DIFF
--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -484,7 +484,10 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 				? planObject.get2023PlanComparisonFeatureOverride().slice()
 				: planObject.get2023PricingGridSignupWpcomFeatures?.().slice() ?? [];
 
-			const jetpackFeatures = planObject.get2023PricingGridSignupJetpackFeatures?.() ?? [];
+			const jetpackFeatures = planObject.get2023PlanComparisonJetpackFeatureOverride
+				? planObject.get2023PlanComparisonJetpackFeatureOverride().slice()
+				: planObject.get2023PricingGridSignupJetpackFeatures?.().slice() ?? [];
+
 			const annualOnlyFeatures = planObject.getAnnualPlansOnlyFeatures?.() ?? [];
 
 			let featuresAvailable = [ ...wpcomFeatures, ...jetpackFeatures ];

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -431,9 +431,7 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_SMART_REDIRECTS,
 		FEATURE_ALWAYS_ONLINE,
 	],
-	// This function returns the features that are to be overridden and shown in the plans comparison table.
-	// The gist is that we want the plan comparison grid to be as comprehensive as possible, while keeping the plans table easy to follow.
-	// For more details why they deviates, please refer to p2-pdgrnI-24M#comment-3413
+
 	get2023PlanComparisonFeatureOverride: () => [
 		FEATURE_BEAUTIFUL_THEMES,
 		FEATURE_PAGES,
@@ -459,6 +457,14 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_LTD_SOCIAL_MEDIA_JP,
 		FEATURE_CONTACT_FORM_JP,
 	],
+	get2023PlanComparisonJetpackFeatureOverride: () => [
+		FEATURE_STATS_JP,
+		FEATURE_SPAM_JP,
+		FEATURE_LTD_SOCIAL_MEDIA_JP,
+		FEATURE_CONTACT_FORM_JP,
+		FEATURE_SITE_ACTIVITY_LOG_JP,
+	],
+
 	get2023PricingGridSignupStorageOptions: () => [ FEATURE_1GB_STORAGE ],
 	getIncludedFeatures: () => [],
 	getInferiorFeatures: () => [],
@@ -633,7 +639,6 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_AD_FREE_EXPERIENCE,
 		FEATURE_FAST_DNS,
-		FEATURE_STYLE_CUSTOMIZATION,
 		FEATURE_SUPPORT_EMAIL,
 	],
 	get2023PricingGridSignupJetpackFeatures: () => [
@@ -1014,11 +1019,11 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_LIVE_CHAT_SUPPORT,
 		FEATURE_PREMIUM_THEMES_V2,
 		FEATURE_WORDADS,
+		FEATURE_STYLE_CUSTOMIZATION,
 	],
 	get2023PricingGridSignupJetpackFeatures: () => [
 		FEATURE_VIDEOPRESS_JP,
 		FEATURE_UNLTD_SOCIAL_MEDIA_JP,
-		FEATURE_SEO_JP,
 		FEATURE_SITE_ACTIVITY_LOG_JP,
 	],
 	get2023PricingGridSignupStorageOptions: () => [ FEATURE_13GB_STORAGE ],
@@ -1180,6 +1185,7 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_UPTIME_MONITOR_JP,
 		FEATURE_ES_SEARCH_JP,
 		FEATURE_PLUGIN_AUTOUPDATE_JP,
+		FEATURE_SEO_JP,
 	],
 	get2023PricingGridSignupStorageOptions: () => [ FEATURE_200GB_STORAGE ],
 	// Features not displayed but used for checking plan abilities

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -150,9 +150,35 @@ export type Plan = BillingTerm & {
 	type: string;
 	availableFor?: ( plan: PlanSlug ) => boolean;
 	getSignupCompareAvailableFeatures?: () => string[];
+
+	/**
+	 * Features to be shown in the plan details table and the plans comparison table.
+	 * If get2023PricingGridSignupWpcomFeature exists,
+	 * this feature list will be ignored in the plans comparison table only.
+	 * Context - pdgrnI-26j
+	 */
 	get2023PricingGridSignupWpcomFeatures?: () => Feature[];
+
+	/**
+	 * This function returns the features that are to be overridden and shown in the plans comparison table.
+	 * Context - pdgrnI-26j
+	 */
 	get2023PlanComparisonFeatureOverride?: () => Feature[];
+
+	/**
+	 * Features to be shown in the plan details jetpack section and the jetpack features in the plans comparison table.
+	 * If get2023PlanComparisonJetpackFeatureOverride exists,
+	 * this feature list will be ignored in the plans comparison table only.
+	 * Context - pdgrnI-26j
+	 */
 	get2023PricingGridSignupJetpackFeatures?: () => Feature[];
+
+	/**
+	 * This function returns the Jetpack features that are to be overridden and shown in the plans comparison table.
+	 * Context - pdgrnI-26j
+	 */
+	get2023PlanComparisonJetpackFeatureOverride?: () => Feature[];
+
 	get2023PricingGridSignupStorageOptions?: () => Feature[];
 	getProductId: () => number;
 	getPathSlug?: () => string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1557

## Proposed Changes

* Changed the feature positions as follows.

| Change | Plan Details Columns | Plan Comparison Grid |
| ------------------- | ------------------- | ----------------------- |
| `Style customisation` | Premium and up | ✅ Premium and up |
| `Site activity log`| Premium and up | ✅ On all plans |
| `Tools for SEO` | Business and up | ✅ On business and up |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/star/plans`
*Make sure the features are structured as shown above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
