### PR TITLE
WooExpress: Added trial upgrade confirmation mobile styles

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -20,11 +20,17 @@ const TrialUpgradeConfirmation = () => {
 						{ translate( 'Woo! Welcome to Commerce' ) }
 					</h1>
 					<div className="trial-upgrade-confirmation__subtitle">
-						{ translate( "Your purchase has been completed and you're on the %(planName)s plan.", {
-							args: { planName: 'Commerce' },
-						} ) }
-						<br />
-						{ translate( "Now it's time to get creative. What would you like to do next?" ) }
+						<span className="trial-upgrade-confirmation__subtitle-line">
+							{ translate(
+								"Your purchase has been completed and you're on the %(planName)s plan.",
+								{
+									args: { planName: 'Commerce' },
+								}
+							) }
+						</span>
+						<span className="trial-upgrade-confirmation__subtitle-line">
+							{ translate( "Now it's time to get creative. What would you like to do next?" ) }
+						</span>
 					</div>
 				</div>
 				<div className="trial-upgrade-confirmation__tasks">

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
@@ -1,4 +1,5 @@
 @import "@automattic/components/src/styles/typography";
+@import "@wordpress/base-styles/breakpoints";
 
 body.ecommerce-trial-upgraded {
 	background-color: var(--color-surface);
@@ -7,22 +8,56 @@ body.ecommerce-trial-upgraded {
 	.trial-upgrade-confirmation__header {
 		text-align: center;
 		padding: 20px 0;
+		margin-top: 20px;
+
+		@media (max-width: $break-mobile) {
+			text-align: left;
+		}
 
 		.trial-upgrade-confirmation__title {
 			font-size: $font-title-large;
-			padding: 20px;
+			padding: 0 20px;
+
+			@media (max-width: $break-mobile) {
+				font-size: $font-title-medium;
+			}
 		}
 
 		.trial-upgrade-confirmation__subtitle {
+			padding: 20px;
 			font-size: $font-body;
+
+			@media (max-width: $break-mobile) {
+				padding-bottom: 0;
+			}
+
+			.trial-upgrade-confirmation__subtitle-line {
+				display: block;
+
+				@media (max-width: $break-mobile) {
+					display: inline;
+
+					// Add space between sentences when they are inline
+					&::after {
+						content: " ";
+					}
+				}
+			}
 		}
 	}
 
 	.trial-upgrade-confirmation__tasks {
 		display: grid;
-		grid-template-columns: repeat(3, 1fr);
+		grid-template-columns: repeat(auto-fill, 320px);
 		grid-column-gap: 32px;
 		grid-row-gap: 32px;
 		margin: 55px 0;
+		justify-content: center;
+
+		@media (max-width: $break-mobile) {
+			margin-top: 10px;
+			padding: 0 20px;
+			grid-template-columns: repeat(1, auto);
+		}
 	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/73500

## Proposed Changes

* This PRs adds mobile styles to the trial post-checkout page.

## Testing Instructions

* Using calypso-live, access `plans/my-plan/trial-upgraded/<site-slug>`
* Switch to mobile mode and compare the results to the Figma designs (jBwlERMS350NqhJNHZzAVF-fi-98%3A33334)

Figma:
![pmbAQD.png](https://user-images.githubusercontent.com/3801502/221684298-90857a91-15b8-43f1-9881-7bb47e5b2b9a.png)

HTML:

![image](https://user-images.githubusercontent.com/3801502/221684385-a16533c3-1acc-4a13-8d52-05c6486ac7d2.png)

"Tablet" version  (not in the designs):
![image](https://user-images.githubusercontent.com/3801502/221684515-f3b0503c-03bf-4131-bf2b-f9d9f1350b5d.png)
