### PR TITLE
Add tracking events to offer jetpack complete page

### DIFF
--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/components/cta-buttons/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/components/cta-buttons/index.tsx
@@ -1,7 +1,9 @@
 import { PLAN_JETPACK_COMPLETE } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import Button from 'calypso/components/forms/form-button';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { buildCheckoutURL } from '../../../get-purchase-url-callback';
@@ -12,6 +14,23 @@ const CtaButtons = () => {
 	const translate = useTranslate();
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId );
+	const dispatch = useDispatch();
+
+	const onGetCompleteClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_complete_page_get_complete_click', {
+				site_id: siteId,
+			} )
+		);
+	}, [ dispatch, siteId ] );
+
+	const onContinueFreeClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_complete_page_continue_free_click', {
+				site_id: siteId,
+			} )
+		);
+	}, [ dispatch, siteId ] );
 
 	const checkoutURL = siteSlug
 		? buildCheckoutURL( siteSlug, PLAN_JETPACK_COMPLETE )
@@ -23,10 +42,19 @@ const CtaButtons = () => {
 
 	return (
 		<div className="jetpack-complete-page__cta-buttons">
-			<Button className="jetpack-complete-page__get-complete-button" primary href={ checkoutURL }>
+			<Button
+				className="jetpack-complete-page__get-complete-button"
+				primary
+				href={ checkoutURL }
+				onClick={ onGetCompleteClick }
+			>
 				{ translate( 'Get Complete' ) }
 			</Button>
-			<Button className="jetpack-complete-page__start-free-button" href={ stayFreeURL }>
+			<Button
+				className="jetpack-complete-page__start-free-button"
+				href={ stayFreeURL }
+				onClick={ onContinueFreeClick }
+			>
 				{ translate( 'Start for free' ) }
 			</Button>
 		</div>

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
@@ -67,14 +67,12 @@ const JetpackCompletePage: React.FC< Props > = ( {
 					cardImage={ rnaImageComplete }
 					cardImage2xRetina={ rnaImageComplete2xRetina }
 				>
-					<>
-						<ProductHeader item={ item } />
-						<PricingPageLink siteSlug={ siteSlug || urlQueryArgs?.site } />
-						<ItemsIncluded />
-						<ItemPrice item={ item } siteId={ siteId } />
+					<ProductHeader item={ item } />
+					<PricingPageLink siteSlug={ siteSlug || urlQueryArgs?.site } />
+					<ItemsIncluded />
+					<ItemPrice item={ item } siteId={ siteId } />
 
-						<CtaButtons />
-					</>
+					<CtaButtons />
 				</JetpackRnaDialogCard>
 			</Main>
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
1203759331596262-as-1203791007131735/f

## Proposed Changes
This PR adds tracking events to the buttons on the offer jetpack complete page. 

## Testing Instructions
- Pull the branch and start dev env locally `yarn start`
- Spin up a new JN site and navigate to plugin activation (Set up Jetpack)
- In URL change `https://wordpress.com` to `http://calypso.localhost:3000`
- Hit `Approve` button and you should be redirected to new complete page `/jetpack/connect/plans/complete`
- Open a Redux menu in Chrome console and verify that tracking events are recorded after clicking the buttons

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203791007131735