### PR TITLE
Plugins: Add left padding to "Browse All" link

### DIFF
--- a/client/my-sites/plugins/plugins-results-header/style.scss
+++ b/client/my-sites/plugins/plugins-results-header/style.scss
@@ -4,6 +4,7 @@
 	align-items: center;
 	justify-content: space-between;
 	flex-wrap: wrap;
+	column-gap: 12px;
 
 	.plugins-results-header__titles {
 		margin-bottom: 6px; // +18 from elements = 24 gap
@@ -26,7 +27,6 @@
 		justify-content: space-between;
 		margin-top: auto;
 		margin-bottom: 6px; // +20 from elements = 26 gap
-		margin-left: 6px;
 
 		.plugins-results-header__action {
 			font-size: $font-body-small;

--- a/client/my-sites/plugins/plugins-results-header/style.scss
+++ b/client/my-sites/plugins/plugins-results-header/style.scss
@@ -7,6 +7,7 @@
 
 	.plugins-results-header__titles {
 		margin-bottom: 6px; // +18 from elements = 24 gap
+		margin-right: 6px;
 
 		.plugins-results-header__title {
 			@extend .wp-brand-font;

--- a/client/my-sites/plugins/plugins-results-header/style.scss
+++ b/client/my-sites/plugins/plugins-results-header/style.scss
@@ -7,7 +7,6 @@
 
 	.plugins-results-header__titles {
 		margin-bottom: 6px; // +18 from elements = 24 gap
-		margin-right: 6px;
 
 		.plugins-results-header__title {
 			@extend .wp-brand-font;
@@ -27,6 +26,7 @@
 		justify-content: space-between;
 		margin-top: auto;
 		margin-bottom: 6px; // +20 from elements = 26 gap
+		margin-left: 6px;
 
 		.plugins-results-header__action {
 			font-size: $font-body-small;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to  https://github.com/Automattic/wp-calypso/issues/68941

## Proposed Changes

* Add space between subtitles / titles and Browse All link so that Browse All link will not be too close to subtitles / titles. 
* Adding margin-left to style for Browse Al link to create space between subtitles / titles and Browse All link. 

<img width="477" alt="margin-left" src="https://user-images.githubusercontent.com/7698330/221484806-b82a25b3-f069-43a0-9a0b-7a581c6ad1c0.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open local environment and navigate to http://calypso.localhost:3000/plugins
* Open developer tools 
* Toggle the device toolbar (Chrome web browser)
* Shrink or maximize the screen size so that Browse All link is on the same line as the subtitle / title
* Shrink the screen size until the Browse All link is as close to the subtitle / title before moving to a new line. 
* Observe that the margin is there to prevent the Browse All link from being too close to the subtitle / title. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

