### PR TITLE
Improve the audience list to divide in different targets

### DIFF
--- a/client/data/promote-post/use-promote-post-campaigns-query.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query.ts
@@ -12,6 +12,7 @@ export const AudienceListKeys = {
 	topics: 'topics',
 	countries: 'countries',
 	devices: 'devices',
+	OSs: 'OSs',
 };
 
 export type AudienceList = {

--- a/client/my-sites/promote-post/components/audience-block/index.tsx
+++ b/client/my-sites/promote-post/components/audience-block/index.tsx
@@ -1,0 +1,26 @@
+import { useTranslate } from 'i18n-calypso';
+import { AudienceList } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
+
+interface Props {
+	audienceList: AudienceList;
+}
+export default function AudienceBlock( { audienceList }: Props ) {
+	const translate = useTranslate();
+
+	const devicesList = audienceList[ 'devices' ] || '';
+	const countriesList = audienceList[ 'countries' ] || '';
+	const topicsList = audienceList[ 'topics' ] || '';
+	const OSsList = audienceList[ 'OSs' ] || '';
+
+	return (
+		<>
+			{ devicesList ? `${ translate( 'Devices' ) }: ${ devicesList }` : '' }
+			<br />
+			{ countriesList ? `${ translate( 'Location' ) }: ${ countriesList }` : '' }
+			<br />
+			{ topicsList ? `${ translate( 'Interests' ) }: ${ topicsList }` : '' }
+			<br />
+			{ OSsList ? `${ translate( 'Operating systems' ) }: ${ OSsList }` : '' }
+		</>
+	);
+}

--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -14,7 +14,6 @@ import resizeImageUrl from 'calypso/lib/resize-image-url';
 import {
 	canCancelCampaign,
 	formatCents,
-	getCampaignAudienceString,
 	getCampaignBudgetData,
 	getCampaignClickthroughRate,
 	getCampaignDurationFormatted,
@@ -26,6 +25,7 @@ import {
 	normalizeCampaignStatus,
 } from 'calypso/my-sites/promote-post/utils';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import AudienceBlock from '../audience-block';
 
 type Props = {
 	campaign: Campaign;
@@ -82,8 +82,6 @@ export default function CampaignItem( { campaign }: Props ) {
 		() => getCampaignEstimatedImpressions( display_delivery_estimate ),
 		[ display_delivery_estimate ]
 	);
-
-	const audience = useMemo( () => getCampaignAudienceString( audience_list ), [ audience_list ] );
 
 	const safeUrl = safeImageUrl( content_config.imageUrl );
 	const adCreativeUrl = safeUrl && resizeImageUrl( safeUrl, { h: 80 }, 0 );
@@ -295,7 +293,7 @@ export default function CampaignItem( { campaign }: Props ) {
 								{ __( 'Audience' ) }
 							</div>
 							<div className="campaign-item__block_value campaign-item__audience-value">
-								{ audience }
+								<AudienceBlock audienceList={ audience_list } />
 							</div>
 						</div>
 					</div>

--- a/client/my-sites/promote-post/utils/index.ts
+++ b/client/my-sites/promote-post/utils/index.ts
@@ -1,10 +1,6 @@
 import { __, sprintf } from '@wordpress/i18n';
 import moment from 'moment';
-import {
-	AudienceList,
-	AudienceListKeys,
-	Campaign,
-} from 'calypso/data/promote-post/use-promote-post-campaigns-query';
+import { Campaign } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
 
 export const campaignStatus = {
 	SCHEDULED: 'scheduled',
@@ -194,19 +190,6 @@ export const getCampaignEstimatedImpressions = ( displayDeliveryEstimate: string
 	}
 	const [ minEstimate, maxEstimate ] = displayDeliveryEstimate.split( ':' );
 	return `${ ( +minEstimate ).toLocaleString() } - ${ ( +maxEstimate ).toLocaleString() }`;
-};
-
-export const getCampaignAudienceString = ( audience_list: AudienceList ) => {
-	if ( ! audience_list ) {
-		return '';
-	}
-	const audience = Object.keys( audience_list )
-		.reduce( ( acc, key ) => {
-			return `${ acc }, ${ audience_list[ key as keyof typeof AudienceListKeys ] }`;
-		}, '' )
-		.substring( 2 );
-
-	return audience;
 };
 
 export const canCancelCampaign = ( status: string ) => {


### PR DESCRIPTION
Related to #

## Proposed Changes

* Improve the audience list to divide text by target category

## Testing Instructions
- Create a campaign with multiple categories and different targets
- The Audience list should be shown separately by target category as shown in the image

![image](https://user-images.githubusercontent.com/43957544/222195879-84c238c7-9cc7-4bc6-8eae-59c90e004b78.png)


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
