### PR TITLE
Add/info message dot gay tld checkout

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -23,6 +23,7 @@ export { getUnformattedDomainSalePrice } from './get-unformatted-domain-sale-pri
 export { isDomainUpdateable } from './is-domain-updateable';
 export { isDomainInGracePeriod } from './is-domain-in-grace-period';
 export { isHstsRequired } from './is-hsts-required';
+export { isDotGayNoticeRequired } from './is-dot-gay-notice-required';
 export { isSubdomain } from './is-subdomain';
 export {
 	getMappedDomains,

--- a/client/lib/domains/is-dot-gay-notice-required.js
+++ b/client/lib/domains/is-dot-gay-notice-required.js
@@ -1,0 +1,7 @@
+import { find, get } from 'lodash';
+
+export function isDotGayNoticeRequired( productSlug, productsList ) {
+	const product = find( productsList, [ 'product_slug', productSlug ] ) || {};
+
+	return get( product, 'is_dot_gay_notice_required', false );
+}

--- a/client/lib/domains/is-dot-gay-notice-required.js
+++ b/client/lib/domains/is-dot-gay-notice-required.js
@@ -1,7 +1,4 @@
-import { find, get } from 'lodash';
-
 export function isDotGayNoticeRequired( productSlug, productsList ) {
-	const product = find( productsList, [ 'product_slug', productSlug ] ) || {};
-
-	return get( product, 'is_dot_gay_notice_required', false );
+	const product = productsList[ productSlug ] || {};
+	return product?.is_dot_gay_notice_required ?? false;
 }

--- a/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-terms.jsx
@@ -4,6 +4,7 @@ import { hasRenewableSubscription } from 'calypso/lib/cart-values/cart-items';
 import AdditionalTermsOfServiceInCart from './additional-terms-of-service-in-cart';
 import BundledDomainNotice from './bundled-domain-notice';
 import DomainRegistrationAgreement from './domain-registration-agreement';
+import DomainRegistrationDotGay from './domain-registration-dot-gay';
 import DomainRegistrationHsts from './domain-registration-hsts';
 import { EbanxTermsOfService } from './ebanx-terms-of-service';
 import { InternationalFeeNotice } from './international-fee-notice';
@@ -37,6 +38,7 @@ class CheckoutTerms extends Component {
 				/>
 				{ ! isGiftPurchase && <DomainRegistrationAgreement cart={ cart } /> }
 				{ ! isGiftPurchase && <DomainRegistrationHsts cart={ cart } /> }
+				{ ! isGiftPurchase && <DomainRegistrationDotGay cart={ cart } /> }
 				<RefundPolicies cart={ cart } />
 				{ ! isGiftPurchase && <BundledDomainNotice cart={ cart } /> }
 				{ ! isGiftPurchase && <TitanTermsOfService cart={ cart } /> }

--- a/client/my-sites/checkout/composite-checkout/components/domain-registration-dot-gay.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-registration-dot-gay.jsx
@@ -44,7 +44,7 @@ class DomainRegistrationDotGay extends PureComponent {
 		return (
 			<CheckoutTermsItem>
 				{ translate(
-					'Any anti-LGBTQ content is prohibited and can result in registration termination. The registry will donate 20% of all registration revenue to LGBTQ non-profit organizations.'
+					'The use of .gay domains to host any anti-LGBTQ content is prohibited and can result in registration termination. The registry will donate 20% of all registration revenue to LGBTQ non-profit organizations.'
 				) }
 			</CheckoutTermsItem>
 		);

--- a/client/my-sites/checkout/composite-checkout/components/domain-registration-dot-gay.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-registration-dot-gay.jsx
@@ -1,0 +1,61 @@
+import { localize } from 'i18n-calypso';
+import { isEmpty, merge, reduce } from 'lodash';
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import { getDomainRegistrations, getDomainTransfers } from 'calypso/lib/cart-values/cart-items';
+import { getTld, isDotGayNoticeRequired } from 'calypso/lib/domains';
+import CheckoutTermsItem from 'calypso/my-sites/checkout/composite-checkout/components/checkout-terms-item';
+import { getProductsList } from 'calypso/state/products-list/selectors';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+class DomainRegistrationDotGay extends PureComponent {
+	getDotGayTlds = () => {
+		const { cart, productsList } = this.props;
+		const domains = merge( getDomainRegistrations( cart ), getDomainTransfers( cart ) );
+
+		if ( isEmpty( domains ) ) {
+			return null;
+		}
+
+		const dotGayTlds = reduce(
+			domains,
+			( tlds, domain ) => {
+				if ( isDotGayNoticeRequired( domain.product_slug, productsList ) ) {
+					const tld = '.' + getTld( domain.meta );
+
+					if ( tlds.indexOf( tld ) === -1 ) {
+						tlds.push( tld );
+					}
+				}
+
+				return tlds;
+			},
+			[]
+		);
+
+		return dotGayTlds.join( ', ' );
+	};
+
+	render() {
+		const tlds = this.getDotGayTlds();
+
+		if ( ! tlds ) {
+			return null;
+		}
+
+		const { translate } = this.props;
+
+		return (
+			<CheckoutTermsItem>
+				{ translate(
+					'Any anti-LGBTQ content is prohibited and can result in registration termination. The registry will donate 20% of all registration revenue to LGBTQ non-profit organizations.'
+				) }
+			</CheckoutTermsItem>
+		);
+	}
+}
+
+export default connect( ( state ) => ( {
+	productsList: getProductsList( state ),
+} ) )( localize( DomainRegistrationDotGay ) );

--- a/client/my-sites/checkout/composite-checkout/components/domain-registration-dot-gay.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/domain-registration-dot-gay.jsx
@@ -1,5 +1,4 @@
 import { localize } from 'i18n-calypso';
-import { isEmpty, merge, reduce } from 'lodash';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { getDomainRegistrations, getDomainTransfers } from 'calypso/lib/cart-values/cart-items';
@@ -12,27 +11,23 @@ import { getProductsList } from 'calypso/state/products-list/selectors';
 class DomainRegistrationDotGay extends PureComponent {
 	getDotGayTlds = () => {
 		const { cart, productsList } = this.props;
-		const domains = merge( getDomainRegistrations( cart ), getDomainTransfers( cart ) );
+		const domains = [ ...getDomainRegistrations( cart ), ...getDomainTransfers( cart ) ];
 
-		if ( isEmpty( domains ) ) {
+		if ( ! domains.length ) {
 			return null;
 		}
 
-		const dotGayTlds = reduce(
-			domains,
-			( tlds, domain ) => {
-				if ( isDotGayNoticeRequired( domain.product_slug, productsList ) ) {
-					const tld = '.' + getTld( domain.meta );
+		const dotGayTlds = domains.reduce( ( tlds, domain ) => {
+			if ( isDotGayNoticeRequired( domain.product_slug, productsList ) ) {
+				const tld = '.' + getTld( domain.meta );
 
-					if ( tlds.indexOf( tld ) === -1 ) {
-						tlds.push( tld );
-					}
+				if ( tlds.indexOf( tld ) === -1 ) {
+					tlds.push( tld );
 				}
+			}
 
-				return tlds;
-			},
-			[]
-		);
+			return tlds;
+		}, [] );
 
 		return dotGayTlds.join( ', ' );
 	};

--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -139,6 +139,11 @@ export interface DomainSuggestion {
 	hsts_required?: boolean;
 
 	/**
+	 * Whether the domain requires to show the notice for .gay tld
+	 */
+	is_dot_gay_notice_required?: boolean;
+
+	/**
 	 * Whether the domain is unavailable
 	 */
 	unavailable: boolean;
@@ -211,6 +216,11 @@ export interface DomainAvailability {
 	 * Whether the domain requires HSTS
 	 */
 	hsts_required?: boolean;
+
+	/**
+	 * Whether the domain requires to show the notice for .gay tld
+	 */
+	is_dot_gay_notice_required?: boolean;
 }
 
 export type TimestampMS = ReturnType< typeof Date.now >;

--- a/packages/domain-picker/src/components/domain-suggestion-item/__tests__/suggestion-item.tsx
+++ b/packages/domain-picker/src/components/domain-suggestion-item/__tests__/suggestion-item.tsx
@@ -67,6 +67,7 @@ describe( 'traintracks events', () => {
 			renderComponent();
 
 			fireEvent.click( screen.getByRole( 'button' ) );
+
 			expect( MOCK_SUGGESTION_ITEM_PARTIAL_PROPS.onSelect ).toHaveBeenCalledWith(
 				MOCK_SUGGESTION_ITEM_PARTIAL_PROPS.domain
 			);

--- a/packages/domain-picker/src/components/domain-suggestion-item/__tests__/suggestion-item.tsx
+++ b/packages/domain-picker/src/components/domain-suggestion-item/__tests__/suggestion-item.tsx
@@ -118,6 +118,35 @@ describe( 'conditional elements', () => {
 		// use `queryBy` to avoid throwing an error with `getBy`
 		expect( screen.queryByTestId( 'info-tooltip' ) ).toBeFalsy();
 	} );
+
+	it.skip( 'renders info tooltip for domains that require .gay information notice', async () => {
+		render(
+			<SuggestionItem { ...MOCK_SUGGESTION_ITEM_PARTIAL_PROPS } isDotGayNoticeRequired={ true } />
+		);
+
+		expect( screen.getByTestId( 'info-tooltip' ) ).toBeInTheDocument();
+	} );
+
+	it.skip( 'clicking info tooltip icon reveals popover for .gay information notice', async () => {
+		const testRequiredProps = {
+			domain: 'testdomain.gay',
+			cost: '€37.00',
+			railcarId: 'id',
+		};
+
+		render(
+			<SuggestionItem
+				{ ...testRequiredProps }
+				onSelect={ jest.fn() }
+				onRender={ jest.fn() }
+				isDotGayNoticeRequired={ true }
+			/>
+		);
+
+		fireEvent.click( screen.getByTestId( 'info-tooltip' ) );
+
+		expect( screen.queryByText( /LGBT content/i ) ).toBeTruthy();
+	} );
 	/*eslint-enable*/
 
 	it( 'should render a recommendation badge if given prop isRecommended true', async () => {

--- a/packages/domain-picker/src/components/domain-suggestion-item/__tests__/suggestion-item.tsx
+++ b/packages/domain-picker/src/components/domain-suggestion-item/__tests__/suggestion-item.tsx
@@ -13,6 +13,10 @@ const renderComponent = ( props = {} ): RenderResult =>
 	render( <SuggestionItem { ...MOCK_SUGGESTION_ITEM_PARTIAL_PROPS } { ...props } /> );
 
 describe( 'traintracks events', () => {
+	beforeEach( () => {
+		global.ResizeObserver = require( 'resize-observer-polyfill' );
+	} );
+
 	afterEach( () => {
 		jest.clearAllMocks();
 	} );
@@ -63,7 +67,6 @@ describe( 'traintracks events', () => {
 			renderComponent();
 
 			fireEvent.click( screen.getByRole( 'button' ) );
-
 			expect( MOCK_SUGGESTION_ITEM_PARTIAL_PROPS.onSelect ).toHaveBeenCalledWith(
 				MOCK_SUGGESTION_ITEM_PARTIAL_PROPS.domain
 			);
@@ -129,23 +132,17 @@ describe( 'conditional elements', () => {
 
 	it.skip( 'clicking info tooltip icon reveals popover for .gay information notice', async () => {
 		const testRequiredProps = {
+			...MOCK_SUGGESTION_ITEM_PARTIAL_PROPS,
 			domain: 'testdomain.gay',
 			cost: '€37.00',
 			railcarId: 'id',
+			isDotGayNoticeRequired: true,
 		};
 
-		render(
-			<SuggestionItem
-				{ ...testRequiredProps }
-				onSelect={ jest.fn() }
-				onRender={ jest.fn() }
-				isDotGayNoticeRequired={ true }
-			/>
-		);
-
+		render( <SuggestionItem { ...testRequiredProps } /> );
 		fireEvent.click( screen.getByTestId( 'info-tooltip' ) );
 
-		expect( screen.queryByText( /LGBT content/i ) ).toBeTruthy();
+		expect( screen.queryByText( /Any anti-LGBTQ content/i ) ).toBeTruthy();
 	} );
 	/*eslint-enable*/
 

--- a/packages/domain-picker/src/components/domain-suggestion-item/suggestion-item.tsx
+++ b/packages/domain-picker/src/components/domain-suggestion-item/suggestion-item.tsx
@@ -124,6 +124,7 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 
 	const selectButtonLabelSelected = __( 'Selected', __i18n_text_domain__ );
 	const selectButtonLabelUnselected = __( 'Select', __i18n_text_domain__ );
+
 	return (
 		<WrappingComponent
 			ref={ buttonRef }

--- a/packages/domain-picker/src/components/domain-suggestion-item/suggestion-item.tsx
+++ b/packages/domain-picker/src/components/domain-suggestion-item/suggestion-item.tsx
@@ -26,6 +26,7 @@ interface Props {
 	isLoading?: boolean;
 	cost?: string;
 	hstsRequired?: boolean;
+	isDotGayNoticeRequired?: boolean;
 	isFree?: boolean;
 	isExistingSubdomain?: boolean;
 	isRecommended?: boolean;
@@ -33,7 +34,6 @@ interface Props {
 	onRender: () => void;
 	onSelect: ( domain: string ) => void;
 	selected?: boolean;
-	showDotGayNotice?: boolean;
 	type?: SUGGESTION_ITEM_TYPE;
 	buttonRef?: React.Ref< HTMLButtonElement >;
 }
@@ -45,13 +45,13 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 	cost,
 	railcarId,
 	hstsRequired = false,
+	isDotGayNoticeRequired = false,
 	isFree = false,
 	isExistingSubdomain = false,
 	isRecommended = false,
 	onSelect,
 	onRender,
 	selected,
-	showDotGayNotice = false,
 	type = SUGGESTION_ITEM_TYPE_RADIO,
 	buttonRef,
 } ) => {
@@ -124,7 +124,6 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 
 	const selectButtonLabelSelected = __( 'Selected', __i18n_text_domain__ );
 	const selectButtonLabelUnselected = __( 'Select', __i18n_text_domain__ );
-	// console.log( 'showDotGayNotice', showDotGayNotice );
 	return (
 		<WrappingComponent
 			ref={ buttonRef }
@@ -158,7 +157,7 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 				<div className="domain-picker__suggestion-item-name-inner">
 					<span
 						className={ classnames( 'domain-picker__domain-wrapper', {
-							'with-margin': ! ( hstsRequired || showDotGayNotice ),
+							'with-margin': ! ( hstsRequired || isDotGayNoticeRequired ),
 						} ) }
 					>
 						<span className="domain-picker__domain-sub-domain">{ domainName }</span>
@@ -193,27 +192,15 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 							) }
 						</InfoTooltip>
 					) }
-					{ showDotGayNotice && (
+					{ isDotGayNoticeRequired && (
 						<InfoTooltip
 							position={ isMobile ? 'bottom center' : 'middle right' }
 							noArrow={ false }
 							className="domain-picker__info-tooltip"
 						>
-							{ createInterpolateElement(
-								__(
-									'All domains ending with <tld /> require an SSL certificate to host a website. When you host this domain at WordPress.com an SSL certificate is included. <learn_more_link>Learn more</learn_more_link>',
-									__i18n_text_domain__
-								),
-								{
-									tld: <b>{ domainTld }</b>,
-									learn_more_link: (
-										<a
-											target="_blank"
-											rel="noreferrer"
-											href={ localizeUrl( 'https://wordpress.com/support/domains/https-ssl/' ) }
-										/>
-									),
-								}
+							{ __(
+								'Any anti-LGBTQ content is prohibited and can result in registration termination. The registry will donate 20% of all registration revenue to LGBTQ non-profit organizations.',
+								__i18n_text_domain__
 							) }
 						</InfoTooltip>
 					) }

--- a/packages/domain-picker/src/components/domain-suggestion-item/suggestion-item.tsx
+++ b/packages/domain-picker/src/components/domain-suggestion-item/suggestion-item.tsx
@@ -33,6 +33,7 @@ interface Props {
 	onRender: () => void;
 	onSelect: ( domain: string ) => void;
 	selected?: boolean;
+	showDotGayNotice?: boolean;
 	type?: SUGGESTION_ITEM_TYPE;
 	buttonRef?: React.Ref< HTMLButtonElement >;
 }
@@ -50,6 +51,7 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 	onSelect,
 	onRender,
 	selected,
+	showDotGayNotice = false,
 	type = SUGGESTION_ITEM_TYPE_RADIO,
 	buttonRef,
 } ) => {
@@ -122,7 +124,7 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 
 	const selectButtonLabelSelected = __( 'Selected', __i18n_text_domain__ );
 	const selectButtonLabelUnselected = __( 'Select', __i18n_text_domain__ );
-
+	// console.log( 'showDotGayNotice', showDotGayNotice );
 	return (
 		<WrappingComponent
 			ref={ buttonRef }
@@ -156,7 +158,7 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 				<div className="domain-picker__suggestion-item-name-inner">
 					<span
 						className={ classnames( 'domain-picker__domain-wrapper', {
-							'with-margin': ! hstsRequired,
+							'with-margin': ! ( hstsRequired || showDotGayNotice ),
 						} ) }
 					>
 						<span className="domain-picker__domain-sub-domain">{ domainName }</span>
@@ -168,6 +170,30 @@ const DomainPickerSuggestionItem: React.FC< Props > = ( {
 						</div>
 					) }
 					{ hstsRequired && (
+						<InfoTooltip
+							position={ isMobile ? 'bottom center' : 'middle right' }
+							noArrow={ false }
+							className="domain-picker__info-tooltip"
+						>
+							{ createInterpolateElement(
+								__(
+									'All domains ending with <tld /> require an SSL certificate to host a website. When you host this domain at WordPress.com an SSL certificate is included. <learn_more_link>Learn more</learn_more_link>',
+									__i18n_text_domain__
+								),
+								{
+									tld: <b>{ domainTld }</b>,
+									learn_more_link: (
+										<a
+											target="_blank"
+											rel="noreferrer"
+											href={ localizeUrl( 'https://wordpress.com/support/domains/https-ssl/' ) }
+										/>
+									),
+								}
+							) }
+						</InfoTooltip>
+					) }
+					{ showDotGayNotice && (
 						<InfoTooltip
 							position={ isMobile ? 'bottom center' : 'middle right' }
 							noArrow={ false }

--- a/packages/domain-picker/src/components/index.tsx
+++ b/packages/domain-picker/src/components/index.tsx
@@ -395,6 +395,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 																isCheckingDomainAvailability
 															}
 															hstsRequired={ suggestion.hsts_required }
+															isDotGayNoticeRequired={ suggestion.is_dot_gay_notice_required }
 															isFree={ suggestion.is_free }
 															isRecommended={ showRecommendationLabel && isRecommended }
 															railcarId={

--- a/packages/launch/src/hooks/use-domain-selection.ts
+++ b/packages/launch/src/hooks/use-domain-selection.ts
@@ -58,6 +58,7 @@ export function useDomainSuggestionFromCart(): DomainSuggestions.DomainSuggestio
 	) {
 		return {
 			hsts_required: domainDetails.hsts_required,
+			is_dot_gay_notice_required: domainDetails.is_dot_gay_notice_required,
 			domain_name: domainName,
 			raw_price: domainProductFromCart.cost,
 			currency_code: domainProductFromCart.currency,


### PR DESCRIPTION
## Proposed Changes

This PR add Calypso support for `.gay` tld registrations.

For this tld we are required to show a notice in domain suggestions and in the checkout (see screenshots below).


![dot-gay-notice-suggestion](https://user-images.githubusercontent.com/2797601/221914242-62e1e071-8d34-4312-a2e4-cd5202485a3e.png)

![dot-gay-notice-checkout](https://user-images.githubusercontent.com/2797601/221914262-71229f61-9b4b-4fe2-9abf-4910e7e8ea89.png)

## Testing Instructions

- Apply this patch locally or open the Calypso live link
- Select a site and navigate to `Upgrades>Domains`, then click `Add a domain>Search for a domain`
- In the input field, search for any `.gay` domain (i.e. `mytestdomain.gay`)
- Verify that the popover is show next to the domain name
- Add the domain in the cart and proceed to the checkout
- Verify that the notice is showed in the checkout too

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
