### PR TITLE
GitHub Integration: Add beta badge to GitHub feature in hosting config

### DIFF
--- a/client/my-sites/hosting/github/github-card-heading/index.tsx
+++ b/client/my-sites/hosting/github/github-card-heading/index.tsx
@@ -1,13 +1,20 @@
 import { translate } from 'i18n-calypso';
+import Badge from 'calypso/components/badge';
 import CardHeading from 'calypso/components/card-heading';
 import SocialLogo from 'calypso/components/social-logo';
+import './style.scss';
 
 export function GitHubCardHeading() {
 	return (
 		<>
 			<SocialLogo className="material-icon" icon="github" size={ 32 } />
 			{ /* Element ID allows direct linking from the /sites page */ }
-			<CardHeading id="connect-github">{ translate( 'Deploy from GitHub' ) }</CardHeading>
+			<CardHeading id="connect-github">
+				{ translate( 'Deploy from GitHub' ) }
+				<Badge className="github-hosting-heading-badge" type="info-purple">
+					Beta
+				</Badge>
+			</CardHeading>
 		</>
 	);
 }

--- a/client/my-sites/hosting/github/github-card-heading/style.scss
+++ b/client/my-sites/hosting/github/github-card-heading/style.scss
@@ -1,0 +1,5 @@
+.github-hosting-heading-badge {
+	position: relative;
+	bottom: 3px;
+	margin-left: 8px;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add beta badge to the GitHub integration card on `/hosting-config`

![CleanShot 2023-03-01 at 17 16 12@2x](https://user-images.githubusercontent.com/1500769/222043568-577cdcce-1d7a-4c86-85bc-6f97ead7f6c3.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Test:
* RTL
* Different Calypso themes
* Screen sizes
* Long headings two see how wrapping works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
