### PR TITLE
Launchpad: Update task-helpers to use addQueryArgs

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -54,7 +54,9 @@ export function getEnhancedTasks(
 	// send user to Home page editor, fallback to FSE if page id is not known
 	const launchpadUploadVideoLink = homePageId
 		? `/page/${ siteSlug }/${ homePageId }`
-		: `/site-editor/${ siteSlug }?canvas=edit`;
+		: addQueryArgs( `/site-editor/${ siteSlug }`, {
+				canvas: 'edit',
+		  } );
 
 	let planWarningText = displayGlobalStylesWarning
 		? translate(
@@ -88,7 +90,9 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								`/setup/free-post-setup/freePostSetup?siteSlug=${ siteSlug }`
+								addQueryArgs( `/setup/free-post-setup/freePostSetup`, {
+									siteSlug,
+								} )
 							);
 						},
 					};
@@ -99,7 +103,9 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								`/setup/newsletter-post-setup/newsletterPostSetup?siteSlug=${ siteSlug }`
+								addQueryArgs( `/setup/newsletter-post-setup/newsletterPostSetup`, {
+									siteSlug,
+								} )
 							);
 						},
 					};
@@ -115,7 +121,11 @@ export function getEnhancedTasks(
 						completed: siteEditCompleted,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, siteEditCompleted, task.id );
-							window.location.assign( `/site-editor/${ siteSlug }?canvas=edit` );
+							window.location.assign(
+								addQueryArgs( `/site-editor/${ siteSlug }`, {
+									canvas: 'edit',
+								} )
+							);
 						},
 					};
 					break;
@@ -173,7 +183,10 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								`/setup/update-design/designSetup?siteSlug=${ siteSlug }&flowToReturnTo=${ flow }`
+								addQueryArgs( `/setup/update-design/designSetup`, {
+									siteSlug,
+									flowToReturnTo: flow,
+								} )
 							);
 						},
 					};
@@ -184,7 +197,9 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								`/setup/link-in-bio-post-setup/linkInBioPostSetup?siteSlug=${ siteSlug }`
+								addQueryArgs( `/setup/link-in-bio-post-setup/linkInBioPostSetup`, {
+									siteSlug,
+								} )
 							);
 						},
 					};
@@ -195,7 +210,11 @@ export function getEnhancedTasks(
 						completed: linkInBioLinksEditCompleted,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, linkInBioLinksEditCompleted, task.id );
-							window.location.assign( `/site-editor/${ siteSlug }?canvas=edit` );
+							window.location.assign(
+								addQueryArgs( `/site-editor/${ siteSlug }`, {
+									canvas: 'edit',
+								} )
+							);
 						},
 					};
 					break;
@@ -285,7 +304,11 @@ export function getEnhancedTasks(
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );
-									window.location.replace( `/home/${ siteSlug }?forceLoadLaunchpadData=true` );
+									window.location.replace(
+										addQueryArgs( `/home/${ siteSlug }`, {
+											forceLoadLaunchpadData: true,
+										} )
+									);
 								} );
 
 								submit?.();
@@ -306,7 +329,11 @@ export function getEnhancedTasks(
 							site?.options?.launchpad_checklist_tasks_statuses?.publish_first_course || false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.assign( `${ site?.URL }/wp-admin/post-new.php?post_type=course` );
+							window.location.assign(
+								addQueryArgs( `${ site?.URL }/wp-admin/post-new.php?`, {
+									post_type: 'course',
+								} )
+							);
 						},
 					};
 					break;
@@ -318,7 +345,9 @@ export function getEnhancedTasks(
 							recordTaskClickTracksEvent( flow, isPaidPlan, task.id );
 							const destinationUrl = isPaidPlan
 								? `/domains/manage/${ siteSlug }`
-								: `/domains/add/${ siteSlug }?domainAndPlanPackage=true`;
+								: addQueryArgs( `/domains/add/${ siteSlug }`, {
+										domainAndPlanPackage: true,
+								  } );
 							window.location.assign( destinationUrl );
 						},
 						badgeText: isPaidPlan ? '' : translate( 'Upgrade plan' ),


### PR DESCRIPTION
Related Issue: https://github.com/Automattic/wp-calypso/issues/73341
Related PR: https://github.com/Automattic/wp-calypso/pull/73975

### Proposed Changes

We decided to update how we're adding and parsing query params. This work was originally done in https://github.com/Automattic/wp-calypso/pull/73975. I'm just moving it to a separate PR for simpler testing and more atomic PRs. 

### Testing Instructions

**Review Time: Short**
**Testing Time: Medium (simple but touches many flows)**

Launchpad behavior **should be unchanged** before and after this PR. To test: 

1. Check this branch and run yarn and yarn start if needed. 
2. Start a free site at http://calypso.localhost:3000/setup/free/intro. Go through to launchpad. Confirm that links for the following tasks all continue to work exactly as they did before: 
   - setup_free (Free Flow > Personalize Your Site)
   - design_selected (Free Flow > Select a Design)
   - design_edited (Free Flow > Edit Site Design)
3. Start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro. Go through to launchpad. Confirm that links for the following tasks all continue to work exactly as they did before: 
    - setup_newsletter (Newsletter > Personalize Your Site)
4. Start a link in bio site at http://calypso.localhost:3000/setup/link-in-bio/intro. Go through to launchpad. Confirm that links for the following tasks all continue to work exactly as they did before: 
   - setup_link-in-bio (LIB > Personalize Your Site)
   - links_added (LIB > Edit Links)
5. Start a videopress site at http://calypso.localhost:3000/setup/videopress/intro. Go through to launchpad. Confirm that links for the following tasks all continue to work exactly as they did before: 
   - launchpadUploadVideoLink (VideoPress > Upload First Video)
   - videopress_launched (VideoPress > Launch Your Site)
6. Sensei: Note we do not need to test this. Sensei has removed the launchpad screen from the Sensei flow. So we can actually remove all sensei references from the launchpad screen. I will handle that in a separate PR. [I've added issue here](https://github.com/Automattic/wp-calypso/issues/74141). 