### PR TITLE
Launchpad: Add required Verify Email task

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,6 +1,7 @@
 import { Gridicon, CircularProgressBar } from '@automattic/components';
 import { useRef, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
 import Badge from 'calypso/components/badge';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
@@ -10,9 +11,14 @@ import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/int
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ResponseDomain } from 'calypso/lib/domains/types';
+import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import Checklist from './checklist';
-import { getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
+import {
+	getArrayOfFilteredTasks,
+	getEnhancedTasks,
+	updateTasksBasedOnEmailVerification,
+} from './task-helper';
 import { tasks } from './tasks';
 import { getLaunchpadTranslations } from './translations';
 import { Task } from './types';
@@ -58,12 +64,12 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 	const site = useSite();
 	const clipboardButtonEl = useRef< HTMLButtonElement >( null );
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
-
+	const isEmailVerified = useSelector( ( state ) => isCurrentUserEmailVerified( state ) );
 	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 
 	const { flowName, title, launchTitle, subtitle } = getLaunchpadTranslations( flow );
 	const arrayOfFilteredTasks: Task[] | null = getArrayOfFilteredTasks( tasks, flow );
-	const enhancedTasks =
+	let enhancedTasks =
 		site &&
 		getEnhancedTasks(
 			arrayOfFilteredTasks,
@@ -74,7 +80,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 			goToStep,
 			flow
 		);
-
+	enhancedTasks = updateTasksBasedOnEmailVerification( enhancedTasks, isEmailVerified );
 	const currentTask = getTasksProgress( enhancedTasks );
 	const launchTask = enhancedTasks?.find( ( task ) => task.isLaunchTask === true );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -351,6 +351,10 @@
 	pointer-events: none;
 }
 
+.launchpad__checklist-item[data-task="verify_email"] {
+	color: var(--color-text);
+}
+
 .launchpad__checklist-item-checkmark-container,
 .launchpad__checklist-item-warning-container {
 	margin-right: 8px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -324,6 +324,11 @@ export function getEnhancedTasks(
 						badgeText: isPaidPlan ? '' : translate( 'Upgrade plan' ),
 					};
 					break;
+				case 'verify_email':
+					taskData = {
+						title: translate( 'Verify Email (Check Your Inbox)' ),
+					};
+					break;
 			}
 			enhancedTaskList.push( { ...task, ...taskData } );
 		} );
@@ -356,5 +361,22 @@ export function getArrayOfFilteredTasks( tasks: Task[], flow: string | null ) {
 			} );
 			return accumulator;
 		}, [] as Task[] )
+	);
+}
+
+// If email is verified, filter out verify_email task
+// If email is not verified, disable all other tasks
+export function updateTasksBasedOnEmailVerification(
+	enhancedTasks: Task[] | null,
+	isEmailVerified: boolean
+) {
+	if ( ! enhancedTasks ) {
+		return enhancedTasks;
+	}
+	if ( isEmailVerified ) {
+		return enhancedTasks.filter( ( task ) => task.id !== 'verify_email' );
+	}
+	return enhancedTasks.map( ( task ) =>
+		task.id === 'verify_email' ? task : { ...task, disabled: true }
 	);
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -116,23 +116,37 @@ export const tasks: Task[] = [
 		disabled: false,
 		taskType: 'blog',
 	},
+	{
+		id: 'verify_email',
+		completed: false,
+		disabled: true,
+		taskType: 'blog',
+	},
 ];
 
 const linkInBioTaskList = [
 	'design_selected',
 	'setup_link_in_bio',
 	'plan_selected',
+	'verify_email',
 	'links_added',
 	'link_in_bio_launched',
 ];
 
 export const launchpadFlowTasks: LaunchpadFlowTaskList = {
-	newsletter: [ 'setup_newsletter', 'plan_selected', 'subscribers_added', 'first_post_published' ],
+	newsletter: [
+		'setup_newsletter',
+		'plan_selected',
+		'subscribers_added',
+		'verify_email',
+		'first_post_published',
+	],
 	[ LINK_IN_BIO_FLOW ]: linkInBioTaskList,
 	[ LINK_IN_BIO_TLD_FLOW ]: linkInBioTaskList,
 	free: [
 		'setup_free',
 		'design_selected',
+		'verify_email',
 		'domain_upsell',
 		'first_post_published',
 		'design_edited',
@@ -141,6 +155,7 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 	build: [
 		'setup_general',
 		'design_selected',
+		'verify_email',
 		'domain_upsell',
 		'first_post_published',
 		'design_edited',
@@ -149,10 +164,17 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 	write: [
 		'setup_write',
 		'design_selected',
+		'verify_email',
 		'domain_upsell',
 		'first_post_published',
 		'site_launched',
 	],
-	videopress: [ 'videopress_setup', 'plan_selected', 'videopress_upload', 'videopress_launched' ],
+	videopress: [
+		'videopress_setup',
+		'plan_selected',
+		'verify_email',
+		'videopress_upload',
+		'videopress_launched',
+	],
 	sensei: [ 'sensei_setup', 'plan_selected', 'sensei_publish_first_course' ],
 };


### PR DESCRIPTION
### Proposed Changes

Based on feedback and testing, this PR adds a Verify Email task to Launchpad. It works as follows. I think many of these points might still be worth discussing, so consider this PR a demo of how this functionality works based on existing decisions. We can test and decide if we're comfortable with it as is, or would like to make further changes.
  - The Verify Email task appears on ALL flows.
  - This task is required. If a user does not have a verified email, we disable other tasks until email is verified. 
  - Once email is verified, we no longer show the task.
  - Because verification is handled via the user's email, the task does not link anywhere. 
  
Because the email verification requires the user to leave our interface, there is a reasonable chance this change may reduce the Launchpad conversion rate (ie, the rate at which users launch their sites). That is also worth discussing. 

### Testing Instructions

**Testing Time: Medium**
**Review Time: Medium**

These testing instructions involve testing on Free Flow only. If we release, we will release to all flows and will need to test all flows. But given there may be discussion and changes, I would recommend testing one flow for now. 

1. You can test via Calypso localhost or via the Calypso Live link below.
2. Logout of WordPress.com or use a browser where you are not logged into WordPress.com.
3. Create a temporary email account at https://temp-mail.org
4. Create a new site at http://calypso.localhost:3000/setup/free/intro. If you are testing via live testing link go to [CALYPSOLIVELINK]/setup/free/intro. Use the email you created in step 3.
5. Continue through flow until Launchpad. Confirm the Verify Email (Check Your Inbox) task shows as active, but is not clickable and has no chevron/arrow. Confirm all other tasks are disabled. Overall, it should look like this: 
<img width="300" alt="verify-email" src="https://user-images.githubusercontent.com/21228350/221978553-e265ac12-b395-4b5e-8366-8297551fb08c.png">


6. Go to your temp email https://temp-mail.org, open the WordPress confirmation email, click the link to verify your email.
7. You should be automatically redirected to Launchpad. Confirm the Verify Email no longer shows. All other tasks should now show in their usual/normal state. Overall, it should look like this: 

<img width="300" alt="verify-email-2" src="https://user-images.githubusercontent.com/21228350/221978576-88d5a4c3-4591-4d91-a581-b63dd3a4b349.png">
