### PR TITLE
Plan page: Fix shifting comparison UI page.

### DIFF
--- a/client/jetpack-cloud/sections/comparison/header/style.scss
+++ b/client/jetpack-cloud/sections/comparison/header/style.scss
@@ -3,35 +3,24 @@
 
 .is-group-jetpack-cloud.is-section-jetpack-cloud-features-comparison {
 
-	.header__main-title {
-		h1 {
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-			font-size: 2.5em;
-			font-weight: 600;
-			margin: 1.5em auto 0.25em;
-		}
-	}
 	.header__main-title
 	.formatted-header__title {
 		max-width: 280px;
-		margin-bottom: 1rem;
-		margin-right: auto;
-		margin-left: auto;
+		margin: 1.5rem auto 1rem;
 
 		font-size: 1.5rem;
 		font-weight: 700;
 		letter-spacing: -1px;
-		line-height: 1.4;
 
 		@include break-small {
 			max-width: none;
-
+			font-weight: 600;
 			font-size: 2rem;
-			line-height: 1.2;
 		}
 	}
 	.formatted-header__subtitle {
-		font-size: 1.25rem;
+		font-size: 1rem;
+		margin: 0;
 	}
 }
 

--- a/client/jetpack-cloud/sections/comparison/style.scss
+++ b/client/jetpack-cloud/sections/comparison/style.scss
@@ -6,5 +6,6 @@
 
 	.main {
 		max-width: 1200px;
+		padding: 0;
 	}
 }

--- a/client/jetpack-cloud/sections/comparison/table/style.scss
+++ b/client/jetpack-cloud/sections/comparison/table/style.scss
@@ -118,6 +118,7 @@
 
 	tr {
 		border-bottom: 1px solid var(--studio-white);
+		padding: 0 1rem;
 
 		@media (max-width: $break-large) {
 			display: block;

--- a/client/jetpack-cloud/sections/comparison/table/style.scss
+++ b/client/jetpack-cloud/sections/comparison/table/style.scss
@@ -42,9 +42,9 @@
 				&:not(.is-placeholder) {
 					.display-price__details,
 					.display-price__billing-time-frame {
+						display: block;
 						line-height: 0.5;
 						white-space: normal;
-						margin-top: 0;
 					}
 
 					.display-price__prices {

--- a/client/jetpack-cloud/sections/comparison/table/style.scss
+++ b/client/jetpack-cloud/sections/comparison/table/style.scss
@@ -20,23 +20,39 @@
 
 		.item-price {
 			margin: 0.5rem 0;
+			max-height: 2rem;
+			min-height: rem(50px);
 
-			.display-price:not(.is-placeholder) {
+			.display-price,
+			.display-price.is-placeholder {
 				display: flex;
 				flex-direction: column;
 				align-items: center;
-				max-height: 2rem;
 
-				.display-price__details,
-				.display-price__billing-time-frame {
-					line-height: 0.5;
+				.plan-price {
+					transform: none;
+					max-height: rem(30px);
 				}
 
-				.display-price__prices {
-					.plan-price__currency-symbol,
-					.plan-price__integer,
-					.plan-price__fraction {
-						font-size: 1.5rem;
+				.display-price__billing-time-frame {
+					margin-top: 3px;
+					max-height: rem(15px);
+				}
+
+				&:not(.is-placeholder) {
+					.display-price__details,
+					.display-price__billing-time-frame {
+						line-height: 0.5;
+						white-space: normal;
+						margin-top: 0;
+					}
+
+					.display-price__prices {
+						.plan-price__currency-symbol,
+						.plan-price__integer,
+						.plan-price__fraction {
+							font-size: 1.5rem;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
When [cloud.jetpack.com/features/comparison](https://cloud.jetpack.com/features/comparison) loads, the placeholder we use for pricing doesn't precisely match the shape of the final result. Because of this, the page layout noticeably shifts as it finishes loading. This hurts the user experience and lowers our Google PageSpeed score, which is one factor in how we're ranked on search engines.


https://user-images.githubusercontent.com/56598660/222120440-6a3b6eaf-a8cf-447e-b5fc-11f0d74a16e6.mov



Related to 1202858161751496-as-1203837080683452

## Proposed Changes

* This PR updates the styling of the display price placeholder to match the height of the actual display price and prevent UI from shifting.
* Additionally, the header causes a shift upward. For some reason, the styling we added in the header has a slight delay in rendering. I updated the styling to avoid the shifting however, as a side effect, there are changes in the font styling.

## Testing Instructions

Run this branch by following the steps below (or you can use the Jetpack Cloud live link commented on this PR)
* Run `git fetch && git checkout fix/jp-feature-comparison-shifting-ui`
* Run `yarn start-jetpack-cloud`

1. Go to http://jetpack.cloud.localhost:3000/features/comparison or use the Jetpack Cloud live link and append `/features/comparison`.
2. Confirm that the UI no longer shifts.


https://user-images.githubusercontent.com/56598660/222122505-6608c8db-0290-4e0d-93e5-6ba96a08453b.mov



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1203837080683452