### PR TITLE
Plugin Details: Avoid the shrink of icon when the plugin title is too big

### DIFF
--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -34,16 +34,15 @@ $mobile-icon-height: 175px;
 		margin-bottom: 15px;
 		width: $mobile-icon-height;
 		height: $mobile-icon-height;
+		flex-shrink: 0;
 	}
 }
 
 .plugin-details-header__title-container {
 	margin-top: 30px;
-	width: auto;
 
 	@include break-mobile {
 		margin-top: 0;
-		width: calc(100% - 72px - 20px); // full width - icon width - icon margin
 	}
 }
 

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -39,9 +39,11 @@ $mobile-icon-height: 175px;
 
 .plugin-details-header__title-container {
 	margin-top: 30px;
+	width: auto;
 
 	@include break-mobile {
 		margin-top: 0;
+		width: calc(100% - 72px - 20px); // full width - icon width - icon margin
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

Avoid the icon to shrink and always use the set width in order to avoid the stretch of the icon.

| Before  | After |
| ------------- | ------------- |
|<img width="1120" alt="CleanShot 2023-02-28 at 15 27 29@2x" src="https://user-images.githubusercontent.com/5039531/221946439-2d599466-b505-415e-bd7c-e77bd8b5d9d2.png">|<img width="1128" alt="CleanShot 2023-02-28 at 15 28 14@2x" src="https://user-images.githubusercontent.com/5039531/221946380-833c7240-64be-405c-9669-9a1671d1efe6.png">|


## Testing Instructions

* Go to a plugin details page of a plugin with a big name. Ex: `/plugins/trustpulse-api/`
* Check if the icon is stretched as displayed above
* The prod version SHOULD show a stretched icon
* This branch version SHOULD NOT show a stretched icon

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
