### PR TITLE
Fix: Blaze modal mobile web scroll

### DIFF
--- a/client/components/blank-canvas/index.js
+++ b/client/components/blank-canvas/index.js
@@ -13,10 +13,10 @@ const BlankCanvas = ( { className, children } ) => {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		document.body.classList.add( 'has-blank-canvas' );
+		document.documentElement.classList.add( 'has-blank-canvas' );
 		dispatch( setLayoutFocus( 'content' ) );
 
-		return () => document.body.classList.remove( 'has-blank-canvas' );
+		return () => document.documentElement.classList.remove( 'has-blank-canvas' );
 	}, [] );
 
 	return ReactDOM.createPortal(

--- a/client/components/blank-canvas/style.scss
+++ b/client/components/blank-canvas/style.scss
@@ -12,6 +12,7 @@
 	min-height: 100vh;
 	background: #fdfdfd;
 	overflow: hidden;
+	overscroll-behavior: contain;
 
 	// Hide masterbar behind.
 	z-index: z-index("root", ".masterbar");

--- a/client/components/blank-canvas/style.scss
+++ b/client/components/blank-canvas/style.scss
@@ -153,7 +153,16 @@
 	}
 }
 
-.has-blank-canvas .layout {
-	max-height: 100vh;
-	overflow: hidden;
+.has-blank-canvas {
+	touch-action: none;
+	overscroll-behavior: none;
+	-webkit-overflow-scrolling: auto;
+
+	.layout {
+		max-height: 100vh;
+		overflow: hidden;
+		touch-action: none;
+		overscroll-behavior: none;
+		-webkit-overflow-scrolling: auto;
+	}
 }

--- a/client/components/blank-canvas/style.scss
+++ b/client/components/blank-canvas/style.scss
@@ -154,15 +154,10 @@
 }
 
 .has-blank-canvas {
-	touch-action: none;
 	overscroll-behavior: none;
-	-webkit-overflow-scrolling: auto;
-
-	.layout {
-		max-height: 100vh;
-		overflow: hidden;
-		touch-action: none;
-		overscroll-behavior: none;
-		-webkit-overflow-scrolling: auto;
-	}
+	touch-action: none;
+}
+.has-blank-canvas .layout {
+	max-height: 100vh;
+	overflow: hidden;
 }


### PR DESCRIPTION
This PR fixes the overscroll on mobile devices that we found while testing blaze. 

## Proposed Changes

* Contain the overscroll to the modal.
* Set the class on the HTML element vs the body so that we can disable the scroll. 


This is done so that we don't allow the "refresh" on overscroll (top) as well as the hiding of the blaze create form buttons on the bottom. 

before:
Top Overscroll
<img width="300" src="https://user-images.githubusercontent.com/115071/221236407-bf0c2a7e-ddfe-46a8-910f-32f06d86f74c.PNG" />

bottom overscroll.
<img width="300" src="https://user-images.githubusercontent.com/115071/221237142-9355d06c-01b1-4284-a72f-67e586cf8181.PNG" />


## Testing Instructions

Navigate to a blaze campain using the mobile web browser. Use the QR code in the live link. 
Notice that when you are in the create blaze mode that you are not able to overscroll any more. THis should be the case for all blank-canvas overlays.
> Tools > Advertising > Promote (button)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
