### PR TITLE
Add back coming soon flag to Sensei Flow

### DIFF
--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -128,6 +128,7 @@ export function* createSenseiSite( {
 			use_patterns: true,
 			site_intent: 'sensei',
 			selected_features: selectedFeatures,
+			wpcom_public_coming_soon: 1,
 			...( selectedDesign && { is_blank_canvas: isBlankCanvasDesign( selectedDesign ) } ),
 		},
 	} );


### PR DESCRIPTION


## Proposed Changes

* We're adding back the `wpcom_public_coming_soon` flag to our Sensei Flow setup.

## Testing Instructions

1. Checkout this branch
2. `yarn start` on your local machine
3. Go to `http://calypso.localhost:3000/setup/sensei/`
4. Go through the regular Sensei Flow
5. At the end, go to the "My Home" page in Calypso, and make sure the Launch step is not completed.  It should look like this:
<img width="368" alt="Screenshot 2023-02-27 at 3 13 17 PM" src="https://user-images.githubusercontent.com/3220162/221710557-34d1dc7c-0a30-4bd8-9c98-4e6227afe0a2.png">

Then try to "Launch" the site and make sure it launches properly.
