### PR TITLE
Launchpad: Add domain upgrade badge tests

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -13,7 +13,7 @@ import { ResponseDomain } from 'calypso/lib/domains/types';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import Checklist from './checklist';
 import { getArrayOfFilteredTasks, getEnhancedTasks } from './task-helper';
-import { tasks } from './tasks';
+import { DOMAIN_UPSELL, tasks } from './tasks';
 import { getLaunchpadTranslations } from './translations';
 import { Task } from './types';
 
@@ -82,6 +82,8 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 	const domainUpgradeBadgeUrl = ! site?.plan?.is_free
 		? `/domains/manage/${ siteSlug }`
 		: `/domains/add/${ siteSlug }?domainAndPlanPackage=true`;
+	const showDomainUpgradeBadge =
+		sidebarDomain?.isWPCOMDomain && ! enhancedTasks?.find( ( task ) => task.id === DOMAIN_UPSELL );
 
 	if ( sidebarDomain ) {
 		const { domain, isPrimary, isWPCOMDomain, sslStatus } = sidebarDomain;
@@ -145,7 +147,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 							</>
 						) }
 					</div>
-					{ sidebarDomain?.isWPCOMDomain && (
+					{ showDomainUpgradeBadge && (
 						<a href={ domainUpgradeBadgeUrl }>
 							<Badge className="launchpad__domain-upgrade-badge" type="info-blue">
 								{ translate( 'Customize' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -1,6 +1,8 @@
 import { LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import { LaunchpadFlowTaskList, Task } from './types';
 
+export const DOMAIN_UPSELL = 'domain_upsell';
+
 export const tasks: Task[] = [
 	{
 		id: 'setup_newsletter',
@@ -111,7 +113,7 @@ export const tasks: Task[] = [
 		taskType: 'blog',
 	},
 	{
-		id: 'domain_upsell',
+		id: DOMAIN_UPSELL,
 		completed: false,
 		disabled: false,
 		taskType: 'blog',
@@ -133,7 +135,7 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 	free: [
 		'setup_free',
 		'design_selected',
-		'domain_upsell',
+		DOMAIN_UPSELL,
 		'first_post_published',
 		'design_edited',
 		'site_launched',
@@ -141,7 +143,7 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 	build: [
 		'setup_general',
 		'design_selected',
-		'domain_upsell',
+		DOMAIN_UPSELL,
 		'first_post_published',
 		'design_edited',
 		'site_launched',
@@ -149,7 +151,7 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 	write: [
 		'setup_write',
 		'design_selected',
-		'domain_upsell',
+		DOMAIN_UPSELL,
 		'first_post_published',
 		'site_launched',
 	],

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -108,6 +108,22 @@ describe( 'Sidebar', () => {
 		expect( upgradeDomainBadgeElement ).not.toBeInTheDocument;
 	} );
 
+	it( 'does not display customize badge for a flow with a redundant domain upsell task', () => {
+		props.sidebarDomain = buildDomainResponse( {
+			domain: 'paidtestlinkinbio.blog',
+			flow: 'free',
+			isWPCOMDomain: true,
+		} );
+
+		renderSidebar( props );
+
+		const upgradeDomainBadgeElement = screen.queryByRole( 'link', {
+			name: 'upgradeDomainBadgeText',
+		} );
+
+		expect( upgradeDomainBadgeElement ).not.toBeInTheDocument;
+	} );
+
 	it( 'displays a progress bar based off of task completion', () => {
 		renderSidebar( props );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/73866

## Proposed Changes

* Adds tests for https://github.com/Automattic/wp-calypso/pull/73984

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Run `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
