### PR TITLE
Plugins: Redirect to /plans when on the commerce trial

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -7,7 +7,9 @@ import { getSiteFragment, sectionify } from 'calypso/lib/route';
 import { navigation } from 'calypso/my-sites/controller';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { fetchSitePlans } from 'calypso/state/sites/plans/actions';
+import { isSiteOnECommerceTrial, getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ALLOWED_CATEGORIES } from './categories/use-categories';
 import PlanSetup from './jetpack-plugins-setup';
 import PluginListComponent from './main';
@@ -135,6 +137,44 @@ export function jetpackCanUpdate( context, next ) {
 			return;
 		}
 	}
+	next();
+}
+
+function waitForState( context ) {
+	return new Promise( ( resolve ) => {
+		const unsubscribe = context.store.subscribe( () => {
+			const state = context.store.getState();
+
+			const siteId = getSelectedSiteId( state );
+			if ( ! siteId ) {
+				return;
+			}
+
+			const currentPlan = getCurrentPlan( state, siteId );
+			if ( ! currentPlan ) {
+				return;
+			}
+			unsubscribe();
+			resolve();
+		} );
+		// Trigger a `store.subscribe()` callback
+		context.store.dispatch( fetchSitePlans( getSelectedSiteId( context.store.getState() ) ) );
+	} );
+}
+
+export async function redirectTrialSites( context, next ) {
+	const { store } = context;
+	// Make sure state is populated with plan info
+	await waitForState( context );
+	const state = store.getState();
+	const selectedSite = getSelectedSite( state );
+
+	// If the site is on an ecommerce trial, redirect to the plans page
+	if ( isSiteOnECommerceTrial( state, selectedSite?.ID ) ) {
+		page.redirect( `/plans/${ selectedSite.slug }` );
+		return false;
+	}
+
 	next();
 }
 

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -31,7 +31,6 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		renderProvisionPlugins,
-		redirectTrialSites,
 		makeLayout,
 		clientRender
 	);
@@ -68,7 +67,6 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		sites,
-		redirectTrialSites,
 		makeLayout,
 		clientRender
 	);
@@ -91,7 +89,6 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigationIfLoggedIn,
-		redirectTrialSites,
 		browsePlugins,
 		makeLayout,
 		clientRender

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -14,6 +14,7 @@ import {
 	renderProvisionPlugins,
 	jetpackCanUpdate,
 	plugins,
+	redirectTrialSites,
 	scrollTopIfNoHash,
 	navigationIfLoggedIn,
 	maybeRedirectLoggedOut,
@@ -30,6 +31,7 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		renderProvisionPlugins,
+		redirectTrialSites,
 		makeLayout,
 		clientRender
 	);
@@ -41,6 +43,7 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		renderProvisionPlugins,
+		redirectTrialSites,
 		makeLayout,
 		clientRender
 	);
@@ -52,6 +55,7 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigationIfLoggedIn,
+		redirectTrialSites,
 		browsePlugins,
 		makeLayout,
 		clientRender
@@ -64,6 +68,7 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		sites,
+		redirectTrialSites,
 		makeLayout,
 		clientRender
 	);
@@ -74,6 +79,7 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
+		redirectTrialSites,
 		upload,
 		makeLayout,
 		clientRender
@@ -85,6 +91,7 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigationIfLoggedIn,
+		redirectTrialSites,
 		browsePlugins,
 		makeLayout,
 		clientRender
@@ -99,6 +106,7 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
+		redirectTrialSites,
 		plans,
 		makeLayout,
 		clientRender
@@ -111,6 +119,7 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
+		redirectTrialSites,
 		plugins,
 		makeLayout,
 		clientRender
@@ -123,6 +132,7 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
+		redirectTrialSites,
 		jetpackCanUpdate,
 		plugins,
 		makeLayout,
@@ -136,6 +146,7 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigationIfLoggedIn,
+		redirectTrialSites,
 		browsePluginsOrPlugin,
 		makeLayout,
 		clientRender
@@ -148,6 +159,7 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
+		redirectTrialSites,
 		renderPluginWarnings,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73753

## Proposed Changes

* Add an async function to wait for plan details to be populated in state before checking the plan
* Add new method for all `/plugins` routes with a site ID/slug provided to check for the commerce trial plan; if found, redirect to `/plans/siteSlug`

**Visual**

https://user-images.githubusercontent.com/2124984/222200504-5f12359e-e590-4022-b77b-d5a64059bf39.mov


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/plugins` and `/plugins/manage` on a site with the ecommerce trial
* Ensure you're redirected to `/plans/siteSlug` each time
* Navigate to `/plugins/siteSlug` on a site with a different plan
* You should be able to see the plugin browser

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
