### PR TITLE
Add Akismet checkout routes, allow for site-less cart

### DIFF
--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -14,7 +14,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import CheckoutMain from './composite-checkout/components/checkout-main';
 import PrePurchaseNotices from './composite-checkout/components/prepurchase-notices';
-import type { CheckoutType } from '@automattic/composite-checkout';
+import type { SitelessCheckoutType } from '@automattic/composite-checkout';
 
 const logCheckoutError = ( error: Error ) => {
 	logToLogstash( {
@@ -40,7 +40,7 @@ export default function CheckoutMainWrapper( {
 	plan,
 	selectedSite,
 	redirectTo,
-	checkoutType,
+	sitelessCheckoutType,
 	isLoggedOutCart,
 	isNoSiteCart,
 	isGiftPurchase,
@@ -57,7 +57,7 @@ export default function CheckoutMainWrapper( {
 	plan?: string;
 	selectedSite?: { slug?: string };
 	redirectTo?: string;
-	checkoutType: CheckoutType;
+	sitelessCheckoutType: SitelessCheckoutType;
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
 	isGiftPurchase?: boolean;
@@ -118,7 +118,7 @@ export default function CheckoutMainWrapper( {
 							plan={ plan }
 							isComingFromUpsell={ isComingFromUpsell }
 							infoMessage={ prepurchaseNotices }
-							checkoutType={ checkoutType }
+							sitelessCheckoutType={ sitelessCheckoutType }
 							isLoggedOutCart={ isLoggedOutCart }
 							isNoSiteCart={ isNoSiteCart }
 							isGiftPurchase={ isGiftPurchase }

--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -14,6 +14,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import CheckoutMain from './composite-checkout/components/checkout-main';
 import PrePurchaseNotices from './composite-checkout/components/prepurchase-notices';
+import type { CheckoutType } from '@automattic/composite-checkout';
 
 const logCheckoutError = ( error: Error ) => {
 	logToLogstash( {
@@ -39,10 +40,9 @@ export default function CheckoutMainWrapper( {
 	plan,
 	selectedSite,
 	redirectTo,
-	isAkismetSitelessCheckout,
+	checkoutType,
 	isLoggedOutCart,
 	isNoSiteCart,
-	isJetpackCheckout,
 	isGiftPurchase,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
@@ -57,10 +57,9 @@ export default function CheckoutMainWrapper( {
 	plan?: string;
 	selectedSite?: { slug?: string };
 	redirectTo?: string;
-	isAkismetSitelessCheckout?: boolean;
+	checkoutType: CheckoutType;
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
-	isJetpackCheckout?: boolean;
 	isGiftPurchase?: boolean;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
@@ -119,10 +118,9 @@ export default function CheckoutMainWrapper( {
 							plan={ plan }
 							isComingFromUpsell={ isComingFromUpsell }
 							infoMessage={ prepurchaseNotices }
-							isAkismetSitelessCheckout={ isAkismetSitelessCheckout }
+							checkoutType={ checkoutType }
 							isLoggedOutCart={ isLoggedOutCart }
 							isNoSiteCart={ isNoSiteCart }
-							isJetpackCheckout={ isJetpackCheckout }
 							isGiftPurchase={ isGiftPurchase }
 							jetpackSiteSlug={ jetpackSiteSlug }
 							jetpackPurchaseToken={ jetpackPurchaseToken }

--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -39,6 +39,7 @@ export default function CheckoutMainWrapper( {
 	plan,
 	selectedSite,
 	redirectTo,
+	isAkismetSitelessCheckout,
 	isLoggedOutCart,
 	isNoSiteCart,
 	isJetpackCheckout,
@@ -56,6 +57,7 @@ export default function CheckoutMainWrapper( {
 	plan?: string;
 	selectedSite?: { slug?: string };
 	redirectTo?: string;
+	isAkismetSitelessCheckout?: boolean;
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
 	isJetpackCheckout?: boolean;
@@ -117,6 +119,7 @@ export default function CheckoutMainWrapper( {
 							plan={ plan }
 							isComingFromUpsell={ isComingFromUpsell }
 							infoMessage={ prepurchaseNotices }
+							isAkismetSitelessCheckout={ isAkismetSitelessCheckout }
 							isLoggedOutCart={ isLoggedOutCart }
 							isNoSiteCart={ isNoSiteCart }
 							isJetpackCheckout={ isJetpackCheckout }

--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -14,7 +14,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import CheckoutMain from './composite-checkout/components/checkout-main';
 import PrePurchaseNotices from './composite-checkout/components/prepurchase-notices';
-import type { SitelessCheckoutType } from '@automattic/composite-checkout';
+import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
 
 const logCheckoutError = ( error: Error ) => {
 	logToLogstash( {

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -95,7 +95,6 @@ export default function CheckoutMain( {
 	disabledThankYouPage,
 	sitelessCheckoutType,
 	jetpackSiteSlug,
-	akismetSiteSlug,
 	jetpackPurchaseToken,
 	isUserComingFromLoginForm,
 	customizedPreviousPath,
@@ -124,7 +123,6 @@ export default function CheckoutMain( {
 	disabledThankYouPage?: boolean;
 	sitelessCheckoutType?: SitelessCheckoutType;
 	jetpackSiteSlug?: string;
-	akismetSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 	isUserComingFromLoginForm?: boolean;
 	customizedPreviousPath?: string;
@@ -140,20 +138,16 @@ export default function CheckoutMain( {
 	const isSiteless = sitelessCheckoutType === 'jetpack' || sitelessCheckoutType === 'akismet';
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
 	const createUserAndSiteBeforeTransaction =
-		Boolean( isLoggedOutCart || isNoSiteCart ) &&
-		sitelessCheckoutType !== 'akismet' &&
-		sitelessCheckoutType !== 'jetpack';
+		Boolean( isLoggedOutCart || isNoSiteCart ) && ! isSiteless;
 	const reduxDispatch = useDispatch();
 
-	const updatedSiteSlug = useCallback( () => {
+	const updatedSiteSlug = useMemo( () => {
 		if ( sitelessCheckoutType === 'jetpack' ) {
 			return jetpackSiteSlug;
 		}
-		if ( sitelessCheckoutType === 'akismet' ) {
-			return akismetSiteSlug;
-		}
+
 		return siteSlug;
-	}, [ akismetSiteSlug, jetpackSiteSlug, sitelessCheckoutType, siteSlug ] );
+	}, [ jetpackSiteSlug, sitelessCheckoutType, siteSlug ] );
 
 	const showErrorMessageBriefly = useCallback(
 		( error ) => {
@@ -188,7 +182,7 @@ export default function CheckoutMain( {
 		isInModal,
 		usesJetpackProducts: isJetpackNotAtomic,
 		isPrivate,
-		siteSlug: updatedSiteSlug(),
+		siteSlug: updatedSiteSlug,
 		sitelessCheckoutType,
 		isLoggedOutCart,
 		isNoSiteCart,
@@ -241,7 +235,7 @@ export default function CheckoutMain( {
 	// post-checkout page decided by `getThankYouUrl` and therefore must be
 	// passed the post-checkout URL before the transaction begins.
 	const getThankYouUrlBase = useGetThankYouUrl( {
-		siteSlug: updatedSiteSlug(),
+		siteSlug: updatedSiteSlug,
 		redirectTo,
 		purchaseId,
 		feature,
@@ -318,7 +312,7 @@ export default function CheckoutMain( {
 
 	const { isRemovingProductFromCart, removeProductFromCartAndMaybeRedirect } =
 		useRemoveFromCartAndRedirect(
-			updatedSiteSlug(),
+			updatedSiteSlug,
 			createUserAndSiteBeforeTransaction,
 			customizedPreviousPath
 		);
@@ -345,7 +339,7 @@ export default function CheckoutMain( {
 		stripeConfiguration,
 		stripe,
 		storedCards,
-		siteSlug: updatedSiteSlug(),
+		siteSlug: updatedSiteSlug,
 	} );
 	debug( 'created payment method objects', paymentMethodObjects );
 
@@ -379,7 +373,7 @@ export default function CheckoutMain( {
 	const { analyticsPath, analyticsProps } = getAnalyticsPath(
 		purchaseId,
 		productAliasFromUrl,
-		updatedSiteSlug(),
+		updatedSiteSlug,
 		feature,
 		plan,
 		sitelessCheckoutType,
@@ -431,7 +425,7 @@ export default function CheckoutMain( {
 			reduxDispatch,
 			responseCart,
 			siteId: updatedSiteId,
-			siteSlug: updatedSiteSlug(),
+			siteSlug: updatedSiteSlug,
 			stripeConfiguration,
 			stripe,
 			recaptchaClientId,
@@ -575,7 +569,7 @@ export default function CheckoutMain( {
 		isInModal,
 		isComingFromUpsell,
 		disabledThankYouPage,
-		siteSlug: updatedSiteSlug(),
+		siteSlug: updatedSiteSlug,
 		sitelessCheckoutType,
 		checkoutFlow,
 	} );
@@ -735,7 +729,7 @@ export default function CheckoutMain( {
 					removeProductFromCart={ removeProductFromCartAndMaybeRedirect }
 					showErrorMessageBriefly={ showErrorMessageBriefly }
 					siteId={ updatedSiteId }
-					siteUrl={ updatedSiteSlug() }
+					siteUrl={ updatedSiteSlug }
 				/>
 			</CheckoutProvider>
 		</Fragment>

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -148,6 +148,9 @@ export default function CheckoutMain( {
 			return jetpackSiteSlug;
 		}
 
+		// Currently, the `akismetSiteSlug` prop is not being passed to this component anywhere
+		// We are not doing any site specific things with akismet checkout, so this should always be undefined for now
+		// If this was not here to return `undefined`, the akismet routes would get messed with due to `siteSlug` returning "no-user" in akismet siteless checkout
 		if ( sitelessCheckoutType === 'akismet' ) {
 			return akismetSiteSlug;
 		}

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -59,12 +59,13 @@ import { StoredCard } from '../types/stored-cards';
 import WPCheckout from './wp-checkout';
 import type { WpcomCheckoutStoreSelectors as _WpcomCheckoutStoreSelectors } from '../hooks/wpcom-store';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
-import type {
-	CheckoutPageErrorCallback,
-	SitelessCheckoutType,
-} from '@automattic/composite-checkout';
+import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import type { CountryListItem, CheckoutPaymentMethodSlug } from '@automattic/wpcom-checkout';
+import type {
+	CountryListItem,
+	CheckoutPaymentMethodSlug,
+	SitelessCheckoutType,
+} from '@automattic/wpcom-checkout';
 
 type WpcomCheckoutStoreSelectors = _WpcomCheckoutStoreSelectors | undefined;
 

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -59,7 +59,10 @@ import { StoredCard } from '../types/stored-cards';
 import WPCheckout from './wp-checkout';
 import type { WpcomCheckoutStoreSelectors as _WpcomCheckoutStoreSelectors } from '../hooks/wpcom-store';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
-import type { CheckoutPageErrorCallback, CheckoutType } from '@automattic/composite-checkout';
+import type {
+	CheckoutPageErrorCallback,
+	SitelessCheckoutType,
+} from '@automattic/composite-checkout';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { CountryListItem, CheckoutPaymentMethodSlug } from '@automattic/wpcom-checkout';
 
@@ -89,7 +92,7 @@ export default function CheckoutMain( {
 	isInModal,
 	onAfterPaymentComplete,
 	disabledThankYouPage,
-	checkoutType,
+	sitelessCheckoutType,
 	jetpackSiteSlug,
 	akismetSiteSlug,
 	jetpackPurchaseToken,
@@ -118,7 +121,7 @@ export default function CheckoutMain( {
 	// `getThankYouUrl`.
 	onAfterPaymentComplete?: () => void;
 	disabledThankYouPage?: boolean;
-	checkoutType?: CheckoutType;
+	sitelessCheckoutType?: SitelessCheckoutType;
 	jetpackSiteSlug?: string;
 	akismetSiteSlug?: string;
 	jetpackPurchaseToken?: string;
@@ -131,25 +134,25 @@ export default function CheckoutMain( {
 	const isJetpackNotAtomic =
 		useSelector( ( state ) => {
 			return siteId && isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId );
-		} ) || checkoutType === 'jetpack';
+		} ) || sitelessCheckoutType === 'jetpack';
 	const isPrivate = useSelector( ( state ) => siteId && isPrivateSite( state, siteId ) ) || false;
-	const isSiteless = checkoutType === 'jetpack' || checkoutType === 'akismet';
+	const isSiteless = sitelessCheckoutType === 'jetpack' || sitelessCheckoutType === 'akismet';
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
 	const createUserAndSiteBeforeTransaction =
 		Boolean( isLoggedOutCart || isNoSiteCart ) &&
-		checkoutType !== 'akismet' &&
-		checkoutType !== 'jetpack';
+		sitelessCheckoutType !== 'akismet' &&
+		sitelessCheckoutType !== 'jetpack';
 	const reduxDispatch = useDispatch();
 
 	const updatedSiteSlug = useCallback( () => {
-		if ( checkoutType === 'jetpack' ) {
+		if ( sitelessCheckoutType === 'jetpack' ) {
 			return jetpackSiteSlug;
 		}
-		if ( checkoutType === 'akismet' ) {
+		if ( sitelessCheckoutType === 'akismet' ) {
 			return akismetSiteSlug;
 		}
 		return siteSlug;
-	}, [ akismetSiteSlug, jetpackSiteSlug, checkoutType, siteSlug ] );
+	}, [ akismetSiteSlug, jetpackSiteSlug, sitelessCheckoutType, siteSlug ] );
 
 	const showErrorMessageBriefly = useCallback(
 		( error ) => {
@@ -166,7 +169,7 @@ export default function CheckoutMain( {
 
 	const checkoutFlow = useCheckoutFlowTrackKey( {
 		hasJetpackSiteSlug: !! jetpackSiteSlug,
-		checkoutType,
+		sitelessCheckoutType,
 		isJetpackNotAtomic,
 		isLoggedOutCart,
 		isUserComingFromLoginForm,
@@ -185,7 +188,7 @@ export default function CheckoutMain( {
 		usesJetpackProducts: isJetpackNotAtomic,
 		isPrivate,
 		siteSlug: updatedSiteSlug(),
-		checkoutType,
+		sitelessCheckoutType,
 		isLoggedOutCart,
 		isNoSiteCart,
 		jetpackSiteSlug,
@@ -245,7 +248,7 @@ export default function CheckoutMain( {
 		isJetpackNotAtomic,
 		productAliasFromUrl,
 		hideNudge: !! isComingFromUpsell,
-		checkoutType,
+		sitelessCheckoutType,
 		isInModal,
 		domains,
 	} );
@@ -378,7 +381,7 @@ export default function CheckoutMain( {
 		updatedSiteSlug(),
 		feature,
 		plan,
-		checkoutType,
+		sitelessCheckoutType,
 		checkoutFlow
 	);
 
@@ -572,7 +575,7 @@ export default function CheckoutMain( {
 		isComingFromUpsell,
 		disabledThankYouPage,
 		siteSlug: updatedSiteSlug(),
-		checkoutType,
+		sitelessCheckoutType,
 		checkoutFlow,
 	} );
 
@@ -696,8 +699,8 @@ export default function CheckoutMain( {
 				title="Checkout"
 				properties={ analyticsProps }
 				options={ {
-					useJetpackGoogleAnalytics: checkoutType === 'jetpack' || isJetpackNotAtomic,
-					useAkismetGoogleAnalytics: checkoutType === 'akismet',
+					useJetpackGoogleAnalytics: sitelessCheckoutType === 'jetpack' || isJetpackNotAtomic,
+					useAkismetGoogleAnalytics: sitelessCheckoutType === 'akismet',
 				} }
 			/>
 			<CheckoutProvider
@@ -744,7 +747,7 @@ function getAnalyticsPath(
 	selectedSiteSlug: string | undefined,
 	selectedFeature: string | undefined,
 	plan: string | undefined,
-	checkoutType: CheckoutType,
+	sitelessCheckoutType: SitelessCheckoutType,
 	checkoutFlow: string
 ): { analyticsPath: string; analyticsProps: Record< string, string > } {
 	debug( 'getAnalyticsPath', {
@@ -753,7 +756,7 @@ function getAnalyticsPath(
 		selectedSiteSlug,
 		selectedFeature,
 		plan,
-		checkoutType,
+		sitelessCheckoutType,
 		checkoutFlow,
 	} );
 	let analyticsPath = '';
@@ -781,11 +784,11 @@ function getAnalyticsPath(
 		analyticsPath = '/checkout/no-site';
 	}
 
-	if ( checkoutType === 'jetpack' ) {
+	if ( sitelessCheckoutType === 'jetpack' ) {
 		analyticsPath = analyticsPath.replace( 'checkout', 'checkout/jetpack' );
 	}
 
-	if ( checkoutType === 'akismet' ) {
+	if ( sitelessCheckoutType === 'akismet' ) {
 		analyticsPath = analyticsPath.replace( 'checkout', 'checkout/akismet' );
 	}
 

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -94,6 +94,7 @@ export default function CheckoutMain( {
 	onAfterPaymentComplete,
 	disabledThankYouPage,
 	sitelessCheckoutType,
+	akismetSiteSlug,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
 	isUserComingFromLoginForm,
@@ -122,6 +123,7 @@ export default function CheckoutMain( {
 	onAfterPaymentComplete?: () => void;
 	disabledThankYouPage?: boolean;
 	sitelessCheckoutType?: SitelessCheckoutType;
+	akismetSiteSlug?: string;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 	isUserComingFromLoginForm?: boolean;
@@ -146,8 +148,12 @@ export default function CheckoutMain( {
 			return jetpackSiteSlug;
 		}
 
+		if ( sitelessCheckoutType === 'akismet' ) {
+			return akismetSiteSlug;
+		}
+
 		return siteSlug;
-	}, [ jetpackSiteSlug, sitelessCheckoutType, siteSlug ] );
+	}, [ akismetSiteSlug, jetpackSiteSlug, sitelessCheckoutType, siteSlug ] );
 
 	const showErrorMessageBriefly = useCallback(
 		( error ) => {

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -141,10 +141,16 @@ export default function CheckoutMain( {
 		! isJetpackCheckout &&
 		! isAkismetSitelessCheckout;
 	const reduxDispatch = useDispatch();
-	let updatedSiteSlug = isJetpackCheckout ? jetpackSiteSlug : siteSlug;
-	if ( isAkismetSitelessCheckout ) {
-		updatedSiteSlug = akismetSiteSlug;
-	}
+
+	const updatedSiteSlug = useCallback( () => {
+		if ( isJetpackCheckout ) {
+			return jetpackSiteSlug;
+		}
+		if ( isAkismetSitelessCheckout ) {
+			return akismetSiteSlug;
+		}
+		return siteSlug;
+	}, [ akismetSiteSlug, jetpackSiteSlug, isJetpackCheckout, isAkismetSitelessCheckout, siteSlug ] );
 
 	const showErrorMessageBriefly = useCallback(
 		( error ) => {
@@ -180,7 +186,7 @@ export default function CheckoutMain( {
 		isInModal,
 		usesJetpackProducts: isJetpackNotAtomic,
 		isPrivate,
-		siteSlug: updatedSiteSlug,
+		siteSlug: updatedSiteSlug(),
 		isAkismetSitelessCheckout,
 		isLoggedOutCart,
 		isNoSiteCart,
@@ -237,7 +243,7 @@ export default function CheckoutMain( {
 	// post-checkout page decided by `getThankYouUrl` and therefore must be
 	// passed the post-checkout URL before the transaction begins.
 	const getThankYouUrlBase = useGetThankYouUrl( {
-		siteSlug: updatedSiteSlug,
+		siteSlug: updatedSiteSlug(),
 		redirectTo,
 		purchaseId,
 		feature,
@@ -315,7 +321,7 @@ export default function CheckoutMain( {
 
 	const { isRemovingProductFromCart, removeProductFromCartAndMaybeRedirect } =
 		useRemoveFromCartAndRedirect(
-			updatedSiteSlug,
+			updatedSiteSlug(),
 			createUserAndSiteBeforeTransaction,
 			customizedPreviousPath
 		);
@@ -342,7 +348,7 @@ export default function CheckoutMain( {
 		stripeConfiguration,
 		stripe,
 		storedCards,
-		siteSlug: updatedSiteSlug,
+		siteSlug: updatedSiteSlug(),
 	} );
 	debug( 'created payment method objects', paymentMethodObjects );
 
@@ -376,7 +382,7 @@ export default function CheckoutMain( {
 	const { analyticsPath, analyticsProps } = getAnalyticsPath(
 		purchaseId,
 		productAliasFromUrl,
-		updatedSiteSlug,
+		updatedSiteSlug(),
 		feature,
 		plan,
 		isAkismetSitelessCheckout,
@@ -429,7 +435,7 @@ export default function CheckoutMain( {
 			reduxDispatch,
 			responseCart,
 			siteId: updatedSiteId,
-			siteSlug: updatedSiteSlug,
+			siteSlug: updatedSiteSlug(),
 			stripeConfiguration,
 			stripe,
 			recaptchaClientId,
@@ -573,7 +579,7 @@ export default function CheckoutMain( {
 		isInModal,
 		isComingFromUpsell,
 		disabledThankYouPage,
-		siteSlug: updatedSiteSlug,
+		siteSlug: updatedSiteSlug(),
 		isAkismetSitelessCheckout,
 		isJetpackCheckout,
 		checkoutFlow,
@@ -734,7 +740,7 @@ export default function CheckoutMain( {
 					removeProductFromCart={ removeProductFromCartAndMaybeRedirect }
 					showErrorMessageBriefly={ showErrorMessageBriefly }
 					siteId={ updatedSiteId }
-					siteUrl={ updatedSiteSlug }
+					siteUrl={ updatedSiteSlug() }
 				/>
 			</CheckoutProvider>
 		</Fragment>

--- a/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 interface Props {
 	hasJetpackSiteSlug: boolean;
+	isAkismetSitelessCheckout: boolean;
 	isJetpackCheckout: boolean;
 	isJetpackNotAtomic: boolean;
 	isLoggedOutCart?: boolean;
@@ -10,6 +11,7 @@ interface Props {
 
 export default function useCheckoutFlowTrackKey( {
 	hasJetpackSiteSlug,
+	isAkismetSitelessCheckout,
 	isJetpackCheckout, // this flag is used for both "siteless checkout" and "site-only(userless) checkout"
 	isJetpackNotAtomic,
 	isLoggedOutCart,
@@ -27,6 +29,12 @@ export default function useCheckoutFlowTrackKey( {
 			}
 			return isSitelessJetpackCheckout ? 'jetpack_siteless_checkout' : 'jetpack_site_only_checkout';
 		}
+
+		if ( isAkismetSitelessCheckout ) {
+			// TODO: do we need to handle checking out with a site slug but without a logged in user?
+			return 'akismet_siteless_checkout';
+		}
+
 		if ( isLoggedOutCart ) {
 			return 'wpcom_registrationless';
 		}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import type { SitelessCheckoutType } from '@automattic/composite-checkout';
+import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
 
 interface Props {
 	hasJetpackSiteSlug: boolean;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
+import type { CheckoutType } from '@automattic/composite-checkout';
 
 interface Props {
 	hasJetpackSiteSlug: boolean;
-	isAkismetSitelessCheckout: boolean;
-	isJetpackCheckout: boolean;
+	checkoutType: CheckoutType;
 	isJetpackNotAtomic: boolean;
 	isLoggedOutCart?: boolean;
 	isUserComingFromLoginForm?: boolean;
@@ -11,16 +11,15 @@ interface Props {
 
 export default function useCheckoutFlowTrackKey( {
 	hasJetpackSiteSlug,
-	isAkismetSitelessCheckout,
-	isJetpackCheckout, // this flag is used for both "siteless checkout" and "site-only(userless) checkout"
+	checkoutType, // the value of 'jetpack' is used for both "siteless checkout" and "site-only(userless) checkout"
 	isJetpackNotAtomic,
 	isLoggedOutCart,
 	isUserComingFromLoginForm,
 }: Props ): string {
 	return useMemo( () => {
-		const isSitelessJetpackCheckout = isJetpackCheckout && ! hasJetpackSiteSlug;
+		const isSitelessJetpackCheckout = checkoutType === 'jetpack' && ! hasJetpackSiteSlug;
 
-		if ( isJetpackCheckout ) {
+		if ( checkoutType === 'jetpack' ) {
 			if ( isUserComingFromLoginForm ) {
 				// this allows us to track the flow: Checkout --> Login --> Checkout
 				return isSitelessJetpackCheckout
@@ -30,7 +29,7 @@ export default function useCheckoutFlowTrackKey( {
 			return isSitelessJetpackCheckout ? 'jetpack_siteless_checkout' : 'jetpack_site_only_checkout';
 		}
 
-		if ( isAkismetSitelessCheckout ) {
+		if ( checkoutType === 'akismet' ) {
 			// TODO: do we need to handle checking out with a site slug but without a logged in user?
 			return 'akismet_siteless_checkout';
 		}
@@ -41,7 +40,7 @@ export default function useCheckoutFlowTrackKey( {
 		return isJetpackNotAtomic ? 'jetpack_checkout' : 'wpcom_checkout';
 	}, [
 		hasJetpackSiteSlug,
-		isJetpackCheckout,
+		checkoutType,
 		isJetpackNotAtomic,
 		isLoggedOutCart,
 		isUserComingFromLoginForm,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-checkout-flow-track-key.ts
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
-import type { CheckoutType } from '@automattic/composite-checkout';
+import type { SitelessCheckoutType } from '@automattic/composite-checkout';
 
 interface Props {
 	hasJetpackSiteSlug: boolean;
-	checkoutType: CheckoutType;
+	sitelessCheckoutType: SitelessCheckoutType;
 	isJetpackNotAtomic: boolean;
 	isLoggedOutCart?: boolean;
 	isUserComingFromLoginForm?: boolean;
@@ -11,15 +11,15 @@ interface Props {
 
 export default function useCheckoutFlowTrackKey( {
 	hasJetpackSiteSlug,
-	checkoutType, // the value of 'jetpack' is used for both "siteless checkout" and "site-only(userless) checkout"
+	sitelessCheckoutType, // the value of 'jetpack' is used for both "siteless checkout" and "site-only(userless) checkout"
 	isJetpackNotAtomic,
 	isLoggedOutCart,
 	isUserComingFromLoginForm,
 }: Props ): string {
 	return useMemo( () => {
-		const isSitelessJetpackCheckout = checkoutType === 'jetpack' && ! hasJetpackSiteSlug;
+		const isSitelessJetpackCheckout = sitelessCheckoutType === 'jetpack' && ! hasJetpackSiteSlug;
 
-		if ( checkoutType === 'jetpack' ) {
+		if ( sitelessCheckoutType === 'jetpack' ) {
 			if ( isUserComingFromLoginForm ) {
 				// this allows us to track the flow: Checkout --> Login --> Checkout
 				return isSitelessJetpackCheckout
@@ -29,7 +29,7 @@ export default function useCheckoutFlowTrackKey( {
 			return isSitelessJetpackCheckout ? 'jetpack_siteless_checkout' : 'jetpack_site_only_checkout';
 		}
 
-		if ( checkoutType === 'akismet' ) {
+		if ( sitelessCheckoutType === 'akismet' ) {
 			// TODO: do we need to handle checking out with a site slug but without a logged in user?
 			return 'akismet_siteless_checkout';
 		}
@@ -40,7 +40,7 @@ export default function useCheckoutFlowTrackKey( {
 		return isJetpackNotAtomic ? 'jetpack_checkout' : 'wpcom_checkout';
 	}, [
 		hasJetpackSiteSlug,
-		checkoutType,
+		sitelessCheckoutType,
 		isJetpackNotAtomic,
 		isLoggedOutCart,
 		isUserComingFromLoginForm,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -31,7 +31,7 @@ import normalizeTransactionResponse from '../lib/normalize-transaction-response'
 import { absoluteRedirectThroughPending, redirectThroughPending } from '../lib/pending-page';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from '../lib/translate-payment-method-names';
 import type {
-	CheckoutType,
+	SitelessCheckoutType,
 	PaymentEventCallback,
 	PaymentEventCallbackArguments,
 } from '@automattic/composite-checkout';
@@ -59,7 +59,7 @@ export default function useCreatePaymentCompleteCallback( {
 	isComingFromUpsell,
 	disabledThankYouPage,
 	siteSlug,
-	checkoutType,
+	sitelessCheckoutType,
 	checkoutFlow,
 }: {
 	createUserAndSiteBeforeTransaction?: boolean;
@@ -71,7 +71,7 @@ export default function useCreatePaymentCompleteCallback( {
 	isComingFromUpsell?: boolean;
 	disabledThankYouPage?: boolean;
 	siteSlug: string | undefined;
-	checkoutType?: CheckoutType;
+	sitelessCheckoutType?: SitelessCheckoutType;
 	checkoutFlow?: string;
 } ): PaymentEventCallback {
 	const cartKey = useCartKey();
@@ -104,7 +104,7 @@ export default function useCreatePaymentCompleteCallback( {
 			// created site in the Thank You page URL.
 			// TODO: It does not seem like this would be needed for Akismet, but marking to follow up
 			let jetpackTemporarySiteId;
-			if ( checkoutType === 'jetpack' && ! siteSlug && responseCart.create_new_blog ) {
+			if ( sitelessCheckoutType === 'jetpack' && ! siteSlug && responseCart.create_new_blog ) {
 				jetpackTemporarySiteId =
 					transactionResult.purchases && Object.keys( transactionResult.purchases ).pop();
 			}
@@ -117,7 +117,7 @@ export default function useCreatePaymentCompleteCallback( {
 				purchaseId,
 				feature,
 				cart: responseCart,
-				checkoutType,
+				sitelessCheckoutType,
 				isJetpackNotAtomic,
 				productAliasFromUrl,
 				hideNudge: isComingFromUpsell,
@@ -236,7 +236,7 @@ export default function useCreatePaymentCompleteCallback( {
 			responseCart,
 			createUserAndSiteBeforeTransaction,
 			disabledThankYouPage,
-			checkoutType,
+			sitelessCheckoutType,
 			checkoutFlow,
 			adminPageRedirect,
 			domains,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -58,6 +58,7 @@ export default function useCreatePaymentCompleteCallback( {
 	isComingFromUpsell,
 	disabledThankYouPage,
 	siteSlug,
+	isAkismetSitelessCheckout = false,
 	isJetpackCheckout = false,
 	checkoutFlow,
 }: {
@@ -70,6 +71,7 @@ export default function useCreatePaymentCompleteCallback( {
 	isComingFromUpsell?: boolean;
 	disabledThankYouPage?: boolean;
 	siteSlug: string | undefined;
+	isAkismetSitelessCheckout?: boolean;
 	isJetpackCheckout?: boolean;
 	checkoutFlow?: string;
 } ): PaymentEventCallback {
@@ -101,6 +103,7 @@ export default function useCreatePaymentCompleteCallback( {
 
 			// In the case of a Jetpack product site-less purchase, we need to include the blog ID of the
 			// created site in the Thank You page URL.
+			// TODO: It does not seem like this would be needed for Akismet, but marking to follow up
 			let jetpackTemporarySiteId;
 			if ( isJetpackCheckout && ! siteSlug && responseCart.create_new_blog ) {
 				jetpackTemporarySiteId =
@@ -115,6 +118,7 @@ export default function useCreatePaymentCompleteCallback( {
 				purchaseId,
 				feature,
 				cart: responseCart,
+				isAkismetSitelessCheckout,
 				isJetpackNotAtomic,
 				productAliasFromUrl,
 				hideNudge: isComingFromUpsell,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -31,12 +31,14 @@ import normalizeTransactionResponse from '../lib/normalize-transaction-response'
 import { absoluteRedirectThroughPending, redirectThroughPending } from '../lib/pending-page';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from '../lib/translate-payment-method-names';
 import type {
-	SitelessCheckoutType,
 	PaymentEventCallback,
 	PaymentEventCallbackArguments,
 } from '@automattic/composite-checkout';
 import type { ResponseCart } from '@automattic/shopping-cart';
-import type { WPCOMTransactionEndpointResponse } from '@automattic/wpcom-checkout';
+import type {
+	WPCOMTransactionEndpointResponse,
+	SitelessCheckoutType,
+} from '@automattic/wpcom-checkout';
 import type { PostCheckoutUrlArguments } from 'calypso/my-sites/checkout/get-thank-you-page-url';
 import type { CalypsoDispatch } from 'calypso/state/types';
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -31,6 +31,7 @@ import normalizeTransactionResponse from '../lib/normalize-transaction-response'
 import { absoluteRedirectThroughPending, redirectThroughPending } from '../lib/pending-page';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from '../lib/translate-payment-method-names';
 import type {
+	CheckoutType,
 	PaymentEventCallback,
 	PaymentEventCallbackArguments,
 } from '@automattic/composite-checkout';
@@ -58,8 +59,7 @@ export default function useCreatePaymentCompleteCallback( {
 	isComingFromUpsell,
 	disabledThankYouPage,
 	siteSlug,
-	isAkismetSitelessCheckout = false,
-	isJetpackCheckout = false,
+	checkoutType,
 	checkoutFlow,
 }: {
 	createUserAndSiteBeforeTransaction?: boolean;
@@ -71,8 +71,7 @@ export default function useCreatePaymentCompleteCallback( {
 	isComingFromUpsell?: boolean;
 	disabledThankYouPage?: boolean;
 	siteSlug: string | undefined;
-	isAkismetSitelessCheckout?: boolean;
-	isJetpackCheckout?: boolean;
+	checkoutType?: CheckoutType;
 	checkoutFlow?: string;
 } ): PaymentEventCallback {
 	const cartKey = useCartKey();
@@ -105,7 +104,7 @@ export default function useCreatePaymentCompleteCallback( {
 			// created site in the Thank You page URL.
 			// TODO: It does not seem like this would be needed for Akismet, but marking to follow up
 			let jetpackTemporarySiteId;
-			if ( isJetpackCheckout && ! siteSlug && responseCart.create_new_blog ) {
+			if ( checkoutType === 'jetpack' && ! siteSlug && responseCart.create_new_blog ) {
 				jetpackTemporarySiteId =
 					transactionResult.purchases && Object.keys( transactionResult.purchases ).pop();
 			}
@@ -118,12 +117,11 @@ export default function useCreatePaymentCompleteCallback( {
 				purchaseId,
 				feature,
 				cart: responseCart,
-				isAkismetSitelessCheckout,
+				checkoutType,
 				isJetpackNotAtomic,
 				productAliasFromUrl,
 				hideNudge: isComingFromUpsell,
 				isInModal,
-				isJetpackCheckout,
 				jetpackTemporarySiteId,
 				adminPageRedirect,
 				domains,
@@ -238,7 +236,7 @@ export default function useCreatePaymentCompleteCallback( {
 			responseCart,
 			createUserAndSiteBeforeTransaction,
 			disabledThankYouPage,
-			isJetpackCheckout,
+			checkoutType,
 			checkoutFlow,
 			adminPageRedirect,
 			domains,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
@@ -30,6 +30,7 @@ export default function useGetThankYouUrl( {
 	purchaseId,
 	feature,
 	cart,
+	isAkismetSitelessCheckout = false,
 	isJetpackNotAtomic,
 	productAliasFromUrl,
 	hideNudge,
@@ -49,6 +50,7 @@ export default function useGetThankYouUrl( {
 			purchaseId,
 			feature,
 			cart,
+			isAkismetSitelessCheckout,
 			isJetpackNotAtomic,
 			productAliasFromUrl,
 			hideNudge,
@@ -66,6 +68,7 @@ export default function useGetThankYouUrl( {
 		isInModal,
 		siteSlug,
 		adminUrl,
+		isAkismetSitelessCheckout,
 		isJetpackNotAtomic,
 		productAliasFromUrl,
 		redirectTo,
@@ -85,6 +88,7 @@ export interface GetThankYouUrlProps {
 	purchaseId?: number | undefined;
 	feature?: string | undefined;
 	cart: ResponseCart;
+	isAkismetSitelessCheckout?: boolean;
 	isJetpackNotAtomic?: boolean;
 	productAliasFromUrl?: string | undefined;
 	hideNudge?: boolean;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
@@ -3,8 +3,8 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/get-thank-you-page-url';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { SitelessCheckoutType } from '@automattic/composite-checkout';
 import type { ResponseCart } from '@automattic/shopping-cart';
+import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { PostCheckoutUrlArguments } from 'calypso/my-sites/checkout/get-thank-you-page-url';
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/get-thank-you-page-url';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { CheckoutType } from '@automattic/composite-checkout';
+import type { SitelessCheckoutType } from '@automattic/composite-checkout';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { PostCheckoutUrlArguments } from 'calypso/my-sites/checkout/get-thank-you-page-url';
@@ -31,7 +31,7 @@ export default function useGetThankYouUrl( {
 	purchaseId,
 	feature,
 	cart,
-	checkoutType,
+	sitelessCheckoutType,
 	isJetpackNotAtomic,
 	productAliasFromUrl,
 	hideNudge,
@@ -50,7 +50,7 @@ export default function useGetThankYouUrl( {
 			purchaseId,
 			feature,
 			cart,
-			checkoutType,
+			sitelessCheckoutType,
 			isJetpackNotAtomic,
 			productAliasFromUrl,
 			hideNudge,
@@ -74,7 +74,7 @@ export default function useGetThankYouUrl( {
 		purchaseId,
 		cart,
 		hideNudge,
-		checkoutType,
+		sitelessCheckoutType,
 		domains,
 	] );
 	return getThankYouUrl;
@@ -86,7 +86,7 @@ export interface GetThankYouUrlProps {
 	purchaseId?: number | undefined;
 	feature?: string | undefined;
 	cart: ResponseCart;
-	checkoutType: CheckoutType;
+	sitelessCheckoutType: SitelessCheckoutType;
 	productAliasFromUrl?: string | undefined;
 	hideNudge?: boolean;
 	isInModal?: boolean;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/get-thank-you-page-url';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { CheckoutType } from '@automattic/composite-checkout';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { PostCheckoutUrlArguments } from 'calypso/my-sites/checkout/get-thank-you-page-url';
@@ -30,12 +31,11 @@ export default function useGetThankYouUrl( {
 	purchaseId,
 	feature,
 	cart,
-	isAkismetSitelessCheckout = false,
+	checkoutType,
 	isJetpackNotAtomic,
 	productAliasFromUrl,
 	hideNudge,
 	isInModal,
-	isJetpackCheckout = false,
 	domains,
 }: GetThankYouUrlProps ): GetThankYouUrl {
 	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
@@ -50,12 +50,11 @@ export default function useGetThankYouUrl( {
 			purchaseId,
 			feature,
 			cart,
-			isAkismetSitelessCheckout,
+			checkoutType,
 			isJetpackNotAtomic,
 			productAliasFromUrl,
 			hideNudge,
 			isInModal,
-			isJetpackCheckout,
 			domains,
 		};
 
@@ -68,7 +67,6 @@ export default function useGetThankYouUrl( {
 		isInModal,
 		siteSlug,
 		adminUrl,
-		isAkismetSitelessCheckout,
 		isJetpackNotAtomic,
 		productAliasFromUrl,
 		redirectTo,
@@ -76,7 +74,7 @@ export default function useGetThankYouUrl( {
 		purchaseId,
 		cart,
 		hideNudge,
-		isJetpackCheckout,
+		checkoutType,
 		domains,
 	] );
 	return getThankYouUrl;
@@ -88,11 +86,10 @@ export interface GetThankYouUrlProps {
 	purchaseId?: number | undefined;
 	feature?: string | undefined;
 	cart: ResponseCart;
-	isAkismetSitelessCheckout?: boolean;
-	isJetpackNotAtomic?: boolean;
+	checkoutType: CheckoutType;
 	productAliasFromUrl?: string | undefined;
 	hideNudge?: boolean;
 	isInModal?: boolean;
-	isJetpackCheckout?: boolean;
+	isJetpackNotAtomic?: boolean;
 	domains: ResponseDomain[] | undefined;
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -41,6 +41,7 @@ export default function usePrepareProductsForCart( {
 	usesJetpackProducts,
 	isPrivate,
 	siteSlug,
+	isAkismetSitelessCheckout,
 	isLoggedOutCart,
 	isNoSiteCart,
 	isJetpackCheckout,
@@ -55,6 +56,7 @@ export default function usePrepareProductsForCart( {
 	usesJetpackProducts: boolean;
 	isPrivate: boolean;
 	siteSlug: string | undefined;
+	isAkismetSitelessCheckout: boolean;
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
 	isJetpackCheckout?: boolean;
@@ -72,6 +74,8 @@ export default function usePrepareProductsForCart( {
 		originalPurchaseId,
 		'and isLoggedOutCart',
 		isLoggedOutCart,
+		'and isAkismetSitelessCheckout',
+		isAkismetSitelessCheckout,
 		'and isNoSiteCart',
 		isNoSiteCart,
 		'and isJetpackCheckout',
@@ -88,6 +92,7 @@ export default function usePrepareProductsForCart( {
 		isLoading: state.isLoading,
 		originalPurchaseId,
 		productAliasFromUrl,
+		isAkismetSitelessCheckout,
 		isLoggedOutCart,
 		isNoSiteCart,
 		isJetpackCheckout,
@@ -108,6 +113,7 @@ export default function usePrepareProductsForCart( {
 		usesJetpackProducts,
 		isPrivate,
 		addHandler,
+		isAkismetSitelessCheckout,
 		isJetpackCheckout,
 		jetpackSiteSlug,
 		jetpackPurchaseToken,
@@ -125,7 +131,10 @@ export default function usePrepareProductsForCart( {
 	// Do not strip products from url until the URL has been parsed
 	const areProductsRetrievedFromUrl = ! state.isLoading && ! isInModal;
 	const doNotStripProducts = Boolean(
-		! areProductsRetrievedFromUrl || isJetpackCheckout || isGiftPurchase
+		! areProductsRetrievedFromUrl ||
+			isJetpackCheckout ||
+			isAkismetSitelessCheckout ||
+			isGiftPurchase
 	);
 	useStripProductsFromUrl( siteSlug, doNotStripProducts );
 
@@ -165,6 +174,7 @@ function chooseAddHandler( {
 	isLoading,
 	originalPurchaseId,
 	productAliasFromUrl,
+	isAkismetSitelessCheckout,
 	isLoggedOutCart,
 	isNoSiteCart,
 	isJetpackCheckout,
@@ -173,12 +183,13 @@ function chooseAddHandler( {
 	isLoading: boolean;
 	originalPurchaseId: string | number | null | undefined;
 	productAliasFromUrl: string | null | undefined;
+	isAkismetSitelessCheckout: boolean;
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
 	isJetpackCheckout?: boolean;
 	isGiftPurchase?: boolean;
 } ): AddHandler {
-	if ( isJetpackCheckout ) {
+	if ( isJetpackCheckout || isAkismetSitelessCheckout ) {
 		return 'addProductFromSlug';
 	}
 
@@ -316,6 +327,7 @@ function useAddProductFromSlug( {
 	usesJetpackProducts,
 	isPrivate,
 	addHandler,
+	isAkismetSitelessCheckout,
 	isJetpackCheckout,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
@@ -326,6 +338,7 @@ function useAddProductFromSlug( {
 	usesJetpackProducts: boolean;
 	isPrivate: boolean;
 	addHandler: AddHandler;
+	isAkismetSitelessCheckout: boolean;
 	isJetpackCheckout?: boolean;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
@@ -360,6 +373,7 @@ function useAddProductFromSlug( {
 			createItemToAddToCart( {
 				productSlug: product.productSlug,
 				productAlias: product.productAlias,
+				isAkismetSitelessCheckout,
 				isJetpackCheckout,
 				jetpackSiteSlug,
 				jetpackPurchaseToken,
@@ -398,6 +412,7 @@ function useAddProductFromSlug( {
 		usesJetpackProducts,
 		productAliasFromUrl,
 		validProducts,
+		isAkismetSitelessCheckout,
 		isJetpackCheckout,
 		dispatch,
 		jetpackSiteSlug,
@@ -509,6 +524,7 @@ function createRenewalItemToAddToCart( {
 function createItemToAddToCart( {
 	productSlug,
 	productAlias,
+	isAkismetSitelessCheckout,
 	isJetpackCheckout,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
@@ -516,6 +532,7 @@ function createItemToAddToCart( {
 }: {
 	productSlug: string;
 	productAlias: string;
+	isAkismetSitelessCheckout?: boolean;
 	isJetpackCheckout?: boolean;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
@@ -543,6 +560,7 @@ function createItemToAddToCart( {
 		product_slug: productSlug,
 		quantity,
 		extra: {
+			isAkismetSitelessCheckout,
 			isJetpackCheckout,
 			jetpackSiteSlug,
 			jetpackPurchaseToken,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -7,8 +7,8 @@ import { useEffect, useMemo, useReducer } from 'react';
 import getCartFromLocalStorage from '../lib/get-cart-from-local-storage';
 import useFetchProductsIfNotLoaded from './use-fetch-products-if-not-loaded';
 import useStripProductsFromUrl from './use-strip-products-from-url';
-import type { SitelessCheckoutType } from '@automattic/composite-checkout';
 import type { RequestCartProduct, RequestCartProductExtra } from '@automattic/shopping-cart';
+import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-prepare-products-for-cart' );
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -7,7 +7,7 @@ import { useEffect, useMemo, useReducer } from 'react';
 import getCartFromLocalStorage from '../lib/get-cart-from-local-storage';
 import useFetchProductsIfNotLoaded from './use-fetch-products-if-not-loaded';
 import useStripProductsFromUrl from './use-strip-products-from-url';
-import type { CheckoutType } from '@automattic/composite-checkout';
+import type { SitelessCheckoutType } from '@automattic/composite-checkout';
 import type { RequestCartProduct, RequestCartProductExtra } from '@automattic/shopping-cart';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-prepare-products-for-cart' );
@@ -42,7 +42,7 @@ export default function usePrepareProductsForCart( {
 	usesJetpackProducts,
 	isPrivate,
 	siteSlug,
-	checkoutType,
+	sitelessCheckoutType,
 	isLoggedOutCart,
 	isNoSiteCart,
 	jetpackSiteSlug,
@@ -56,7 +56,7 @@ export default function usePrepareProductsForCart( {
 	usesJetpackProducts: boolean;
 	isPrivate: boolean;
 	siteSlug: string | undefined;
-	checkoutType: CheckoutType;
+	sitelessCheckoutType: SitelessCheckoutType;
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
 	jetpackSiteSlug?: string;
@@ -74,11 +74,11 @@ export default function usePrepareProductsForCart( {
 		'and isLoggedOutCart',
 		isLoggedOutCart,
 		'and isAkismetSitelessCheckout',
-		checkoutType === 'akismet',
+		sitelessCheckoutType === 'akismet',
 		'and isNoSiteCart',
 		isNoSiteCart,
 		'and isJetpackCheckout',
-		checkoutType === 'jetpack',
+		sitelessCheckoutType === 'jetpack',
 		'and jetpackSiteSlug',
 		jetpackSiteSlug,
 		'and jetpackPurchaseToken',
@@ -91,7 +91,7 @@ export default function usePrepareProductsForCart( {
 		isLoading: state.isLoading,
 		originalPurchaseId,
 		productAliasFromUrl,
-		checkoutType,
+		sitelessCheckoutType,
 		isLoggedOutCart,
 		isNoSiteCart,
 		isGiftPurchase,
@@ -111,7 +111,7 @@ export default function usePrepareProductsForCart( {
 		usesJetpackProducts,
 		isPrivate,
 		addHandler,
-		checkoutType,
+		sitelessCheckoutType,
 		jetpackSiteSlug,
 		jetpackPurchaseToken,
 		source,
@@ -129,8 +129,8 @@ export default function usePrepareProductsForCart( {
 	const areProductsRetrievedFromUrl = ! state.isLoading && ! isInModal;
 	const doNotStripProducts = Boolean(
 		! areProductsRetrievedFromUrl ||
-			checkoutType === 'jetpack' ||
-			checkoutType === 'akismet' ||
+			sitelessCheckoutType === 'jetpack' ||
+			sitelessCheckoutType === 'akismet' ||
 			isGiftPurchase
 	);
 	useStripProductsFromUrl( siteSlug, doNotStripProducts );
@@ -171,7 +171,7 @@ function chooseAddHandler( {
 	isLoading,
 	originalPurchaseId,
 	productAliasFromUrl,
-	checkoutType,
+	sitelessCheckoutType,
 	isLoggedOutCart,
 	isNoSiteCart,
 	isGiftPurchase,
@@ -179,12 +179,12 @@ function chooseAddHandler( {
 	isLoading: boolean;
 	originalPurchaseId: string | number | null | undefined;
 	productAliasFromUrl: string | null | undefined;
-	checkoutType: CheckoutType;
+	sitelessCheckoutType: SitelessCheckoutType;
 	isLoggedOutCart?: boolean;
 	isNoSiteCart?: boolean;
 	isGiftPurchase?: boolean;
 } ): AddHandler {
-	if ( checkoutType === 'jetpack' || checkoutType === 'akismet' ) {
+	if ( sitelessCheckoutType === 'jetpack' || sitelessCheckoutType === 'akismet' ) {
 		return 'addProductFromSlug';
 	}
 
@@ -322,7 +322,7 @@ function useAddProductFromSlug( {
 	usesJetpackProducts,
 	isPrivate,
 	addHandler,
-	checkoutType,
+	sitelessCheckoutType,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
 	source,
@@ -332,7 +332,7 @@ function useAddProductFromSlug( {
 	usesJetpackProducts: boolean;
 	isPrivate: boolean;
 	addHandler: AddHandler;
-	checkoutType: CheckoutType;
+	sitelessCheckoutType: SitelessCheckoutType;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 	source?: string;
@@ -366,7 +366,7 @@ function useAddProductFromSlug( {
 			createItemToAddToCart( {
 				productSlug: product.productSlug,
 				productAlias: product.productAlias,
-				checkoutType,
+				sitelessCheckoutType,
 				jetpackSiteSlug,
 				jetpackPurchaseToken,
 				source,
@@ -404,7 +404,7 @@ function useAddProductFromSlug( {
 		usesJetpackProducts,
 		productAliasFromUrl,
 		validProducts,
-		checkoutType,
+		sitelessCheckoutType,
 		dispatch,
 		jetpackSiteSlug,
 		jetpackPurchaseToken,
@@ -515,14 +515,14 @@ function createRenewalItemToAddToCart( {
 function createItemToAddToCart( {
 	productSlug,
 	productAlias,
-	checkoutType,
+	sitelessCheckoutType,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
 	source,
 }: {
 	productSlug: string;
 	productAlias: string;
-	checkoutType: CheckoutType;
+	sitelessCheckoutType: SitelessCheckoutType;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 	source?: string;
@@ -549,8 +549,8 @@ function createItemToAddToCart( {
 		product_slug: productSlug,
 		quantity,
 		extra: {
-			isAkismetSitelessCheckout: checkoutType === 'akismet',
-			isJetpackCheckout: checkoutType === 'jetpack',
+			isAkismetSitelessCheckout: sitelessCheckoutType === 'akismet',
+			isJetpackCheckout: sitelessCheckoutType === 'jetpack',
 			jetpackSiteSlug,
 			jetpackPurchaseToken,
 			context: 'calypstore',

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -44,11 +44,11 @@ import { getProductSlugFromContext, isContextJetpackSitelessCheckout } from './u
 const debug = debugFactory( 'calypso:checkout-controller' );
 
 export function checkoutJetpackSiteless( context, next ) {
-	sitelessCheckout( context, next, { isJetpackCheckout: true } );
+	sitelessCheckout( context, next, { checkoutType: 'jetpack' } );
 }
 
 export function checkoutAkismetSiteless( context, next ) {
-	sitelessCheckout( context, next, { isAkismetSitelessCheckout: true } );
+	sitelessCheckout( context, next, { checkoutType: 'akismet' } );
 }
 
 function sitelessCheckout( context, next, extraProps ) {
@@ -193,7 +193,7 @@ export function checkout( context, next ) {
 				// TODO: in theory, isJetpackCheckout should always be false here if it is indicating whether this is a siteless Jetpack purchase
 				// However, in this case, it's indicating that this checkout is a logged-out site purchase for Jetpack.
 				// This is creating some mixed use cases for the isJetpackCheckout prop
-				isJetpackCheckout={ isJetpackCheckout }
+				checkoutType={ isJetpackCheckout ? 'jetpack' : undefined }
 				isGiftPurchase={ isGiftPurchase }
 				jetpackSiteSlug={ jetpackSiteSlug }
 				jetpackPurchaseToken={ jetpackPurchaseToken || jetpackPurchaseNonce }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -192,7 +192,7 @@ export function checkout( context, next ) {
 				isNoSiteCart={ isNoSiteCart }
 				// TODO: in theory, isJetpackCheckout should always be false here if it is indicating whether this is a siteless Jetpack purchase
 				// However, in this case, it's indicating that this checkout is a logged-out site purchase for Jetpack.
-				// This is creating some mixed use cases for the isJetpackCheckout prop
+				// This is creating some mixed use cases for the sitelessCheckoutType prop
 				sitelessCheckoutType={ isJetpackCheckout ? 'jetpack' : undefined }
 				isGiftPurchase={ isGiftPurchase }
 				jetpackSiteSlug={ jetpackSiteSlug }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -51,7 +51,7 @@ export function checkoutAkismetSiteless( context, next ) {
 	sitelessCheckout( context, next, { isAkismetSitelessCheckout: true } );
 }
 
-function sitelessCheckout( context, next, props ) {
+function sitelessCheckout( context, next, extraProps ) {
 	const state = context.store.getState();
 	const isLoggedOut = ! isUserLoggedIn( state );
 	const { productSlug: product } = context.params;
@@ -80,7 +80,7 @@ function sitelessCheckout( context, next, props ) {
 				isLoggedOutCart={ isLoggedOut }
 				isNoSiteCart={ true }
 				isUserComingFromLoginForm={ isUserComingFromLoginForm }
-				{ ...props }
+				{ ...extraProps }
 			/>
 		</>
 	);

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -44,11 +44,11 @@ import { getProductSlugFromContext, isContextJetpackSitelessCheckout } from './u
 const debug = debugFactory( 'calypso:checkout-controller' );
 
 export function checkoutJetpackSiteless( context, next ) {
-	sitelessCheckout( context, next, { checkoutType: 'jetpack' } );
+	sitelessCheckout( context, next, { sitelessCheckoutType: 'jetpack' } );
 }
 
 export function checkoutAkismetSiteless( context, next ) {
-	sitelessCheckout( context, next, { checkoutType: 'akismet' } );
+	sitelessCheckout( context, next, { sitelessCheckoutType: 'akismet' } );
 }
 
 function sitelessCheckout( context, next, extraProps ) {
@@ -193,7 +193,7 @@ export function checkout( context, next ) {
 				// TODO: in theory, isJetpackCheckout should always be false here if it is indicating whether this is a siteless Jetpack purchase
 				// However, in this case, it's indicating that this checkout is a logged-out site purchase for Jetpack.
 				// This is creating some mixed use cases for the isJetpackCheckout prop
-				checkoutType={ isJetpackCheckout ? 'jetpack' : undefined }
+				sitelessCheckoutType={ isJetpackCheckout ? 'jetpack' : undefined }
 				isGiftPurchase={ isGiftPurchase }
 				jetpackSiteSlug={ jetpackSiteSlug }
 				jetpackPurchaseToken={ jetpackPurchaseToken || jetpackPurchaseNonce }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -44,6 +44,14 @@ import { getProductSlugFromContext, isContextJetpackSitelessCheckout } from './u
 const debug = debugFactory( 'calypso:checkout-controller' );
 
 export function checkoutJetpackSiteless( context, next ) {
+	sitelessCheckout( context, next, { isJetpackCheckout: true } );
+}
+
+export function checkoutAkismetSiteless( context, next ) {
+	sitelessCheckout( context, next, { isAkismetSitelessCheckout: true } );
+}
+
+function sitelessCheckout( context, next, props ) {
 	const state = context.store.getState();
 	const isLoggedOut = ! isUserLoggedIn( state );
 	const { productSlug: product } = context.params;
@@ -71,8 +79,8 @@ export function checkoutJetpackSiteless( context, next ) {
 				redirectTo={ context.query.redirect_to }
 				isLoggedOutCart={ isLoggedOut }
 				isNoSiteCart={ true }
-				isJetpackCheckout={ true }
 				isUserComingFromLoginForm={ isUserComingFromLoginForm }
+				{ ...props }
 			/>
 		</>
 	);
@@ -94,6 +102,10 @@ export function checkout( context, next ) {
 	const jetpackPurchaseToken = context.query.purchasetoken;
 	const jetpackPurchaseNonce = context.query.purchaseNonce;
 	const isUserComingFromLoginForm = context.query?.flow === 'coming_from_login';
+	// TODO: The only thing that we really need to check for here is whether or not the user is logged out.
+	// A siteless Jetpack purchase (logged in or out) will be handled by checkoutJetpackSiteless
+	// Additionally, the isJetpackCheckout variable would be more aptly named isJetpackSitelessCheckout
+	// isContextJetpackSitelessCheckout is really checking for whether this is a logged-out purchase, but this is uncelar at first
 	const isJetpackCheckout = isContextJetpackSitelessCheckout( context );
 	const jetpackSiteSlug = context.params.siteSlug;
 
@@ -178,6 +190,9 @@ export function checkout( context, next ) {
 				redirectTo={ context.query.redirect_to }
 				isLoggedOutCart={ isLoggedOutCart }
 				isNoSiteCart={ isNoSiteCart }
+				// TODO: in theory, isJetpackCheckout should always be false here if it is indicating whether this is a siteless Jetpack purchase
+				// However, in this case, it's indicating that this checkout is a logged-out site purchase for Jetpack.
+				// This is creating some mixed use cases for the isJetpackCheckout prop
 				isJetpackCheckout={ isJetpackCheckout }
 				isGiftPurchase={ isGiftPurchase }
 				jetpackSiteSlug={ jetpackSiteSlug }

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -57,7 +57,7 @@ import {
 	persistSignupDestination,
 	retrieveSignupDestination,
 } from 'calypso/signup/storageUtils';
-import type { CheckoutType } from '@automattic/composite-checkout';
+import type { SitelessCheckoutType } from '@automattic/composite-checkout';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
@@ -93,7 +93,7 @@ export interface PostCheckoutUrlArguments {
 	saveUrlToCookie?: SaveUrlToCookie;
 	hideNudge?: boolean;
 	isInModal?: boolean;
-	checkoutType?: CheckoutType;
+	sitelessCheckoutType?: SitelessCheckoutType;
 	jetpackTemporarySiteId?: string;
 	adminPageRedirect?: string;
 	domains?: ResponseDomain[];
@@ -123,7 +123,7 @@ export default function getThankYouPageUrl( {
 	purchaseId,
 	feature,
 	cart,
-	checkoutType,
+	sitelessCheckoutType,
 	isJetpackNotAtomic,
 	productAliasFromUrl,
 	getUrlFromCookie = retrieveSignupDestination,
@@ -213,7 +213,7 @@ export default function getThankYouPageUrl( {
 	debug( 'receiptIdOrPlaceholder is', receiptIdOrPlaceholder );
 
 	// jetpack userless & siteless checkout uses a special thank you page
-	if ( checkoutType === 'jetpack' ) {
+	if ( sitelessCheckoutType === 'jetpack' ) {
 		// extract a product from the cart, in userless/siteless checkout there should only be one
 		const productSlug = cart?.products[ 0 ]?.product_slug ?? 'no_product';
 
@@ -236,7 +236,7 @@ export default function getThankYouPageUrl( {
 	}
 
 	// Asismet site-less checkout
-	if ( checkoutType === 'akismet' ) {
+	if ( sitelessCheckoutType === 'akismet' ) {
 		// extract a product from the cart, in siteless checkout there should only be one
 		const productSlug = cart?.products[ 0 ]?.product_slug ?? 'no_product';
 

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -57,6 +57,7 @@ import {
 	persistSignupDestination,
 	retrieveSignupDestination,
 } from 'calypso/signup/storageUtils';
+import type { CheckoutType } from '@automattic/composite-checkout';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
@@ -86,14 +87,13 @@ export interface PostCheckoutUrlArguments {
 	purchaseId?: number | string;
 	feature?: string;
 	cart?: ResponseCart;
-	isAkismetSitelessCheckout?: boolean;
 	isJetpackNotAtomic?: boolean;
 	productAliasFromUrl?: string;
 	getUrlFromCookie?: GetUrlFromCookie;
 	saveUrlToCookie?: SaveUrlToCookie;
 	hideNudge?: boolean;
 	isInModal?: boolean;
-	isJetpackCheckout?: boolean;
+	checkoutType?: CheckoutType;
 	jetpackTemporarySiteId?: string;
 	adminPageRedirect?: string;
 	domains?: ResponseDomain[];
@@ -123,14 +123,13 @@ export default function getThankYouPageUrl( {
 	purchaseId,
 	feature,
 	cart,
-	isAkismetSitelessCheckout = false,
+	checkoutType,
 	isJetpackNotAtomic,
 	productAliasFromUrl,
 	getUrlFromCookie = retrieveSignupDestination,
 	saveUrlToCookie = persistSignupDestination,
 	hideNudge,
 	isInModal,
-	isJetpackCheckout = false,
 	jetpackTemporarySiteId,
 	adminPageRedirect,
 	domains,
@@ -214,7 +213,7 @@ export default function getThankYouPageUrl( {
 	debug( 'receiptIdOrPlaceholder is', receiptIdOrPlaceholder );
 
 	// jetpack userless & siteless checkout uses a special thank you page
-	if ( isJetpackCheckout ) {
+	if ( checkoutType === 'jetpack' ) {
 		// extract a product from the cart, in userless/siteless checkout there should only be one
 		const productSlug = cart?.products[ 0 ]?.product_slug ?? 'no_product';
 
@@ -237,7 +236,7 @@ export default function getThankYouPageUrl( {
 	}
 
 	// Asismet site-less checkout
-	if ( isAkismetSitelessCheckout ) {
+	if ( checkoutType === 'akismet' ) {
 		// extract a product from the cart, in siteless checkout there should only be one
 		const productSlug = cart?.products[ 0 ]?.product_slug ?? 'no_product';
 

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -86,7 +86,7 @@ export interface PostCheckoutUrlArguments {
 	purchaseId?: number | string;
 	feature?: string;
 	cart?: ResponseCart;
-	isAkismetSitelessCheckout: boolean;
+	isAkismetSitelessCheckout?: boolean;
 	isJetpackNotAtomic?: boolean;
 	productAliasFromUrl?: string;
 	getUrlFromCookie?: GetUrlFromCookie;

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -86,6 +86,7 @@ export interface PostCheckoutUrlArguments {
 	purchaseId?: number | string;
 	feature?: string;
 	cart?: ResponseCart;
+	isAkismetSitelessCheckout: boolean;
 	isJetpackNotAtomic?: boolean;
 	productAliasFromUrl?: string;
 	getUrlFromCookie?: GetUrlFromCookie;
@@ -122,6 +123,7 @@ export default function getThankYouPageUrl( {
 	purchaseId,
 	feature,
 	cart,
+	isAkismetSitelessCheckout = false,
 	isJetpackNotAtomic,
 	productAliasFromUrl,
 	getUrlFromCookie = retrieveSignupDestination,
@@ -232,6 +234,15 @@ export default function getThankYouPageUrl( {
 			},
 			thankYouUrl
 		);
+	}
+
+	// Asismet site-less checkout
+	if ( isAkismetSitelessCheckout ) {
+		// extract a product from the cart, in siteless checkout there should only be one
+		const productSlug = cart?.products[ 0 ]?.product_slug ?? 'no_product';
+
+		debug( 'redirecting to siteless Akismet thank you' );
+		return `/checkout/akismet/thank-you/${ productSlug }`;
 	}
 
 	// If there is no purchase, then send the user to a generic page (not

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -57,8 +57,8 @@ import {
 	persistSignupDestination,
 	retrieveSignupDestination,
 } from 'calypso/signup/storageUtils';
-import type { SitelessCheckoutType } from '@automattic/composite-checkout';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
+import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 const debug = debugFactory( 'calypso:composite-checkout:get-thank-you-page-url' );

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1484,7 +1484,7 @@ describe( 'getThankYouPageUrl', () => {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
-			isJetpackCheckout: true,
+			sitelessCheckoutType: 'jetpack',
 		} );
 		expect( url ).toBe( '/checkout/jetpack/thank-you/foo.bar/jetpack_backup_daily' );
 	} );
@@ -1503,7 +1503,7 @@ describe( 'getThankYouPageUrl', () => {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
-			isAkismetSitelessCheckout: true,
+			sitelessCheckoutType: 'akismet',
 		} );
 		expect( url ).toBe( '/checkout/akismet/thank-you/ak_plus_yearly_2' );
 	} );
@@ -1512,7 +1512,7 @@ describe( 'getThankYouPageUrl', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
-			isJetpackCheckout: true,
+			sitelessCheckoutType: 'jetpack',
 		} );
 		expect( url ).toBe( '/checkout/jetpack/thank-you/foo.bar/no_product' );
 	} );
@@ -1652,7 +1652,7 @@ describe( 'getThankYouPageUrl', () => {
 				...defaultArgs,
 				siteSlug: undefined,
 				cart,
-				isJetpackCheckout: true,
+				sitelessCheckoutType: 'jetpack',
 			} );
 			expect( url ).toBe(
 				'/checkout/jetpack/thank-you/licensing-auto-activate/jetpack_backup_daily?receiptId=%3AreceiptId'
@@ -1673,7 +1673,7 @@ describe( 'getThankYouPageUrl', () => {
 				...defaultArgs,
 				siteSlug: undefined,
 				cart,
-				isJetpackCheckout: true,
+				sitelessCheckoutType: 'jetpack',
 				receiptId: 80023,
 			} );
 			expect( url ).toBe(
@@ -1695,7 +1695,7 @@ describe( 'getThankYouPageUrl', () => {
 				...defaultArgs,
 				siteSlug: undefined,
 				cart,
-				isJetpackCheckout: true,
+				sitelessCheckoutType: 'jetpack',
 				receiptId: '80023',
 			} );
 			expect( url ).toBe(
@@ -1717,7 +1717,7 @@ describe( 'getThankYouPageUrl', () => {
 				...defaultArgs,
 				siteSlug: undefined,
 				cart,
-				isJetpackCheckout: true,
+				sitelessCheckoutType: 'jetpack',
 				// We have to type cast this because we're specifying invalid data.
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				receiptId: 'invalid receipt ID' as any,
@@ -1741,7 +1741,7 @@ describe( 'getThankYouPageUrl', () => {
 				...defaultArgs,
 				siteSlug: undefined,
 				cart,
-				isJetpackCheckout: true,
+				sitelessCheckoutType: 'jetpack',
 				receiptId: 80023,
 				jetpackTemporarySiteId: '123456789',
 			} );

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -30,7 +30,7 @@ jest.mock( '@automattic/calypso-products', () => ( {
 const samplePurchaseId = 12342424241;
 
 const defaultArgs = {
-	getUrlFromCookie: jest.fn( () => null ),
+	getUrlFromCookie: jest.fn( () => undefined ),
 	saveUrlToCookie: jest.fn(),
 };
 
@@ -1743,7 +1743,7 @@ describe( 'getThankYouPageUrl', () => {
 						},
 					],
 					is_gift_purchase: true,
-					gift_details: { receiver_blog_slug: 'foo.bar' },
+					gift_details: { receiver_blog_slug: 'foo.bar', receiver_blog_id: 123 },
 				},
 			} );
 			expect( url ).toBe( '/checkout/gift/thank-you/foo.bar' );
@@ -1796,7 +1796,7 @@ describe( 'getThankYouPageUrl', () => {
 							},
 						],
 						is_gift_purchase: true,
-						gift_details: {},
+						gift_details: { receiver_blog_id: 123 },
 					},
 				} )
 			).toThrow();

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1489,6 +1489,25 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/jetpack/thank-you/foo.bar/jetpack_backup_daily' );
 	} );
 
+	it( 'redirects to the akismet checkout thank you when akismet siteless arg is set', () => {
+		const cart = {
+			...getEmptyResponseCart(),
+			products: [
+				{
+					...getEmptyResponseCartProduct(),
+					product_slug: 'ak_plus_yearly_2',
+				},
+			],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+			isAkismetSitelessCheckout: true,
+		} );
+		expect( url ).toBe( '/checkout/akismet/thank-you/ak_plus_yearly_2' );
+	} );
+
 	it( 'redirects to the jetpack checkout thank you with `no_product` when jetpack checkout arg is set and the cart is empty', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -10,6 +10,7 @@ import { recordSiftScienceUser } from 'calypso/lib/siftscience';
 import { loggedInSiteSelection, noSite, siteSelection } from 'calypso/my-sites/controller';
 import {
 	checkout,
+	checkoutAkismetSiteless,
 	checkoutPending,
 	checkoutJetpackSiteless,
 	checkoutThankYou,
@@ -93,6 +94,20 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
+	// Akismet siteless checkout works logged-out, so do not include redirectLoggedOut or siteSelection.
+	if ( isEnabled( 'akismet/siteless-checkout' ) ) {
+		page(
+			`/checkout/akismet/:productSlug`,
+			setLocaleMiddleware(),
+			noSite,
+			checkoutAkismetSiteless,
+			makeLayout,
+			clientRender
+		);
+	}
+
+	// TODO: need thank you page for akismet
 
 	// The no-site post-checkout route is for purchases not tied to a site so do
 	// not include the `siteSelection` middleware.

--- a/client/my-sites/checkout/use-cart-key.ts
+++ b/client/my-sites/checkout/use-cart-key.ts
@@ -15,8 +15,11 @@ export default function useCartKey(): ReturnType< typeof getCartKey > {
 		currentUrlPath.includes( '/checkout/jetpack' ) &&
 		isLoggedOutCart &&
 		( !! jetpackPurchaseToken || !! jetpackPurchaseNonce );
+	const isAkismetSitelessCheckout =
+		currentUrlPath.includes( '/checkout/akismet' ) && isLoggedOutCart;
 	const isNoSiteCart =
 		isJetpackCheckout ||
+		isAkismetSitelessCheckout ||
 		( ! isLoggedOutCart &&
 			currentUrlPath.includes( '/checkout/no-site' ) &&
 			'no-user' === searchParams.get( 'cart' ) );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -417,9 +417,16 @@ export function noSite( context, next ) {
 	const hasSite = currentUser && currentUser.visible_site_count >= 1;
 	const isDomainOnlyFlow = context.query?.isDomainOnly === '1';
 	const isJetpackCheckoutFlow = context.pathname.includes( '/checkout/jetpack' );
+	const isAkismetCheckoutFlow = context.pathname.includes( '/checkout/akismet' );
 	const isGiftCheckoutFlow = context.pathname.includes( '/gift/' );
 
-	if ( ! isDomainOnlyFlow && ! isJetpackCheckoutFlow && ! isGiftCheckoutFlow && hasSite ) {
+	if (
+		! isDomainOnlyFlow &&
+		! isJetpackCheckoutFlow &&
+		! isAkismetCheckoutFlow &&
+		! isGiftCheckoutFlow &&
+		hasSite
+	) {
 		siteSelection( context, next );
 		return;
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -27,6 +27,7 @@
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": false,
+		"akismet/siteless-checkout": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -12,6 +12,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
 		"ad-tracking": false,
+		"akismet/siteless-checkout": false,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/production.json
+++ b/config/production.json
@@ -17,6 +17,7 @@
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": true,
+		"akismet/siteless-checkout": false,
 		"bilmur-script": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -15,6 +15,7 @@
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": false,
+		"akismet/siteless-checkout": false,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/test.json
+++ b/config/test.json
@@ -24,6 +24,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
 		"ad-tracking": false,
+		"akismet/siteless-checkout": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -15,6 +15,7 @@
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": false,
+		"akismet/siteless-checkout": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -15,7 +15,7 @@
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
 		"ad-tracking": false,
-		"akismet/siteless-checkout": true,
+		"akismet/siteless-checkout": false,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -124,6 +124,8 @@ export interface CheckoutProviderProps {
 	children: React.ReactNode;
 }
 
+export type CheckoutType = 'jetpack' | 'akismet' | undefined;
+
 export interface PaymentProcessorProp {
 	[ key: string ]: PaymentProcessorFunction;
 }

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -124,8 +124,6 @@ export interface CheckoutProviderProps {
 	children: React.ReactNode;
 }
 
-export type SitelessCheckoutType = 'jetpack' | 'akismet' | undefined;
-
 export interface PaymentProcessorProp {
 	[ key: string ]: PaymentProcessorFunction;
 }

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -124,7 +124,7 @@ export interface CheckoutProviderProps {
 	children: React.ReactNode;
 }
 
-export type CheckoutType = 'jetpack' | 'akismet' | undefined;
+export type SitelessCheckoutType = 'jetpack' | 'akismet' | undefined;
 
 export interface PaymentProcessorProp {
 	[ key: string ]: PaymentProcessorFunction;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -576,6 +576,7 @@ export interface ResponseCartGiftDetails {
 
 export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	purchaseId?: string;
+	isAkismetSitelessCheckout?: boolean;
 	isJetpackCheckout?: boolean;
 	isGiftPurchase?: boolean;
 	jetpackSiteSlug?: string;

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -505,3 +505,5 @@ export interface CountryListItem {
 	tax_needs_organization?: boolean;
 	tax_needs_address?: boolean;
 }
+
+export type SitelessCheckoutType = 'jetpack' | 'akismet' | undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12049,9 +12049,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001196, caniuse-lite@npm:^1.0.30001313":
-  version: 1.0.30001458
-  resolution: "caniuse-lite@npm:1.0.30001458"
-  checksum: 92ddb0819736d5d2e0efcbb0a729c172ddebc409c4fc39f2a8a8b5e0083fed795cf3efbaec299215298979d4f88da94e6be0ad2f1988cb25ec9be0772c29d0af
+  version: 1.0.30001464
+  resolution: "caniuse-lite@npm:1.0.30001464"
+  checksum: 82f711ecca1c22d66a0ffc166a818b75ea720c04a3d937c9ccf2bb3e3c10c9f347e95b66d4da4f5745e838e7f88ab6648441b0369a6298b747e6712f2ab5e006
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

* This PR adds new routes for `/akismet/checkout` and allows products at that route to be added to the cart without an associated site.
* This PR does not add the full purchase flow for the products (there is no thank you page post-purchase and there are some other improvements to add). The goal of this PR is to add the structure for the checkout flow enough to complete a purchase so that additional PRs can iterate in tandem.

## Testing Instructions

* Apply this patch to your local calypso Environment. Note that this patch is only configured to run in development and testing environments at the moment.
* You will need apply D102794-code on your sandbox to run this test. **Follow the setup instructions on that diff before proceeding here**.
* After setting up D102794-code, navigate to `calypso.localhost:3000/checkout/akismet/ak_plus_yearly_1`. This should take you a checkout page with the Akismet Plus product in the cart. If this does not work, make sure you followed the setup steps in D102794-code.

![Screen Shot 2023-03-08 at 4 49 58 PM](https://user-images.githubusercontent.com/18016357/223865345-c6ac24d0-c108-498d-a7ca-8e6fe19789b7.png)

* Click to complete the purchase. You should be redirected to a thank you page `http://calypso.localhost:3000/checkout/akismet/thank-you/ak_plus_yearly_1`. This page does not exist yet, and will be blank.
* You should see the purchase in the list at `me/purchases`, however, you will not be able to view details or manage the purchase yet. This is how you confirm that the purchase was successful. (You might also get an emailed reciept)

![Screen Shot 2023-03-08 at 5 25 36 PM](https://user-images.githubusercontent.com/18016357/223865298-a1808e35-5d00-49cd-abbf-8f7f36fd5325.png)


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?