### PR TITLE
Payment Methods: Support address field for tax information

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -40,7 +40,7 @@ const wpcomCreatePayPalAgreement = (
 	tax_address: string,
 	tax_organization: string,
 	tax_city: string,
-	tax_state: string
+	tax_subdivision_code: string
 ): Promise< string > =>
 	wp.req.post( {
 		path: '/payment-methods/create-paypal-agreement',
@@ -53,7 +53,7 @@ const wpcomCreatePayPalAgreement = (
 			tax_address,
 			tax_organization,
 			tax_city,
-			tax_state,
+			tax_subdivision_code,
 		},
 		apiVersion: '1',
 	} );

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -77,8 +77,16 @@ export async function assignNewCardProcessor(
 			throw new Error( 'Cannot assign payment method if there is no card number' );
 		}
 
-		const { name, countryCode, postalCode, state, city, organization, useForAllSubscriptions } =
-			submitData;
+		const {
+			name,
+			countryCode,
+			postalCode,
+			state,
+			city,
+			organization,
+			address,
+			useForAllSubscriptions,
+		} = submitData;
 
 		const contactInfo: ManagedContactDetails = {
 			countryCode: {
@@ -109,6 +117,13 @@ export async function assignNewCardProcessor(
 		if ( organization ) {
 			contactInfo.organization = {
 				value: organization,
+				isTouched: true,
+				errors: [],
+			};
+		}
+		if ( address ) {
+			contactInfo.address1 = {
+				value: address,
 				isTouched: true,
 				errors: [],
 			};
@@ -157,6 +172,7 @@ export async function assignNewCardProcessor(
 				state,
 				city,
 				organization,
+				address,
 			} );
 
 			return makeSuccessResponse( result );
@@ -172,6 +188,7 @@ export async function assignNewCardProcessor(
 			state,
 			city,
 			organization,
+			address,
 		} );
 
 		return makeSuccessResponse( result );
@@ -221,6 +238,7 @@ interface NewCardSubmitData {
 	state?: string;
 	city?: string;
 	organization?: string;
+	address?: string;
 	useForAllSubscriptions: boolean;
 }
 

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -37,7 +37,10 @@ const wpcomCreatePayPalAgreement = (
 	cancel_url: string,
 	tax_country_code: string,
 	tax_postal_code: string,
-	tax_address: string
+	tax_address: string,
+	tax_organization: string,
+	tax_city: string,
+	tax_state: string
 ): Promise< string > =>
 	wp.req.post( {
 		path: '/payment-methods/create-paypal-agreement',
@@ -48,6 +51,9 @@ const wpcomCreatePayPalAgreement = (
 			tax_postal_code,
 			tax_country_code,
 			tax_address,
+			tax_organization,
+			tax_city,
+			tax_state,
 		},
 		apiVersion: '1',
 	} );
@@ -284,6 +290,9 @@ interface PayPalSubmitData {
 	postalCode?: string;
 	countryCode: string;
 	address?: string;
+	organization?: string;
+	city?: string;
+	state?: string;
 }
 
 function isValidPayPalData( data: unknown ): data is PayPalSubmitData {
@@ -310,7 +319,10 @@ export async function assignPayPalProcessor(
 			window.location.href,
 			submitData.countryCode,
 			submitData.postalCode ?? '',
-			submitData.address ?? ''
+			submitData.address ?? '',
+			submitData.organization ?? '',
+			submitData.city ?? '',
+			submitData.state ?? ''
 		);
 		return makeRedirectResponse( data );
 	} catch ( error ) {

--- a/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/assignment-processor-functions.ts
@@ -36,11 +36,19 @@ const wpcomCreatePayPalAgreement = (
 	success_url: string,
 	cancel_url: string,
 	tax_country_code: string,
-	tax_postal_code: string
+	tax_postal_code: string,
+	tax_address: string
 ): Promise< string > =>
 	wp.req.post( {
 		path: '/payment-methods/create-paypal-agreement',
-		body: { subscription_id, success_url, cancel_url, tax_postal_code, tax_country_code },
+		body: {
+			subscription_id,
+			success_url,
+			cancel_url,
+			tax_postal_code,
+			tax_country_code,
+			tax_address,
+		},
 		apiVersion: '1',
 	} );
 
@@ -275,6 +283,7 @@ interface ExistingCardSubmitData {
 interface PayPalSubmitData {
 	postalCode?: string;
 	countryCode: string;
+	address?: string;
 }
 
 function isValidPayPalData( data: unknown ): data is PayPalSubmitData {
@@ -300,7 +309,8 @@ export async function assignPayPalProcessor(
 			addQueryArgs( window.location.href, { success: 'true' } ),
 			window.location.href,
 			submitData.countryCode,
-			submitData.postalCode ?? ''
+			submitData.postalCode ?? '',
+			submitData.address ?? ''
 		);
 		return makeRedirectResponse( data );
 	} catch ( error ) {

--- a/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
+++ b/client/me/purchases/manage-purchase/payment-method-selector/stored-payment-method-api.ts
@@ -15,6 +15,7 @@ export async function saveCreditCard( {
 	state,
 	city,
 	organization,
+	address,
 }: {
 	token: string;
 	stripeConfiguration: StripeConfiguration;
@@ -25,6 +26,7 @@ export async function saveCreditCard( {
 	state?: string;
 	city?: string;
 	organization?: string;
+	address?: string;
 } ): Promise< StoredCardEndpointResponse > {
 	const additionalData = getParamsForApi( {
 		cardToken: token,
@@ -36,6 +38,7 @@ export async function saveCreditCard( {
 		state,
 		city,
 		organization,
+		address,
 	} );
 	const response = await wp.req.post(
 		{
@@ -66,6 +69,7 @@ export async function updateCreditCard( {
 	state,
 	city,
 	organization,
+	address,
 	countryCode,
 }: {
 	purchase: Purchase;
@@ -77,6 +81,7 @@ export async function updateCreditCard( {
 	state?: string;
 	city?: string;
 	organization?: string;
+	address?: string;
 	countryCode: string;
 } ): Promise< StoredCardEndpointResponse > {
 	const {
@@ -90,6 +95,7 @@ export async function updateCreditCard( {
 		tax_subdivision_code,
 		tax_city,
 		tax_organization,
+		tax_address,
 	} = getParamsForApi( {
 		cardToken: token,
 		stripeConfiguration,
@@ -101,6 +107,7 @@ export async function updateCreditCard( {
 		state,
 		city,
 		organization,
+		address,
 	} );
 	const response = await wp.req.post(
 		{
@@ -117,6 +124,7 @@ export async function updateCreditCard( {
 			tax_subdivision_code,
 			tax_city,
 			tax_organization,
+			tax_address,
 		}
 	);
 	if ( response.error ) {
@@ -138,6 +146,7 @@ function getParamsForApi( {
 	state,
 	city,
 	organization,
+	address,
 }: {
 	cardToken: string;
 	stripeConfiguration: StripeConfiguration;
@@ -149,6 +158,7 @@ function getParamsForApi( {
 	state?: string;
 	city?: string;
 	organization?: string;
+	address?: string;
 } ) {
 	return {
 		payment_partner: stripeConfiguration ? stripeConfiguration.processor_id : '',
@@ -162,5 +172,6 @@ function getParamsForApi( {
 		tax_subdivision_code: state,
 		tax_city: city,
 		tax_organization: organization,
+		tax_address: address,
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/payment-method-tax-info.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/payment-method-tax-info.tsx
@@ -197,7 +197,7 @@ export function TaxInfoArea( {
 			tax_subdivision_code: inputValues?.state?.value,
 			tax_city: inputValues?.city?.value,
 			tax_organization: inputValues?.organization?.value,
-			tax_address: inputValues?.address?.value,
+			tax_address: inputValues?.address1?.value,
 		} )
 			.then( closeDialog )
 			.catch( setUpdateError );

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/payment-method-tax-info.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/payment-method-tax-info.tsx
@@ -136,6 +136,13 @@ function contactDetailsToTaxInfo( info?: TaxInfo ): ManagedContactDetails {
 			errors: [],
 		};
 	}
+	if ( info?.tax_address ) {
+		taxInfo.address1 = {
+			value: info.tax_address,
+			isTouched: true,
+			errors: [],
+		};
+	}
 	return taxInfo;
 }
 
@@ -190,6 +197,7 @@ export function TaxInfoArea( {
 			tax_subdivision_code: inputValues?.state?.value,
 			tax_city: inputValues?.city?.value,
 			tax_organization: inputValues?.organization?.value,
+			tax_address: inputValues?.address?.value,
 		} )
 			.then( closeDialog )
 			.catch( setUpdateError );

--- a/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/types.ts
+++ b/client/my-sites/checkout/composite-checkout/components/payment-method-tax-info/types.ts
@@ -4,6 +4,7 @@ export interface TaxInfo {
 	tax_subdivision_code?: string;
 	tax_city?: string;
 	tax_organization?: string;
+	tax_address?: string;
 }
 
 export interface TaxGetInfo extends TaxInfo {

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.tsx
@@ -3,6 +3,7 @@ import { useSelect } from '@wordpress/data';
 import TaxFields from 'calypso/my-sites/checkout/composite-checkout/components/tax-fields';
 import useCountryList from 'calypso/my-sites/checkout/composite-checkout/hooks/use-country-list';
 import { CountrySpecificPaymentFields } from '../../components/country-specific-payment-fields';
+import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
 
 export default function ContactFields( {
 	getFieldValue,
@@ -21,18 +22,13 @@ export default function ContactFields( {
 	const isDisabled = formStatus !== FormStatus.READY;
 	const countriesList = useCountryList();
 	const fields = useSelect( ( select ) => select( 'wpcom-credit-card' ).getFields() );
-	const onChangeContactInfo = ( newInfo: {
-		countryCode?: { value?: string };
-		postalCode?: { value?: string };
-		state?: { value?: string };
-		city?: { value?: string };
-		organization?: { value?: string };
-	} ) => {
+	const onChangeContactInfo = ( newInfo: ManagedContactDetails ) => {
 		setFieldValue( 'countryCode', newInfo.countryCode?.value ?? '' );
 		setFieldValue( 'postalCode', newInfo.postalCode?.value ?? '' );
 		setFieldValue( 'state', newInfo.state?.value ?? '' );
 		setFieldValue( 'city', newInfo.city?.value ?? '' );
 		setFieldValue( 'organization', newInfo.organization?.value ?? '' );
+		setFieldValue( 'address1', newInfo.address1?.value ?? '' );
 	};
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -65,6 +65,7 @@ export default function CreditCardPayButton( {
 							state: fields?.state?.value,
 							city: fields?.city?.value,
 							organization: fields?.organization?.value,
+							address: fields?.address1?.value, // TODO: is this address1 or address?
 							useForAllSubscriptions,
 							eventSource: 'checkout',
 						} );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -65,7 +65,7 @@ export default function CreditCardPayButton( {
 							state: fields?.state?.value,
 							city: fields?.city?.value,
 							organization: fields?.organization?.value,
-							address: fields?.address1?.value, // TODO: is this address1 or address?
+							address: fields?.address1?.value,
 							useForAllSubscriptions,
 							eventSource: 'checkout',
 						} );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
@@ -31,7 +31,7 @@ const debug = debugFactory( 'calypso:paypal-payment-method' );
 
 const storeKey = 'paypal';
 type StoreKey = typeof storeKey;
-type NounsInStore = 'postalCode' | 'countryCode' | 'address1';
+type NounsInStore = 'postalCode' | 'countryCode' | 'address1' | 'organization' | 'city' | 'state';
 type PayPalStore = PaymentMethodStore< NounsInStore >;
 
 declare module '@wordpress/data' {
@@ -49,6 +49,15 @@ const actions: StoreActions< NounsInStore > = {
 	changeAddress1( payload ) {
 		return { type: 'ADDRESS_SET', payload };
 	},
+	changeOrganization( payload ) {
+		return { type: 'ORGANIZATION_SET', payload };
+	},
+	changeCity( payload ) {
+		return { type: 'CITY_SET', payload };
+	},
+	changeState( payload ) {
+		return { type: 'STATE_SET', payload };
+	},
 };
 
 const selectors: StoreSelectorsWithState< NounsInStore > = {
@@ -61,6 +70,15 @@ const selectors: StoreSelectorsWithState< NounsInStore > = {
 	getAddress1( state ) {
 		return state.address1 || '';
 	},
+	getOrganization( state ) {
+		return state.organization || '';
+	},
+	getCity( state ) {
+		return state.city || '';
+	},
+	getState( state ) {
+		return state.state || '';
+	},
 };
 
 export function createPayPalStore(): PayPalStore {
@@ -71,6 +89,9 @@ export function createPayPalStore(): PayPalStore {
 				postalCode: { value: '', isTouched: false },
 				countryCode: { value: '', isTouched: false },
 				address1: { value: '', isTouched: false },
+				organization: { value: '', isTouched: false },
+				city: { value: '', isTouched: false },
+				state: { value: '', isTouched: false },
 			},
 			action
 		): StoreState< NounsInStore > {
@@ -81,6 +102,12 @@ export function createPayPalStore(): PayPalStore {
 					return { ...state, countryCode: { value: action.payload, isTouched: true } };
 				case 'ADDRESS_SET':
 					return { ...state, address1: { value: action.payload, isTouched: true } };
+				case 'ORGANIZATION_SET':
+					return { ...state, organization: { value: action.payload, isTouched: true } };
+				case 'CITY_SET':
+					return { ...state, city: { value: action.payload, isTouched: true } };
+				case 'STATE_SET':
+					return { ...state, state: { value: action.payload, isTouched: true } };
 			}
 			return state;
 		},
@@ -153,19 +180,35 @@ function PayPalTaxFields() {
 	const postalCode = useSelect( ( select ) => select( storeKey ).getPostalCode() );
 	const countryCode = useSelect( ( select ) => select( storeKey ).getCountryCode() );
 	const address1 = useSelect( ( select ) => select( storeKey ).getAddress1() );
+	const organization = useSelect( ( select ) => select( storeKey ).getOrganization() );
+	const city = useSelect( ( select ) => select( storeKey ).getCity() );
+	const state = useSelect( ( select ) => select( storeKey ).getState() );
 	const fields = useMemo(
 		() => ( {
 			postalCode: { ...postalCode, errors: [] },
 			countryCode: { ...countryCode, errors: [] },
 			address1: { ...address1, errors: [] },
+			organization: { ...organization, errors: [] },
+			city: { ...city, errors: [] },
+			state: { ...state, errors: [] },
 		} ),
-		[ postalCode, countryCode, address1 ]
+		[ postalCode, countryCode, address1, organization, city, state ]
 	);
-	const { changePostalCode, changeCountryCode, changeAddress1 } = useDispatch( storeKey );
+	const {
+		changePostalCode,
+		changeCountryCode,
+		changeAddress1,
+		changeCity,
+		changeState,
+		changeOrganization,
+	} = useDispatch( storeKey );
 	const onChangeContactInfo = ( newInfo: ManagedContactDetails ) => {
 		changeCountryCode( newInfo.countryCode?.value ?? '' );
 		changePostalCode( newInfo.postalCode?.value ?? '' );
 		changeAddress1( newInfo.address1?.value ?? '' );
+		changeOrganization( newInfo.organization?.value ?? '' );
+		changeCity( newInfo.city?.value ?? '' );
+		changeState( newInfo.state?.value ?? '' );
 	};
 	return (
 		<PayPalFieldsWrapper>
@@ -224,6 +267,9 @@ function PayPalSubmitButton( {
 	const postalCode = useSelect( ( select ) => select( storeKey )?.getPostalCode() );
 	const countryCode = useSelect( ( select ) => select( storeKey )?.getCountryCode() );
 	const address1 = useSelect( ( select ) => select( storeKey )?.getAddress1() );
+	const organization = useSelect( ( select ) => select( storeKey )?.getOrganization() );
+	const city = useSelect( ( select ) => select( storeKey ).getCity() );
+	const state = useSelect( ( select ) => select( storeKey ).getState() );
 
 	const handleButtonPress = () => {
 		if ( ! onClick ) {
@@ -235,6 +281,9 @@ function PayPalSubmitButton( {
 			postalCode: postalCode?.value,
 			countryCode: countryCode?.value,
 			address: address1?.value,
+			organization: organization?.value,
+			city: city?.value,
+			state: state?.value,
 		} );
 	};
 	return (

--- a/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/paypal.tsx
@@ -31,7 +31,7 @@ const debug = debugFactory( 'calypso:paypal-payment-method' );
 
 const storeKey = 'paypal';
 type StoreKey = typeof storeKey;
-type NounsInStore = 'postalCode' | 'countryCode';
+type NounsInStore = 'postalCode' | 'countryCode' | 'address1';
 type PayPalStore = PaymentMethodStore< NounsInStore >;
 
 declare module '@wordpress/data' {
@@ -46,6 +46,9 @@ const actions: StoreActions< NounsInStore > = {
 	changeCountryCode( payload ) {
 		return { type: 'COUNTRY_CODE_SET', payload };
 	},
+	changeAddress1( payload ) {
+		return { type: 'ADDRESS_SET', payload };
+	},
 };
 
 const selectors: StoreSelectorsWithState< NounsInStore > = {
@@ -54,6 +57,9 @@ const selectors: StoreSelectorsWithState< NounsInStore > = {
 	},
 	getCountryCode( state ) {
 		return state.countryCode || '';
+	},
+	getAddress1( state ) {
+		return state.address1 || '';
 	},
 };
 
@@ -64,6 +70,7 @@ export function createPayPalStore(): PayPalStore {
 			state: StoreState< NounsInStore > = {
 				postalCode: { value: '', isTouched: false },
 				countryCode: { value: '', isTouched: false },
+				address1: { value: '', isTouched: false },
 			},
 			action
 		): StoreState< NounsInStore > {
@@ -72,6 +79,8 @@ export function createPayPalStore(): PayPalStore {
 					return { ...state, postalCode: { value: action.payload, isTouched: true } };
 				case 'COUNTRY_CODE_SET':
 					return { ...state, countryCode: { value: action.payload, isTouched: true } };
+				case 'ADDRESS_SET':
+					return { ...state, address1: { value: action.payload, isTouched: true } };
 			}
 			return state;
 		},
@@ -143,17 +152,20 @@ function PayPalTaxFields() {
 	const countriesList = useCountryList();
 	const postalCode = useSelect( ( select ) => select( storeKey ).getPostalCode() );
 	const countryCode = useSelect( ( select ) => select( storeKey ).getCountryCode() );
+	const address1 = useSelect( ( select ) => select( storeKey ).getAddress1() );
 	const fields = useMemo(
 		() => ( {
 			postalCode: { ...postalCode, errors: [] },
 			countryCode: { ...countryCode, errors: [] },
+			address1: { ...address1, errors: [] },
 		} ),
-		[ postalCode, countryCode ]
+		[ postalCode, countryCode, address1 ]
 	);
-	const { changePostalCode, changeCountryCode } = useDispatch( storeKey );
+	const { changePostalCode, changeCountryCode, changeAddress1 } = useDispatch( storeKey );
 	const onChangeContactInfo = ( newInfo: ManagedContactDetails ) => {
 		changeCountryCode( newInfo.countryCode?.value ?? '' );
 		changePostalCode( newInfo.postalCode?.value ?? '' );
+		changeAddress1( newInfo.address1?.value ?? '' );
 	};
 	return (
 		<PayPalFieldsWrapper>
@@ -211,6 +223,7 @@ function PayPalSubmitButton( {
 	const { transactionStatus } = useTransactionStatus();
 	const postalCode = useSelect( ( select ) => select( storeKey )?.getPostalCode() );
 	const countryCode = useSelect( ( select ) => select( storeKey )?.getCountryCode() );
+	const address1 = useSelect( ( select ) => select( storeKey )?.getAddress1() );
 
 	const handleButtonPress = () => {
 		if ( ! onClick ) {
@@ -221,6 +234,7 @@ function PayPalSubmitButton( {
 		onClick( {
 			postalCode: postalCode?.value,
 			countryCode: countryCode?.value,
+			address: address1?.value,
 		} );
 	};
 	return (


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/73782 added a new tax field, "Address" to checkout's tax location collection when required by a country. Because the `TaxFields` component used by checkout is also used by the payment method management interface, that PR also adds an Address field there (when required). However, the payment method management pages do not yet send that data to their respective endpoints.

## Proposed Changes

This PR updates the payment method management interfaces for new and saved cards so that they also include the new address field. It is similar to https://github.com/Automattic/wp-calypso/pull/73693 which did this for other fields.

In addition, this makes the city, state, and organization fields work for the PayPal option in the "Change Payment Method" form, which was overlooked in the aforementioned PR.

Note that these new fields will not actually do anything on the backend until D102477-code is merged. Note also that these new fields will never be shown outside of a sandboxed environment until we enable the requirements on the backend.

<img width="1405" alt="tax_address" src="https://user-images.githubusercontent.com/2036909/221931880-7a7079f6-0579-4b78-97e3-6f7eafd474d6.png">

<img width="1250" alt="Screenshot 2023-02-28 at 12 30 52 PM" src="https://user-images.githubusercontent.com/2036909/221931912-4ff5be39-a308-46ef-834b-d509e526e225.png">

<img width="470" alt="Screenshot 2023-02-28 at 12 31 20 PM" src="https://user-images.githubusercontent.com/2036909/221932069-0e14041f-116c-4b2f-bf5b-cbc30910699a.png">

<img width="1183" alt="Screenshot 2023-03-01 at 1 25 17 PM" src="https://user-images.githubusercontent.com/2036909/222230415-b983aa58-29f5-4d58-af66-3cf971dfc326.png">


## Testing Instructions

First, apply D102799-code and sandbox the API to force Switzerland to require an Address field.

To test the new card form:

- Visit the "Add new payment method" form and set the country code to "Switzerland".
- Fill in the "Address" field and the other fields with valid test data.
- Open your browser's devtools to view network transactions.
- Click to submit the new card.
- Make sure that `tax_address` is sent to the endpoint when creating the new card.

To test PayPal:

- Use an account which has an existing subscription.
- Visit that subscription's page.
- Click "Change payment method".
- Select "PayPal" as the method.
- Set the country code to "Switzerland".
- Fill in the "Address" field and the other fields with valid test data.
- Open your browser's devtools to view network transactions.
- Click to submit the new card.
- Make sure that `tax_address` is sent to the endpoint when submitting the payment method.

To test the existing card form:

- Visit the list of payment methods and make sure you have at least one saved card.
- Click the address (country and postal code) link on the payment method to open the address form.
- Set the country to "Switzerland".
- Fill in the "Address" field and the other fields with valid test data.
- Open your browser's devtools to view network transactions.
- Click to submit the updated location.
- Make sure that `tax_address` is sent to the endpoint when updating the card.