### PR TITLE
Fix config of ICFY job

### DIFF
--- a/.github/workflows/icfy-stats.yml
+++ b/.github/workflows/icfy-stats.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Fetch git history
         run: git fetch --prune --unshallow
       - name: Install dependencies
-        env:
         run: yarn install --inline-builds
       - name: Build ICFY stats
         env:


### PR DESCRIPTION
Trying to fix the config of the ICFY GitHub action which stopped running after #73622 was merged. I suspect that the empty `env:` field is a kind of YAML syntax error that prevents the action from running.