### PR TITLE
Launchpad: Stop duplicate calypso_signup_start call for newsletter flow

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -6,7 +6,11 @@ import {
 	is2023PricingGridActivePage,
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
-import { isNewsletterOrLinkInBioFlow, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
+import {
+	isNewsletterOrLinkInBioFlow,
+	isNewsletterFlow,
+	LINK_IN_BIO_TLD_FLOW,
+} from '@automattic/onboarding';
 import debugModule from 'debug';
 import {
 	clone,
@@ -255,7 +259,11 @@ class Signup extends Component {
 		debug( 'Signup component mounted' );
 		this.props.flowName === 'onboarding' && ! this.props.isLoggedIn && addHotJarScript();
 		this.startTrackingForBusinessSite();
-		recordSignupStart( this.props.flowName, this.props.refParameter, this.getRecordProps() );
+
+		if ( ! isNewsletterFlow( this.props.flowName ) ) {
+			recordSignupStart( this.props.flowName, this.props.refParameter, this.getRecordProps() );
+		}
+
 		if ( ! this.state.shouldShowLoadingScreen ) {
 			recordSignupStep( this.props.flowName, this.props.stepName, this.getRecordProps() );
 		}

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -27,6 +27,12 @@ export const isLinkInBioFlow = ( flowName: string | null ) => {
 	);
 };
 
+export const isNewsletterFlow = ( flowName: string | null ) => {
+	return Boolean(
+		flowName && [ NEWSLETTER_FLOW, NEWSLETTER_POST_SETUP_FLOW ].includes( flowName )
+	);
+};
+
 export const isFreeFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ FREE_FLOW, FREE_POST_SETUP_FLOW ].includes( flowName ) );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/72252#issuecomment-1442500812

## Proposed Changes

* Prevent the calypso_signup_start tracks event from being called twice in the newsletter flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch and run yarn and yarn start if needed. 
2. Clear tracks events from tracks vigilante or from your dev console. 
3. Go to http://calypso.localhost:3000/setup/newsletter/intro and confirm calypso_signup_start fires. Go through other steps of flow to launchpad, and confirm calypso_signup_start does not fire again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
