### PR TITLE
happy-blocks: Fix filepath keys in translation-manifest

### DIFF
--- a/apps/happy-blocks/bin/build-translations-manifest.js
+++ b/apps/happy-blocks/bin/build-translations-manifest.js
@@ -35,8 +35,7 @@ CHUNKS_MAP_PATHS.map( ( CHUNKS_MAP_PATH ) => {
 				const normalizedRefs = refs
 					.map( ( ref ) => path.relative( ROOT_DIR, ref ) )
 					.filter( ( ref ) => stringRefs.has( ref ) );
-				const key =
-					'block-library/' + pathSegments[ pathSegments.length - 3 ] + '/dist/' + filename;
+				const key = 'block-library/' + pathSegments[ pathSegments.length - 3 ] + '/' + filename;
 				return [ key, normalizedRefs ];
 			} )
 		),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Remove `/dist` sub-directory from translations manifest keys in order to match the file structure from the release files.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Inspect Happy Blocks build artifacts and confirm keys in `translations-manifest.json` match the actual relative file paths in the build files.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
