### PR TITLE
Staging Sites: Query for staging site attributes for use in UI

### DIFF
--- a/client/data/sites/site-excerpt-constants.ts
+++ b/client/data/sites/site-excerpt-constants.ts
@@ -14,6 +14,7 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 	'plan',
 	'jetpack',
 	'is_wpcom_atomic',
+	'is_staging_site',
 	'user_interactions',
 	'lang',
 	'site_owner',
@@ -29,4 +30,6 @@ export const SITE_EXCERPT_REQUEST_OPTIONS = [
 	'site_intent',
 	'unmapped_url',
 	'updated_at',
+	'wpcom_production_blog_id',
+	'wpcom_staging_blog_ids',
 ] as const;

--- a/client/data/sites/site-excerpt-constants.ts
+++ b/client/data/sites/site-excerpt-constants.ts
@@ -14,7 +14,7 @@ export const SITE_EXCERPT_REQUEST_FIELDS = [
 	'plan',
 	'jetpack',
 	'is_wpcom_atomic',
-	'is_staging_site',
+	'is_wpcom_staging_site',
 	'user_interactions',
 	'lang',
 	'site_owner',

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -113,7 +113,7 @@ export interface SiteDetails {
 	is_private?: boolean;
 	is_vip?: boolean;
 	is_wpcom_atomic?: boolean;
-	is_staging_site?: boolean;
+	is_wpcom_staging_site?: boolean;
 	jetpack: boolean;
 	lang?: string;
 	launch_status: string;

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -113,6 +113,7 @@ export interface SiteDetails {
 	is_private?: boolean;
 	is_vip?: boolean;
 	is_wpcom_atomic?: boolean;
+	is_staging_site?: boolean;
 	jetpack: boolean;
 	lang?: string;
 	launch_status: string;
@@ -230,6 +231,8 @@ export interface SiteDetailsOptions {
 	wordads?: boolean;
 	launchpad_screen?: false | 'off' | 'full' | 'minimized';
 	launchpad_checklist_tasks_statuses?: LaunchPadCheckListTasksStatuses;
+	wpcom_production_blog_id?: number;
+	wpcom_staging_blog_ids?: number[];
 }
 
 export type SiteOption = keyof SiteDetails[ 'options' ];


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/1848
See https://github.com/Automattic/dotcom-forge/issues/1697

## Proposed Changes

Pulls `is_wpcom_staging_site`, `wpcom_production_blog_id`, and `wpcom_staging_blog_ids` into Calypso for use with staging site UI.

## Testing Instructions

See https://github.com/Automattic/jetpack/pull/29192