### PR TITLE
Theme Showcase: Add global style upgrade modal in the Theme Detail page

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -31,6 +31,7 @@ import SyncActiveTheme from 'calypso/components/data/sync-active-theme';
 import HeaderCake from 'calypso/components/header-cake';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
 import SectionHeader from 'calypso/components/section-header';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
@@ -92,6 +93,7 @@ import ThemeStyleVariations from './theme-style-variations';
 
 import './style.scss';
 
+const DEFAULT_VARIATION_SLUG = 'default';
 const noop = () => {};
 
 class ThemeSheet extends Component {
@@ -147,7 +149,9 @@ class ThemeSheet extends Component {
 		section: '',
 	};
 
-	state = {};
+	state = {
+		showUnlockStyleUpgradeModal: false,
+	};
 
 	scrollToTop = () => {
 		window.scroll( 0, 0 );
@@ -202,6 +206,10 @@ class ThemeSheet extends Component {
 		}
 
 		defaultOption.action && defaultOption.action( themeId );
+	};
+
+	onUnlockStyleButtonClick = () => {
+		this.setState( { showUnlockStyleUpgradeModal: true } );
 	};
 
 	onSecondaryButtonClick = () => {
@@ -340,6 +348,11 @@ class ThemeSheet extends Component {
 	shouldRenderPreviewButton() {
 		const { isWPForTeamsSite } = this.props;
 		return this.isThemeAvailable() && ! this.isThemeCurrentOne() && ! isWPForTeamsSite;
+	}
+
+	shouldRenderUnlockStyleButton() {
+		const { selectedStyleVariationSlug, shouldLimitGlobalStyles, styleVariations } = this.props;
+		return shouldLimitGlobalStyles && styleVariations.length > 0 && !! selectedStyleVariationSlug;
 	}
 
 	isThemeCurrentOne() {
@@ -586,7 +599,10 @@ class ThemeSheet extends Component {
 						<span className="theme__sheet-main-info-tag">{ tag }</span>
 					</div>
 					<div className="theme__sheet-main-actions">
-						{ shouldRenderButton && this.renderButton() }
+						{ shouldRenderButton &&
+							( this.shouldRenderUnlockStyleButton()
+								? this.renderUnlockStyleButton()
+								: this.renderButton() ) }
 						{ this.shouldRenderPreviewButton() && (
 							<Button
 								onClick={ ( e ) => {
@@ -948,6 +964,19 @@ class ThemeSheet extends Component {
 		);
 	};
 
+	renderUnlockStyleButton = () => {
+		return (
+			<Button
+				className="theme__sheet-primary-button"
+				primary
+				disabled={ this.isLoading() }
+				onClick={ this.onUnlockStyleButtonClick }
+			>
+				{ this.props.translate( 'Unlock this style' ) }
+			</Button>
+		);
+	};
+
 	appendSelectedStyleVariationToUrl = ( url ) => {
 		const { selectedStyleVariationSlug } = this.props;
 		if ( ! selectedStyleVariationSlug ) {
@@ -1024,6 +1053,43 @@ class ThemeSheet extends Component {
 		return translate(
 			'Instantly unlock all premium themes, more storage space, advanced customization, video support, and more when you upgrade.'
 		);
+	};
+
+	getPremiumGlobalStylesEventProps = () => {
+		const { selectedStyleVariationSlug, themeId } = this.props;
+		return {
+			theme_name: themeId,
+			style_variation: selectedStyleVariationSlug ?? DEFAULT_VARIATION_SLUG,
+		};
+	};
+
+	onPremiumGlobalStylesUpgradeModalCheckout = () => {
+		this.props.recordTracksEvent(
+			'calypso_theme_sheet_global_styles_gating_modal_checkout_button_click',
+			this.getPremiumGlobalStylesEventProps()
+		);
+
+		this.setState( { showUnlockStyleUpgradeModal: false } );
+		page( `/checkout/${ this.props.siteSlug || '' }/premium` );
+	};
+
+	onPremiumGlobalStylesUpgradeModalTryStyle = () => {
+		this.props.recordTracksEvent(
+			'calypso_theme_sheet_global_styles_gating_modal_try_button_click',
+			this.getPremiumGlobalStylesEventProps()
+		);
+
+		this.setState( { showUnlockStyleUpgradeModal: false } );
+		this.onButtonClick();
+	};
+
+	onPremiumGlobalStylesUpgradeModalClose = () => {
+		this.props.recordTracksEvent(
+			'calypso_theme_sheet_global_styles_gating_modal_close_button_click',
+			this.getPremiumGlobalStylesEventProps()
+		);
+
+		this.setState( { showUnlockStyleUpgradeModal: false } );
 	};
 
 	onAtomicThemeActive = () => {
@@ -1289,6 +1355,12 @@ class ThemeSheet extends Component {
 					) }
 				</div>
 				<ThemePreview belowToolbar={ previewUpsellBanner } />
+				<PremiumGlobalStylesUpgradeModal
+					checkout={ this.onPremiumGlobalStylesUpgradeModalCheckout }
+					tryStyle={ this.onPremiumGlobalStylesUpgradeModalTryStyle }
+					closeModal={ this.onPremiumGlobalStylesUpgradeModalClose }
+					isOpen={ this.state.showUnlockStyleUpgradeModal }
+				/>
 				<PerformanceTrackerStop />
 				{ isThemeActivationSyncStarted && (
 					<SyncActiveTheme

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1069,8 +1069,11 @@ class ThemeSheet extends Component {
 			this.getPremiumGlobalStylesEventProps()
 		);
 
+		const params = new URLSearchParams();
+		params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );
+
 		this.setState( { showUnlockStyleUpgradeModal: false } );
-		page( `/checkout/${ this.props.siteSlug || '' }/premium` );
+		page( `/checkout/${ this.props.siteSlug || '' }/premium?${ params.toString() }` );
 	};
 
 	onPremiumGlobalStylesUpgradeModalTryStyle = () => {


### PR DESCRIPTION
## Proposed Changes

This PR updates the Theme Detail page so that when users select a premium style variation, the action button is updated to "Unlock this style". Clicking the button will open the premium plan upsell modal.

Action button when the default style variation is selected:
<img width="730" alt="Screenshot 2023-03-03 at 11 45 12 AM" src="https://user-images.githubusercontent.com/797888/222626472-8bb8700c-779b-4284-9217-b1e79c641d78.png">

Action button when a premium style variation is selected:
<img width="729" alt="Screenshot 2023-03-03 at 11 45 17 AM" src="https://user-images.githubusercontent.com/797888/222626521-58ee7980-0d5b-4384-ba4a-8553d893ccbd.png">

Premium plan upsell modal:
<img width="1006" alt="Screenshot 2023-03-03 at 11 45 28 AM" src="https://user-images.githubusercontent.com/797888/222626556-86851972-5218-404e-8253-90c75ded2b72.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Select a theme with style variations, such as Twenty Twenty-Three.
* Ensure that the action button changes to "Unlock this style" when selecting a premium style variation.
* Ensure that clicking the "Unlock this style" button opens the premium plan upsell modal.
* Ensure that in the premium plan upsell modal, clicking on the "Try it out first" button will have the same behavior as the original action button.
* Ensure that in the premium plan upsell modal, clicking on the "Upgrade plan" button will redirect users to the checkout page with the Premium plan pre-selected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
