### PR TITLE
Happy Blocks: fix missing index in build

### DIFF
--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -18,7 +18,7 @@
 		"build:universal-footer": "calypso-build --env block='universal-footer'",
 		"build-translations-manifest": "yarn run build-calypso-strings && node bin/build-translations-manifest.js",
 		"clean": "rm -rf dist block-library/*/build || true",
-		"dev": "yarn run calypso-apps-builder --localPath /block-library --remotePath /home/wpcom/public_html/wp-content/a8c-plugins/happy-blocks"
+		"dev": "yarn run calypso-apps-builder --localPath / --remotePath /home/wpcom/public_html/wp-content/a8c-plugins/happy-blocks"
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "workspace:^",

--- a/apps/happy-blocks/webpack.config.js
+++ b/apps/happy-blocks/webpack.config.js
@@ -40,6 +40,13 @@ function getWebpackConfig( env = { block: '' }, argv ) {
 			new CopyPlugin( {
 				patterns: [
 					{
+						from: path.resolve( blockPath, 'index.php' ),
+						to: path.resolve( blockPath, 'build', '[name][ext]' ),
+						transform( content ) {
+							return content.toString().replace( '/build/rtl', '/rtl' ).replace( '/build', '/' );
+						},
+					},
+					{
 						from: path.resolve( blockPath, 'block.json' ),
 						to: path.resolve( blockPath, 'build', '[name][ext]' ),
 					},


### PR DESCRIPTION
## Proposed Changes

This adds the index.php to the build for each block AND removes the `/build` from the path. It allows the build package to work as well as the src files when in dev mode.

## Testing Instructions

Pull branch and run `cd apps/happy-blocks && yarn build`
Check the build directory includes index.php AND that the path for the register block is correct.