### PR TITLE
Launchpad: Fix typescript and eslint notices

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -30,11 +30,11 @@ function getUrlInfo( url: string ) {
 	const urlWithoutProtocol = url.replace( /^https?:\/\//, '' );
 
 	// Ex. mytest.wordpress.com matches mytest
-	const siteName = urlWithoutProtocol.match( /^[^.]*/ );
+	const siteName = urlWithoutProtocol.match( /^[^.]*/ )?.[ 0 ] || '';
 	// Ex. mytest.wordpress.com matches .wordpress.com
-	const topLevelDomain = urlWithoutProtocol.match( /\..*/ ) || [];
+	const topLevelDomain = urlWithoutProtocol.match( /\..*/ )?.[ 0 ] || '';
 
-	return [ siteName ? siteName[ 0 ] : '', topLevelDomain ? topLevelDomain[ 0 ] : '' ];
+	return [ siteName, topLevelDomain ];
 }
 
 function getTasksProgress( tasks: Task[] | null ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -62,7 +62,7 @@ const StepContent = ( { siteSlug, submit, goNext, goToStep, flow }: StepContentP
 		if ( email && ! isEmailVerified && flow === NEWSLETTER_FLOW ) {
 			setShowEmailValidationBanner( true );
 		}
-	}, [ email, isEmailVerified ] );
+	}, [ email, isEmailVerified, flow ] );
 
 	return (
 		<main className="launchpad__container">


### PR DESCRIPTION
### Proposed Changes

This PR fixes some small TypeScript errors by slightly modifying how we define and return values from a function.

I also took the opportunity to fix an eslint warning about a missing dependency in launchpad's step-content.tsx file. 

### Testing

**Review Time: Short**
**Testing Time: Short**

1) Checkout this branch and run yarn and yarn start if needed. 
2) Navigate to the following line of code in your editor, and confirm there are no longer TS errors. 
3) Create a new free site or pull up the Launchpad screen for an existing free site, and confirm that the domain field populates correctly with *.wordpress.com domains. 
4) Create a new site with a custom domain, or pull up the launchpad screen for an existing site with custom domain, and confirm the domain field populates correctly with the custom domain. 