### PR TITLE
[Offer jetpack complete]: cleanup and some tests

### DIFF
--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -90,15 +90,10 @@ export const productSelect =
 	};
 
 export function offerJetpackComplete( context: PageJS.Context, next: () => void ): void {
-	const { site, lang } = context.params;
+	const { site } = context.params;
 	const urlQueryArgs: QueryArgs = context.query;
 	context.primary = (
-		<JetpackCompletePage
-			defaultDuration={ TERM_ANNUALLY }
-			urlQueryArgs={ urlQueryArgs }
-			siteSlug={ site || context.query.site }
-			locale={ lang }
-		/>
+		<JetpackCompletePage urlQueryArgs={ urlQueryArgs } siteSlug={ site || context.query.site } />
 	);
 	next();
 }

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
@@ -28,19 +28,11 @@ import PricingPageLink from './view-all-products-link';
 import './style.scss';
 
 interface Props {
-	defaultDuration: Duration;
 	urlQueryArgs?: QueryArgs;
 	siteSlug?: string;
-	locale?: string;
 }
 
-const JetpackCompletePage: React.FC< Props > = ( {
-	// these unused props I think will be needed later for the price componentt and the getCheckoutUrl() functions/buttons
-	defaultDuration,
-	urlQueryArgs,
-	siteSlug,
-	locale,
-} ) => {
+const JetpackCompletePage: React.FC< Props > = ( { urlQueryArgs, siteSlug } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/test/index.js
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/test/index.js
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import JetpackCompletePage from '../index';
+
+jest.mock( 'calypso/state/ui/selectors/get-selected-site-id', () => jest.fn() );
+
+jest.mock( 'calypso/my-sites/plans/jetpack-plans/use-item-price', () =>
+	jest.fn().mockReturnValue( {
+		originalPrice: 10,
+		discountedPrice: 5,
+		discountedPriceDuration: 1,
+		isFetching: false,
+	} )
+);
+
+jest.mock( 'calypso/state/products-list/selectors', () => ( {
+	isProductsListFetching: jest.fn().mockReturnValue( false ),
+} ) );
+
+const renderWithRedux = ( el ) => renderWithProvider( el, {} );
+
+describe( 'jetpack complete page', () => {
+	it( 'page renders without errors with buttons', async () => {
+		renderWithRedux( <JetpackCompletePage /> );
+
+		expect( screen.getByText( 'Get Complete' ) ).toBeTruthy();
+		expect( screen.getByText( 'Start for free' ) ).toBeTruthy();
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
1203759331596262-as-1203759331598530

## Proposed Changes
This PR does some cleanup of unused parameters on the Complete page as well as adds a very simple test to verify that the page renders. We could improve the tests in the future. Also, we might just remove the unit test if we come up with some good e2e tests for Jetpack onboarding flows.

## Testing Instructions
- Download the branch locally
- Run test: `yarn test-client client/my-sites/plans/jetpack-plans/jetpack-complete-page/test/index.js`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?