### PR TITLE
Launchpad: Update choose domain task

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -12,7 +12,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import Checklist from './checklist';
-import { filterDomainUpsellTask, getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
+import { getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
 import { tasks } from './tasks';
 import { getLaunchpadTranslations } from './translations';
 import { Task } from './types';
@@ -63,7 +63,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 
 	const { flowName, title, launchTitle, subtitle } = getLaunchpadTranslations( flow );
 	const arrayOfFilteredTasks: Task[] | null = getArrayOfFilteredTasks( tasks, flow );
-	let enhancedTasks =
+	const enhancedTasks =
 		site &&
 		getEnhancedTasks(
 			arrayOfFilteredTasks,
@@ -77,8 +77,6 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 
 	const currentTask = getTasksProgress( enhancedTasks );
 	const launchTask = enhancedTasks?.find( ( task ) => task.isLaunchTask === true );
-
-	enhancedTasks = filterDomainUpsellTask( enhancedTasks, site );
 
 	const showLaunchTitle = launchTask && ! launchTask.disabled;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -314,12 +314,14 @@ export function getEnhancedTasks(
 					taskData = {
 						title: translate( 'Choose a domain' ),
 						completed: isPaidPlan,
-						disabled: isPaidPlan,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, isPaidPlan, task.id );
-							window.location.assign( `/domains/add/${ siteSlug }?domainAndPlanPackage=true` );
+							const destinationUrl = isPaidPlan
+								? `/domains/manage/${ siteSlug }`
+								: `/domains/add/${ siteSlug }?domainAndPlanPackage=true`;
+							window.location.assign( destinationUrl );
 						},
-						badgeText: translate( 'Upgrade plan' ),
+						badgeText: isPaidPlan ? '' : translate( 'Upgrade plan' ),
 					};
 					break;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -48,6 +48,8 @@ export function getEnhancedTasks(
 	const allowUpdateDesign =
 		flow && ( isFreeFlow( flow ) || isBuildFlow( flow ) || isWriteFlow( flow ) );
 
+	const isPaidPlan = ! site?.plan?.is_free;
+
 	const homePageId = site?.options?.page_on_front;
 	// send user to Home page editor, fallback to FSE if page id is not known
 	const launchpadUploadVideoLink = homePageId
@@ -311,8 +313,10 @@ export function getEnhancedTasks(
 				case 'domain_upsell':
 					taskData = {
 						title: translate( 'Choose a domain' ),
+						completed: isPaidPlan,
+						disabled: isPaidPlan,
 						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
+							recordTaskClickTracksEvent( flow, isPaidPlan, task.id );
 							window.location.assign( `/domains/add/${ siteSlug }?domainAndPlanPackage=true` );
 						},
 						badgeText: translate( 'Upgrade plan' ),
@@ -351,14 +355,4 @@ export function getArrayOfFilteredTasks( tasks: Task[], flow: string | null ) {
 			return accumulator;
 		}, [] as Task[] )
 	);
-}
-
-// Filter out the domain_upsell task from the enhanced task list when the user is not on a free plan anymore
-export function filterDomainUpsellTask( enhancedTasks: Task[] | null, site: SiteDetails | null ) {
-	if ( enhancedTasks && ! site?.plan?.is_free ) {
-		return enhancedTasks?.filter( ( task ) => {
-			return task.id !== 'domain_upsell';
-		} );
-	}
-	return enhancedTasks;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -120,7 +120,6 @@ export const tasks: Task[] = [
 
 const linkInBioTaskList = [
 	'design_selected',
-	'domain_upsell',
 	'setup_link_in_bio',
 	'plan_selected',
 	'links_added',
@@ -128,13 +127,7 @@ const linkInBioTaskList = [
 ];
 
 export const launchpadFlowTasks: LaunchpadFlowTaskList = {
-	newsletter: [
-		'setup_newsletter',
-		'plan_selected',
-		'subscribers_added',
-		'domain_upsell',
-		'first_post_published',
-	],
+	newsletter: [ 'setup_newsletter', 'plan_selected', 'subscribers_added', 'first_post_published' ],
 	[ LINK_IN_BIO_FLOW ]: linkInBioTaskList,
 	[ LINK_IN_BIO_TLD_FLOW ]: linkInBioTaskList,
 	free: [

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -1,9 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { filterDomainUpsellTask, getArrayOfFilteredTasks, getEnhancedTasks } from '../task-helper';
+import { getArrayOfFilteredTasks, getEnhancedTasks } from '../task-helper';
 import { tasks, launchpadFlowTasks } from '../tasks';
-import { buildTask, buildSiteDetails } from './lib/fixtures';
+import { buildTask } from './lib/fixtures';
 
 describe( 'Task Helpers', () => {
 	describe( 'getEnhancedTasks', () => {
@@ -91,43 +91,40 @@ describe( 'Task Helpers', () => {
 		} );
 	} );
 
-	describe( 'filterDomainUpsellTask', () => {
-		describe( 'when site plan is free', () => {
-			it( 'return original enchanceTasks', () => {
-				const task = buildTask( {
-					id: 'domain_upsell',
-					completed: false,
-					disabled: true,
-					taskType: 'blog',
-					title: 'domain upsell task',
-				} );
-				const tasks = [ task ];
-				const site = buildSiteDetails( { plan: { is_free: true } } );
-				// domain_upsell is still in the array
+	describe( 'domain upsell task', () => {
+		describe( 'when flow is newsletter', () => {
+			it( 'does not include upsell task', () => {
 				expect(
-					filterDomainUpsellTask( tasks, site )?.findIndex(
-						( task ) => ( task.id = 'domain_upsell' )
-					)
+					launchpadFlowTasks[ 'newsletter' ].filter( ( task ) => task === 'domain_upsell' ).length
 				).toBe( 0 );
 			} );
 		} );
-		describe( 'when site plan is not free', () => {
-			it( 'filters out the domain_upsell task', () => {
-				const task = buildTask( {
-					id: 'domain_upsell',
-					completed: false,
-					disabled: true,
-					taskType: 'blog',
-					title: 'domain upsell task',
-				} );
-				const tasks = [ task ];
-				const site = buildSiteDetails( { plan: { is_free: false } } );
-				// domain_upsell is NOT in the array
+		describe( 'when flow is link-in-bio', () => {
+			it( 'does not include upsell task', () => {
 				expect(
-					filterDomainUpsellTask( tasks, site )?.findIndex(
-						( task ) => ( task.id = 'domain_upsell' )
-					)
-				).toBe( -1 );
+					launchpadFlowTasks[ 'link-in-bio' ].filter( ( task ) => task === 'domain_upsell' ).length
+				).toBe( 0 );
+			} );
+		} );
+		describe( 'when flow is write', () => {
+			it( 'does not include upsell task', () => {
+				expect(
+					launchpadFlowTasks[ 'write' ].filter( ( task ) => task === 'domain_upsell' ).length
+				).toBe( 1 );
+			} );
+		} );
+		describe( 'when flow is build', () => {
+			it( 'does not include upsell task', () => {
+				expect(
+					launchpadFlowTasks[ 'build' ].filter( ( task ) => task === 'domain_upsell' ).length
+				).toBe( 1 );
+			} );
+		} );
+		describe( 'when flow is free', () => {
+			it( 'does not include upsell task', () => {
+				expect(
+					launchpadFlowTasks[ 'free' ].filter( ( task ) => task === 'domain_upsell' ).length
+				).toBe( 1 );
 			} );
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -107,21 +107,21 @@ describe( 'Task Helpers', () => {
 			} );
 		} );
 		describe( 'when flow is write', () => {
-			it( 'does not include upsell task', () => {
+			it( 'does include upsell task', () => {
 				expect(
 					launchpadFlowTasks[ 'write' ].filter( ( task ) => task === 'domain_upsell' ).length
 				).toBe( 1 );
 			} );
 		} );
 		describe( 'when flow is build', () => {
-			it( 'does not include upsell task', () => {
+			it( 'does include upsell task', () => {
 				expect(
 					launchpadFlowTasks[ 'build' ].filter( ( task ) => task === 'domain_upsell' ).length
 				).toBe( 1 );
 			} );
 		} );
 		describe( 'when flow is free', () => {
-			it( 'does not include upsell task', () => {
+			it( 'does include upsell task', () => {
 				expect(
 					launchpadFlowTasks[ 'free' ].filter( ( task ) => task === 'domain_upsell' ).length
 				).toBe( 1 );


### PR DESCRIPTION
### Proposed Changes

This PR adjusts the behavior of the Choose Domain task. 
  - The task will now always show for flows that have this task (we no longer filter it out)
  - This task will no longer show for link in bio or newsletter tasks (these already have a Choose Plan task)
  - If a user is on a free plan, the task will be incomplete, enabled, and link to the add domain screen
  - If a user is on a paid plan, the task will be complete but STILL enabled, and link to domain management screen
  - If a user is on a paid plan, the Upgrade badge will no longer show
 
This is a frontend-only alternative to [this PR](https://github.com/Automattic/wp-calypso/pull/73698), but with a few additional adjustments based on feedback.
  
### GIFs
![2023-02-24 10 21 54](https://user-images.githubusercontent.com/5414230/221260559-9f6da7f2-5b93-424c-bb6a-b2984fe048b9.gif)

### Testing

**Review Time: Short to Medium**
**Testing Time: Medium (easy, but just many flows)**

1. Checkout this branch and run yarn or yarn start if needed.

2. TEST NEWSLETTER FLOW: Start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro, go through to Launchpad, and confirm the Choose Domain task no longer shows. 

3. TEST LINK IN BIO FLOW: Start a link in bio site at http://calypso.localhost:3000/setup/link-in-bio/intro, go through to Launchpad, and confirm the Choose Domain task no longer shows. 

4. TEST FREE FLOW. Start a free site at http://calypso.localhost:3000/setup/free/intro. Go through to Launchpad. Confirm task shows, and confirm clicking it takes you to screen to add a domain. Add domain/plan, return to domain, return to launchpad, and confirm task a) is complete b) no longer shows upgrade badge and c) clicking it takes you to domain management screen. 

5. TEST BUILD AND/OR WRITE FLOW. Start a write/build site at http://calypso.localhost:3000/start. Choose free plan/domain, and chose build or write flow from Goals page. Go through to Launchpad. Confirm task shows, and confirm clicking it takes you to screen to add a domain. Add domain/plan, return to domain, return to launchpad, and confirm task a) is complete b) no longer shows upgrade badge and c) clicking it takes you to domain management screen. 

6. CONFIRM TESTS PASS. Confirm Launchpad tests pass by running `yarn run test-client client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/`. 
