### PR TITLE
SELFSERVE-341: Adds a note - blaze statistics are not in real time

### DIFF
--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -182,7 +182,7 @@ export default function CampaignItem( { campaign }: Props ) {
 					<Notice isDismissible={ false } className="campaign-item__notice" status="info">
 						<Gridicon className="campaign-item__notice-icon" icon="info-outline" />
 						{ translate(
-							'Statistics are not in real-time, there can be a short delay before they update.'
+							'Campaign statistics may be delayed by up to 3 hours.'
 						) }
 					</Notice>
 				</div>

--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -181,9 +181,7 @@ export default function CampaignItem( { campaign }: Props ) {
 				<div className="campaign-item__row">
 					<Notice isDismissible={ false } className="campaign-item__notice" status="info">
 						<Gridicon className="campaign-item__notice-icon" icon="info-outline" />
-						{ translate(
-							'Campaign statistics may be delayed by up to 3 hours.'
-						) }
+						{ translate( 'Campaign statistics may be delayed by up to 3 hours.' ) }
 					</Notice>
 				</div>
 				<div className="campaign-item__section campaign-item__stats">

--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -178,33 +178,14 @@ export default function CampaignItem( { campaign }: Props ) {
 				hideSummary={ true }
 				className="campaign-item__foldable-card"
 			>
-				{ campaignStatus === 'rejected' && moderation_reason && (
-					<Notice isDismissible={ false } className="campaign-item__notice" status="warning">
+				<div className="campaign-item__row">
+					<Notice isDismissible={ false } className="campaign-item__notice" status="info">
 						<Gridicon className="campaign-item__notice-icon" icon="info-outline" />
 						{ translate(
-							'Your ad was not approved, please review our {{wpcomTos}}WordPress.com Terms{{/wpcomTos}} and {{advertisingTos}}Advertising Policy{{/advertisingTos}}.',
-							{
-								components: {
-									wpcomTos: (
-										<a
-											href="https://wordpress.com/tos/"
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-									advertisingTos: (
-										<a
-											href="https://automattic.com/advertising-policy/"
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-								},
-							}
+							'Statistics are not in real-time, there can be a short delay before they update.'
 						) }
 					</Notice>
-				) }
-
+				</div>
 				<div className="campaign-item__section campaign-item__stats">
 					<div className="campaign-item__row campaign-item__stats-row1">
 						<div className="campaign-item__column campaign-item__reach">
@@ -309,6 +290,33 @@ export default function CampaignItem( { campaign }: Props ) {
 						</Button>
 					) }
 				</div>
+
+				{ campaignStatus === 'rejected' && moderation_reason && (
+					<Notice isDismissible={ false } className="campaign-item__notice" status="warning">
+						<Gridicon className="campaign-item__notice-icon" icon="info-outline" />
+						{ translate(
+							'Your ad was not approved, please review our {{wpcomTos}}WordPress.com Terms{{/wpcomTos}} and {{advertisingTos}}Advertising Policy{{/advertisingTos}}.',
+							{
+								components: {
+									wpcomTos: (
+										<a
+											href="https://wordpress.com/tos/"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+									advertisingTos: (
+										<a
+											href="https://automattic.com/advertising-policy/"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
+						) }
+					</Notice>
+				) }
 			</FoldableCard>
 		</>
 	);

--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -55,11 +55,11 @@ export default function CampaignItem( { campaign }: Props ) {
 		display_name,
 	} = campaign;
 
-	const campaignStatus = useMemo( () => normalizeCampaignStatus( campaign ), [ campaign.status ] );
+	const campaignStatus = useMemo( () => normalizeCampaignStatus( campaign ), [ campaign ] );
 
 	const overallSpending = useMemo(
 		() => getCampaignOverallSpending( spent_budget_cents, budget_cents, start_date, end_date ),
-		[ spent_budget_cents, start_date, end_date ]
+		[ spent_budget_cents, budget_cents, start_date, end_date ]
 	);
 
 	const clickthroughRate = useMemo(
@@ -74,7 +74,7 @@ export default function CampaignItem( { campaign }: Props ) {
 
 	const { totalBudget, totalBudgetLeft, campaignDays } = useMemo(
 		() => getCampaignBudgetData( budget_cents, start_date, end_date, spent_budget_cents ),
-		[ budget_cents, spent_budget_cents ]
+		[ budget_cents, end_date, spent_budget_cents, start_date ]
 	);
 	const totalBudgetLeftString = `($${ formatCents( totalBudgetLeft || 0 ) } ${ __( 'left' ) })`;
 


### PR DESCRIPTION
SELFSERVE-341-jira-tumblr

## Proposed Changes

* Adds a message that Blaze statistics are not in real time.

This will help address some reports of confusion.   This message will help users understand this before reaching out to support.   We're separately looking to improve the accuracy of this data, but this notice will help us in the immediate term.

So they don't occupy the same space.  The rejected notice has been moved down.

## Testing Instructions


Pre-requisites
- You need to have ran a campaign using WP Blaze - any point in time is fine.
- You need to have a rejected campaign.
- If not please create one at `wordpress.com/advertising/your-site.co.uk` and ask for it to be rejected (either manually or creating an ad with a title like "Testing, please reject"

Testing: 
- [ ] Visit the campaigns page for one of your sites `wordpress.com/advertising/your-site.co.uk/campaigns`
- [ ] You should see the notice "Stats are not in real-time"

**Regular camapaign**
![Screenshot 2023-02-24 at 00 19 48](https://user-images.githubusercontent.com/6440498/221155599-138f92b5-2f82-48d9-879e-1eb508e1c3a8.png)

**Rejected campaign**
![Screenshot 2023-02-24 at 00 17 52](https://user-images.githubusercontent.com/6440498/221156128-85bbee91-dda5-422e-a6dd-54ccb3b6107f.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
