### PR TITLE
Theme Showcase: Show upsell banner for free themes with style variations

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -384,10 +384,15 @@ class ThemeSheet extends Component {
 	}
 
 	hasSiteGlobalStyleUpsellBanner() {
-		const { isActive, shouldLimitGlobalStyles } = this.props;
+		const { shouldLimitGlobalStyles } = this.props;
 
-		// Show theme upsell banner on an active Free theme with global style gating.
-		return isActive && shouldLimitGlobalStyles;
+		// Show theme upsell banner on a Free theme with global style gating.
+		// Don't show if other upsell banners are displayed.
+		return (
+			! this.hasWpComThemeUpsellBanner() &&
+			! this.hasThemeUpsellBannerAtomic() &&
+			shouldLimitGlobalStyles
+		);
 	}
 
 	// Render "Open Live Demo" pseudo-button for mobiles.


### PR DESCRIPTION
## Proposed Changes

This PR updates the logic for the new upsell banner so that it's displayed in all free themes with style variations instead of just the active one. Note that precedence is given to other upsell banners, meaning that if another banner is set to be displayed, we won't display this new upsell banner. 

![Screenshot 2023-02-24 at 4 35 04 PM](https://user-images.githubusercontent.com/797888/221131098-357648d9-80a4-4d60-8814-1137a0b979d9.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Using a Free plan, select a theme with style variations, such as Bitácora.
* Ensure that the new upsell banner is shown.
* Then select a Premium theme with style variations, such as Varese.
* Ensure that the new upsell banner is not shown, due to being de-prioritized by another upsell banner. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
