### PR TITLE
Import onboarding flow: fix issue with flickering screens

### DIFF
--- a/client/blocks/importer/wordpress/index.tsx
+++ b/client/blocks/importer/wordpress/index.tsx
@@ -62,14 +62,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	 */
 	useEffect( checkOptionQueryParam, [ queryParams.get( 'option' ) ] );
 	useEffect( checkImporterAvailability, [ siteId ] );
-	useEffect( () => {
-		if ( isMigrateFromWp ) {
-			storeMigrateSource();
-		}
-		if ( 'true' === retrieveMigrateSource() ) {
-			setIsMigrateFromWp( true );
-		}
-	}, [] );
+	useEffect( checkIfImportInitFromMigratePlugin, [] );
 
 	/**
 	 ↓ Methods
@@ -89,6 +82,15 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 		isSiteAtomic
 			? redirectToWpAdminWordPressImporter()
 			: updateCurrentPageQueryParam( { option: WPImportOption.CONTENT_ONLY } );
+	}
+
+	function checkIfImportInitFromMigratePlugin() {
+		if ( isMigrateFromWp ) {
+			storeMigrateSource();
+		}
+		if ( 'true' === retrieveMigrateSource() ) {
+			setIsMigrateFromWp( true );
+		}
 	}
 
 	function checkImporterAvailability() {

--- a/client/blocks/importer/wordpress/index.tsx
+++ b/client/blocks/importer/wordpress/index.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { convertToFriendlyWebsiteName } from 'calypso/blocks/import/util';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { addQueryArgs } from 'calypso/lib/route';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
@@ -40,7 +41,10 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	/**
 	 ↓ Fields
 	 */
-	const [ option, setOption ] = useState< WPImportOption >();
+	const queryParams = useQuery();
+	const [ option, setOption ] = useState< WPImportOption | undefined >(
+		getValidOptionParam( queryParams.get( 'option' ) )
+	);
 	const { job, fromSite, siteSlug, siteId, stepNavigator, showConfirmDialog } = props;
 	const siteItem = useSelector( ( state ) => getSite( state, siteId ) );
 	const fromSiteItem = useSelector( ( state ) =>
@@ -56,7 +60,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	/**
 	 ↓ Effects
 	 */
-	useEffect( checkOptionQueryParam );
+	useEffect( checkOptionQueryParam, [ queryParams.get( 'option' ) ] );
 	useEffect( checkImporterAvailability, [ siteId ] );
 	useEffect( () => {
 		if ( isMigrateFromWp ) {
@@ -96,15 +100,18 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	}
 
 	function checkOptionQueryParam() {
-		const urlSearchParams = new URLSearchParams( window.location.search );
-		const optionParam = urlSearchParams.get( 'option' );
+		const optionParam = queryParams.get( 'option' );
+		setOption( getValidOptionParam( optionParam ) );
+	}
+
+	function getValidOptionParam( param: string | null ) {
 		const options: string[] = Object.values( WPImportOption );
 
-		if ( optionParam && options.indexOf( optionParam ) >= 0 ) {
-			setOption( optionParam as WPImportOption );
-		} else {
-			setOption( undefined );
+		if ( param && options.indexOf( param ) >= 0 ) {
+			return param as WPImportOption;
 		}
+
+		return undefined;
 	}
 
 	function updateCurrentPageQueryParam( params: {

--- a/client/blocks/importer/wordpress/index.tsx
+++ b/client/blocks/importer/wordpress/index.tsx
@@ -8,7 +8,12 @@ import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { addQueryArgs } from 'calypso/lib/route';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { getSiteBySlug, getSite, isJetpackSite } from 'calypso/state/sites/selectors';
+import {
+	getSiteBySlug,
+	getSite,
+	isJetpackSite,
+	hasAllSitesList,
+} from 'calypso/state/sites/selectors';
 import { Importer, ImportJob, StepNavigator } from '../types';
 import { ContentChooser } from './content-chooser';
 import ImportContentOnly from './import-content-only';
@@ -43,6 +48,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	);
 	const isSiteAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 	const isSiteJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const hasAllSitesFetched = useSelector( ( state ) => hasAllSitesList( state ) );
 	const fromSiteAnalyzedData = useSelector( getUrlData );
 	const { setIsMigrateFromWp } = useDispatch( ONBOARD_STORE );
 	const isMigrateFromWp = useSelect( ( select ) => select( ONBOARD_STORE ).getIsMigrateFromWp() );
@@ -124,7 +130,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	return (
 		<>
 			{ ( () => {
-				if ( isNotAtomicJetpack() ) {
+				if ( isNotAtomicJetpack() || ! hasAllSitesFetched ) {
 					return <LoadingEllipsis />;
 				} else if ( undefined === option && fromSite ) {
 					return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -27,7 +27,7 @@ import {
 import { analyzeUrl } from 'calypso/state/imports/url-analyzer/actions';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { getSite } from 'calypso/state/sites/selectors';
+import { getSite, hasAllSitesList } from 'calypso/state/sites/selectors';
 import { StepProps } from '../../types';
 import { useAtomicTransferQueryParamUpdate } from './hooks/use-atomic-transfer-query-param-update';
 import { useInitialQueryRun } from './hooks/use-initial-query-run';
@@ -56,6 +56,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		const canImport = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );
 		const siteItem = useSelector( ( state ) => getSite( state, siteId ) );
 		const siteImports = useSelector( ( state ) => getImporterStatusForSiteId( state, siteId ) );
+		const hasAllSitesFetched = useSelector( ( state ) => hasAllSitesList( state ) );
 		const isImporterStatusHydrated = useSelector( isImporterStatusHydratedSelector );
 		const isMigrateFromWp = useSelect( ( select ) => select( ONBOARD_STORE ).getIsMigrateFromWp() );
 
@@ -113,7 +114,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		}
 
 		function isLoading(): boolean {
-			return ! isImporterStatusHydrated;
+			return ! isImporterStatusHydrated || ! hasAllSitesFetched;
 		}
 
 		function checkFromSiteData(): void {


### PR DESCRIPTION
## Proposed Changes

Fixed the flickering screen issue between Not found, Loading, and Not Authorized screens.
The solution is that we are going to wait to render the import module until we fetch all the necessary data.

Video, how it was before:
https://user-images.githubusercontent.com/1241413/221694053-112e05c0-c844-4324-964e-583c70bc855f.mp4

## Testing Instructions

* Go to `/setup/import-focused?siteSlug={SITE_SLUG}`
* Enter self-hosted website address (could be jurassic.ninja)
* Press the "Import your content" button
* The Import chooser screen loads
* Press the browser's refresh button
* **Check if the Import chooser screen loads without flickering between states (see video above)**
* Choose "Import everything"
* Press the browser's refresh button 
* **Check if the screen loads without screen flickering (see video above)**

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
