### PR TITLE
GitHub Integration: Add a skeleton screen loading placeholder

### DIFF
--- a/client/my-sites/hosting/github/github-placeholder-card/index.tsx
+++ b/client/my-sites/hosting/github/github-placeholder-card/index.tsx
@@ -1,13 +1,48 @@
-import { Card, Spinner } from '@automattic/components';
+import { Card, LoadingPlaceholder } from '@automattic/components';
+import styled from '@emotion/styled';
 import { GitHubCardHeading } from '../github-card-heading';
 
 import '../style.scss';
+
+const FirstPlaceholder = styled( LoadingPlaceholder )( {
+	height: 24,
+	width: '85%',
+	marginBottom: '1.25em',
+} );
+const SecondPlaceholder = styled( LoadingPlaceholder )( {
+	height: 16,
+	width: '50px',
+	marginBottom: '.25em',
+} );
+const PlaceholderContainer = styled.div( {
+	display: 'flex',
+	gap: '10px',
+	marginBottom: '1.5em',
+} );
+const ThirdPlaceholder = styled( LoadingPlaceholder )( {
+	height: 24,
+	width: '120px',
+} );
+const FourthPlaceholder = styled( LoadingPlaceholder )( {
+	height: 24,
+	width: '100px',
+} );
+const ButtonPlaceholder = styled( LoadingPlaceholder )( {
+	width: '148px',
+	height: '40px',
+} );
 
 export const GitHubPlaceholderCard = () => {
 	return (
 		<Card className="github-hosting-card">
 			<GitHubCardHeading />
-			<Spinner />
+			<FirstPlaceholder />
+			<SecondPlaceholder />
+			<PlaceholderContainer>
+				<ThirdPlaceholder />
+				<FourthPlaceholder />
+			</PlaceholderContainer>
+			<ButtonPlaceholder />
 		</Card>
 	);
 };


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/1879

## Proposed Changes

Switches `<GitHubPlaceholderCard>` to use a skeleton screen loading placeholder. I tried to match the three versions of the module as much as possible.

https://user-images.githubusercontent.com/36432/222293558-9c22d60c-ccea-4224-80c9-0db466894c50.mp4

## Testing Instructions

1. Navigate to 'Hosting Configuration'
2. Verify the skeleton screen appears as expected.