### PR TITLE
Add new 'Reports' mailing list category to the notifications settings

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -102,6 +102,8 @@ class MainComponent extends Component {
 			return this.props.translate( 'Newsletter' );
 		} else if ( 'promotion' === category ) {
 			return this.props.translate( 'Promotions' );
+		} else if ( 'reports' === category ) {
+			return this.props.translate( 'Reports' );
 		} else if ( 'jetpack_marketing' === category ) {
 			return this.props.translate( 'Jetpack Suggestions' );
 		} else if ( 'jetpack_research' === category ) {
@@ -134,14 +136,16 @@ class MainComponent extends Component {
 				'Information on WordPress.com courses and events (online and in-person).'
 			);
 		} else if ( 'digest' === category ) {
-			return this.props.translate(
-				'Popular content from the blogs you follow, and reports on your own site and its performance.'
-			);
+			return this.props.translate( 'Popular content from the blogs you follow.' );
 		} else if ( 'news' === category ) {
 			return this.props.translate( 'WordPress.com news, announcements, and product spotlights.' );
 		} else if ( 'promotion' === category ) {
 			return this.props.translate(
 				'Sales and promotions for WordPress.com products and services.'
+			);
+		} else if ( 'reports' === category ) {
+			return this.props.translate(
+				'Complimentary reports and updates regarding site performance and traffic.'
 			);
 		} else if ( 'jetpack_marketing' === category ) {
 			return this.props.translate( 'Tips for getting the most out of Jetpack.' );

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -128,7 +128,9 @@ class WPCOMNotifications extends Component {
 					name={ options.reports }
 					isEnabled={ get( settings, options.reports ) }
 					title={ translate( 'Reports' ) }
-					description={ translate( 'Monthly reports on your own site and its performance.' ) }
+					description={ translate(
+						'Complimentary reports and updates regarding site performance and traffic.'
+					) }
 				/>
 
 				{ this.props.hasJetpackSites ? (

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -35,6 +35,7 @@ const options = {
 	promotion: 'promotion',
 	news: 'news',
 	digest: 'digest',
+	reports: 'reports',
 	jetpack_marketing: 'jetpack_marketing',
 	jetpack_research: 'jetpack_research',
 	jetpack_promotion: 'jetpack_promotion',
@@ -120,10 +121,14 @@ class WPCOMNotifications extends Component {
 					name={ options.digest }
 					isEnabled={ get( settings, options.digest ) }
 					title={ translate( 'Digests' ) }
-					description={ translate(
-						'Popular content from the blogs you follow, and reports on ' +
-							'your own site and its performance.'
-					) }
+					description={ translate( 'Popular content from the blogs you follow.' ) }
+				/>
+
+				<EmailCategory
+					name={ options.reports }
+					isEnabled={ get( settings, options.reports ) }
+					title={ translate( 'Reports' ) }
+					description={ translate( 'Monthly reports on your own site and its performance.' ) }
 				/>
 
 				{ this.props.hasJetpackSites ? (


### PR DESCRIPTION
Related to the WPCOM Monthly Stats Email project.

## Proposed Changes
* Add new mailing list category for the WordPress.com monthly reports.

## Testing Instructions

Because the backend patch D101616 is already merged and deployed to production, it is sufficient to:
* Visit http://calypso.localhost:3000/me/notifications/updates and make sure that the new "Reports" category and its description are in place at the end of the WP.com notification settings section, right before the Jetpack one.
<img width="1104" alt="Screenshot 2023-03-01 at 18 07 49" src="https://user-images.githubusercontent.com/24655386/222225396-57bcc6d5-3c36-4f98-9c48-5946bea9e171.png">

* Uncheck the "Reports" category and click "Save Settings". You should see a "Settings saved successfully!" notice.

* Visit [this unsubscribe URL](http://calypso.localhost:3000/mailing-lists/unsubscribe?category=reports&email=codefourcomics%40gmail.com&hmac=a8d509cedfc005f1d5eba544ca207ef3). Confirm that the subscribe and resubscribe actions work, and that the title and description of each message type is correctly displayed.

<img width="1083" alt="Screenshot 2023-03-02 at 15 55 08" src="https://user-images.githubusercontent.com/24655386/222481621-59d497f6-91e4-4154-ab04-4d23625137a6.png">


