### PR TITLE
Prevent calypso_signup_design_scrolled_to_end from being tracked if designs have not been loaded

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -44,7 +44,7 @@ jest.mock( 'calypso/state/sites/hooks/use-premium-global-styles', () => ( {
 } ) );
 
 jest.mock( 'calypso/lib/explat', () => ( {
-	useExperiment: () => [ false, 'control' ],
+	useExperiment: () => [ false, null ],
 } ) );
 
 /**

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -43,6 +43,10 @@ jest.mock( 'calypso/state/sites/hooks/use-premium-global-styles', () => ( {
 	usePremiumGlobalStyles: () => ( { shouldLimitGlobalStyles: false } ),
 } ) );
 
+jest.mock( 'calypso/lib/explat', () => ( {
+	useExperiment: () => [ false, 'control' ],
+} ) );
+
 /**
  * Mock wpcom-proxy-request so that we could use wpcom-xhr-request to call the endpoint
  * and get the response from nock

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -275,9 +275,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	}
 
 	function trackAllDesignsView() {
-		if ( isLoadingVirtualThemesExperiment || isLoadingDesigns ) {
-			return;
-		}
 		recordTracksEvent( 'calypso_signup_design_scrolled_to_end', {
 			intent,
 			category: categorization?.selection,
@@ -584,7 +581,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	// ********** Main render logic
 
 	// Don't render until we've done fetching all the data needed for initial render.
-	if ( ! site || isLoadingSiteVertical || isLoadingDesigns ) {
+	if ( ! site || isLoadingSiteVertical || isLoadingDesigns || isLoadingVirtualThemesExperiment ) {
 		return null;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -275,6 +275,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	}
 
 	function trackAllDesignsView() {
+		if ( isLoadingVirtualThemesExperiment || isLoadingDesigns ) {
+			return;
+		}
 		recordTracksEvent( 'calypso_signup_design_scrolled_to_end', {
 			intent,
 			category: categorization?.selection,


### PR DESCRIPTION
## Proposed Changes

Fixes a regression introduced by https://github.com/Automattic/wp-calypso/pull/73663 that caused the `calypso_signup_design_scrolled_to_end` event to be tracked without the user viewing all the designs.

The culprit is that we need to determine first the assignment group of the virtual themes i1 experiment and then fetch the designs based on that group. During that time, we render an empty page so the user technically has reached the end of the page and thus `calypso_signup_design_scrolled_to_end` gets tracked. However the event is intended to be triggered when a user has scrolled to the end of the page AFTER viewing all designs.

So this PR mitigates the issue by adding a safeguard to prevent the component from being rendered (effectively  blocking the `calypso_signup_design_scrolled_to_end` event) if we're still loading the A/B test group.

Props to @taipeicoder for finding out the culprit (and to @ianstewart for noting the spike).

Further context: pekYwv-O9-p2

## Testing Instructions

- Open a new incognito/private session (to prevent the cache from altering the results).
- Open the network tab in the browser devtools.
- Observe the `t.gif` requests.
- Go to `wordpress.com/setup/site-setup/designSetup?siteSlug=<SITE_SLUG>`.
- Note how there is a `t.gif` request to track the `calypso_signup_design_scrolled_to_end` event upon loading the page.
- Repeat the same steps using the Calypso live link below.
- Make sure the `calypso_signup_design_scrolled_to_end` event is not tracked when loading the page.