### PR TITLE
Skip the "Editor canvas loads" test

### DIFF
--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -47,7 +47,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		await page.waitForURL( /.*site-editor.*/ );
 	} );
 
-	it( 'Editor canvas loads', async function () {
+	// Skipping test until we have a way to reliably close the nav sidebar.
+	it.skip( 'Editor canvas loads', async function () {
 		fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 		// The site editor navigation sidebar opens by default, so we close it
 		await fullSiteEditorPage.closeNavSidebar();


### PR DESCRIPTION
## Proposed Changes

The logic of the test is correct. It knows the sidebar is open by default and it tries to close it. The problem is that there's now no longer a a dedicated "close sidebar" button. We used to click the same "open nav" button which would toggle the state of the sidebar. The "open" button is now no longer available when the sidebar is open.
