### PR TITLE
My Home Upsell: Update domain suggestion to ccTLD or .com

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -41,7 +41,9 @@ export function RenderDomainUpsell() {
 	const siteSubDomain = siteSlug.split( '.' )[ 0 ];
 	const locale = useLocale();
 	const { allDomainSuggestions } =
-		useDomainSuggestions( siteSubDomain, 3, undefined, locale ) || {};
+		useDomainSuggestions( siteSubDomain, 3, undefined, locale, {
+			vendor: 'domain-upsell',
+		} ) || {};
 
 	const cartKey = useCartKey();
 	const shoppingCartManager = useShoppingCart( cartKey );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/73549

## Proposed Changes

Update domain name suggestion for My Home Upsell.
It suggests a ccTLD (like .ca, .us, etc..) if the user is in a supported country. If not, it will show a `.com` suggestion

## Screenshots
| Before | After (Non ccTLD supported) | After (Canada) |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/402286/221662107-6c8aeb0a-dca7-414e-9f9c-db505606e517.png) | ![image](https://user-images.githubusercontent.com/402286/221662128-e55507be-6a12-45a3-a803-3de3221def8c.png) | ![image](https://user-images.githubusercontent.com/402286/221662139-2cfe3d6f-ecfc-48fc-ad76-65c196caeaf4.png) |

## Testing Instructions

- Use a site with a free plan without custom domain names.
- On the homepage, you should see the Upsell like the Screenshots
- If you are in a `ccTLD` supported country, you should see the domain suggestion of this country.
- If not, you should see a `.com` suggestion.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
