### PR TITLE
Add a warning for Jetpack plugin version and Unified importer

### DIFF
--- a/client/blocks/jetpack-plugin-update-warning/index.tsx
+++ b/client/blocks/jetpack-plugin-update-warning/index.tsx
@@ -11,6 +11,7 @@ import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 interface ExternalProps {
 	siteId: number;
 	minJetpackVersion: string;
+	warningRequirement?: string;
 }
 
 /**
@@ -19,10 +20,12 @@ interface ExternalProps {
  * @param {Object} props - the id of the current site
  * @param {number} props.siteId – the ID of the current site
  * @param {string} props.minJetpackVersion – the minimum accepted Jetpack version
+ * @param {string?} props.warningRequirement – the requirement that triggered the warning
  */
 export const JetpackPluginUpdateWarning: FC< ExternalProps > = ( {
 	siteId,
 	minJetpackVersion,
+	warningRequirement,
 }: ExternalProps ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -59,8 +62,7 @@ export const JetpackPluginUpdateWarning: FC< ExternalProps > = ( {
 			{ preventWidows(
 				translate(
 					'Your Jetpack plugin is out of date. ' +
-						'To make sure it will work with our recommended' +
-						' plans, {{JetpackUpdateLink}}update Jetpack{{/JetpackUpdateLink}}.',
+						'{{WarningRequirement/}}, {{JetpackUpdateLink}}update Jetpack{{/JetpackUpdateLink}}.',
 					{
 						components: {
 							JetpackUpdateLink: (
@@ -69,6 +71,12 @@ export const JetpackPluginUpdateWarning: FC< ExternalProps > = ( {
 									onClick={ updatePluginClick }
 									target="_blank"
 								/>
+							),
+							WarningRequirement: (
+								<>
+									{ warningRequirement ??
+										translate( 'To make sure it will work with our recommended plans' ) }
+								</>
 							),
 						},
 					}

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -5,6 +5,7 @@ import { once } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import JetpackPluginUpdateWarning from 'calypso/blocks/jetpack-plugin-update-warning';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import EmptyContent from 'calypso/components/empty-content';
@@ -57,6 +58,13 @@ const importerComponents = {
 };
 
 const getImporterTypeForEngine = ( engine ) => `importer-type-${ engine }`;
+
+/**
+ * The minimum version of the Jetpack plugin required to use the Jetpack Importer API.
+ *
+ * @see https://github.com/Automattic/jetpack/pull/28824#issuecomment-1439031413
+ */
+const JETPACK_IMPORT_MIN_PLUGIN_VERSION = '11.9-a.5';
 
 class SectionImport extends Component {
 	static propTypes = {
@@ -307,7 +315,17 @@ class SectionImport extends Component {
 					{ isJetpack && ! isAtomic && ! isEnabled( 'importer/unified' ) ? (
 						<JetpackImporter />
 					) : (
-						this.renderImportersList()
+						<>
+							{ /** Show a plugin update warning if Jetpack version does not support import endpoints */ }
+							{ isJetpack && ! isAtomic && (
+								<JetpackPluginUpdateWarning
+									siteId={ this.props.siteId }
+									minJetpackVersion={ JETPACK_IMPORT_MIN_PLUGIN_VERSION }
+									warningRequirement={ translate( 'To make sure you can import reliably' ) }
+								/>
+							) }
+							{ this.renderImportersList() }
+						</>
 					) }
 				</EmailVerificationGate>
 			</Main>

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -32,7 +32,7 @@ import {
 	isImporterStatusHydrated,
 } from 'calypso/state/imports/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { getSiteTitle } from 'calypso/state/sites/selectors';
+import { getSiteTitle, getSiteOption } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -292,6 +292,9 @@ class SectionImport extends Component {
 			options: { is_wpcom_atomic: isAtomic },
 		} = site;
 
+		const jetpackVersionInCompatible =
+			this.props.siteJetpackVersion < JETPACK_IMPORT_MIN_PLUGIN_VERSION;
+
 		return (
 			<Main>
 				<ScreenOptionsTab wpAdminPath="import.php" />
@@ -324,7 +327,9 @@ class SectionImport extends Component {
 									warningRequirement={ translate( 'To make sure you can import reliably' ) }
 								/>
 							) }
-							{ this.renderImportersList() }
+							{ jetpackVersionInCompatible
+								? this.renderIdleImporters( appStates.DISABLED )
+								: this.renderImportersList() }
 						</>
 					) }
 				</EmailVerificationGate>
@@ -344,6 +349,7 @@ export default connect(
 			siteImports: getImporterStatusForSiteId( state, siteId ),
 			canImport: canCurrentUser( state, siteId, 'manage_options' ),
 			isImporterStatusHydrated: isImporterStatusHydrated( state ),
+			siteJetpackVersion: getSiteOption( state, siteId, 'jetpack_version' ),
 		};
 	},
 	{ recordTracksEvent, startImport, fetchImporterState, cancelImport }


### PR DESCRIPTION
To use the Unified Importer, we need a Jetpack version of at least 11.9-a.5. This commit adds a warning to the Importer section if the Jetpack version is too old.

See: https://github.com/Automattic/wp-calypso/issues/73139

Related to #

## Proposed Changes

* Tweaks `JetpackPluginUpdateWarning` to add an optional `warningRequirement`
* Uses this component above the import section only for Jetpack-connected sites.

## Testing Instructions

* Use a Jetpack connected site with an older version of Jetpack. You can use JN to spin up a site with an older Jetpack version.
* Now test with this Calypso branch, and go to Tools > Import.
* You should see this screen:

<img width="773" alt="CleanShot 2023-02-28 at 13 16 06@2x" src="https://user-images.githubusercontent.com/533/221788644-d34ac6f3-87fa-49be-843d-46d7a13de837.png">



* Test with the latest version of Jetpack (or anything after `11.9.a.5`). 
* Make sure the Warning goes away.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
