### PR TITLE
Site Assembler: Add global styles gating

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.ts
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { urlToSlug } from 'calypso/lib/url';
+import { useSite } from '../../../../../hooks/use-site';
+import { useSiteSlugParam } from '../../../../../hooks/use-site-slug-param';
+
+interface Props {
+	recordTracksEvent: ( eventName: string, eventProps?: { [ key: string ]: unknown } ) => void;
+	onSubmit: () => void;
+}
+
+const useGlobalStylesUpgradeModal = ( { recordTracksEvent, onSubmit }: Props ) => {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const site = useSite();
+	const siteSlug = useSiteSlugParam();
+	const siteUrl = siteSlug || urlToSlug( site?.URL || '' ) || '';
+
+	const openModal = () => {
+		recordTracksEvent( 'calypso_signup_pattern_assembler_global_styles_gating_modal_show' );
+		setIsOpen( true );
+	};
+
+	const closeModal = () => {
+		recordTracksEvent(
+			'calypso_signup_pattern_assembler_global_styles_gating_modal_close_button_click'
+		);
+		setIsOpen( false );
+	};
+
+	const checkout = () => {
+		recordTracksEvent(
+			'calypso_signup_pattern_assembler_global_styles_gating_modal_checkout_button_click'
+		);
+
+		// When the user is done with checkout, send them back to the current url
+		const destUrl = new URL( window.location.href );
+		const redirectUrl = destUrl.toString().replace( window.location.origin, '' );
+		const params = new URLSearchParams( {
+			redirect_to: redirectUrl,
+		} );
+
+		// The theme upsell link does not work with siteId and requires a siteSlug.
+		// See https://github.com/Automattic/wp-calypso/pull/64899
+		window.location.href = `/checkout/${ encodeURIComponent( siteUrl ) }/premium?${ params }`;
+	};
+
+	const tryStyle = () => {
+		recordTracksEvent(
+			'calypso_signup_pattern_assembler_global_styles_gating_modal_try_button_click'
+		);
+
+		onSubmit();
+	};
+
+	return { isOpen, openModal, closeModal, checkout, tryStyle };
+};
+
+export default useGlobalStylesUpgradeModal;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -11,7 +11,9 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useRef, useMemo } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
+import { createRecordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import { requestActiveTheme } from 'calypso/state/themes/actions';
 import { useSite } from '../../../../hooks/use-site';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
@@ -19,6 +21,7 @@ import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import { recordSelectedDesign } from '../../analytics/record-design';
 import { SITE_TAGLINE, PLACEHOLDER_SITE_ID } from './constants';
+import useGlobalStylesUpgradeModal from './hooks/use-global-styles-upgrade-modal';
 import NavigatorListener from './navigator-listener';
 import PatternAssemblerContainer from './pattern-assembler-container';
 import PatternLargePreview from './pattern-large-preview';
@@ -62,19 +65,24 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 	const stylesheet = selectedDesign?.recipe?.stylesheet || '';
 
 	const isSidebarRevampEnabled = isEnabled( 'pattern-assembler/sidebar-revamp' );
-
-	const commonEventProps = {
-		flow,
-		step: stepName,
-		intent,
-	};
-
 	const isEnabledColorAndFonts = isEnabled( 'pattern-assembler/color-and-fonts' );
 
 	const [ selectedColorPaletteVariation, setSelectedColorPaletteVariation ] =
 		useState< GlobalStylesObject | null >( null );
 	const [ selectedFontPairingVariation, setSelectedFontPairingVariation ] =
 		useState< GlobalStylesObject | null >( null );
+
+	const recordTracksEvent = useMemo(
+		() =>
+			createRecordTracksEvent( {
+				flow,
+				step: stepName,
+				intent,
+				stylesheet,
+				color_style_slug: selectedColorPaletteVariation?.title,
+			} ),
+		[ flow, stepName, intent ]
+	);
 
 	const selectedVariations = useMemo(
 		() =>
@@ -83,6 +91,9 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 			) as GlobalStylesObject[],
 		[ selectedColorPaletteVariation, selectedFontPairingVariation ]
 	);
+
+	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles();
+	const shouldUnlockGlobalStyles = shouldLimitGlobalStyles && selectedVariations.length > 0;
 
 	const syncedGlobalStylesUserConfig = useSyncGlobalStylesUserConfig(
 		selectedVariations,
@@ -112,7 +123,6 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 
 	const trackEventPatternAdd = ( patternType: string ) => {
 		recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_add_click', {
-			...commonEventProps,
 			pattern_type: patternType,
 		} );
 	};
@@ -127,7 +137,6 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 		patternName: string;
 	} ) => {
 		recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_select_click', {
-			...commonEventProps,
 			pattern_type: patternType,
 			pattern_id: patternId,
 			pattern_name: patternName,
@@ -137,7 +146,6 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 	const trackEventContinue = () => {
 		const patterns = getPatterns();
 		recordTracksEvent( 'calypso_signup_pattern_assembler_continue_click', {
-			...commonEventProps,
 			pattern_types: [ header && 'header', sections.length && 'section', footer && 'footer' ]
 				.filter( Boolean )
 				.join( ',' ),
@@ -147,7 +155,6 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 		} );
 		patterns.forEach( ( { id, name, category_slug } ) => {
 			recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_final_select', {
-				...commonEventProps,
 				pattern_id: id,
 				pattern_name: name,
 				pattern_category: category_slug,
@@ -261,7 +268,6 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 	const onBack = () => {
 		const patterns = getPatterns();
 		recordTracksEvent( 'calypso_signup_pattern_assembler_back_click', {
-			...commonEventProps,
 			has_selected_patterns: patterns.length > 0,
 			pattern_count: patterns.length,
 		} );
@@ -270,13 +276,12 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 	};
 
 	const onSubmit = () => {
+		const design = getDesign();
+		const theme = stylesheet?.split( '/' )[ 1 ] || design.theme;
+
 		if ( ! siteSlugOrId ) {
 			return;
 		}
-
-		const design = getDesign();
-		const stylesheet = design.recipe!.stylesheet!;
-		const theme = stylesheet?.split( '/' )[ 1 ] || design.theme;
 
 		setPendingAction( () =>
 			// We have to switch theme first. Otherwise, the unique suffix might append to
@@ -310,9 +315,14 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 		submit?.();
 	};
 
+	const { openModal: openGlobalStylesUpgradeModal, ...globalStylesUpgradeModalProps } =
+		useGlobalStylesUpgradeModal( {
+			onSubmit,
+			recordTracksEvent,
+		} );
+
 	const onPatternSelectorBack = ( type: string ) => {
 		recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_select_back_click', {
-			...commonEventProps,
 			pattern_type: type,
 		} );
 	};
@@ -320,7 +330,6 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 	const onDoneClick = ( type: string ) => {
 		const patterns = getPatterns( type );
 		recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_select_done_click', {
-			...commonEventProps,
 			pattern_type: type,
 			pattern_ids: patterns.map( ( { id } ) => id ).join( ',' ),
 			pattern_names: patterns.map( ( { name } ) => name ).join( ',' ),
@@ -329,6 +338,12 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 
 	const onContinueClick = () => {
 		trackEventContinue();
+
+		if ( shouldLimitGlobalStyles && selectedVariations.length > 0 ) {
+			openGlobalStylesUpgradeModal();
+			return;
+		}
+
 		onSubmit();
 	};
 
@@ -341,10 +356,7 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 			trackEventPatternAdd( 'section' );
 		}
 
-		recordTracksEvent( 'calypso_signup_pattern_assembler_main_item_select', {
-			...commonEventProps,
-			name,
-		} );
+		recordTracksEvent( 'calypso_signup_pattern_assembler_main_item_select', { name } );
 	};
 
 	const onAddSection = () => {
@@ -373,7 +385,11 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 			<NavigatorProvider className="pattern-assembler__sidebar" initialPath="/">
 				<NavigatorScreen path="/">
 					{ isEnabled( 'pattern-assembler/sidebar-revamp' ) ? (
-						<ScreenMain onSelect={ onMainItemSelect } onContinueClick={ onContinueClick } />
+						<ScreenMain
+							shouldUnlockGlobalStyles={ shouldUnlockGlobalStyles }
+							onSelect={ onMainItemSelect }
+							onContinueClick={ onContinueClick }
+						/>
 					) : (
 						<ScreenMainDeprecated
 							sections={ sections }
@@ -471,6 +487,7 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 				footer={ footer }
 				activePosition={ activePosition }
 			/>
+			<PremiumGlobalStylesUpgradeModal { ...globalStylesUpgradeModalProps } />
 		</div>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -82,7 +82,14 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 				color_style_slug: selectedColorPaletteVariation?.title,
 				font_style_slug: selectedFontPairingVariation?.title,
 			} ),
-		[ flow, stepName, intent ]
+		[
+			flow,
+			stepName,
+			intent,
+			stylesheet,
+			selectedColorPaletteVariation,
+			selectedFontPairingVariation,
+		]
 	);
 
 	const selectedVariations = useMemo(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -80,6 +80,7 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 				intent,
 				stylesheet,
 				color_style_slug: selectedColorPaletteVariation?.title,
+				font_style_slug: selectedFontPairingVariation?.title,
 			} ),
 		[ flow, stepName, intent ]
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -79,8 +79,8 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 				step: stepName,
 				intent,
 				stylesheet,
-				color_style_slug: selectedColorPaletteVariation?.title,
-				font_style_slug: selectedFontPairingVariation?.title,
+				color_style_title: selectedColorPaletteVariation?.title,
+				font_style_title: selectedFontPairingVariation?.title,
 			} ),
 		[
 			flow,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -90,7 +90,7 @@ const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Pr
 			</div>
 			<div className="screen-container__footer">
 				<Button className="pattern-assembler__button" onClick={ onContinueClick } primary>
-					{ shouldUnlockGlobalStyles ? translate( 'Unlock this design' ) : translate( 'Continue' ) }
+					{ shouldUnlockGlobalStyles ? translate( 'Unlock this style' ) : translate( 'Continue' ) }
 				</Button>
 			</div>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -10,11 +10,12 @@ import { NavigationButtonAsItem } from './navigator-buttons';
 import NavigatorHeader from './navigator-header';
 
 interface Props {
+	shouldUnlockGlobalStyles: boolean;
 	onSelect: ( name: string ) => void;
 	onContinueClick: () => void;
 }
 
-const ScreenMain = ( { onSelect, onContinueClick }: Props ) => {
+const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Props ) => {
 	const translate = useTranslate();
 
 	return (
@@ -89,7 +90,7 @@ const ScreenMain = ( { onSelect, onContinueClick }: Props ) => {
 			</div>
 			<div className="screen-container__footer">
 				<Button className="pattern-assembler__button" onClick={ onContinueClick } primary>
-					{ translate( 'Continue' ) }
+					{ shouldUnlockGlobalStyles ? translate( 'Unlock this design' ) : translate( 'Continue' ) }
 				</Button>
 			</div>
 		</>

--- a/client/lib/analytics/tracks.js
+++ b/client/lib/analytics/tracks.js
@@ -16,6 +16,14 @@ export function recordTracksEvent( eventName, eventProperties ) {
 	baseRecordTracksEvent( eventName, eventProperties );
 }
 
+export function createRecordTracksEvent( defaultProperties ) {
+	return ( eventName, eventProperties ) =>
+		recordTracksEvent( eventName, {
+			...defaultProperties,
+			...eventProperties,
+		} );
+}
+
 export function recordTracksPageView( urlPath, params ) {
 	baseRecordTracksPageView( urlPath, params );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71980

## Proposed Changes

* This PR is focusing on adding the global styles gating when you select any color variation. If you select any color variation on a free site, the text on the "Continue" button will become "Unlock this design". Click on that button, the upgrade modal will show.

![image](https://user-images.githubusercontent.com/13596067/222131904-d3b35019-0eb1-4c70-a3df-5d5fb838e43b.png)

https://user-images.githubusercontent.com/13596067/221129220-5ee78c96-73e2-491d-819d-19396cd950c0.mov

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/sidebar-revamp,pattern-assembler/color-and-fonts`
  * Note that the site should be the site with free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Click on "Change colors"
  * Select any color variation
  * Click on "Done" and go back to the main screen
  * Ensure the text on the "Continue" button becomes "Unlock this design"
  * Click on "Unlock this design", and ensure the upgrade modal shows
    * Click on "Try it out first", and you will land on the site editor
    * Click on "Upgrade plan", and you will land on the checkout page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
