### PR TITLE
Staging Sites: Fix icon styling on smaller screens

### DIFF
--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -1,5 +1,6 @@
 .hosting {
-	.card > .material-icon {
+	.card > .material-icon,
+	.card > .gridicon {
 		display: inline-block;
 		margin-right: 16px;
 		margin-bottom: 16px;


### PR DESCRIPTION
## Proposed Changes

Fixes icon styling on smaller screens.

### Before

<img width="680" alt="image" src="https://user-images.githubusercontent.com/36432/222574509-13277872-6ebf-4efc-8ae7-8819add12202.png">

### After

<img width="688" alt="image" src="https://user-images.githubusercontent.com/36432/222574451-43beda32-f269-488a-9722-aa872a2af961.png">

## Testing Instructions

1. Navigate to 'Hosting Configuration'.
2. Verify the icon appears as expected.