### PR TITLE
[ETK][GB 15.2.x] Patch the modules in `@wordpress/interface@4.8.0` to match recent changes in Gutenberg 15.2.x

### DIFF
--- a/.yarn/patches/@wordpress-interface-npm-4.8.0-8a39ad37cf.patch
+++ b/.yarn/patches/@wordpress-interface-npm-4.8.0-8a39ad37cf.patch
@@ -1,0 +1,74 @@
+diff --git a/build-module/store/selectors.js b/build-module/store/selectors.js
+index f213c22d1685c56a2b7686a35ef0c53481569993..aebaaed394b4bb310b908cdbbe994a3a89977609 100644
+--- a/build-module/store/selectors.js
++++ b/build-module/store/selectors.js
+@@ -25,12 +25,25 @@ export const getActiveComplementaryArea = createRegistrySelector(select => (stat
+   } // Return `null` to indicate the user hid the complementary area.
+ 
+ 
+-  if (!isComplementaryAreaVisible) {
++  if ( isComplementaryAreaVisible === false ) {
+     return null;
+   }
+ 
+   return state === null || state === void 0 ? void 0 : (_state$complementaryA = state.complementaryAreas) === null || _state$complementaryA === void 0 ? void 0 : _state$complementaryA[scope];
+ });
++
++export const isComplementaryAreaLoading = createRegistrySelector(
++	( select ) => ( state, scope ) => {
++		const isVisible = select( preferencesStore ).get(
++			scope,
++			'isComplementaryAreaVisible'
++		);
++		const identifier = state?.complementaryAreas?.[ scope ];
++
++		return isVisible && identifier === undefined;
++	}
++);
++
+ /**
+  * Returns a boolean indicating if an item is pinned or not.
+  *
+diff --git a/src/components/complementary-area/index.js b/src/components/complementary-area/index.js
+index 71fb6a610d6a32e8e381032743769222ba05df9a..f240ab8bb2f08261c062b99f3f2982b41d72174d 100644
+--- a/src/components/complementary-area/index.js
++++ b/src/components/complementary-area/index.js
+@@ -98,13 +98,14 @@ function ComplementaryArea( {
+ 	isActiveByDefault,
+ 	showIconLabels = false,
+ } ) {
+-	const { isActive, isPinned, activeArea, isSmall, isLarge } = useSelect(
++	const { isLoading, isActive, isPinned, activeArea, isSmall, isLarge } = useSelect(
+ 		( select ) => {
+-			const { getActiveComplementaryArea, isItemPinned } = select(
++			const { getActiveComplementaryArea, isComplementaryAreaLoading, isItemPinned } = select(
+ 				interfaceStore
+ 			);
+ 			const _activeArea = getActiveComplementaryArea( scope );
+ 			return {
++				isLoading: isComplementaryAreaLoading( scope ),
+ 				isActive: _activeArea === identifier,
+ 				isPinned: isItemPinned( scope, identifier ),
+ 				activeArea: _activeArea,
+@@ -129,8 +130,13 @@ function ComplementaryArea( {
+ 	} = useDispatch( interfaceStore );
+ 
+ 	useEffect( () => {
++		// Set initial visibility: For large screens, enable if it's active by
++		// default. For small screens, always initially disable.
+ 		if ( isActiveByDefault && activeArea === undefined && ! isSmall ) {
+ 			enableComplementaryArea( scope, identifier );
++		} else if ( activeArea === undefined && isSmall ) {
++			disableComplementaryArea( scope, identifier );
++
+ 		}
+ 	}, [ activeArea, isActiveByDefault, scope, identifier, isSmall ] );
+ 
+@@ -146,6 +152,7 @@ function ComplementaryArea( {
+ 								isActive && ( ! showIconLabels || isLarge )
+ 							}
+ 							aria-expanded={ isActive }
++							aria-disabled={ isLoading }
+ 							label={ title }
+ 							icon={ showIconLabels ? check : icon }
+ 							showTooltip={ ! showIconLabels }

--- a/package.json
+++ b/package.json
@@ -297,7 +297,8 @@
 		"newspack-components/@wordpress/element": "4.7.0",
 		"newspack-components/@wordpress/i18n": "4.9.0",
 		"keytar@npm:7.7.0/node-addon-api": "3.1.0",
-		"lzma-native": "^8.0.5"
+		"lzma-native": "^8.0.5",
+		"@wordpress/interface@^4.8.0": "patch:@wordpress/interface@npm%3A4.8.0#./.yarn/patches/@wordpress-interface-npm-4.8.0-8a39ad37cf.patch"
 	},
 	"packageManager": "yarn@3.2.3",
 	"dependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8947,7 +8947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/interface@npm:^4.8.0":
+"@wordpress/interface@npm:4.8.0":
   version: 4.8.0
   resolution: "@wordpress/interface@npm:4.8.0"
   dependencies:
@@ -8969,6 +8969,31 @@ __metadata:
     react: ^17.0.0
     react-dom: ^17.0.0
   checksum: 2b77361bcfdb6ff1e61d26ad4804bf6701efb4c59418a6e0427857dcd74511c28888c83e195f0e2b25a04c5d49a3f52a8e19fd09826063a085a7c468303583be
+  languageName: node
+  linkType: hard
+
+"@wordpress/interface@patch:@wordpress/interface@npm%3A4.8.0#./.yarn/patches/@wordpress-interface-npm-4.8.0-8a39ad37cf.patch::locator=wp-calypso%40workspace%3A.":
+  version: 4.8.0
+  resolution: "@wordpress/interface@patch:@wordpress/interface@npm%3A4.8.0#./.yarn/patches/@wordpress-interface-npm-4.8.0-8a39ad37cf.patch::version=4.8.0&hash=2df8dc&locator=wp-calypso%40workspace%3A."
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/a11y": ^3.9.0
+    "@wordpress/components": ^19.11.0
+    "@wordpress/compose": ^5.7.0
+    "@wordpress/data": ^6.9.0
+    "@wordpress/deprecated": ^3.9.0
+    "@wordpress/element": ^4.7.0
+    "@wordpress/i18n": ^4.9.0
+    "@wordpress/icons": ^9.0.0
+    "@wordpress/plugins": ^4.7.0
+    "@wordpress/preferences": ^2.1.0
+    "@wordpress/viewport": ^4.7.0
+    classnames: ^2.3.1
+    lodash: ^4.17.21
+  peerDependencies:
+    react: ^17.0.0
+    react-dom: ^17.0.0
+  checksum: 135ac4a7970a958c49fc04cd040f20d24a03d3a866507a42d4d6b6e25a6516b090bdec0a464618f6cbcfe31283e2cf553a33e5aaa8936713d4e2c7ba9c7802b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Simpler workaround to https://github.com/Automattic/wp-calypso/pull/73629. And it works!

Solves the WPCOM WSOD caused by Gutenberg 15.2. You can read about the issue in the PR above.

## Proposed Changes

Patches the `@wordpress/interface@4.8.0` (using `yarn patch-package`) with the relevant changes from https://github.com/Automattic/wp-calypso/pull/73629. This allows us to surgically update the code with the needed changes without update the package to its latest version, which turned out to be a more complicated process than we initially thought (see this Slack thread for more about that: p1677172931351469/1677020860.615489-slack-CBTN58FT).

## Testing Instructions

1. Install Gutenberg 15.2.2 in your WPCOM sandbox
2. Try to create a new post or page
3. You'll see the editor crash
4. Now build and sync ETK from this branch to your sandbox (`yarn && yarn dev --sync`)
5. Try to create a new page or post
6. Profit! The editor works now :)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?