### PR TITLE
Developer UX: display privacy settings only for launched sites

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -261,12 +261,6 @@ function useSubmenuItems( {
 		() =>
 			[
 				{
-					condition: isLaunched,
-					label: __( 'Privacy settings' ),
-					href: `/settings/general/${ siteSlug }#site-privacy-settings`,
-					eventName: 'calypso_sites_dashboard_site_action_submenu_privacy_settings_click',
-				},
-				{
 					condition: isAtomic,
 					label: __( 'Database access' ),
 					href: `/hosting-config/${ siteSlug }#database-access`,
@@ -306,6 +300,12 @@ function useSubmenuItems( {
 					label: __( 'Clear cache' ),
 					href: `/hosting-config/${ siteSlug }#cache`,
 					eventName: 'calypso_sites_dashboard_site_action_submenu_cache_click',
+				},
+				{
+					condition: isLaunched,
+					label: __( 'Privacy settings' ),
+					href: `/settings/general/${ siteSlug }#site-privacy-settings`,
+					eventName: 'calypso_sites_dashboard_site_action_submenu_privacy_settings_click',
 				},
 			].filter( ( { condition } ) => condition ?? true ),
 		[ __, isAtomic, isCustomDomain, isLaunched, siteSlug ]

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -249,16 +249,19 @@ function useSubmenuItems( {
 	siteSlug,
 	isCustomDomain,
 	isAtomic,
+	isLaunched,
 }: {
 	siteSlug: string;
 	isCustomDomain: boolean;
 	isAtomic: boolean;
+	isLaunched: boolean;
 } ) {
 	const { __ } = useI18n();
 	return useMemo(
 		() =>
 			[
 				{
+					condition: isLaunched,
 					label: __( 'Privacy settings' ),
 					href: `/settings/general/${ siteSlug }#site-privacy-settings`,
 					eventName: 'calypso_sites_dashboard_site_action_submenu_privacy_settings_click',
@@ -305,7 +308,7 @@ function useSubmenuItems( {
 					eventName: 'calypso_sites_dashboard_site_action_submenu_cache_click',
 				},
 			].filter( ( { condition } ) => condition ?? true ),
-		[ __, isAtomic, isCustomDomain, siteSlug ]
+		[ __, isAtomic, isCustomDomain, isLaunched, siteSlug ]
 	);
 }
 
@@ -315,6 +318,7 @@ function DeveloperSettingsSubmenu( { site, recordTracks }: SitesMenuItemProps ) 
 		siteSlug: site.slug,
 		isCustomDomain: isCustomDomain( site.slug ),
 		isAtomic: Boolean( site.is_wpcom_atomic ),
+		isLaunched: site.launch_status !== 'unlaunched',
 	} );
 	const developerSubmenuProps = useSubmenuPopoverProps< HTMLDivElement >( { offsetTop: -8 } );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/1699

## Proposed Changes

* Add a condition to hide `Privacy settings` for unlaunched sites.
* Move the Privacy settings to the bottom of the submenu.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites`
* Open the unlaunched site's actions menu
* Observe there is no `Privacy settings` under the `Developer settings` menu.
* Open the actions menu of a launched site
* Observe the `Privacy settings` sube menu item is under the `Developer settings` menu.

## Screenshots

| **Launched** | **Unlaunched** |
|---|---|
| <img width="481" alt="Screenshot 2023-02-27 at 11 48 01" src="https://user-images.githubusercontent.com/779993/221557068-cfe382eb-d387-47d3-b467-339df216d6c8.png"> | <img width="503" alt="Screenshot 2023-02-27 at 11 51 55" src="https://user-images.githubusercontent.com/779993/221556847-45b487e6-8425-4535-b343-c095d3b95884.png"> |




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
