### PR TITLE
Theme Showcase: Update install upsell for commerce trial sites

### DIFF
--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -7,7 +7,6 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSiteMultiSite, isJetpackSite } from 'calypso/state/sites/selectors';
-import { isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { trackClick } from './helpers';
 
@@ -21,9 +20,8 @@ const InstallThemeButton = ( {
 	siteCanInstallThemes,
 	dispatchTracksEvent,
 	atomicSite,
-	isCommerceTrial,
 } ) => {
-	if ( ! isLoggedIn || isMultisite || isCommerceTrial ) {
+	if ( ! isLoggedIn || isMultisite ) {
 		return null;
 	}
 
@@ -78,7 +76,6 @@ const mapStateToProps = ( state ) => {
 		isLoggedIn: isUserLoggedIn( state ),
 		isMultisite: isJetpackSiteMultiSite( state, selectedSiteId ),
 		jetpackSite: isJetpackSite( state, selectedSiteId ),
-		isCommerceTrial: isSiteOnECommerceTrial( state, selectedSiteId ),
 		siteCanInstallThemes:
 			siteHasFeature( state, selectedSiteId, FEATURE_INSTALL_THEMES ) && atomicSite,
 		atomicSite,

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -7,6 +7,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSiteMultiSite, isJetpackSite } from 'calypso/state/sites/selectors';
+import { isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { trackClick } from './helpers';
 
@@ -20,8 +21,9 @@ const InstallThemeButton = ( {
 	siteCanInstallThemes,
 	dispatchTracksEvent,
 	atomicSite,
+	isCommerceTrial,
 } ) => {
-	if ( ! isLoggedIn || isMultisite ) {
+	if ( ! isLoggedIn || isMultisite || isCommerceTrial ) {
 		return null;
 	}
 
@@ -76,6 +78,7 @@ const mapStateToProps = ( state ) => {
 		isLoggedIn: isUserLoggedIn( state ),
 		isMultisite: isJetpackSiteMultiSite( state, selectedSiteId ),
 		jetpackSite: isJetpackSite( state, selectedSiteId ),
+		isCommerceTrial: isSiteOnECommerceTrial( state, selectedSiteId ),
 		siteCanInstallThemes:
 			siteHasFeature( state, selectedSiteId, FEATURE_INSTALL_THEMES ) && atomicSite,
 		atomicSite,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #73489

## Proposed Changes

* Update the upsell on the "Install new theme" page at `/themes/upload/siteSlug` to account for the ecommerce trial
* If on the ecommerce trial, point to `/plans/siteSlug`, and remove wording about specific plan in the copy
* Use the siteSlug rather than siteId for URL formation as it's prettier

**Before**

<img width="1664" alt="Screen Shot 2023-03-01 at 12 40 45 PM" src="https://user-images.githubusercontent.com/2124984/222222440-bf49875d-000b-4e98-90e4-5fe8f16f1383.png">

**After**

<img width="1666" alt="Screen Shot 2023-03-01 at 12 45 31 PM" src="https://user-images.githubusercontent.com/2124984/222222457-fcc73397-d836-441e-8d6e-1c14656cd006.png">


## Testing Instructions

* Switch to this PR, navigate to `/themes/upload/siteSlug`
* If on a commerce trial site, you should see the upsell pointed to `/plans/siteSlug`, and the wording should not mention a specific plan name.
* On a different site, you'll either see the upgrade to Business, pointing to `/checkout/siteSlug/business`, or an upgrade to Pro (depends on site age/eligibility)
* On a site with a Business or higher plan, you shouldn't see the upsell at all.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- NA [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- NA Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- NA Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- NA For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
