### PR TITLE
Sensei Tailored Flow: Don't install WooCommerce, save selected purposes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
@@ -1,83 +1,66 @@
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import { useAtomicSitePlugins } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/use-atomic-site-plugins';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { SenseiStepContainer } from '../components/sensei-step-container';
 import { Progress, SenseiStepProgress } from '../components/sensei-step-progress';
-import { getSelectedPlugins } from '../sensei-purpose/purposes';
+import {
+	getSelectedPlugins,
+	saveSelectedPurposesAsSenseiSiteSettings,
+} from '../sensei-purpose/purposes';
+import { useAtomicSitePlugins } from './use-atomic-site-plugins';
+import { useSubSteps, wait } from './use-sub-steps';
 import type { Step } from '../../types';
 
 import './style.scss';
 
 const SENSEI_PRO_PLUGIN_SLUG = 'sensei-pro';
 
-const useRetriesProgress = (
-	retries: number,
-	maxRetries: number,
-	expectedRetries: number
-): Progress => {
-	const progress: Progress = {
-		percentage: ( retries * 100 ) / expectedRetries,
-		title: __( 'Installing Sensei' ),
-		subtitle: __( 'Our flexible LMS to power your online courses' ),
-	};
-
-	if ( retries > expectedRetries / 2 || maxRetries === retries ) {
-		progress.title = __( 'Setting up your new Sensei Home' );
-	}
-
-	// Slow down progress bar increase during the last steps.
-	if ( retries > ( expectedRetries * 2 ) / 3 ) {
-		const slowPercentage = 66.6 + ( retries * 15 ) / expectedRetries;
-		progress.percentage = slowPercentage > 90 ? 90 : slowPercentage;
-	} else if ( retries < 0 ) {
-		progress.percentage = 100;
-	}
-	return progress;
-};
-
 const SenseiLaunch: Step = ( { navigation: { submit } } ) => {
-	const [ retries, setRetries ] = useState< number >( 0 );
-	const maxRetries = 40;
-	const progress = useRetriesProgress( retries, maxRetries, 15 );
+	const siteId = useSite()?.ID as number;
 
 	const { pollPlugins, isPluginInstalled, queuePlugin } = useAtomicSitePlugins();
 	const additionalPlugins = useMemo( () => getSelectedPlugins(), [] );
 
-	useEffect( () => {
-		additionalPlugins.forEach( queuePlugin );
-	}, [ additionalPlugins, queuePlugin ] );
-
-	const allPlugins = [ SENSEI_PRO_PLUGIN_SLUG, ...additionalPlugins.map( ( p ) => p.slug ) ];
+	const allPlugins = useMemo(
+		() => [ SENSEI_PRO_PLUGIN_SLUG, ...additionalPlugins.map( ( p ) => p.slug ) ],
+		[ additionalPlugins ]
+	);
 	const arePluginsInstalled = allPlugins.every( isPluginInstalled );
-	const isComplete = retries >= maxRetries || arePluginsInstalled;
 
-	useEffect(
-		function pollSitePlugins() {
-			function poll() {
-				pollPlugins();
-				setRetries( ( retries ) => retries + 1 );
-			}
-
-			if ( retries < maxRetries ) {
-				setTimeout( poll, 3000 );
-			}
+	const percentage = useSubSteps( [
+		async function queueAdditionalPlugins() {
+			additionalPlugins.forEach( queuePlugin );
+			return true;
 		},
-		// Do not trigger when pollPlugins changes.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[ retries ]
-	);
-
-	useEffect(
-		function submitWhenComplete() {
-			if ( isComplete ) {
-				setRetries( maxRetries );
-				submit?.();
-			}
+		async function waitForAllPlugins() {
+			pollPlugins();
+			await wait( 3000 );
+			return arePluginsInstalled;
 		},
-		[ isComplete, submit ]
-	);
+		async function savePurposeData() {
+			await saveSelectedPurposesAsSenseiSiteSettings( siteId );
+			return true;
+		},
+		async function done() {
+			setTimeout( () => submit?.(), 1000 );
+			return true;
+		},
+	] );
+
+	const progress: Progress = {
+		percentage,
+		title: __( 'Installing Sensei' ),
+		subtitle: __( 'Our flexible LMS to power your online courses' ),
+	};
+
+	if ( percentage > 50 ) {
+		Object.assign( progress, {
+			title: __( 'Setting up your new Sensei Home' ),
+			subtitle: null,
+		} );
+	}
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
@@ -31,36 +31,42 @@ const SenseiLaunch: Step = ( { navigation: { submit } } ) => {
 	);
 	const arePluginsInstalled = allPlugins.every( isPluginInstalled );
 
-	const percentage = useSubSteps( [
-		async function queueAdditionalPlugins() {
-			additionalPlugins.forEach( queuePlugin );
-			return true;
-		},
-		async function waitForAllPlugins() {
-			pollPlugins();
-			await wait( 3000 );
-			return arePluginsInstalled;
-		},
-		async function waitForJetpackTransfer( retries ) {
-			// Calling requestChecklist() below is causing Jetpack Identity Crisis (IDC) if used too early, so we wait
-			// a bit to give more time jetpack sync to complete.
-			await wait( 5000 );
-			return retries >= 3;
-		},
-		async function savePurposeData() {
-			await saveSelectedPurposesAsSenseiSiteSettings( siteId );
-			return true;
-		},
-		async function waitForChecklist() {
-			requestChecklist();
-			await wait( 5000 );
-			return isSenseiIncluded();
-		},
-		async function done() {
-			setTimeout( () => submit?.(), 1000 );
-			return true;
-		},
-	] );
+	const percentage = useSubSteps(
+		[
+			async function queueAdditionalPlugins() {
+				additionalPlugins.forEach( queuePlugin );
+				return true;
+			},
+			async function waitForAllPlugins() {
+				pollPlugins();
+				await wait( 3000 );
+				return arePluginsInstalled;
+			},
+			async function waitForJetpackTransfer( retries ) {
+				// Calling requestChecklist() below is causing Jetpack Identity Crisis (IDC) if used too early, so we wait
+				// a bit to give more time jetpack sync to complete.
+				await wait( 5000 );
+				return retries >= 3;
+			},
+			async function savePurposeData() {
+				await saveSelectedPurposesAsSenseiSiteSettings( siteId );
+				return true;
+			},
+			async function waitForChecklist() {
+				requestChecklist();
+				await wait( 5000 );
+				return isSenseiIncluded();
+			},
+			async function done() {
+				setTimeout( () => submit?.(), 1000 );
+				return true;
+			},
+		],
+		{
+			maxRetries: 40,
+			onFail: () => submit?.(),
+		}
+	);
 
 	const progress: Progress = {
 		percentage,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
@@ -1,8 +1,10 @@
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
 import { SenseiStepContainer } from '../components/sensei-step-container';
 import { Progress, SenseiStepProgress } from '../components/sensei-step-progress';
 import {
@@ -20,6 +22,7 @@ const SENSEI_PRO_PLUGIN_SLUG = 'sensei-pro';
 
 const SenseiLaunch: Step = ( { navigation: { submit } } ) => {
 	const siteId = useSite()?.ID as number;
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) ) as string;
 
 	const { pollPlugins, isPluginInstalled, queuePlugin } = useAtomicSitePlugins();
 	const { requestChecklist, isSenseiIncluded } = useAtomicSiteChecklist();
@@ -49,7 +52,7 @@ const SenseiLaunch: Step = ( { navigation: { submit } } ) => {
 				return retries >= 3;
 			},
 			async function savePurposeData() {
-				await saveSelectedPurposesAsSenseiSiteSettings( siteId );
+				await saveSelectedPurposesAsSenseiSiteSettings( siteSlug );
 				return true;
 			},
 			async function waitForChecklist() {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
@@ -63,7 +63,7 @@ const SenseiLaunch: Step = ( { navigation: { submit } } ) => {
 			},
 		],
 		{
-			maxRetries: 40,
+			maxRetries: 25,
 			onFail: () => submit?.(),
 		}
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
@@ -42,8 +42,8 @@ const SenseiLaunch: Step = ( { navigation: { submit } } ) => {
 			return arePluginsInstalled;
 		},
 		async function waitForJetpackTransfer( retries ) {
-			// Calling reqeustChecklist() below is causing Jetpack Identity Crisis if used to early so we wait a bit
-			// to give more time jetpack sync to complete.
+			// Calling requestChecklist() below is causing Jetpack Identity Crisis (IDC) if used too early, so we wait
+			// a bit to give more time jetpack sync to complete.
 			await wait( 5000 );
 			return retries >= 3;
 		},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/use-atomic-site-checklist.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/use-atomic-site-checklist.ts
@@ -1,0 +1,28 @@
+import { useCallback } from '@wordpress/element';
+import { useDispatch as useRootDispatch, useSelector } from 'react-redux';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { requestSiteChecklist } from 'calypso/state/checklist/actions';
+import getSiteChecklist from 'calypso/state/selectors/get-site-checklist';
+
+/**
+ * Gets the WPcom home checklist and checks if Sensei is one if its tasks.
+ */
+export function useAtomicSiteChecklist() {
+	const dispatch = useRootDispatch();
+	const siteId = useSite()?.ID || '';
+	const { siteChecklist } = useSelector( ( state ) => ( {
+		siteChecklist: getSiteChecklist( state, Number( siteId ) ),
+	} ) );
+
+	const requestChecklist = useCallback(
+		() => dispatch( requestSiteChecklist( siteId.toString() ) ),
+		[ dispatch, siteId ]
+	);
+
+	const isSenseiIncluded = useCallback(
+		() => siteChecklist?.tasks?.some( ( task ) => 'sensei_setup' === task.id ) || false,
+		[ siteChecklist ]
+	);
+
+	return { requestChecklist, isSenseiIncluded };
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/use-sub-steps.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/use-sub-steps.ts
@@ -5,9 +5,11 @@ export const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, m
 /**
  * A step in a linear installation process.
  *
+ * @param {number} retries Number of times this step was executed.
+ *
  * @returns Should resolve to true if the step was completed, false if it needs to be run again.
  */
-type SubStep = () => Promise< boolean >;
+type SubStep = ( retries: number ) => Promise< boolean >;
 
 type StepStatus = {
 	current: number;
@@ -36,7 +38,7 @@ export const useSubSteps = ( steps: SubStep[] ) => {
 			return;
 		}
 
-		stepFunction().then( ( result ) => {
+		stepFunction( retries ).then( ( result ) => {
 			setStepStatus( {
 				current: result ? current + 1 : current,
 				retries: result ? 0 : retries + 1,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/use-sub-steps.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/use-sub-steps.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+
+export const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
+
+/**
+ * A step in a linear installation process.
+ *
+ * @returns Should resolve to true if the step was completed, false if it needs to be run again.
+ */
+type SubStep = () => Promise< boolean >;
+
+type StepStatus = {
+	current: number;
+	retries: number;
+};
+
+/**
+ * Run a series of steps in order, re-running each step until it's complete.
+ *
+ * Steps should take care of waiting for requests or time delays, and resolve the returned promise
+ * to false when they are ready to run again, or true when they are complete and we can proceed
+ * with the next step.
+ *
+ * @param {SubStep[]} steps
+ * @returns {number} Progress percentage.
+ */
+export const useSubSteps = ( steps: SubStep[] ) => {
+	const [ { current, retries }, setStepStatus ] = useState< StepStatus >( {
+		current: 0,
+		retries: 0,
+	} );
+
+	useEffect( () => {
+		const stepFunction = steps[ current ];
+		if ( ! stepFunction ) {
+			return;
+		}
+
+		stepFunction().then( ( result ) => {
+			setStepStatus( {
+				current: result ? current + 1 : current,
+				retries: result ? 0 : retries + 1,
+			} );
+		} );
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- Only run on state change.
+	}, [ current, retries ] );
+
+	const percentagePerStep = 100 / ( steps.length || 10 );
+	const currentStepProgress = Math.min(
+		percentagePerStep * 0.9,
+		( percentagePerStep / 10 ) * retries
+	);
+	const progress = current * percentagePerStep + currentStepProgress;
+
+	return progress;
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/index.tsx
@@ -12,7 +12,7 @@ import {
 	clearSelectedPurposes,
 	SitePurpose,
 	purposes as purposeOptions,
-	saveSelectedPurposes,
+	setSelectedPurposes,
 } from './purposes';
 import type { Step } from '../../types';
 import './style.scss';
@@ -59,7 +59,7 @@ const SenseiPurpose: Step = ( { navigation: { submit } } ) => {
 	};
 
 	const submitPage = async () => {
-		saveSelectedPurposes( sitePurpose );
+		setSelectedPurposes( sitePurpose );
 		submit?.();
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/purposes.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/purposes.ts
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import wpcom from 'calypso/lib/wp';
 
 export type SitePurpose = {
 	selected: string[];
@@ -46,7 +47,7 @@ export const purposes: Purpose[] = [
 ];
 const STORAGE_KEY = 'sensei-site-purpose';
 
-export function saveSelectedPurposes( value: SitePurpose ) {
+export function setSelectedPurposes( value: SitePurpose ) {
 	window.sessionStorage.setItem( STORAGE_KEY, ( value && JSON.stringify( value ) ) || '' );
 }
 
@@ -72,4 +73,26 @@ export function getSelectedPlugins(): Plugin[] {
 				purpose.plugins ? plugins.concat( purpose.plugins as [] ) : plugins,
 			[]
 		);
+}
+
+export async function saveSelectedPurposesAsSenseiSiteSettings( siteId: number ) {
+	const purpose = getSelectedPurposes();
+	if ( ! purpose || ! siteId ) {
+		return;
+	}
+	try {
+		return await wpcom.req.post(
+			{
+				path: `/sites/${ siteId }/settings`,
+				apiNamespace: 'wp/v2',
+			},
+			{
+				sensei_setup_wizard_data: { purpose },
+			}
+		);
+	} catch ( e ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Failed to save Sensei purpose step data', e );
+		return false;
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/purposes.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/purposes.ts
@@ -75,15 +75,15 @@ export function getSelectedPlugins(): Plugin[] {
 		);
 }
 
-export async function saveSelectedPurposesAsSenseiSiteSettings( siteId: number ) {
+export async function saveSelectedPurposesAsSenseiSiteSettings( siteSlug: string ) {
 	const purpose = getSelectedPurposes();
-	if ( ! purpose || ! siteId ) {
+	if ( ! purpose || ! siteSlug ) {
 		return;
 	}
 	try {
 		return await wpcom.req.post(
 			{
-				path: `/sites/${ siteId }/settings`,
+				path: `/sites/${ siteSlug }/settings`,
 				apiNamespace: 'wp/v2',
 			},
 			{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/purposes.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/purposes.ts
@@ -22,17 +22,7 @@ export const purposes: Purpose[] = [
 	{
 		id: 'sell_courses',
 		label: __( 'Sell courses and generate income' ),
-		plugins: [
-			{
-				softwareSet: 'woo-on-plans',
-				slug: 'woocommerce',
-			},
-			{
-				slug: 'woocommerce-google-analytics-integration',
-				id: 'woocommerce-google-analytics-integration/woocommerce-google-analytics-integration',
-			},
-		],
-		description: __( 'WooCommerce will be installed for free.' ),
+		plugins: [],
 	},
 	{
 		id: 'provide_certification',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2147-gh-Automattic/sensei-pro
Partially fixes [this one](https://github.com/Automattic/sensei-pro/issues/2133).

## Proposed Changes

* Remove installing WooCommerce when the 'Sell courses and generate income' purpose is selected during onboarding
* Save the selected purposes to the site's setting after it's created
* Refactor the SenseiLaunch component to more easily define linear install steps 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Saving the option requires the following Sensei branch on the site https://github.com/Automattic/sensei/pull/6590
* Because of this, testing it on a new site created in the flow is not really possible for now.
* Create a business site or uninstall the managed Sensei LMS plugin
* Install and activate the plugin zip from the above PR (Download the ['Plugin build' job's artifact](https://github.com/Automattic/sensei/actions/runs/4308313078))
* Make sure Sensei Pro is also installed ([the latest release is fine](https://github.com/Automattic/sensei-pro/releases/tag/version%2Fsensei-pro-1.11.1))
* Open the site in the Sensei Tailored Flow: `http://calypso.localhost:3000/setup/sensei/senseiPurpose?siteSlug= onewhocomesbefore.wpcomstaging.com`
* Select some purposes, including other. Proceed. 
* Check that the option is saved in via WP-CLI

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?