### PR TITLE
BBE In-Progress page: Add submission due date

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -1,19 +1,23 @@
+import { WPCOM_DIFM_LITE } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import SiteBuildInProgressIllustration from 'calypso/assets/images/difm/site-build-in-progress.svg';
 import WebsiteContentRequiredIllustration from 'calypso/assets/images/difm/website-content-required.svg';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
+import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { hasGSuiteWithUs } from 'calypso/lib/gsuite';
 import { hasTitanMailWithUs } from 'calypso/lib/titan';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { emailManagement } from 'calypso/my-sites/email/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSitePurchases, isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import isDIFMLiteWebsiteContentSubmitted from 'calypso/state/selectors/is-difm-lite-website-content-submitted';
 import { getSiteSlug, isRequestingSite, isRequestingSites } from 'calypso/state/sites/selectors';
-import { AppState } from 'calypso/types';
+import type { AppState } from 'calypso/types';
 
 import './difm-lite-in-progress.scss';
 
@@ -23,8 +27,12 @@ type DIFMLiteInProgressProps = {
 
 function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ) {
 	const slug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
+	useQuerySitePurchases( siteId );
 	const isLoadingSite = useSelector(
-		( state: AppState ) => isRequestingSite( state, siteId ) || isRequestingSites( state )
+		( state: AppState ) =>
+			isRequestingSite( state, siteId ) ||
+			isRequestingSites( state ) ||
+			isFetchingSitePurchases( state )
 	);
 	const isWebsiteContentSubmitted = useSelector( ( state ) =>
 		isDIFMLiteWebsiteContentSubmitted( state, siteId )
@@ -34,6 +42,22 @@ function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ) {
 	);
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
+	const difmPurchase = sitePurchases.find(
+		( purchase ) => WPCOM_DIFM_LITE === purchase.productSlug
+	);
+
+	const moment = useLocalizedMoment();
+	let contentSubmissionDueDate: string | null = null;
+	if ( difmPurchase?.subscribedDate ) {
+		const subscribedDate = new Date( difmPurchase.subscribedDate );
+		subscribedDate.setDate( subscribedDate.getDate() + difmPurchase.refundPeriodInDays );
+		// Due dates in the past are invalid.
+		if ( subscribedDate.getTime() > Date.now() ) {
+			contentSubmissionDueDate = moment( subscribedDate ).format( 'MMMM Do, YYYY' );
+		}
+	}
 
 	if ( ! primaryDomain || isLoadingSite ) {
 		return (
@@ -62,57 +86,73 @@ function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ) {
 		);
 	};
 
-	return isWebsiteContentSubmitted ? (
-		<EmptyContent
-			title={ translate( 'Your content submission was successful!' ) }
-			line={ translate(
-				"We are currently building your site and will send you an email when it's ready, within %d business days.{{br}}{{/br}}" +
+	if ( isWebsiteContentSubmitted ) {
+		return (
+			<EmptyContent
+				title={ translate( 'Your content submission was successful!' ) }
+				line={ translate(
+					"We are currently building your site and will send you an email when it's ready, within %d business days.{{br}}{{/br}}" +
+						'{{SupportLink}}Contact support{{/SupportLink}} if you have any questions.',
+					{
+						components: {
+							br: <br />,
+							SupportLink: (
+								<a
+									href={ `mailto:builtby+express@wordpress.com?subject=${ encodeURIComponent(
+										`I need help with my site: ${ primaryDomain.domain }`
+									) }` }
+								/>
+							),
+						},
+						args: [ 4 ],
+					}
+				) }
+				action={ translate( 'Manage domain' ) }
+				actionURL={ domainManagementList( slug ) }
+				secondaryAction={ hasEmailWithUs ? translate( 'Manage email' ) : translate( 'Add email' ) }
+				secondaryActionURL={ emailManagement( slug, null ) }
+				secondaryActionCallback={ recordEmailClick }
+				illustration={ SiteBuildInProgressIllustration }
+				illustrationWidth={ 144 }
+				className="difm-lite-in-progress__content"
+			/>
+		);
+	}
+
+	const lineTextTranslateOptions = {
+		components: {
+			br: <br />,
+			SupportLink: (
+				<a
+					href={ `mailto:builtby+express@wordpress.com?subject=${ encodeURIComponent(
+						`I need help with my site: ${ primaryDomain.domain }`
+					) }` }
+				/>
+			),
+		},
+		args: {
+			contentSubmissionDueDate,
+		},
+	};
+
+	const lineText = contentSubmissionDueDate
+		? translate(
+				'Click the button below to provide the content we need to build your site by %(contentSubmissionDueDate)s.{{br}}{{/br}}' +
 					'{{SupportLink}}Contact support{{/SupportLink}} if you have any questions.',
-				{
-					components: {
-						br: <br />,
-						SupportLink: (
-							<a
-								href={ `mailto:builtby+express@wordpress.com?subject=${ encodeURIComponent(
-									`I need help with my site: ${ primaryDomain.domain }`
-								) }` }
-							/>
-						),
-					},
-					args: [ 4 ],
-				}
-			) }
-			action={ translate( 'Manage domain' ) }
-			actionURL={ domainManagementList( slug ) }
-			secondaryAction={ hasEmailWithUs ? translate( 'Manage email' ) : translate( 'Add email' ) }
-			secondaryActionURL={ emailManagement( slug, null ) }
-			secondaryActionCallback={ recordEmailClick }
-			illustration={ SiteBuildInProgressIllustration }
-			illustrationWidth={ 144 }
-			className="difm-lite-in-progress__content"
-		/>
-	) : (
+				lineTextTranslateOptions
+		  )
+		: translate(
+				'Click the button below to provide the content we need to build your site.{{br}}{{/br}}' +
+					'{{SupportLink}}Contact support{{/SupportLink}} if you have any questions.',
+				lineTextTranslateOptions
+		  );
+
+	return (
 		<EmptyContent
 			title={ translate( 'Website content not submitted' ) }
-			line={ translate(
-				'Please provide the necessary information for the creation of your website. To access click on the button below.{{br}}{{/br}}' +
-					'{{SupportLink}}Contact support{{/SupportLink}} if you have any questions.',
-				{
-					components: {
-						br: <br />,
-						SupportLink: (
-							<a
-								href={ `mailto:builtby+express@wordpress.com?subject=${ encodeURIComponent(
-									`I need help with my site: ${ primaryDomain.domain }`
-								) }` }
-							/>
-						),
-					},
-				}
-			) }
-			action={ translate( 'Add content to your website' ) }
+			line={ lineText }
+			action={ translate( 'Provide website content' ) }
 			actionURL={ `/start/site-content-collection/website-content?siteSlug=${ slug }` }
-			secondaryActionCallback={ recordEmailClick }
 			illustration={ WebsiteContentRequiredIllustration }
 			illustrationWidth={ 144 }
 			className="difm-lite-in-progress__content"

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -147,7 +147,6 @@ function WebsiteContentSubmitted( { primaryDomain, siteSlug }: Props ) {
 
 function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ) {
 	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
-	useQuerySitePurchases( siteId );
 	const isLoadingSite = useSelector(
 		( state: AppState ) =>
 			isRequestingSite( state, siteId ) ||
@@ -160,6 +159,8 @@ function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ) {
 	const primaryDomain = useSelector( ( state: AppState ) =>
 		getPrimaryDomainBySiteId( state, siteId )
 	);
+
+	useQuerySitePurchases( siteId );
 
 	if ( ! primaryDomain || ! siteSlug || isLoadingSite ) {
 		return (

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -40,15 +40,18 @@ function WebsiteContentSubmissionPending( { primaryDomain, siteId, siteSlug }: P
 	);
 
 	const moment = useLocalizedMoment();
-	let contentSubmissionDueDate: string | null = null;
+	let contentSubmissionDueDate: number | null = null;
 	if ( difmPurchase?.subscribedDate ) {
 		const subscribedDate = new Date( difmPurchase.subscribedDate );
-		subscribedDate.setDate( subscribedDate.getDate() + difmPurchase.refundPeriodInDays );
+		contentSubmissionDueDate = subscribedDate.setDate(
+			subscribedDate.getDate() + difmPurchase.refundPeriodInDays
+		);
 		// Due dates in the past are invalid.
-		if ( subscribedDate.getTime() > Date.now() ) {
-			contentSubmissionDueDate = moment( subscribedDate ).format( 'MMMM Do, YYYY' );
+		if ( contentSubmissionDueDate < Date.now() ) {
+			contentSubmissionDueDate = null;
 		}
 	}
+
 	const lineTextTranslateOptions = {
 		components: {
 			br: <br />,
@@ -61,7 +64,9 @@ function WebsiteContentSubmissionPending( { primaryDomain, siteId, siteSlug }: P
 			),
 		},
 		args: {
-			contentSubmissionDueDate,
+			contentSubmissionDueDate: contentSubmissionDueDate
+				? moment( contentSubmissionDueDate ).format( 'MMMM Do, YYYY' )
+				: null,
 		},
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1567

## Proposed Changes

* Updates the copy on the BBE In-Progress page and adds the content submission due date. The due date is calculated as the purchase date + refund period in days.
<img width="1635" alt="image" src="https://user-images.githubusercontent.com/5436027/222426688-26ab8395-6d4e-4273-ac20-4a3c35e95eaf.png">

* If the due date is in the past, it's omitted from the copy.
<img width="1243" alt="image" src="https://user-images.githubusercontent.com/5436027/222426721-e1c4d139-0376-4113-a630-2764e877f3f5.png">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me` and complete purchase.
* Go to `/home/<site slug>`
* Confirm the copy matches the screenshot above.
* If you have an old existing BBE site, switch to it. If you have already submitted content, you can reset the submission status via the Blog RC. Confirm that the copy matches the second screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
