### PR TITLE
Stepper: Refactor query param handling for some flows

### DIFF
--- a/client/landing/stepper/declarative-flow/build.ts
+++ b/client/landing/stepper/declarative-flow/build.ts
@@ -1,5 +1,6 @@
 import { useFlowProgress, BUILD_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
 import { useSiteSlug } from '../hooks/use-site-slug';
@@ -47,7 +48,10 @@ const build: Flow = {
 				case 'processing':
 					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
 						return window.location.replace(
-							`/home/${ providedDependencies?.siteSlug }?celebrateLaunch=true&launchpadComplete=true`
+							addQueryArgs( `/home/${ providedDependencies?.siteSlug }`, {
+								celebrateLaunch: true,
+								launchpadComplete: true,
+							} )
 						);
 					}
 

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -1,6 +1,7 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, FREE_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import wpcom from 'calypso/lib/wp';
@@ -78,7 +79,10 @@ const free: Flow = {
 				case 'processing':
 					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
 						return window.location.replace(
-							`/home/${ providedDependencies?.siteSlug }?celebrateLaunch=true&launchpadComplete=true`
+							addQueryArgs( `/home/${ providedDependencies?.siteSlug }`, {
+								celebrateLaunch: true,
+								launchpadComplete: true,
+							} )
 						);
 					}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -54,7 +54,9 @@ export function getEnhancedTasks(
 	// send user to Home page editor, fallback to FSE if page id is not known
 	const launchpadUploadVideoLink = homePageId
 		? `/page/${ siteSlug }/${ homePageId }`
-		: `/site-editor/${ siteSlug }?canvas=edit`;
+		: addQueryArgs( `/site-editor/${ siteSlug }`, {
+				canvas: 'edit',
+		  } );
 
 	let planWarningText = displayGlobalStylesWarning
 		? translate(
@@ -88,7 +90,9 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								`/setup/free-post-setup/freePostSetup?siteSlug=${ siteSlug }`
+								addQueryArgs( `/setup/free-post-setup/freePostSetup`, {
+									siteSlug,
+								} )
 							);
 						},
 					};
@@ -99,7 +103,9 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								`/setup/newsletter-post-setup/newsletterPostSetup?siteSlug=${ siteSlug }`
+								addQueryArgs( `/setup/newsletter-post-setup/newsletterPostSetup`, {
+									siteSlug,
+								} )
 							);
 						},
 					};
@@ -115,7 +121,11 @@ export function getEnhancedTasks(
 						completed: siteEditCompleted,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, siteEditCompleted, task.id );
-							window.location.assign( `/site-editor/${ siteSlug }?canvas=edit` );
+							window.location.assign(
+								addQueryArgs( `/site-editor/${ siteSlug }`, {
+									canvas: 'edit',
+								} )
+							);
 						},
 					};
 					break;
@@ -173,7 +183,10 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								`/setup/update-design/designSetup?siteSlug=${ siteSlug }&flowToReturnTo=${ flow }`
+								addQueryArgs( `/setup/update-design/designSetup`, {
+									siteSlug,
+									flowToReturnTo: flow,
+								} )
 							);
 						},
 					};
@@ -184,7 +197,9 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								`/setup/link-in-bio-post-setup/linkInBioPostSetup?siteSlug=${ siteSlug }`
+								addQueryArgs( `/setup/link-in-bio-post-setup/linkInBioPostSetup`, {
+									siteSlug,
+								} )
 							);
 						},
 					};
@@ -195,7 +210,11 @@ export function getEnhancedTasks(
 						completed: linkInBioLinksEditCompleted,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, linkInBioLinksEditCompleted, task.id );
-							window.location.assign( `/site-editor/${ siteSlug }?canvas=edit` );
+							window.location.assign(
+								addQueryArgs( `/site-editor/${ siteSlug }`, {
+									canvas: 'edit',
+								} )
+							);
 						},
 					};
 					break;
@@ -285,7 +304,11 @@ export function getEnhancedTasks(
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );
-									window.location.replace( `/home/${ siteSlug }?forceLoadLaunchpadData=true` );
+									window.location.replace(
+										addQueryArgs( `/home/${ siteSlug }`, {
+											forceLoadLaunchpadData: true,
+										} )
+									);
 								} );
 
 								submit?.();
@@ -301,7 +324,9 @@ export function getEnhancedTasks(
 							recordTaskClickTracksEvent( flow, isPaidPlan, task.id );
 							const destinationUrl = isPaidPlan
 								? `/domains/manage/${ siteSlug }`
-								: `/domains/add/${ siteSlug }?domainAndPlanPackage=true`;
+								: addQueryArgs( `/domains/add/${ siteSlug }`, {
+										domainAndPlanPackage: true,
+								  } );
 							window.location.assign( destinationUrl );
 						},
 						badgeText: isPaidPlan ? '' : translate( 'Upgrade plan' ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -54,9 +54,7 @@ export function getEnhancedTasks(
 	// send user to Home page editor, fallback to FSE if page id is not known
 	const launchpadUploadVideoLink = homePageId
 		? `/page/${ siteSlug }/${ homePageId }`
-		: addQueryArgs( `/site-editor/${ siteSlug }`, {
-				canvas: 'edit',
-		  } );
+		: `/site-editor/${ siteSlug }?canvas=edit`;
 
 	let planWarningText = displayGlobalStylesWarning
 		? translate(
@@ -90,9 +88,7 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								addQueryArgs( `/setup/free-post-setup/freePostSetup`, {
-									siteSlug,
-								} )
+								`/setup/free-post-setup/freePostSetup?siteSlug=${ siteSlug }`
 							);
 						},
 					};
@@ -103,9 +99,7 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								addQueryArgs( `/setup/newsletter-post-setup/newsletterPostSetup`, {
-									siteSlug,
-								} )
+								`/setup/newsletter-post-setup/newsletterPostSetup?siteSlug=${ siteSlug }`
 							);
 						},
 					};
@@ -121,11 +115,7 @@ export function getEnhancedTasks(
 						completed: siteEditCompleted,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, siteEditCompleted, task.id );
-							window.location.assign(
-								addQueryArgs( `/site-editor/${ siteSlug }`, {
-									canvas: 'edit',
-								} )
-							);
+							window.location.assign( `/site-editor/${ siteSlug }?canvas=edit` );
 						},
 					};
 					break;
@@ -183,10 +173,7 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								addQueryArgs( `/setup/update-design/designSetup`, {
-									siteSlug,
-									flowToReturnTo: flow,
-								} )
+								`/setup/update-design/designSetup?siteSlug=${ siteSlug }&flowToReturnTo=${ flow }`
 							);
 						},
 					};
@@ -197,9 +184,7 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								addQueryArgs( `/setup/link-in-bio-post-setup/linkInBioPostSetup`, {
-									siteSlug,
-								} )
+								`/setup/link-in-bio-post-setup/linkInBioPostSetup?siteSlug=${ siteSlug }`
 							);
 						},
 					};
@@ -210,11 +195,7 @@ export function getEnhancedTasks(
 						completed: linkInBioLinksEditCompleted,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, linkInBioLinksEditCompleted, task.id );
-							window.location.assign(
-								addQueryArgs( `/site-editor/${ siteSlug }`, {
-									canvas: 'edit',
-								} )
-							);
+							window.location.assign( `/site-editor/${ siteSlug }?canvas=edit` );
 						},
 					};
 					break;
@@ -304,11 +285,7 @@ export function getEnhancedTasks(
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );
-									window.location.replace(
-										addQueryArgs( `/home/${ siteSlug }`, {
-											forceLoadLaunchpadData: true,
-										} )
-									);
+									window.location.replace( `/home/${ siteSlug }?forceLoadLaunchpadData=true` );
 								} );
 
 								submit?.();
@@ -324,9 +301,7 @@ export function getEnhancedTasks(
 							recordTaskClickTracksEvent( flow, isPaidPlan, task.id );
 							const destinationUrl = isPaidPlan
 								? `/domains/manage/${ siteSlug }`
-								: addQueryArgs( `/domains/add/${ siteSlug }`, {
-										domainAndPlanPackage: true,
-								  } );
+								: `/domains/add/${ siteSlug }?domainAndPlanPackage=true`;
 							window.location.assign( destinationUrl );
 						},
 						badgeText: isPaidPlan ? '' : translate( 'Upgrade plan' ),

--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -1,6 +1,7 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
 import {
@@ -93,7 +94,10 @@ const linkInBio: Flow = {
 				case 'processing':
 					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
 						return window.location.replace(
-							`/home/${ providedDependencies?.siteSlug }?celebrateLaunch=true&launchpadComplete=true`
+							addQueryArgs( `/home/${ providedDependencies?.siteSlug }`, {
+								celebrateLaunch: true,
+								launchpadComplete: true,
+							} )
 						);
 					}
 					if ( providedDependencies?.goToCheckout ) {

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -1,6 +1,7 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
 import {
@@ -97,7 +98,10 @@ const linkInBio: Flow = {
 				case 'processing':
 					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
 						return window.location.replace(
-							`/home/${ providedDependencies?.siteSlug }?celebrateLaunch=true&launchpadComplete=true`
+							addQueryArgs( `/home/${ providedDependencies?.siteSlug }`, {
+								celebrateLaunch: true,
+								launchpadComplete: true,
+							} )
 						);
 					}
 

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -1,6 +1,7 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, WRITE_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
 import { useSiteSlug } from '../hooks/use-site-slug';
@@ -53,7 +54,10 @@ const write: Flow = {
 				case 'processing':
 					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
 						return window.location.replace(
-							`/home/${ providedDependencies?.siteSlug }?celebrateLaunch=true&launchpadComplete=true`
+							addQueryArgs( `/home/${ providedDependencies?.siteSlug }`, {
+								celebrateLaunch: true,
+								launchpadComplete: true,
+							} )
 						);
 					}
 


### PR DESCRIPTION
Issue: https://github.com/Automattic/wp-calypso/issues/73341
Related PRs: https://github.com/Automattic/wp-calypso/pull/74006 and https://github.com/Automattic/wp-calypso/pull/74020

### Proposed Changes
Improve handling of query params by setting query params in stepper flow files by using `addQueryArgs`.

### Testing

**Review: Short**
**Testing: Short to Medium** (simple, but touches many flows)

1. **Free Flow**. Start a free site at http://calypso.localhost:3000/setup/free/intro. Go through to Launchpad, then launch site. Confirm that you see celebration modal, and confirm Launchpad screen is off (go to My Home and confirm you are not redirected. 

2. **Build Flow**. Start a build site at http://calypso.localhost:3000/start. Choose 'Promote' option on Goals page. Go through to Launchpad, then launch site. Confirm that you see celebration modal, and confirm Launchpad screen is off (go to My Home and confirm you are not redirected. 

3. **Write Flow**. Start a build site at http://calypso.localhost:3000/start. Choose 'Write' option on Goals page. Go through to Launchpad, then launch site. Confirm that you see celebration modal, and confirm Launchpad screen is off (go to My Home and confirm you are not redirected. 

4. **Link in Bio**. Start a LIB site at http://calypso.localhost:3000/setup/link-in-bio/intro. Go through to Launchpad, then launch site. Confirm that you see celebration modal, and confirm Launchpad screen is off (go to My Home and confirm you are not redirected. 

