### PR TITLE
Happyblocks: Fix incorrect block name

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/block.json
+++ b/apps/happy-blocks/block-library/pricing-plans/block.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
-	"name": "happy-blocks/pricing-plan",
+	"name": "happy-blocks/pricing-plans",
 	"category": "embed",
 	"textdomain": "happy-blocks",
 	"title": "Pricing Plans",

--- a/apps/happy-blocks/block-library/pricing-plans/rtl/block.json
+++ b/apps/happy-blocks/block-library/pricing-plans/rtl/block.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
-	"name": "happy-blocks/pricing-plan",
+	"name": "happy-blocks/pricing-plans",
 	"category": "embed",
 	"textdomain": "happy-blocks",
 	"title": "Pricing Plan",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

fixes 318-gh-Automattic/lighthouse-forums

## Proposed Changes
There was a misspelling in the block name introduced in https://github.com/Automattic/wp-calypso/pull/7353  and causing 318-gh-Automattic/lighthouse-forums


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync these changes with `yarn dev --sync`
* Ensure the related issue is fixed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
