### PR TITLE
Contact form/Help-Center: track q&a results display

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -209,7 +209,7 @@ export class HelpContactForm extends PureComponent {
 				const sameQuestionsReturned = areSameQuestions( this.state.qanda, qanda );
 				if ( ! sameQuestionsReturned ) {
 					recordTracksEvent( 'calypso_sibyl_display_results', {
-						results_count: qanda.length,
+						results_count: qanda?.length,
 					} );
 				}
 				this.setState( {

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -36,6 +36,14 @@ import { generateSubjectFromMessage } from './utils';
 
 import './style.scss';
 
+const trackSibylResultsDisplayed = ( results ) =>
+	composeAnalytics(
+		bumpStat( 'sibyl_results_displayed' ),
+		recordTracksEventAction( 'calypso_sibyl_display_results', {
+			resultsCount: results.length,
+		} )
+	);
+
 const trackSibylClick = ( event, helpLink ) =>
 	composeAnalytics(
 		bumpStat( 'sibyl_question_clicks', helpLink.id ),
@@ -622,6 +630,7 @@ export class HelpContactForm extends PureComponent {
 						helpLinks={ this.state.qanda }
 						iconTypeDescription="book"
 						onClick={ this.trackSibylClick }
+						onLinksDisplay={ this.props.trackSibylResultsDisplayed }
 						compact
 					/>
 				) }
@@ -668,6 +677,7 @@ const mapDispatchToProps = {
 	onChangeSite: selectSiteId,
 	recordTracksEventAction,
 	requestSite,
+	trackSibylResultsDisplayed,
 	trackSibylClick,
 	trackSibylFirstClick,
 	trackSupportAfterSibylClick,

--- a/client/me/help/help-results/index.jsx
+++ b/client/me/help/help-results/index.jsx
@@ -7,6 +7,7 @@ export default function HelpResults( {
 	compact,
 	footer,
 	helpLinks,
+	onLinksDisplay,
 	header,
 	iconTypeDescription,
 	onClick,
@@ -15,6 +16,8 @@ export default function HelpResults( {
 	if ( ! helpLinks.length ) {
 		return null;
 	}
+
+	onLinksDisplay( helpLinks );
 
 	return (
 		<>

--- a/client/me/help/help-results/index.jsx
+++ b/client/me/help/help-results/index.jsx
@@ -7,7 +7,6 @@ export default function HelpResults( {
 	compact,
 	footer,
 	helpLinks,
-	onLinksDisplay,
 	header,
 	iconTypeDescription,
 	onClick,
@@ -16,8 +15,6 @@ export default function HelpResults( {
 	if ( ! helpLinks.length ) {
 		return null;
 	}
-
-	onLinksDisplay( helpLinks );
 
 	return (
 		<>

--- a/packages/help-center/src/components/help-center-sibyl-articles.tsx
+++ b/packages/help-center/src/components/help-center-sibyl-articles.tsx
@@ -106,6 +106,13 @@ export function SibylArticles( {
 
 	const sectionName = useSelector( getSectionName );
 	const articles = useMemo( () => {
+		if ( sibylArticles?.length ) {
+			recordTracksEvent( 'calypso_helpcenter_sibyl_display_results', {
+				location: 'help-center',
+				resultsCount: sibylArticles.length,
+			} );
+		}
+
 		return (
 			sibylArticles?.length
 				? sibylArticles

--- a/packages/help-center/src/components/help-center-sibyl-articles.tsx
+++ b/packages/help-center/src/components/help-center-sibyl-articles.tsx
@@ -13,7 +13,7 @@ import {
 import { useLocale } from '@automattic/i18n-utils';
 import { external, Icon, page } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { Link, LinkProps } from 'react-router-dom';
 import { useDebounce } from 'use-debounce';
@@ -106,13 +106,6 @@ export function SibylArticles( {
 
 	const sectionName = useSelector( getSectionName );
 	const articles = useMemo( () => {
-		if ( sibylArticles?.length ) {
-			recordTracksEvent( 'calypso_helpcenter_sibyl_display_results', {
-				location: 'help-center',
-				results_count: sibylArticles.length,
-			} );
-		}
-
 		return (
 			sibylArticles?.length
 				? sibylArticles
@@ -128,6 +121,15 @@ export function SibylArticles( {
 			};
 		} );
 	}, [ sibylArticles, sectionName, intent?.site_intent, locale, message, articleCanNavigateBack ] );
+
+	useEffect( () => {
+		if ( sibylArticles?.length ) {
+			recordTracksEvent( 'calypso_helpcenter_sibyl_display_results', {
+				location: 'help-center',
+				results_count: sibylArticles.length,
+			} );
+		}
+	}, [ sibylArticles ] );
 
 	return (
 		<div className="help-center-sibyl-articles__container">

--- a/packages/help-center/src/components/help-center-sibyl-articles.tsx
+++ b/packages/help-center/src/components/help-center-sibyl-articles.tsx
@@ -109,7 +109,7 @@ export function SibylArticles( {
 		if ( sibylArticles?.length ) {
 			recordTracksEvent( 'calypso_helpcenter_sibyl_display_results', {
 				location: 'help-center',
-				resultsCount: sibylArticles.length,
+				results_count: sibylArticles.length,
 			} );
 		}
 


### PR DESCRIPTION
## Proposed Changes

This adds a tracks event to both the contact form and help-center, tracking when we display sibyl (q&a results). 
This will help us better understand sibyl's performance

## Testing Instructions

For the contact form
* Visit`/help/contact` and type in a subject (and the "How can we help section"). 
* Check that when the q&a results are displayed a network request to tracks (t.gif) is sent with the event name `calypso_sibyl_display_results`

For help center
* Launch the help center and select "Still need help"
* Chose Email, then type in a subject (and the "How can we help" section)
* Check that when the q&a results are displayed a network request to tracks (t.gif) is sent with the event name `calypso_helpcenter_sibyl_display_results`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
