### PR TITLE
Theme Showcase: Remove style variation collapsibility 

### DIFF
--- a/client/my-sites/theme/theme-style-variations/index.tsx
+++ b/client/my-sites/theme/theme-style-variations/index.tsx
@@ -1,7 +1,4 @@
-import { Button } from '@automattic/components';
 import { PremiumBadge } from '@automattic/design-picker';
-import { useEffect, useRef, useState } from '@wordpress/element';
-import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
 import type { StyleVariation } from '@automattic/design-picker/src/types';
@@ -22,91 +19,16 @@ const ThemeStyleVariations = ( {
 	variations,
 	onClick,
 }: ThemeStyleVariationsProps ) => {
-	const observerRef = useRef< HTMLDivElement | null >( null );
-	const [ collapsibleMaxHeight, setCollapsibleMaxHeight ] = useState< number | undefined >();
-	const [ isCollapsible, setIsCollapsible ] = useState< boolean >( false );
-	const [ isCollapsed, setIsCollapsed ] = useState< boolean >( false );
-	const isCollapsibleRef = useRef( false );
-	const isCollapsedRef = useRef( false );
-
-	isCollapsibleRef.current = isCollapsible;
-	isCollapsedRef.current = isCollapsed;
-
-	const updateCollapsibleMaxHeight = ( shouldCollapse: boolean ) => {
-		const node = observerRef.current;
-		const nodeFirstChild = node?.firstChild as HTMLElement;
-		if ( ! node || ! nodeFirstChild ) {
-			return null;
-		}
-
-		setCollapsibleMaxHeight( shouldCollapse ? nodeFirstChild.offsetHeight : node.scrollHeight );
-	};
-
-	useEffect( () => {
-		if ( ! observerRef.current ) {
-			return;
-		}
-
-		const resizeObserver = new ResizeObserver( ( [ observerNode ] ) => {
-			const node = observerNode.target;
-			const nodeFirstChild = node.firstChild as HTMLElement;
-			const nodeLastChild = node.lastChild as HTMLElement;
-			if ( ! nodeFirstChild || ! nodeLastChild ) {
-				return;
-			}
-
-			// Detect flex wrap.
-			const currentIsCollapsible = nodeLastChild.offsetTop > nodeFirstChild.offsetTop;
-			const shouldCollapse =
-				isCollapsibleRef.current !== currentIsCollapsible || isCollapsedRef.current;
-
-			setIsCollapsible( currentIsCollapsible );
-			setIsCollapsed( shouldCollapse );
-			updateCollapsibleMaxHeight( shouldCollapse );
-		} );
-
-		resizeObserver.observe( observerRef.current );
-		return () => {
-			resizeObserver.disconnect();
-		};
-	}, [] );
-
-	const handleCollapseButtonClick = () => {
-		const shouldCollapse = ! isCollapsed;
-
-		setIsCollapsed( shouldCollapse );
-		updateCollapsibleMaxHeight( shouldCollapse );
-	};
-
 	return (
 		<div className="theme__sheet-style-variations">
 			<div className="theme__sheet-style-variations-header">
 				<h2>
 					{ translate( 'Styles' ) }
 					<PremiumBadge shouldHideTooltip />
-					{ isCollapsible && (
-						<Button borderless onClick={ handleCollapseButtonClick }>
-							{ isCollapsed
-								? translate( 'Show all (%(variationsCount)d)', {
-										args: { variationsCount: variations?.length },
-										comment: 'The number of style variations',
-								  } )
-								: translate( 'Show less' ) }
-						</Button>
-					) }
 				</h2>
 				<p>{ description }</p>
 			</div>
-			<div
-				className={ classNames( 'theme__sheet-style-variations-previews', {
-					'theme__sheet-style-variations-previews--is-collapsible': isCollapsible,
-					'theme__sheet-style-variations-previews--is-collapsed': isCollapsed,
-				} ) }
-				style={ {
-					...( isCollapsible && { maxHeight: collapsibleMaxHeight } ),
-				} }
-				ref={ observerRef }
-			>
+			<div className="theme__sheet-style-variations-previews">
 				<AsyncLoad
 					require="@automattic/design-preview/src/components/style-variation"
 					placeholder={ null }

--- a/client/my-sites/theme/theme-style-variations/style.scss
+++ b/client/my-sites/theme/theme-style-variations/style.scss
@@ -31,22 +31,8 @@
 			display: none;
 		}
 
-		&--is-collapsible {
-			transition: max-height 0.2s ease-in-out;
-		}
-
-		&--is-collapsed {
-			overflow: hidden;
-			padding-bottom: 3px;
-		}
-
 		@include breakpoint-deprecated( "<960px" ) {
 			flex-wrap: nowrap;
-
-			&--is-collapsed {
-				overflow: scroll;
-				padding-bottom: 12px;
-			}
 		}
 	}
 
@@ -58,18 +44,6 @@
 		@include breakpoint-deprecated( "<960px" ) {
 			button {
 				display: none;
-			}
-		}
-
-		button {
-			color: var(--color-link);
-			float: right;
-			padding: 0;
-
-			&:active,
-			&:focus,
-			&:hover {
-				color: var(--color-link-dark);
 			}
 		}
 


### PR DESCRIPTION
## Proposed Changes

As per discussions in pekYwv-OA-p2, in this PR we are removing the functionality of collapsing/expanding style variations in the Theme Detail page. As a result, the Theme Detail page will show all style variations at once.

| Before | After |
| --- | --- |
| <img width="741" alt="Screenshot 2023-03-02 at 5 36 03 PM" src="https://user-images.githubusercontent.com/797888/222389966-db1e5723-80f7-4e18-8b9a-d7ca4b96b45d.png"> | <img width="745" alt="Screenshot 2023-03-02 at 5 36 08 PM" src="https://user-images.githubusercontent.com/797888/222390002-5b72b5be-60fc-4f60-a01a-d5ee95bed738.png"> |



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Select a theme with style variations, such as Twenty Twenty-Three.
* Ensure that the style variation section is no longer collapsible in desktop view.
* Ensure that the style variation section works as before in mobile view (horizontally scrollable).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?