### PR TITLE
Launchpad: Refactor query param retrieval for launchpad related logic

### DIFF
--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -48,7 +48,7 @@ export async function maybeRedirect( context, next ) {
 	// See https://cylonp2.wordpress.com/2022/09/19/question-about-infinite-redirect/#comment-1731
 	if (
 		( maybeStalelaunchpadScreenOption && maybeStalelaunchpadScreenOption === 'full' ) ||
-		getQueryArgs()?.showLaunchpad === true
+		getQueryArgs()?.showLaunchpad === 'true'
 	) {
 		await context.store.dispatch( requestSite( siteId ) );
 	}
@@ -58,7 +58,7 @@ export async function maybeRedirect( context, next ) {
 		refetchedOptions?.launchpad_screen === 'full' &&
 		// Temporary hack/band-aid to resolve a stale issue with atomic that the requestSite
 		// dispatch above doesnt always seem to resolve.
-		! getQueryArgs()?.launchpadComplete === true;
+		! getQueryArgs()?.launchpadComplete === 'true';
 
 	if ( shouldRedirectToLaunchpad ) {
 		// The new stepper launchpad onboarding flow isn't registered within the "page"

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,5 +1,6 @@
 import { isEcommerce } from '@automattic/calypso-products/src';
 import page from 'page';
+import { getQueryArgs } from 'calypso/lib/query-args';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 import { requestSite } from 'calypso/state/sites/actions';
@@ -38,7 +39,6 @@ export async function maybeRedirect( context, next ) {
 
 	const siteId = getSelectedSiteId( state );
 	const maybeStalelaunchpadScreenOption = getSiteOptions( state, siteId )?.launchpad_screen;
-	const currentUrl = window.location.href;
 
 	// We need the latest site info to determine if a user should be redirected to Launchpad.
 	// As a result, we can't use locally cached data, which might think that Launchpad is
@@ -48,7 +48,7 @@ export async function maybeRedirect( context, next ) {
 	// See https://cylonp2.wordpress.com/2022/09/19/question-about-infinite-redirect/#comment-1731
 	if (
 		( maybeStalelaunchpadScreenOption && maybeStalelaunchpadScreenOption === 'full' ) ||
-		currentUrl?.includes( 'showLaunchpad=true' )
+		getQueryArgs()?.showLaunchpad === true
 	) {
 		await context.store.dispatch( requestSite( siteId ) );
 	}
@@ -58,13 +58,13 @@ export async function maybeRedirect( context, next ) {
 		refetchedOptions?.launchpad_screen === 'full' &&
 		// Temporary hack/band-aid to resolve a stale issue with atomic that the requestSite
 		// dispatch above doesnt always seem to resolve.
-		! currentUrl?.includes( 'launchpadComplete=true' );
+		! getQueryArgs()?.launchpadComplete === true;
 
 	if ( shouldRedirectToLaunchpad ) {
 		// The new stepper launchpad onboarding flow isn't registered within the "page"
 		// client-side router, so page.redirect won't work. We need to use the
 		// traditional window.location Web API.
-		const verifiedParam = new URLSearchParams( window.location.search ).has( 'verified' );
+		const verifiedParam = getQueryArgs()?.verified;
 		redirectToLaunchpad( slug, refetchedOptions?.site_intent, verifiedParam );
 		return;
 	}

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -16,6 +16,7 @@ import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 import { preventWidows } from 'calypso/lib/formatting';
+import { getQueryArgs } from 'calypso/lib/query-args';
 import Primary from 'calypso/my-sites/customer-home/locations/primary';
 import Secondary from 'calypso/my-sites/customer-home/locations/secondary';
 import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
@@ -50,7 +51,7 @@ const Home = ( {
 	isNew7DUser,
 } ) => {
 	const [ celebrateLaunchModalIsOpen, setCelebrateLaunchModalIsOpen ] = useState(
-		window.location.href.includes( 'celebrateLaunch=true' )
+		getQueryArgs().celebrateLaunch === 'true'
 	);
 
 	const translate = useTranslate();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73341

## Test/Review Estimation

Test: Medium
Review: Short

## Proposed Changes

This PR is separating @Sharpirate's work: https://github.com/Automattic/wp-calypso/pull/73975

* Refactor query param retrieval for launchpad-related logic 

1. `showLaunchpad` query param after creating a launchpad-enabled general onboard site 
2. `launchpadComplete` query param after user launches their site from the launchpad screen
3. `verified` query param to display email verified notification
4. `celebrateLaunch` param to display the celebrate launch modal.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Create a new site (write or build flow)
* Confirm the user is redirected to the launchpad screen after they complete the onboarding flow
* Navigate to `/home/{siteSlug}?verified=true` (you should get redirected to the launchpad screen) and confirm the email verified notification appears on the launchpad screen
* Click the launch button, confirm the site is launched and the user is redirected to `/home`
* Confirm the launch celebration modal appears and the `celebrateLaunch` query param gets removed from the URL

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
