### PR TITLE
LNB: Set the request for the free domain suggestion to only return one w.link subdomain

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -135,7 +135,7 @@ export function DomainFormControl( {
 
 	const getOtherManagedSubdomainsCountOverride = () => {
 		if ( flow === LINK_IN_BIO_TLD_FLOW ) {
-			return 2;
+			return 1;
 		}
 	};
 


### PR DESCRIPTION
## Proposed Changes

This PR limits the number of suggestions for w.link subdomains (in link.-in-bio-tld flow) to one.

## Testing Instructions

Locally apply the patch and navigate to `/setup/link-in-bio-tld`.

Fill the search field and verified that only one w.link subdomain is displayed (see screenshot)


![Markup on 2023-03-01 at 17:43:16](https://user-images.githubusercontent.com/2797601/222205325-ddc39a76-b7af-450a-8c43-3c90bbe18e40.png)


## Pre-merge Checklist
- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
