### PR TITLE
Add context when adding global-stylesstickers

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -343,7 +343,9 @@ function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
 
 	switch_to_blog( $blog_id );
 
-	add_blog_sticker( 'wpcom-premium-global-styles-exemption-checked', null, null, $blog_id );
+	$note = 'See https://wp.me/p7DVsv-fY6#comment-44778';
+
+	add_blog_sticker( 'wpcom-premium-global-styles-exemption-checked', $note, null, $blog_id );
 
 	$global_styles_used = false;
 
@@ -361,7 +363,7 @@ function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
 	}
 
 	if ( $global_styles_used ) {
-		add_blog_sticker( 'wpcom-premium-global-styles-exempt', null, null, $blog_id );
+		add_blog_sticker( 'wpcom-premium-global-styles-exempt', $note, null, $blog_id );
 	}
 
 	restore_current_blog();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1677499469079609-slack-C025Q5RK2

## Proposed Changes

Add a link to the P2 describing the global styles gating stickers when adding them.

The stickers can be added when superadmins visit the sites blog report card, this shows up in the audit log and may be alarming. Adding this link means that people who notice this can read more about it and gain some reassurance.

## Testing Instructions

 1. Apply this change to your sandbox
 1. Find a site which pre-dates the global styles gating rollout date that hasn't yet had exemption checking stickers applied (or find one that has and remove the stickers)
 2. If using your sandbox dev ETK folder, change `tools/reportcard/includes/cards/full-site-editing.php` in your dev MC to load from your sandbox dev ETK folder
 3. Sandbox MC and visit the sites blog report card in dev mc
 4. Look at the audit log, it should link the global styles gating message to a P2 comment

![image](https://user-images.githubusercontent.com/93301/222548464-df26ba11-637d-495d-9a10-efc99fe8b21d.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?