### PR TITLE
Odyssey: hide mini carousel

### DIFF
--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -30,7 +30,7 @@ const EVENT_NO_CONTENT_BANNER_VIEW = 'calypso_stats_no_content_banner_view';
 const EVENT_NO_CONTENT_BANNER_CLICK = 'calypso_stats_no_content_banner_click';
 const EVENT_NO_CONTENT_BANNER_DISMISS = 'calypso_stats_no_content_banner_dismiss';
 
-const MiniCarousel = ( { slug, isOdysseyStats, isSitePrivate } ) => {
+const MiniCarousel = ( { slug, isSitePrivate } ) => {
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 
 	const { data: hasNeverPublishedPost, isLoading: isHasNeverPublishedPostLoading } =
@@ -62,14 +62,11 @@ const MiniCarousel = ( { slug, isOdysseyStats, isSitePrivate } ) => {
 	// Blaze promo is disabled for Odyssey.
 	const showBlazePromo =
 		! useSelector( isBlockDismissed( EVENT_TRAFFIC_BLAZE_PROMO_DISMISS ) ) &&
-		! isOdysseyStats &&
 		shouldShowAdvertisingOption;
 
 	// Yoast promo is disabled for Odyssey & self-hosted & non-traffic pages.
 	const showYoastPromo =
-		! useSelector( isBlockDismissed( EVENT_YOAST_PROMO_DISMISS ) ) &&
-		! isOdysseyStats &&
-		! jetpackNonAtomic;
+		! useSelector( isBlockDismissed( EVENT_YOAST_PROMO_DISMISS ) ) && ! jetpackNonAtomic;
 
 	const viewEvents = useMemo( () => {
 		const events = [];

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -256,11 +256,7 @@ class StatsSite extends Component {
 						/>
 					</>
 
-					<MiniCarousel
-						isOdysseyStats={ isOdysseyStats }
-						slug={ slug }
-						isSitePrivate={ isSitePrivate }
-					/>
+					{ ! isOdysseyStats && <MiniCarousel slug={ slug } isSitePrivate={ isSitePrivate } /> }
 
 					<div className="stats__module-list stats__module-list--traffic is-events stats__module--unified">
 						<StatsModule


### PR DESCRIPTION
## Proposed Changes

<img width="788" alt="image" src="https://user-images.githubusercontent.com/1425433/222033001-5abe6ede-1692-4612-bb87-4351c30bad9d.png">

The items in mini carousel are either not relevant or broken. For example the link of `Write a post` is broken. The PR proposes to hide it all for Odyssey.

## Testing Instructions
* Spin a JN site with Jetpack
* Point widgets.wp.com to your sandbox in your hosts file
- Wait for the Odyssey Stats build to succeed in the PR
- SSH to your sandbox and run the following command, which will pull the build and extract it into the Odyssey Stats folder: `bin/install-plugin.sh odyssey-stats update/hide-mini-carousel`
* Ensure `Write a post` doesn't pop up on the Traffic page

![image](https://user-images.githubusercontent.com/1425433/222033646-55684441-8b07-486f-9baf-e9a08800be1c.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?