### PR TITLE
Hosting Configuration: Use skeleton screen for 'Web server settings'

### DIFF
--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -1,4 +1,5 @@
-import { Button, Card, Spinner } from '@automattic/components';
+import { Button, Card, LoadingPlaceholder } from '@automattic/components';
+import styled from '@emotion/styled';
 import { localize } from 'i18n-calypso';
 import { useState } from 'react';
 import { connect } from 'react-redux';
@@ -22,6 +23,24 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
+const ParagraphPlaceholder = styled( LoadingPlaceholder )( {
+	height: 24,
+	width: '85%',
+	marginBottom: '1.25em',
+} );
+
+const LabelPlaceholder = styled( LoadingPlaceholder )( {
+	height: 16,
+	width: '80px',
+	marginBottom: '.25em',
+} );
+
+const InputPlaceholder = styled( LoadingPlaceholder )( {
+	height: 24,
+	width: '220px',
+	marginBottom: '1em',
+} );
+
 const WebServerSettingsCard = ( {
 	disabled,
 	isGettingGeoAffinity,
@@ -39,6 +58,8 @@ const WebServerSettingsCard = ( {
 } ) => {
 	const [ selectedPhpVersion, setSelectedPhpVersion ] = useState( '' );
 	const [ selectedStaticFile404, setSelectedStaticFile404 ] = useState( '' );
+
+	const isLoading = isGettingGeoAffinity || isGettingPhpVersion || isGettingStaticFile404;
 
 	const getGeoAffinityContent = () => {
 		if ( isGettingGeoAffinity || ! geoAffinity ) {
@@ -261,6 +282,18 @@ const WebServerSettingsCard = ( {
 		);
 	};
 
+	const getPlaceholderContent = () => {
+		return (
+			<>
+				<ParagraphPlaceholder />
+				<LabelPlaceholder />
+				<InputPlaceholder />
+				<LabelPlaceholder />
+				<InputPlaceholder />
+			</>
+		);
+	};
+
 	return (
 		<Card className="web-server-settings-card">
 			<QuerySiteGeoAffinity siteId={ siteId } />
@@ -273,10 +306,10 @@ const WebServerSettingsCard = ( {
 					'For sites with specialized needs, fine-tune how the web server runs your website.'
 				) }
 			</p>
-			{ getGeoAffinityContent() }
-			{ getPhpVersionContent() }
-			{ getStaticFile404Content() }
-			{ ( isGettingGeoAffinity || isGettingPhpVersion || isGettingStaticFile404 ) && <Spinner /> }
+			{ ! isLoading && getGeoAffinityContent() }
+			{ ! isLoading && getPhpVersionContent() }
+			{ ! isLoading && getStaticFile404Content() }
+			{ isLoading && getPlaceholderContent() }
 		</Card>
 	);
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1879

## Proposed Changes

Adds a skeleton screen for 'Web server settings':

<img width="1429" alt="image" src="https://user-images.githubusercontent.com/36432/222788349-f60f2011-c676-409f-8871-ff62eeef91fe.png">


https://user-images.githubusercontent.com/36432/222573318-b4e88231-fb9e-4084-93d1-e4640e1565b0.mp4

## Testing Instructions

1. Navigate to Hosting Configuration.
2. Scroll down on load and verify 'Web server settings' appears as expected.