### PR TITLE
Odyssey: remove dup query string on reload

### DIFF
--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -49,7 +49,7 @@ async function AppBoot() {
 	if ( ! window.location?.hash ) {
 		window.location.hash = `#!/stats/day/${ siteId }`;
 	} else {
-		// The URL could already be broken by page.js by the appended `?page=stats`.
+		// The URL could already get broken by page.js by the appended `?page=stats`.
 		window.location.hash = `#!${ getPathWithUpdatedQueryString(
 			{},
 			window.location.hash.substring( 2 )

--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -3,6 +3,7 @@
  */
 import './load-config';
 import config from '@automattic/calypso-config';
+import page from 'page';
 import '@automattic/calypso-polyfills';
 import { QueryClient } from 'react-query';
 import { createStore, applyMiddleware, compose } from 'redux';
@@ -47,16 +48,19 @@ async function AppBoot() {
 
 	if ( ! window.location?.hash ) {
 		window.location.hash = `#!/stats/day/${ siteId }`;
+	} else {
+		// The URL could already be broken by page.js by the appended `?page=stats`.
+		window.location.hash = `#!${ getPathWithUpdatedQueryString(
+			{},
+			window.location.hash.substring( 2 )
+		) }`;
 	}
 
 	registerStatsPages( window.location.pathname + window.location.search );
 
 	// HACK: getPathWithUpdatedQueryString filters duplicate query parameters added by `page.js`.
 	// It has to come after `registerStatsPages` because the duplicate string added in the function.
-	window.location.hash = `#!${ getPathWithUpdatedQueryString(
-		{},
-		window.location.hash.substring( 2 )
-	) }`;
+	page.show( `${ getPathWithUpdatedQueryString( {}, window.location.hash.substring( 2 ) ) }` );
 }
 
 AppBoot();

--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -51,6 +51,7 @@ async function AppBoot() {
 
 	registerStatsPages( window.location.pathname + window.location.search );
 
+	// HACK: getPathWithUpdatedQueryString filters duplicate query parameters added by `page.js`.
 	window.location.hash = `#!${ getPathWithUpdatedQueryString() }`;
 }
 

--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -53,7 +53,7 @@ async function AppBoot() {
 	// Test whether there are two query strings (two '?').
 	if ( window.location.hash.replaceAll( /[^?]/g, '' ).length > 1 ) {
 		// If so, we remove the last '?' and the query string following it with the lazy match regex.
-		window.location.hash = window.location.hash.replace( /\?[^?]*?page=stats[^?]*?$/, '' );
+		window.location.hash = window.location.hash.replace( /(\?[^?]*)\?.*page=stats.*$/, '$1' );
 	}
 }
 

--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -52,7 +52,11 @@ async function AppBoot() {
 	registerStatsPages( window.location.pathname + window.location.search );
 
 	// HACK: getPathWithUpdatedQueryString filters duplicate query parameters added by `page.js`.
-	window.location.hash = `#!${ getPathWithUpdatedQueryString() }`;
+	// It has to come after `registerStatsPages` because the duplicate string added in the function.
+	window.location.hash = `#!${ getPathWithUpdatedQueryString(
+		{},
+		window.location.hash.substring( 2 )
+	) }`;
 }
 
 AppBoot();

--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -7,6 +7,7 @@ import '@automattic/calypso-polyfills';
 import { QueryClient } from 'react-query';
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunkMiddleware from 'redux-thunk';
+import { getPathWithUpdatedQueryString } from 'calypso/my-sites/stats/utils';
 import consoleDispatcher from 'calypso/state/console-dispatch';
 import currentUser from 'calypso/state/current-user/reducer';
 import wpcomApiMiddleware from 'calypso/state/data-layer/wpcom-api-middleware';
@@ -47,13 +48,13 @@ async function AppBoot() {
 	if ( ! window.location?.hash ) {
 		window.location.hash = `#!/stats/day/${ siteId }`;
 	}
+
 	registerStatsPages( window.location.pathname + window.location.search );
 
-	// HACK: page.js adds a `?...page=stats&...` query param to the URL in Odyssey on page refresh everytime.
-	// Test whether there are two query strings (two '?').
-	if ( window.location.hash.replaceAll( /[^?]/g, '' ).length > 1 ) {
-		// If so, we remove the last '?' and the query string following it with the lazy match regex.
-		window.location.hash = window.location.hash.replace( /(\?[^?]*)\?.*page=stats.*$/, '$1' );
+	// HACK: page.js adds a `?...page=stats...` query param to the URL in Odyssey on page refresh everytime.
+	const newHash = `#!${ getPathWithUpdatedQueryString() }`;
+	if ( newHash !== window.location.hash ) {
+		window.location.hash = `#!${ getPathWithUpdatedQueryString() }`;
 	}
 }
 

--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -48,6 +48,13 @@ async function AppBoot() {
 		window.location.hash = `#!/stats/day/${ siteId }`;
 	}
 	registerStatsPages( window.location.pathname + window.location.search );
+
+	// HACK: page.js adds a `?...page=stats&...` query param to the URL in Odyssey on page refresh everytime.
+	// Test whether there are two query strings (two '?').
+	if ( window.location.hash.replaceAll( /[^?]/g, '' ).length > 1 ) {
+		// If so, we remove the last '?' and the query string following it with the lazy match regex.
+		window.location.hash = window.location.hash.replace( /\?[^?]*?page=stats[^?]*?$/, '' );
+	}
 }
 
 AppBoot();

--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -51,11 +51,7 @@ async function AppBoot() {
 
 	registerStatsPages( window.location.pathname + window.location.search );
 
-	// HACK: page.js adds a `?...page=stats...` query param to the URL in Odyssey on page refresh everytime.
-	const newHash = `#!${ getPathWithUpdatedQueryString() }`;
-	if ( newHash !== window.location.hash ) {
-		window.location.hash = `#!${ getPathWithUpdatedQueryString() }`;
-	}
+	window.location.hash = `#!${ getPathWithUpdatedQueryString() }`;
 }
 
 AppBoot();

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -60,7 +60,7 @@ function updateQueryString( url = null, query = {} ) {
 	}
 
 	return {
-		...parseQs( search.substring( 1 ) ),
+		...parseQs( search.substring( 1 ), { parseArrays: false } ),
 		...query,
 	};
 }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -1,12 +1,10 @@
 import config from '@automattic/calypso-config';
-import { getUrlParts } from '@automattic/calypso-url';
 import { eye } from '@automattic/components/src/icons';
 import { Icon, people, starEmpty, commentContent } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
 import { find } from 'lodash';
 import page from 'page';
-import { parse as parseQs, stringify as stringifyQs } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
@@ -48,22 +46,7 @@ import StatsNotices from './stats-notices';
 import StatsPeriodHeader from './stats-period-header';
 import StatsPeriodNavigation from './stats-period-navigation';
 import statsStrings from './stats-strings';
-
-function getPageUrl() {
-	return getUrlParts( page.current );
-}
-
-function updateQueryString( url = null, query = {} ) {
-	let search = window.location.search;
-	if ( url ) {
-		search = url.search;
-	}
-
-	return {
-		...parseQs( search.substring( 1 ), { parseArrays: false } ),
-		...query,
-	};
-}
+import { getPathWithUpdatedQueryString } from './utils';
 
 const memoizedQuery = memoizeLast( ( period, endOf ) => ( {
 	period,
@@ -143,9 +126,7 @@ class StatsSite extends Component {
 
 	barClick = ( bar ) => {
 		this.props.recordGoogleEvent( 'Stats', 'Clicked Chart Bar' );
-		const parsed = getPageUrl();
-		const updatedQs = stringifyQs( updateQueryString( parsed, { startDate: bar.data.period } ) );
-		page.redirect( `${ parsed.pathname }?${ updatedQs }` );
+		page.redirect( getPathWithUpdatedQueryString( { startDate: bar.data.period } ) );
 	};
 
 	onChangeLegend = ( activeLegend ) => this.setState( { activeLegend } );
@@ -154,8 +135,7 @@ class StatsSite extends Component {
 		if ( ! tab.loading && tab.attr !== this.props.chartTab ) {
 			this.props.recordGoogleEvent( 'Stats', 'Clicked ' + titlecase( tab.attr ) + ' Tab' );
 			// switch the tab by navigating to route with updated query string
-			const updatedQs = stringifyQs( updateQueryString( getPageUrl(), { tab: tab.attr } ) );
-			page.show( `${ getPageUrl().pathname }?${ updatedQs }` );
+			page.show( getPathWithUpdatedQueryString( { tab: tab.attr } ) );
 		}
 	};
 

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -1,11 +1,9 @@
-import { getUrlParts } from '@automattic/calypso-url';
 import { Spinner } from '@automattic/components';
 import { localize, translate } from 'i18n-calypso';
 import { find, flowRight } from 'lodash';
 import moment from 'moment';
 import page from 'page';
 import PropTypes from 'prop-types';
-import { parse as parseQs, stringify as stringifyQs } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
@@ -34,28 +32,13 @@ import StatsEmailTopRow from '../stats-email-top-row';
 import { StatsNoContentBanner } from '../stats-no-content-banner';
 import StatsPeriodHeader from '../stats-period-header';
 import StatsPeriodNavigation from '../stats-period-navigation';
+import { getPathWithUpdatedQueryString } from '../utils';
 import './style.scss';
 
 const pageTitles = {
 	opens: translate( 'Email opens' ),
 	clicks: translate( 'Email clicks' ),
 };
-
-function getPageUrl() {
-	return getUrlParts( page.current );
-}
-
-function updateQueryString( url = null, query = {} ) {
-	let search = window.location.search;
-	if ( url ) {
-		search = url.search;
-	}
-
-	return {
-		...parseQs( search.substring( 1 ) ),
-		...query,
-	};
-}
 
 const getActiveTab = ( chartTab, statType ) => {
 	const charts = getCharts( statType );
@@ -151,8 +134,7 @@ class StatsEmailDetail extends Component {
 		if ( ! tab.loading && tab.attr !== this.props.chartTab ) {
 			this.props.recordGoogleEvent( 'Stats', 'Clicked ' + titlecase( tab.attr ) + ' Tab' );
 			// switch the tab by navigating to route with updated query string
-			const updatedQs = stringifyQs( updateQueryString( getPageUrl(), { tab: tab.attr } ) );
-			page.show( `${ getPageUrl().pathname }?${ updatedQs }` );
+			page.show( getPathWithUpdatedQueryString( { tab: tab.attr } ) );
 		}
 	};
 

--- a/client/my-sites/stats/test/utils.js
+++ b/client/my-sites/stats/test/utils.js
@@ -1,0 +1,29 @@
+import { getPathWithUpdatedQueryString } from '../utils';
+
+describe( 'getPathWithUpdatedQueryString', () => {
+	it( 'should return the path with the updated query string', () => {
+		expect( getPathWithUpdatedQueryString( { h: 'i' }, '/a/b/c?d=e&f=g' ) ).toEqual(
+			'/a/b/c?d=e&f=g&h=i'
+		);
+		expect( getPathWithUpdatedQueryString( { f: 'i' }, '/a/b/c?d=e&f=g' ) ).toEqual(
+			'/a/b/c?d=e&f=i'
+		);
+		expect( getPathWithUpdatedQueryString( { f: 'i' }, '/a/b/c' ) ).toEqual( '/a/b/c?f=i' );
+		expect( getPathWithUpdatedQueryString( {}, '/a/b/c' ) ).toEqual( '/a/b/c' );
+		expect( getPathWithUpdatedQueryString( {}, '/a/b/c?d=e' ) ).toEqual( '/a/b/c?d=e' );
+	} );
+	it( 'should walk around the page.js bug', () => {
+		expect( getPathWithUpdatedQueryString( { h: 'i' }, '/a/b/c?d=e&f=g?page=stats' ) ).toEqual(
+			'/a/b/c?d=e&f=g&h=i'
+		);
+		expect(
+			getPathWithUpdatedQueryString( { h: 'i' }, '/a/b/c?d=e&f=g?page=stats?page=stats?page=stats' )
+		).toEqual( '/a/b/c?d=e&f=g&h=i' );
+		expect(
+			getPathWithUpdatedQueryString( { h: 'i' }, '/a/b/c?page=stats?page=stats?page=stats' )
+		).toEqual( '/a/b/c?page=stats&h=i' );
+		expect(
+			getPathWithUpdatedQueryString( { h: 'i' }, '/a/b/c?h=k?page=stats?page=stats?page=stats' )
+		).toEqual( '/a/b/c?h=i' );
+	} );
+} );

--- a/client/my-sites/stats/utils.js
+++ b/client/my-sites/stats/utils.js
@@ -1,0 +1,30 @@
+import { getUrlParts } from '@automattic/calypso-url';
+import page from 'page';
+import { parse as parseQs, stringify as stringifyQs } from 'qs';
+
+/**
+ * Update query for current page or passed in URL
+ *
+ * @param {Object} query query object
+ * @param {string} path full or partial URL. pathname and search required
+ * @returns pathname concatenated with query string
+ */
+export function getPathWithUpdatedQueryString( query = {}, path = page.current ) {
+	const parsedUrl = getUrlParts( path );
+	let search = parsedUrl.search;
+	const pathname = parsedUrl.pathname;
+
+	// HACK: page.js adds a `?...page=stats...` query param to the URL in Odyssey on page refresh everytime.
+	// Test whether there are two query strings (two '?').
+	if ( search.replaceAll( /[^?]/g, '' ).length > 1 ) {
+		// If so, we remove the last '?' and the query string following it with the lazy match regex.
+		search = search?.replace( /(\?[^?]*)\?.*$/, '$1' );
+	}
+
+	const updatedSearch = {
+		...parseQs( search.substring( 1 ), { parseArrays: false } ),
+		...query,
+	};
+
+	return `${ pathname }?${ stringifyQs( updatedSearch ) }`;
+}

--- a/client/my-sites/stats/utils.js
+++ b/client/my-sites/stats/utils.js
@@ -26,5 +26,10 @@ export function getPathWithUpdatedQueryString( query = {}, path = page.current )
 		...query,
 	};
 
-	return `${ pathname }?${ stringifyQs( updatedSearch ) }`;
+	const updatedSearchString = stringifyQs( updatedSearch );
+	if ( ! updatedSearchString ) {
+		return pathname;
+	}
+
+	return `${ pathname }?${ updatedSearchString }`;
 }


### PR DESCRIPTION
Related to #71171 

## Proposed Changes

The PR proposes a hack to fix the issue when duplicate query string is appended to the hash on every page reload. Thanks for the suggestion @jsnmoon 👍 

## Testing Instructions

* Use your local Jetpack dev env
* Enable Odyssey if not yet enabled
* Run `STATS_PACKAGE_PATH=~/A8C/jetpack/projects/packages/stats-admin yarn dev`
* Open `/wp-admin/admin.php?page=stats&ab=c&c=d&123`
* Click around and randomly refresh the page
* Ensure there are no duplicate query strings
* Open `/wp-admin/admin.php?page=stats`
* Click around and randomly refresh the page
* Ensure there are no duplicate query strings

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
