### PR TITLE
Subscription Management: Create `subscription-manager` package

### DIFF
--- a/client/my-sites/subscriptions/index.tsx
+++ b/client/my-sites/subscriptions/index.tsx
@@ -1,22 +1,11 @@
 import config from '@automattic/calypso-config';
+import { SubscriptionManagerContainer } from '@automattic/subscription-manager';
 import page, { Callback } from 'page';
 import { createElement } from 'react';
-import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
-import Main from 'calypso/components/main';
 import { makeLayout, render } from 'calypso/controller';
 
-const Subscriptions = () => {
-	return (
-		<Main className="site-settings">
-			<DocumentHead title="Subscriptions" />
-			<FormattedHeader brandFont headerText="Subscriptions" align="left" />
-		</Main>
-	);
-};
-
 const createSubscriptions: Callback = ( context, next ) => {
-	context.primary = createElement( Subscriptions );
+	context.primary = createElement( SubscriptionManagerContainer );
 	next();
 };
 

--- a/client/package.json
+++ b/client/package.json
@@ -60,6 +60,7 @@
 		"@automattic/social-previews": "workspace:^",
 		"@automattic/state-utils": "workspace:^",
 		"@automattic/subscriber": "workspace:^",
+		"@automattic/subscription-manager": "workspace:^",
 		"@automattic/tree-select": "workspace:^",
 		"@automattic/viewport": "workspace:^",
 		"@automattic/viewport-react": "workspace:^",

--- a/packages/subscription-manager/README.md
+++ b/packages/subscription-manager/README.md
@@ -1,0 +1,4 @@
+# Subscription Manager
+This package creates the subscription management views that are displayed as:
+1. Part of Reader for wpcom logged-in users
+2. Externally facing single page app for users who use their e-mail address for subscribing to wpcom websites, but they do not have a wpcom account

--- a/packages/subscription-manager/package.json
+++ b/packages/subscription-manager/package.json
@@ -1,0 +1,42 @@
+{
+	"name": "@automattic/subscription-manager",
+	"version": "0.0.1",
+	"description": "Subnscription Manager",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.tsx",
+	"sideEffects": [
+		"*.css",
+		"*.scss"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/subscription-manager"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": "https://github.com/Automattic/wp-calypso/issues",
+	"types": "dist/types",
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && run -T copy-assets",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch"
+	},
+	"devDependencies": {
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"typescript": "^4.5.5"
+	},
+	"peerDependencies": {
+		"@wordpress/data": "^6.1.5",
+		"react": "^17.0.2",
+		"react-dom": "^17.0.2",
+		"reakit-utils": "^0.15.1",
+		"redux": "^4.1.2"
+	}
+}

--- a/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
+++ b/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
@@ -1,0 +1,23 @@
+/* eslint-disable no-restricted-imports */
+/**
+ * External dependencies
+ */
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
+
+export type SubscriptionManagerContainerProps = {
+	children?: React.ReactNode;
+};
+
+const SubscriptionManagerContainer = ( { children }: SubscriptionManagerContainerProps ) => {
+	return (
+		<Main className="site-settings">
+			<DocumentHead title="Subscriptions" />
+			<FormattedHeader brandFont headerText="Subscriptions" align="left" />
+			{ children }
+		</Main>
+	);
+};
+
+export default SubscriptionManagerContainer;

--- a/packages/subscription-manager/src/components/SubscriptionManagerContainer/index.ts
+++ b/packages/subscription-manager/src/components/SubscriptionManagerContainer/index.ts
@@ -1,0 +1,1 @@
+export { default as SubscriptionManagerContainer } from './SubscriptionManagerContainer';

--- a/packages/subscription-manager/src/components/index.d.ts
+++ b/packages/subscription-manager/src/components/index.d.ts
@@ -1,0 +1,43 @@
+declare module 'calypso/components/data/document-head' {
+	const DocumentHead: React.FC< {
+		title?: string;
+		skipTitleFormatting?: boolean;
+		unreadCount?: number;
+		link?: unknown[];
+		meta?: unknown[];
+		setTitle?: ( title: string ) => void;
+		setLink?: ( link: unknown[] ) => void;
+		setMeta?: ( meta: unknown[] ) => void;
+		setUnreadCount?: ( unreadCount: number ) => void;
+	} >;
+	export default DocumentHead;
+}
+
+declare module 'calypso/components/formatted-header' {
+	const FormattedHeader: React.FC< {
+		id?: string;
+		className?: string;
+		brandFont?: boolean;
+		headerText?: React.ReactNode;
+		subHeaderText?: React.ReactNode;
+		tooltipText?: React.ReactNode;
+		compactOnMobile?: boolean;
+		isSecondary?: boolean;
+		align?: 'center' | 'left' | 'right';
+		hasScreenOptions?: boolean;
+		children?: React.ReactNode;
+	} >;
+	export default FormattedHeader;
+}
+
+declare module 'calypso/components/main' {
+	const Main: React.FC< {
+		className?: string;
+		id?: string;
+		children?: React.ReactNode;
+		wideLayout?: boolean;
+		fullWidthLayout?: boolean;
+		isLoggedOut?: boolean;
+	} >;
+	export default Main;
+}

--- a/packages/subscription-manager/src/index.tsx
+++ b/packages/subscription-manager/src/index.tsx
@@ -1,0 +1,1 @@
+export { SubscriptionManagerContainer } from './components/SubscriptionManagerContainer';

--- a/packages/subscription-manager/tsconfig.json
+++ b/packages/subscription-manager/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src"
+	},
+	"include": [ "src" ],
+	"exclude": [ "**/test/*" ],
+	"references": [ { "path": "../viewport" } ]
+}

--- a/packages/subscription-manager/tsconfig.json
+++ b/packages/subscription-manager/tsconfig.json
@@ -6,6 +6,5 @@
 		"rootDir": "src"
 	},
 	"include": [ "src" ],
-	"exclude": [ "**/test/*" ],
-	"references": [ { "path": "../viewport" } ]
+	"exclude": [ "**/test/*" ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1558,6 +1558,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/subscription-manager@workspace:^, @automattic/subscription-manager@workspace:packages/subscription-manager":
+  version: 0.0.0-use.local
+  resolution: "@automattic/subscription-manager@workspace:packages/subscription-manager"
+  dependencies:
+    "@automattic/calypso-typescript-config": "workspace:^"
+    typescript: ^4.5.5
+  peerDependencies:
+    "@wordpress/data": ^6.1.5
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    reakit-utils: ^0.15.1
+    redux: ^4.1.2
+  languageName: unknown
+  linkType: soft
+
 "@automattic/tour-kit@workspace:^, @automattic/tour-kit@workspace:packages/tour-kit":
   version: 0.0.0-use.local
   resolution: "@automattic/tour-kit@workspace:packages/tour-kit"
@@ -11775,6 +11790,7 @@ __metadata:
     "@automattic/social-previews": "workspace:^"
     "@automattic/state-utils": "workspace:^"
     "@automattic/subscriber": "workspace:^"
+    "@automattic/subscription-manager": "workspace:^"
     "@automattic/tree-select": "workspace:^"
     "@automattic/viewport": "workspace:^"
     "@automattic/viewport-react": "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/73932

## Proposed Changes

* Create `subscription-manager` package

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/subscriptions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?



![Screen Shot 2023-03-07 at 09 41 09](https://user-images.githubusercontent.com/2019970/223369310-535abc28-d3e2-467b-93c6-26da0eed362f.png)
