### PR TITLE
Staging Sites: Use `share-computer` icon

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -1,11 +1,10 @@
-import { Button, Card, Spinner } from '@automattic/components';
+import { Button, Card, Spinner, Gridicon } from '@automattic/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { localize } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
-import MaterialIcon from 'calypso/components/material-icon';
 import { useAddStagingSiteMutation } from 'calypso/my-sites/hosting/staging-site-card/use-add-staging-site';
 import { useCheckStagingSiteStatus } from 'calypso/my-sites/hosting/staging-site-card/use-check-staging-site-status';
 import { useStagingSite } from 'calypso/my-sites/hosting/staging-site-card/use-staging-site';
@@ -106,7 +105,10 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 
 	return (
 		<Card className="staging-site-card">
-			<MaterialIcon icon="share" size={ 24 } />
+			{
+				// eslint-disable-next-line wpcalypso/jsx-gridicon-size
+				<Gridicon icon="share-computer" size={ 32 } />
+			}
 			<CardHeading id="staging-site">{ translate( 'Staging site' ) }</CardHeading>
 			{ showAddStagingSite && ! addingStagingSite && getNewStagingSiteContent() }
 			{ showManageStagingSite && isStagingSiteTransferComplete && getManageStagingSiteContent() }

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -19,7 +19,8 @@
 			.card {
 				padding-left: 72px;
 
-				> .material-icon {
+				> .material-icon,
+				> .gridicon {
 					display: block;
 					position: absolute;
 					left: 24px;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1856

## Proposed Changes

Switches to the `share-computer` icon:

<img width="778" alt="image" src="https://user-images.githubusercontent.com/36432/221862089-02e8f82b-0ba4-44af-90a2-82735b0493b1.png">


## Testing Instructions

1. Navigate to 'Hosting Configuration'.
2. View the icon in all of its glory.