### PR TITLE
Jetpack Pro Dashboard: implement backup storage expanded content on large & small screens

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -25,7 +25,6 @@ const BackupStorageContent = ( { siteId, siteUrl }: { siteId: number; siteUrl: s
 		{
 			after: startDate?.toISOString() ?? undefined,
 			before: endDate?.toISOString() ?? undefined,
-			sortOrder: 'desc',
 		},
 		{
 			select: ( data: any[] ) => data.filter( ( a ) => isSuccessfulRealtimeBackup( a ) ),

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -35,7 +35,6 @@ const BackupStorageContent = ( { siteId, siteUrl }: { siteId: number; siteUrl: s
 	const realtimeBackup = data?.[ 0 ] ?? null;
 
 	const lastBackupDate = useDateWithOffset( realtimeBackup?.activityTs );
-
 	const getDisplayDate = useGetDisplayDate();
 	const displayDate = getDisplayDate( lastBackupDate, false );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -13,6 +13,8 @@ interface Props {
 	site: Site;
 }
 
+const BACKUP_ERROR_STATUSES = [ 'rewind_backup_error', 'backup_only_error' ];
+
 const BackupStorageContent = ( { siteId, siteUrl }: { siteId: number; siteUrl: string } ) => {
 	const translate = useTranslate();
 
@@ -27,24 +29,25 @@ const BackupStorageContent = ( { siteId, siteUrl }: { siteId: number; siteUrl: s
 			before: endDate?.toISOString() ?? undefined,
 		},
 		{
-			select: ( data: any[] ) => data.filter( ( a ) => isSuccessfulRealtimeBackup( a ) ),
+			select: ( backups: any[] ) =>
+				backups.filter( ( backup ) => isSuccessfulRealtimeBackup( backup ) ),
 		}
 	);
 
-	const realtimeBackup = data?.[ 0 ] ?? null;
+	const backup = data?.[ 0 ] ?? null;
 
-	const lastBackupDate = useDateWithOffset( realtimeBackup?.activityTs );
+	const lastBackupDate = useDateWithOffset( backup?.activityTs );
 	const getDisplayDate = useGetDisplayDate();
 	const displayDate = getDisplayDate( lastBackupDate, false );
 
+	// Show plugin name only if it is a activity from a plugin
 	const pluginName =
-		realtimeBackup?.activityName.startsWith( 'plugin__' ) &&
-		realtimeBackup.activityDescription[ 0 ]?.children[ 0 ];
+		backup?.activityName.startsWith( 'plugin__' ) && backup.activityDescription[ 0 ]?.children[ 0 ];
 
 	const backupTitle =
-		realtimeBackup?.activityDescription[ 0 ]?.children[ 0 ]?.text ?? realtimeBackup?.activityTitle;
+		backup?.activityDescription[ 0 ]?.children[ 0 ]?.text ?? backup?.activityTitle;
 
-	const showLoader = isLoading || ! realtimeBackup;
+	const showLoader = isLoading || ! backup;
 
 	return (
 		<div className="site-expanded-content__card-content-container">
@@ -81,9 +84,7 @@ const BackupStorageContent = ( { siteId, siteUrl }: { siteId: number; siteUrl: s
 export default function BackupStorage( { site }: Props ) {
 	const translate = useTranslate();
 
-	const hasBackupError = [ 'rewind_backup_error', 'backup_only_error' ].includes(
-		site.latest_backup_status
-	);
+	const hasBackupError = BACKUP_ERROR_STATUSES.includes( site.latest_backup_status );
 
 	const components = {
 		strong: <strong></strong>,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -50,7 +50,17 @@ export default function BackupStorage( { site }: Props ) {
 				<div className="site-expanded-content__card-content">
 					<div className="site-expanded-content__card-content-column">
 						<div className="site-expanded-content__card-content-count">{ displayDate }</div>
-						<div className="site-expanded-content__card-content-count-title">2 posts, 1 page</div>
+						<div className="site-expanded-content__card-content-count-title">
+							{ translate( '%(totalPosts)d post', '%(totalPosts)d posts', {
+								args: { totalPosts: data.backupInfo.backedUpItems.posts },
+								count: data.backupInfo.backedUpItems.posts,
+							} ) }
+							,&nbsp;
+							{ translate( '%(totalPages)d page', '%(totalPages)d pages', {
+								args: { totalPages: data.backupInfo.backedUpItems.pages },
+								count: data.backupInfo.backedUpItems.pages,
+							} ) }
+						</div>
 					</div>
 				</div>
 				<div className="site-expanded-content__card-footer">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -6,8 +6,9 @@ import useRewindableActivityLogQuery from 'calypso/data/activity-log/use-rewinda
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { isSuccessfulRealtimeBackup } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
+import { getExtractedBackupTitle } from '../utils';
 import ExpandedCard from './expanded-card';
-import type { Site } from '../types';
+import type { Site, Backup } from '../types';
 
 interface Props {
 	site: Site;
@@ -29,7 +30,7 @@ const BackupStorageContent = ( { siteId, siteUrl }: { siteId: number; siteUrl: s
 			before: endDate?.toISOString() ?? undefined,
 		},
 		{
-			select: ( backups: any[] ) =>
+			select: ( backups: Backup[] ) =>
 				backups.filter( ( backup ) => isSuccessfulRealtimeBackup( backup ) ),
 		}
 	);
@@ -43,9 +44,6 @@ const BackupStorageContent = ( { siteId, siteUrl }: { siteId: number; siteUrl: s
 	// Show plugin name only if it is a activity from a plugin
 	const pluginName =
 		backup?.activityName.startsWith( 'plugin__' ) && backup.activityDescription[ 0 ]?.children[ 0 ];
-
-	const backupTitle =
-		backup?.activityDescription[ 0 ]?.children[ 0 ]?.text ?? backup?.activityTitle;
 
 	const showLoader = isLoading || ! backup;
 
@@ -61,7 +59,7 @@ const BackupStorageContent = ( { siteId, siteUrl }: { siteId: number; siteUrl: s
 							<TextPlaceholder />
 						) : (
 							<>
-								{ backupTitle }
+								{ getExtractedBackupTitle( backup ) }
 								{ pluginName ? ` - ${ pluginName }` : '' }
 							</>
 						) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -1,6 +1,10 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
+import { useRealtimeBackupStatus } from 'calypso/my-sites/backup/status/hooks';
 import ExpandedCard from './expanded-card';
 import type { Site } from '../types';
 
@@ -8,36 +12,84 @@ interface Props {
 	site: Site;
 }
 
+const BackupStorageContent = ( { siteId, siteUrl }: { siteId: number; siteUrl: string } ) => {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+	const selectedDate = useDateWithOffset( moment() );
+
+	const { lastSuccessfulBackupOnDate, lastBackupAttemptOnDate, isLoading } =
+		useRealtimeBackupStatus( siteId, selectedDate );
+
+	const realtimeBackup = lastSuccessfulBackupOnDate || lastBackupAttemptOnDate;
+
+	const lastBackupDate = useDateWithOffset( realtimeBackup?.activityTs );
+
+	const getDisplayDate = useGetDisplayDate();
+	const displayDate = getDisplayDate( lastBackupDate, false );
+
+	const pluginName = [ 'plugin__activated', 'plugin__installed' ].includes(
+		realtimeBackup?.activityName
+	)
+		? realtimeBackup?.activityDescription[ 0 ]?.children[ 0 ]
+		: null;
+
+	const backupTitle =
+		realtimeBackup?.activityDescription[ 0 ]?.children[ 0 ]?.text ?? realtimeBackup?.activityTitle;
+
+	const showLoader = isLoading || ! realtimeBackup;
+
+	return (
+		<div className="site-expanded-content__card-content-container">
+			<div className="site-expanded-content__card-content">
+				<div className="site-expanded-content__card-content-column">
+					<div className="site-expanded-content__card-content-count">
+						{ showLoader ? <TextPlaceholder /> : displayDate }
+					</div>
+					<div className="site-expanded-content__card-content-count-title">
+						{ showLoader ? (
+							<TextPlaceholder />
+						) : (
+							<>
+								{ backupTitle
+									? `${ backupTitle } ${ pluginName ? ` - ${ pluginName }` : '' }`
+									: '' }
+							</>
+						) }
+					</div>
+				</div>
+			</div>
+			<div className="site-expanded-content__card-footer">
+				<Button
+					href={ `/activity-log/${ siteUrl }` }
+					className="site-expanded-content__card-button"
+					compact
+				>
+					{ translate( 'Activity log' ) }
+				</Button>
+			</div>
+		</div>
+	);
+};
+
 export default function BackupStorage( { site }: Props ) {
 	const translate = useTranslate();
 
-	const data = {
-		hasBackup: site.has_backup,
-		hasBackupError: [ 'rewind_backup_error', 'backup_only_error' ].includes(
-			site.latest_backup_status
-		),
-		backupInfo: {
-			backupDate: '2023-03-03T11:09:44.777+00:00',
-			backedUpItems: {
-				posts: 2,
-				pages: 1,
-			},
-		},
-	};
+	const hasBackupError = [ 'rewind_backup_error', 'backup_only_error' ].includes(
+		site.latest_backup_status
+	);
 
 	const components = {
 		strong: <strong></strong>,
 	};
 
-	const getDisplayDate = useGetDisplayDate();
-	const displayDate = getDisplayDate( data.backupInfo.backupDate, false );
+	const isBackupEnabled = hasBackupError ? false : site.has_backup;
 
 	return (
 		<ExpandedCard
 			header={ translate( 'Latest backup' ) }
-			isEnabled={ data.hasBackupError ? false : data.hasBackup }
+			isEnabled={ isBackupEnabled }
 			emptyContent={
-				data.hasBackupError
+				hasBackupError
 					? translate( 'Fix {{strong}}Backup{{/strong}} connection to see your backup storage', {
 							components,
 					  } )
@@ -46,33 +98,7 @@ export default function BackupStorage( { site }: Props ) {
 					  } )
 			}
 		>
-			<div className="site-expanded-content__card-content-container">
-				<div className="site-expanded-content__card-content">
-					<div className="site-expanded-content__card-content-column">
-						<div className="site-expanded-content__card-content-count">{ displayDate }</div>
-						<div className="site-expanded-content__card-content-count-title">
-							{ translate( '%(totalPosts)d post', '%(totalPosts)d posts', {
-								args: { totalPosts: data.backupInfo.backedUpItems.posts },
-								count: data.backupInfo.backedUpItems.posts,
-							} ) }
-							,&nbsp;
-							{ translate( '%(totalPages)d page', '%(totalPages)d pages', {
-								args: { totalPages: data.backupInfo.backedUpItems.pages },
-								count: data.backupInfo.backedUpItems.pages,
-							} ) }
-						</div>
-					</div>
-				</div>
-				<div className="site-expanded-content__card-footer">
-					<Button
-						href={ `/activity-log/${ site.url }` }
-						className="site-expanded-content__card-button"
-						compact
-					>
-						{ translate( 'Activity log' ) }
-					</Button>
-				</div>
-			</div>
+			{ isBackupEnabled && <BackupStorageContent siteId={ site.blog_id } siteUrl={ site.url } /> }
 		</ExpandedCard>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -1,0 +1,73 @@
+import { Button } from '@automattic/components';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { getMemoryHumanReadable } from '../utils';
+import ExpandedCard from './expanded-card';
+import type { Site } from '../types';
+
+interface Props {
+	site: Site;
+}
+
+export default function BackupStorage( { site }: Props ) {
+	const translate = useTranslate();
+
+	const data = {
+		backupUsed: 9600000000,
+		backupAvailable: 26000,
+		backupStorageAlmostFull: false,
+		hasBackup: site.has_backup,
+		hasBackupError: [ 'rewind_backup_error', 'backup_only_error' ].includes(
+			site.latest_backup_status
+		),
+	};
+
+	const components = {
+		strong: <strong></strong>,
+	};
+
+	return (
+		<ExpandedCard
+			header={ translate( 'Backup Storage' ) }
+			isEnabled={ data.hasBackupError ? false : data.hasBackup }
+			emptyContent={
+				data.hasBackupError
+					? translate( 'Fix {{strong}}Backup{{/strong}} connection to see your backup storage', {
+							components,
+					  } )
+					: translate( 'Add {{strong}}Backup{{/strong}} to see your backup storage', {
+							components,
+					  } )
+			}
+		>
+			<div className="site-expanded-content__card-content-container">
+				<div className="site-expanded-content__card-content">
+					<div className="site-expanded-content__card-content-column">
+						<div className="site-expanded-content__card-content-count">
+							<span className="site-expanded-content__card-content-count-used">
+								{ getMemoryHumanReadable( data.backupUsed ) }
+							</span>
+							<span
+								className={ classNames( data.backupStorageAlmostFull ? 'is-full' : 'is-free' ) }
+							>
+								{ translate( '%(backupAvailable)s Available', {
+									args: {
+										backupAvailable: getMemoryHumanReadable( data.backupAvailable ),
+									},
+								} ) }
+							</span>
+						</div>
+						<div className="site-expanded-content__card-content-count-title">
+							{ translate( 'Used storage' ) }
+						</div>
+					</div>
+				</div>
+				<div className="site-expanded-content__card-footer">
+					<Button className="site-expanded-content__card-button" compact>
+						{ translate( 'Activity log' ) }
+					</Button>
+				</div>
+			</div>
+		</ExpandedCard>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@automattic/components';
-import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { getMemoryHumanReadable } from '../utils';
+import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
 import ExpandedCard from './expanded-card';
 import type { Site } from '../types';
 
@@ -13,29 +12,36 @@ export default function BackupStorage( { site }: Props ) {
 	const translate = useTranslate();
 
 	const data = {
-		backupUsed: 9600000000,
-		backupAvailable: 26000,
-		backupStorageAlmostFull: false,
 		hasBackup: site.has_backup,
 		hasBackupError: [ 'rewind_backup_error', 'backup_only_error' ].includes(
 			site.latest_backup_status
 		),
+		backupInfo: {
+			backupDate: '2023-03-03T11:09:44.777+00:00',
+			backedUpItems: {
+				posts: 2,
+				pages: 1,
+			},
+		},
 	};
 
 	const components = {
 		strong: <strong></strong>,
 	};
 
+	const getDisplayDate = useGetDisplayDate();
+	const displayDate = getDisplayDate( data.backupInfo.backupDate, false );
+
 	return (
 		<ExpandedCard
-			header={ translate( 'Backup Storage' ) }
+			header={ translate( 'Latest backup' ) }
 			isEnabled={ data.hasBackupError ? false : data.hasBackup }
 			emptyContent={
 				data.hasBackupError
 					? translate( 'Fix {{strong}}Backup{{/strong}} connection to see your backup storage', {
 							components,
 					  } )
-					: translate( 'Add {{strong}}Backup{{/strong}} to see your backup storage', {
+					: translate( 'Add {{strong}}Backup{{/strong}} to see your backup', {
 							components,
 					  } )
 			}
@@ -43,27 +49,16 @@ export default function BackupStorage( { site }: Props ) {
 			<div className="site-expanded-content__card-content-container">
 				<div className="site-expanded-content__card-content">
 					<div className="site-expanded-content__card-content-column">
-						<div className="site-expanded-content__card-content-count">
-							<span className="site-expanded-content__card-content-count-used">
-								{ getMemoryHumanReadable( data.backupUsed ) }
-							</span>
-							<span
-								className={ classNames( data.backupStorageAlmostFull ? 'is-full' : 'is-free' ) }
-							>
-								{ translate( '%(backupAvailable)s Available', {
-									args: {
-										backupAvailable: getMemoryHumanReadable( data.backupAvailable ),
-									},
-								} ) }
-							</span>
-						</div>
-						<div className="site-expanded-content__card-content-count-title">
-							{ translate( 'Used storage' ) }
-						</div>
+						<div className="site-expanded-content__card-content-count">{ displayDate }</div>
+						<div className="site-expanded-content__card-content-count-title">2 posts, 1 page</div>
 					</div>
 				</div>
 				<div className="site-expanded-content__card-footer">
-					<Button className="site-expanded-content__card-button" compact>
+					<Button
+						href={ `/activity-log/${ site.url }` }
+						className="site-expanded-content__card-button"
+						compact
+					>
 						{ translate( 'Activity log' ) }
 					</Button>
 				</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -53,10 +53,10 @@ const BackupStorageContent = ( { siteId, siteUrl }: { siteId: number; siteUrl: s
 		<div className="site-expanded-content__card-content-container">
 			<div className="site-expanded-content__card-content">
 				<div className="site-expanded-content__card-content-column">
-					<div className="site-expanded-content__card-content-count">
+					<div className="site-expanded-content__card-content-score">
 						{ showLoader ? <TextPlaceholder /> : displayDate }
 					</div>
-					<div className="site-expanded-content__card-content-count-title">
+					<div className="site-expanded-content__card-content-score-title">
 						{ showLoader ? (
 							<TextPlaceholder />
 						) : (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import BackupStorage from './backup-storage';
 import BoostSitePerformance from './boost-site-performance';
 import InsightsStats from './insights-stats';
 import type { Site } from '../types';
@@ -11,7 +12,7 @@ interface Props {
 	isSmallScreen?: boolean;
 }
 
-const defaultColumns = [ 'stats', 'boost' ];
+const defaultColumns = [ 'stats', 'boost', 'backup' ];
 
 export default function SiteExpandedContent( {
 	site,
@@ -31,6 +32,7 @@ export default function SiteExpandedContent( {
 			{ columns.includes( 'boost' ) && (
 				<BoostSitePerformance boostData={ boostData } hasBoost={ site.has_boost } />
 			) }
+			{ columns.includes( 'backup' ) && stats && <BackupStorage site={ site } /> }
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -102,7 +102,7 @@ $color-yellow: var(--studio-yellow-50);
 	@include svg-color($color-red, $color-red, $color-red);
 }
 
-.site-expanded-content__card-content-count-title {
+.site-expanded-content__card-content-score-title {
 	font-size: 0.75rem;
 	color: var(--studio-gray-40);
 	overflow: hidden;
@@ -120,7 +120,7 @@ $color-yellow: var(--studio-yellow-50);
 	.expanded-card {
 		width: 100%;
 		margin: 0;
-		min-height: auto;
+		min-height: 180px;
 	}
 
 	.site-expanded-content__card-content-column {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -165,18 +165,6 @@ $color-yellow: var(--studio-yellow-50);
 			margin-inline-start: 8px;
 		}
 	}
-
-	.site-expanded-content__card-footer {
-		padding: 16px 0 0;
-
-		.site-expanded-content__card-button {
-			white-space: nowrap;
-		}
-	}
-
-	.expanded-card__empty-content {
-		padding: 0 0 16px;
-	}
 }
 
 .boost-score-good {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -176,7 +176,6 @@ $color-yellow: var(--studio-yellow-50);
 
 	.expanded-card__empty-content {
 		padding: 0 0 16px;
-		justify-content: flex-start;
 	}
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -89,24 +89,22 @@ $color-yellow: var(--studio-yellow-50);
 	}
 }
 
-.is-up,
-.is-free {
+.is-up {
 	@include svg-color($color-green, $color-green, $color-green);
 }
 
-.is-down,
-.is-full {
+.is-down {
 	@include svg-color($color-red, $color-red, $color-red);
 }
 
-.site-expanded-content__card-content-score-title {
+.site-expanded-content__card-content-count-title {
 	font-size: 0.75rem;
 	color: var(--studio-gray-40);
 }
 
-button.site-expanded-content__card-button {
+.site-expanded-content__card-button {
 	color: var(--studio-black) !important;
-	border-color: var(--studio-black);
+	width: fit-content;
 }
 
 .is-small-screen {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -89,11 +89,13 @@ $color-yellow: var(--studio-yellow-50);
 	}
 }
 
-.is-up {
+.is-up,
+.is-free {
 	@include svg-color($color-green, $color-green, $color-green);
 }
 
-.is-down {
+.is-down,
+.is-full {
 	@include svg-color($color-red, $color-red, $color-red);
 }
 
@@ -157,6 +159,11 @@ button.site-expanded-content__card-button {
 		.site-expanded-content__device-score {
 			margin-inline-start: 8px;
 		}
+	}
+
+	.expanded-card__empty-content {
+		padding: 0 0 16px;
+		justify-content: flex-start;
 	}
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -33,6 +33,8 @@ $color-yellow: var(--studio-yellow-50);
 .expanded-card__header {
 	font-size: 0.875rem;
 	color: var(--studio-gray-80);
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .expanded-card__empty-content {
@@ -56,11 +58,14 @@ $color-yellow: var(--studio-yellow-50);
 
 .site-expanded-content__card-content-column {
 	flex: auto;
+	max-width: 100%;
 }
 
 .site-expanded-content__card-content-score {
 	font-weight: 500;
 	font-size: 1.25rem;
+	overflow: hidden;
+	text-overflow: ellipsis;
 
 	span {
 		font-size: 1rem;
@@ -100,6 +105,8 @@ $color-yellow: var(--studio-yellow-50);
 .site-expanded-content__card-content-count-title {
 	font-size: 0.75rem;
 	color: var(--studio-gray-40);
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .site-expanded-content__card-button {
@@ -156,6 +163,14 @@ $color-yellow: var(--studio-yellow-50);
 	.site-expanded-content__card-content-column-mobile {
 		.site-expanded-content__device-score {
 			margin-inline-start: 8px;
+		}
+	}
+
+	.site-expanded-content__card-footer {
+		padding: 16px 0 0;
+
+		.site-expanded-content__card-button {
+			white-space: nowrap;
 		}
 	}
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
@@ -102,7 +102,7 @@ td.site-table__td-critical {
 }
 
 tr.site-table__table-row-expanded {
-	background: var(--studio-gray-0);
+	background: var(--studio-gray-0) !important;
 	td {
 		border-top: none;
 	}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -233,3 +233,8 @@ export interface ToggleActivateMonitorArgs {
 	siteId: number;
 	params: { monitor_active: boolean };
 }
+
+export interface Backup {
+	activityTitle: string;
+	activityDescription: { children: { text: string }[] }[];
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -17,6 +17,7 @@ import type {
 	ScanNode,
 	MonitorNode,
 	SiteColumns,
+	Backup,
 } from './types';
 
 const INITIAL_UNIX_EPOCH = '1970-01-01 00:00:00';
@@ -548,4 +549,49 @@ export const getBoostRatingClass = ( boostScore: number ): string => {
 		default:
 			return 'boost-score-bad';
 	}
+};
+
+function extractBackupTextValues( str: string ): { [ key: string ]: number } {
+	const regex = /(\d+)\s+(\w+)(s)?\b/g;
+
+	let match;
+	const result: { [ key: string ]: number } = {};
+
+	while ( ( match = regex.exec( str ) ) !== null ) {
+		const key = match[ 2 ].replace( /s$/, '' ); // remove "s" from the end of the key if present since we store plural(pages and posts) as singular(page and post)
+		result[ key ] = parseInt( match[ 1 ], 10 );
+	}
+
+	return result;
+}
+
+export const getExtractedBackupTitle = ( backup: Backup ) => {
+	const backupText = backup?.activityDescription[ 0 ]?.children[ 0 ]?.text;
+
+	if ( ! backupText ) {
+		return backup?.activityTitle;
+	}
+
+	const { post: postCount, page: pageCount } = extractBackupTextValues( backupText );
+
+	let backupTitle;
+
+	if ( postCount ) {
+		backupTitle = translate( '%(posts)d post', '%(posts)d posts', {
+			args: { posts: postCount },
+			comment: '%(posts) is the no of posts"',
+			count: postCount,
+		} );
+	}
+
+	if ( pageCount ) {
+		const pageCountText = translate( '%(pages)d page', '%(pages)d pages', {
+			args: { pages: pageCount },
+			comment: '%(pages) is the no of pages"',
+			count: pageCount,
+		} );
+		backupTitle = backupTitle ? `${ backupTitle }, ${ pageCountText }` : pageCountText;
+	}
+
+	return backupTitle;
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -105,6 +105,10 @@ const backupEventNames: StatusEventNames = {
 		small_screen: 'calypso_jetpack_agency_dashboard_backup_failed_click_small_screen',
 		large_screen: 'calypso_jetpack_agency_dashboard_backup_failed_click_large_screen',
 	},
+	critical: {
+		small_screen: 'calypso_jetpack_agency_dashboard_backup_failed_click_small_screen',
+		large_screen: 'calypso_jetpack_agency_dashboard_backup_failed_click_large_screen',
+	},
 	warning: {
 		small_screen: 'calypso_jetpack_agency_dashboard_backup_warning_click_small_screen',
 		large_screen: 'calypso_jetpack_agency_dashboard_backup_warning_click_large_screen',


### PR DESCRIPTION
Related to 1203940061556608-as-1204076721671719

#### Proposed Changes

This PR implements the site expanded content for backup storage on large and small screens.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_** 

> These changes are behind a feature flag and will not be effective in production immediately after merging. Please verify these changes are not visible in the live link below. 

> The text `11 plugins, 3 themes, 11 uploads, 1 post, 5 pages` is not translated as it is directly coming from the API

> There could be some API signature changes that shouldn't affect the functionality.

**Instructions**

1. Run `git checkout add/site-expanded-content-for-backup-storage` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on the expand icon on any site, and verify that you can see the `Latest backup` card. Verify the same for different scenarios mentioned below with different screen sizes

**When there is no backup added**

Large screen

<img width="343" alt="Screenshot 2023-03-15 at 6 07 49 PM" src="https://user-images.githubusercontent.com/10586875/225316813-58c37c95-2323-4044-82ae-953e51ccaa8f.png">

Mobile

![mobile (16)](https://user-images.githubusercontent.com/10586875/225827275-2514f672-9346-4649-8a18-ede4e4dfdc0f.png)


Tablet

![mobile (15)](https://user-images.githubusercontent.com/10586875/225827259-74a71e6d-8fce-4e17-8973-b21be4c3696c.png)

**When there is a failed backup**

<img width="333" alt="Screenshot 2023-03-15 at 6 09 10 PM" src="https://user-images.githubusercontent.com/10586875/225317222-8eeb2628-2d41-4ab3-9e78-60a67afd357d.png">

**When there is a successful backup**

Large screen

<img width="335" alt="Screenshot 2023-03-15 at 5 54 53 PM" src="https://user-images.githubusercontent.com/10586875/225317550-31c4aaf1-91b1-427f-98e1-3fefea2da782.png">

Mobile

![mobile (13)](https://user-images.githubusercontent.com/10586875/225827421-17ff6e1e-4b0f-4544-82a8-c8640cab4682.png)

Tablet

![mobile (14)](https://user-images.githubusercontent.com/10586875/225827441-a5b33eda-6634-48b4-86e7-87c370dbb506.png)

**When there is a successful backup related to plugin**

<img width="332" alt="Screenshot 2023-03-14 at 1 58 25 PM" src="https://user-images.githubusercontent.com/10586875/225317711-54a04407-b7a8-45a8-af88-7da9c4e99a28.png">

<img width="337" alt="Screenshot 2023-03-14 at 1 58 59 PM" src="https://user-images.githubusercontent.com/10586875/225317719-5e368dc2-9280-4ed6-afc9-3b9a2b4babc7.png">

<img width="341" alt="Screenshot 2023-03-14 at 2 00 25 PM" src="https://user-images.githubusercontent.com/10586875/225317728-5acf81df-bbc7-482e-9779-6b45fcd5d82c.png">

<img width="336" alt="Screenshot 2023-03-14 at 2 09 29 PM" src="https://user-images.githubusercontent.com/10586875/225317733-22659092-43f8-4584-be60-9544c0140e32.png">

**Other scenarios**

<img width="347" alt="Screenshot 2023-03-14 at 1 46 09 PM" src="https://user-images.githubusercontent.com/10586875/225317860-ea85a2b9-4a12-4ad7-a7b2-60df57d64f1b.png">

<img width="345" alt="Screenshot 2023-03-14 at 1 47 23 PM" src="https://user-images.githubusercontent.com/10586875/225317872-f602e419-2429-4726-8857-7634b112597f.png">

<img width="338" alt="Screenshot 2023-03-14 at 1 48 17 PM" src="https://user-images.githubusercontent.com/10586875/225317971-b021175e-2a41-4f54-b92f-39e2082fb4a6.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?