### PR TITLE
Added styles for Woo related font-sizes

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/style.scss
@@ -1,3 +1,4 @@
+@import "@automattic/typography/styles/woo-commerce";
 @import "@wordpress/base-styles/breakpoints";
 
 body.is-section-plans.is-ecommerce-trial-plan {
@@ -52,12 +53,12 @@ body.is-section-plans.is-ecommerce-trial-plan {
 			flex-direction: column;
 
 			.e-commerce-trial-plans__price-card-title {
-				font-size: $font-title-medium;
+				font-size: $woo-font-title-medium;
 			}
 
 			.e-commerce-trial-plans__price-card-subtitle {
 				flex: 1;
-				font-size: $font-body-small;
+				font-size: $woo-font-body-small;
 				color: var(--color-neutral-80);
 			}
 		}
@@ -84,11 +85,11 @@ body.is-section-plans.is-ecommerce-trial-plan {
 			}
 
 			.e-commerce-trial-plans__price-card-value {
-				font-size: $font-title-large;
+				font-size: $woo-font-title-large;
 				font-weight: 500;
 
 				@media (max-width: $break-mobile) {
-					font-size: $font-headline-small;
+					font-size: $woo-font-headline-small;
 					margin-top: 30px;
 					font-weight: 400;
 				}
@@ -96,12 +97,12 @@ body.is-section-plans.is-ecommerce-trial-plan {
 
 			.e-commerce-trial-plans__price-card-interval {
 				color: var(--color-neutral-50);
-				font-size: $font-body-extra-small;
+				font-size: $woo-font-body-extra-small;
 			}
 
 			.e-commerce-trial-plans__price-card-savings {
 				color: var(--color-success-60);
-				font-size: $font-body-extra-small;
+				font-size: $woo-font-body-extra-small;
 				font-weight: 600;
 				text-transform: uppercase;
 				padding: 5px 0;

--- a/packages/typography/styles/woo-commerce.scss
+++ b/packages/typography/styles/woo-commerce.scss
@@ -1,5 +1,8 @@
 @import "./variables.scss";
 
+$woo-font-headline-large: rem(54px);
+$woo-font-headline-medium: rem(48px);
+$woo-font-headline-small: rem(36px);
 $woo-font-title-large: rem(32px);
 $woo-font-title-medium: rem(24px);
 $woo-font-title-small: rem(20px);

--- a/packages/typography/styles/woo-commerce.scss
+++ b/packages/typography/styles/woo-commerce.scss
@@ -1,0 +1,10 @@
+@import "./variables.scss";
+
+$woo-font-title-large: rem(32px);
+$woo-font-title-medium: rem(24px);
+$woo-font-title-small: rem(20px);
+$woo-font-body-large: rem(18px);
+$woo-font-body: rem(16px);
+$woo-font-body-small: rem(14px);
+$woo-font-body-extra-small: rem(13px);
+$woo-font-body-xx-small: rem(12px);


### PR DESCRIPTION
## Proposed Changes

* Adds a new file holding `font-size` definitions for WooCommerce-related/branded pages on calypso.
* Updates the Commerce trial Plans page to use the new definitions.

## Testing Instructions

* Open calypso live and navigate to the Plans page using a site in the Commerce trial plan.
* Check that the page still matches the designs (jBwlERMS350NqhJNHZzAVF-fi-98%3A33334) 
* Check that the new file is in a sensible and accessible path/package.
