### PR TITLE
My home upsell: Show the upsell to monthly paid plans without a domain

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -55,9 +55,7 @@ export default function DomainUpsell( { context } ) {
 			isP2Site( primarySite ) ||
 			isNotAtomicJetpack( primarySite ) );
 
-	const shouldNotShowMyHomeUpsell =
-		! isProfileUpsell &&
-		( siteDomainsLength || ! isEmailVerified || ( ! isFreePlan && isMonthlyPlan ) );
+	const shouldNotShowMyHomeUpsell = ! isProfileUpsell && ( siteDomainsLength || ! isEmailVerified );
 
 	if ( shouldNotShowProfileUpsell || shouldNotShowMyHomeUpsell ) {
 		return null;

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -67,43 +67,65 @@ function DomainAndPlanUpsellNotice() {
 		/>
 	);
 }
-function DomainUpsellDescription( { planType, yourDomainName, siteSlug } ) {
+function DescriptionMessage( { isDomainUpsell, isFreePlan, yourDomainName, siteSlug } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	// show Warning only on free plans.
+	if ( ! isDomainUpsell ) {
+		return (
+			<>
+				<p>
+					{ translate(
+						'With your annual plan, you’ll get %(domainName)s {{strong}}free for the first year{{/strong}}.',
+						{
+							args: {
+								domainName: yourDomainName,
+							},
+							components: {
+								strong: <strong />,
+							},
+						}
+					) }
+				</p>
+				<p>
+					{ translate(
+						'You’ll also unlock advanced features that make it easy to build and grow your site.'
+					) }
+				</p>
+			</>
+		);
+	}
+
 	const skipPlan = () => {
 		recordTracksEvent( 'calypso_plans_page_domain_upsell_skip_click' );
-		planType === 'free'
+		// show Warning only on free plans.
+		isFreePlan === 'free'
 			? dispatch( WPCOM_PLANS_UI_STORE ).setShowDomainUpsellDialog( true )
 			: page( `/checkout/${ siteSlug }` );
 	};
 
-	const subtitle =
-		planType === 'free'
-			? translate( 'See and compare the features available on each WordPress.com plan' )
-			: translate( 'All of our annual plans include a free domain name for one year.' );
+	const subtitle = isFreePlan
+		? translate( 'See and compare the features available on each WordPress.com plan' )
+		: translate( 'All of our annual plans include a free domain name for one year.' );
 
-	const subtitle2 =
-		planType === 'free'
-			? ''
-			: translate(
-					'Upgrade to a yearly plan and claim {{strong}}%(domainName)s for free{{/strong}}.',
-					{
-						args: {
-							domainName: yourDomainName,
-						},
-						components: {
-							strong: <strong />,
-							br: <br />,
-						},
-					}
-			  );
+	const subtitle2 = isFreePlan
+		? ''
+		: translate(
+				'Upgrade to a yearly plan and claim {{strong}}%(domainName)s for free{{/strong}}.',
+				{
+					args: {
+						domainName: yourDomainName,
+					},
+					components: {
+						strong: <strong />,
+						br: <br />,
+					},
+				}
+		  );
 
-	const skipText =
-		planType === 'free'
-			? translate( 'Or continue with the free plan.' )
-			: translate( 'Or continue with your monthly plan.' );
+	const skipText = isFreePlan
+		? translate( 'Or continue with the free plan.' )
+		: translate( 'Or continue with your monthly plan.' );
 
 	return (
 		<>
@@ -320,28 +342,12 @@ class Plans extends Component {
 
 									<FormattedHeader brandFont headerText={ headline } align="center" />
 
-									{ isDomainUpsell && (
-										<DomainUpsellDescription
-											planType={ isFreePlan ? 'free' : currentPlanIntervalType }
-											yourDomainName={ yourDomainName }
-											siteSlug={ selectedSite.slug }
-										/>
-									) }
-									{ ! isDomainUpsell && (
-										<p>
-											{ translate(
-												'With your annual plan, you’ll get %(domainName)s {{strong}}free for the first year{{/strong}}. You’ll also unlock advanced features that make it easy to build and grow your site.',
-												{
-													args: {
-														domainName: yourDomainName,
-													},
-													components: {
-														strong: <strong />,
-													},
-												}
-											) }
-										</p>
-									) }
+									<DescriptionMessage
+										isFreePlan={ isFreePlan }
+										yourDomainName={ yourDomainName }
+										siteSlug={ selectedSite.slug }
+										isDomainUpsell={ isDomainUpsell }
+									/>
 								</div>
 							</>
 						) }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -99,7 +99,7 @@ function DescriptionMessage( { isDomainUpsell, isFreePlan, yourDomainName, siteS
 	const skipPlan = () => {
 		recordTracksEvent( 'calypso_plans_page_domain_upsell_skip_click' );
 		// show Warning only on free plans.
-		isFreePlan === 'free'
+		isFreePlan
 			? dispatch( WPCOM_PLANS_UI_STORE ).setShowDomainUpsellDialog( true )
 			: page( `/checkout/${ siteSlug }` );
 	};

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -79,17 +79,23 @@ function DomainUpsellDescription( { planType, yourDomainName, siteSlug } ) {
 			: page( `/checkout/${ siteSlug }` );
 	};
 
-	const mainText =
+	const subtitle =
 		planType === 'free'
 			? translate( 'See and compare the features available on each WordPress.com plan' )
+			: translate( 'All of our annual plans include a free domain name for one year.' );
+
+	const subtitle2 =
+		planType === 'free'
+			? ''
 			: translate(
-					'All of our annual plans include a free domain name for one year. Upgrade to a yearly plan and claim {{strong}}%(domainName)s for free{{/strong}}.',
+					'Upgrade to a yearly plan and claim {{strong}}%(domainName)s for free{{/strong}}.',
 					{
 						args: {
 							domainName: yourDomainName,
 						},
 						components: {
 							strong: <strong />,
+							br: <br />,
 						},
 					}
 			  );
@@ -101,11 +107,10 @@ function DomainUpsellDescription( { planType, yourDomainName, siteSlug } ) {
 
 	return (
 		<>
-			<p className="plans__copy-domain-upsell">{ mainText }</p>
+			<p>{ subtitle }</p>
+			{ subtitle2 && <p>{ subtitle2 }</p> }
 			<p>
-				<button className="plans__copy-button" onClick={ skipPlan }>
-					{ skipText }
-				</button>
+				<button onClick={ skipPlan }>{ skipText }</button>
 			</p>
 		</>
 	);

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -54,10 +54,11 @@ body.is-section-plans.is-domain-plan-package-flow {
 			color: var(--color-text-subtle);
 			text-align: center;
 			padding: 0 10px;
-			&.plans__copy-domain-upsell {
-				margin-bottom: 0;
+			margin-bottom: 0;
+			&:last-child {
+				margin-bottom: 1.5em;
 			}
-			button.plans__copy-button {
+			button {
 				font-size: $font-body;
 				text-decoration: underline;
 				cursor: pointer;

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -34,7 +34,8 @@ const selectors = {
 		return `.plan-features__${ viewportSuffix } >> .plan-features__actions-button.is-${ plan.toLowerCase() }-plan:has-text("${ buttonText }")`;
 	},
 	activePlan: ( plan: Plans ) => `a.is-${ plan.toLowerCase() }-plan.is-current-plan:visible`,
-	ContinueWithPlanButton: ( buttonText: string ) => `button:has-text("${ buttonText }")`,
+	ContinueWithPlanButton: ( buttonText: string ) =>
+		`.plans__header button:has-text("${ buttonText }")`,
 	SkipPlanConfirmButton: ( message: string ) => `.dialog__button-label:has-text("${ message }")`,
 
 	// My Plans tab

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -34,7 +34,7 @@ const selectors = {
 		return `.plan-features__${ viewportSuffix } >> .plan-features__actions-button.is-${ plan.toLowerCase() }-plan:has-text("${ buttonText }")`;
 	},
 	activePlan: ( plan: Plans ) => `a.is-${ plan.toLowerCase() }-plan.is-current-plan:visible`,
-	SkipPlanButton: '.plans__copy-button',
+	ContinueWithPlanButton: ( buttonText: string ) => `button:has-text("${ buttonText }")`,
 	SkipPlanConfirmButton: ( message: string ) => `.dialog__button-label:has-text("${ message }")`,
 
 	// My Plans tab
@@ -186,8 +186,8 @@ export class PlansPage {
 	/**
 	 * Click on skip button on the plan page.
 	 */
-	async clickSkipPlanActionButton(): Promise< void > {
-		await this.page.click( selectors.SkipPlanButton );
+	async clickSkipPlanActionButton( buttonText: string ): Promise< void > {
+		await this.page.click( selectors.ContinueWithPlanButton( buttonText ) );
 	}
 
 	/**

--- a/test/e2e/specs/domain-upsell/domain-upsell__my-home.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__my-home.ts
@@ -67,7 +67,7 @@ describe( DataHelper.createSuiteTitle( 'My Home: Domain upsell' ), function () {
 	} );
 
 	it( 'Click button to skip plan', async function () {
-		await plansPage.clickSkipPlanActionButton();
+		await plansPage.clickSkipPlanActionButton( 'Or continue with the free plan.' );
 	} );
 
 	it( 'Continue to checkout without a plan', async function () {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/73841

## Proposed Changes

Show My Home Upsell on Monthly plans without a custom domain.
<img width="700" alt="home domain upsell@2x" src="https://user-images.githubusercontent.com/6586048/222659123-6694b7e3-29f7-45d2-837d-74321adb5eec.png">

![upsell@2x](https://user-images.githubusercontent.com/6586048/222659581-d8b54daa-8943-478b-b637-00f01aeab5b6.png)

| Sidebar Nudge | Domain Upsell + free plan | Domain Upsell + free warning | Domain Upsell + monthly |
| --- | --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/402286/222805542-4426b5b9-eafa-4d6e-b432-aa368bd5838e.png) | ![image](https://user-images.githubusercontent.com/402286/222805557-0b0e3b59-8d47-47df-87a8-50990a8bb746.png) | ![image](https://user-images.githubusercontent.com/402286/222807482-84e72c88-1dac-4252-b9cd-7939abb02f97.png) | ![image](https://user-images.githubusercontent.com/402286/222805569-aa9b14e4-f337-4597-b03e-0a8949e53865.png) |



To do: Tests

## Testing Instructions

- Use a site with Monthly plan and without a custom domain.
- Go to /home
- You should see the Upsell like the screenshot.
- Also check with a Free plan site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
