### PR TITLE
Stats: Simplify module headings on insights page

### DIFF
--- a/client/my-sites/stats/stats-reach/index.jsx
+++ b/client/my-sites/stats/stats-reach/index.jsx
@@ -93,10 +93,10 @@ export const StatsReach = ( props ) => {
 				<StatsListCard
 					moduleType="publicize"
 					data={ data }
-					title={ translate( 'Social subscribers' ) }
+					title={ translate( 'Number of Subscribers' ) }
 					emptyMessage={ translate( 'No subscribers recorded' ) }
-					mainItemLabel={ translate( 'Service' ) }
-					metricLabel={ translate( 'Total subscribers' ) }
+					mainItemLabel=""
+					metricLabel=""
 					splitHeader
 					useShortNumber
 					// Shares don't have a summary page yet.

--- a/client/my-sites/stats/stats-shares/index.jsx
+++ b/client/my-sites/stats/stats-shares/index.jsx
@@ -60,10 +60,10 @@ const StatShares = ( { siteId } ) => {
 				<StatsListCard
 					moduleType="shares"
 					data={ data }
-					title={ translate( 'Shares' ) }
+					title={ translate( 'Number of Shares' ) }
 					emptyMessage={ translate( 'No shares recorded' ) }
-					mainItemLabel={ translate( 'Service' ) }
-					metricLabel={ translate( 'Total shares' ) }
+					mainItemLabel=""
+					metricLabel=""
 					splitHeader
 					useShortNumber
 					// Shares don't have a summary page yet.


### PR DESCRIPTION
Fixes #73250.

## Proposed Changes

Before|After
-|-
<img width="1254" alt="image" src="https://user-images.githubusercontent.com/4044428/222003781-26e66a11-5a27-4e06-a760-1817600f6b0d.png">|<img width="1252" alt="image" src="https://user-images.githubusercontent.com/4044428/222004078-dd02c8b1-87c1-4504-ba25-54aa79297bed.png">

Renames and removes column headers for "Number of Shares" and "Number of Subscribers" modules.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a live branch for this PR.
* Navigate to the insights page and ensure it looks as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
