### PR TITLE
Allow undefined plugin objects on the ES mapping method

### DIFF
--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -41,29 +41,28 @@ const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 	}
 	return results.map( ( { fields: hit, railcar } ) => {
 		const plugin: Plugin = {
-			name: hit.plugin.title, // TODO: add localization
+			name: hit.plugin?.title, // TODO: add localization
 			slug: hit.slug,
 			version: hit[ 'plugin.stable_tag' ],
 			author: hit.author,
-			author_name: hit.plugin.author,
+			author_name: hit.plugin?.author,
 			author_profile: '', // TODO: get author profile URL
 			tested: hit[ 'plugin.tested' ],
-			rating: mapStarRatingToPercent( hit.plugin.rating ),
-			num_ratings: hit.plugin.num_ratings,
+			rating: mapStarRatingToPercent( hit.plugin?.rating ),
+			num_ratings: hit.plugin?.num_ratings,
 			support_threads: hit[ 'plugin.support_threads' ],
 			support_threads_resolved: hit[ 'plugin.support_threads_resolved' ],
-			active_installs: hit.plugin.active_installs,
+			active_installs: hit.plugin?.active_installs,
 			last_updated: hit.modified,
-			short_description: hit.plugin.excerpt, // TODO: add localization
-			icon: getIconUrl( hit.slug, hit.plugin.icons ),
-			premium_slug: hit.plugin.premium_slug,
+			short_description: hit.plugin?.excerpt, // TODO: add localization
+			icon: getIconUrl( hit.slug, hit.plugin?.icons ),
+			premium_slug: hit.plugin?.premium_slug,
 			variations: {
-				monthly: { product_id: hit.plugin.store_product_monthly_id },
-				yearly: { product_id: hit.plugin.store_product_yearly_id },
+				monthly: { product_id: hit.plugin?.store_product_monthly_id },
+				yearly: { product_id: hit.plugin?.store_product_yearly_id },
 			},
 			railcar,
 		};
-
 		plugin.variations = getPreinstalledPremiumPluginsVariations( plugin );
 
 		return plugin;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #73668 

## Proposed Changes

Allow `undefined` plugin objects to avoid js errors on runtime when mapping ES objects.


## Testing Instructions

* On the live version
* Go to a plugin details page of a plugin without premium equivalent. Ex: `/plugins/gutenberg` or `/plugins/contact-form-7`
* Check if you can see the error below


![Screenshot 2023-02-21 at 14 32 59](https://user-images.githubusercontent.com/8436925/220346075-9a930479-3a7a-4f9d-821a-21c1d6e1d53b.png)
![Screenshot 2023-02-21 at 14 33 12](https://user-images.githubusercontent.com/8436925/220346079-55e41db9-87e4-4b05-bfcd-000602dbf7b0.png)

* Go to this branch version
* You shouldn't see the error above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
