### PR TITLE
Fix overall budget and 0 day campaign duration string

### DIFF
--- a/client/my-sites/promote-post/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post/components/campaign-item/index.tsx
@@ -72,7 +72,7 @@ export default function CampaignItem( { campaign }: Props ) {
 		[ start_date, end_date ]
 	);
 
-	const { totalBudget, totalBudgetLeft } = useMemo(
+	const { totalBudget, totalBudgetLeft, campaignDays } = useMemo(
 		() => getCampaignBudgetData( budget_cents, start_date, end_date, spent_budget_cents ),
 		[ budget_cents, spent_budget_cents ]
 	);
@@ -149,6 +149,8 @@ export default function CampaignItem( { campaign }: Props ) {
 			label: __( 'Ok' ),
 		},
 	];
+
+	const budgetString = campaignDays ? `$${ totalBudget } ${ totalBudgetLeftString }` : '-';
 
 	return (
 		<>
@@ -257,7 +259,9 @@ export default function CampaignItem( { campaign }: Props ) {
 							<div className="campaign-item__block_label campaign-item__budget-label">
 								{ __( 'Budget' ) }
 							</div>
-							<div className="campaign-item__block_value campaign-item__budget-value">{ `$${ totalBudget } ${ totalBudgetLeftString }` }</div>
+							<div className="campaign-item__block_value campaign-item__budget-value">
+								{ budgetString }
+							</div>
 						</div>
 					</div>
 

--- a/client/my-sites/promote-post/utils/index.ts
+++ b/client/my-sites/promote-post/utils/index.ts
@@ -118,7 +118,7 @@ export const getCampaignOverallSpending = (
 			? budget_cents * campaignDays
 			: spent_budget_cents;
 
-	const totalBudgetUsed = spentBudgetCents / 100;
+	const totalBudgetUsed = ( spentBudgetCents / 100 ).toFixed( 2 );
 	let daysRun = moment().diff( moment( start_date ), 'days' );
 	daysRun = daysRun > campaignDays ? campaignDays : daysRun;
 
@@ -145,11 +145,16 @@ export const getCampaignClickthroughRate = ( clicks_total: number, impressions_t
 export const getCampaignDurationFormatted = ( start_date: string, end_date: string ) => {
 	const campaignDays = getCampaignDurationDays( start_date, end_date );
 
-	const dateStartFormatted = moment.utc( start_date ).format( 'MMM D' );
-	const dateEndFormatted = moment.utc( end_date ).format( 'MMM D' );
-	const durationFormatted = `${ dateStartFormatted } - ${ dateEndFormatted } (${ campaignDays } ${ __(
-		'days'
-	) })`;
+	let durationFormatted;
+	if ( campaignDays === 0 ) {
+		durationFormatted = '-';
+	} else {
+		const dateStartFormatted = moment.utc( start_date ).format( 'MMM D' );
+		const dateEndFormatted = moment.utc( end_date ).format( 'MMM D' );
+		durationFormatted = `${ dateStartFormatted } - ${ dateEndFormatted } (${ campaignDays } ${ __(
+			'days'
+		) })`;
+	}
 
 	return durationFormatted;
 };
@@ -161,6 +166,7 @@ export const getCampaignBudgetData = (
 	spent_budget_cents: number
 ) => {
 	const campaignDays = getCampaignDurationDays( start_date, end_date );
+
 	const spentBudgetCents =
 		spent_budget_cents > budget_cents * campaignDays
 			? budget_cents * campaignDays
@@ -173,6 +179,7 @@ export const getCampaignBudgetData = (
 		totalBudget,
 		totalBudgetUsed,
 		totalBudgetLeft,
+		campaignDays,
 	};
 };
 


### PR DESCRIPTION
Related to #

## Proposed Changes

* When a campaign that was created and cancelled the same day it was displaying an odd text in the duration section:
Duration: Mar 2 - Mar 1 ( 0 days ) 

This label is actually correct because the campaign will be live tomorrow but it was cancelled before even starting. This change removes this label when the campaign hasn't even started

- The overall spending was showing a big decimal number: I've added a toFixed(2) to this value so this number stops growing that much

## Testing Instructions

* Create a blazepress campaign
* Stop it
* check the stats. The dates should display like this picture:
* For checking the overall, you will need to have a valid campaign. If needed I can modify this value in DB for a test campaign

![image](https://user-images.githubusercontent.com/43957544/222482546-af5b3883-096e-4fdc-a6f9-30318eeb1d0b.png)


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
