### PR TITLE
Hosting Configuration: Add a missing period

### DIFF
--- a/client/my-sites/hosting/cache-card/index.js
+++ b/client/my-sites/hosting/cache-card/index.js
@@ -26,7 +26,7 @@ const CacheCard = ( {
 			<div>
 				<p>
 					{ translate(
-						'Be careful, clearing the cache may make your site unresponsive while it is being rebuilt. {{a}}Learn more about clearing your site’s cache{{/a}}',
+						'Be careful, clearing the cache may make your site unresponsive while it is being rebuilt. {{a}}Learn more about clearing your site’s cache{{/a}}.',
 						{
 							components: {
 								a: <InlineSupportLink supportContext="hosting-clear-cache" showIcon={ false } />,


### PR DESCRIPTION
## Proposed Changes

Adds a missing period to the end of the sentence:

<img width="784" alt="image" src="https://user-images.githubusercontent.com/36432/222190848-cf5ae9dd-1a30-498e-8ecb-24544a4a6bc5.png">

## Testing Instructions

1. Navigate to 'Hosting Configuration' and verify everything appears as expected.