### PR TITLE
BlazePress Widget: Pass `locale` param on init

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -1,5 +1,6 @@
 import { getUrlParts } from '@automattic/calypso-url';
 import { Dialog } from '@automattic/components';
+import { useLocale } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { TranslateOptionsText, useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -46,6 +47,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, selectedSiteId ) );
 	const { closeModal } = useRouteModal( 'blazepress-widget', keyValue );
 	const queryClient = useQueryClient();
+	const localeSlug = useLocale();
 
 	// Scroll to top on initial load regardless of previous page position
 	useEffect( () => {
@@ -96,7 +98,8 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 					},
 					widgetContainer.current,
 					handleShowCancel,
-					handleGetStartedMessageClose
+					handleGetStartedMessageClose,
+					localeSlug
 				);
 				setIsLoading( false );
 			} )();

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -23,6 +23,7 @@ declare global {
 				onLoaded?: () => void;
 				onClose?: () => void;
 				translateFn?: ( value: string, options?: any ) => string;
+				locale?: string;
 				showDialog?: boolean;
 				setShowCancelButton?: ( show: boolean ) => void;
 				uploadImageLabel?: string;
@@ -58,7 +59,8 @@ export async function showDSP(
 	translateFn: ( value: string, options?: any ) => string,
 	domNodeOrId?: HTMLElement | string | null,
 	setShowCancelButton?: ( show: boolean ) => void,
-	onGetStartedMessageClose?: ( dontShowAgain: boolean ) => void
+	onGetStartedMessageClose?: ( dontShowAgain: boolean ) => void,
+	locale?: string
 ) {
 	await loadDSPWidgetJS();
 	return new Promise( ( resolve, reject ) => {
@@ -76,6 +78,7 @@ export async function showDSP(
 				onLoaded: () => resolve( true ),
 				onClose: onClose,
 				translateFn: translateFn,
+				locale,
 				urn: `urn:wpcom:post:${ siteId }:${ postId || 0 }`,
 				setShowCancelButton: setShowCancelButton,
 				uploadImageLabel: isWpMobileApp() ? __( 'Tap to add image' ) : undefined,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Pass `locale` param when initializing BlazePress widget.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* **Changes from dsp-widget PR #.1630 should be deployed (or sandboxed).**
* Checkout branch locally or use calypso.live build.
* Change UI language to English (`Promote with Blaze` would otherwise be disabled).
* Navigate to `/posts/[site]/?flags=quick-language-switcher`. Note the `quick-language-switcher` flag.
* Change the UI to a Mag-16 language from the quick language switcher 
![CleanShot 2023-02-27 at 16 21 15](https://user-images.githubusercontent.com/2722412/221588708-fedb6767-8b30-439b-a9d0-b0a98c3f2b0b.png)
* Open the BlazePress widget from `Promote with Blaze` menu option:
![CleanShot 2023-02-27 at 16 23 47](https://user-images.githubusercontent.com/2722412/221589098-16d7eea5-f457-4303-8934-521b70d75e35.png)
* Confirm continent names and topics on the `Audience & Budget` step are translated: ![CleanShot 2023-02-27 at 16 06 26](https://user-images.githubusercontent.com/2722412/221589393-1cf33954-503a-4c21-a513-799fd94eae9c.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
