### PR TITLE
Remove/rollback last changes on help center for wpsupport theme

### DIFF
--- a/packages/help-center/src/components/help-center-inline-chat.tsx
+++ b/packages/help-center/src/components/help-center-inline-chat.tsx
@@ -15,7 +15,6 @@ document.body.appendChild( theIframe );
 theIframe.style.display = 'none';
 theIframe.style.position = 'fixed';
 theIframe.style.zIndex = '100000';
-theIframe.style.border = 'none';
 
 // cache for a day
 const cacheBuster = Math.floor( Date.now() / 1000 / 60 / 60 / 24 );


### PR DESCRIPTION
## Proposed changes

This is a Rollback PR, it caused significant changes to the number of page views that have React, Lodash, and Moment enqueued. more context p1677770767917399-slack-C02T4NVL4JJ

PR that caused the issue https://github.com/Automattic/wp-calypso/pull/73882

## How to test

- Pull and run this branch
- Navigate to apps/editing-toolkit and run yarn dev --sync to sync your sandbox
- Make sure to sandbox wordpress.com/support
- Navigate to https://wordpress.com/support
- Help Center should NOT be rendered on the admin bar
