### PR TITLE
TSC: Fix unsupported TS syntax in `getTransformedStreamItems` selector

### DIFF
--- a/client/state/reader/streams/selectors/get-reader-stream-transformed-items.ts
+++ b/client/state/reader/streams/selectors/get-reader-stream-transformed-items.ts
@@ -17,12 +17,13 @@ import 'calypso/state/reader/init';
  * function( state, { streamKey: string, recsStreamKey: string }): Array
  */
 export const getTransformedStreamItems = treeSelect(
-	( state, { streamKey, recsStreamKey } ) => [
+	( state, { streamKey, recsStreamKey }: { streamKey: string; recsStreamKey: string } ) => [
 		getReaderStream( state, streamKey ).items,
 		getReaderStream( state, recsStreamKey ).items,
 		getReaderFollows( state ),
 	],
-	( [ items, recs, follows ] ) => {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	( [ items, recs, follows ]: Array< any > ) => {
 		if ( items.length === 0 ) {
 			return [];
 		}

--- a/packages/tree-select/src/index.ts
+++ b/packages/tree-select/src/index.ts
@@ -26,7 +26,7 @@ interface Options< A extends unknown[] > {
 	getCacheKey?: GenerateCacheKey< A >;
 }
 
-interface CachedSelector< S, A extends unknown[], R = unknown > {
+export interface CachedSelector< S, A extends unknown[], R = unknown > {
 	( state: S, ...args: A ): R;
 	clearCache: () => void;
 }


### PR DESCRIPTION
## Proposed Changes

While working on #73890 I stumbled upon an error that I see when I run `yarn tsc --noEmit --project client/tsconfig.json`:

![Screenshot 2023-03-02 at 14 02 17](https://user-images.githubusercontent.com/8436925/222423464-6a1357d1-c521-4cd3-be1c-fd4723151460.png)

The fix is straightforward: we're renaming the offending file from `.js` to `.ts` and specifying a type for the deps argument of the `treeSelect`'s `selector` argument. Without the type, TS was crashing.

This has also been reported in #66894.

Fixes #66894.

## Testing Instructions

* Checkout latest `trunk` locally.
* Run `yarn tsc --noEmit --project client/tsconfig.json`
* Verify you get the error from above.
* Now checkout this branch.
* Run the command again.
* Verify that it passes without errors (nothing should be output by the command).
* Smoke test the reader and a few different stream types.
* Verify that all checks are green. There are e2e tests that test the reader that would fail if we broke this selector.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?