### PR TITLE
WIP Offer Complete E2E test

### DIFF
--- a/test/e2e/specs/jetpack/jetpack__connect-offer-complete.ts
+++ b/test/e2e/specs/jetpack/jetpack__connect-offer-complete.ts
@@ -1,0 +1,92 @@
+/**
+ * @group jetpack
+ */
+
+import {
+	BrowserManager,
+	// CartCheckoutPage,
+	DataHelper,
+	LoginPage,
+	TestAccount,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Jetpack Connect, offer Complete' ), function () {
+	let page: Page;
+	let testAccount: TestAccount;
+	//define calypso URL
+
+	//for prod
+	//const calypsoURL = DataHelper.getCalypsoURL();
+
+	//for dev
+	const calypsoUrl = 'http://calypso.localhost:3000/';
+	beforeAll( async function () {
+		// Launch a new browser window
+		page = await browser.newPage();
+
+		//temporary local url
+		await page.goto( calypsoUrl );
+
+		await page.locator( 'a:text-is("Log In to WordPress.com")' ).click();
+		// wait for navigation to complete
+		await page.waitForNavigation();
+		const loginPage = new LoginPage( page );
+		testAccount = new TestAccount( 'jetpackUser' );
+		await loginPage.logInWithCredentials(
+			testAccount.credentials.username,
+			testAccount.credentials.password
+		);
+	} );
+
+	describe( 'Navigate to complete offer page', function () {
+		beforeAll( async function () {
+			// Set the store cookie to simulate payment processing.
+			await BrowserManager.setStoreCookie( page );
+		} );
+
+		//navigate to http://calypso.localhost:3000/jetpack/connect/plans/complete/ (append the test user's site URL)
+		it( 'Navigate to get complete page', async function () {
+			//get url for test account's site
+			const siteUrl = () => {
+				const formattedSiteUrl = DataHelper.getAccountSiteURL( 'jetpackUser' ).replace(
+					/^https?:\/\//,
+					''
+				);
+				return formattedSiteUrl;
+			};
+
+			//append site url to complete page url
+			const completePageUrl = calypsoUrl + 'jetpack/connect/plans/complete/' + siteUrl();
+
+			await page.goto( completePageUrl );
+		} );
+		// it( 'is pausing', async () => {
+		// 	await new Promise( () =>
+		// 		setTimeout( () => {
+		// 			console.log( "Why don't I run?" );
+		// 			expect( true ).toBe( true );
+		// 		}, 15000 )
+		// 	);
+		// } );
+
+		it( 'clicks complete', async function () {
+			//click complete button
+			const completeBtn = page.locator( 'a:text-is("Get Complete")' );
+			await completeBtn.click();
+		} );
+
+		// this is purely for dev builds.  For staging/prod, use the cart checkout page and validateCartItem
+		it( 'Validate checkout items', async function () {
+			//wait for page load
+			const cartItem = await page
+				.locator( 'div.order-review-section > ul > li > div' )
+				.textContent();
+			expect( cartItem ).toContain( 'Jetpack Complete' );
+		} );
+
+		//todo: in production we'll need to test the actual purchase and thank you page redirect
+	} );
+} );

--- a/test/e2e/specs/jetpack/jetpack__connect-offer-complete.ts
+++ b/test/e2e/specs/jetpack/jetpack__connect-offer-complete.ts
@@ -4,7 +4,7 @@
 
 import {
 	BrowserManager,
-	// CartCheckoutPage,
+	CartCheckoutPage,
 	DataHelper,
 	LoginPage,
 	TestAccount,
@@ -13,63 +13,87 @@ import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
+//temporary testing block that can be used to stop execution between tests
+// it( 'is pausing', async () => {
+// 	await new Promise( () =>
+// 		setTimeout( () => {
+// 			console.log( "Why don't I run?" );
+// 			expect( true ).toBe( true );
+// 		}, 15000 )
+// 	);
+// } );
+
 describe( DataHelper.createSuiteTitle( 'Jetpack Connect, offer Complete' ), function () {
+	let cartCheckoutPage: CartCheckoutPage;
 	let page: Page;
 	let testAccount: TestAccount;
 	//define calypso URL
 
-	//for prod
-	//const calypsoURL = DataHelper.getCalypsoURL();
+	//temp feature flag
+	const featureFlag = '?flags=jetpack/offer-complete-after-activation';
 
-	//for dev
-	const calypsoUrl = 'http://calypso.localhost:3000/';
 	beforeAll( async function () {
 		// Launch a new browser window
 		page = await browser.newPage();
-
 		//temporary local url
-		await page.goto( calypsoUrl );
+	} );
 
-		await page.locator( 'a:text-is("Log In to WordPress.com")' ).click();
-		// wait for navigation to complete
-		await page.waitForNavigation();
+	it( 'login to Jetpack Connect page', async function () {
+		//it appears the test site set up by the helper is already connected to Jetpack, so for now
+		// this test navigates to the get complete page.  We will need to figure out how to get to an
+		// unconnected site.
+		const siteUrl = () => {
+			const formattedSiteUrl = DataHelper.getAccountSiteURL( 'jetpackUser' ).replace(
+				/^https?:\/\//,
+				''
+			);
+			return formattedSiteUrl;
+		};
+		//append site url to complete page url
+		const completePageUrl =
+			DataHelper.getCalypsoURL( '/jetpack/connect/plans/complete/' ) + siteUrl() + featureFlag;
+
+		await page.goto( completePageUrl );
+
+		// temporary testing function to pause execution at a given step
+		// await new Promise( () =>
+		// 	setTimeout( () => {
+		// 		console.log( "Why don't I run?" );
+		// 		expect( true ).toBe( true );
+		// 	}, 15000 )
+		// );
+
 		const loginPage = new LoginPage( page );
 		testAccount = new TestAccount( 'jetpackUser' );
+
 		await loginPage.logInWithCredentials(
 			testAccount.credentials.username,
 			testAccount.credentials.password
 		);
 	} );
 
+	//the first part of this test is duplicating what we have in the first part
 	describe( 'Navigate to complete offer page', function () {
 		beforeAll( async function () {
 			// Set the store cookie to simulate payment processing.
 			await BrowserManager.setStoreCookie( page );
 		} );
 
-		//navigate to http://calypso.localhost:3000/jetpack/connect/plans/complete/ (append the test user's site URL)
-		it( 'Navigate to get complete page', async function () {
-			//get url for test account's site
-			const siteUrl = () => {
-				const formattedSiteUrl = DataHelper.getAccountSiteURL( 'jetpackUser' ).replace(
-					/^https?:\/\//,
-					''
-				);
-				return formattedSiteUrl;
-			};
+		// This function probably will not be necessary as its own step, but leaving it for reference for now
+		// it( 'Navigate to get complete page', async function () {
+		// 	//get url for test account's site
+		// 	const siteUrl = () => {
+		// 		const formattedSiteUrl = DataHelper.getAccountSiteURL( 'jetpackUser' ).replace(
+		// 			/^https?:\/\//,
+		// 			''
+		// 		);
+		// 		return formattedSiteUrl;
+		// 	};
+		// 	//append site url to complete page url
+		// 	const completePageUrl =
+		// 		DataHelper.getCalypsoURL( '/jetpack/connect/plans/complete/' ) + siteUrl() + featureFlag;
 
-			//append site url to complete page url
-			const completePageUrl = calypsoUrl + 'jetpack/connect/plans/complete/' + siteUrl();
-
-			await page.goto( completePageUrl );
-		} );
-		// it( 'is pausing', async () => {
-		// 	await new Promise( () =>
-		// 		setTimeout( () => {
-		// 			console.log( "Why don't I run?" );
-		// 			expect( true ).toBe( true );
-		// 		}, 15000 )
-		// 	);
+		// 	await page.goto( completePageUrl );
 		// } );
 
 		it( 'clicks complete', async function () {
@@ -78,15 +102,22 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Connect, offer Complete' ), func
 			await completeBtn.click();
 		} );
 
-		// this is purely for dev builds.  For staging/prod, use the cart checkout page and validateCartItem
+		//validate Complete was added to the cart
 		it( 'Validate checkout items', async function () {
 			//wait for page load
-			const cartItem = await page
-				.locator( 'div.order-review-section > ul > li > div' )
-				.textContent();
-			expect( cartItem ).toContain( 'Jetpack Complete' );
+			cartCheckoutPage = new CartCheckoutPage( page );
+			// Validate that the cart contains the correct product
+			await cartCheckoutPage.validateCartItem( 'Jetpack Complete' );
 		} );
 
-		//todo: in production we'll need to test the actual purchase and thank you page redirect
+		// purchase Complete
+		it( 'Compelete the purchase', async function () {
+			await cartCheckoutPage.purchase( { timeout: 60 * 1000 } );
+
+			// wait for navigation to complete
+			await page.waitForNavigation();
+		} );
+
+		// another step is needed to verify whatever page one should land on after purchase
 	} );
 } );


### PR DESCRIPTION
This is an initial quick and dirty E2E test for the project Offer Jetpack complete after connection.

As the code for this hasn't been merged in, it uses hard variables to refer to the calypso.localhost environment.

## Proposed Changes

Checkout this PR and then run yarn start to fire up the local calypso environment.

run the test: yarn workspace wp-e2e-tests test -- test/e2e/specs/jetpack/jetpack__connect-offer-complete.ts

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
