### PR TITLE
Subscription Management: Scaffold a `/subscriptions` page

### DIFF
--- a/client/my-sites/subscriptions/index.tsx
+++ b/client/my-sites/subscriptions/index.tsx
@@ -21,8 +21,9 @@ const createSubscriptions: Callback = ( context, next ) => {
 };
 
 const checkFeatureFlag: Callback = ( context, next ) => {
-	if ( ! config.isEnabled( 'subscription-management' ) ) {
+	if ( config.isEnabled( 'subscription-management' ) ) {
 		next();
+		return;
 	}
 	page.redirect( '/' );
 };

--- a/client/my-sites/subscriptions/index.tsx
+++ b/client/my-sites/subscriptions/index.tsx
@@ -1,0 +1,32 @@
+import config from '@automattic/calypso-config';
+import page, { Callback } from 'page';
+import { createElement } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
+import { makeLayout, render } from 'calypso/controller';
+
+const Subscriptions = () => {
+	return (
+		<Main className="site-settings">
+			<DocumentHead title="Subscriptions" />
+			<FormattedHeader brandFont headerText="Subscriptions" align="left" />
+		</Main>
+	);
+};
+
+const createSubscriptions: Callback = ( context, next ) => {
+	context.primary = createElement( Subscriptions );
+	next();
+};
+
+const checkFeatureFlag: Callback = ( context, next ) => {
+	if ( ! config.isEnabled( 'subscription-management' ) ) {
+		next();
+	}
+	page.redirect( '/' );
+};
+
+export default function () {
+	page( '/subscriptions', checkFeatureFlag, createSubscriptions, makeLayout, render );
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -562,6 +562,12 @@ const sections = [
 		module: 'calypso/my-sites/promote-post',
 		group: 'sites',
 	},
+	{
+		name: 'subscriptions',
+		paths: [ '/subscriptions' ],
+		module: 'calypso/my-sites/subscriptions',
+		group: 'sites',
+	},
 ];
 
 module.exports = sections;

--- a/config/development.json
+++ b/config/development.json
@@ -197,6 +197,6 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
-		"newsletter/stats": true,
+		"newsletter/stats": true
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -180,6 +180,7 @@
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,
+		"subscription-management": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
 		"themes/showcase-i4/details-and-preview": true,
@@ -196,6 +197,6 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
-		"newsletter/stats": true
+		"newsletter/stats": true,
 	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -125,6 +125,7 @@
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,
+		"subscription-management": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
 		"themes/showcase-i4/details-and-preview": false,

--- a/config/production.json
+++ b/config/production.json
@@ -145,6 +145,7 @@
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,
+		"subscription-management": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
 		"themes/showcase-i4/details-and-preview": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -141,6 +141,7 @@
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,
+		"subscription-management": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
 		"themes/showcase-i4/details-and-preview": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -152,6 +152,7 @@
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
 		"subscription-gifting": true,
+		"subscription-management": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
 		"themes/showcase-i4/details-and-preview": false,


### PR DESCRIPTION
![Screen Shot 2023-02-27 at 14 03 43](https://user-images.githubusercontent.com/2019970/221572401-35e68c76-1794-46fc-918b-a90618598813.png)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/73803

## Proposed Changes

* add a barebones `/subscriptions` page to Calypso that will be used for the development of the new subscriptions management portal
* keep the page behind `subscription-management` feature flag
* the page is only to be available to logged in users

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/subscriptions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
