### PR TITLE
Fix happy-blocks translations

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/edit.tsx
+++ b/apps/happy-blocks/block-library/pricing-plans/edit.tsx
@@ -2,6 +2,7 @@ import { useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useEffect } from '@wordpress/element';
 import { FunctionComponent } from 'react';
+import useI18nCalypsoTranslations from '../shared/use-i18n-calypso-translations';
 import BlockSettings from './components/block-settings';
 import PricingPlans from './components/pricing-plans';
 import Skeleton from './components/skeleton';
@@ -13,6 +14,7 @@ export const Edit: FunctionComponent< BlockEditProps< BlockAttributes > > = ( {
 	setAttributes,
 } ) => {
 	const { data: plans, isLoading } = usePricingPlans();
+	useI18nCalypsoTranslations();
 	// Set default values for attributes which are required when rendering the block
 	// See https://github.com/WordPress/gutenberg/issues/7342
 	useEffect( () => {

--- a/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
+++ b/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
@@ -1,7 +1,8 @@
 import { calculateMonthlyPriceForPlan, getPlan, Plan } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { useEffect, useState } from '@wordpress/element';
-import { sprintf, __ } from '@wordpress/i18n';
+import { sprintf, __, getLocaleData } from '@wordpress/i18n';
+import i18n from 'i18n-calypso';
 import config from '../config';
 import { ApiPricingPlan } from '../types.js';
 
@@ -61,6 +62,7 @@ const usePricingPlans = () => {
 				const response = await fetch( PLANS_API_URL );
 				const data = await response.json();
 				setPlans( parsePlans( data ) );
+				i18n.addTranslations( getLocaleData( 'happy-blocks' ) );
 			} catch ( e: unknown ) {
 				setError( e );
 			} finally {

--- a/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
+++ b/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
@@ -1,8 +1,7 @@
 import { calculateMonthlyPriceForPlan, getPlan, Plan } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { useEffect, useState } from '@wordpress/element';
-import { sprintf, __, getLocaleData } from '@wordpress/i18n';
-import i18n from 'i18n-calypso';
+import { sprintf, __ } from '@wordpress/i18n';
 import config from '../config';
 import { ApiPricingPlan } from '../types.js';
 
@@ -62,7 +61,6 @@ const usePricingPlans = () => {
 				const response = await fetch( PLANS_API_URL );
 				const data = await response.json();
 				setPlans( parsePlans( data ) );
-				i18n.addTranslations( getLocaleData( 'happy-blocks' ) );
 			} catch ( e: unknown ) {
 				setError( e );
 			} finally {

--- a/apps/happy-blocks/block-library/pricing-plans/index.php
+++ b/apps/happy-blocks/block-library/pricing-plans/index.php
@@ -91,8 +91,10 @@ HTML;
  */
 function happyblocks_pricing_plans_normalize_translations_relative_path( $relative, $src ) {
 	// Rewrite our CDN path to a relative path to calculate the right filename.
-	if ( preg_match( '#https?://s[0123]\.wp\.com/wp-content/a8c-plugins/happy-blocks/(block-library.*\.js)#', $src, $m ) ) {
-		return $m[1];
+	if ( preg_match( '#https?://s[0123]\.wp\.com/wp-content/a8c-plugins/happy-blocks/(.*\.js)#', $src, $m ) ) {
+		// Fix the path to support `yarn dev --sync`.
+		$relative = str_replace( 'build/', '', $m[1] );
+		return $relative;
 	}
 	return $relative;
 }
@@ -111,10 +113,9 @@ function happyblocks_pricing_plans_normalize_translations_filepath( $file, $hand
 	}
 	// Fix the filepath to use the correct location for the translation file.
 	if ( 'happy-blocks' === $domain ) {
-		$languages_path = '/home/wpcom/public_html/wp-content/languages/';
-		$old_path       = $languages_path . 'happy-blocks';
-		$new_path       = $languages_path . 'a8c-plugins/happy-blocks';
-		$file           = str_replace( $old_path, $new_path, $file );
+		$old_path = WP_LANG_DIR . 'happy-blocks';
+		$new_path = WP_LANG_DIR . 'a8c-plugins/happy-blocks';
+		$file     = str_replace( $old_path, $new_path, $file );
 	}
 	return $file;
 }

--- a/apps/happy-blocks/block-library/pricing-plans/index.php
+++ b/apps/happy-blocks/block-library/pricing-plans/index.php
@@ -82,6 +82,45 @@ HTML;
 }
 
 /**
+ * Return the correct asset relative path to determine the translation file name,
+ * when loading the translation files from wp.com CDN.
+ *
+ * @param string|false $relative The relative path of the script. False if it could not be determined.
+ * @param string       $src      The full source URL of the script.
+ * @return string|false          The new relative path
+ */
+function happyblocks_pricing_plans_normalize_translations_relative_path( $relative, $src ) {
+	// Rewrite our CDN path to a relative path to calculate the right filename.
+	if ( preg_match( '#https?://s[0123]\.wp\.com/wp-content/a8c-plugins/happy-blocks/(block-library.*\.js)#', $src, $m ) ) {
+		return $m[1];
+	}
+	return $relative;
+}
+add_filter( 'load_script_textdomain_relative_path', 'happyblocks_pricing_plans_normalize_translations_relative_path', 10, 2 );
+
+/**
+ * Adjust the file path for loading script translations to match the files structure on WordPress.com
+ *
+ * @param string|false $file   Path to the translation file to load. False if there isn't one.
+ * @param string       $handle Name of the script to register a translation domain to.
+ * @param string       $domain The text domain.
+ */
+function happyblocks_pricing_plans_normalize_translations_filepath( $file, $handle, $domain ) {
+	if ( ! $file ) {
+		return $file;
+	}
+	// Fix the filepath to use the correct location for the translation file.
+	if ( 'happy-blocks' === $domain ) {
+		$languages_path = '/home/wpcom/public_html/wp-content/languages/';
+		$old_path       = $languages_path . 'happy-blocks';
+		$new_path       = $languages_path . 'a8c-plugins/happy-blocks';
+		$file           = str_replace( $old_path, $new_path, $file );
+	}
+	return $file;
+}
+add_filter( 'load_script_translation_file', 'happyblocks_pricing_plans_normalize_translations_filepath', 10, 3 );
+
+/**
  * Register happy-blocks.
  */
 function happyblocks_pricing_plan_register() {

--- a/apps/happy-blocks/block-library/pricing-plans/view.tsx
+++ b/apps/happy-blocks/block-library/pricing-plans/view.tsx
@@ -1,6 +1,7 @@
 import './view.scss';
 import domReady from '@wordpress/dom-ready';
 import { useState, render } from '@wordpress/element';
+import useI18nCalypsoTranslations from '../shared/use-i18n-calypso-translations';
 import PricingPlans from './components/pricing-plans';
 import Skeleton from './components/skeleton';
 import usePricingPlans from './hooks/pricing-plans';
@@ -12,6 +13,7 @@ const ViewPricingPlans = ( { attributes }: { attributes: BlockAttributes } ) => 
 	const setAttributes = ( newValues: Partial< BlockAttributes > ) => {
 		setDummyAttributes( ( values: BlockAttributes ) => ( { ...values, ...newValues } ) );
 	};
+	useI18nCalypsoTranslations();
 
 	if ( isLoading || ! plans?.length ) {
 		return <Skeleton />;

--- a/apps/happy-blocks/block-library/shared/use-i18n-calypso-translations.ts
+++ b/apps/happy-blocks/block-library/shared/use-i18n-calypso-translations.ts
@@ -1,0 +1,13 @@
+import { getLocaleData } from '@wordpress/i18n';
+import { addTranslations } from 'i18n-calypso';
+import { useEffect } from 'react';
+
+/**
+ * Load translation data from @wordpress/i18n into i18n-calypso, in order to
+ * provide translations to external components that use the latter library.
+ */
+export default function useI18nCalypsoTranslations() {
+	useEffect( () => {
+		addTranslations( getLocaleData( 'happy-blocks' ) );
+	}, [] );
+}

--- a/apps/happy-blocks/block-library/universal-footer/edit.tsx
+++ b/apps/happy-blocks/block-library/universal-footer/edit.tsx
@@ -1,7 +1,9 @@
 import { UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
+import useI18nCalypsoTranslations from '../shared/use-i18n-calypso-translations';
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 function noop() {}
 
 export default function Edit() {
+	useI18nCalypsoTranslations();
 	return <UniversalNavbarFooter currentRoute="/" isLoggedIn onLanguageChange={ noop } />;
 }

--- a/apps/happy-blocks/block-library/universal-footer/view.tsx
+++ b/apps/happy-blocks/block-library/universal-footer/view.tsx
@@ -2,20 +2,25 @@ import { LocaleProvider } from '@automattic/i18n-utils';
 import { UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
 import domReady from '@wordpress/dom-ready';
 import { render } from '@wordpress/element';
+import useI18nCalypsoTranslations from '../shared/use-i18n-calypso-translations';
 
-domReady( () => {
-	const isLoggedIn = document.body.classList.contains( 'logged-in' );
-	const block = document.querySelector( '.happy-blocks-universal-footer-block' );
-	const attributes = JSON.parse( ( block as HTMLElement )?.dataset?.attributes ?? `{}` );
-
-	render(
+function View( { isLoggedIn = false, attributes = {} as any } ) {
+	useI18nCalypsoTranslations();
+	return (
 		<LocaleProvider localeSlug={ attributes.locale }>
 			<UniversalNavbarFooter
 				currentRoute={ window.location.pathname }
 				onLanguageChange={ ( event ) => window.location.assign( event.target.value ) }
 				isLoggedIn={ isLoggedIn }
 			/>
-		</LocaleProvider>,
-		block
+		</LocaleProvider>
 	);
+}
+
+domReady( () => {
+	const isLoggedIn = document.body.classList.contains( 'logged-in' );
+	const block = document.querySelector( '.happy-blocks-universal-footer-block' );
+	const attributes = JSON.parse( ( block as HTMLElement )?.dataset?.attributes ?? `{}` );
+
+	render( <View isLoggedIn={ isLoggedIn } attributes={ attributes } />, block );
 } );

--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -40,6 +40,7 @@
 		"@wordpress/i18n": "^4.9.0",
 		"classnames": "^2.3.2",
 		"glob": "^7.1.6",
+		"i18n-calypso": "workspace:^",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -18512,6 +18512,7 @@ fsevents@^1.2.7:
     classnames: ^2.3.2
     copy-webpack-plugin: ^10.1.0
     glob: ^7.1.6
+    i18n-calypso: "workspace:^"
     jest: ^27.3.1
     postcss: ^8.4.5
     react: ^17.0.2


### PR DESCRIPTION
## Proposed Changes

* Load the translations for happy-blocks
* Add support for i18n-calypso translations

## Testing Instructions

* Run `install-plugin.sh happy-blocks fix/happy-blocks-translations` on your sandbox
* Point wordpress.com and br.forums.wordpress.com to your sandbox
* Open https://wordpress.com/pt-br/forums/?new=1, add an `Upgrade` block and confirm that it's fully translated into Brazilian Portuguese

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
