### PR TITLE
Staging Sites: Remove Tracks event for staging site add success

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -36,7 +36,6 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 
 	useEffect( () => {
 		if ( isStagingSiteTransferComplete ) {
-			dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_success' ) );
 			dispatch( successNotice( __( 'Staging site added.' ) ) );
 		}
 	}, [ dispatch, __, isStagingSiteTransferComplete ] );


### PR DESCRIPTION
From https://github.com/Automattic/wp-calypso/pull/73709

## Proposed Changes

Removes the `calypso_hosting_configuration_staging_site_add_success` Tracks event from the UI.

The user may or may not still be on the page. This is better tracked by the `atomic_clone_complete` event.

## Testing Instructions

N/A