### PR TITLE
BlazePress Widget: Update translatable strings v0.5.8

### DIFF
--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -21,6 +21,11 @@ const BlazePressStrings = () => {
 	translate( 'Ad destination' );
 	translate( 'Audience' );
 	translate( 'Budget & Duration' );
+	translate( 'Save' );
+	translate( 'Save selection' );
+	translate( 'Use post image' );
+	translate( 'Upload' );
+	translate( 'Use + / - or simply drag the image to adjust it' );
 	translate( 'Payment' );
 	translate( 'You won’t be charged until the ad is approved and starts running.' );
 	translate( 'You can pause spending at any time.' );
@@ -62,7 +67,6 @@ const BlazePressStrings = () => {
 	translate( 'Checking payment information' );
 	translate( 'Appearance' );
 	translate( 'Image' );
-	translate( 'Change' );
 	translate( 'Title' );
 	translate( '%(charactersLeft)s characters remaining' );
 	translate( 'Snippet' );
@@ -82,11 +86,11 @@ const BlazePressStrings = () => {
 	translate( 'Next' );
 	translate( 'Drop image here' );
 	translate( 'Click or Drag an image here' );
-	translate( 'Reset' );
-	translate( 'Save selection' );
-	translate( 'Crop ad image' );
 	translate( 'All fields marked as required' );
 	translate( 'must be completed to continue' );
+	translate( 'All' );
+	translate( 'Mobile devices' );
+	translate( 'Desktop devices' );
 };
 
 if ( window.BlazePress ) {


### PR DESCRIPTION
Related to 551-gh-Automattic/i18n-issues

## Proposed Changes

* Update `promote-post/string.ts` with strings from v0.5.8

![CleanShot 2023-02-24 at 16 39 31](https://user-images.githubusercontent.com/2722412/221206291-89c123ff-4591-4fe0-9722-15dc24fdc672.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
