### PR TITLE
[Offer jetpack complete]: CSS fix CTA buttons breaking to new line (in other languages)

### DIFF
--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/components/cta-buttons/style.scss
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/components/cta-buttons/style.scss
@@ -11,9 +11,9 @@
 		border: 1px solid;
 		border-radius: 4px;
 		font-weight: 600;
-		width: 276px;
+		min-width: 276px;
 		@include breakpoint-deprecated( ">960px" ) {
-			width: 164px;
+			min-width: 164px;
 		}
 	}
 	.jetpack-complete-page__get-complete-button {


### PR DESCRIPTION
This PR is just a small CSS fix to the CTA buttons. In other languages where the button content can be longer, the fixed width buttons un-necessarily force the text content to break to a new line. This PR fixes this to allow buttons text content to have varying width without breaking to a new line. (See screenshots):

## Screenshots

**BEFORE**

![Markup 2023-03-01 at 16 32 21](https://user-images.githubusercontent.com/11078128/222272388-3a062a79-4240-4dff-8a92-5eb8e6c45881.png)

<hr/>
.

**AFTER**

![Markup 2023-03-01 at 16 31 20](https://user-images.githubusercontent.com/11078128/222272434-bfe39a72-560a-419d-91f2-e142f0d931d3.png)


## Testing Instructions
* First go to https://wordpress.com/me/account
* Change your "Interface Language" to Spanish (I'm sure many other languages produce this behavior also).
* boot up this PR 
    * Run `git fetch && git checkout fix/complete-page-css-buttons-width-2`
    * Run `yarn start`
* **OR** use the Calypso Live (direct link) provided below
* Create a new JN site (or use a site you have connected (with Jetpack Free (No owned products or plans))
* Navigate to `calypso.localhost:3000/jetpack/connect/plans/complete/[JN Site]`.  Or if using the Live Link, add `/jetpack/connect/plans/complete/[JN Site]` to the container hostname (ie.- `https://mycontainer.calypso.live`) and also append `?flags=jetpack/offer-complete-after-activation` to the url.
* Verify the bottom CTA buttons text content does not break onto a new line (Like shown in "Before" screenshot)
* Verify the buttons look fine (the same) in mobile view.
* To see the regression (how the button(s) was breaking to a new line, like in "Before" screenshot), view the page in production (`https://wordpress.com/jetpack/connect/plans/complete/[JN Site]`) .

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204092339261872