### PR TITLE
[Offer jetpack complete]: CSS fix CTA buttons breaking to new line (in other languages).

### DIFF
--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -90,15 +90,10 @@ export const productSelect =
 	};
 
 export function offerJetpackComplete( context: PageJS.Context, next: () => void ): void {
-	const { site, lang } = context.params;
+	const { site } = context.params;
 	const urlQueryArgs: QueryArgs = context.query;
 	context.primary = (
-		<JetpackCompletePage
-			defaultDuration={ TERM_ANNUALLY }
-			urlQueryArgs={ urlQueryArgs }
-			siteSlug={ site || context.query.site }
-			locale={ lang }
-		/>
+		<JetpackCompletePage urlQueryArgs={ urlQueryArgs } siteSlug={ site || context.query.site } />
 	);
 	next();
 }

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
@@ -28,19 +28,11 @@ import PricingPageLink from './view-all-products-link';
 import './style.scss';
 
 interface Props {
-	defaultDuration: Duration;
 	urlQueryArgs?: QueryArgs;
 	siteSlug?: string;
-	locale?: string;
 }
 
-const JetpackCompletePage: React.FC< Props > = ( {
-	// these unused props I think will be needed later for the price componentt and the getCheckoutUrl() functions/buttons
-	defaultDuration,
-	urlQueryArgs,
-	siteSlug,
-	locale,
-} ) => {
+const JetpackCompletePage: React.FC< Props > = ( { urlQueryArgs, siteSlug } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/test/index.js
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/test/index.js
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import JetpackCompletePage from '../index';
+
+jest.mock( 'calypso/state/ui/selectors/get-selected-site-id', () => jest.fn() );
+
+jest.mock( 'calypso/my-sites/plans/jetpack-plans/use-item-price', () =>
+	jest.fn().mockReturnValue( {
+		originalPrice: 10,
+		discountedPrice: 5,
+		discountedPriceDuration: 1,
+		isFetching: false,
+	} )
+);
+
+jest.mock( 'calypso/state/products-list/selectors', () => ( {
+	isProductsListFetching: jest.fn().mockReturnValue( false ),
+} ) );
+
+const renderWithRedux = ( el ) => renderWithProvider( el, {} );
+
+describe( 'jetpack complete page', () => {
+	it( 'page renders without errors with buttons', async () => {
+		renderWithRedux( <JetpackCompletePage /> );
+
+		expect( screen.getByText( 'Get Complete' ) ).toBeTruthy();
+		expect( screen.getByText( 'Start for free' ) ).toBeTruthy();
+	} );
+} );


### PR DESCRIPTION
This PR is just a small CSS fix to the CTA buttons. In other languages where the button content can be longer, the fixed width buttons un-necessarily force the text content to break to a new line. This PR fixes this to allow buttons text content to have varying width without breaking to a new line. (See screenshots):

## Screenshots

**BEFORE**
![Markup 2023-03-01 at 16 32 21](https://user-images.githubusercontent.com/11078128/222272388-3a062a79-4240-4dff-8a92-5eb8e6c45881.png)

.
**AFTER**
![Markup 2023-03-01 at 16 31 20](https://user-images.githubusercontent.com/11078128/222272434-bfe39a72-560a-419d-91f2-e142f0d931d3.png)


## Testing Instructions

* boot up this PR 
    * Run `git fetch && git checkout fix/complete-page-css-buttons-width`
    * Run `yarn start`
* OR use the Live Link provided below
* Go to https://wordpress.com/me/account
* Change your "Interface Language" to Spanish (I'm sure many other languages produce this behavior also).
* Create a new JN site (or use a site (with Jetpack Free (No owned products or plans))
* Navigate to `calypso.localhost:3000/jetpack/connect/plans/complete/[JN Site]`.  If using the Live Link, please append `?flags=jetpack/offer-complete-after-activation` to the url.
* Verify the bottom CTA buttons text content does not break onto a new line (Like shown in "Before" screenshot)
* View the page in production (`calypso.localhost:3000/jetpack/connect/plans/complete/[JN Site]`) to see the regression (how the button(s) was breaking to a new line).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
