### PR TITLE
Offer Jetpack Complete: Add plan title and description

### DIFF
--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
@@ -69,7 +69,7 @@ const JetpackCompletePage: React.FC< Props > = ( {
 				>
 					<>
 						<ProductHeader item={ item } />
-						<PricingPageLink siteSlug={ ( siteSlug || urlQueryArgs?.site ) ?? '' } />
+						<PricingPageLink siteSlug={ siteSlug || urlQueryArgs?.site } />
 						<ItemsIncluded />
 						<ItemPrice item={ item } siteId={ siteId } />
 

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
@@ -21,7 +21,10 @@ import { QueryArgs, Duration } from '../types';
 import CtaButtons from './components/cta-buttons';
 import { ItemPrice } from './item-price';
 import ItemsIncluded from './items-included';
+import ProductHeader from './product-header';
 import ShowLicenseActivationLinkIfAvailable from './show-license-activation-link-if-available';
+import PricingPageLink from './view-all-products-link';
+
 import './style.scss';
 
 interface Props {
@@ -65,22 +68,8 @@ const JetpackCompletePage: React.FC< Props > = ( {
 					cardImage2xRetina={ rnaImageComplete2xRetina }
 				>
 					<>
-						{ /* This is just example/fill text here, that should be made into various components */ }
-						<h1
-							style={ {
-								fontSize: '36px',
-								lineHeight: '40px',
-								fontWeight: 700,
-								marginBottom: '16px',
-							} }
-						>
-							{ translate( 'Get Jetpack Complete' ) }
-						</h1>
-						<p style={ { fontSize: '20px', lineHeight: '30px', fontWeight: 500 } }>
-							The full Jetpack suite with real-time security, instant site search, ad-free video,
-							all CRM extensions, and extra storage for backups and video.
-						</p>
-
+						<ProductHeader item={ item } />
+						<PricingPageLink siteSlug={ ( siteSlug || urlQueryArgs?.site ) ?? '' } />
 						<ItemsIncluded />
 						<ItemPrice item={ item } siteId={ siteId } />
 

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/product-header/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/product-header/index.tsx
@@ -1,0 +1,30 @@
+import { useTranslate } from 'i18n-calypso';
+import * as React from 'react';
+import { preventWidows } from 'calypso/lib/formatting';
+import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
+
+import './style.scss';
+
+type Props = {
+	item: SelectorProduct | null;
+};
+
+const ProductHeader: React.FC< Props > = ( { item } ) => {
+	const translate = useTranslate();
+
+	if ( item && item?.displayName && item?.lightboxDescription ) {
+		return (
+			<div className="product-header">
+				<h1 className="product-header__heading">
+					{ translate( 'Get Jetpack %(productName)s', {
+						args: { productName: item.displayName },
+					} ) }
+				</h1>
+				<p className="product-header__sub-heading">{ preventWidows( item.lightboxDescription ) }</p>
+			</div>
+		);
+	}
+	return null;
+};
+
+export default ProductHeader;

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/product-header/style.scss
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/product-header/style.scss
@@ -1,0 +1,21 @@
+@import "@automattic/typography/styles/variables";
+
+.product-header {
+	font-family: "SF Pro Display", $sans;
+	color: var(--studio-black);
+	.product-header__heading {
+		font-family: inherit;
+		font-size: $font-headline-small;
+		line-height: 40px;
+		font-weight: 700;
+		margin-bottom: 16px;
+	}
+
+	.product-header__sub-heading {
+		font-family: inherit;
+		font-size: $font-title-small;
+		line-height: 30px;
+		font-weight: 500;
+		margin-bottom: 1rem;
+	}
+}

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/view-all-products-link/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/view-all-products-link/index.tsx
@@ -1,0 +1,26 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useTranslate } from 'i18n-calypso';
+
+import './style.scss';
+
+type Props = {
+	siteSlug?: string;
+};
+
+const ViewAllProductsLink: React.FC< Props > = ( { siteSlug } ) => {
+	const translate = useTranslate();
+
+	return (
+		<a
+			className="view-all-products-link"
+			onClick={ () => recordTracksEvent( 'calypso_view_individual_products_link_click' ) }
+			href={ `https://cloud.jetpack.com/pricing/${ siteSlug }` }
+			target="_blank"
+			rel="noreferrer"
+		>
+			{ translate( 'View individual products' ) }
+		</a>
+	);
+};
+
+export default ViewAllProductsLink;

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/view-all-products-link/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/view-all-products-link/index.tsx
@@ -15,8 +15,6 @@ const ViewAllProductsLink: React.FC< Props > = ( { siteSlug } ) => {
 			className="view-all-products-link"
 			onClick={ () => recordTracksEvent( 'calypso_view_individual_products_link_click' ) }
 			href={ `https://cloud.jetpack.com/pricing/${ siteSlug }` }
-			target="_blank"
-			rel="noreferrer"
 		>
 			{ translate( 'View individual products' ) }
 		</a>

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/view-all-products-link/style.scss
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/view-all-products-link/style.scss
@@ -1,0 +1,16 @@
+a.view-all-products-link {
+	display: inline-block;
+	margin-bottom: 40px;
+
+	font-family: "SF Pro Display", $sans;
+	font-size: $font-body;
+	font-weight: 600;
+	line-height: 24px;
+	color: var(--studio-black);
+	text-decoration: underline;
+
+	&:hover,
+	&:active {
+		text-decoration: none;
+	}
+}


### PR DESCRIPTION
This PR Adds the main heading (product title) and sub-heading (product description) to the Offer Jetpack Complete immediately project page.

Asana Task: 1203759331596262-as-1203791007934505/f
Project Thread: p1HpG7-jYo-p2
Figma Design: R1U6Ww74mdgMrKUJ21BnTL-fi-3061%3A11111

## Proposed Changes

- Added a new `<ProductHeader />' component (that displays the product title and product description).
- Added a new `PricingPageLink/>` component (that displays the "View individual products" link.

## Testing Instructions

* boot up this PR 
    * Run `git fetch && git checkout add/complete-plan-title-and-description`
    * Run `yarn start`
* OR use the Live Link provided below
* Create a new JN site
* Navigate to `wordpress.com/jetpack/connect/plans/complete/[JN Site]`.  If using the Live Link, please append `?flags=jetpack/offer-complete-after-activation` to the url.
* Verify the product title, description, and "View individual products" link is showing (Like the screenshots below).
* Verify fonts, color, spacing, etc matches the Figma design. Verify both desktop & mobile views. Compare with Figma designs.

## Screenshots:

**DESKTOP**

![Markup 2023-02-24 at 09 00 59](https://user-images.githubusercontent.com/11078128/221204124-c2f0d5c4-35b2-4fb7-9fd4-78086f424459.png)

.
**MOBILE**

![Markup 2023-02-24 at 09 18 50](https://user-images.githubusercontent.com/11078128/221204421-2e736bdd-0f30-420a-b37f-71e4f3743d86.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203791007934505