### PR TITLE
Hosting Configuration: Enable log access for all users

### DIFF
--- a/client/my-sites/hosting/web-server-logs-card/index.js
+++ b/client/my-sites/hosting/web-server-logs-card/index.js
@@ -242,11 +242,11 @@ const WebServerLogsCard = ( props ) => {
 
 	const logTypes = [
 		{
-			label: translate( 'PHP error' ),
+			label: translate( 'PHP error logs' ),
 			value: 'php',
 		},
 		{
-			label: translate( 'Web request' ),
+			label: translate( 'Web request logs' ),
 			value: 'web',
 		},
 	];

--- a/client/my-sites/hosting/web-server-logs-card/index.js
+++ b/client/my-sites/hosting/web-server-logs-card/index.js
@@ -15,7 +15,6 @@ import MaterialIcon from 'calypso/components/material-icon';
 import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
-import { isAtomicSiteLogAccessEnabled } from 'calypso/state/selectors/is-atomic-site-log-access-enabled';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -213,7 +212,6 @@ const WebServerLogsCard = ( props ) => {
 		siteId,
 		siteSlug,
 		translate,
-		isAtomicSiteLogAccessEnabled: siteLogsEnabled,
 		atomicLogsDownloadStarted: recordDownloadStarted,
 		atomicLogsDownloadCompleted: recordDownloadCompleted,
 		atomicLogsDownloadError: recordDownloadError,
@@ -511,10 +509,6 @@ const WebServerLogsCard = ( props ) => {
 		);
 	};
 
-	if ( ! siteLogsEnabled ) {
-		return null;
-	}
-
 	return (
 		<Card className="web-server-logs-card">
 			<MaterialIcon icon="settings" size={ 32 } />
@@ -538,7 +532,6 @@ export default connect(
 		return {
 			siteId: getSelectedSiteId( state ),
 			siteSlug: getSelectedSiteSlug( state ),
-			isAtomicSiteLogAccessEnabled: isAtomicSiteLogAccessEnabled( state ),
 		};
 	},
 	{

--- a/client/state/selectors/is-atomic-site-log-access-enabled.js
+++ b/client/state/selectors/is-atomic-site-log-access-enabled.js
@@ -1,6 +1,0 @@
-import { currentUserHasFlag } from 'calypso/state/current-user/selectors';
-import { isSupportSession } from 'calypso/state/support/selectors';
-
-export function isAtomicSiteLogAccessEnabled( state ) {
-	return currentUserHasFlag( state, 'calypso_atomic_site_logs' ) || isSupportSession( state );
-}


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/1748

## Proposed Changes

Makes 'Web server logs' available to all users:

<img width="792" alt="image" src="https://user-images.githubusercontent.com/36432/222208440-dcce1c40-e8ad-4aff-ab8a-927496a5e8bf.png">

## Testing Instructions

1. Navigate to 'Hosting Configuration'.
2. Verify you can download web server logs as expected.