### PR TITLE
Gutenberg: Avoid redirecting to home from within the iframe

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1023,6 +1023,7 @@ function handleSiteEditorBackButton( calypsoPort ) {
 	// have to do this event delegation style because the Editor isn't fully initialized yet.
 	document.getElementById( 'wpwrap' ).addEventListener( 'click', ( event ) => {
 		const clickedElement = event.target;
+
 		const isOldDashboardButton =
 			clickedElement.classList.contains( 'edit-site-navigation-panel__back-to-dashboard' ) ||
 			// The above fails if user clicked internal SVG. So check the parent again.
@@ -1042,7 +1043,17 @@ function handleSiteEditorBackButton( calypsoPort ) {
 			clickedElement.attributes?.href?.value &&
 			clickedElement.attributes?.href?.value === dashboardLink;
 
-		if ( isOldDashboardButton || isNewDashboardButton ) {
+		// The new NEW dashboard button is also failing us.
+		let isNewNewButton = false;
+		if ( ! ( isOldDashboardButton || isNewDashboardButton ) ) {
+			const classItem = 'edit-site-sidebar-navigation-screen__back';
+			isNewNewButton =
+				clickedElement?.classList.contains( classItem ) ||
+				clickedElement.parentElement?.classList.contains( classItem ) ||
+				clickedElement.parentElement?.parentElement?.classList.contains( classItem );
+		}
+
+		if ( isOldDashboardButton || isNewDashboardButton || isNewNewButton ) {
 			event.preventDefault();
 			calypsoPort.postMessage( { action: 'navigateToHome' } );
 		}


### PR DESCRIPTION
- The Site Editor back button selector has changed and is broken (when iframed)
- We update the selector for the site editor back button. This allows us to identify when it's clicked, pass a message from the iframe to the top frame of the browser, and redirect properly to my home

## Screenshots
https://user-images.githubusercontent.com/5414230/222586586-a785066f-440c-4f8f-a872-32fe2826b6d2.mp4

## Testing
- Check out branch
- Create site through free onboarding flow wordpress.com/setup/free/intro
- When at the launchpad, click on the "Edit site design" task
- Open the site editor navigation sidebar 
- Click on the back button
- Verify that the url is correct ( does not have `site-editor` in the path )