### PR TITLE
GitHub Deploy: show a message when no branches are returned; auto refresh on refocus

### DIFF
--- a/client/my-sites/hosting/github/github-connect-card/search-branches.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/search-branches.tsx
@@ -22,20 +22,31 @@ export const SearchBranches = ( {
 }: SearchBranchesProps ) => {
 	const { __ } = useI18n();
 
-	const { data: branches, isLoading: isLoading } = useGithubBranchesQuery(
-		siteId,
-		repoName,
-		connectionId,
-		{
-			onSuccess( branches ) {
-				if ( branches.length < 30 ) {
-					onSelect( branches[ 0 ] );
-				}
-			},
-		}
-	);
+	const { data: branches, isFetching } = useGithubBranchesQuery( siteId, repoName, connectionId, {
+		onSuccess( branches ) {
+			if ( branches.length < 30 ) {
+				onSelect( branches[ 0 ] );
+			}
+		},
+	} );
 
-	if ( branches && branches.length < 30 ) {
+	if ( ! repoName || isFetching ) {
+		return (
+			<div style={ { position: 'relative' } }>
+				<FormTextInput
+					id="branch"
+					disabled={ ! repoName || isFetching }
+					className="connect-branch__repository-field"
+					placeholder={ branches ? __( 'Type a branch' ) : __( 'Choose a branch' ) }
+					onChange={ ( e: ChangeEvent< HTMLInputElement > ) => onSelect( e.target.value ) }
+					value={ selectedBranch }
+				/>
+				{ isFetching && <Spinner className="connect-branch__loading" /> }
+			</div>
+		);
+	}
+
+	if ( branches && branches.length > 0 && branches.length < 30 ) {
 		return (
 			<FormSelect
 				id="branch"
@@ -54,16 +65,12 @@ export const SearchBranches = ( {
 	}
 
 	return (
-		<div style={ { position: 'relative' } }>
-			<FormTextInput
-				id="branch"
-				disabled={ ! repoName || isLoading }
-				className="connect-branch__repository-field"
-				placeholder={ branches ? __( 'Type a branch' ) : __( 'Choose a branch' ) }
-				onChange={ ( e: ChangeEvent< HTMLInputElement > ) => onSelect( e.target.value ) }
-				value={ selectedBranch }
-			/>
-			{ isLoading && <Spinner className="connect-branch__loading" /> }
-		</div>
+		<FormTextInput
+			id="branch"
+			disabled
+			className="connect-branch__repository-field"
+			placeholder={ __( 'No branches found' ) }
+			value=""
+		/>
 	);
 };

--- a/client/my-sites/hosting/github/github-connect-card/search-branches.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/search-branches.tsx
@@ -28,7 +28,11 @@ export const SearchBranches = ( {
 
 	const { data: branches, isFetching } = useGithubBranchesQuery( siteId, repoName, connectionId, {
 		onSuccess( branches ) {
-			if ( branches.length < SEARCH_BRANCHES_LIMIT ) {
+			if (
+				branches.length > 0 &&
+				branches.length < SEARCH_BRANCHES_LIMIT &&
+				( ! selectedBranch || ! branches.includes( selectedBranch ) )
+			) {
 				onSelect( branches[ 0 ] );
 			}
 		},

--- a/client/my-sites/hosting/github/github-connect-card/search-branches.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/search-branches.tsx
@@ -13,6 +13,10 @@ interface SearchBranchesProps {
 	selectedBranch?: string;
 }
 
+// If there are too many branches we're forcing the user to type its name because GH API
+// has no search functionality for branches.
+const SEARCH_BRANCHES_LIMIT = 30;
+
 export const SearchBranches = ( {
 	siteId,
 	connectionId,
@@ -24,7 +28,7 @@ export const SearchBranches = ( {
 
 	const { data: branches, isFetching } = useGithubBranchesQuery( siteId, repoName, connectionId, {
 		onSuccess( branches ) {
-			if ( branches.length < 30 ) {
+			if ( branches.length < SEARCH_BRANCHES_LIMIT ) {
 				onSelect( branches[ 0 ] );
 			}
 		},
@@ -46,7 +50,7 @@ export const SearchBranches = ( {
 		);
 	}
 
-	if ( branches && branches.length > 0 && branches.length < 30 ) {
+	if ( branches && branches.length > 0 && branches.length < SEARCH_BRANCHES_LIMIT ) {
 		return (
 			<FormSelect
 				id="branch"

--- a/client/my-sites/hosting/github/github-connect-card/search-branches.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/search-branches.tsx
@@ -38,23 +38,37 @@ export const SearchBranches = ( {
 		},
 	} );
 
-	if ( ! repoName || isFetching ) {
+	if ( ! repoName || ! branches ) {
 		return (
 			<div style={ { position: 'relative' } }>
 				<FormTextInput
 					id="branch"
-					disabled={ ! repoName || isFetching }
+					disabled
 					className="connect-branch__repository-field"
-					placeholder={ branches ? __( 'Type a branch' ) : __( 'Choose a branch' ) }
-					onChange={ ( e: ChangeEvent< HTMLInputElement > ) => onSelect( e.target.value ) }
-					value={ selectedBranch }
+					placeholder={ __( 'Choose a branch' ) }
+					value=""
 				/>
 				{ isFetching && <Spinner className="connect-branch__loading" /> }
 			</div>
 		);
 	}
 
-	if ( branches && branches.length > 0 && branches.length < SEARCH_BRANCHES_LIMIT ) {
+	if ( branches.length === 0 ) {
+		return (
+			<div style={ { position: 'relative' } }>
+				<FormTextInput
+					id="branch"
+					disabled
+					className="connect-branch__repository-field"
+					placeholder={ __( 'No branches found' ) }
+					value=""
+				/>
+				{ isFetching && <Spinner className="connect-branch__loading" /> }
+			</div>
+		);
+	}
+
+	if ( branches.length < SEARCH_BRANCHES_LIMIT ) {
 		return (
 			<FormSelect
 				id="branch"
@@ -73,12 +87,16 @@ export const SearchBranches = ( {
 	}
 
 	return (
-		<FormTextInput
-			id="branch"
-			disabled
-			className="connect-branch__repository-field"
-			placeholder={ __( 'No branches found' ) }
-			value=""
-		/>
+		<div style={ { position: 'relative' } }>
+			<FormTextInput
+				id="branch"
+				disabled={ isFetching }
+				className="connect-branch__repository-field"
+				placeholder={ __( 'Type a branch' ) }
+				onChange={ ( e: ChangeEvent< HTMLInputElement > ) => onSelect( e.target.value ) }
+				value={ selectedBranch }
+			/>
+			{ isFetching && <Spinner className="connect-branch__loading" /> }
+		</div>
 	);
 };

--- a/client/my-sites/hosting/github/github-connect-card/use-github-branches-query.ts
+++ b/client/my-sites/hosting/github/github-connect-card/use-github-branches-query.ts
@@ -32,7 +32,6 @@ export const useGithubBranchesQuery = (
 			meta: {
 				persist: false,
 			},
-			refetchOnWindowFocus: false,
 			...options,
 			cacheTime: CACHE_TIME,
 		}


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Now shows a message "No branches found" if there are no branches for repo. 
* If you refocus the window, the branches are auto-refreshed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new repo at GH and confirm the message "No branches found" is shown
* Add a branch and return to the window and confirm the new branch is shown



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
