### PR TITLE
Stats: Adjust the layout on the Insight page for Jetpack sites

### DIFF
--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -31,6 +31,34 @@ $grid-vertical-gutters: 32px;
 
 
 .stats__module-list.stats__module--unified.is-insights-page-enabled {
+
+	&.is-odyssey-stats {
+		@include stats-desktop-grid(
+			"tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories comments comments comments comments comments comments"
+			"followers followers followers followers followers followers publicize publicize publicize publicize publicize publicize"
+			"latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary latest-post-summary social-followers social-followers social-followers social-followers social-followers social-followers",
+			3
+		);
+
+		@include stats-tablet-grid(
+			"tags-categories tags-categories tags-categories tags-categories comments comments comments comments"
+			"followers followers followers followers followers followers followers followers"
+			"publicize publicize publicize publicize latest-post-summary latest-post-summary latest-post-summary latest-post-summary"
+			"social-followers social-followers social-followers social-followers social-followers social-followers social-followers social-followers",
+			4
+		);
+
+		@include stats-mobile-grid(
+			"tags-categories tags-categories tags-categories tags-categories"
+			"comments comments comments comments"
+			"followers followers followers followers"
+			"publicize publicize publicize publicize"
+			"latest-post-summary latest-post-summary latest-post-summary latest-post-summary"
+			"social-followers social-followers social-followers social-followers",
+			7
+		);
+	}
+
 	@include stats-desktop-grid(
 		"tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories comments comments comments comments comments comments"
 		"shares shares shares shares followers followers followers followers publicize publicize publicize publicize"
@@ -117,6 +145,7 @@ $grid-vertical-gutters: 32px;
 		grid-area: publicize;
 	}
 }
+
 
 .is-section-stats .stats__module-list--traffic {
 	@include stats-desktop-grid(

--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -55,7 +55,7 @@ $grid-vertical-gutters: 32px;
 			"publicize publicize publicize publicize"
 			"latest-post-summary latest-post-summary latest-post-summary latest-post-summary"
 			"social-followers social-followers social-followers social-followers",
-			7
+			6
 		);
 	}
 

--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -32,7 +32,7 @@ $grid-vertical-gutters: 32px;
 
 .stats__module-list.stats__module--unified.is-insights-page-enabled {
 
-	&.is-odyssey-stats {
+	&.is-jetpack {
 		@include stats-desktop-grid(
 			"tags-categories tags-categories tags-categories tags-categories tags-categories tags-categories comments comments comments comments comments comments"
 			"followers followers followers followers followers followers publicize publicize publicize publicize publicize publicize"

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -35,6 +35,7 @@ const StatsInsights = ( props ) => {
 
 	const statsModuleListClass = classNames( 'stats__module-list stats__module--unified', {
 		'is-insights-page-enabled': isInsightsPageGridEnabled,
+		'is-odyssey-stats': isOdysseyStats,
 		'is-jetpack': isJetpack,
 	} );
 

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -79,8 +79,8 @@ const StatsInsights = ( props ) => {
 						/>
 						<Comments path="comments" />
 
-						{ /** TODO: The feature depends on Jetpack Sharing module and is disabled for Odyssey for now. */ }
-						{ ! isOdysseyStats && <StatShares siteId={ siteId } /> }
+						{ /** TODO: The feature depends on Jetpack Sharing module and is disabled for all Jetpack Sites for now. */ }
+						{ ! isJetpack && <StatShares siteId={ siteId } /> }
 
 						<Followers path="followers" />
 						<Reach />
@@ -102,8 +102,8 @@ const StatsInsights = ( props ) => {
 									hideSummaryLink
 									hideNewModule // remove when cleaning 'stats/horizontal-bars-everywhere' FF
 								/>
-								{ /** TODO: The feature depends on Jetpack Sharing module and is disabled for Odyssey for now. */ }
-								{ ! isOdysseyStats && <StatShares siteId={ siteId } /> }
+								{ /** TODO: The feature depends on Jetpack Sharing module and is disabled for all Jetpack Sites for now. */ }
+								{ ! isJetpack && <StatShares siteId={ siteId } /> }
 							</div>
 							<div className="stats__module-column">
 								<Reach />

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -34,6 +34,7 @@ const StatsInsights = ( props ) => {
 
 	const statsModuleListClass = classNames( 'stats__module-list stats__module--unified', {
 		'is-insights-page-enabled': isInsightsPageGridEnabled,
+		'is-odyssey-stats': isOdysseyStats,
 	} );
 
 	// Track the last viewed tab.

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -12,6 +12,7 @@ import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import AllTimelHighlightsSection from '../all-time-highlights-section';
 import AllTimeViewsSection from '../all-time-views-section';
@@ -26,7 +27,7 @@ import StatShares from '../stats-shares';
 import statsStrings from '../stats-strings';
 
 const StatsInsights = ( props ) => {
-	const { siteId, siteSlug, translate, isOdysseyStats } = props;
+	const { siteId, siteSlug, translate, isOdysseyStats, isJetpack } = props;
 	const moduleStrings = statsStrings();
 
 	const isInsightsPageGridEnabled = config.isEnabled( 'stats/insights-page-grid' );
@@ -34,7 +35,7 @@ const StatsInsights = ( props ) => {
 
 	const statsModuleListClass = classNames( 'stats__module-list stats__module--unified', {
 		'is-insights-page-enabled': isInsightsPageGridEnabled,
-		'is-odyssey-stats': isOdysseyStats,
+		'is-jetpack': isJetpack,
 	} );
 
 	// Track the last viewed tab.
@@ -139,6 +140,7 @@ const connectComponent = connect( ( state ) => {
 		siteId,
 		siteSlug: getSelectedSiteSlug( state, siteId ),
 		isOdysseyStats,
+		isJetpack: isJetpackSite( state, siteId ),
 	};
 } );
 


### PR DESCRIPTION
Related to #73745

## Proposed Changes

* Temporary solution expands the Subscriber cards to fill the width and hide the gap left from hiding the share card for Jetpack sites (for now till our designers have better solutions)

## Testing Instructions

* Using this branch on your local enviornment, navigate to the insights page on a simple site at `/stats/insights/{Site URL}` to check that the `shares` card is there, and that it is taking up 1/3 of the width along with 2 other cards. 
* Switch to a Jetpack site, and check  the `shares` card is *not* there, and that the two cards expand to 50% of the width each to cover the gap left by the shares card. 
* Setup Odyssey with Option 1 in `PejTkB-3E-p2` 
* Visit the insights page at `/stats/insights/{Site URL}` to check that the `shares` card is *not* there, and that the two cards expand to 50% of the width each to cover the gap left by the shares card. 

| Simple Site  | Jetpack Site |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/30754158/221967931-d0a96997-9ee7-46f8-aa96-04149e587b6e.png)  | ![image](https://user-images.githubusercontent.com/30754158/221967909-90a164cb-8091-4e46-8acd-1de9b0bd729d.png)  |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
