### PR TITLE
Fix Jetpack version incompatible check only for Jetpack sites

### DIFF
--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -327,7 +327,7 @@ class SectionImport extends Component {
 									warningRequirement={ translate( 'To make sure you can import reliably' ) }
 								/>
 							) }
-							{ jetpackVersionInCompatible
+							{ isJetpack && ! isAtomic && jetpackVersionInCompatible
 								? this.renderIdleImporters( appStates.DISABLED )
 								: this.renderImportersList() }
 						</>


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/Automattic/wp-calypso/pull/73802 where for Atomic sites, the site option was grayed out due to Jetpack version not being correctly installed on Atomic. We never want such checks to be on Atomic sites.

Related to https://github.com/Automattic/wp-calypso/issues/73139

## Proposed Changes

* Restrict the versionIncompatible checks only to Atomic sites.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See testing instructions here: https://github.com/Automattic/wp-calypso/pull/73802 make sure all of that works.
* Make sure that for an Atomic site this happens:

Instead of this:
<img width="804" alt="CleanShot 2023-03-01 at 15 58 33@2x" src="https://user-images.githubusercontent.com/533/222113400-34c395b6-0f41-4b47-90a7-6a595df84af8.png">

You should see this:
<img width="806" alt="CleanShot 2023-03-01 at 15 59 52@2x" src="https://user-images.githubusercontent.com/533/222113676-fba0e298-985f-41ca-b877-64edf35f7a7b.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
~~- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
~~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
