### PR TITLE
WooExpress: Added confetti component

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -1,3 +1,4 @@
+import { Confetti } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
@@ -15,6 +16,8 @@ const TrialUpgradeConfirmation = () => {
 		<>
 			<BodySectionCssClass bodyClass={ [ 'ecommerce-trial-upgraded' ] } />
 			<Main wideLayout>
+				<Confetti className="trial-upgrade-confirmation__confetti" />
+
 				<div className="trial-upgrade-confirmation__header">
 					<h1 className="trial-upgrade-confirmation__title">
 						{ translate( 'Woo! Welcome to Commerce' ) }

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
@@ -1,4 +1,5 @@
 @import "@automattic/components/src/styles/typography";
+@import "@wordpress/base-styles/breakpoints";
 
 body.ecommerce-trial-upgraded {
 	background-color: var(--color-surface);
@@ -24,5 +25,18 @@ body.ecommerce-trial-upgraded {
 		grid-column-gap: 32px;
 		grid-row-gap: 32px;
 		margin: 55px 0;
+	}
+
+	.trial-upgrade-confirmation__confetti {
+		width: 550px;
+		position: absolute;
+		top: -20px;
+		left: 0;
+		right: 0;
+		margin: auto;
+
+		@media (max-width: $break-mobile) {
+			display: none;
+		}
 	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/73500

## Proposed Changes

* This PRs adds the `<Confetti />` component from `@automattic/onbarding` to the trial post-checkout page.
* If the component is not good enough, we can add the confetti from Figma as a new svg.

## Testing Instructions

* Using calypso-live, access `plans/my-plan/trial-upgraded/<site-slug>`
* See the Confetti

Figma:
![image](https://user-images.githubusercontent.com/3801502/221690992-9d6ab683-c38a-4322-b6db-7d5c3e110165.png)

HTML: 
![image](https://user-images.githubusercontent.com/3801502/221691063-e4862561-06d3-4803-8eb6-7de136d32e02.png)
