### PR TITLE
GitHub Integration: Translate description and proper casing

### DIFF
--- a/client/my-sites/hosting/github/github-authorize-card/index.tsx
+++ b/client/my-sites/hosting/github/github-authorize-card/index.tsx
@@ -58,7 +58,7 @@ export const GithubAuthorizeCard = () => {
 				disabled={ ! github || isAuthorizing }
 				onClick={ () => authorize( github.connect_URL ) }
 			>
-				{ translate( 'Authorize access to Github' ) }
+				{ translate( 'Authorize access to GitHub' ) }
 			</Button>
 		</Card>
 	);

--- a/client/my-sites/hosting/github/github-connect-card/index.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/index.tsx
@@ -121,7 +121,9 @@ export const GithubConnectCard = ( { connection }: GithubConnectCardProps ) => {
 				</div>
 
 				<FormSettingExplanation>
-					Don't see a specific repo? Try re-authorizing with Github as a different organization.
+					{ __(
+						"Don't see a specific repo? Try re-authorizing with GitHub as a different organization."
+					) }
 				</FormSettingExplanation>
 			</div>
 			<div className={ classNames( 'connect-branch__buttons' ) }>


### PR DESCRIPTION
## Proposed Changes

Runs the description through `__()` and properly cases 'GitHub'

<img width="803" alt="image" src="https://user-images.githubusercontent.com/36432/222286349-5244b883-434a-4898-865c-66ec9eac59a0.png">
