### PR TITLE
Plugins: Update the popular list to search only on wporg data

### DIFF
--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -117,11 +117,15 @@ export const getESPluginsInfiniteQueryParams = (
 	const [ searchTerm, author ] = extractSearchInformation( options.searchTerm );
 	const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE;
 	const cacheKey = getPluginsListKey( 'DEBUG-new-site-seach', options, true );
+	const groupId =
+		config.isEnabled( 'marketplace-jetpack-plugin-search' ) && options.category !== 'popular'
+			? 'marketplace'
+			: 'wporg';
 	const fetchFn = ( { pageParam = 1 } ) =>
 		search( {
 			query: searchTerm,
 			author,
-			groupId: config.isEnabled( 'marketplace-jetpack-plugin-search' ) ? 'marketplace' : 'wporg',
+			groupId,
 			category: options.category,
 			pageHandle: pageParam + '',
 			pageSize,


### PR DESCRIPTION
## Proposed Changes

Add a new condition to search on wporg data. The condition is when searching for "popular" plugins.

## Testing Instructions

* Go to popular plugins list on `/plugins/browse/popular`
* Check if the results shows only free plugins


| Before  | After |
| ------------- | ------------- |
|<img width="980" alt="CleanShot 2023-02-28 at 14 11 13@2x" src="https://user-images.githubusercontent.com/5039531/221928317-9afc10b6-6b6b-4e72-ac1f-63bb1100f8a1.png">|<img width="956" alt="CleanShot 2023-02-28 at 14 12 09@2x" src="https://user-images.githubusercontent.com/5039531/221928344-96a72a25-5c42-4458-97e8-ac9a4737c8e0.png">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
