### PR TITLE
Hosting Configuration: add ssh loading state and improve scrollToAnchor

### DIFF
--- a/client/components/scroll-to-anchor-on-mount/index.tsx
+++ b/client/components/scroll-to-anchor-on-mount/index.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
+
+export function ScrollToAnchorOnMount() {
+	useEffect( () => {
+		setTimeout( () => {
+			scrollToAnchor( { offset: 30 } );
+		}, 100 );
+	}, [] );
+	return null;
+}

--- a/client/components/scroll-to-anchor-on-mount/index.tsx
+++ b/client/components/scroll-to-anchor-on-mount/index.tsx
@@ -1,11 +1,11 @@
 import { useEffect } from 'react';
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 
-export function ScrollToAnchorOnMount() {
+export function ScrollToAnchorOnMount( { offset = 0, timeout = 100 } ) {
 	useEffect( () => {
 		setTimeout( () => {
-			scrollToAnchor( { offset: 30 } );
-		}, 100 );
-	}, [] );
+			scrollToAnchor( { offset } );
+		}, timeout );
+	}, [ offset, timeout ] );
 	return null;
 }

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_SFTP, FEATURE_SFTP_DATABASE } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
-import { Component, Fragment } from 'react';
+import { Component, Fragment, useEffect } from 'react';
 import wrapWithClickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -28,6 +28,8 @@ import {
 	getAutomatedTransferStatus,
 	isAutomatedTransferActive,
 } from 'calypso/state/automated-transfer/selectors';
+import { getAtomicHostingIsLoadingSftpUsers } from 'calypso/state/selectors/get-atomic-hosting-is-loading-sftp-users';
+import { getAtomicHostingIsLoadingSshAccess } from 'calypso/state/selectors/get-atomic-hosting-is-loading-ssh-access';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
@@ -45,6 +47,13 @@ import SupportCard from './support-card';
 import WebServerLogsCard from './web-server-logs-card';
 import WebServerSettingsCard from './web-server-settings-card';
 import './style.scss';
+
+function ScrollToTopOnMount() {
+	useEffect( () => {
+		scrollToAnchor( { offset: 30 } );
+	}, [] );
+	return null;
+}
 
 class Hosting extends Component {
 	state = {
@@ -69,7 +78,6 @@ class Hosting extends Component {
 			// Try to refresh the transfer state
 			this.props.fetchAutomatedTransferStatus( this.props.siteId );
 		}
-		setTimeout( () => scrollToAnchor( { offset: 30 } ), 2000 );
 	}
 
 	render() {
@@ -85,6 +93,7 @@ class Hosting extends Component {
 			siteSlug,
 			translate,
 			transferState,
+			isLoadingSftpData,
 		} = this.props;
 
 		const getUpgradeBanner = () => {
@@ -205,6 +214,7 @@ class Hosting extends Component {
 
 		return (
 			<Main wideLayout className="hosting">
+				{ ! isLoadingSftpData && <ScrollToTopOnMount /> }
 				<PageViewTracker path="/hosting-config/:site" title="Hosting Configuration" />
 				<DocumentHead title={ translate( 'Hosting Configuration' ) } />
 				<FormattedHeader
@@ -237,6 +247,9 @@ export default connect(
 			transferState: getAutomatedTransferStatus( state, siteId ),
 			isTransferring: isAutomatedTransferActive( state, siteId ),
 			isDisabled: ! hasSftpFeature || ! isSiteAutomatedTransfer( state, siteId ),
+			isLoadingSftpData:
+				getAtomicHostingIsLoadingSftpUsers( state, siteId ) ||
+				getAtomicHostingIsLoadingSshAccess( state, siteId ),
 			hasSftpFeature,
 			siteSlug: getSelectedSiteSlug( state ),
 			siteId,

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_SFTP, FEATURE_SFTP_DATABASE } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
-import { Component, Fragment, useEffect } from 'react';
+import { Component, Fragment } from 'react';
 import wrapWithClickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -16,9 +16,9 @@ import Column from 'calypso/components/layout/column';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
+import { ScrollToAnchorOnMount } from 'calypso/components/scroll-to-anchor-on-mount';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import { GitHubCard } from 'calypso/my-sites/hosting/github';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -28,8 +28,7 @@ import {
 	getAutomatedTransferStatus,
 	isAutomatedTransferActive,
 } from 'calypso/state/automated-transfer/selectors';
-import { getAtomicHostingIsLoadingSftpUsers } from 'calypso/state/selectors/get-atomic-hosting-is-loading-sftp-users';
-import { getAtomicHostingIsLoadingSshAccess } from 'calypso/state/selectors/get-atomic-hosting-is-loading-ssh-access';
+import { getAtomicHostingIsLoadingSftpData } from 'calypso/state/selectors/get-atomic-hosting-is-loading-sftp-data';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
@@ -47,13 +46,6 @@ import SupportCard from './support-card';
 import WebServerLogsCard from './web-server-logs-card';
 import WebServerSettingsCard from './web-server-settings-card';
 import './style.scss';
-
-function ScrollToTopOnMount() {
-	useEffect( () => {
-		scrollToAnchor( { offset: 30 } );
-	}, [] );
-	return null;
-}
 
 class Hosting extends Component {
 	state = {
@@ -214,7 +206,7 @@ class Hosting extends Component {
 
 		return (
 			<Main wideLayout className="hosting">
-				{ ! isLoadingSftpData && <ScrollToTopOnMount /> }
+				{ ! isLoadingSftpData && <ScrollToAnchorOnMount /> }
 				<PageViewTracker path="/hosting-config/:site" title="Hosting Configuration" />
 				<DocumentHead title={ translate( 'Hosting Configuration' ) } />
 				<FormattedHeader
@@ -247,9 +239,7 @@ export default connect(
 			transferState: getAutomatedTransferStatus( state, siteId ),
 			isTransferring: isAutomatedTransferActive( state, siteId ),
 			isDisabled: ! hasSftpFeature || ! isSiteAutomatedTransfer( state, siteId ),
-			isLoadingSftpData:
-				getAtomicHostingIsLoadingSftpUsers( state, siteId ) ||
-				getAtomicHostingIsLoadingSshAccess( state, siteId ),
+			isLoadingSftpData: getAtomicHostingIsLoadingSftpData( state, siteId ),
 			hasSftpFeature,
 			siteSlug: getSelectedSiteSlug( state ),
 			siteId,

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -47,6 +47,8 @@ import WebServerLogsCard from './web-server-logs-card';
 import WebServerSettingsCard from './web-server-settings-card';
 import './style.scss';
 
+const HEADING_OFFSET = 30;
+
 class Hosting extends Component {
 	state = {
 		clickOutside: false,
@@ -206,7 +208,7 @@ class Hosting extends Component {
 
 		return (
 			<Main wideLayout className="hosting">
-				{ ! isLoadingSftpData && <ScrollToAnchorOnMount /> }
+				{ ! isLoadingSftpData && <ScrollToAnchorOnMount offset={ HEADING_OFFSET } /> }
 				<PageViewTracker path="/hosting-config/:site" title="Hosting Configuration" />
 				<DocumentHead title={ translate( 'Hosting Configuration' ) } />
 				<FormattedHeader

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -31,10 +31,12 @@ import {
 	enableAtomicSshAccess,
 	disableAtomicSshAccess,
 } from 'calypso/state/hosting/actions';
+import { getAtomicHostingIsLoadingSftpData } from 'calypso/state/selectors/get-atomic-hosting-is-loading-sftp-data';
 import { getAtomicHostingSftpUsers } from 'calypso/state/selectors/get-atomic-hosting-sftp-users';
 import { getAtomicHostingSshAccess } from 'calypso/state/selectors/get-atomic-hosting-ssh-access';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { SshKeyLoadingSkeleton } from './ssh-key-loading-skeleton';
 import SshKeys from './ssh-keys';
 
 const FILEZILLA_URL = 'https://filezilla-project.org/';
@@ -78,6 +80,7 @@ export const SftpCard = ( {
 	siteHasSftpFeature,
 	siteHasSshFeature,
 	isSshAccessEnabled,
+	isLoadingSftpData,
 	requestSshAccess,
 	enableSshAccess,
 	disableSshAccess,
@@ -87,6 +90,7 @@ export const SftpCard = ( {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ isPasswordLoading, setPasswordLoading ] = useState( false );
 	const [ isSshAccessLoading, setSshAccessLoading ] = useState( false );
+	const hasSftpFeatureAndIsLoading = siteHasSftpFeature && isLoadingSftpData;
 
 	const sshConnectString = `ssh ${ username }@sftp.wp.com`;
 
@@ -197,7 +201,7 @@ export const SftpCard = ( {
 		);
 	};
 
-	const displayQuestionsAndButton = ! ( username || isLoading );
+	const displayQuestionsAndButton = ! hasSftpFeatureAndIsLoading && ! ( username || isLoading );
 	const showSshPanel = ! siteHasSftpFeature || siteHasSshFeature;
 
 	const featureExplanation = siteHasSshFeature
@@ -216,20 +220,22 @@ export const SftpCard = ( {
 					? translate( 'SFTP/SSH credentials' )
 					: translate( 'SFTP credentials' ) }
 			</CardHeading>
-			<div className="sftp-card__body">
-				<p>
-					{ username
-						? translate(
-								'Use the credentials below to access and edit your website files using an SFTP client. {{a}}Learn more about SFTP on WordPress.com{{/a}}.',
-								{
-									components: {
-										a: <InlineSupportLink supportContext="hosting-sftp" showIcon={ false } />,
-									},
-								}
-						  )
-						: featureExplanation }
-				</p>
-			</div>
+			{ ! hasSftpFeatureAndIsLoading && (
+				<div className="sftp-card__body">
+					<p>
+						{ username
+							? translate(
+									'Use the credentials below to access and edit your website files using an SFTP client. {{a}}Learn more about SFTP on WordPress.com{{/a}}.',
+									{
+										components: {
+											a: <InlineSupportLink supportContext="hosting-sftp" showIcon={ false } />,
+										},
+									}
+							  )
+							: featureExplanation }
+					</p>
+				</div>
+			) }
 			{ displayQuestionsAndButton && (
 				<SftpQuestionsContainer>
 					<PanelBody title={ translate( 'What is SFTP?' ) } initialOpen={ false }>
@@ -309,6 +315,7 @@ export const SftpCard = ( {
 				</FormFieldset>
 			) }
 			{ isLoading && <Spinner /> }
+			{ hasSftpFeatureAndIsLoading && <SshKeyLoadingSkeleton /> }
 		</Card>
 	);
 };
@@ -386,6 +393,7 @@ export default connect(
 			siteHasSftpFeature: siteHasFeature( state, siteId, FEATURE_SFTP ),
 			siteHasSshFeature: siteHasFeature( state, siteId, FEATURE_SSH ),
 			isSshAccessEnabled: 'ssh' === getAtomicHostingSshAccess( state, siteId ),
+			isLoadingSftpData: getAtomicHostingIsLoadingSftpData( state, siteId ),
 		};
 	},
 	{

--- a/client/my-sites/hosting/sftp-card/index.js
+++ b/client/my-sites/hosting/sftp-card/index.js
@@ -36,7 +36,7 @@ import { getAtomicHostingSftpUsers } from 'calypso/state/selectors/get-atomic-ho
 import { getAtomicHostingSshAccess } from 'calypso/state/selectors/get-atomic-hosting-ssh-access';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { SshKeyLoadingSkeleton } from './ssh-key-loading-skeleton';
+import { SftpCardLoadingPlaceholder } from './sftp-card-loading-placeholder';
 import SshKeys from './ssh-keys';
 
 const FILEZILLA_URL = 'https://filezilla-project.org/';
@@ -315,7 +315,7 @@ export const SftpCard = ( {
 				</FormFieldset>
 			) }
 			{ isLoading && <Spinner /> }
-			{ hasSftpFeatureAndIsLoading && <SshKeyLoadingSkeleton /> }
+			{ hasSftpFeatureAndIsLoading && <SftpCardLoadingPlaceholder /> }
 		</Card>
 	);
 };

--- a/client/my-sites/hosting/sftp-card/sftp-card-loading-placeholder.tsx
+++ b/client/my-sites/hosting/sftp-card/sftp-card-loading-placeholder.tsx
@@ -24,7 +24,7 @@ export function SftpCardLoadingPlaceholder() {
 		<PlaceholderGroup>
 			<ParagraphPlaceholder />
 			<LinkPlaceholder />
-			{ [ 1, 2, 3 ].map( ( i ) => (
+			{ [ 1, 2 ].map( ( i ) => (
 				<PlaceholderGroup key={ i }>
 					<LabelPlaceholder />
 					<InputPlaceholder />

--- a/client/my-sites/hosting/sftp-card/sftp-card-loading-placeholder.tsx
+++ b/client/my-sites/hosting/sftp-card/sftp-card-loading-placeholder.tsx
@@ -19,7 +19,7 @@ const InputPlaceholder = styled( ParagraphPlaceholder )( {
 	marginBottom: 20,
 } );
 
-export function SshKeyLoadingSkeleton() {
+export function SftpCardLoadingPlaceholder() {
 	return (
 		<PlaceholderGroup>
 			<ParagraphPlaceholder />

--- a/client/my-sites/hosting/sftp-card/ssh-key-loading-skeleton.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-key-loading-skeleton.tsx
@@ -1,0 +1,38 @@
+import { LoadingPlaceholder } from '@automattic/components';
+import styled from '@emotion/styled';
+
+const PlaceholderGroup = styled.div( {
+	display: 'flex',
+	flexDirection: 'column',
+	gap: '0.5em',
+} );
+
+const ParagraphPlaceholder = styled( LoadingPlaceholder )( {
+	width: 560,
+	maxWidth: '100%',
+} );
+const LinkPlaceholder = styled( ParagraphPlaceholder )( { width: 290, marginBottom: 30 } );
+const LabelPlaceholder = styled( ParagraphPlaceholder )( { width: 50 } );
+const InputPlaceholder = styled( ParagraphPlaceholder )( {
+	width: '80%',
+	height: 36,
+	marginBottom: 20,
+} );
+
+export function SshKeyLoadingSkeleton() {
+	return (
+		<PlaceholderGroup>
+			<ParagraphPlaceholder />
+			<LinkPlaceholder />
+			{ [ 1, 2, 3 ].map( ( i ) => (
+				<PlaceholderGroup key={ i }>
+					<LabelPlaceholder />
+					<InputPlaceholder />
+				</PlaceholderGroup>
+			) ) }
+			<LabelPlaceholder />
+			<ParagraphPlaceholder />
+			<LinkPlaceholder />
+		</PlaceholderGroup>
+	);
+}

--- a/client/state/hosting/reducer.js
+++ b/client/state/hosting/reducer.js
@@ -8,6 +8,8 @@ import {
 	HOSTING_SSH_ACCESS_SET,
 	HOSTING_STATIC_FILE_404_SET,
 	HOSTING_CLEAR_CACHE_REQUEST,
+	HOSTING_SFTP_USERS_REQUEST,
+	HOSTING_SSH_ACCESS_REQUEST,
 } from 'calypso/state/action-types';
 import {
 	combineReducers,
@@ -34,9 +36,12 @@ export const sftpUsers = ( state = {}, { type, users } ) => {
 	return state;
 };
 
-export const isLoadingSftpUsers = ( state = true, { type } ) => {
-	if ( type === HOSTING_SFTP_USERS_SET ) {
-		return false;
+export const isLoadingSftpUsers = ( state = false, { type } ) => {
+	switch ( type ) {
+		case HOSTING_SFTP_USERS_REQUEST:
+			return true;
+		case HOSTING_SFTP_USERS_SET:
+			return false;
 	}
 
 	return state;
@@ -80,8 +85,10 @@ const sshAccess = ( state = null, { type, status } ) => {
 	return state;
 };
 
-const isLoadingSshAccess = ( state = true, { type } ) => {
+const isLoadingSshAccess = ( state = false, { type } ) => {
 	switch ( type ) {
+		case HOSTING_SSH_ACCESS_REQUEST:
+			return true;
 		case HOSTING_SSH_ACCESS_SET:
 			return false;
 	}

--- a/client/state/hosting/reducer.js
+++ b/client/state/hosting/reducer.js
@@ -72,6 +72,15 @@ const sshAccess = ( state = null, { type, status } ) => {
 	return state;
 };
 
+const isLoadingSshAccess = ( state = true, { type } ) => {
+	switch ( type ) {
+		case HOSTING_SSH_ACCESS_SET:
+			return false;
+	}
+
+	return state;
+};
+
 const staticFile404 = ( state = null, { type, setting } ) => {
 	switch ( type ) {
 		case HOSTING_STATIC_FILE_404_SET:
@@ -99,6 +108,7 @@ const atomicHostingReducer = combineReducers( {
 	phpVersion,
 	sftpUsers,
 	sshAccess,
+	isLoadingSshAccess,
 	staticFile404,
 	lastCacheClearTimestamp,
 } );

--- a/client/state/hosting/reducer.js
+++ b/client/state/hosting/reducer.js
@@ -34,6 +34,14 @@ export const sftpUsers = ( state = {}, { type, users } ) => {
 	return state;
 };
 
+export const isLoadingSftpUsers = ( state = true, { type } ) => {
+	if ( type === HOSTING_SFTP_USERS_SET ) {
+		return false;
+	}
+
+	return state;
+};
+
 const geoAffinity = ( state = null, { type, setting } ) => {
 	switch ( type ) {
 		case HOSTING_GEO_AFFINITY_SET:
@@ -107,6 +115,7 @@ const atomicHostingReducer = combineReducers( {
 	isFetchingGeoAffinity,
 	phpVersion,
 	sftpUsers,
+	isLoadingSftpUsers,
 	sshAccess,
 	isLoadingSshAccess,
 	staticFile404,

--- a/client/state/hosting/test/reducer.js
+++ b/client/state/hosting/test/reducer.js
@@ -129,6 +129,8 @@ describe( 'reducer', () => {
 				sftpUsers: [ 1, 2, 3 ],
 				sshAccess: null,
 				staticFile404: null,
+				isLoadingSftpUsers: false,
+				isLoadingSshAccess: true,
 			},
 		} );
 	} );
@@ -143,6 +145,8 @@ describe( 'reducer', () => {
 				sftpUsers: [ 1, 2, 3 ],
 				sshAccess: null,
 				staticFile404: null,
+				isLoadingSftpUsers: false,
+				isLoadingSshAccess: true,
 			},
 		};
 		const state = reducer( previousState, {
@@ -160,6 +164,8 @@ describe( 'reducer', () => {
 				sftpUsers: [ 1, 2, 3 ],
 				sshAccess: null,
 				staticFile404: null,
+				isLoadingSftpUsers: false,
+				isLoadingSshAccess: true,
 			},
 			9876543: {
 				lastCacheClearTimestamp: null,
@@ -169,6 +175,8 @@ describe( 'reducer', () => {
 				sftpUsers: [ 9, 8, 7 ],
 				sshAccess: null,
 				staticFile404: null,
+				isLoadingSftpUsers: false,
+				isLoadingSshAccess: true,
 			},
 		} );
 	} );

--- a/client/state/hosting/test/reducer.js
+++ b/client/state/hosting/test/reducer.js
@@ -130,7 +130,7 @@ describe( 'reducer', () => {
 				sshAccess: null,
 				staticFile404: null,
 				isLoadingSftpUsers: false,
-				isLoadingSshAccess: true,
+				isLoadingSshAccess: false,
 			},
 		} );
 	} );
@@ -146,7 +146,7 @@ describe( 'reducer', () => {
 				sshAccess: null,
 				staticFile404: null,
 				isLoadingSftpUsers: false,
-				isLoadingSshAccess: true,
+				isLoadingSshAccess: false,
 			},
 		};
 		const state = reducer( previousState, {
@@ -165,7 +165,7 @@ describe( 'reducer', () => {
 				sshAccess: null,
 				staticFile404: null,
 				isLoadingSftpUsers: false,
-				isLoadingSshAccess: true,
+				isLoadingSshAccess: false,
 			},
 			9876543: {
 				lastCacheClearTimestamp: null,
@@ -176,7 +176,7 @@ describe( 'reducer', () => {
 				sshAccess: null,
 				staticFile404: null,
 				isLoadingSftpUsers: false,
-				isLoadingSshAccess: true,
+				isLoadingSshAccess: false,
 			},
 		} );
 	} );

--- a/client/state/selectors/get-atomic-hosting-is-loading-sftp-data.js
+++ b/client/state/selectors/get-atomic-hosting-is-loading-sftp-data.js
@@ -1,0 +1,17 @@
+import 'calypso/state/hosting/init';
+import { getAtomicHostingIsLoadingSftpUsers } from './get-atomic-hosting-is-loading-sftp-users';
+import { getAtomicHostingIsLoadingSshAccess } from './get-atomic-hosting-is-loading-ssh-access';
+
+/**
+ * Returns the sftp users details for given site.
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {number}  siteId The ID of the site we're querying
+ * @returns {Array} List of SFTP user details
+ */
+export function getAtomicHostingIsLoadingSftpData( state, siteId ) {
+	return (
+		getAtomicHostingIsLoadingSftpUsers( state, siteId ) ||
+		getAtomicHostingIsLoadingSshAccess( state, siteId )
+	);
+}

--- a/client/state/selectors/get-atomic-hosting-is-loading-sftp-data.js
+++ b/client/state/selectors/get-atomic-hosting-is-loading-sftp-data.js
@@ -3,11 +3,11 @@ import { getAtomicHostingIsLoadingSftpUsers } from './get-atomic-hosting-is-load
 import { getAtomicHostingIsLoadingSshAccess } from './get-atomic-hosting-is-loading-ssh-access';
 
 /**
- * Returns the sftp users details for given site.
+ * Returns if the SFTP users and SSH access data have loaded for given site.
  *
  * @param  {Object}  state   Global state tree
  * @param  {number}  siteId The ID of the site we're querying
- * @returns {Array} List of SFTP user details
+ * @returns {boolean} If the SFTP users and SSH access data has finished the first request
  */
 export function getAtomicHostingIsLoadingSftpData( state, siteId ) {
 	return (

--- a/client/state/selectors/get-atomic-hosting-is-loading-sftp-users.js
+++ b/client/state/selectors/get-atomic-hosting-is-loading-sftp-users.js
@@ -1,11 +1,11 @@
 import 'calypso/state/hosting/init';
 
 /**
- * Returns the sftp users details for given site.
+ * Returns if the SFTP users data loaded for given site.
  *
  * @param  {Object}  state   Global state tree
  * @param  {number}  siteId The ID of the site we're querying
- * @returns {Array} List of SFTP user details
+ * @returns {boolean} If the SFTP users data has finished the first request
  */
 export function getAtomicHostingIsLoadingSftpUsers( state, siteId ) {
 	return state.atomicHosting?.[ siteId ]?.isLoadingSftpUsers ?? true;

--- a/client/state/selectors/get-atomic-hosting-is-loading-sftp-users.js
+++ b/client/state/selectors/get-atomic-hosting-is-loading-sftp-users.js
@@ -1,0 +1,12 @@
+import 'calypso/state/hosting/init';
+
+/**
+ * Returns the sftp users details for given site.
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {number}  siteId The ID of the site we're querying
+ * @returns {Array} List of SFTP user details
+ */
+export function getAtomicHostingIsLoadingSftpUsers( state, siteId ) {
+	return state.atomicHosting?.[ siteId ]?.isLoadingSftpUsers ?? true;
+}

--- a/client/state/selectors/get-atomic-hosting-is-loading-ssh-access.js
+++ b/client/state/selectors/get-atomic-hosting-is-loading-ssh-access.js
@@ -1,0 +1,12 @@
+import 'calypso/state/hosting/init';
+
+/**
+ * Returns the SSH access status for given site.
+ *
+ * @param  {Object}  state   Global state tree
+ * @param  {number}  siteId The ID of the site we're querying
+ * @returns {string} SSH access status
+ */
+export function getAtomicHostingIsLoadingSshAccess( state, siteId ) {
+	return state.atomicHosting?.[ siteId ]?.isLoadingSshAccess ?? true;
+}

--- a/client/state/selectors/get-atomic-hosting-is-loading-ssh-access.js
+++ b/client/state/selectors/get-atomic-hosting-is-loading-ssh-access.js
@@ -1,11 +1,11 @@
 import 'calypso/state/hosting/init';
 
 /**
- * Returns the SSH access status for given site.
+ * Returns if the SSH access data loaded for given site.
  *
  * @param  {Object}  state   Global state tree
  * @param  {number}  siteId The ID of the site we're querying
- * @returns {string} SSH access status
+ * @returns {boolean} If the SSH access data has finished the first request
  */
 export function getAtomicHostingIsLoadingSshAccess( state, siteId ) {
 	return state.atomicHosting?.[ siteId ]?.isLoadingSshAccess ?? true;


### PR DESCRIPTION
- Closes https://github.com/Automattic/dotcom-forge/issues/1660

## Proposed Changes

* Add SFTP/SSH loading placeholder to avoid showing a wrong state with create credentials button
* Improve the srollToAnchor and run it after the SFTP/SSH data has loaded

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Test SFTP/SSH loading placeholder

* Go to `/hosting-config/{siteSlug}` in any business site
* Observe the new loading placeholder template
* Observe there is no "Create credentials button"
* Enable and disable SSH to verify everything is still working as before.
* Go to `/hosting-config/{siteSlug}` in a free site
* Observe the page is still as before this PR, showing the upsell nudge and the "blocked" SFTP description.

![loadingplaceholder](https://user-images.githubusercontent.com/779993/222385165-ced4788b-0c7d-4d62-8e86-f42499a62855.gif)
*We've changed the placeholder layout with fewer gray rows.

### Test scrollToAnchor improvement

* Go to `/sites`
* Open the actions menu of one of your business sites
* Open the submenu `Developer Settings` 
* Click on `GitHub connection`
* Observe the scroll goes to the right card with a minimum delay

![scroll-to-anchor-github](https://user-images.githubusercontent.com/779993/222386075-d686d5e6-4b5a-4d00-96b6-9b2615726d31.gif)




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
