### PR TITLE
GitHub Integration: Match GitHub beta badge style with FSE's beta badge

### DIFF
--- a/client/my-sites/hosting/github/github-card-heading/index.tsx
+++ b/client/my-sites/hosting/github/github-card-heading/index.tsx
@@ -11,8 +11,8 @@ export function GitHubCardHeading() {
 			{ /* Element ID allows direct linking from the /sites page */ }
 			<CardHeading id="connect-github">
 				{ translate( 'Deploy from GitHub' ) }
-				<Badge className="github-hosting-heading-badge" type="info-purple">
-					Beta
+				<Badge className="github-hosting-heading-badge" type="info">
+					{ translate( 'beta' ) }
 				</Badge>
 			</CardHeading>
 		</>

--- a/client/my-sites/hosting/github/github-card-heading/style.scss
+++ b/client/my-sites/hosting/github/github-card-heading/style.scss
@@ -1,5 +1,10 @@
-.github-hosting-heading-badge {
-	position: relative;
+.github-hosting-heading-badge.badge {
+	background: transparent;
+	border: 1px solid currentColor;
 	bottom: 3px;
+	color: #b45400;
+	font-size: 0.75rem;
 	margin-left: 8px;
+	padding: 1px 6px;
+	position: relative;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Update the GitHub beta badge so it looks more like the badge we use for FSE.

We want a more subtle style for the beta badge because we don't want it competing with the deployment status badge.

![CleanShot 2023-03-02 at 21 36 26@2x](https://user-images.githubusercontent.com/1500769/222375144-c4da4a63-d5b3-45b9-82c2-0288e036bf30.png)


Discussed p1677700899324059/1677644591.559189-slack-C041RHH38NQ

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* View the GitHub card at `/hosting-config`.
