### PR TITLE
Fetch the TLDs for domain filters from endpoint

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -510,17 +510,15 @@ class RegisterDomainStep extends Component {
 	}
 
 	renderQuickFilters() {
-		const items = [
-			{ key: 'all', text: 'All' },
-			{ key: 'blog', text: '.blog' },
-			{ key: 'com', text: '.com' },
-			{ key: 'news', text: '.news' },
-			{ key: 'email', text: '.email' },
-			{ key: 'info', text: '.info' },
-			{ key: 'help', text: '.help' },
-			{ key: 'press', text: '.press' },
-			{ key: 'report', text: '.report' },
-		];
+		if ( this.state.availableTlds.length === 0 ) {
+			return;
+		}
+
+		const items = this.state.availableTlds.slice( 0, 10 ).map( ( tld ) => {
+			return { key: `${ tld }`, text: `.${ tld }` };
+		} );
+
+		items.unshift( { key: 'all', text: 'All' } );
 
 		const handleClick = ( index ) => {
 			const option = items[ index ].key;


### PR DESCRIPTION
In the new domain search layout for the /domains/add page, we want to have some better TLDs for the filters list below the search input.  We also want to be able to update them based on flow and prepare for some future functionality related to promoted TLDs.

## Testing Instructions

Visit this page and make sure that the TLDs shown in the filter bar area correspond to geo-boosted TLDs, promoted TLDs,  TLDs related to the search term, and other popular TLDs.

Example:

<img width="837" alt="Cursor_and_Domain_Search_‹_Site_Title_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/222255645-9c8a0051-860c-4e5f-ade2-467858ec5421.png">



