### PR TITLE
Social: Remove feature flag.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -1,12 +1,7 @@
-import config from '@automattic/calypso-config';
 import {
 	isJetpackPlanSlug,
 	JetpackTag,
 	JETPACK_RELATED_PRODUCTS_MAP,
-	PRODUCT_JETPACK_SOCIAL_ADVANCED,
-	PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY,
-	PRODUCT_JETPACK_SOCIAL_BASIC,
-	PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
@@ -114,16 +109,7 @@ const ProductLightbox: React.FC< Props > = ( {
 		} ) );
 	}, [ product.productSlug ] );
 
-	const isSocialProduct = [
-		PRODUCT_JETPACK_SOCIAL_ADVANCED,
-		PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY,
-		PRODUCT_JETPACK_SOCIAL_BASIC,
-		PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY,
-	].includes( product.productSlug );
-
-	const shouldShowOptions = ! isSocialProduct
-		? variantOptions.length > 1
-		: variantOptions.length > 1 && config.isEnabled( 'jetpack-social/advanced-plan' );
+	const shouldShowOptions = variantOptions.length;
 
 	const isMultiSiteIncompatible = isMultisite && ! getIsMultisiteCompatible( product );
 

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -109,7 +109,7 @@ const ProductLightbox: React.FC< Props > = ( {
 		} ) );
 	}, [ product.productSlug ] );
 
-	const shouldShowOptions = variantOptions.length;
+	const shouldShowOptions = variantOptions.length > 1;
 
 	const isMultiSiteIncompatible = isMultisite && ! getIsMultisiteCompatible( product );
 

--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	isJetpackPlanSlug,
 	PRODUCT_JETPACK_SOCIAL_ADVANCED,
@@ -109,14 +108,10 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 					].includes( item.productSlug );
 
 					// Go to the checkout page for all products when they click on the 'GET' CTA, except for Jetpack Social where we open a modal.
-					const ctaHref =
-						isSocialProduct && config.isEnabled( 'jetpack-social/advanced-plan' )
-							? `#${ item.productSlug }`
-							: getCheckoutURL( item );
-					const onClickCta =
-						isSocialProduct && config.isEnabled( 'jetpack-social/advanced-plan' )
-							? onClickMoreInfoFactory( item )
-							: getOnClickPurchase( item );
+					const ctaHref = isSocialProduct ? `#${ item.productSlug }` : getCheckoutURL( item );
+					const onClickCta = isSocialProduct
+						? onClickMoreInfoFactory( item )
+						: getOnClickPurchase( item );
 
 					return (
 						<li key={ item.productSlug }>

--- a/config/development.json
+++ b/config/development.json
@@ -91,7 +91,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
-		"jetpack-social/advanced-plan": true,
 		"jetpack/offer-complete-after-activation": true,
 		"jitms": true,
 		"lasagna": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -57,7 +57,6 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
-		"jetpack-social/advanced-plan": false,
 		"jetpack/offer-complete-after-activation": true,
 		"jitms": true,
 		"lasagna": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -54,7 +54,6 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/zendesk-chat-for-logged-in-users": true,
-		"jetpack-social/advanced-plan": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -48,7 +48,6 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/zendesk-chat-for-logged-in-users": true,
-		"jetpack-social/advanced-plan": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -50,7 +50,6 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/zendesk-chat-for-logged-in-users": true,
-		"jetpack-social/advanced-plan": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -51,7 +51,6 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/zendesk-chat-for-logged-in-users": true,
-		"jetpack-social/advanced-plan": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Remove feature flag for the advanced plan and enable it by default.

## Proposed Changes
Remove the feature flag which hides the advanced plan

## Testing Instructions
* Boot up calypso cloud
* Go to /pricing?view=products page and make sure it loads fine. 
* Boot up a site and purchase social basic on it.
* Boot up a different site and purchase social advanced on it.
* Go to /pricing/site/<something-your-testsite.com for both of your sites and make sure it loads fine. 
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
