### PR TITLE
Sidebar Upsell Flow: Fix styles when already searching a domain

### DIFF
--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -123,6 +123,12 @@ class DomainSearch extends Component {
 		) {
 			document.body.classList.add( 'is-domain-plan-package-flow' );
 		}
+		if (
+			! this.props.isDomainAndPlanPackageFlow &&
+			document.body.classList.contains( 'is-domain-plan-package-flow' )
+		) {
+			document.body.classList.remove( 'is-domain-plan-package-flow' );
+		}
 	}
 
 	componentWillUnmount() {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -117,6 +117,12 @@ class DomainSearch extends Component {
 		if ( prevProps.selectedSiteId !== this.props.selectedSiteId ) {
 			this.checkSiteIsUpgradeable();
 		}
+		if (
+			this.props.isDomainAndPlanPackageFlow &&
+			! document.body.classList.contains( 'is-domain-plan-package-flow' )
+		) {
+			document.body.classList.add( 'is-domain-plan-package-flow' );
+		}
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
## Proposed Changes

When you are on `/domains/add` and click on the sidebar nudge the styles brokes. This fix by adding the flow class on component update if the class is missing

## Testing Instructions

- Go to /domains/manage
- Click to search for a domain
- Click on the sidebar nudge
- The page should look good

