### PR TITLE
BBE: Add checkbox for page builds with filler content

### DIFF
--- a/client/signup/accordion-form/form-components.tsx
+++ b/client/signup/accordion-form/form-components.tsx
@@ -10,7 +10,6 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextArea from 'calypso/components/forms/form-textarea';
 import InfoPopover from 'calypso/components/info-popover';
 import SocialLogo from 'calypso/components/social-logo';
-import Tooltip from 'calypso/components/tooltip';
 import { tip } from 'calypso/signup/icons';
 
 // TODO: This probably should be moved out to a more suitable folder name like difm-components

--- a/client/signup/accordion-form/form-components.tsx
+++ b/client/signup/accordion-form/form-components.tsx
@@ -119,9 +119,11 @@ const FlexFormFieldset = styled( FormFieldset )`
 	display: flex;
 `;
 
-const StyledFormFieldset = styled( FormFieldset )`
-	margin-bottom: ${ ( props ) => ( props.hasFillerContentCheckbox ? '12px' : '20px' ) };
-`;
+const StyledFormFieldset = styled( FormFieldset, {
+	shouldForwardProp: ( prop ) => prop !== 'hasFillerContentCheckbox',
+} )( ( props ) => ( {
+	marginBottom: props.hasFillerContentCheckbox ? '12px' : '20px',
+} ) );
 
 const StyledFormCheckbox = styled( FormCheckbox )`
 	margin-right: 6px;
@@ -183,12 +185,13 @@ interface TextAreaFieldProps extends TextInputFieldProps {
 }
 
 export function TextAreaField( props: TextAreaFieldProps ) {
+	const { hasFillerContentCheckbox, ...otherProps } = props;
 	return (
-		<StyledFormFieldset hasFillerContentCheckbox={ props.hasFillerContentCheckbox }>
+		<StyledFormFieldset hasFillerContentCheckbox={ hasFillerContentCheckbox }>
 			{ props.label && <LabelBlock inputName={ props.name }>{ props.label } </LabelBlock> }
 			{ props.sublabel && <SubLabel htmlFor={ props.name }>{ props.sublabel }</SubLabel> }
 			<TextArea
-				{ ...props }
+				{ ...otherProps }
 				rows={ props.rows ? props.rows : 10 }
 				isError={ !! props.error }
 				autoCapitalize="off"

--- a/client/signup/accordion-form/form-components.tsx
+++ b/client/signup/accordion-form/form-components.tsx
@@ -1,13 +1,14 @@
-import { FormInputValidation, Gridicon } from '@automattic/components';
+import { FormInputValidation } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Icon } from '@wordpress/icons';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { ChangeEvent, ChangeEventHandler, ReactChild, useRef, useState } from 'react';
+import { ChangeEvent, ChangeEventHandler, ReactChild } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextArea from 'calypso/components/forms/form-textarea';
+import InfoPopover from 'calypso/components/info-popover';
 import SocialLogo from 'calypso/components/social-logo';
 import Tooltip from 'calypso/components/tooltip';
 import { tip } from 'calypso/signup/icons';
@@ -118,35 +119,16 @@ const FlexFormFieldset = styled( FormFieldset )`
 	display: flex;
 `;
 
+const StyledFormFieldset = styled( FormFieldset )`
+	margin-bottom: ${ ( props ) => ( props.hasFillerContentCheckbox ? '12px' : '20px' ) };
+`;
+
 const StyledFormCheckbox = styled( FormCheckbox )`
 	margin-right: 6px;
 `;
 
 const ClickableLabel = styled( Label )`
 	cursor: pointer;
-`;
-
-const TooltipContainer = styled.span`
-	.gridicon {
-		cursor: pointer;
-		margin-left: 8px;
-	}
-`;
-
-const StyledTooltip = styled( Tooltip )`
-	&.tooltip.popover .popover__inner {
-		background: var( --color-masterbar-background );
-		text-align: center;
-		border-radius: 4px;
-		min-height: 32px;
-		width: 210px;
-		align-items: center;
-		font-style: normal;
-		font-weight: 400;
-		font-size: 1em;
-		padding: 8px 10px;
-		top: -8px;
-	}
 `;
 
 interface TextInputFieldProps {
@@ -197,11 +179,12 @@ export function TextInputField( props: TextInputFieldProps ) {
 
 interface TextAreaFieldProps extends TextInputFieldProps {
 	rows?: number;
+	hasFillerContentCheckbox?: boolean;
 }
 
 export function TextAreaField( props: TextAreaFieldProps ) {
 	return (
-		<FormFieldset>
+		<StyledFormFieldset hasFillerContentCheckbox={ props.hasFillerContentCheckbox }>
 			{ props.label && <LabelBlock inputName={ props.name }>{ props.label } </LabelBlock> }
 			{ props.sublabel && <SubLabel htmlFor={ props.name }>{ props.sublabel }</SubLabel> }
 			<TextArea
@@ -213,7 +196,7 @@ export function TextAreaField( props: TextAreaFieldProps ) {
 				spellCheck="false"
 			/>
 			{ props.error && <StyledFormInputValidation isError text={ props.error } /> }
-		</FormFieldset>
+		</StyledFormFieldset>
 	);
 }
 
@@ -225,8 +208,6 @@ export function CheckboxField( props: {
 	label: TranslateResult;
 	helpText: TranslateResult;
 } ) {
-	const [ isVisible, setIsVisible ] = useState( false );
-	const tooltipRef = useRef< HTMLDivElement >( null );
 	return (
 		<FlexFormFieldset>
 			<ClickableLabel>
@@ -240,23 +221,9 @@ export function CheckboxField( props: {
 					{ props.label }
 				</>
 			</ClickableLabel>
-			<TooltipContainer>
-				<span
-					onMouseEnter={ () => setIsVisible( true ) }
-					onMouseLeave={ () => setIsVisible( false ) }
-					ref={ tooltipRef }
-				>
-					<Gridicon size={ 18 } icon="info-outline" />
-				</span>
-				<StyledTooltip
-					position="top"
-					context={ tooltipRef.current }
-					hideArrow
-					isVisible={ isVisible }
-				>
-					{ props.helpText }
-				</StyledTooltip>
-			</TooltipContainer>
+			<InfoPopover showOnHover={ true } position="top">
+				{ props.helpText }
+			</InfoPopover>
 		</FlexFormFieldset>
 	);
 }

--- a/client/signup/accordion-form/form-components.tsx
+++ b/client/signup/accordion-form/form-components.tsx
@@ -1,13 +1,15 @@
-import { FormInputValidation } from '@automattic/components';
+import { FormInputValidation, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Icon } from '@wordpress/icons';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { ChangeEvent, ReactChild } from 'react';
+import { ChangeEvent, ChangeEventHandler, ReactChild, useRef, useState } from 'react';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextArea from 'calypso/components/forms/form-textarea';
 import SocialLogo from 'calypso/components/social-logo';
+import Tooltip from 'calypso/components/tooltip';
 import { tip } from 'calypso/signup/icons';
 
 // TODO: This probably should be moved out to a more suitable folder name like difm-components
@@ -112,6 +114,41 @@ const StyledFormInputValidation = styled( FormInputValidation )`
 	}
 `;
 
+const FlexFormFieldset = styled( FormFieldset )`
+	display: flex;
+`;
+
+const StyledFormCheckbox = styled( FormCheckbox )`
+	margin-right: 6px;
+`;
+
+const ClickableLabel = styled( Label )`
+	cursor: pointer;
+`;
+
+const TooltipContainer = styled.span`
+	.gridicon {
+		cursor: pointer;
+		margin-left: 8px;
+	}
+`;
+
+const StyledTooltip = styled( Tooltip )`
+	&.tooltip.popover .popover__inner {
+		background: var( --color-masterbar-background );
+		text-align: center;
+		border-radius: 4px;
+		min-height: 32px;
+		width: 210px;
+		align-items: center;
+		font-style: normal;
+		font-weight: 400;
+		font-size: 1em;
+		padding: 8px 10px;
+		top: -8px;
+	}
+`;
+
 interface TextInputFieldProps {
 	name: string;
 	label?: TranslateResult;
@@ -121,6 +158,7 @@ interface TextInputFieldProps {
 	sublabel?: TranslateResult;
 	rows?: number;
 	explanation?: TranslateResult;
+	disabled?: boolean;
 	onChange?: ( event: ChangeEvent< HTMLInputElement > ) => void;
 }
 
@@ -176,6 +214,50 @@ export function TextAreaField( props: TextAreaFieldProps ) {
 			/>
 			{ props.error && <StyledFormInputValidation isError text={ props.error } /> }
 		</FormFieldset>
+	);
+}
+
+export function CheckboxField( props: {
+	checked: boolean;
+	name: string;
+	value: string;
+	onChange: ChangeEventHandler< HTMLInputElement >;
+	label: TranslateResult;
+	helpText: TranslateResult;
+} ) {
+	const [ isVisible, setIsVisible ] = useState( false );
+	const tooltipRef = useRef< HTMLDivElement >( null );
+	return (
+		<FlexFormFieldset>
+			<ClickableLabel>
+				<>
+					<StyledFormCheckbox
+						name={ props.name }
+						value={ props.value }
+						checked={ props.checked }
+						onChange={ props.onChange }
+					/>
+					{ props.label }
+				</>
+			</ClickableLabel>
+			<TooltipContainer>
+				<span
+					onMouseEnter={ () => setIsVisible( true ) }
+					onMouseLeave={ () => setIsVisible( false ) }
+					ref={ tooltipRef }
+				>
+					<Gridicon size={ 18 } icon="info-outline" />
+				</span>
+				<StyledTooltip
+					position="top"
+					context={ tooltipRef.current }
+					hideArrow
+					isVisible={ isVisible }
+				>
+					{ props.helpText }
+				</StyledTooltip>
+			</TooltipContainer>
+		</FlexFormFieldset>
 	);
 }
 

--- a/client/signup/steps/website-content/section-generator.tsx
+++ b/client/signup/steps/website-content/section-generator.tsx
@@ -51,7 +51,7 @@ const generateSiteInformationSection = (
 						logoUrl={ formValues.siteInformationSection?.siteLogoUrl }
 					/>
 				),
-				showSkip: true,
+				showSkip: false,
 				validate: () => {
 					const isValid = Boolean( formValues.siteInformationSection?.searchTerms?.length );
 					return {

--- a/client/signup/steps/website-content/section-generator.tsx
+++ b/client/signup/steps/website-content/section-generator.tsx
@@ -108,7 +108,7 @@ const generateWebsiteContentSections = (
 				},
 				comment: 'This is the serial number: 1',
 			} ),
-			summary: page.content,
+			summary: page.useFillerContent ? translate( 'AI Content 🌟' ) : page.content,
 			component: (
 				<DisplayedPageComponent
 					page={ page }
@@ -119,7 +119,8 @@ const generateWebsiteContentSections = (
 			),
 			showSkip: !! OPTIONAL_PAGES[ page.id ],
 			validate: () => {
-				const isValid = OPTIONAL_PAGES[ page.id ] || Boolean( page.content?.length );
+				const isValid =
+					OPTIONAL_PAGES[ page.id ] || Boolean( page.content?.length ) || page.useFillerContent;
 				return {
 					result: isValid,
 					errors: {

--- a/client/signup/steps/website-content/section-types/default-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/default-page-details.tsx
@@ -1,3 +1,4 @@
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -41,6 +42,7 @@ export function DefaultPageDetails( {
 	const pageTitle = page.title;
 	const pageID = page.id;
 	const description = useTranslatedPageDescriptions( pageID, context );
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const onMediaUploadFailed = ( { mediaIndex }: MediaUploadData ) => {
 		dispatch(
@@ -150,16 +152,18 @@ export function DefaultPageDetails( {
 				label={ description }
 				disabled={ !! page.useFillerContent }
 			/>
-			<CheckboxField
-				name="useFillerContent"
-				checked={ page.useFillerContent || false }
-				value="true"
-				onChange={ onCheckboxChanged }
-				label={ translate( 'Build this page with AI-generated text.' ) }
-				helpText={ translate(
-					'When building your site, we will use AI to generate copy based on the search phrases you have provided. The copy can be edited later with the WordPress editor.'
-				) }
-			/>
+			{ isEnglishLocale && (
+				<CheckboxField
+					name="useFillerContent"
+					checked={ page.useFillerContent || false }
+					value="true"
+					onChange={ onCheckboxChanged }
+					label={ translate( 'Build this page with AI-generated text.' ) }
+					helpText={ translate(
+						'When building your site, we will use AI to generate copy based on the search phrases you have provided. The copy can be edited later with the WordPress editor.'
+					) }
+				/>
+			) }
 			<LabelBlock>{ getMediaCaption() }</LabelBlock>
 			<HorizontalGrid>
 				{ page.media.map( ( media, i ) => (

--- a/client/signup/steps/website-content/section-types/default-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/default-page-details.tsx
@@ -151,6 +151,7 @@ export function DefaultPageDetails( {
 				error={ formErrors[ fieldName ] }
 				label={ description }
 				disabled={ !! page.useFillerContent }
+				hasFillerContentCheckbox={ isEnglishLocale }
 			/>
 			{ isEnglishLocale && (
 				<CheckboxField

--- a/client/signup/steps/website-content/section-types/default-page-details.tsx
+++ b/client/signup/steps/website-content/section-types/default-page-details.tsx
@@ -5,6 +5,7 @@ import {
 	TextAreaField,
 	HorizontalGrid,
 	LabelBlock,
+	CheckboxField,
 } from 'calypso/signup/accordion-form/form-components';
 import { useTranslatedPageDescriptions } from 'calypso/signup/difm/translation-hooks';
 import {
@@ -102,6 +103,20 @@ export function DefaultPageDetails( {
 		onChangeField?.( e );
 	};
 
+	const onCheckboxChanged = ( e: ChangeEvent< HTMLInputElement > ) => {
+		const {
+			target: { name, checked },
+		} = e;
+		dispatch(
+			websiteContentFieldChanged( {
+				pageId: page.id,
+				fieldName: name,
+				fieldValue: !! checked,
+			} )
+		);
+		onChangeField && onChangeField( e );
+	};
+
 	const imageCaption = translate(
 		'Upload up to %(noOfImages)d images to be used on your %(pageTitle)s page.',
 		{
@@ -133,6 +148,17 @@ export function DefaultPageDetails( {
 				value={ page.content }
 				error={ formErrors[ fieldName ] }
 				label={ description }
+				disabled={ !! page.useFillerContent }
+			/>
+			<CheckboxField
+				name="useFillerContent"
+				checked={ page.useFillerContent || false }
+				value="true"
+				onChange={ onCheckboxChanged }
+				label={ translate( 'Build this page with AI-generated text.' ) }
+				helpText={ translate(
+					'When building your site, we will use AI to generate copy based on the search phrases you have provided. The copy can be edited later with the WordPress editor.'
+				) }
 			/>
 			<LabelBlock>{ getMediaCaption() }</LabelBlock>
 			<HorizontalGrid>

--- a/client/signup/steps/website-content/section-types/feedback-section.tsx
+++ b/client/signup/steps/website-content/section-types/feedback-section.tsx
@@ -27,7 +27,7 @@ export function FeedbackSection( {
 				rows={ 3 }
 				name="generic_feedback"
 				onChange={ onContentChange }
-				value={ data.genericFeedback }
+				value={ data.genericFeedback || '' }
 				label={ translate(
 					'Optional: Is there anything else you would like the site builder to know?'
 				) }

--- a/client/state/signup/steps/website-content/actions.ts
+++ b/client/state/signup/steps/website-content/actions.ts
@@ -108,7 +108,7 @@ export function updateSearchTerms( searchTerms: string ) {
 export function websiteContentFieldChanged( payload: {
 	pageId: string;
 	fieldName: string;
-	fieldValue: string;
+	fieldValue: string | boolean;
 } ) {
 	return {
 		type: SIGNUP_STEPS_WEBSITE_FIELD_CHANGED,
@@ -195,6 +195,7 @@ export function initializeWebsiteContentForm(
 			displayEmail: savedContent?.displayEmail || undefined,
 			displayPhone: savedContent?.displayPhone || undefined,
 			displayAddress: savedContent?.displayAddress || undefined,
+			useFillerContent: savedContent?.useFillerContent || false,
 			media: getInitialMediaState( pageId, savedContent?.media ),
 		};
 	} );

--- a/client/state/signup/steps/website-content/test/reducer.ts
+++ b/client/state/signup/steps/website-content/test/reducer.ts
@@ -135,6 +135,7 @@ describe( 'reducer', () => {
 						id: CONTACT_PAGE,
 						title: 'Contact',
 						content: '',
+						useFillerContent: false,
 						media: [
 							getSingleMediaPlaceholder( 'IMAGE' ),
 							getSingleMediaPlaceholder( 'IMAGE' ),
@@ -146,6 +147,7 @@ describe( 'reducer', () => {
 						id: VIDEO_GALLERY_PAGE,
 						title: 'Video Gallery',
 						content: '',
+						useFillerContent: false,
 						media: [
 							getSingleMediaPlaceholder( 'VIDEO' ),
 							getSingleMediaPlaceholder( 'VIDEO' ),
@@ -157,6 +159,7 @@ describe( 'reducer', () => {
 						id: PORTFOLIO_PAGE,
 						title: 'Portfolio',
 						content: '',
+						useFillerContent: false,
 						media: [
 							getSingleMediaPlaceholder( 'IMAGE' ),
 							getSingleMediaPlaceholder( 'IMAGE' ),
@@ -188,18 +191,21 @@ describe( 'reducer', () => {
 								title: 'Contact',
 								content: 'test contact page content',
 								media: [ { url: 'test media url 1', mediaType: 'IMAGE' } ],
+								useFillerContent: false,
 							},
 							{
 								id: VIDEO_GALLERY_PAGE,
 								title: 'Video Gallery',
 								content: 'test video gallery page content',
 								media: [ { url: 'test media url 2', mediaType: 'VIDEO' } ],
+								useFillerContent: true,
 							},
 							{
 								id: PORTFOLIO_PAGE,
 								title: 'Portfolio',
 								content: 'test portfolio page content',
 								media: [ { url: 'test media url 3', mediaType: 'IMAGE' } ],
+								useFillerContent: false,
 							},
 						],
 						siteLogoUrl: '',
@@ -224,6 +230,7 @@ describe( 'reducer', () => {
 							getSingleMediaPlaceholder( 'IMAGE' ),
 							getSingleMediaPlaceholder( 'IMAGE' ),
 						],
+						useFillerContent: false,
 					},
 					{
 						id: VIDEO_GALLERY_PAGE,
@@ -235,6 +242,7 @@ describe( 'reducer', () => {
 							getSingleMediaPlaceholder( 'VIDEO' ),
 							getSingleMediaPlaceholder( 'VIDEO' ),
 						],
+						useFillerContent: true,
 					},
 					{
 						id: PORTFOLIO_PAGE,
@@ -250,6 +258,7 @@ describe( 'reducer', () => {
 							getSingleMediaPlaceholder( 'IMAGE' ),
 							getSingleMediaPlaceholder( 'IMAGE' ),
 						],
+						useFillerContent: false,
 					},
 				],
 			},

--- a/client/state/signup/steps/website-content/types.ts
+++ b/client/state/signup/steps/website-content/types.ts
@@ -15,6 +15,7 @@ export type PageData = {
 	id: PageId;
 	title: string;
 	content: string;
+	useFillerContent: boolean;
 	media: Array< Media >;
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1538

## Proposed Changes

Adds a checkbox to the page section of the BBE website content form to allow users to choose if the page can be built with filler (AI) content.
<img width="866" alt="image" src="https://user-images.githubusercontent.com/5436027/221764216-22d53dc7-bde8-4932-ae99-d6273766a5c8.png">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D102972-code
* Go to `/start/do-it-for-me` and complete the purchase.
* On the website content form, open each page section and confirm that the checkbox with the label `Build this page with AI-generated text.` is present. **Note**: This checkbox will not be present on the "Contact" page.
* Hovering over the info icon next to the label should show help text in a tooltip.
* Confirm that clicking on the checkbox disables the text box above it, but it should not erase the text.
* If the section is minimized, the summary should show `AI CONTENT` instead of the entered text if the checkbox for that section is checked.
<img width="937" alt="image" src="https://user-images.githubusercontent.com/5436027/221764785-745e2fc7-78ee-423d-b568-9f99079d7c20.png">

* Click on "Save Changes" and reload the page. Confirm that the checkboxes retain their checked state.
* Confirm that you can submit the form correctly.
* Additional test instructions in D102972-code.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?