### PR TITLE
E2E: fix issues with FSE: Smoke Test introduced with new Gutenberg version

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -132,16 +132,6 @@ export class FullSiteEditorPage {
 	}
 
 	/**
-	 * Clicks on the preview pane on the right to launch the editor window.
-	 */
-	async openEditor(): Promise< void > {
-		await this.editor
-			.frameLocator( 'iframe.edit-site-visual-editor__editor-canvas' )
-			.locator( 'body' )
-			.click( { timeout: 20 * 1000 } );
-	}
-
-	/**
 	 * Waits until the site editor is fully loaded.
 	 */
 	async waitUntilLoaded(): Promise< void > {
@@ -179,6 +169,14 @@ export class FullSiteEditorPage {
 				}
 			} );
 		}
+	}
+
+	/**
+	 * Clicks on a button with the exact name.
+	 */
+	async clickFullSiteNavigatorButton( text: string ): Promise< void > {
+		// await this.editor.locator( `button:has-text("${ text }")` ).click();
+		await this.editor.getByRole( 'button', { name: text, exact: true } ).click();
 	}
 
 	//#endregion

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -175,7 +175,6 @@ export class FullSiteEditorPage {
 	 * Clicks on a button with the exact name.
 	 */
 	async clickFullSiteNavigatorButton( text: string ): Promise< void > {
-		// await this.editor.locator( `button:has-text("${ text }")` ).click();
 		await this.editor.getByRole( 'button', { name: text, exact: true } ).click();
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -132,6 +132,16 @@ export class FullSiteEditorPage {
 	}
 
 	/**
+	 *
+	 */
+	async openEditor(): Promise< void > {
+		await this.editor
+			.frameLocator( 'iframe.edit-site-visual-editor__editor-canvas' )
+			.locator( 'body' )
+			.click();
+	}
+
+	/**
 	 * Waits until the site editor is fully loaded.
 	 */
 	async waitUntilLoaded(): Promise< void > {

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -132,7 +132,7 @@ export class FullSiteEditorPage {
 	}
 
 	/**
-	 *
+	 * Clicks on the preview pane on the right to launch the editor window.
 	 */
 	async openEditor(): Promise< void > {
 		await this.editor

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -138,7 +138,7 @@ export class FullSiteEditorPage {
 		await this.editor
 			.frameLocator( 'iframe.edit-site-visual-editor__editor-canvas' )
 			.locator( 'body' )
-			.click();
+			.click( { timeout: 20 * 1000 } );
 	}
 
 	/**

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -47,10 +47,17 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		await page.waitForURL( /site-editor/ );
 	} );
 
+	it( 'Open the Page template', async function () {
+		fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+
+		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Templates' );
+		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Page' );
+		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Edit' );
+	} );
+
 	it( 'Editor canvas loads', async function () {
 		fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 
-		await fullSiteEditorPage.openEditor();
 		await fullSiteEditorPage.waitUntilLoaded();
 	} );
 } );

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -49,8 +49,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 	it( 'Editor canvas loads', async function () {
 		fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
-		// The site editor navigation sidebar opens by default, so we close it
-		// await fullSiteEditorPage.closeNavSidebar();
+
 		await fullSiteEditorPage.openEditor();
 		await fullSiteEditorPage.waitUntilLoaded();
 	} );

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -44,14 +44,14 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	} );
 
 	it( 'Editor endpoint loads', async function () {
-		await page.waitForURL( /.*site-editor.*/ );
+		await page.waitForURL( /site-editor/ );
 	} );
 
-	// Skipping test until we have a way to reliably close the nav sidebar.
-	it.skip( 'Editor canvas loads', async function () {
+	it( 'Editor canvas loads', async function () {
 		fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 		// The site editor navigation sidebar opens by default, so we close it
-		await fullSiteEditorPage.closeNavSidebar();
+		// await fullSiteEditorPage.closeNavSidebar();
+		await fullSiteEditorPage.openEditor();
 		await fullSiteEditorPage.waitUntilLoaded();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #74009.
Related to https://github.com/Automattic/wp-calypso/pull/73979.

## Proposed Changes

This PR updates the steps involved in the `FSE: Smoke Test`.


## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
