### PR TITLE
Theme Showcase: Update upsell to reflect WooExpress trial changes

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -1,5 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { FEATURE_UPLOAD_THEMES, PLAN_BUSINESS } from '@automattic/calypso-products';
+import {
+	FEATURE_UPLOAD_THEMES,
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+} from '@automattic/calypso-products';
 import { pickBy } from 'lodash';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -50,23 +55,49 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 	} = props;
 
 	const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
-	const displayUpsellBanner = isAtomic && ! requestingSitePlans && currentPlan;
-	const upsellUrl =
-		isAtomic && `/plans/${ siteId }?feature=${ FEATURE_UPLOAD_THEMES }&plan=${ PLAN_BUSINESS }`;
+	const isWooExpressTrial = PLAN_ECOMMERCE_TRIAL_MONTHLY === currentPlan?.productSlug;
 
-	const upsellBanner = (
-		<UpsellNudge
-			className="themes__showcase-banner"
-			event="calypso_themes_list_install_themes"
-			feature={ FEATURE_UPLOAD_THEMES }
-			plan={ PLAN_BUSINESS }
-			title={ translate(
-				'Unlock ALL premium themes and upload your own themes with our Business and eCommerce plans!'
-			) }
-			callToAction={ translate( 'Upgrade now' ) }
-			showIcon={ true }
-		/>
-	);
+	const upsellBanner = () => {
+		if ( isWooExpressTrial ) {
+			return (
+				<UpsellNudge
+					className="themes__showcase-banner"
+					event="calypso_themes_list_install_themes"
+					feature={ FEATURE_UPLOAD_THEMES }
+					plan={ PLAN_ECOMMERCE }
+					title={ translate( 'Upgrade to a plan to upload your own themes!' ) }
+					callToAction={ translate( 'Upgrade now' ) }
+					showIcon={ true }
+				/>
+			);
+		}
+
+		return (
+			<UpsellNudge
+				className="themes__showcase-banner"
+				event="calypso_themes_list_install_themes"
+				feature={ FEATURE_UPLOAD_THEMES }
+				plan={ PLAN_BUSINESS }
+				title={ translate(
+					'Unlock ALL premium themes and upload your own themes with our Business and eCommerce plans!'
+				) }
+				callToAction={ translate( 'Upgrade now' ) }
+				showIcon={ true }
+			/>
+		);
+	};
+
+	const upsellUrl = () => {
+		if ( isWooExpressTrial ) {
+			return `/plans/${ siteId }?feature=${ FEATURE_UPLOAD_THEMES }&plan=${ PLAN_ECOMMERCE }`;
+		}
+
+		return (
+			isAtomic && `/plans/${ siteId }?feature=${ FEATURE_UPLOAD_THEMES }&plan=${ PLAN_BUSINESS }`
+		);
+	};
+
+	const displayUpsellBanner = isAtomic && ! requestingSitePlans && currentPlan;
 
 	useRequestSiteChecklistTaskUpdate( siteId, CHECKLIST_KNOWN_TASKS.THEMES_BROWSED );
 
@@ -80,10 +111,10 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 
 			<ThemeShowcase
 				{ ...props }
-				upsellUrl={ upsellUrl }
+				upsellUrl={ upsellUrl() }
 				siteId={ siteId }
 				isJetpackSite={ true }
-				upsellBanner={ displayUpsellBanner ? upsellBanner : null }
+				upsellBanner={ displayUpsellBanner ? upsellBanner() : null }
 			>
 				{ showWpcomThemesList && (
 					<div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #73491

**Before**

<img width="1368" alt="Screen Shot 2023-02-28 at 12 34 26 PM" src="https://user-images.githubusercontent.com/2124984/221932388-5c71cf24-d46f-4555-923b-71a20d00e4c9.png">

<img width="1325" alt="Screen Shot 2023-02-28 at 12 33 25 PM" src="https://user-images.githubusercontent.com/2124984/221932408-c54c693d-0449-48e4-8efc-236825619479.png">


**After**

<img width="1389" alt="Screen Shot 2023-02-28 at 12 12 26 PM" src="https://user-images.githubusercontent.com/2124984/221931743-a63b0364-32c2-4c5d-9137-caa34afb429a.png">

<img width="1305" alt="Screen Shot 2023-02-28 at 12 12 33 PM" src="https://user-images.githubusercontent.com/2124984/221932092-1bfed382-9327-4864-b19e-76f14f40fb66.png">


## Proposed Changes

* Update upsell nudge with different copy for trial plans focused on the ability to upload themes without calling out a specific plan name (feedback on copy welcome!)
* Point upsell nudge to the `/plans` page focused on the Commerce plan as an upgrade path.
* Also updates `upsellUrl` with the same logic (although from what I could tell, I don't think we're using this prop right now)

## Testing Instructions

* Switch to this PR
* Navigate to `/themes/siteSlug` on a site with the commerce trial
* Note the updated banner; it should have the new copy and point to `/plans`, which highlights the Commerce plan as an upgrade path.
* Check the same screen on a Premium site; you should see the previous copy and link

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- NA [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- NA Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- NA For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
