### PR TITLE
Remove post dependency for BlazePress widget in the advertising section

### DIFF
--- a/client/data/promote-post/use-promote-params.ts
+++ b/client/data/promote-post/use-promote-params.ts
@@ -1,0 +1,31 @@
+import { useSelector } from 'react-redux';
+import { useRouteModal } from 'calypso/lib/route-modal';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+const blazePressWidgetKey = 'blazepress-widget';
+
+type UsePromoteParams = {
+	selectedSiteId: number;
+	selectedPostId: string;
+	isModalOpen: boolean;
+	keyValue: string;
+};
+
+const usePromoteParams = (): UsePromoteParams => {
+	const selectedSite = useSelector( getSelectedSite );
+	const selectedSiteId = selectedSite?.ID || 0;
+	const currentQuery = useSelector( getCurrentQueryArguments );
+	const keyValue = ( currentQuery && ( currentQuery[ blazePressWidgetKey ] as string ) ) || '';
+	const selectedPostId = keyValue?.split( '-' )[ 1 ];
+	const { isModalOpen } = useRouteModal( blazePressWidgetKey, keyValue );
+
+	return {
+		selectedSiteId,
+		selectedPostId,
+		isModalOpen,
+		keyValue,
+	};
+};
+
+export default usePromoteParams;

--- a/client/my-sites/promote-post/components/post-item/index.tsx
+++ b/client/my-sites/promote-post/components/post-item/index.tsx
@@ -5,7 +5,6 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import BlazePressWidget from 'calypso/components/blazepress-widget';
 import { recordDSPEntryPoint } from 'calypso/lib/promote-post';
 import resizeImageUrl from 'calypso/lib/resize-image-url';
 import { useRouteModal } from 'calypso/lib/route-modal';
@@ -37,7 +36,7 @@ export default function PostItem( { post }: Props ) {
 	const [ loading ] = useState( false );
 	const dispatch = useDispatch();
 	const keyValue = 'post-' + post.ID;
-	const { isModalOpen, value, openModal } = useRouteModal( 'blazepress-widget', keyValue );
+	const { openModal } = useRouteModal( 'blazepress-widget', keyValue );
 
 	const onClickPromote = async () => {
 		openModal();
@@ -83,12 +82,6 @@ export default function PostItem( { post }: Props ) {
 			) }
 
 			<div className="post-item__promote-link">
-				<BlazePressWidget
-					isVisible={ isModalOpen && value === keyValue }
-					siteId={ post.site_ID }
-					postId={ post.ID }
-					keyValue={ keyValue }
-				/>
 				<Button
 					isPrimary={ true }
 					isBusy={ loading }

--- a/client/my-sites/promote-post/components/posts-list/index.tsx
+++ b/client/my-sites/promote-post/components/posts-list/index.tsx
@@ -1,6 +1,8 @@
 import { translate } from 'i18n-calypso';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
+import BlazePressWidget from 'calypso/components/blazepress-widget';
 import EmptyContent from 'calypso/components/empty-content';
+import usePromoteParams from 'calypso/data/promote-post/use-promote-params';
 import PostItem, { Post } from 'calypso/my-sites/promote-post/components/post-item';
 import './style.scss';
 
@@ -10,6 +12,8 @@ interface Props {
 }
 
 export default function PostsList( { content, isLoading }: Props ) {
+	const { isModalOpen, selectedSiteId, selectedPostId, keyValue } = usePromoteParams();
+
 	const isEmpty = ! content || ! content.length;
 	return (
 		<>
@@ -34,6 +38,15 @@ export default function PostsList( { content, isLoading }: Props ) {
 						return <PostItem key={ post.ID } post={ post } />;
 					} ) }
 				</>
+			) }
+
+			{ selectedSiteId && selectedPostId && keyValue && (
+				<BlazePressWidget
+					isVisible={ isModalOpen }
+					siteId={ selectedSiteId }
+					postId={ selectedPostId }
+					keyValue={ keyValue }
+				/>
 			) }
 		</>
 	);


### PR DESCRIPTION
Related to #

The user is redirected to the advertising section when promoting a post (Blaze) from The Classic post list. In the advertising section. The widget will open only if the post entry is in the "Ready to Promote" list. This dependency comes because there are many pre-configured entries in the Widget as elements in the list.

This PR removes this dependency by creating just one BlazePress entry that is configured based on the query parameters, which are modified whenever the user clicks on the [PROMOTE] button or just when is being redirected from the classic view

## Proposed Changes

- Remove BlazePress widget generation per post in advertising section
- Create 1 general BlazePress widget wrapper that will receive the props required to display a post
- Create a hook handler to get the required data (use-promote-params)

## Testing Instructions
- Create a post, go to the advertising section, click on PROMOTE and grab the url generated
- You need the post not to show in the advertising section in "ready to blaze" list. This could be a bit tricky, so the best way to test is to remove this line in "posts-list/index.tsx" so the post list won't be rendered

<img width="758" alt="image" src="https://user-images.githubusercontent.com/43957544/221220721-30c64c1b-2108-4951-809c-2cddd1c04e8f.png">


- paste the url we generated initially
- the widget should normally open even if that post isn't rendered in any list


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
