### PR TITLE
Launchpad: Add Next Steps button at the end of domain flow

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
@@ -12,6 +12,7 @@ import {
 	DomainThankYouType,
 } from 'calypso/my-sites/checkout/checkout-thank-you/domains/types';
 import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
+import { useSiteOption } from 'calypso/state/sites/hooks';
 import { hideMasterbar, showMasterbar } from 'calypso/state/ui/masterbar-visibility/actions';
 
 import './style.scss';
@@ -44,6 +45,9 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 		} );
 	}, [ type, domain, selectedSiteSlug, email, hasProfessionalEmail, hideProfessionalEmailStep ] );
 	const dispatch = useDispatch();
+	const launchpadScreen = useSiteOption( 'launchpad_screen' );
+	const isLaunchpadEnabled = launchpadScreen === 'full';
+	const siteIntent = useSiteOption( 'site_intent' );
 
 	useEffect( () => {
 		dispatch( hideMasterbar() );
@@ -52,13 +56,23 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 		};
 	}, [ dispatch ] );
 
-	const renderHeader = () => {
+	const renderHeader = ( isLaunchpadEnabled: boolean, siteIntent: string ) => {
+		const buttonProps = isLaunchpadEnabled
+			? {
+					onClick: () =>
+						window.location.replace(
+							`/setup/${ siteIntent }/launchpad?siteSlug=${ selectedSiteSlug }`
+						),
+			  }
+			: { href: domainManagementRoot() };
 		return (
 			<div className="checkout-thank-you__domains-header">
 				<WordPressLogo className="checkout-thank-you__domains-header-logo" size={ 24 } />
-				<Button borderless href={ domainManagementRoot() }>
+				<Button borderless { ...buttonProps }>
 					<Gridicon icon="chevron-left" size={ 18 } />
-					<span>{ translate( 'All domains' ) }</span>
+					<span>
+						{ isLaunchpadEnabled ? translate( 'Next Steps' ) : translate( 'All domains' ) }
+					</span>
 				</Button>
 			</div>
 		);
@@ -66,12 +80,12 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 
 	return (
 		<>
-			{ renderHeader() }
+			{ renderHeader( isLaunchpadEnabled, siteIntent as string ) }
 			<ThankYou
 				headerBackgroundColor="var( --studio-white )"
 				containerClassName="checkout-thank-you__domains"
 				sections={ thankYouProps.sections }
-				showSupportSection={ true }
+				showSupportSection={ launchpadScreen !== 'full' }
 				thankYouImage={ thankYouProps.thankYouImage }
 				thankYouTitle={ thankYouProps.thankYouTitle }
 				thankYouSubtitle={ thankYouProps.thankYouSubtitle }

--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
@@ -85,7 +85,7 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 				headerBackgroundColor="var( --studio-white )"
 				containerClassName="checkout-thank-you__domains"
 				sections={ thankYouProps.sections }
-				showSupportSection={ launchpadScreen !== 'full' }
+				showSupportSection={ ! isLaunchpadEnabled }
 				thankYouImage={ thankYouProps.thankYouImage }
 				thankYouTitle={ thankYouProps.thankYouTitle }
 				thankYouSubtitle={ thankYouProps.thankYouSubtitle }

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -1,9 +1,13 @@
 import { Icon, info } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import domainRegisteredSuccess from 'calypso/assets/images/domains/domain.svg';
-import { buildDomainStepForProfessionalEmail } from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index';
+import {
+	buildDomainStepForLaunchpadNextSteps,
+	buildDomainStepForProfessionalEmail,
+} from 'calypso/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index';
 import { domainManagementList, createSiteFromDomainOnly } from 'calypso/my-sites/domains/paths';
 import { FullWidthButton } from 'calypso/my-sites/marketplace/components';
+import { useSiteOption } from 'calypso/state/sites/hooks';
 import type {
 	DomainThankYouParams,
 	DomainThankYouProps,
@@ -24,6 +28,17 @@ const DomainRegistrationThankYouProps = ( {
 			hideProfessionalEmailStep,
 			selectedSiteSlug,
 		},
+		'REGISTRATION',
+		true
+	);
+
+	const siteIntent = useSiteOption( 'site_intent' );
+	const launchpadScreen = useSiteOption( 'launchpad_screen' );
+
+	const launchpadNextSteps = buildDomainStepForLaunchpadNextSteps(
+		siteIntent as string,
+		launchpadScreen as string,
+		selectedSiteSlug,
 		'REGISTRATION',
 		true
 	);
@@ -73,11 +88,13 @@ const DomainRegistrationThankYouProps = ( {
 			{
 				sectionKey: 'domain_registration_whats_next',
 				sectionTitle: translate( 'What’s next?' ),
-				nextSteps: [
-					...( professionalEmail ? [ professionalEmail ] : [] ),
-					...( ! selectedSiteSlug ? [ createSiteStep ] : [] ),
-					viewDomainsStep,
-				],
+				nextSteps: launchpadNextSteps
+					? [ launchpadNextSteps ]
+					: [
+							...( professionalEmail ? [ professionalEmail ] : [] ),
+							...( ! selectedSiteSlug ? [ createSiteStep ] : [] ),
+							viewDomainsStep,
+					  ],
 			},
 		],
 		thankYouImage: {

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
@@ -116,7 +116,7 @@ export function buildDomainStepForLaunchpadNextSteps(
 	domainType: DomainThankYouType,
 	primary: boolean
 ): ThankYouNextStepProps | null {
-	if ( launchpadScreen !== 'full' || ! siteIntent ) {
+	if ( launchpadScreen !== 'full' || ! siteIntent || ! selectedSiteSlug ) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
@@ -122,7 +122,6 @@ export function buildDomainStepForLaunchpadNextSteps(
 
 	return {
 		stepKey: `domain_${ domainType }_whats_next_launchpad_next_steps`,
-		stepTitle: translate( 'Launch your site' ),
 		stepDescription: translate(
 			'You are a few steps away from bringing your site to life. Check out the next steps that will help you to launch your site.'
 		),

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/index.tsx
@@ -105,3 +105,41 @@ export function buildDomainStepForProfessionalEmail(
 		stepCta: <StepCTA siteName={ selectedSiteSlug } email={ email } primary={ primary } />,
 	};
 }
+
+/**
+ * Redirect the user back to Launchpad after purchasing a domain
+ */
+export function buildDomainStepForLaunchpadNextSteps(
+	siteIntent: string | undefined,
+	launchpadScreen: string,
+	selectedSiteSlug: string,
+	domainType: DomainThankYouType,
+	primary: boolean
+): ThankYouNextStepProps | null {
+	if ( launchpadScreen !== 'full' || ! siteIntent ) {
+		return null;
+	}
+
+	return {
+		stepKey: `domain_${ domainType }_whats_next_launchpad_next_steps`,
+		stepTitle: translate( 'Launch your site' ),
+		stepDescription: translate(
+			'You are a few steps away from bringing your site to life. Check out the next steps that will help you to launch your site.'
+		),
+		stepCta: (
+			<FullWidthButton
+				onClick={ () =>
+					window.location.replace(
+						`/setup/${ siteIntent }/launchpad?siteSlug=${ selectedSiteSlug }`
+					)
+				}
+				className={ `domain-${ domainType }__thank-you-button domain-thank-you__button` }
+				primary={ primary }
+				busy={ false }
+				disabled={ false }
+			>
+				{ translate( 'Next Steps' ) }
+			</FullWidthButton>
+		),
+	};
+}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/73869

#### Time Estimate
Review: Short
Test: Mid

#### Proposed Changes
Add a new "Launch your site" section at the end of the domain purchase flow to allow the user to go back to Launchpad

<img width="2272" alt="image" src="https://user-images.githubusercontent.com/20927667/222178525-eddf0479-e0e7-43a9-b574-48511b78a16c.png">


#### Testing
1. Checkout this branch
2. Create a new general onboarding site http://calypso.localhost:3000/start
3. Choose a free domain and free plan
4. Once you arrive at Launchpad, click the Choose a domain task and go through the flow to upgrade your domain
5. Once you purchase your domain and arrive at the Next Steps screen you should see the new "Launch your site" section
6. The Next Steps buttons should redirect you back to Launchpad