### PR TITLE
My Home Upsell: Show for yearly plans with different copy

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -24,6 +24,11 @@ const initialState = {
 		domains: {
 			items: [ 'example.wordpress.com' ],
 		},
+		plans: {
+			1: {
+				product_slug: 'free_plan',
+			},
+		},
 	},
 	ui: {
 		selectedSiteId: 1,
@@ -64,7 +69,6 @@ describe( 'index', () => {
 				<DomainUpsell />
 			</Provider>
 		);
-		expect( 1 ).toBe( 1 );
 
 		expect(
 			screen.getByRole( 'heading', { name: 'Own your online identity with a custom domain' } )

--- a/client/my-sites/domains/components/domain-and-plan-package/navigation/index.jsx
+++ b/client/my-sites/domains/components/domain-and-plan-package/navigation/index.jsx
@@ -37,10 +37,12 @@ export default function DomainAndPlanPackageNavigation( props ) {
 					{ translate( 'Select a domain' ) }
 					<Gridicon icon="chevron-right" />
 				</li>
-				<li className={ step === 2 ? 'domain-and-plan-package-navigation__active' : '' }>
-					{ translate( 'Select a plan' ) }
-					<Gridicon icon="chevron-right" />
-				</li>
+				{ ! props.hidePlansPage && (
+					<li className={ step === 2 ? 'domain-and-plan-package-navigation__active' : '' }>
+						{ translate( 'Select a plan' ) }
+						<Gridicon icon="chevron-right" />
+					</li>
+				) }
 				<li>{ translate( 'Complete your purchase' ) }</li>
 			</ol>
 			<div className="domain-and-plan-package-navigation__step-indication">{ stepIndication }</div>

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -309,7 +309,13 @@ class DomainSearch extends Component {
 						<div className="domains__header">
 							{ isDomainAndPlanPackageFlow && (
 								<>
-									<DomainAndPlanPackageNavigation { ...goBackButtonProps } step={ 1 } />
+									<DomainAndPlanPackageNavigation
+										{ ...goBackButtonProps }
+										hidePlansPage={
+											! this.props.isSiteOnFreePlan && ! this.props.isSiteOnMonthlyPlan
+										}
+										step={ 1 }
+									/>
 									<FormattedHeader
 										brandFont
 										headerText={ translate( 'Claim your domain' ) }

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -1,3 +1,4 @@
+import { isFreePlanProduct } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { BackButton } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
@@ -176,15 +177,17 @@ class DomainSearch extends Component {
 			}
 			// Monthly plans don't have free domains
 			const intervalTypePath = this.props.isSiteOnMonthlyPlan ? 'yearly/' : '';
-			page(
-				addQueryArgs(
-					{
-						domainAndPlanPackage: true,
-						domain: this.props.isDomainUpsell ? domain : undefined,
-					},
-					`/plans/${ intervalTypePath }${ this.props.selectedSiteSlug }`
-				)
-			);
+			const nextStepLink =
+				! this.props.isSiteOnFreePlan && ! this.props.isSiteOnMonthlyPlan
+					? `/checkout/${ this.props.selectedSiteSlug }`
+					: addQueryArgs(
+							{
+								domainAndPlanPackage: true,
+								domain: this.props.isDomainUpsell ? domain : undefined,
+							},
+							`/plans/${ intervalTypePath }${ this.props.selectedSiteSlug }`
+					  );
+			page( nextStepLink );
 			return;
 		}
 
@@ -383,6 +386,7 @@ class DomainSearch extends Component {
 
 export default connect(
 	( state ) => {
+		const site = getSelectedSite( state );
 		const siteId = getSelectedSiteId( state );
 
 		return {
@@ -399,6 +403,7 @@ export default connect(
 			isDomainUpsell:
 				!! getCurrentQueryArguments( state )?.domainAndPlanPackage &&
 				!! getCurrentQueryArguments( state )?.domain,
+			isSiteOnFreePlan: isFreePlanProduct( site.plan ),
 		};
 	},
 	{

--- a/test/e2e/specs/domain-upsell/domain-upsell__sidebar.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__sidebar.ts
@@ -65,11 +65,11 @@ describe( DataHelper.createSuiteTitle( 'Sidebar: Domain upsell' ), function () {
 
 	it( 'Search for a domain name', async function () {
 		domainSearchComponent = new DomainSearchComponent( page );
-		await domainSearchComponent.search( blogName + '.live' );
+		await domainSearchComponent.search( blogName + '.com' );
 	} );
 
-	it( 'Choose the .live TLD', async function () {
-		selectedDomain = await domainSearchComponent.selectDomain( '.live' );
+	it( 'Choose the .com TLD', async function () {
+		selectedDomain = await domainSearchComponent.selectDomain( '.com' );
 	} );
 
 	it( 'View available plans', async function () {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/73843

## Proposed Changes

Show My Home Upsell on Yearly plans without a custom domain and with a different copy.

Headline: `You still have a free domain to claim!`
Body: `Own your online identity giving your site a memorable domain name. Your plan includes one for free for one year, so you can still claim it.`
Buy button: `Claim this domain`

To do: Tests

## Testing Instructions

- Use a site with Yearly plan and without a custom domain
- Go to /home
- You should see the Upsell like the screenshot.
- Check the copy
- `Claim this domain` should go to checkout with the domain in cart.
- Clicking on `Search for a domain` should not show step 2 (plans).
- Selecting a domain on the domain search page should go to checkout like `Claim this domain`
- Check the free plans work as before.

## Screenshots
| Upsell | Domains search page |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/402286/222565738-428525b2-79a7-4fea-b4de-665b2b7ff919.png) | ![image](https://user-images.githubusercontent.com/402286/222565969-c0c4bca6-c459-4e08-88fa-8df4a3960bd6.png) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
