### PR TITLE
StoreStatsOrdersChart: Wrap the "since" label for translation

### DIFF
--- a/client/my-sites/store/app/store-stats/store-stats-orders-chart/index.js
+++ b/client/my-sites/store/app/store-stats/store-stats-orders-chart/index.js
@@ -1,3 +1,4 @@
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -27,7 +28,7 @@ class StoreStatsOrdersChart extends Component {
 	};
 
 	renderTabs = ( { chartData, selectedIndex, selectedTabIndex, selectedDate, unit, tabClick } ) => {
-		const { deltas, moment } = this.props;
+		const { deltas, moment, translate } = this.props;
 		return (
 			<Tabs data={ chartData }>
 				{ tabs.map( ( tab, tabIndex ) => {
@@ -58,11 +59,18 @@ class StoreStatsOrdersChart extends Component {
 								{ formatValue( value, tab.type, itemChartData.data.currency ) }
 							</span>
 							<Delta
-								value={ `${ deltaValue }%` }
+								value={
+									// translators: %(percentage)s is a percentage number, %(date)s is a date, month, or year in short format.
+									translate( '%(percentage)s%% since %(date)s', {
+										args: {
+											percentage: deltaValue,
+											date: moment( delta.reference_period, periodFormat ).format(
+												UNITS[ unit ].shortFormat
+											),
+										},
+									} )
+								}
 								className={ `${ delta.favorable } ${ delta.direction }` }
-								suffix={ `since ${ moment( delta.reference_period, periodFormat ).format(
-									UNITS[ unit ].shortFormat
-								) }` }
 								iconSize={ 24 }
 							/>
 						</Tab>
@@ -96,4 +104,4 @@ export default connect( ( state, { query, siteId } ) => {
 		deltas: statsData.deltas,
 		isRequesting: isRequestingSiteStatsForQuery( state, siteId, 'statsOrders', query ),
 	};
-} )( withLocalizedMoment( StoreStatsOrdersChart ) );
+} )( localize( withLocalizedMoment( StoreStatsOrdersChart ) ) );


### PR DESCRIPTION
Related to 540-gh-Automattic/i18n-issues

## Proposed Changes

* The `suffix` string has been moved into the `value` to create a single translatable string.
* In the string, a string-type placeholder has been used for the percentage because it can also contain `-`. This detail has been left out in the comment for translators because it's probably irrelevant to them.

![image](https://user-images.githubusercontent.com/75777864/222417958-54a36f06-f531-480c-98f0-bfd8f4808228.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

NOTE: When running Calypso locally, many more untranslated strings can be seen on the same page. This is caused by a number of static `translate` calls throughout the `store-stats` package. In production, this (fortunately) isn't visible because the translation chunks are loaded in time. Correcting this would require quite a bit of refactoring (preferably by creating hooks and converting class-based components to functions) extending far beyond the scope of this PR. I'll let the relevant developer(s) know.

* Switch to a non-English language.
* Visit `/store/stats/orders/day/[site]` for a site with WooCommerce.
* Verify that the "since" label is still displayed in English (because the string is untranslated) and that the percentage and date are still substituted correctly.
* Run `yarn translate` from Calypso's root directory, open `public/calypso-strings.pot`, and verify that the string can be found along with the comment for translators.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
