### PR TITLE
GitHub Integration: Refactor card heading into shared component

### DIFF
--- a/client/my-sites/hosting/github/deployment-card/index.tsx
+++ b/client/my-sites/hosting/github/deployment-card/index.tsx
@@ -2,11 +2,10 @@ import { Button, Card, Spinner } from '@automattic/components';
 import { sprintf } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
-import CardHeading from 'calypso/components/card-heading';
-import SocialLogo from 'calypso/components/social-logo';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { GitHubCardHeading } from '../github-card-heading';
 import { EmptyDeployments } from './empty-deployments';
 import { LastDeploymentInformation } from './last-deployment-information';
 import { useDeploymentStatusQuery } from './use-deployment-status-query';
@@ -63,10 +62,7 @@ export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardPr
 
 	return (
 		<Card>
-			<SocialLogo className="material-icon" icon="github" size={ 32 } />
-			<CardHeading className="deployment-card__heading">
-				{ translate( 'Deploy from GitHub' ) }
-			</CardHeading>
+			<GitHubCardHeading />
 			<div>
 				<p>
 					{ translate( 'Listening for pushes from {{a}}%(repo)s{{/a}}.', {

--- a/client/my-sites/hosting/github/github-authorize-card/index.tsx
+++ b/client/my-sites/hosting/github/github-authorize-card/index.tsx
@@ -3,15 +3,14 @@ import requestExternalAccess from '@automattic/request-external-access';
 import { translate } from 'i18n-calypso';
 import { useMutation, useQueryClient } from 'react-query';
 import { useSelector, useDispatch } from 'react-redux';
-import CardHeading from 'calypso/components/card-heading';
-import SocialLogo from 'calypso/components/social-logo';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
 import { getKeyringServiceByName } from 'calypso/state/sharing/services/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import '../style.scss';
 import { GITHUB_INTEGRATION_QUERY_KEY } from '../constants';
+import { GitHubCardHeading } from '../github-card-heading';
 import { GithubConnectionData, GITHUB_CONNECTION_QUERY_KEY } from '../use-github-connection-query';
+import '../style.scss';
 
 type Service = {
 	connect_URL: string;
@@ -47,8 +46,7 @@ export const GithubAuthorizeCard = () => {
 
 	return (
 		<Card className="github-hosting-card">
-			<SocialLogo className="material-icon" icon="github" size={ 32 } />
-			<CardHeading>{ translate( 'Deploy from GitHub' ) }</CardHeading>
+			<GitHubCardHeading />
 			<p>
 				{ translate(
 					'Connect this site to a GitHub repository and automatically deploy branches on push.'

--- a/client/my-sites/hosting/github/github-card-heading/index.tsx
+++ b/client/my-sites/hosting/github/github-card-heading/index.tsx
@@ -6,7 +6,8 @@ export function GitHubCardHeading() {
 	return (
 		<>
 			<SocialLogo className="material-icon" icon="github" size={ 32 } />
-			<CardHeading>{ translate( 'Deploy from GitHub' ) }</CardHeading>
+			{ /* Element ID allows direct linking from the /sites page */ }
+			<CardHeading id="connect-github">{ translate( 'Deploy from GitHub' ) }</CardHeading>
 		</>
 	);
 }

--- a/client/my-sites/hosting/github/github-card-heading/index.tsx
+++ b/client/my-sites/hosting/github/github-card-heading/index.tsx
@@ -1,0 +1,12 @@
+import { translate } from 'i18n-calypso';
+import CardHeading from 'calypso/components/card-heading';
+import SocialLogo from 'calypso/components/social-logo';
+
+export function GitHubCardHeading() {
+	return (
+		<>
+			<SocialLogo className="material-icon" icon="github" size={ 32 } />
+			<CardHeading>{ translate( 'Deploy from GitHub' ) }</CardHeading>
+		</>
+	);
+}

--- a/client/my-sites/hosting/github/github-connect-card/index.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/index.tsx
@@ -4,16 +4,15 @@ import { sprintf, __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { ComponentProps, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import CardHeading from 'calypso/components/card-heading';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import Image from 'calypso/components/image';
-import SocialLogo from 'calypso/components/social-logo';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { DisconnectGitHubButton } from '../disconnect-github-button';
+import { GitHubCardHeading } from '../github-card-heading';
 import { SearchBranches } from './search-branches';
 import { SearchRepos } from './search-repos';
 import { useGithubConnectMutation } from './use-github-connect-mutation';
@@ -75,8 +74,7 @@ export const GithubConnectCard = ( { connection }: GithubConnectCardProps ) => {
 
 	return (
 		<Card className="connect-branch-card">
-			<SocialLogo className="material-icon" icon="github" size={ 32 } />
-			<CardHeading>{ __( 'Deploy from GitHub' ) }</CardHeading>
+			<GitHubCardHeading />
 			<div>
 				<p>
 					{ __( 'Changes pushed to the selected branch will be automatically deployed. ' ) }

--- a/client/my-sites/hosting/github/github-placeholder-card/index.tsx
+++ b/client/my-sites/hosting/github/github-placeholder-card/index.tsx
@@ -1,15 +1,12 @@
 import { Card, Spinner } from '@automattic/components';
-import { translate } from 'i18n-calypso';
-import CardHeading from 'calypso/components/card-heading';
-import SocialLogo from 'calypso/components/social-logo';
+import { GitHubCardHeading } from '../github-card-heading';
 
 import '../style.scss';
 
 export const GitHubPlaceholderCard = () => {
 	return (
 		<Card className="github-hosting-card">
-			<SocialLogo className="material-icon" icon="github" size={ 32 } />
-			<CardHeading>{ translate( 'Deploy from GitHub' ) }</CardHeading>
+			<GitHubCardHeading />
 			<Spinner />
 		</Card>
 	);

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -292,7 +292,7 @@ function useSubmenuItems( {
 				},
 				{
 					condition: isAtomic,
-					label: __( 'Github connection' ),
+					label: __( 'GitHub connection' ),
 					href: `/hosting-config/${ siteSlug }#connect-github`,
 					eventName: 'calypso_sites_dashboard_site_action_submenu_connect_github_click',
 				},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Refactor GitHub card heading into separate component
* Fix typo in the GitHub link on `/sites` page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm no changes to the UI in `/hosting-config`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
