### PR TITLE
Launchpad:  Make the domain upsell task and badge url identical

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -79,6 +79,9 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 	const launchTask = enhancedTasks?.find( ( task ) => task.isLaunchTask === true );
 
 	const showLaunchTitle = launchTask && ! launchTask.disabled;
+	const domainUpgradeBadgeUrl = ! site?.plan?.is_free
+		? `/domains/manage/${ siteSlug }`
+		: `/domains/add/${ siteSlug }?domainAndPlanPackage=true`;
 
 	if ( sidebarDomain ) {
 		const { domain, isPrimary, isWPCOMDomain, sslStatus } = sidebarDomain;
@@ -143,7 +146,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 						) }
 					</div>
 					{ sidebarDomain?.isWPCOMDomain && (
-						<a href={ `/domains/add/${ siteSlug }` }>
+						<a href={ domainUpgradeBadgeUrl }>
 							<Badge className="launchpad__domain-upgrade-badge" type="info-blue">
 								{ translate( 'Customize' ) }
 							</Badge>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -27,7 +27,7 @@ const sidebarDomain = buildDomainResponse( {
 } );
 
 const upgradeDomainBadgeText = 'Customize';
-const upgradeDomainBadgeLink = `/domains/add/${ sidebarDomain.domain }`;
+const upgradeDomainBadgeLink = `/domains/add/${ sidebarDomain.domain }?domainAndPlanPackage=true`;
 
 const props = {
 	sidebarDomain,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* When the use clicks on the domain upsell badge, it redirects them to the new domains and plans flow
* If the plan has already been upgraded **but no custom domain has been applied**, it takes the user to the domain management screen
* If the plan has already been upgraded **and a custom domain has been applied**, no customize badge is displayed

## Screenshots
### Free Plan
![2023-02-27 14 32 01](https://user-images.githubusercontent.com/5414230/221700971-a970acf7-08db-496a-9fcc-deedb237602f.gif)

### Paid Plan With No Custom Domain
![2023-02-27 14 33 23](https://user-images.githubusercontent.com/5414230/221701180-87474904-7d27-40ee-a3e6-4471b7b2a5a0.gif)

### Paid Plan With Custom Domain
<img width="1496" alt="Screenshot 2023-02-28 at 1 58 42 PM" src="https://user-images.githubusercontent.com/5414230/221990996-5f964d28-5648-4c47-b14c-e9e7fac485ef.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch
- Run `yarn start`
- Create a new site using the write flow from https://wordpress.com/setup/free
- Walk through the onboarding flow as normal
- Once you arrive at Launchpad, click on `Customize` badge in the sidebar
- Verify that you land in the `/domains/add/${ siteSlug }?domainAndPlanPackage=true`
- Add a domain and upgrade the site plan
- Navigate back to the Launchpad and click on `Customize` badge in the sidebar
- Verify that you land in the `/domains/manage/${ siteSlug }`
- Repeat for the newsletter flow, link in bio flow, and other flows

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
