### PR TITLE
Pricing page: fix pricing billing text alignment issue.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/item-price/style.scss
@@ -43,7 +43,7 @@
 	}
 }
 
-.display-price__billing-time-frame {
+.item-price__complete .display-price__billing-time-frame {
 	display: table;
 	margin-top: 12px;
 	@include break-medium {

--- a/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/item-price/style.scss
@@ -72,7 +72,9 @@
 	}
 
 	.display-price__billing-time-frame {
-		margin-top: 3px;
+		display: flex;
+		align-items: center;
+		margin: 0;
 	}
 }
 


### PR DESCRIPTION
The billing text on the Jetpack pricing page appears to be misaligned. The issue was caused by the CSS styling from the Jetpack Complete page's item price component overriding the original item price component.

<img width="1233" alt="Screen Shot 2023-03-01 at 8 34 24 PM" src="https://user-images.githubusercontent.com/56598660/222141185-36a2e28e-2a0c-43a9-a7e7-d216da3af52a.png">


Related to 1202858161751496-as-1204063189836641

## Proposed Changes

* Fix css styling in the Jetpack Complete page's item price component that causes it to override the Item price component.

## Testing Instructions

### JP Pricing page

Run this branch by following the steps below (or you can use the Jetpack Cloud live link commented on this PR)
* Run `git fetch && git checkout fix/pricing-page-billing-timeframe-alignment-issue`
* Run `yarn start-jetpack-cloud`

1. Go to http://jetpack.cloud.localhost:3000/pricing or use the Jetpack Cloud live link and append `/pricing`.
2. Confirm that the billing text is not misaligned.
<img width="1226" alt="Screen Shot 2023-03-01 at 8 43 05 PM" src="https://user-images.githubusercontent.com/56598660/222142789-27ea4bd3-9f62-46ca-9459-c42349a22548.png">


### JP Complete connection page
Run this branch by following the steps below (or you can use the Jetpack Cloud live link commented on this PR)
* Run `git fetch && git checkout fix/pricing-page-billing-timeframe-alignment-issue`
* Run `yarn start`

1. Go to `http://calypso.localhost:3000/jetpack/connect/plans/complete/<JN-SITE>` or use the Calypso live link and append `/jetpack/connect/plans/complete/<JN-SITE>`
2. Confirm that the billing text is rendered correctly.
<img width="687" alt="Screen Shot 2023-03-01 at 8 41 45 PM" src="https://user-images.githubusercontent.com/56598660/222142415-2b03e4ee-350d-4e81-9e32-f624da866430.png">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React, or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204063189836641