### PR TITLE
Marketplace: Fix encoding issue on plugin search

### DIFF
--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -10,6 +10,7 @@ import {
 	useQuery,
 } from 'react-query';
 import { useSelector } from 'react-redux';
+import { decodeEntities } from 'calypso/lib/formatting';
 import {
 	extractSearchInformation,
 	getPreinstalledPremiumPluginsVariations,
@@ -41,8 +42,8 @@ const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 	}
 	return results.map( ( { fields: hit, railcar } ) => {
 		const plugin: Plugin = {
-			name: hit.plugin?.title, // TODO: add localization
-			slug: hit.slug,
+			name: decodeEntities( hit.plugin?.title ), // TODO: add localization
+			slug: decodeEntities( hit.slug ),
 			version: hit[ 'plugin.stable_tag' ],
 			author: hit.author,
 			author_name: hit.plugin?.author,
@@ -54,9 +55,9 @@ const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 			support_threads_resolved: hit[ 'plugin.support_threads_resolved' ],
 			active_installs: hit.plugin?.active_installs,
 			last_updated: hit.modified,
-			short_description: hit.plugin?.excerpt, // TODO: add localization
+			short_description: decodeEntities( hit.plugin?.excerpt ), // TODO: add localization
 			icon: getIconUrl( hit.slug, hit.plugin?.icons ),
-			premium_slug: hit.plugin?.premium_slug,
+			premium_slug: decodeEntities( hit.plugin?.premium_slug ),
 			variations: {
 				monthly: { product_id: hit.plugin?.store_product_monthly_id },
 				yearly: { product_id: hit.plugin?.store_product_yearly_id },


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #73907

## Proposed Changes

* Use `decodeEntities` to decode html-encoded characters in `title`, `slug` and `short_description`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start at `/plugins/$site`
- Search for `clarity`
- Verify encoded character
- Click on Clarity item
- Verify no encoded character
- Repeat searches for other plugins like `Check & Health`
- Verify there are no encoded characters

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
~- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
