### PR TITLE
Staging Sites: Add better loading and progress indicators

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -1,8 +1,9 @@
-import { Button, Card, Spinner, Gridicon } from '@automattic/components';
+import { Button, Card, Spinner, Gridicon, LoadingPlaceholder } from '@automattic/components';
+import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { localize } from 'i18n-calypso';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Fragment } from 'react';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import { useAddStagingSiteMutation } from 'calypso/my-sites/hosting/staging-site-card/use-add-staging-site';
@@ -15,6 +16,21 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const stagingSiteAddFailureNoticeId = 'staging-site-add-failure';
+
+const FirstPlaceholder = styled( LoadingPlaceholder )( {
+	height: 24,
+	width: '85%',
+	marginBottom: '0.25em',
+} );
+const SecondPlaceholder = styled( LoadingPlaceholder )( {
+	height: 24,
+	width: '60%',
+	marginBottom: '1.5em',
+} );
+const ButtonPlaceholder = styled( LoadingPlaceholder )( {
+	width: '148px',
+	height: '40px',
+} );
 
 const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 	const { __ } = useI18n();
@@ -105,6 +121,16 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 		);
 	};
 
+	const getLoadingStagingSitesPlaceholder = () => {
+		return (
+			<Fragment>
+				<FirstPlaceholder />
+				<SecondPlaceholder />
+				<ButtonPlaceholder />
+			</Fragment>
+		);
+	};
+
 	return (
 		<Card className="staging-site-card">
 			{
@@ -114,9 +140,10 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 			<CardHeading id="staging-site">{ translate( 'Staging site' ) }</CardHeading>
 			{ showAddStagingSite && ! addingStagingSite && getNewStagingSiteContent() }
 			{ showManageStagingSite && isStagingSiteTransferComplete && getManageStagingSiteContent() }
-			{ ( isLoadingStagingSites ||
-				addingStagingSite ||
-				( showManageStagingSite && ! isStagingSiteTransferComplete ) ) && <Spinner /> }
+			{ isLoadingStagingSites && getLoadingStagingSitesPlaceholder() }
+			{ ( addingStagingSite || ( showManageStagingSite && ! isStagingSiteTransferComplete ) ) && (
+				<Spinner />
+			) }
 		</Card>
 	);
 };

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { localize } from 'i18n-calypso';
-import { useState, useEffect, Fragment } from 'react';
+import { useState, useEffect } from 'react';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import { LoadingBar } from 'calypso/components/loading-bar';
@@ -90,7 +90,7 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 
 	const getNewStagingSiteContent = () => {
 		return (
-			<Fragment>
+			<>
 				<p>
 					{ translate(
 						'A staging site is a test version of your website you can use to preview and troubleshoot changes before applying them to your production site.'
@@ -108,13 +108,13 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 				>
 					<span>{ translate( 'Add staging site' ) }</span>
 				</Button>
-			</Fragment>
+			</>
 		);
 	};
 
 	const getManageStagingSiteContent = () => {
 		return (
-			<Fragment>
+			<>
 				<p>
 					{ translate( 'Your staging site is available at {{a}}%(stagingSiteName)s{{/a}}.', {
 						args: {
@@ -128,17 +128,17 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 				<Button primary href={ `/home/${ stagingSiteSlug }` } disabled={ disabled }>
 					<span>{ translate( 'Manage staging site' ) }</span>
 				</Button>
-			</Fragment>
+			</>
 		);
 	};
 
 	const getLoadingStagingSitesPlaceholder = () => {
 		return (
-			<Fragment>
+			<>
 				<FirstPlaceholder />
 				<SecondPlaceholder />
 				<ButtonPlaceholder />
-			</Fragment>
+			</>
 		);
 	};
 
@@ -153,14 +153,14 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 			{ showManageStagingSite && isStagingSiteTransferComplete && getManageStagingSiteContent() }
 			{ isLoadingStagingSites && getLoadingStagingSitesPlaceholder() }
 			{ ( addingStagingSite || ( showManageStagingSite && ! isStagingSiteTransferComplete ) ) && (
-				<Fragment>
+				<>
 					<StyledLoadingBar progress={ progress } />
 					<p>
 						{ __(
 							'Feel free to continue working while we create your staging site. We’ll email you once it is ready.'
 						) }
 					</p>
-				</Fragment>
+				</>
 			) }
 		</Card>
 	);

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -80,7 +80,7 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 
 	const getNewStagingSiteContent = () => {
 		return (
-			<div>
+			<Fragment>
 				<p>
 					{ translate(
 						'A staging site is a test version of your website you can use to preview and troubleshoot changes before applying them to your production site.'
@@ -97,13 +97,13 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 				>
 					<span>{ translate( 'Add staging site' ) }</span>
 				</Button>
-			</div>
+			</Fragment>
 		);
 	};
 
 	const getManageStagingSiteContent = () => {
 		return (
-			<div>
+			<Fragment>
 				<p>
 					{ translate( 'Your staging site is available at {{a}}%(stagingSiteName)s{{/a}}.', {
 						args: {
@@ -117,7 +117,7 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 				<Button primary href={ `/home/${ stagingSiteSlug }` } disabled={ disabled }>
 					<span>{ translate( 'Manage staging site' ) }</span>
 				</Button>
-			</div>
+			</Fragment>
 		);
 	};
 

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -52,7 +52,7 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 	const showManageStagingSite = ! isLoadingStagingSites && stagingSites && stagingSites.length > 0;
 
 	const [ wasCreating, setWasCreating ] = useState( false );
-	const [ progress, setProgress ] = useState( 1 );
+	const [ progress, setProgress ] = useState( 0.3 );
 	const transferStatus = useCheckStagingSiteStatus( stagingSite.id );
 	const isStagingSiteTransferComplete = transferStatus === transferStates.COMPLETE;
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1767
Fixes https://github.com/Automattic/dotcom-forge/issues/1840

## Proposed Changes

Adds a loading placeholder while the component is loading:


https://user-images.githubusercontent.com/36432/222176262-5b775099-60df-4c22-ac3e-7a4766895c11.mp4

Uses a loading bar to indicate progress on creating a staging site:

https://user-images.githubusercontent.com/36432/222176379-95fc1953-287b-44af-b43b-e55840d9af87.mp4

## Testing Instructions

1. Navigate to 'Hosting Configuration'.
2. Verify the loading placeholder displays as expected.
3. Click 'Add staging site'.
4. Verify the loading bar displays as expected.