### PR TITLE
Jetpack Pro Dashboard:  implement site expanded content & add insights data for small screens

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -1,4 +1,5 @@
-import { Card, Gridicon } from '@automattic/components';
+import { Card, Gridicon, Button } from '@automattic/components';
+import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useState, useCallback, MouseEvent, KeyboardEvent } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -12,7 +13,7 @@ import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partn
 import SiteActions from '../site-actions';
 import SiteErrorContent from '../site-error-content';
 import SiteStatusContent from '../site-status-content';
-import type { SiteData, SiteColumns } from '../types';
+import type { SiteData, SiteColumns, AllowedTypes } from '../types';
 
 import './style.scss';
 
@@ -26,12 +27,17 @@ export default function SiteCard( { rows, columns }: Props ) {
 	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
 
 	const [ isExpanded, setIsExpanded ] = useState( false );
+	const [ expandedColumn, setExpandedColumn ] = useState< AllowedTypes | null >( null );
 	const blogId = rows.site.value.blog_id;
 	const isConnectionHealthy = rows.site.value?.is_connection_healthy;
 
 	const { data } = useFetchTestConnection( isPartnerOAuthTokenLoaded, isConnectionHealthy, blogId );
 
 	const isSiteConnected = data ? data.connected : true;
+
+	const handleSetExpandedColumn = ( column: AllowedTypes ) => {
+		setExpandedColumn( expandedColumn === column ? null : column );
+	};
 
 	const toggleIsExpanded = useCallback(
 		( event: MouseEvent< HTMLSpanElement > | KeyboardEvent< HTMLSpanElement > ) => {
@@ -110,10 +116,26 @@ export default function SiteCard( { rows, columns }: Props ) {
 										) }
 										key={ index }
 									>
-										<span className="site-card__expanded-content-key">{ column.title }</span>
-										<span className="site-card__expanded-content-value">
-											<SiteStatusContent rows={ rows } type={ row.type } />
-										</span>
+										<div className="site-card__expanded-content-header">
+											<span className="site-card__expanded-content-key">{ column.title }</span>
+											<span className="site-card__expanded-content-value">
+												<span className="site-card__expanded-content-status">
+													<SiteStatusContent rows={ rows } type={ row.type } />
+												</span>
+												<span className="site-card__expanded-column">
+													{ column.isExpandable && (
+														<Button
+															borderless
+															onClick={ () => handleSetExpandedColumn( column.key ) }
+														>
+															<Icon
+																icon={ expandedColumn === column.key ? chevronUp : chevronDown }
+															/>
+														</Button>
+													) }
+												</span>
+											</span>
+										</div>
 									</div>
 								);
 							}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card, Gridicon, Button } from '@automattic/components';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import classNames from 'classnames';
@@ -79,6 +80,8 @@ export default function SiteCard( { rows, columns }: Props ) {
 	const shouldDisableLicenseSelection =
 		selectedLicenses?.length && ! currentSiteHasSelectedLicenses;
 
+	const isExpandableBlockEnabled = isEnabled( 'jetpack/pro-dashboard-expandable-block' );
+
 	return (
 		<Card
 			className={ classNames( 'site-card__card', {
@@ -117,32 +120,43 @@ export default function SiteCard( { rows, columns }: Props ) {
 										) }
 										key={ index }
 									>
-										<div className="site-card__expanded-content-header">
-											<span className="site-card__expanded-content-key">{ column.title }</span>
-											<span className="site-card__expanded-content-value">
-												<span className="site-card__expanded-content-status">
+										{ isExpandableBlockEnabled ? (
+											<>
+												<div className="site-card__expanded-content-header">
+													<span className="site-card__expanded-content-key">{ column.title }</span>
+													<span className="site-card__expanded-content-value">
+														<span className="site-card__expanded-content-status">
+															<SiteStatusContent rows={ rows } type={ row.type } />
+														</span>
+														<span className="site-card__expanded-column">
+															{ column.isExpandable && (
+																<Button
+																	borderless
+																	onClick={ () => handleSetExpandedColumn( column.key ) }
+																>
+																	<Icon
+																		icon={ expandedColumn === column.key ? chevronUp : chevronDown }
+																	/>
+																</Button>
+															) }
+														</span>
+													</span>
+												</div>
+												{ expandedColumn === column.key && (
+													<SiteExpandedContent
+														isSmallScreen
+														site={ rows.site.value }
+														columns={ [ column.key ] }
+													/>
+												) }
+											</>
+										) : (
+											<>
+												<span className="site-card__expanded-content-key">{ column.title }</span>
+												<span className="site-card__expanded-content-value">
 													<SiteStatusContent rows={ rows } type={ row.type } />
 												</span>
-												<span className="site-card__expanded-column">
-													{ column.isExpandable && (
-														<Button
-															borderless
-															onClick={ () => handleSetExpandedColumn( column.key ) }
-														>
-															<Icon
-																icon={ expandedColumn === column.key ? chevronUp : chevronDown }
-															/>
-														</Button>
-													) }
-												</span>
-											</span>
-										</div>
-										{ expandedColumn === column.key && (
-											<SiteExpandedContent
-												isSmallScreen
-												site={ rows.site.value }
-												columns={ [ column.key ] }
-											/>
+											</>
 										) }
 									</div>
 								);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -139,6 +139,7 @@ export default function SiteCard( { rows, columns }: Props ) {
 										</div>
 										{ expandedColumn === column.key && (
 											<SiteExpandedContent
+												isSmallScreen
 												site={ rows.site.value }
 												columns={ [ column.key ] }
 											/>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -12,6 +12,7 @@ import {
 import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
 import SiteActions from '../site-actions';
 import SiteErrorContent from '../site-error-content';
+import SiteExpandedContent from '../site-expanded-content';
 import SiteStatusContent from '../site-status-content';
 import type { SiteData, SiteColumns, AllowedTypes } from '../types';
 
@@ -136,6 +137,12 @@ export default function SiteCard( { rows, columns }: Props ) {
 												</span>
 											</span>
 										</div>
+										{ expandedColumn === column.key && (
+											<SiteExpandedContent
+												site={ rows.site.value }
+												columns={ [ column.key ] }
+											/>
+										) }
 									</div>
 								);
 							}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/style.scss
@@ -51,7 +51,8 @@
 	display: flex;
 }
 
-.site-card__expanded-content-value {
+.site-card__expanded-content-value,
+.site-card__expanded-content-status {
 	position: absolute;
 	right: 16px;
 	top: 50%;
@@ -76,4 +77,19 @@
 	border-style: solid;
 	border-color: var(--studio-gray-5);
 	box-shadow: 0 0 20px rgba(0, 0, 0, 0.16);
+}
+
+.site-card__expanded-column {
+	width: 20px;
+
+	button {
+		display: flex;
+		position: relative;
+		left: 16px;
+		top: 2px;
+	}
+}
+
+.site-card__expanded-content-header {
+	position: relative;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -5,11 +5,15 @@ import './style.scss';
 
 interface Props {
 	site: Site;
+	columns?: string[];
 }
 
-const columns = [ 'stats' ];
+const defaultColumns = [ 'stats' ];
 
-export default function SiteExpandedContent( { site }: Props ) {
+export default function SiteExpandedContent( {
+	site,
+	columns = defaultColumns,
+}: Props ) {
 	const stats = site.site_stats;
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import InsightsStats from './insights-stats';
 import type { Site } from '../types';
 
@@ -6,6 +7,7 @@ import './style.scss';
 interface Props {
 	site: Site;
 	columns?: string[];
+	isSmallScreen?: boolean;
 }
 
 const defaultColumns = [ 'stats' ];
@@ -13,11 +15,16 @@ const defaultColumns = [ 'stats' ];
 export default function SiteExpandedContent( {
 	site,
 	columns = defaultColumns,
+	isSmallScreen = false,
 }: Props ) {
 	const stats = site.site_stats;
 
 	return (
-		<div className="site-expanded-content">
+		<div
+			className={ classNames( 'site-expanded-content', {
+				'is-small-screen': isSmallScreen,
+			} ) }
+		>
 			{ columns.includes( 'stats' ) && stats && <InsightsStats stats={ stats } /> }
 		</div>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats.tsx
@@ -54,30 +54,32 @@ export default function InsightsStats( { stats }: Props ) {
 
 	return (
 		<ExpandedCard header={ translate( '7 days insights stats' ) }>
-			<div className="site-expanded-content__card-content">
-				<div className="site-expanded-content__card-content-column">
-					<div className="site-expanded-content__card-content-count">
-						<ShortenedNumber value={ data.visitors } />
-						{ getTrendContent( data.visitorsTrend, data.visitorsChange ) }
+			<div className="site-expanded-content__card-content-container">
+				<div className="site-expanded-content__card-content">
+					<div className="site-expanded-content__card-content-column">
+						<div className="site-expanded-content__card-content-count">
+							<ShortenedNumber value={ data.visitors } />
+							{ getTrendContent( data.visitorsTrend, data.visitorsChange ) }
+						</div>
+						<div className="site-expanded-content__card-content-count-title">
+							{ translate( 'Visitors' ) }
+						</div>
 					</div>
-					<div className="site-expanded-content__card-content-count-title">
-						{ translate( 'Visitors' ) }
+					<div className="site-expanded-content__card-content-column">
+						<div className="site-expanded-content__card-content-count">
+							<ShortenedNumber value={ data.views } />
+							{ getTrendContent( data.viewsTrend, data.viewsChange ) }
+						</div>
+						<div className="site-expanded-content__card-content-count-title">
+							{ translate( 'Views' ) }
+						</div>
 					</div>
 				</div>
-				<div className="site-expanded-content__card-content-column">
-					<div className="site-expanded-content__card-content-count">
-						<ShortenedNumber value={ data.views } />
-						{ getTrendContent( data.viewsTrend, data.viewsChange ) }
-					</div>
-					<div className="site-expanded-content__card-content-count-title">
-						{ translate( 'Views' ) }
-					</div>
+				<div className="site-expanded-content__card-footer">
+					<Button className="site-expanded-content__card-button" compact>
+						{ translate( 'See all stats' ) }
+					</Button>
 				</div>
-			</div>
-			<div className="site-expanded-content__card-footer">
-				<Button className="site-expanded-content__card-button" compact>
-					{ translate( 'See all stats' ) }
-				</Button>
 			</div>
 		</ExpandedCard>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -100,3 +100,41 @@ button.site-expanded-content__card-button {
 	color: var(--studio-black) !important;
 	border-color: var(--studio-black);
 }
+
+.is-small-screen {
+	padding-block: 8px 0;
+
+	.expanded-card {
+		width: 100%;
+		margin: 0;
+		box-shadow: none;
+		padding: 0 !important;
+		min-height: auto;
+		background: none;
+	}
+
+	.expanded-card__header {
+		display: none;
+	}
+
+	.site-expanded-content__card-content-container {
+		display: flex;
+	}
+
+	.site-expanded-content__card-content {
+		margin-block: 0;
+		width: auto;
+	}
+
+	.site-expanded-content__card-content-column {
+		padding-inline-end: 24px;
+	}
+
+	.site-expanded-content__card-footer {
+		padding: 10px;
+
+		.site-expanded-content__card-button {
+			white-space: nowrap;
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -174,6 +174,11 @@ export default function SiteStatusContent( {
 		);
 	}
 
+	if ( type === 'stats' ) {
+		// Content will be added later
+		return null;
+	}
+
 	let content;
 
 	switch ( status ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/utils.ts
@@ -204,7 +204,6 @@ describe( 'utils', () => {
 						value: sites[ 0 ],
 					},
 					stats: {
-						status: 'active',
 						type: 'stats',
 						data: sites[ 0 ].site_stats,
 					},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -5,9 +5,10 @@ export type AllowedTypes = 'site' | 'stats' | 'backup' | 'scan' | 'monitor' | 'p
 
 // Site column object which holds key and title of each column
 export type SiteColumns = Array< {
-	key: string;
+	key: AllowedTypes;
 	title: ReactChild;
 	className?: string;
+	isExpandable?: boolean;
 } >;
 
 export type AllowedStatusTypes =
@@ -66,7 +67,6 @@ export interface SiteNode {
 
 export interface StatsNode {
 	type: AllowedTypes;
-	status: AllowedStatusTypes | string;
 	data: SiteStats;
 }
 export interface BackupNode {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -15,18 +15,33 @@ import type {
 	BackupNode,
 	ScanNode,
 	MonitorNode,
+	SiteColumns,
 } from './types';
 
 const INITIAL_UNIX_EPOCH = '1970-01-01 00:00:00';
 
-export const siteColumns = [
+const isExpandedBlockEnabled = config.isEnabled( 'jetpack/pro-dashboard-expandable-block' );
+
+const extraColumns: SiteColumns = isExpandedBlockEnabled
+	? [
+			{
+				key: 'stats',
+				title: translate( 'Stats' ),
+				isExpandable: true,
+			},
+	  ]
+	: [];
+
+export const siteColumns: SiteColumns = [
 	{
 		key: 'site',
 		title: translate( 'Site' ),
 	},
+	...extraColumns,
 	{
 		key: 'backup',
 		title: translate( 'Backup' ),
+		isExpandable: isExpandedBlockEnabled,
 	},
 	{
 		key: 'scan',
@@ -36,6 +51,7 @@ export const siteColumns = [
 		key: 'monitor',
 		title: translate( 'Monitor' ),
 		className: 'min-width-100px',
+		isExpandable: isExpandedBlockEnabled,
 	},
 	{
 		key: 'plugin',
@@ -299,7 +315,6 @@ export const getRowMetaData = (
 
 const formatStatsData = ( site: Site ) => {
 	const statsData: StatsNode = {
-		status: 'active',
 		type: 'stats',
 		data: site.site_stats,
 	};
@@ -307,7 +322,6 @@ const formatStatsData = ( site: Site ) => {
 };
 
 const formatBackupData = ( site: Site ) => {
-	const isExpandedBlockEnabled = config.isEnabled( 'jetpack/pro-dashboard-expandable-block' );
 	const backup: BackupNode = {
 		value: '',
 		status: '',


### PR DESCRIPTION
Related to 1203940061556608-as-1203943609783474

#### Proposed Changes

This PR implements the site expanded content and adds 7 days of insights stats data for small screens.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_** These changes are behind a feature flag and will not be effective in production immediately after merging. The Stats data on the table and card will be added here - https://github.com/Automattic/wp-calypso/pull/73687

**Instructions**

1. Run `add/site-expanded-content-small-screen` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Switch to small screen device using the dev tool(<1080px) and verify the below steps in multiple devices(320px, 720px, 1024px, etc.)
4. Expand any site card -> Verify you can see expand for Stats(data for stats will be added later), Backup & Monitor. 
5. Verify you can expand the column to see more details. Expanded data for Backup & Monitor will be added in a different PR.

![mobile](https://user-images.githubusercontent.com/10586875/221794174-16e06565-df84-4ad9-8125-3a3106905fd3.png)

![mobile (1)](https://user-images.githubusercontent.com/10586875/221794130-22d78c65-2509-4335-bab4-713f22a58165.png)

![mobile (2)](https://user-images.githubusercontent.com/10586875/221794156-076bb385-af17-4868-a8f4-50318238e16b.png)

![mobile (3)](https://user-images.githubusercontent.com/10586875/221794163-0a8002ce-d5ff-4dfa-9e46-25f3a816332a.png)

![mobile (4)](https://user-images.githubusercontent.com/10586875/221794166-f35ba453-d4dd-4d59-aac9-cede7f325768.png)

![mobile (5)](https://user-images.githubusercontent.com/10586875/221794171-b5b56c24-ad1c-4de4-b265-575788f331e4.png)

6. Open the live links and verify these changes are not visible there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?