### PR TITLE
Sites Management Page: Use `react-intersection-observer` for `inView`

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -176,6 +176,7 @@
 		"react-day-picker": "^7.4.10",
 		"react-dom": "^17.0.2",
 		"react-element-to-jsx-string": "^14.3.2",
+		"react-intersection-observer": "^9.4.3",
 		"react-live": "^2.3.0",
 		"react-modal": "^3.14.3",
 		"react-query": "^3.32.1",

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -2,9 +2,9 @@ import { useSiteLaunchStatusLabel, getSiteLaunchStatus } from '@automattic/sites
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { AnchorHTMLAttributes, memo, useState } from 'react';
+import { AnchorHTMLAttributes, memo } from 'react';
+import { useInView } from 'react-intersection-observer';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
-import { useInView } from 'calypso/lib/use-in-view';
 import { displaySiteUrl, getDashboardUrl } from '../utils';
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
 import { SitesGridActionRenew } from './sites-grid-action-renew';
@@ -78,8 +78,7 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 	const isP2Site = site.options?.is_wpforteams_site;
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 
-	const [ inViewOnce, setInViewOnce ] = useState( false );
-	const ref = useInView< HTMLDivElement >( () => setInViewOnce( true ) );
+	const { ref, inView } = useInView( { triggerOnce: true } );
 
 	const siteDashboardUrlProps: AnchorHTMLAttributes< HTMLAnchorElement > = {
 		href: getDashboardUrl( site.slug ),
@@ -100,7 +99,7 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 						<SiteItemThumbnail
 							displayMode="tile"
 							className={ siteThumbnail }
-							showPlaceholder={ ! inViewOnce }
+							showPlaceholder={ ! inView }
 							site={ site }
 							width={ THUMBNAIL_DIMENSION.width }
 							height={ THUMBNAIL_DIMENSION.height }
@@ -122,7 +121,7 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 							<SitesLaunchStatusBadge>{ translatedStatus }</SitesLaunchStatusBadge>
 						) }
 						<EllipsisMenuContainer>
-							{ inViewOnce && <SitesEllipsisMenu className={ ellipsis } site={ site } /> }
+							{ inView && <SitesEllipsisMenu className={ ellipsis } site={ site } /> }
 						</EllipsisMenuContainer>
 					</div>
 				</>

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -3,12 +3,12 @@ import { useSiteLaunchStatusLabel } from '@automattic/sites';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { memo, useState } from 'react';
+import { memo } from 'react';
+import { useInView } from 'react-intersection-observer';
 import { useSelector } from 'react-redux';
 import StatsSparkline from 'calypso/blocks/stats-sparkline';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import TimeSince from 'calypso/components/time-since';
-import { useInView } from 'calypso/lib/use-in-view';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { displaySiteUrl, getDashboardUrl, isNotAtomicJetpack, MEDIA_QUERIES } from '../utils';
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
@@ -98,8 +98,7 @@ const PlanRenewNagContainer = styled.div`
 export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 	const { __ } = useI18n();
 	const translatedStatus = useSiteLaunchStatusLabel( site );
-	const [ inViewOnce, setInViewOnce ] = useState( false );
-	const ref = useInView< HTMLTableRowElement >( () => setInViewOnce( true ) );
+	const { ref, inView } = useInView( { triggerOnce: true } );
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 
 	const isP2Site = site.options?.is_wpforteams_site;
@@ -121,11 +120,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 							href={ getDashboardUrl( site.slug ) }
 							title={ __( 'Visit Dashboard' ) }
 						>
-							<SiteItemThumbnail
-								displayMode="list"
-								showPlaceholder={ ! inViewOnce }
-								site={ site }
-							/>
+							<SiteItemThumbnail displayMode="list" showPlaceholder={ ! inView } site={ site } />
 						</ListTileLeading>
 					}
 					title={
@@ -173,15 +168,13 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 				{ site.options?.updated_at ? <TimeSince date={ site.options.updated_at } /> : '' }
 			</Column>
 			<Column mobileHidden>
-				{ inViewOnce && (
+				{ inView && (
 					<a href={ `/stats/day/${ site.slug }` }>
 						<StatsSparkline siteId={ site.ID } showLoader={ true }></StatsSparkline>
 					</a>
 				) }
 			</Column>
-			<Column style={ { width: '24px' } }>
-				{ inViewOnce && <SitesEllipsisMenu site={ site } /> }
-			</Column>
+			<Column style={ { width: '24px' } }>{ inView && <SitesEllipsisMenu site={ site } /> }</Column>
 		</Row>
 	);
 } );

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
 		"photon": "workspace:^",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",
+		"react-intersection-observer": "^9.4.3",
 		"react-modal": "^3.14.3",
 		"reakit-utils": "^0.15.1",
 		"redux": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11904,6 +11904,7 @@ __metadata:
     react-day-picker: ^7.4.10
     react-dom: ^17.0.2
     react-element-to-jsx-string: ^14.3.2
+    react-intersection-observer: ^9.4.3
     react-live: ^2.3.0
     react-modal: ^3.14.3
     react-query: ^3.32.1
@@ -27179,6 +27180,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"react-intersection-observer@npm:^9.4.3":
+  version: 9.4.3
+  resolution: "react-intersection-observer@npm:9.4.3"
+  peerDependencies:
+    react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: ac0bf29c1105abbe3edff875469f2c6cc55431de02269dbd2e4529babced1a77a7d4e61a325a3a9cc03a844d97b9329ba6e546f79db818c9e53cbad0b43c143d
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.12.0 || ^17.0.0, react-is@npm:^17.0.0, react-is@npm:^17.0.1, react-is@npm:^17.0.2":
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
@@ -34017,6 +34027,7 @@ fsevents@^1.2.7:
     prettier: "npm:wp-prettier@2.6.2"
     react: ^17.0.2
     react-dom: ^17.0.2
+    react-intersection-observer: ^9.4.3
     react-modal: ^3.14.3
     readline-sync: ^1.4.10
     reakit-utils: ^0.15.1


### PR DESCRIPTION
See conversation in p1677514081942499-slack-C0347E545HR

Remaining use will be handled in https://github.com/Automattic/wp-calypso/issues/74022

## Proposed Changes

Switches to `react-intersection-observer` to manage `inView` state for various Sites Management Page components.

## Testing Instructions

1. Navigate to `/sites`.
2. Switch to list view.
3. Verify stats and the ellipsis menu appear as expected.
4. Verify `/rest/v1.1/sites/<site>/stats/insights` API requests are only made for the sites inview.
5. Scroll the page and verify the sites appear as expected while you scroll.
6. Switch to Grid view.
7. Verify the ellipsis menu appears as expected.
8. Scroll the page and verify the sites appear as expected.