### PR TITLE
Staging Sites: Prevent added notice from appearing on mount

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -2,7 +2,7 @@ import { Button, Card, Spinner } from '@automattic/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { localize } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import MaterialIcon from 'calypso/components/material-icon';
@@ -31,14 +31,15 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 	const showAddStagingSite = ! isLoadingStagingSites && stagingSites && stagingSites.length === 0;
 	const showManageStagingSite = ! isLoadingStagingSites && stagingSites && stagingSites.length > 0;
 
+	const [ wasCreating, setWasCreating ] = useState( false );
 	const transferStatus = useCheckStagingSiteStatus( stagingSite.id );
 	const isStagingSiteTransferComplete = transferStatus === transferStates.COMPLETE;
 
 	useEffect( () => {
-		if ( isStagingSiteTransferComplete ) {
+		if ( wasCreating && isStagingSiteTransferComplete ) {
 			dispatch( successNotice( __( 'Staging site added.' ) ) );
 		}
-	}, [ dispatch, __, isStagingSiteTransferComplete ] );
+	}, [ dispatch, __, isStagingSiteTransferComplete, wasCreating ] );
 
 	const { addStagingSite, isLoading: addingStagingSite } = useAddStagingSiteMutation( siteId, {
 		onMutate: () => {
@@ -75,6 +76,7 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 					disabled={ disabled || addingStagingSite }
 					onClick={ () => {
 						dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_click' ) );
+						setWasCreating( true );
 						addStagingSite();
 					} }
 				>


### PR DESCRIPTION
I introduced a buggy bug in https://github.com/Automattic/wp-calypso/pull/73709

## Proposed Changes

Prevents the 'Staging site added.' notice from appearing when loading the Hosting Configuration page if the site already has a staging site.

## Testing Instructions

1. Create a new Business site and take it Atomic.
2. Navigate to 'Hosting Configuration'.
3. Click 'Add staging site'.
4. Verify the 'Staging site added.' notice appears after the staging site is created.
5. Refresh the page.
6. Verify no 'Staging site added.' notice appears.