### PR TITLE
Stats: Set "Stats" sidebar menu item as selected for the Store and Google My Business pages - Take 2

### DIFF
--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -76,7 +76,7 @@ export const itemLinkMatches = ( path, currentPath ) => {
 		currentPath.startsWith( '/store/stats/' ) ||
 		currentPath.startsWith( '/google-my-business/stats/' )
 	) {
-		return fragmentIsEqual( path, '/stats', 1 );
+		return path.startsWith( '/stats/' );
 	}
 
 	return fragmentIsEqual( path, currentPath, 1 );

--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -75,7 +75,8 @@ export const itemLinkMatches = ( path, currentPath ) => {
 		// For `/store/stats/*` and `/google-my-business/stats/*` paths, show Stats menu as selected.
 		return (
 			currentPath.startsWith( '/store/stats/' ) ||
-			currentPath.startsWith( '/google-my-business/stats/' )
+			currentPath.startsWith( '/google-my-business/stats/' ) ||
+			fragmentIsEqual( path, currentPath, 1 )
 		);
 	}
 

--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -6,14 +6,6 @@ const pathIncludes = ( currentPath, term, position ) =>
 const fragmentIsEqual = ( path, currentPath, position ) =>
 	currentPath.split( /[/,?]/ )?.[ position ] === path.split( /[/,?]/ )?.[ position ];
 
-const fragmentIsEqualDifferentPositions = (
-	path,
-	pathPosition,
-	currentPath,
-	currentPathPosition
-) =>
-	currentPath.split( /[/,?]/ )?.[ currentPathPosition ] === path.split( /[/,?]/ )?.[ pathPosition ];
-
 const isManageAllSitesPluginsPath = ( path ) =>
 	path.match( /^\/plugins\/(?:manage|active|inactive|updates)/ ) !== null;
 
@@ -80,10 +72,10 @@ export const itemLinkMatches = ( path, currentPath ) => {
 	}
 
 	if ( pathIncludes( path, 'stats', 1 ) ) {
-		// For /store/stats and /google-my-business/stats paths.
+		// For `/store/stats/*` and `/google-my-business/stats/*` paths, show Stats menu as selected.
 		return (
-			fragmentIsEqual( path, currentPath, 1 ) ||
-			fragmentIsEqualDifferentPositions( path, 1, currentPath, 2 )
+			currentPath.startsWith( '/store/stats/' ) ||
+			currentPath.startsWith( '/google-my-business/stats/' )
 		);
 	}
 

--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -71,13 +71,12 @@ export const itemLinkMatches = ( path, currentPath ) => {
 		return isManageAllSitesPluginsPath( path );
 	}
 
-	if ( pathIncludes( path, 'stats', 1 ) ) {
-		// For `/store/stats/*` and `/google-my-business/stats/*` paths, show Stats menu as selected.
-		return (
-			currentPath.startsWith( '/store/stats/' ) ||
-			currentPath.startsWith( '/google-my-business/stats/' ) ||
-			fragmentIsEqual( path, currentPath, 1 )
-		);
+	// For `/store/stats/*` and `/google-my-business/stats/*` paths, show Stats menu as selected.
+	if (
+		currentPath.startsWith( '/store/stats/' ) ||
+		currentPath.startsWith( '/google-my-business/stats/' )
+	) {
+		return fragmentIsEqual( path, '/stats', 1 );
 	}
 
 	return fragmentIsEqual( path, currentPath, 1 );


### PR DESCRIPTION
Related to #73917

## Proposed Changes

The approach in #73917 could have unpredictable matches, so it's better to only match the certain URL prefixes.

## Testing Instructions
- Open Calypso Live Branch
- Open a site with WooCommerce
- Click `Store`
- Ensure Stats menu is selected in the sidebar

![image](https://user-images.githubusercontent.com/1425433/222039792-e5d8bb41-5bd5-48f2-b5f0-f258ab6e624a.png)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
