### PR TITLE
Revert "Purchase Management: Add correct status information when owner removed from site"

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -98,27 +98,7 @@ class PurchaseItem extends Component {
 			if ( isJetpack ) {
 				return (
 					<span className="purchase-item__is-error">
-						{ translate(
-							'You no longer have access to this site. {{button}}Contact support{{/button}}',
-							{
-								args: {
-									site: name,
-								},
-								components: {
-									button: (
-										<button
-											className="purchase-item__link purchase-item__link--error"
-											onClick={ ( event ) => {
-												event.stopPropagation();
-												event.preventDefault();
-												page( CALYPSO_CONTACT );
-											} }
-											title={ translate( 'Contact Support' ) }
-										/>
-									),
-								},
-							}
-						) }
+						{ translate( 'Disconnected from WordPress.com' ) }
 					</span>
 				);
 			}


### PR DESCRIPTION
Reverts Automattic/wp-calypso#72696

Related issue: Issue: https://github.com/Automattic/payments-shilling/issues/1405