### PR TITLE
My Home Upsell: Update default domain suggestion to .com

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -41,7 +41,9 @@ export function RenderDomainUpsell() {
 	const siteSubDomain = siteSlug.split( '.' )[ 0 ];
 	const locale = useLocale();
 	const { allDomainSuggestions } =
-		useDomainSuggestions( siteSubDomain, 3, undefined, locale ) || {};
+		useDomainSuggestions( siteSubDomain, 3, undefined, locale, {
+			vendor: 'domain-upsell',
+		} ) || {};
 
 	const cartKey = useCartKey();
 	const shoppingCartManager = useShoppingCart( cartKey );
@@ -58,7 +60,6 @@ export function RenderDomainUpsell() {
 	const searchLink = addQueryArgs(
 		{
 			domainAndPlanPackage: true,
-			domain: true,
 		},
 		`/domains/add/${ siteSlug }`
 	);
@@ -72,7 +73,7 @@ export function RenderDomainUpsell() {
 
 	const purchaseLink = addQueryArgs(
 		{
-			domain: true,
+			get_domain: domainSuggestionName,
 			domainAndPlanPackage: true,
 		},
 		`/plans/yearly/${ siteSlug }`

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -41,9 +41,7 @@ export function RenderDomainUpsell() {
 	const siteSubDomain = siteSlug.split( '.' )[ 0 ];
 	const locale = useLocale();
 	const { allDomainSuggestions } =
-		useDomainSuggestions( siteSubDomain, 3, undefined, locale, {
-			vendor: 'domain-upsell',
-		} ) || {};
+		useDomainSuggestions( siteSubDomain, 3, undefined, locale ) || {};
 
 	const cartKey = useCartKey();
 	const shoppingCartManager = useShoppingCart( cartKey );
@@ -53,13 +51,14 @@ export function RenderDomainUpsell() {
 		( suggestion ) => ! suggestion.is_free
 	)[ 0 ];
 
-	// It takes awhile to suggest a domain name. Set a default to siteSubDomain.blog.
-	const domainSuggestionName = domainSuggestion?.domain_name ?? siteSubDomain + '.blog';
+	// It takes awhile to suggest a domain name. Set a default to siteSubDomain.com.
+	const domainSuggestionName = domainSuggestion?.domain_name ?? siteSubDomain + '.com';
 	const domainSuggestionProductSlug = domainSuggestion?.product_slug;
 
 	const searchLink = addQueryArgs(
 		{
 			domainAndPlanPackage: true,
+			domain: true,
 		},
 		`/domains/add/${ siteSlug }`
 	);
@@ -73,7 +72,8 @@ export function RenderDomainUpsell() {
 
 	const purchaseLink = addQueryArgs(
 		{
-			get_domain: domainSuggestionName,
+			domain: true,
+			domainAndPlanPackage: true,
 		},
 		`/plans/yearly/${ siteSlug }`
 	);

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -74,7 +74,6 @@ export function RenderDomainUpsell() {
 	const purchaseLink = addQueryArgs(
 		{
 			get_domain: domainSuggestionName,
-			domainAndPlanPackage: true,
 		},
 		`/plans/yearly/${ siteSlug }`
 	);

--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -95,6 +95,6 @@ describe( 'index', () => {
 
 		const user = userEvent.setup();
 		await user.click( screen.getByRole( 'button', { name: 'Buy this domain' } ) );
-		expect( pageLink ).toBe( '/plans/yearly/example.wordpress.com?get_domain=example.blog' );
+		expect( pageLink ).toBe( '/plans/yearly/example.wordpress.com?get_domain=example.com' );
 	} );
 } );


### PR DESCRIPTION
Follow up of https://github.com/Automattic/wp-calypso/pull/73839

## Proposed Changes

While loading the suggested domains, we show the subdomain + `.com` instead of `.com`

## Testing Instructions

- Use a site with a free plan without custom domain names.
- On the homepage's Domain Upsell you should see a `.com` domain suggestion while loading the real suggestions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~