### PR TITLE
Pricing page: Fix 'product_slugs_concatenated' data construction for tracking event.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-shopping-cart-tracker.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-shopping-cart-tracker.ts
@@ -52,7 +52,10 @@ export const useShoppingCartTracker = () => {
 				eventData = {
 					...eventData,
 					...reduceProducts( responseCart.products ),
-					product_slugs_concatenated: responseCart.products.sort().join( '-' ),
+					product_slugs_concatenated: responseCart.products
+						.map( ( product ) => product.product_slug )
+						.sort()
+						.join( ',' ),
 					number_of_products: responseCart.products.length,
 				};
 			}


### PR DESCRIPTION
Related to 1202858161751496-as-1204006587900263

This PR fixes issue with `calypso_jetpack_shopping_cart_checkout_from_cart` event having incorrect `product_slugs_concatenated` attribute value.

## Proposed Changes

* Update how `product_slugs_concatenated` is constructed from `responseCart.products`.

## Testing Instructions

Run this branch by following the steps below **_(note that we will need to run calypso locally to make the testing easier)_**:
    * Run `git fetch && git checkout fix/jp-shopping-cart-checkout-product-slugs-parsing`
    * Run `yarn start-jetpack-cloud`

1. Goto pricing page http://jetpack.cloud.localhost:3000/pricing/<JN-SITE>.
2. Add some products to the cart.
<img width="607" alt="Screen Shot 2023-02-27 at 5 06 30 PM" src="https://user-images.githubusercontent.com/56598660/221520598-b2c8e02a-1804-490b-bbc9-b3a672ec6ef5.png">

3. We will use our browser to verify that the `product_slugs_concatenated` will have correct data by adding a breakpoint to our runtime code. There are another methods to test this, but it will require some tools. This approach will only require you to use your browser. For this example, I will be using the Chrome browser to do this.
   1. Open dev tool then goto **Source** tab.
   2. Right click the **top** item in the sidebar and press **search in all files** context menu item to display the **search** tab.
   3. In the Search tab, input `product_slugs_concatenated` to locate the correct file.
<img width="624" alt="Screen Shot 2023-02-27 at 5 19 36 PM" src="https://user-images.githubusercontent.com/56598660/221524505-48998697-f2ba-4381-978e-da6282934560.png">
   5. Once you locate the file, add a breakpoint at line 61.
<img width="792" alt="Screen Shot 2023-02-27 at 5 25 46 PM" src="https://user-images.githubusercontent.com/56598660/221525120-6f1d1fc2-6801-43ac-ae83-165137df1c65.png">

4. After setting up a breakpoint in our runtime code, press the **"Go to checkout"** button inside the shopping cart menu.
 
<img width="533" alt="Screen Shot 2023-02-27 at 5 07 28 PM" src="https://user-images.githubusercontent.com/56598660/221520743-c0d911fe-a2ba-45c0-a6c1-963270fe7b9d.png">

8. Your browser should stop at the breakpoint. hover on the eventData to reveal the value of product_slugs_concatenated props.

<img width="898" alt="Screen Shot 2023-02-27 at 5 28 22 PM" src="https://user-images.githubusercontent.com/56598660/221525896-495e4bfb-d0ef-4f21-81be-ddeadaa8ab78.png">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1204006587900263