### PR TITLE
Developer UX: add upsell information to developer settings submenu and manage plugins

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -257,59 +257,60 @@ function useSubmenuItems( {
 	isLaunched: boolean;
 } ) {
 	const { __ } = useI18n();
-	return useMemo(
-		() =>
-			[
-				{
-					condition: isAtomic,
-					label: __( 'Database access' ),
-					href: `/hosting-config/${ siteSlug }#database-access`,
-					eventName: 'calypso_sites_dashboard_site_action_submenu_database_access_click',
-				},
-				{
-					condition: isAtomic,
-					label: __( 'SFTP/SSH credentials' ),
-					href: `/hosting-config/${ siteSlug }#sftp-credentials`,
-					eventName: 'calypso_sites_dashboard_site_action_submenu_sftp_credentials_click',
-				},
-				{
-					condition: isAtomic,
-					label: __( 'Web server settings' ),
-					href: `/hosting-config/${ siteSlug }#web-server-settings`,
-					eventName: 'calypso_sites_dashboard_site_action_submenu_web_server_settings_click',
-				},
-				{
-					label: __( 'Performance settings' ),
-					href: `/settings/performance/${ siteSlug }`,
-					eventName: 'calypso_sites_dashboard_site_action_submenu_performance_settings_click',
-				},
-				{
-					condition: isCustomDomain,
-					label: __( 'DNS records' ),
-					href: `/domains/manage/${ siteSlug }/dns/${ siteSlug }`,
-					eventName: 'calypso_sites_dashboard_site_action_submenu_dns_records_click',
-				},
-				{
-					condition: isAtomic,
-					label: __( 'Github connection' ),
-					href: `/hosting-config/${ siteSlug }#connect-github`,
-					eventName: 'calypso_sites_dashboard_site_action_submenu_connect_github_click',
-				},
-				{
-					condition: isAtomic,
-					label: __( 'Clear cache' ),
-					href: `/hosting-config/${ siteSlug }#cache`,
-					eventName: 'calypso_sites_dashboard_site_action_submenu_cache_click',
-				},
-				{
-					condition: isLaunched,
-					label: __( 'Privacy settings' ),
-					href: `/settings/general/${ siteSlug }#site-privacy-settings`,
-					eventName: 'calypso_sites_dashboard_site_action_submenu_privacy_settings_click',
-				},
-			].filter( ( { condition } ) => condition ?? true ),
-		[ __, isAtomic, isCustomDomain, isLaunched, siteSlug ]
-	);
+	return useMemo<
+		{ label: string; href: string; eventName: string; info?: string; condition?: boolean }[]
+	>( () => {
+		const upsellInfo = isAtomic ? __( 'Included in your plan' ) : __( 'Requires a Business Plan' );
+		return [
+			{
+				info: upsellInfo,
+				label: __( 'Database access' ),
+				href: `/hosting-config/${ siteSlug }#database-access`,
+				eventName: 'calypso_sites_dashboard_site_action_submenu_database_access_click',
+			},
+			{
+				info: upsellInfo,
+				label: __( 'SFTP/SSH credentials' ),
+				href: `/hosting-config/${ siteSlug }#sftp-credentials`,
+				eventName: 'calypso_sites_dashboard_site_action_submenu_sftp_credentials_click',
+			},
+			{
+				info: upsellInfo,
+				label: __( 'Web server settings' ),
+				href: `/hosting-config/${ siteSlug }#web-server-settings`,
+				eventName: 'calypso_sites_dashboard_site_action_submenu_web_server_settings_click',
+			},
+			{
+				label: __( 'Performance settings' ),
+				href: `/settings/performance/${ siteSlug }`,
+				eventName: 'calypso_sites_dashboard_site_action_submenu_performance_settings_click',
+			},
+			{
+				condition: isCustomDomain,
+				label: __( 'DNS records' ),
+				href: `/domains/manage/${ siteSlug }/dns/${ siteSlug }`,
+				eventName: 'calypso_sites_dashboard_site_action_submenu_dns_records_click',
+			},
+			{
+				info: upsellInfo,
+				label: __( 'Github connection' ),
+				href: `/hosting-config/${ siteSlug }#connect-github`,
+				eventName: 'calypso_sites_dashboard_site_action_submenu_connect_github_click',
+			},
+			{
+				info: upsellInfo,
+				label: __( 'Clear cache' ),
+				href: `/hosting-config/${ siteSlug }#cache`,
+				eventName: 'calypso_sites_dashboard_site_action_submenu_cache_click',
+			},
+			{
+				condition: isLaunched,
+				label: __( 'Privacy settings' ),
+				href: `/settings/general/${ siteSlug }#site-privacy-settings`,
+				eventName: 'calypso_sites_dashboard_site_action_submenu_privacy_settings_click',
+			},
+		].filter( ( { condition } ) => condition ?? true );
+	}, [ __, isAtomic, isCustomDomain, isLaunched, siteSlug ] );
 }
 
 function DeveloperSettingsSubmenu( { site, recordTracks }: SitesMenuItemProps ) {
@@ -337,6 +338,7 @@ function DeveloperSettingsSubmenu( { site, recordTracks }: SitesMenuItemProps ) 
 						key={ item.label }
 						href={ item.href }
 						onClick={ () => recordTracks( item.eventName ) }
+						info={ item.info }
 					>
 						{ item.label }
 					</MenuItemLink>

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -261,32 +261,15 @@ function useSubmenuItems( site: SiteExcerptData ) {
 		return [
 			{
 				info: upsellInfo,
-				label: __( 'Database access' ),
-				href: `/hosting-config/${ siteSlug }#database-access`,
-				eventName: 'calypso_sites_dashboard_site_action_submenu_database_access_click',
-			},
-			{
-				info: upsellInfo,
 				label: __( 'SFTP/SSH credentials' ),
 				href: `/hosting-config/${ siteSlug }#sftp-credentials`,
 				eventName: 'calypso_sites_dashboard_site_action_submenu_sftp_credentials_click',
 			},
 			{
 				info: upsellInfo,
-				label: __( 'Web server settings' ),
-				href: `/hosting-config/${ siteSlug }#web-server-settings`,
-				eventName: 'calypso_sites_dashboard_site_action_submenu_web_server_settings_click',
-			},
-			{
-				label: __( 'Performance settings' ),
-				href: `/settings/performance/${ siteSlug }`,
-				eventName: 'calypso_sites_dashboard_site_action_submenu_performance_settings_click',
-			},
-			{
-				condition: hasCustomDomain,
-				label: __( 'DNS records' ),
-				href: `/domains/manage/${ siteSlug }/dns/${ siteSlug }`,
-				eventName: 'calypso_sites_dashboard_site_action_submenu_dns_records_click',
+				label: __( 'Database access' ),
+				href: `/hosting-config/${ siteSlug }#database-access`,
+				eventName: 'calypso_sites_dashboard_site_action_submenu_database_access_click',
 			},
 			{
 				info: upsellInfo,
@@ -296,15 +279,32 @@ function useSubmenuItems( site: SiteExcerptData ) {
 			},
 			{
 				info: upsellInfo,
+				label: __( 'Web server settings' ),
+				href: `/hosting-config/${ siteSlug }#web-server-settings`,
+				eventName: 'calypso_sites_dashboard_site_action_submenu_web_server_settings_click',
+			},
+			{
+				info: upsellInfo,
 				label: __( 'Clear cache' ),
 				href: `/hosting-config/${ siteSlug }#cache`,
 				eventName: 'calypso_sites_dashboard_site_action_submenu_cache_click',
+			},
+			{
+				label: __( 'Performance settings' ),
+				href: `/settings/performance/${ siteSlug }`,
+				eventName: 'calypso_sites_dashboard_site_action_submenu_performance_settings_click',
 			},
 			{
 				condition: isLaunched,
 				label: __( 'Privacy settings' ),
 				href: `/settings/general/${ siteSlug }#site-privacy-settings`,
 				eventName: 'calypso_sites_dashboard_site_action_submenu_privacy_settings_click',
+			},
+			{
+				condition: hasCustomDomain,
+				label: __( 'DNS records' ),
+				href: `/domains/manage/${ siteSlug }/dns/${ siteSlug }`,
+				eventName: 'calypso_sites_dashboard_site_action_submenu_dns_records_click',
 			},
 		].filter( ( { condition } ) => condition ?? true );
 	}, [ __, siteSlug, hasCustomDomain, isLaunched, upsellInfo ] );

--- a/client/sites-dashboard/hooks/use-upsell-info.ts
+++ b/client/sites-dashboard/hooks/use-upsell-info.ts
@@ -1,0 +1,7 @@
+import { useI18n } from '@wordpress/react-i18n';
+import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+
+export function useUpsellInfo( site: SiteExcerptData ): string {
+	const { __ } = useI18n();
+	return site.is_wpcom_atomic ? __( 'Included in your plan' ) : __( 'Requires a Business Plan' );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/1746

## Proposed Changes

* Add upsell information in hosting configuration submenu items and manage plugins.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites`
* Open the actions menu of a free site
* Observe the info description says `Requires a Business Plan`
* Open the actions menu of a business site
* Observe the info description says `Included in your plan`

## Screenshots

| **Free** | **Business** |
|---|---|
| <img width="381" alt="Screenshot 2023-02-27 at 14 26 38" src="https://user-images.githubusercontent.com/779993/221589833-3aec9e5c-c645-4567-81b1-781614a406a0.png"> | <img width="378" alt="Screenshot 2023-02-27 at 14 26 01" src="https://user-images.githubusercontent.com/779993/221589853-bde02291-51df-4030-9c92-9034f6da5d3e.png"> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
