### PR TITLE
i18n: Fix unescaped BusinessPlanUpgradeUpsellTreatment discount string

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/treatment.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/treatment.jsx
@@ -178,20 +178,31 @@ export class BusinessPlanUpgradeUpsellTreatment extends PureComponent {
 						) }
 					</p>
 					<p>
-						{ translate(
-							"Upgrade now and we'll give you {{b}}%(discount)d% off your first %(term)s{{/b}}.",
-							{
-								components: {
-									b: <b />,
-								},
-								args: {
-									discount: 15,
-									term: hasSevenDayRefundPeriod ? 'month' : 'year',
-									comment:
-										'%(discount)d is a percentage like 15% and %(term)s will be either "month" or "year"',
-								},
-							}
-						) }
+						{ hasSevenDayRefundPeriod
+							? translate(
+									"Upgrade now and we'll give you {{b}}%(discount)d%% off your first month{{/b}}.",
+									{
+										components: {
+											b: <b />,
+										},
+										args: {
+											discount: 15,
+											comment: '%(discount)d is a percentage like 15%"',
+										},
+									}
+							  )
+							: translate(
+									"Upgrade now and we'll give you {{b}}%(discount)d%% off your first year{{/b}}.",
+									{
+										components: {
+											b: <b />,
+										},
+										args: {
+											discount: 15,
+											comment: '%(discount)d is a percentage like 15%"',
+										},
+									}
+							  ) }
 					</p>
 					<div className="business-plan-upgrade-upsell-new-design__countdown-counter">
 						<span>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 577-gh-Automattic/i18n-issues

## Proposed Changes

* Escape the `%` character in `Upgrade now and we'll give you {{b}}%(discount)d%% off your...`.
* Split into two separate strings for month and year terms to allow for more accurate translations for languages with gendered nouns.

![CleanShot 2023-03-01 at 11 01 51](https://user-images.githubusercontent.com/2722412/222093697-1841c877-b1e9-486f-b985-5d199c06bec4.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you are assigned to the treatment group for `calypso_postpurchase_upsell_countdown_timer` experiment.
* Create a new site with Premium plan or upgrade an existing site to Premium.
* Finish the checkout process (using credits).
* Confirm the `%` character is being rendered as expected on the Business plan upgrade screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
