### PR TITLE
VAT: Add VAT text fallback for Business Tax ID

### DIFF
--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -35,8 +35,8 @@ function BillingHistory() {
 	let editVatText = translate( 'Edit Business Tax ID details' );
 	let addVatText = translate( 'Add Business Tax ID details' );
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
 		! i18n.hasTranslation( 'Edit Business Tax ID details' )
 	) {
 		editVatText = translate( 'Edit VAT details (for Europe only)' );

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { CompactCard, Card } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -32,8 +32,16 @@ export function BillingHistoryContent( {
 function BillingHistory() {
 	const translate = useTranslate();
 	const { vatDetails } = useVatDetails();
-	const editVatText = translate( 'Edit Business Tax ID details' );
-	const addVatText = translate( 'Add Business Tax ID details' );
+	let editVatText = translate( 'Edit Business Tax ID details' );
+	let addVatText = translate( 'Add Business Tax ID details' );
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation( 'Edit Business Tax ID details' )
+	) {
+		editVatText = translate( 'Edit VAT details (for Europe only)' );
+		addVatText = translate( 'Add VAT details (for Europe only)' );
+	}
 	const vatText = vatDetails.id ? editVatText : addVatText;
 
 	return (

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -58,8 +58,8 @@ Object.defineProperties( titles, {
 	vatDetails: {
 		get: () => {
 			if (
-				getLocaleSlug() !== 'en' ||
-				getLocaleSlug() !== 'en-gb' ||
+				getLocaleSlug() !== 'en' &&
+				getLocaleSlug() !== 'en-gb' &&
 				! i18n.hasTranslation( 'Business Tax ID details' )
 			) {
 				return i18n.translate( 'VAT Details' );

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -1,4 +1,4 @@
-import i18n from 'i18n-calypso';
+import i18n, { getLocaleSlug } from 'i18n-calypso';
 
 const titles = {
 	addCreditCard: i18n.translate( 'Add Credit Card' ),
@@ -56,7 +56,17 @@ Object.defineProperties( titles, {
 		get: () => i18n.translate( 'Payment Methods' ),
 	},
 	vatDetails: {
-		get: () => i18n.translate( 'Business Tax ID details' ),
+		get: () => {
+			if (
+				getLocaleSlug() !== 'en' ||
+				getLocaleSlug() !== 'en-gb' ||
+				! i18n.hasTranslation( 'Business Tax ID details' )
+			) {
+				return i18n.translate( 'VAT Details' );
+			}
+
+			return i18n.translate( 'Business Tax ID details' );
+		},
 	},
 } );
 

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -27,8 +27,8 @@ export default function VatInfoPage() {
 
 	let errorText = translate( 'An error occurred while fetching Business Tax ID details.' );
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
 		! i18n.hasTranslation( 'An error occurred while fetching Business Tax ID details.' )
 	) {
 		errorText = translate( 'An error occurred while fetching VAT details.' );
@@ -44,8 +44,8 @@ export default function VatInfoPage() {
 
 	let headerText = translate( 'Business Tax ID details' );
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
 		! i18n.hasTranslation( 'Business Tax ID details' )
 	) {
 		headerText = translate( 'VAT Information' );
@@ -55,8 +55,8 @@ export default function VatInfoPage() {
 		"We currently only provide Business Tax ID invoices to users who are properly registered. Business Tax ID information saved on this page will be applied to all of your account's receipts."
 	);
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
 		! i18n.hasTranslation(
 			"We currently only provide Business Tax ID invoices to users who are properly registered. Business Tax ID information saved on this page will be applied to all of your account's receipts."
 		)
@@ -109,8 +109,8 @@ function VatForm() {
 
 	let vatNumberHeader = translate( 'Business Tax ID Number' );
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
 		! i18n.hasTranslation( 'Business Tax ID Number' )
 	) {
 		vatNumberHeader = translate( 'VAT Number' );
@@ -127,8 +127,8 @@ function VatForm() {
 		}
 	);
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
 		! i18n.hasTranslation(
 			'To change your Business Tax ID number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.'
 		)
@@ -284,8 +284,8 @@ function useDisplayVatNotices( {
 		'Your Business Tax ID details are not valid. Please check each field and try again.'
 	);
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
 		! i18n.hasTranslation(
 			'Your Business Tax ID details are not valid. Please check each field and try again.'
 		)
@@ -299,8 +299,8 @@ function useDisplayVatNotices( {
 		'An error occurred while updating your Business Tax ID details. Please try again or contact support.'
 	);
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
 		! i18n.hasTranslation(
 			'An error occurred while updating your Business Tax ID details. Please try again or contact support.'
 		)
@@ -312,8 +312,8 @@ function useDisplayVatNotices( {
 
 	const vatSuccessNotice = translate( 'Your Business Tax ID details have been updated!' );
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
 		! i18n.hasTranslation( 'Your Business Tax ID details have been updated!' )
 	) {
 		vatUpdateError = translate( 'Your VAT details have been updated!' );

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -1,5 +1,5 @@
 import { CompactCard, Button, Card } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
@@ -25,13 +25,44 @@ export default function VatInfoPage() {
 
 	useRecordVatEvents( { fetchError } );
 
+	let errorText = translate( 'An error occurred while fetching Business Tax ID details.' );
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation( 'An error occurred while fetching Business Tax ID details.' )
+	) {
+		errorText = translate( 'An error occurred while fetching VAT details.' );
+	}
+
 	if ( fetchError ) {
 		return (
 			<div className="vat-info">
-				<CompactCard>
-					{ translate( 'An error occurred while fetching Business Tax ID details.' ) }
-				</CompactCard>
+				<CompactCard>{ errorText }</CompactCard>
 			</div>
+		);
+	}
+
+	let headerText = translate( 'Business Tax ID details' );
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation( 'Business Tax ID details' )
+	) {
+		headerText = translate( 'VAT Information' );
+	}
+
+	let sidebarText = translate(
+		"We currently only provide Business Tax ID invoices to users who are properly registered. Business Tax ID information saved on this page will be applied to all of your account's receipts."
+	);
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation(
+			"We currently only provide Business Tax ID invoices to users who are properly registered. Business Tax ID information saved on this page will be applied to all of your account's receipts."
+		)
+	) {
+		sidebarText = translate(
+			"We currently only provide VAT invoices to users who are properly listed in the VIES (VAT Information Exchange System) or the UK VAT databases. VAT information saved on this page will be applied to all of your account's receipts."
 		);
 	}
 
@@ -46,13 +77,9 @@ export default function VatInfoPage() {
 			<Column type="sidebar">
 				<Card className="vat-info__sidebar-card">
 					<CardHeading tagName="h1" size={ 16 } isBold={ true } className="vat-info__sidebar-title">
-						{ translate( 'Business Tax ID details' ) }
+						{ headerText }
 					</CardHeading>
-					<p className="vat-info__sidebar-paragraph">
-						{ translate(
-							"We currently only provide Business Tax ID invoices to users who are properly registered. Business Tax ID information saved on this page will be applied to all of your account's receipts."
-						) }
-					</p>
+					<p className="vat-info__sidebar-paragraph">{ sidebarText }</p>
 				</Card>
 			</Column>
 		</Layout>
@@ -80,6 +107,44 @@ function VatForm() {
 
 	const isVatAlreadySet = !! vatDetails.id;
 
+	let vatNumberHeader = translate( 'Business Tax ID Number' );
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation( 'Business Tax ID Number' )
+	) {
+		vatNumberHeader = translate( 'VAT Number' );
+	}
+
+	let vatNumberWarning = translate(
+		'To change your Business Tax ID number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+		{
+			components: {
+				contactSupportLink: (
+					<a target="_blank" href={ CALYPSO_CONTACT } rel="noreferrer" onClick={ clickSupport } />
+				),
+			},
+		}
+	);
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation(
+			'To change your Business Tax ID number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.'
+		)
+	) {
+		vatNumberWarning = translate(
+			'To change your VAT number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+			{
+				components: {
+					contactSupportLink: (
+						<a target="_blank" href={ CALYPSO_CONTACT } rel="noreferrer" onClick={ clickSupport } />
+					),
+				},
+			}
+		);
+	}
+
 	return (
 		<>
 			<FormFieldset className="vat-info__country-field">
@@ -94,7 +159,7 @@ function VatForm() {
 				/>
 			</FormFieldset>
 			<FormFieldset className="vat-info__vat-field">
-				<FormLabel htmlFor="vat">{ translate( 'Business Tax ID Number' ) }</FormLabel>
+				<FormLabel htmlFor="vat">{ vatNumberHeader }</FormLabel>
 				<FormTextInput
 					name="vat"
 					disabled={ isUpdating || isVatAlreadySet }
@@ -103,25 +168,7 @@ function VatForm() {
 						setCurrentVatDetails( { ...currentVatDetails, id: event.target.value } )
 					}
 				/>
-				{ isVatAlreadySet && (
-					<FormSettingExplanation>
-						{ translate(
-							'To change your Business Tax ID number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
-							{
-								components: {
-									contactSupportLink: (
-										<a
-											target="_blank"
-											href={ CALYPSO_CONTACT }
-											rel="noreferrer"
-											onClick={ clickSupport }
-										/>
-									),
-								},
-							}
-						) }
-					</FormSettingExplanation>
-				) }
+				{ isVatAlreadySet && <FormSettingExplanation>{ vatNumberWarning }</FormSettingExplanation> }
 			</FormFieldset>
 			<FormFieldset className="vat-info__name-field">
 				<FormLabel htmlFor="name">{ translate( 'Name' ) }</FormLabel>
@@ -233,31 +280,58 @@ function useDisplayVatNotices( {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
 
+	let vatFailedMessage = translate(
+		'Your Business Tax ID details are not valid. Please check each field and try again.'
+	);
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation(
+			'Your Business Tax ID details are not valid. Please check each field and try again.'
+		)
+	) {
+		vatFailedMessage = translate(
+			'Your VAT details are not valid. Please check each field and try again.'
+		);
+	}
+
+	let vatUpdateError = translate(
+		'An error occurred while updating your Business Tax ID details. Please try again or contact support.'
+	);
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation(
+			'An error occurred while updating your Business Tax ID details. Please try again or contact support.'
+		)
+	) {
+		vatUpdateError = translate(
+			'An error occurred while updating your VAT details. Please try again or contact support.'
+		);
+	}
+
+	const vatSuccessNotice = translate( 'Your Business Tax ID details have been updated!' );
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation( 'Your Business Tax ID details have been updated!' )
+	) {
+		vatUpdateError = translate( 'Your VAT details have been updated!' );
+	}
+
 	useEffect( () => {
 		if ( error?.error === 'validation_failed' ) {
 			reduxDispatch( removeNotice( 'vat_info_notice' ) );
-			reduxDispatch(
-				errorNotice(
-					translate(
-						'Your Business Tax ID details are not valid. Please check each field and try again.'
-					),
-					{ id: 'vat_info_notice' }
-				)
-			);
+			reduxDispatch( errorNotice( vatFailedMessage, { id: 'vat_info_notice' } ) );
 			return;
 		}
 
 		if ( error ) {
 			reduxDispatch( removeNotice( 'vat_info_notice' ) );
 			reduxDispatch(
-				errorNotice(
-					translate(
-						'An error occurred while updating your Business Tax ID details. Please try again or contact support.'
-					),
-					{
-						id: 'vat_info_notice',
-					}
-				)
+				errorNotice( vatUpdateError, {
+					id: 'vat_info_notice',
+				} )
 			);
 			return;
 		}
@@ -265,13 +339,21 @@ function useDisplayVatNotices( {
 		if ( success ) {
 			reduxDispatch( removeNotice( 'vat_info_notice' ) );
 			reduxDispatch(
-				successNotice( translate( 'Your Business Tax ID details have been updated!' ), {
+				successNotice( vatSuccessNotice, {
 					id: 'vat_info_notice',
 				} )
 			);
 			return;
 		}
-	}, [ error, success, reduxDispatch, translate ] );
+	}, [
+		error,
+		success,
+		reduxDispatch,
+		translate,
+		vatFailedMessage,
+		vatSuccessNotice,
+		vatUpdateError,
+	] );
 }
 
 function useRecordVatEvents( {

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -1,7 +1,7 @@
 import { Field } from '@automattic/wpcom-checkout';
 import { CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -183,6 +183,79 @@ export function VatForm( {
 		reduxDispatch( recordTracksEvent( 'calypso_vat_details_support_click' ) );
 	};
 
+	let vatButtonText = translate( 'Add Business Tax ID details' );
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation( 'Add Business Tax ID details' )
+	) {
+		vatButtonText = translate( 'Add VAT details' );
+	}
+
+	let northernIrelandText = translate( 'Is the tax ID for Northern Ireland?' );
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation( 'Is the VAT for Northern Ireland?' )
+	) {
+		northernIrelandText = translate( 'Add VAT details' );
+	}
+
+	let vatOrgLabel = translate( 'Organization for tax ID' );
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation( 'Organization for tax ID' )
+	) {
+		vatOrgLabel = translate( 'Organization for VAT' );
+	}
+
+	let vatNumberHeader = translate( 'Business Tax ID Number' );
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation( 'Business Tax ID Number' )
+	) {
+		vatNumberHeader = translate( 'VAT Number' );
+	}
+	let vatAddressLabel = translate( 'Address for tax ID' );
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation( 'Address for tax ID' )
+	) {
+		vatAddressLabel = translate( 'Address for VAT' );
+	}
+
+	let vatNumberWarning = translate(
+		'To change your Business Tax ID number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+		{
+			components: {
+				contactSupportLink: (
+					<a target="_blank" href={ CALYPSO_CONTACT } rel="noreferrer" onClick={ clickSupport } />
+				),
+			},
+		}
+	);
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation(
+			'To change your Business Tax ID number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.'
+		)
+	) {
+		vatNumberWarning = translate(
+			'To change your VAT number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+			{
+				components: {
+					contactSupportLink: (
+						<a target="_blank" href={ CALYPSO_CONTACT } rel="noreferrer" onClick={ clickSupport } />
+					),
+				},
+			}
+		);
+	}
+
 	if ( ! isFormActive ) {
 		return (
 			<div className="vat-form__row">
@@ -190,7 +263,7 @@ export function VatForm( {
 					className="vat-form__expand-button"
 					checked={ isFormActive }
 					onChange={ toggleVatForm }
-					label={ translate( 'Add Business Tax ID details' ) }
+					label={ vatButtonText }
 					disabled={ isDisabled }
 				/>
 			</div>
@@ -204,7 +277,7 @@ export function VatForm( {
 					className="vat-form__expand-button"
 					checked={ isFormActive }
 					onChange={ toggleVatForm }
-					label={ translate( 'Add Business Tax ID details' ) }
+					label={ vatButtonText }
 					disabled={ isDisabled || Boolean( vatDetailsFromServer.id ) }
 				/>
 				{ countryCode === 'GB' && (
@@ -212,7 +285,7 @@ export function VatForm( {
 						className="vat-form__expand-button"
 						checked={ vatDetailsInForm.country === 'XI' }
 						onChange={ toggleNorthernIreland }
-						label={ translate( 'Is the tax ID for Northern Ireland?' ) }
+						label={ northernIrelandText }
 						disabled={ isDisabled }
 					/>
 				) }
@@ -221,7 +294,7 @@ export function VatForm( {
 				<Field
 					id={ section + '-vat-organization' }
 					type="text"
-					label={ String( translate( 'Organization for tax ID' ) ) }
+					label={ String( vatOrgLabel ) }
 					value={ vatDetailsInForm.name ?? '' }
 					disabled={ isDisabled }
 					onChange={ ( newValue: string ) => {
@@ -234,7 +307,7 @@ export function VatForm( {
 				<Field
 					id={ section + '-vat-id' }
 					type="text"
-					label={ String( translate( 'Business Tax ID Number' ) ) }
+					label={ String( vatNumberHeader ) }
 					value={ vatDetailsInForm.id ?? '' }
 					disabled={ isDisabled || Boolean( vatDetailsFromServer.id ) }
 					onChange={ ( newValue: string ) => {
@@ -249,7 +322,7 @@ export function VatForm( {
 				<Field
 					id={ section + '-vat-address' }
 					type="text"
-					label={ String( translate( 'Address for tax ID' ) ) }
+					label={ String( vatAddressLabel ) }
 					value={ vatDetailsInForm.address ?? '' }
 					autoComplete="address"
 					disabled={ isDisabled }
@@ -263,23 +336,7 @@ export function VatForm( {
 			</div>
 			{ vatDetailsFromServer.id && (
 				<div>
-					<FormSettingExplanation>
-						{ translate(
-							'To change your Business Tax ID number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
-							{
-								components: {
-									contactSupportLink: (
-										<a
-											target="_blank"
-											href={ CALYPSO_CONTACT }
-											rel="noreferrer"
-											onClick={ clickSupport }
-										/>
-									),
-								},
-							}
-						) }
-					</FormSettingExplanation>
+					<FormSettingExplanation>{ vatNumberWarning }</FormSettingExplanation>
 				</div>
 			) }
 		</>

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -185,8 +185,8 @@ export function VatForm( {
 
 	let vatButtonText = translate( 'Add Business Tax ID details' );
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
 		! i18n.hasTranslation( 'Add Business Tax ID details' )
 	) {
 		vatButtonText = translate( 'Add VAT details' );
@@ -194,17 +194,17 @@ export function VatForm( {
 
 	let northernIrelandText = translate( 'Is the tax ID for Northern Ireland?' );
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
-		! i18n.hasTranslation( 'Is the VAT for Northern Ireland?' )
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
+		! i18n.hasTranslation( 'Is the tax ID for Northern Ireland?' )
 	) {
-		northernIrelandText = translate( 'Add VAT details' );
+		northernIrelandText = translate( 'Is the VAT for Northern Ireland?' );
 	}
 
 	let vatOrgLabel = translate( 'Organization for tax ID' );
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
 		! i18n.hasTranslation( 'Organization for tax ID' )
 	) {
 		vatOrgLabel = translate( 'Organization for VAT' );
@@ -212,16 +212,16 @@ export function VatForm( {
 
 	let vatNumberHeader = translate( 'Business Tax ID Number' );
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
 		! i18n.hasTranslation( 'Business Tax ID Number' )
 	) {
 		vatNumberHeader = translate( 'VAT Number' );
 	}
 	let vatAddressLabel = translate( 'Address for tax ID' );
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
 		! i18n.hasTranslation( 'Address for tax ID' )
 	) {
 		vatAddressLabel = translate( 'Address for VAT' );
@@ -238,8 +238,8 @@ export function VatForm( {
 		}
 	);
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
 		! i18n.hasTranslation(
 			'To change your Business Tax ID number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.'
 		)

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -22,7 +22,7 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled } from '@automattic/wpcom-checkout';
 import { useSelect, useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
 import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import MaterialIcon from 'calypso/components/material-icon';
@@ -308,6 +308,21 @@ export default function WPCheckout( {
 
 	const isDIFMInCart = hasDIFMProduct( responseCart );
 
+	let vatFailedMessage = translate(
+		'Your Business Tax ID details are not valid. Please check each field and try again.'
+	);
+	if (
+		getLocaleSlug() !== 'en' ||
+		getLocaleSlug() !== 'en-gb' ||
+		! i18n.hasTranslation(
+			'Your Business Tax ID details are not valid. Please check each field and try again.'
+		)
+	) {
+		vatFailedMessage = translate(
+			'Your VAT details are not valid. Please check each field and try again.'
+		);
+	}
+
 	return (
 		<CheckoutStepGroup
 			stepAreaHeader={
@@ -392,14 +407,7 @@ export default function WPCheckout( {
 							} catch ( error ) {
 								reduxDispatch( removeNotice( 'vat_info_notice' ) );
 								if ( shouldShowContactDetailsValidationErrors ) {
-									reduxDispatch(
-										errorNotice(
-											translate(
-												'Your Business Tax ID details are not valid. Please check each field and try again.'
-											),
-											{ id: 'vat_info_notice' }
-										)
-									);
+									reduxDispatch( errorNotice( vatFailedMessage, { id: 'vat_info_notice' } ) );
 								}
 								return false;
 							}

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -312,8 +312,8 @@ export default function WPCheckout( {
 		'Your Business Tax ID details are not valid. Please check each field and try again.'
 	);
 	if (
-		getLocaleSlug() !== 'en' ||
-		getLocaleSlug() !== 'en-gb' ||
+		getLocaleSlug() !== 'en' &&
+		getLocaleSlug() !== 'en-gb' &&
 		! i18n.hasTranslation(
 			'Your Business Tax ID details are not valid. Please check each field and try again.'
 		)


### PR DESCRIPTION
## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/73686 changed the labels for checkout and payments method management  so that instead of referencing "VAT" they referenced "Business Tax" to better support the wording used for taxes in different countries. However, that PR was deployed before the new translations were complete. This PR restores the old translations if the translations are not yet complete.

Fixes https://github.com/Automattic/payments-shilling/issues/1415

Before:

<img width="569" alt="Screenshot 2023-03-02 at 11 47 04 AM" src="https://user-images.githubusercontent.com/2036909/222497929-6b51ba47-cbac-4802-9e97-2776a4186c74.png">


After:

<img width="570" alt="Screenshot 2023-03-02 at 11 53 09 AM" src="https://user-images.githubusercontent.com/2036909/222497695-d068ccfa-7c31-4276-afcf-f94ab1fdc280.png">


## Testing Instructions

See the testing instructions on https://github.com/Automattic/wp-calypso/pull/73686 but view them in locales other than `en` to verify they are still translated. (This may actually be difficult because you'll need to find a language where the text has not yet been translated.)