### PR TITLE
Theme Showcase: Theme Detail page UI improvements

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -35,6 +35,7 @@ import SectionHeader from 'calypso/components/section-header';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
+import StickyPanel from 'calypso/components/sticky-panel';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
@@ -457,14 +458,16 @@ class ThemeSheet extends Component {
 		);
 
 		return (
-			<div className="theme__sheet-web-preview">
-				<ThemeWebPreview
-					url={ url }
-					inlineCss={ this.getSelectedStyleVariation()?.inline_css }
-					isShowFrameBorder={ false }
-					isShowDeviceSwitcher={ false }
-				/>
-			</div>
+			<StickyPanel>
+				<div className="theme__sheet-web-preview">
+					<ThemeWebPreview
+						url={ url }
+						inlineCss={ this.getSelectedStyleVariation()?.inline_css }
+						isShowFrameBorder={ false }
+						isShowDeviceSwitcher={ false }
+					/>
+				</div>
+			</StickyPanel>
 		);
 	};
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -88,8 +88,13 @@ body.is-section-theme-i4 {
 
 	.theme__sheet-content {
 		box-shadow: none;
+		font-size: 1rem;
 		min-height: auto;
 		padding: 0;
+
+		h2 {
+			font-size: 1.25rem;
+		}
 
 		.notes {
 			background: transparent;
@@ -439,7 +444,7 @@ body.is-section-theme-i4 {
 		margin-top: 0;
 		top: 0;
 		width: 100%;
-		height: 75vw; // force proportions
+		height: 100vw; // force proportions
 		overflow: hidden;
 		box-shadow: none;
 
@@ -465,10 +470,12 @@ body.is-section-theme-i4 {
 }
 
 .theme__sheet-web-preview {
+	pointer-events: none;
 	position: relative;
 
 	@include breakpoint-deprecated( ">960px" ) {
-		height: 85vh;
+		height: calc(100vh - 128px);
+		pointer-events: all;
 	}
 }
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -60,6 +60,29 @@ body.is-section-theme-i4 {
 
 		.theme__sheet-column-right {
 			grid-area: preview;
+
+			.sticky-panel {
+				width: 100%;
+
+				&.is-sticky .sticky-panel__content {
+					margin-top: 16px;
+
+					@include breakpoint-deprecated( "<960px" ) {
+						margin-top: 0;
+						position: relative;
+					}
+				}
+
+				.sticky-panel__content {
+					transition: all 200ms ease-in-out;
+				}
+
+				.sticky-panel__spacer {
+					@include breakpoint-deprecated( "<960px" ) {
+						display: none;
+					}
+				}
+			}
 		}
 
 		.theme__sheet-column-left,

--- a/client/my-sites/theme/theme-style-variations/index.tsx
+++ b/client/my-sites/theme/theme-style-variations/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { PremiumBadge } from '@automattic/design-picker';
-import { useLayoutEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
@@ -42,7 +42,7 @@ const ThemeStyleVariations = ( {
 		setCollapsibleMaxHeight( shouldCollapse ? nodeFirstChild.offsetHeight : node.scrollHeight );
 	};
 
-	useLayoutEffect( () => {
+	useEffect( () => {
 		if ( ! observerRef.current ) {
 			return;
 		}
@@ -86,7 +86,12 @@ const ThemeStyleVariations = ( {
 					<PremiumBadge shouldHideTooltip />
 					{ isCollapsible && (
 						<Button borderless onClick={ handleCollapseButtonClick }>
-							{ isCollapsed ? translate( 'Show all' ) : translate( 'Show less' ) }
+							{ isCollapsed
+								? translate( 'Show all (%(variationsCount)d)', {
+										args: { variationsCount: variations?.length },
+										comment: 'The number of style variations',
+								  } )
+								: translate( 'Show less' ) }
 						</Button>
 					) }
 				</h2>

--- a/client/my-sites/theme/theme-style-variations/style.scss
+++ b/client/my-sites/theme/theme-style-variations/style.scss
@@ -3,12 +3,19 @@
 @import "@wordpress/base-styles/mixins";
 
 .theme__sheet-style-variations {
+	position: relative;
+
 	@include breakpoint-deprecated( "<960px" ) {
 		margin-bottom: -16px;
 		padding: 0 0 0 24px;
 
+		&::after {
+			@include long-content-fade( $direction: right, $size: 24px );
+			height: 100%;
+		}
+
 		.theme__sheet-style-variations-previews {
-			padding: 2px 24px 16px 2px;
+			padding: 12px 24px 16px 2px;
 		}
 	}
 
@@ -18,6 +25,11 @@
 		gap: 8px;
 		overflow: scroll;
 		padding: 12px 2px;
+		scrollbar-width: none;
+
+		&::-webkit-scrollbar {
+			display: none;
+		}
 
 		&--is-collapsible {
 			transition: max-height 0.2s ease-in-out;


### PR DESCRIPTION
## Proposed Changes

This PR improves the Theme Detail page based on the feedback in pekYwv-L9-p2, including:

1. Hiding scrollbar in style variation previews when scrollbar is set to always visible.
![Screenshot 2023-03-01 at 2 27 53 PM](https://user-images.githubusercontent.com/797888/222061698-5acb1342-162e-4fee-83b2-8b8cb7498a5d.png)

2. Show total number of style variations in the Show All button.
![Screenshot 2023-03-01 at 2 28 26 PM](https://user-images.githubusercontent.com/797888/222061804-c27b857b-c0ec-455f-b9db-28d823b528d0.png)

3. Set theme description text to 16px for paragraphs and 20px for titles.

| Before | After |
| --- | --- |
| ![Screenshot 2023-03-01 at 2 29 57 PM](https://user-images.githubusercontent.com/797888/222062026-ded4d114-c334-468a-aad5-03b9d0524213.png) | ![Screenshot 2023-03-01 at 2 30 37 PM](https://user-images.githubusercontent.com/797888/222062130-60a1a7b3-32a5-4fcf-8d9f-0d002b4086a5.png) |
 
4. Add gradient to style variation previews in mobile view to indicate that it's scrollable.
![Screenshot 2023-03-01 at 2 31 44 PM](https://user-images.githubusercontent.com/797888/222062360-3415ed63-db43-406f-9d1e-d4118f75a895.png)

5. Increase theme preview iframe in both mobile and desktop views.
6. Set theme preview iframe to be fixed on scroll.
7. Disable pointer-events in the theme preview iframe in mobile view.
8. Other layout spacing adjustments.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Ensure that the UI updates are as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?