### PR TITLE
Stats: Refactor the All-time highlights section layouts with ComponentSwapper

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import {
 	Card,
+	ComponentSwapper,
 	PercentCalculator as percentCalculator,
 	ShortenedNumber,
 	formattedNumber,
@@ -151,6 +152,124 @@ export default function AllTimeHighlightsSection( {
 	const isLatestPostReplaced = config.isEnabled( 'stats/latest-post-stats' );
 	const isMostPopularPostShow = config.isEnabled( 'stats/most-popular-post' );
 
+	const mobileCards = (
+		<div className="highlight-cards-mobile">
+			<h1 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h1>
+			<DotPager>
+				<Card className="highlight-card">
+					<div className="highlight-card-heading">{ translate( 'All-time stats' ) }</div>
+					<div className="highlight-card-info-item-list">
+						{ infoItems
+							.filter( ( i ) => ! i.hidden )
+							.map( ( info ) => {
+								return (
+									<div key={ info.id } className="highlight-card-info-item">
+										<Icon icon={ info.icon } />
+
+										<span className="highlight-card-info-item-title">{ info.title }</span>
+
+										<span
+											className="highlight-card-info-item-count"
+											title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
+										>
+											{ formattedNumber( info.count ) }
+										</span>
+									</div>
+								);
+							} ) }
+					</div>
+				</Card>
+
+				{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
+					return (
+						<Card key={ card.id } className="highlight-card">
+							<div className="highlight-card-heading">{ card.heading }</div>
+							<div className="highlight-card-detail-item-list">
+								{ card.items.map( ( item ) => {
+									return (
+										<div key={ item.id } className="highlight-card-detail-item">
+											<div className="highlight-card-detail-item-header">{ item.header }</div>
+
+											<div className="highlight-card-detail-item-content">{ item.content }</div>
+
+											<div className="highlight-card-detail-item-footer">{ item.footer }</div>
+										</div>
+									);
+								} ) }
+							</div>
+						</Card>
+					);
+				} ) }
+			</DotPager>
+
+			<div className="highlight-cards-list">
+				<LatestPostCard siteId={ siteId } siteSlug={ siteSlug } />
+			</div>
+		</div>
+	);
+
+	const highlightCards = (
+		<div className="highlight-cards">
+			<h1 className="highlight-cards-heading">{ translate( 'All-time highlights' ) }</h1>
+
+			<div className="highlight-cards-list">
+				<Card className="highlight-card">
+					<div className="highlight-card-heading">{ translate( 'All-time stats' ) }</div>
+					<div className="highlight-card-info-item-list">
+						{ infoItems
+							.filter( ( i ) => ! i.hidden )
+							.map( ( info ) => {
+								return (
+									<div key={ info.id } className="highlight-card-info-item">
+										<Icon icon={ info.icon } />
+
+										<span className="highlight-card-info-item-title">{ info.title }</span>
+
+										<span
+											className="highlight-card-info-item-count"
+											title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
+										>
+											{ formattedNumber( info.count ) }
+										</span>
+									</div>
+								);
+							} ) }
+					</div>
+				</Card>
+
+				{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
+					return (
+						<Card key={ card.id } className="highlight-card">
+							<div className="highlight-card-heading">{ card.heading }</div>
+							<div className="highlight-card-detail-item-list">
+								{ card.items.map( ( item ) => {
+									return (
+										<div key={ item.id } className="highlight-card-detail-item">
+											<div className="highlight-card-detail-item-header">{ item.header }</div>
+
+											<div className="highlight-card-detail-item-content">{ item.content }</div>
+
+											<div className="highlight-card-detail-item-footer">{ item.footer }</div>
+										</div>
+									);
+								} ) }
+							</div>
+						</Card>
+					);
+				} ) }
+			</div>
+
+			{ isLatestPostReplaced && (
+				<div className="highlight-cards-list">
+					<LatestPostCard siteId={ siteId } siteSlug={ siteSlug } />
+					{ isMostPopularPostShow && (
+						<MostPopularPostCard siteId={ siteId } siteSlug={ siteSlug } />
+					) }
+				</div>
+			) }
+		</div>
+	);
+
 	return (
 		<div className="stats__all-time-highlights-section">
 			{ siteId && (
@@ -165,119 +284,12 @@ export default function AllTimeHighlightsSection( {
 				</>
 			) }
 
-			<div className="stats__all-time-highlights-mobile">
-				<h1 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h1>
-				<DotPager>
-					<Card className="highlight-card">
-						<div className="highlight-card-heading">{ translate( 'All-time stats' ) }</div>
-						<div className="highlight-card-info-item-list">
-							{ infoItems
-								.filter( ( i ) => ! i.hidden )
-								.map( ( info ) => {
-									return (
-										<div key={ info.id } className="highlight-card-info-item">
-											<Icon icon={ info.icon } />
-
-											<span className="highlight-card-info-item-title">{ info.title }</span>
-
-											<span
-												className="highlight-card-info-item-count"
-												title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
-											>
-												{ formattedNumber( info.count ) }
-											</span>
-										</div>
-									);
-								} ) }
-						</div>
-					</Card>
-
-					{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
-						return (
-							<Card key={ card.id } className="highlight-card">
-								<div className="highlight-card-heading">{ card.heading }</div>
-								<div className="highlight-card-detail-item-list">
-									{ card.items.map( ( item ) => {
-										return (
-											<div key={ item.id } className="highlight-card-detail-item">
-												<div className="highlight-card-detail-item-header">{ item.header }</div>
-
-												<div className="highlight-card-detail-item-content">{ item.content }</div>
-
-												<div className="highlight-card-detail-item-footer">{ item.footer }</div>
-											</div>
-										);
-									} ) }
-								</div>
-							</Card>
-						);
-					} ) }
-				</DotPager>
-
-				<div className="highlight-cards-list">
-					<LatestPostCard siteId={ siteId } siteSlug={ siteSlug } />
-				</div>
-			</div>
-
-			<div className="highlight-cards">
-				<h1 className="highlight-cards-heading">{ translate( 'All-time highlights' ) }</h1>
-
-				<div className="highlight-cards-list">
-					<Card className="highlight-card">
-						<div className="highlight-card-heading">{ translate( 'All-time stats' ) }</div>
-						<div className="highlight-card-info-item-list">
-							{ infoItems
-								.filter( ( i ) => ! i.hidden )
-								.map( ( info ) => {
-									return (
-										<div key={ info.id } className="highlight-card-info-item">
-											<Icon icon={ info.icon } />
-
-											<span className="highlight-card-info-item-title">{ info.title }</span>
-
-											<span
-												className="highlight-card-info-item-count"
-												title={ Number.isFinite( info.count ) ? String( info.count ) : undefined }
-											>
-												{ formattedNumber( info.count ) }
-											</span>
-										</div>
-									);
-								} ) }
-						</div>
-					</Card>
-
-					{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
-						return (
-							<Card key={ card.id } className="highlight-card">
-								<div className="highlight-card-heading">{ card.heading }</div>
-								<div className="highlight-card-detail-item-list">
-									{ card.items.map( ( item ) => {
-										return (
-											<div key={ item.id } className="highlight-card-detail-item">
-												<div className="highlight-card-detail-item-header">{ item.header }</div>
-
-												<div className="highlight-card-detail-item-content">{ item.content }</div>
-
-												<div className="highlight-card-detail-item-footer">{ item.footer }</div>
-											</div>
-										);
-									} ) }
-								</div>
-							</Card>
-						);
-					} ) }
-				</div>
-
-				{ isLatestPostReplaced && (
-					<div className="highlight-cards-list">
-						<LatestPostCard siteId={ siteId } siteSlug={ siteSlug } />
-						{ isMostPopularPostShow && (
-							<MostPopularPostCard siteId={ siteId } siteSlug={ siteSlug } />
-						) }
-					</div>
-				) }
-			</div>
+			<ComponentSwapper
+				className="all-time-highlights-section__highlight-cards-swapper"
+				breakpoint="<660px"
+				breakpointActiveComponent={ mobileCards }
+				breakpointInactiveComponent={ highlightCards }
+			/>
 		</div>
 	);
 }

--- a/client/my-sites/stats/all-time-highlights-section/style.scss
+++ b/client/my-sites/stats/all-time-highlights-section/style.scss
@@ -1,48 +1,9 @@
 @import "@automattic/typography/styles/variables";
-@import "@wordpress/base-styles/breakpoints";
-
-$mobile-layout-breakpoint: $break-small;
 
 .stats__all-time-highlights-section {
 	.highlight-cards {
 		background-color: inherit;
 		box-shadow: none;
-
-		@media ( max-width: $mobile-layout-breakpoint ) {
-			display: none;
-		}
-	}
-
-	// Mobile layout
-	.stats__all-time-highlights-mobile {
-		display: none;
-		margin: 16px 0;
-
-		@media ( max-width: $mobile-layout-breakpoint ) {
-			display: block;
-		}
-
-		.highlight-cards-heading {
-			margin: 16px 16px 24px;
-		}
-
-		.dot-pager,
-		.highlight-cards-list {
-			padding: 24px;
-			border: 1px var(--color-border-subtle);
-			border-style: solid none;
-			background-color: var(--color-surface);
-		}
-
-		.card {
-			&.highlight-card,
-			&.post-stats-card {
-				padding: 0;
-				margin: 0;
-				box-shadow: none;
-				border: 0;
-			}
-		}
 	}
 
 	.highlight-cards-list {
@@ -140,5 +101,32 @@ $mobile-layout-breakpoint: $break-small;
 		line-height: 20px;
 		color: var(--color-neutral-60);
 		margin-top: 4px;
+	}
+
+	// Mobile layout
+	.highlight-cards-mobile {
+		margin: 16px 0;
+
+		.highlight-cards-heading {
+			margin: 16px 16px 24px;
+		}
+
+		.dot-pager,
+		.highlight-cards-list {
+			padding: 24px;
+			border: 1px var(--color-border-subtle);
+			border-style: solid none;
+			background-color: var(--color-surface);
+		}
+
+		.card {
+			&.highlight-card,
+			&.post-stats-card {
+				padding: 0;
+				margin: 0;
+				box-shadow: none;
+				border: 0;
+			}
+		}
 	}
 }

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -32,9 +32,12 @@ $sidebar-appearance-break-point: 783px;
 	}
 
 	// Ensures horizontal padding for all sections.
-	@media ( min-width: $custom-mobile-breakpoint ) {
-		> * {
-			padding: 0 max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
+	> * {
+		padding: 0 max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
+
+		@media ( max-width: $custom-mobile-breakpoint ) {
+			padding-left: 0;
+			padding-right: 0;
 		}
 	}
 

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -26,10 +26,10 @@ $lowestLevelColor: var(--color-neutral-5);
 
 .post-trends__heading,
 .post-trends__wrapper {
-	margin: 0 $mobile-container-margin;
+	margin: 0;
 
-	@media (min-width: 660px) {
-		margin: 0;
+	@media (max-width: $custom-mobile-breakpoint) {
+		margin: 0 $mobile-container-margin;
 	}
 }
 

--- a/packages/components/src/component-swapper/index.tsx
+++ b/packages/components/src/component-swapper/index.tsx
@@ -9,10 +9,10 @@ const ComponentSwapper = ( {
 	onSwap,
 	children,
 }: {
-	children: ReactChild[];
+	children?: ReactChild[];
 	breakpoint: string;
-	breakpointActiveComponent: React.Component;
-	breakpointInactiveComponent: React.Component;
+	breakpointActiveComponent: React.Component | React.ReactElement;
+	breakpointInactiveComponent: React.Component | React.ReactElement;
 	onSwap?: () => void;
 	className?: string;
 } ) => {

--- a/packages/components/src/post-stats-card/style.scss
+++ b/packages/components/src/post-stats-card/style.scss
@@ -2,6 +2,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/components/src/styles/mixins";
 @import "@automattic/components/src/styles/typography";
+@import "@automattic/components/src/highlight-cards/variables.scss";
 
 $card-padding: 24px;
 $border-radius: 5px; // stylelint-disable-line scales/radii
@@ -124,7 +125,7 @@ $break-wpcom-smallest: 320px;
 	}
 }
 
-@media ( max-width: $break-small ) {
+@media ( max-width: $custom-mobile-breakpoint ) {
 	.post-stats-card {
 		border-bottom: 1px solid var(--color-border-subtle);
 		border-radius: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72893

## Proposed Changes

* Swap PC and mobile elements with `ComponentSwapper` rather than showing and hiding via CSS.
* Modify the breakpoint of mobile to `max-width: 660px`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Calypso Live link.
* Navigate to the Stats `Insights` page.
* Ensure the `All-time highlights` section switching between PC and mobile layouts correctly for the breakpoint `660px`.

<img width="1272" alt="截圖 2023-02-24 下午11 46 01" src="https://user-images.githubusercontent.com/6869813/221222666-eb76139b-7b74-4762-8ad1-664b82df8079.png">

|Before at 600px|After at 660px|
|-|-|
|<img width="656" alt="截圖 2023-02-24 下午11 42 49" src="https://user-images.githubusercontent.com/6869813/221222014-b1a2af9e-170f-44be-ab15-e620fb96d6f2.png">|<img width="721" alt="截圖 2023-02-24 下午11 43 07" src="https://user-images.githubusercontent.com/6869813/221222082-43397a67-6eb1-49e3-b016-bdabc6f6f4ba.png">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
