### PR TITLE
Launchpad: Change Back Button Text & URL for Domain Flow

### DIFF
--- a/client/my-sites/domains/components/domain-and-plan-package/navigation/index.jsx
+++ b/client/my-sites/domains/components/domain-and-plan-package/navigation/index.jsx
@@ -1,6 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 
 import './style.scss';
 
@@ -9,7 +8,7 @@ export default function DomainAndPlanPackageNavigation( props ) {
 
 	const goBack = () => {
 		if ( props.goBackLink ) {
-			page( props.goBackLink );
+			window.location.assign( props.goBackLink );
 		} else {
 			window.history.go( -1 );
 		}

--- a/client/my-sites/domains/components/domain-and-plan-package/navigation/index.jsx
+++ b/client/my-sites/domains/components/domain-and-plan-package/navigation/index.jsx
@@ -21,16 +21,15 @@ export default function DomainAndPlanPackageNavigation( props ) {
 		args: { currentStep: step, stepCount: 3 },
 	} );
 
+	const buttonText =
+		props.goBackText || ( props.step !== 1 ? translate( 'Back' ) : translate( 'Home' ) );
+
 	return (
 		<div className="domain-and-plan-package-navigation">
 			<div className="domain-and-plan-package-navigation__back">
 				<Button borderless="true" onClick={ goBack }>
 					<Gridicon icon="chevron-left" />
-					{ props.step !== 1 ? (
-						<span>{ translate( 'Back' ) }</span>
-					) : (
-						<span>{ translate( 'Home' ) }</span>
-					) }
+					<span>{ buttonText }</span>
 				</Button>
 			</div>
 			<ol className="domain-and-plan-package-navigation__steps">

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -247,6 +247,9 @@ class DomainSearch extends Component {
 
 		let content;
 
+		const launchpadScreen = this.props.selectedSite?.options?.launchpad_screen;
+		const siteIntent = this.props.selectedSite?.options?.site_intent;
+
 		if ( ! this.state.domainRegistrationAvailable ) {
 			let maintenanceEndTime = translate( 'shortly', {
 				comment: 'If a specific maintenance end time is unavailable, we will show this instead.',
@@ -269,6 +272,16 @@ class DomainSearch extends Component {
 				/>
 			);
 		} else {
+			const goBackButtonProps =
+				launchpadScreen === 'full'
+					? {
+							goBackText: translate( 'Next Steps' ),
+							goBackLink: `/setup/${ siteIntent }/launchpad?siteSlug=${ selectedSiteSlug }`,
+					  }
+					: {
+							goBackLink: `/home/${ selectedSiteSlug }`,
+					  };
+
 			content = (
 				<span>
 					<div className="domain-search__content">
@@ -286,10 +299,7 @@ class DomainSearch extends Component {
 						<div className="domains__header">
 							{ isDomainAndPlanPackageFlow && (
 								<>
-									<DomainAndPlanPackageNavigation
-										goBackLink={ `/home/${ selectedSiteSlug }` }
-										step={ 1 }
-									/>
+									<DomainAndPlanPackageNavigation { ...goBackButtonProps } step={ 1 } />
 									<FormattedHeader
 										brandFont
 										headerText={ translate( 'Claim your domain' ) }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/73869

### Time Estimate
Test: Short
Review: Short

### Proposed Changes
 Change the Back Button text to "**Next Steps**" and redirect back to Launchpad (when Launchpad is enabled) on the first step of the domain flow

### Testing
1. Checkout this branch
2. Create a new Launchpad site
3. Once you arrive at Launchpad, click the **Choose a domain** task
4. Confirm the back button in the top-left corner says "**Next Steps**" and redirects you back to Launchpad


https://user-images.githubusercontent.com/20927667/222249701-3e0ef8dc-21b4-4e51-8f1e-95185f8aaae9.mov