### PR TITLE
add tracking event on page render

### DIFF
--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
@@ -45,7 +45,7 @@ const JetpackCompletePage: React.FC< Props > = ( { urlQueryArgs, siteSlug } ) =>
 		}
 
 		dispatch(
-			recordTracksEvent( 'calypso_jetpack_complete_page_render', {
+			recordTracksEvent( 'calypso_jetpack_complete_page_open', {
 				site_id: siteId,
 			} )
 		);

--- a/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/jetpack-complete-page/index.tsx
@@ -15,9 +15,10 @@ import JetpackRnaDialogCard from 'calypso/components/jetpack/card/jetpack-rna-di
 import Main from 'calypso/components/main';
 import { JPC_PATH_PLANS } from 'calypso/jetpack-connect/constants';
 import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { successNotice } from 'calypso/state/notices/actions';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
-import { QueryArgs, Duration } from '../types';
+import { QueryArgs } from '../types';
 import CtaButtons from './components/cta-buttons';
 import { ItemPrice } from './item-price';
 import ItemsIncluded from './items-included';
@@ -42,6 +43,12 @@ const JetpackCompletePage: React.FC< Props > = ( { urlQueryArgs, siteSlug } ) =>
 		if ( window.location.pathname.startsWith( JPC_PATH_PLANS ) ) {
 			dispatch( successNotice( translate( 'Jetpack is successfully connected' ) ) );
 		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_complete_page_render', {
+				site_id: siteId,
+			} )
+		);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
1203759331596262-asboard

## Proposed Changes
This PR adds a tracking event when the page renders.

## Testing Instructions
- Download the branch locally and start `yarn start`
- Spin up a new JN site and navigate to activate Jetpack Plugin
- After activation you should be redirected to a Complete page: `wordpress.com/jetpack/connect/plans/complete/:site`
- Change `worpdress.com` to `calypso.localhost:3000`
- Open Redux tab in your dev console and verify that event `calypso_jetpack_complete_page_open` fires
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?