### PR TITLE
Import focus flow: skip `from` query param if it's a falsy value

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -146,7 +146,9 @@ const importFlow: Flow = {
 				case 'processing': {
 					if ( providedDependencies?.siteSlug ) {
 						const from = urlQueryParams.get( 'from' );
-						return navigate( `import?siteSlug=${ providedDependencies?.siteSlug }&from=${ from }` );
+						return ! from
+							? navigate( `import?siteSlug=${ providedDependencies?.siteSlug }` )
+							: navigate( `import?siteSlug=${ providedDependencies?.siteSlug }&from=${ from }` );
 					}
 					// End of Pattern Assembler flow
 					if ( isBlankCanvasDesign( selectedDesign ) ) {


### PR DESCRIPTION
## Proposed Changes

Import focused flow, site creation step:
* Skip `from` query param if it's a falsy (null) value; avoiding populating NULL as a URL

<img width="580" alt="Screenshot 2023-02-28 at 15 12 48" src="https://user-images.githubusercontent.com/1241413/221886564-232fb80a-fffe-4902-8925-10036aa813b7.png">


## Testing Instructions

* Go to `/setup/import-focused/siteCreationStep`
* Check if there is an empty input for entering the URL of existing website

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
