### PR TITLE
Plugins: Use category on tags search when tags are not found

### DIFF
--- a/client/data/marketplace/search-api.ts
+++ b/client/data/marketplace/search-api.ts
@@ -169,10 +169,10 @@ function getFilterByCategory( category: string ): {
 			should: [
 				// matching wp.org categories and tags
 				{ term: { 'taxonomy.plugin_category.slug': category } },
-				{ terms: { 'taxonomy.plugin_tags.slug': categoryTags } },
+				{ terms: { 'taxonomy.plugin_tags.slug': categoryTags || [ category ] } },
 				// matching wc.com categories and tags
 				{ term: { 'taxonomy.wpcom_marketplace_categories.slug': category } },
-				{ terms: { 'taxonomy.plugin_tag.slug': categoryTags } },
+				{ terms: { 'taxonomy.plugin_tag.slug': categoryTags || [ category ] } },
 			],
 		},
 	};


### PR DESCRIPTION
Fixes #73884

## Proposed Changes

Use category on tags search when tags are not found.



## Testing Instructions
* Go to a free plugin details page. Ex: `/plugins/wordpress-seo`
* Click in one of the tags of the product

![CleanShot 2023-03-02 at 12 43 01@2x](https://user-images.githubusercontent.com/5039531/222476969-a53001e9-5e10-4e77-a50f-8df90b191386.png)

* On the search page that will open check:
  * On the production version NO PLUGINS should be shown
  * On this branch version at least a plugin WILL BE SHOWN
  
| Before  | After |
| ------------- | ------------- |
|<img width="969" alt="CleanShot 2023-03-02 at 12 35 47@2x" src="https://user-images.githubusercontent.com/5039531/222477254-509360d6-0c03-4bbd-9a79-70751401324a.png">|<img width="990" alt="CleanShot 2023-03-02 at 12 37 20@2x" src="https://user-images.githubusercontent.com/5039531/222477266-861432b4-9ec2-4d10-ab3c-1b0b1a3374d1.png">|

   

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
