### PR TITLE
Update help center launchpad site options

### DIFF
--- a/packages/help-center/src/components/help-center-launchpad.tsx
+++ b/packages/help-center/src/components/help-center-launchpad.tsx
@@ -3,10 +3,12 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { CircularProgressBar } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { useSelect } from '@wordpress/data';
 import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
-import { getSectionName } from 'calypso/state/ui/selectors';
+import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { SITE_STORE } from '../stores';
 
 const getEnvironmentHostname = () => {
 	try {
@@ -26,8 +28,17 @@ const getEnvironmentHostname = () => {
 
 export const HelpCenterLaunchpad = () => {
 	const { __ } = useI18n();
-	const siteIntent = window?.helpCenterData?.currentSite?.site_intent;
-	const siteSlug = window?.location?.host;
+
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const site = useSelect( ( select ) => siteId && select( SITE_STORE ).getSite( siteId ) );
+	let siteIntent = site && site?.options?.site_intent;
+	let siteSlug = site && new URL( site.URL ).host;
+
+	if ( ! siteIntent || ! siteSlug ) {
+		siteIntent = window?.helpCenterData?.currentSite?.site_intent;
+		siteSlug = window?.location?.host;
+	}
+
 	const launchpadURL = `${ getEnvironmentHostname() }/setup/${ siteIntent }/launchpad?siteSlug=${ siteSlug }`;
 	const sectionName = useSelector( ( state ) => getSectionName( state ) );
 	const handleLaunchpadHelpLinkClick = () => {

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -1,16 +1,19 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 /* eslint-disable no-restricted-imports */
+import { useSelect } from '@wordpress/data';
 import { useState, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import InlineHelpSearchCard from 'calypso/blocks/inline-help/inline-help-search-card';
 import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { HelpCenterLaunchpad } from './help-center-launchpad';
 import { HelpCenterMoreResources } from './help-center-more-resources';
 import HelpCenterSearchResults from './help-center-search-results';
 import './help-center-search.scss';
 import './help-center-launchpad.scss';
-import { SibylArticles } from './help-center-sibyl-articles';
+import { SibylArticles, SITE_STORE } from './help-center-sibyl-articles';
 
 export const HelpCenterSearch = () => {
 	const history = useHistory();
@@ -20,7 +23,13 @@ export const HelpCenterSearch = () => {
 
 	const [ searchQuery, setSearchQuery ] = useState( query || '' );
 
-	const launchpadEnabled = window?.helpCenterData?.currentSite?.launchpad_screen === 'full';
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const site = useSelect( ( select ) => siteId && select( SITE_STORE ).getSite( siteId ) );
+	let launchpadEnabled = site && site?.options.launchpad_screen === 'full';
+
+	if ( ! launchpadEnabled ) {
+		launchpadEnabled = window?.helpCenterData?.currentSite?.launchpad_screen === 'full';
+	}
 
 	// Search query can be a query param, if the user searches or clears the search field
 	// we need to keep the query param up-to-date with that

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -8,12 +8,13 @@ import { useHistory, useLocation } from 'react-router-dom';
 import InlineHelpSearchCard from 'calypso/blocks/inline-help/inline-help-search-card';
 import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { SITE_STORE } from '../stores';
 import { HelpCenterLaunchpad } from './help-center-launchpad';
 import { HelpCenterMoreResources } from './help-center-more-resources';
 import HelpCenterSearchResults from './help-center-search-results';
 import './help-center-search.scss';
 import './help-center-launchpad.scss';
-import { SibylArticles, SITE_STORE } from './help-center-sibyl-articles';
+import { SibylArticles } from './help-center-sibyl-articles';
 
 export const HelpCenterSearch = () => {
 	const history = useHistory();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72276

## Proposed Changes

* Add launchpad related site options to help center `helpCenterData` window object.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* To test on simple site: `cd apps/editing-toolkit` and run `yarn dev --sync`
* To test on atomic site: Download the editing-toolkit.zip and upload to your atomic site (PCYsg-ly5-p2)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
