### PR TITLE
Plugin Details: Add tags and category to the plugin installation event

### DIFF
--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -387,7 +387,7 @@ export const getCategories: () => Record< string, Category > = () => ( {
  * @param {Array<string>} pluginTags - array of tags of a plugin
  * @returns string | undefined - category name or undefined if no category is found
  */
-export function getCategory( pluginTags: Array< string > ) {
+export function getFirstCategoryFromTags( pluginTags: Array< string > ) {
 	const categories = getCategories();
 
 	return Object.keys( categories ).find( ( category ) => {

--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -381,6 +381,20 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 } );
 
+/**
+ * Get the first matching category from a collection of tags
+ *
+ * @param {Array<string>} pluginTags - array of tags of a plugin
+ * @returns string | undefined - category name or undefined if no category is found
+ */
+export function getCategory( pluginTags: Array< string > ) {
+	const categories = getCategories();
+
+	return Object.keys( categories ).find( ( category ) => {
+		return pluginTags.some( ( pluginTag ) => categories[ category ].tags.includes( pluginTag ) );
+	} );
+}
+
 export function useCategories(
 	allowedCategories = ALLOWED_CATEGORIES
 ): Record< string, Category > {

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -30,7 +30,7 @@ import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { getCategory } from '../categories/use-categories';
+import { getFirstCategoryFromTags } from '../categories/use-categories';
 import { PluginCustomDomainDialog } from '../plugin-custom-domain-dialog';
 import { getPeriodVariationValue } from '../plugin-price';
 import usePreinstalledPremiumPlugin from '../use-preinstalled-premium-plugin';
@@ -256,7 +256,7 @@ function onClickInstallPlugin( {
 			marketplace_product: isMarketplaceProduct,
 			needs_plan_upgrade: upgradeAndInstall,
 			tags: tags.join( ',' ),
-			category: getCategory( tags ),
+			category: getFirstCategoryFromTags( tags ),
 		} )
 	);
 

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -30,6 +30,7 @@ import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getCategory } from '../categories/use-categories';
 import { PluginCustomDomainDialog } from '../plugin-custom-domain-dialog';
 import { getPeriodVariationValue } from '../plugin-price';
 import usePreinstalledPremiumPlugin from '../use-preinstalled-premium-plugin';
@@ -235,6 +236,8 @@ function onClickInstallPlugin( {
 	preinstalledPremiumPluginProduct,
 	productsList,
 } ) {
+	const tags = Object.keys( plugin.tags );
+
 	dispatch( removePluginStatuses( 'completed', 'error', 'up-to-date' ) );
 
 	dispatch(
@@ -252,6 +255,8 @@ function onClickInstallPlugin( {
 			blog_id: selectedSite?.ID,
 			marketplace_product: isMarketplaceProduct,
 			needs_plan_upgrade: upgradeAndInstall,
+			tags: tags.join( ',' ),
+			category: getCategory( tags ),
 		} )
 	);
 


### PR DESCRIPTION
Fixes #66643

## Proposed Changes

Add tags and category to the plugin installation event. The category will be defined from first matching plugin tag, if none is found this attribute will be sent.

## Testing Instructions
* Log the calypso events pasting this into the terminal: `localStorage.setItem( 'debug', 'calypso:analytics*' );`
* Filter by `calypso_plugin_install_activate_click`
* Go to a plugin details page. Ex: `/plugins/woocommerce-subscriptions/:site`
* Click on `Purchase and activate`
* Check if the event will be logged with all plugin tags and with a category if its found

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
