### PR TITLE
Blaze: Only query for page and posts in the Jetpack App

### DIFF
--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -10,6 +10,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import useCampaignsQuery from 'calypso/data/promote-post/use-promote-post-campaigns-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { usePromoteWidget, PromoteWidgetStatus } from 'calypso/lib/promote-post';
 import CampaignsList from 'calypso/my-sites/promote-post/components/campaigns-list';
 import PostsList from 'calypso/my-sites/promote-post/components/posts-list';
@@ -145,7 +146,9 @@ export default function PromotedPosts( { tab }: Props ) {
 		( a, b ) => b.ID - a.ID
 	);
 
-	const isLoading = isLoadingPage && isLoadingPost && isLoadingProducts;
+	const isLoading = isWpMobileApp()
+		? isLoadingPage && isLoadingPost
+		: isLoadingPage && isLoadingPost && isLoadingProducts;
 
 	return (
 		<Main wideLayout className="promote-post">
@@ -178,7 +181,9 @@ export default function PromotedPosts( { tab }: Props ) {
 
 			<QueryPosts siteId={ selectedSiteId } query={ queryPost } postId={ null } />
 			<QueryPosts siteId={ selectedSiteId } query={ queryPage } postId={ null } />
-			<QueryPosts siteId={ selectedSiteId } query={ queryProducts } postId={ null } />
+			{ ! isWpMobileApp() && (
+				<QueryPosts siteId={ selectedSiteId } query={ queryProducts } postId={ null } />
+			) }
 
 			{ selectedTab === 'posts' && <PostsList content={ content } isLoading={ isLoading } /> }
 		</Main>


### PR DESCRIPTION
## Proposed Changes

* This PR removes the product query from the blaze advertising view when the view is embedded in the Jetpack mobile app because products currently are not supported by the Jetpack app. This also makes the page load faster. 

## Testing Instructions

In order to test out this PR you will need a site with products. (Woo Store products)
One way you can do this is be creating a jurassic.ninja site (connecting jetpack) and then installing WooCommerce and adding a product to the store. 
After you have a site with a couple of products. You need to do the following. 

1. Visit the calypso live link.
2. Update the User agent to `Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 wp-android` to mimic the app.
3. Navigate to /advertising/example.com for a site that has products. Open up the network tab. Notice that there are no more products being requested. 
4. Revert to a standard user agent (refresh of a page is required) notice that the request for products still happens. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
