### PR TITLE
Blazepress: Add scheduled status

### DIFF
--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -23,6 +23,7 @@ import {
 	getCampaignStatus,
 	getCampaignStatusBadgeColor,
 	getPostType,
+	normalizeCampaignStatus,
 } from 'calypso/my-sites/promote-post/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -40,7 +41,6 @@ export default function CampaignItem( { campaign }: Props ) {
 
 	const {
 		impressions_total,
-		status: campaignStatus,
 		clicks_total,
 		target_url,
 		type,
@@ -54,6 +54,8 @@ export default function CampaignItem( { campaign }: Props ) {
 		display_delivery_estimate,
 		display_name,
 	} = campaign;
+
+	const campaignStatus = useMemo( () => normalizeCampaignStatus( campaign ), [ campaign.status ] );
 
 	const overallSpending = useMemo(
 		() => getCampaignOverallSpending( spent_budget_cents, budget_cents, start_date, end_date ),

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -141,7 +141,9 @@ export default function PromotedPosts( { tab }: Props ) {
 		);
 	}
 
-	const content = [ ...( posts || [] ), ...( pages || [] ), ...( products || [] ) ];
+	const content = [ ...( posts || [] ), ...( pages || [] ), ...( products || [] ) ].sort(
+		( a, b ) => b.ID - a.ID
+	);
 
 	const isLoading = isLoadingPage && isLoadingPost && isLoadingProducts;
 

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -32,7 +32,7 @@ const queryPost = {
 	number: 20, // max supported by /me/posts endpoint for all-sites mode
 	status: 'publish', // do not allow private or unpublished posts
 	type: 'post',
-	order_by: 'comment_count',
+	order_by: 'id',
 };
 const queryPage = {
 	...queryPost,

--- a/client/my-sites/promote-post/utils/index.ts
+++ b/client/my-sites/promote-post/utils/index.ts
@@ -3,7 +3,18 @@ import moment from 'moment';
 import {
 	AudienceList,
 	AudienceListKeys,
+	Campaign,
 } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
+
+export const campaignStatus = {
+	SCHEDULED: 'scheduled',
+	CREATED: 'created',
+	REJECTED: 'rejected',
+	APPROVED: 'approved',
+	ACTIVE: 'active',
+	CANCELED: 'canceled',
+	FINISHED: 'finished',
+};
 
 export const getPostType = ( type: string ) => {
 	switch ( type ) {
@@ -23,22 +34,25 @@ export const getPostType = ( type: string ) => {
 
 export const getCampaignStatusBadgeColor = ( status: string ) => {
 	switch ( status ) {
-		case 'created': {
+		case campaignStatus.SCHEDULED: {
 			return 'info-blue';
 		}
-		case 'rejected': {
+		case campaignStatus.CREATED: {
+			return 'info-blue';
+		}
+		case campaignStatus.REJECTED: {
 			return 'error';
 		}
-		case 'approved': {
+		case campaignStatus.APPROVED: {
 			return 'info-blue';
 		}
-		case 'active': {
+		case campaignStatus.ACTIVE: {
 			return 'info-green';
 		}
-		case 'canceled': {
+		case campaignStatus.CANCELED: {
 			return 'error';
 		}
-		case 'finished': {
+		case campaignStatus.FINISHED: {
 			return 'info-purple';
 		}
 		default:
@@ -48,27 +62,42 @@ export const getCampaignStatusBadgeColor = ( status: string ) => {
 
 export const getCampaignStatus = ( status: string ) => {
 	switch ( status ) {
-		case 'created': {
+		case campaignStatus.SCHEDULED: {
+			return __( 'Scheduled' );
+		}
+		case campaignStatus.CREATED: {
 			return __( 'Pending review' );
 		}
-		case 'rejected': {
+		case campaignStatus.REJECTED: {
 			return __( 'Rejected' );
 		}
-		case 'approved': {
+		case campaignStatus.APPROVED: {
 			return __( 'Approved' );
 		}
-		case 'active': {
+		case campaignStatus.ACTIVE: {
 			return __( 'Active' );
 		}
-		case 'canceled': {
+		case campaignStatus.CANCELED: {
 			return __( 'Canceled' );
 		}
-		case 'finished': {
+		case campaignStatus.FINISHED: {
 			return __( 'Finished' );
 		}
 		default:
 			return status;
 	}
+};
+
+export const normalizeCampaignStatus = ( campaign: Campaign ): string => {
+	// This is a transactional status, so we just alter this in calypso
+	if (
+		campaign.status === campaignStatus.ACTIVE &&
+		moment().isBefore( campaign.start_date, 'day' )
+	) {
+		return campaignStatus.SCHEDULED;
+	}
+
+	return campaign.status;
 };
 
 export const getCampaignDurationDays = ( start_date: string, end_date: string ) => {
@@ -180,6 +209,8 @@ export const getCampaignAudienceString = ( audience_list: AudienceList ) => {
 	return audience;
 };
 
-export const canCancelCampaign = ( campaignStatus: string ) => {
-	return [ 'created', 'active' ].includes( campaignStatus );
+export const canCancelCampaign = ( status: string ) => {
+	return [ campaignStatus.SCHEDULED, campaignStatus.CREATED, campaignStatus.ACTIVE ].includes(
+		status
+	);
 };


### PR DESCRIPTION
Related to #

* We don't have a scheduled status for blazepress campaigns, yet we want to make sure users know that a campaign has not started when the start_date is not before today(). This PR creates this status:

## Testing Instructions
- Create a campaign. The campaign start_date will be added at least 1 day after creation. The campaign should display "Scheduled" in calypso blazepress campaign list
 
![image](https://user-images.githubusercontent.com/43957544/222153751-472b6309-74f0-4679-bd87-0536eab5db45.png)

- Wait a day (or just change the campaign start_date in the DB to be today: The campaign should display "Active"

![image](https://user-images.githubusercontent.com/43957544/222153875-ce9f127b-510d-4a39-8915-fbab354f766d.png)

Note: The date will always correspond with the server date (the date we're displaying)  **without timezone conversion**. This will be tackled with a different approach.

## Pre-merge Checklist
- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
