### PR TITLE
GitHub Integration: Tweak copy in notices

### DIFF
--- a/client/my-sites/hosting/github/deployment-card/index.tsx
+++ b/client/my-sites/hosting/github/deployment-card/index.tsx
@@ -35,9 +35,7 @@ export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardPr
 		connectionId,
 		{
 			onSuccess: () => {
-				dispatch(
-					successNotice( translate( 'Disconnected from repository successfully' ), noticeOptions )
-				);
+				dispatch( successNotice( translate( 'Repository disconnected.' ), noticeOptions ) );
 			},
 			onError: ( error ) => {
 				dispatch(
@@ -100,7 +98,7 @@ export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardPr
 					disconnectRepo( siteId );
 				} }
 			>
-				<span>{ translate( 'Disconnect repository' ) }</span>
+				<span>{ translate( 'Disconnect from repository' ) }</span>
 			</Button>
 		</Card>
 	);

--- a/client/my-sites/hosting/github/deployment-card/index.tsx
+++ b/client/my-sites/hosting/github/deployment-card/index.tsx
@@ -98,7 +98,7 @@ export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardPr
 					disconnectRepo( siteId );
 				} }
 			>
-				<span>{ translate( 'Disconnect from repository' ) }</span>
+				<span>{ translate( 'Disconnect repository' ) }</span>
 			</Button>
 		</Card>
 	);

--- a/client/my-sites/hosting/github/github-connect-card/index.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/index.tsx
@@ -35,7 +35,7 @@ export const GithubConnectCard = ( { connection }: GithubConnectCardProps ) => {
 
 	const { connectBranch, isLoading: isConnecting } = useGithubConnectMutation( siteId, {
 		onSuccess: () => {
-			dispatch( successNotice( __( 'Branch connected.' ), noticeOptions ) );
+			dispatch( successNotice( __( 'Repository connected.' ), noticeOptions ) );
 		},
 		onError: ( error ) => {
 			dispatch(

--- a/client/my-sites/hosting/github/github-connect-card/index.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/index.tsx
@@ -35,7 +35,7 @@ export const GithubConnectCard = ( { connection }: GithubConnectCardProps ) => {
 
 	const { connectBranch, isLoading: isConnecting } = useGithubConnectMutation( siteId, {
 		onSuccess: () => {
-			dispatch( successNotice( __( 'Branch connected successfully' ), noticeOptions ) );
+			dispatch( successNotice( __( 'Branch connected.' ), noticeOptions ) );
 		},
 		onError: ( error ) => {
 			dispatch(


### PR DESCRIPTION
## Proposed Changes

Uses `<noun> <verb-past-tense>.` for notices (for consistency with WordPress core):

<img width="723" alt="image" src="https://user-images.githubusercontent.com/36432/222290487-34ec6d17-54a1-451f-b6ec-07662423b746.png">

<img width="648" alt="image" src="https://user-images.githubusercontent.com/36432/222290161-9bcf9023-cf5d-4411-b3ec-a39200a0631c.png">
