### PR TITLE
Upsells: Hide second upsell in /themes if fewer than 6 rows

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -28,7 +28,11 @@ const getGridColumns = ( gridContainerRef, minColumnWidth, margin ) => {
 	}
 	const containerWidth = container.offsetWidth;
 	const availableWidth = containerWidth - margin;
-	const columnsPerRow = Math.floor( availableWidth / ( minColumnWidth + margin ) );
+
+	// Changing from desktop to mobile view can cause the container width to be smaller than the
+	// minimum column width because it calculates before hiding the sidebar, which would result
+	// in a division by zero. In that case, we just assume that there's only one column.
+	const columnsPerRow = Math.floor( availableWidth / ( minColumnWidth + margin ) ) || 1;
 	return columnsPerRow;
 };
 
@@ -107,14 +111,6 @@ export const ThemesList = ( props ) => {
 			/>
 		);
 	}
-
-	// const showSecondUpsellNudge = () => {
-	// 	const minColumnWidth = 320; // minimum column width in pixels
-	// 	const margin = 32; // horizontal margin in pixels
-	// 	const columnsPerRow = getGridColumns( themesListRef, minColumnWidth, margin );
-	// 	// Show second upsell nudge at 7th row
-	// 	return columnsPerRow && props.themes.length >= columnsPerRow * 6;
-	// };
 
 	const SecondUpsellNudge = props.upsellBanner && (
 		<div className="second-upsell-wrapper">

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -6,6 +6,7 @@ import { WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { Icon, addTemplate, brush, cloudUpload } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { isEmpty, times } from 'lodash';
+import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { connect, useSelector } from 'react-redux';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
@@ -15,11 +16,13 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { upsellCardDisplayed as upsellCardDisplayedAction } from 'calypso/state/themes/actions';
+import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
 import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
+const noop = () => {};
 /* Used for second upsell nudge */
 const getGridColumns = ( gridContainerRef, minColumnWidth, margin ) => {
 	const container = gridContainerRef.current;
@@ -136,6 +139,49 @@ export const ThemesList = ( props ) => {
 			<InfiniteScroll nextPageMethod={ fetchNextPage } />
 		</div>
 	);
+};
+
+ThemesList.propTypes = {
+	themes: PropTypes.array.isRequired,
+	wpOrgThemes: PropTypes.array,
+	loading: PropTypes.bool.isRequired,
+	recordTracksEvent: PropTypes.func.isRequired,
+	fetchNextPage: PropTypes.func.isRequired,
+	getButtonOptions: PropTypes.func,
+	getScreenshotUrl: PropTypes.func,
+	onScreenshotClick: PropTypes.func.isRequired,
+	onStyleVariationClick: PropTypes.func,
+	onMoreButtonClick: PropTypes.func,
+	onMoreButtonItemClick: PropTypes.func,
+	getActionLabel: PropTypes.func,
+	isActive: PropTypes.func,
+	getPrice: PropTypes.func,
+	isInstalling: PropTypes.func,
+	// i18n function provided by localize()
+	translate: PropTypes.func,
+	placeholderCount: PropTypes.number,
+	bookmarkRef: PropTypes.oneOfType( [
+		PropTypes.func,
+		PropTypes.shape( { current: PropTypes.any } ),
+	] ),
+	siteId: PropTypes.number,
+	searchTerm: PropTypes.string,
+	upsellCardDisplayed: PropTypes.func,
+};
+
+ThemesList.defaultProps = {
+	loading: false,
+	searchTerm: '',
+	themes: [],
+	wpOrgThemes: [],
+	recordTracksEvent: noop,
+	fetchNextPage: noop,
+	placeholderCount: DEFAULT_THEME_QUERY.number,
+	optionsGenerator: () => [],
+	getActionLabel: () => '',
+	isActive: () => false,
+	getPrice: () => '',
+	isInstalling: () => false,
 };
 
 function ThemeBlock( props ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #73672

TODO

- [x] Check tests

## Proposed Changes

* Hide second upsell in /themes if fewer than 6 rows

https://user-images.githubusercontent.com/6586048/221195375-ca9cd1e4-edc1-47a2-865b-be5c0a06af0e.mp4


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /themes
* If less than 6 rows, second upsell nudge is not present
* If >= 6 rows, second upsell nudge is present

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
