### PR TITLE
Users management: Refactor pending invites

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -12,6 +12,7 @@ import PeopleList from './main';
 import PeopleAddSubscribers from './people-add-subscribers';
 import PeopleInviteDetails from './people-invite-details';
 import PeopleInvites from './people-invites';
+import PeopleInvitesPending from './people-invites-pending';
 import SubscriberDetails from './subscriber-details';
 import SubscribersTeam from './subscribers-team';
 import TeamInvite from './team-invite';
@@ -48,6 +49,10 @@ export default {
 
 	peopleInviteDetails( context, next ) {
 		renderPeopleInviteDetails( context, next );
+	},
+
+	peoplePendingInvites( context, next ) {
+		renderPendingInvites( context, next );
 	},
 
 	teamMembers( context, next ) {
@@ -132,6 +137,25 @@ function renderPeopleInvites( context, next ) {
 		<>
 			<PeopleInvitesTitle />
 			<PeopleInvites />
+		</>
+	);
+	next();
+}
+
+function renderPendingInvites( context, next ) {
+	const state = context.store.getState();
+	const site = getSelectedSite( state );
+
+	const PeopleInvitesTitle = () => {
+		const translate = useTranslate();
+
+		return <DocumentHead title={ translate( 'Pending Invites', { textOnly: true } ) } />;
+	};
+
+	context.primary = (
+		<>
+			<PeopleInvitesTitle />
+			<PeopleInvitesPending site={ site } />
 		</>
 	);
 	next();

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -55,6 +55,16 @@ export default function () {
 	);
 
 	page(
+		'/people/pending-invites/:site_id',
+		peopleController.enforceSiteEnding,
+		siteSelection,
+		navigation,
+		peopleController.peoplePendingInvites,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/people/:filter(subscribers)/:site_id',
 		peopleController.enforceSiteEnding,
 		siteSelection,

--- a/client/my-sites/people/people-invites-pending/index.tsx
+++ b/client/my-sites/people/people-invites-pending/index.tsx
@@ -1,7 +1,10 @@
 import { SiteDetails } from '@automattic/data-stores';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
+import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TeamInvites from 'calypso/my-sites/people/team-invites';
@@ -25,6 +28,26 @@ export default function PeopleInvitesPending( props: Props ) {
 			<PageViewTracker
 				path="/people/pending-invites/:site"
 				title="People > Pending Invite People"
+			/>
+			<FormattedHeader
+				brandFont
+				className="people__page-heading"
+				headerText={ translate( 'Users' ) }
+				subHeaderText={ translate(
+					'Invite subscribers and team members to your site and manage their access settings. {{learnMore}}Learn more{{/learnMore}}.',
+					{
+						components: {
+							learnMore: (
+								<InlineSupportLink
+									showIcon={ false }
+									supportLink={ localizeUrl( 'https://wordpress.com/support/invite-people/' ) }
+								/>
+							),
+						},
+					}
+				) }
+				align="left"
+				hasScreenOptions
 			/>
 			<HeaderCake onClick={ goBack }>{ translate( 'Pending invites' ) }</HeaderCake>
 			<TeamInvites />

--- a/client/my-sites/people/people-invites-pending/index.tsx
+++ b/client/my-sites/people/people-invites-pending/index.tsx
@@ -2,20 +2,24 @@ import { SiteDetails } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
+import { useSelector } from 'react-redux';
+import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TeamInvites from 'calypso/my-sites/people/team-invites';
+import { getPendingInvitesForSite } from 'calypso/state/invites/selectors';
 
 interface Props {
 	site: SiteDetails;
 }
 
 export default function PeopleInvitesPending( props: Props ) {
-	const { site } = props;
 	const translate = useTranslate();
+	const { site } = props;
+	const pendingInvites = useSelector( ( state ) => getPendingInvitesForSite( state, site.ID ) );
 
 	function goBack() {
 		const fallback = site?.slug ? '/people/team/' + site?.slug : '/people/team';
@@ -51,6 +55,12 @@ export default function PeopleInvitesPending( props: Props ) {
 			/>
 			<HeaderCake onClick={ goBack }>{ translate( 'Pending invites' ) }</HeaderCake>
 			<TeamInvites />
+			{ ! pendingInvites?.length && (
+				<EmptyContent
+					title={ translate( 'Oops, the invites list is empty' ) }
+					illustration="/calypso/images/illustrations/illustration-empty-results.svg"
+				/>
+			) }
 		</Main>
 	);
 }

--- a/client/my-sites/people/people-invites-pending/index.tsx
+++ b/client/my-sites/people/people-invites-pending/index.tsx
@@ -1,0 +1,33 @@
+import { SiteDetails } from '@automattic/data-stores';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import TeamInvites from 'calypso/my-sites/people/team-invites';
+
+interface Props {
+	site: SiteDetails;
+}
+
+export default function PeopleInvitesPending( props: Props ) {
+	const { site } = props;
+	const translate = useTranslate();
+
+	function goBack() {
+		const fallback = site?.slug ? '/people/team/' + site?.slug : '/people/team';
+
+		page.redirect( fallback );
+	}
+
+	return (
+		<Main>
+			<PageViewTracker
+				path="/people/pending-invites/:site"
+				title="People > Pending Invite People"
+			/>
+			<HeaderCake onClick={ goBack }>{ translate( 'Pending invites' ) }</HeaderCake>
+			<TeamInvites />
+		</Main>
+	);
+}

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -9,6 +9,7 @@ import SectionNav from 'calypso/components/section-nav';
 import useFollowersQuery from 'calypso/data/followers/use-followers-query';
 import useUsersQuery from 'calypso/data/users/use-users-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getPendingInvitesForSite } from 'calypso/state/invites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PeopleSectionNavCompact from '../people-section-nav-compact';
 import Subscribers from '../subscribers';
@@ -25,6 +26,9 @@ function SubscribersTeam( props: Props ) {
 	const translate = useTranslate();
 	const { filter, search } = props;
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const pendingInvites = useSelector( ( state ) =>
+		getPendingInvitesForSite( state, site?.ID as number )
+	);
 
 	// fetching data config
 	const followersFetchOptions = { search };
@@ -102,8 +106,12 @@ function SubscribersTeam( props: Props ) {
 										title="People > Team Members / Invites"
 									/>
 
-									<TeamMembers search={ search } usersQuery={ usersQuery } />
-									<TeamInvites />
+									<TeamInvites singleInviteView={ true } />
+									<TeamMembers
+										search={ search }
+										usersQuery={ usersQuery }
+										showAddTeamMembersBtn={ ! pendingInvites?.length }
+									/>
 								</>
 							);
 					}

--- a/client/my-sites/people/team-invites/index.tsx
+++ b/client/my-sites/people/team-invites/index.tsx
@@ -67,11 +67,11 @@ function TeamInvites( props: Props ) {
 					) }
 					{ singleInviteView && (
 						<>
-							<Card className="people-team-invites-list">
+							<Card className="people-team-invites-list people-team-invites-list-single-view">
 								{ renderInvite( pendingInvites?.[ 0 ] ) }
 								{ pendingInvites.length > 1 && (
 									<CompactCard
-										className="people-team-invites-list-view-all"
+										className="people-list-item-view-all"
 										href={ viewAllPendingInvitesLink }
 									>
 										{ translate( 'View all' ) }

--- a/client/my-sites/people/team-invites/index.tsx
+++ b/client/my-sites/people/team-invites/index.tsx
@@ -21,6 +21,7 @@ function TeamInvites( props: Props ) {
 	const siteId = site?.ID as number;
 	const pendingInvites = useSelector( ( state ) => getPendingInvitesForSite( state, siteId ) );
 	const addTeamMemberLink = `/people/new/${ site?.slug }`;
+	const viewAllPendingInvitesLink = `/people/pending-invites/${ site?.slug }`;
 
 	useGetInvitesQuery( siteId );
 
@@ -69,7 +70,10 @@ function TeamInvites( props: Props ) {
 							<Card className="people-team-invites-list">
 								{ renderInvite( pendingInvites?.[ 0 ] ) }
 								{ pendingInvites.length > 1 && (
-									<CompactCard href={ `/people/pending-invites/${ site?.slug }` }>
+									<CompactCard
+										className="people-team-invites-list-view-all"
+										href={ viewAllPendingInvitesLink }
+									>
 										{ translate( 'View all' ) }
 									</CompactCard>
 								) }

--- a/client/my-sites/people/team-invites/index.tsx
+++ b/client/my-sites/people/team-invites/index.tsx
@@ -46,8 +46,8 @@ function TeamInvites( props: Props ) {
 				<>
 					<PeopleListSectionHeader
 						label={ translate(
-							'You have a pending invite for %(number)d user',
-							'You have a pending invite for %(number)d users',
+							'You have %(number)d pending invite',
+							'You have %(number)d pending invites',
 							{
 								args: { number: pendingInvites?.length },
 								count: pendingInvites?.length as number,

--- a/client/my-sites/people/team-invites/index.tsx
+++ b/client/my-sites/people/team-invites/index.tsx
@@ -20,6 +20,7 @@ function TeamInvites( props: Props ) {
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const siteId = site?.ID as number;
 	const pendingInvites = useSelector( ( state ) => getPendingInvitesForSite( state, siteId ) );
+	const addTeamMemberLink = `/people/new/${ site?.slug }`;
 
 	useGetInvitesQuery( siteId );
 
@@ -53,7 +54,7 @@ function TeamInvites( props: Props ) {
 						) }
 					>
 						{ singleInviteView && (
-							<Button compact primary>
+							<Button compact primary href={ addTeamMemberLink }>
 								{ translate( 'Add a team member' ) }
 							</Button>
 						) }
@@ -68,7 +69,9 @@ function TeamInvites( props: Props ) {
 							<Card className="people-team-invites-list">
 								{ renderInvite( pendingInvites?.[ 0 ] ) }
 								{ pendingInvites.length > 1 && (
-									<CompactCard href="pending-invites">{ translate( 'View all' ) }</CompactCard>
+									<CompactCard href={ `/people/pending-invites/${ site?.slug }` }>
+										{ translate( 'View all' ) }
+									</CompactCard>
 								) }
 							</Card>
 						</>

--- a/client/my-sites/people/team-invites/index.tsx
+++ b/client/my-sites/people/team-invites/index.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@automattic/components';
+import { Button, Card, CompactCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import useGetInvitesQuery from 'calypso/data/invites/use-get-invites-query';
@@ -10,8 +10,13 @@ import type { Invite } from './types';
 
 import './style.scss';
 
-function TeamInvites() {
+interface Props {
+	singleInviteView?: boolean;
+}
+
+function TeamInvites( props: Props ) {
 	const translate = useTranslate();
+	const { singleInviteView } = props;
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const siteId = site?.ID as number;
 	const pendingInvites = useSelector( ( state ) => getPendingInvitesForSite( state, siteId ) );
@@ -46,8 +51,28 @@ function TeamInvites() {
 								count: pendingInvites?.length as number,
 							}
 						) }
-					/>
-					<Card className="people-team-invites-list">{ pendingInvites?.map( renderInvite ) }</Card>
+					>
+						{ singleInviteView && (
+							<Button compact primary>
+								{ translate( 'Add a team member' ) }
+							</Button>
+						) }
+					</PeopleListSectionHeader>
+					{ ! singleInviteView && (
+						<Card className="people-team-invites-list">
+							{ pendingInvites?.map( renderInvite ) }
+						</Card>
+					) }
+					{ singleInviteView && (
+						<>
+							<Card className="people-team-invites-list">
+								{ renderInvite( pendingInvites?.[ 0 ] ) }
+								{ pendingInvites.length > 1 && (
+									<CompactCard href="pending-invites">{ translate( 'View all' ) }</CompactCard>
+								) }
+							</Card>
+						</>
+					) }
 				</>
 			) }
 		</>

--- a/client/my-sites/people/team-invites/style.scss
+++ b/client/my-sites/people/team-invites/style.scss
@@ -1,3 +1,17 @@
 .people-team-invites-list {
 	padding: 0;
 }
+
+.people-team-invites-list-single-view {
+	.people-list-item.card.is-compact {
+		border-bottom: solid 1px var(--color-border-subtle);
+	}
+
+	.people-list-item-view-all.card {
+		font-size: 0.875rem;
+	}
+}
+
+.people-list-item-view-all {
+	box-shadow: none;
+}

--- a/client/my-sites/people/team-invites/style.scss
+++ b/client/my-sites/people/team-invites/style.scss
@@ -5,6 +5,11 @@
 .people-team-invites-list-single-view {
 	.people-list-item.card.is-compact {
 		border-bottom: solid 1px var(--color-border-subtle);
+
+		&:last-child {
+			border-bottom: none;
+			margin-bottom: 0;
+		}
 	}
 
 	.people-list-item-view-all.card {

--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -14,10 +14,11 @@ import './style.scss';
 interface Props {
 	search?: string;
 	usersQuery: UsersQuery;
+	showAddTeamMembersBtn?: boolean;
 }
 function TeamMembers( props: Props ) {
 	const translate = useTranslate();
-	const { search, usersQuery } = props;
+	const { search, usersQuery, showAddTeamMembersBtn = true } = props;
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 
 	const listKey = [ 'team-members', site?.ID, search ].join( '-' );
@@ -78,9 +79,11 @@ function TeamMembers( props: Props ) {
 			return (
 				<>
 					<PeopleListSectionHeader isPlaceholder={ isLoading } label={ getHeaderLabel() }>
-						<Button compact primary href={ addTeamMemberLink }>
-							{ translate( 'Add a team member' ) }
-						</Button>
+						{ showAddTeamMembersBtn && (
+							<Button compact primary href={ addTeamMemberLink }>
+								{ translate( 'Add a team member' ) }
+							</Button>
+						) }
 					</PeopleListSectionHeader>
 					<Card className="people-team-members-list">
 						{ isLoading && renderLoadingPeople() }


### PR DESCRIPTION
Closes #73867

## Proposed Changes

* Introduced a new `/people/pending-invites/{SITE_SLUG}` route
* Created a new Pending Invites page
* Adapted Team Invites component to support single invite view
* Reorder position of Pending invites block inside the Team screen

## Testing Instructions

- Go to `/people/team/{SITE_SLUG}`
- Make sure you have pending invites for the selected site
- Check if the Pending Invites block is above the Team Members block (before this change, it was below)
- Press "View all" card item (View all will be presented only if there is more than one pending invite)
- Check if the pending invites list is rendered (it is supposed to work as before, and it will because we reuse the same component)

## Screenshots
![Markup on 2023-03-03 at 14:53:25](https://user-images.githubusercontent.com/1241413/222737881-fd9968e6-378e-4ddb-a9e0-93cdc4a50074.png)

![Markup on 2023-03-03 at 14:54:58](https://user-images.githubusercontent.com/1241413/222737913-950ba126-f538-4e8f-a7ab-ef870cdf041c.png)

<img width="772" alt="Screenshot 2023-03-03 at 13 48 07" src="https://user-images.githubusercontent.com/1241413/222737080-39054179-0c00-4a45-bbd7-1c5029e3ddb3.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
