### PR TITLE
Site Assembler: Fix the padding and background of the preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -15,15 +15,13 @@
 	margin: 0;
 	list-style-type: none;
 	overflow: auto;
-	// @TODO: Use theme setting "styles.color.background"
-	background: var(--studio-white);
+	background: var(--pattern-large-preview-background);
 
-	// @TODO: Use theme setting "styles.spacing.blockGap"
 	.pattern-large-preview__pattern-header {
-		margin-block-end: 1.5rem;
+		margin-block-end: var(--pattern-large-preview-block-gap);
 	}
 	.pattern-large-preview__pattern-footer {
-		margin-block-start: 1.5rem;
+		margin-block-start: var(--pattern-large-preview-block-gap);
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -1,8 +1,9 @@
 import { PatternRenderer } from '@automattic/block-renderer';
 import { DeviceSwitcher } from '@automattic/components';
+import { useStyle } from '@automattic/global-styles';
 import { Icon, layout } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useState, CSSProperties } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { encodePatternId } from './utils';
 import type { Pattern } from './types';
@@ -24,6 +25,12 @@ const PatternLargePreview = ( { header, sections, footer, activePosition }: Prop
 	const frameRef = useRef< HTMLDivElement | null >( null );
 	const listRef = useRef< HTMLUListElement | null >( null );
 	const [ viewportHeight, setViewportHeight ] = useState< number | undefined >( 0 );
+	const [ blockGap ] = useStyle( 'spacing.blockGap' );
+	const [ backgroundColor ] = useStyle( 'color.background' );
+	const patternLargePreviewStyle = {
+		'--pattern-large-preview-block-gap': blockGap,
+		'--pattern-large-preview-background': backgroundColor,
+	} as CSSProperties;
 
 	const renderPattern = ( key: string, pattern: Pattern ) => (
 		<li key={ key } className={ `pattern-large-preview__pattern-${ key }` }>
@@ -90,7 +97,11 @@ const PatternLargePreview = ( { header, sections, footer, activePosition }: Prop
 			} }
 		>
 			{ hasSelectedPattern ? (
-				<ul className="pattern-large-preview__patterns" ref={ listRef }>
+				<ul
+					className="pattern-large-preview__patterns"
+					style={ patternLargePreviewStyle }
+					ref={ listRef }
+				>
 					{ header && renderPattern( 'header', header ) }
 					{ sections.map( ( pattern ) => renderPattern( pattern.key!, pattern ) ) }
 					{ footer && renderPattern( 'footer', footer ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -27,10 +27,10 @@ const PatternLargePreview = ( { header, sections, footer, activePosition }: Prop
 	const [ viewportHeight, setViewportHeight ] = useState< number | undefined >( 0 );
 	const [ blockGap ] = useStyle( 'spacing.blockGap' );
 	const [ backgroundColor ] = useStyle( 'color.background' );
-	const patternLargePreviewStyle = {
+	const [ patternLargePreviewStyle, setPatternLargePreviewStyle ] = useState( {
 		'--pattern-large-preview-block-gap': blockGap,
 		'--pattern-large-preview-background': backgroundColor,
-	} as CSSProperties;
+	} as CSSProperties );
 
 	const renderPattern = ( key: string, pattern: Pattern ) => (
 		<li key={ key } className={ `pattern-large-preview__pattern-${ key }` }>
@@ -83,6 +83,15 @@ const PatternLargePreview = ( { header, sections, footer, activePosition }: Prop
 
 		return () => window.removeEventListener( 'resize', handleResize );
 	} );
+
+	// Delay updating the styles to make the transition smooth
+	// See https://github.com/Automattic/wp-calypso/pull/74033#issuecomment-1453056703
+	useEffect( () => {
+		setPatternLargePreviewStyle( {
+			'--pattern-large-preview-block-gap': blockGap,
+			'--pattern-large-preview-background': backgroundColor,
+		} as CSSProperties );
+	}, [ blockGap, backgroundColor ] );
 
 	return (
 		<DeviceSwitcher

--- a/packages/block-renderer/src/components/block-renderer-provider.tsx
+++ b/packages/block-renderer/src/components/block-renderer-provider.tsx
@@ -27,6 +27,11 @@ const useBlockRendererContext = ( siteId: number | string, stylesheet: string ) 
 						css: 'body{height:auto;overflow:hidden;}',
 						__unstableType: 'presets',
 					},
+					// Avoid unwanted editor styles
+					{
+						css: 'body{padding:0;}',
+						__unstableType: 'presets',
+					},
 				],
 			},
 		} ),

--- a/packages/global-styles/src/index.tsx
+++ b/packages/global-styles/src/index.tsx
@@ -1,3 +1,5 @@
+// Re-export useStyle from `@automattic/global-styles` to avoid calypso using `@wordpress/edit-site` directly
+export { useStyle } from '@wordpress/edit-site/build-module/components/global-styles/hooks';
 export * from './components';
 export { useSyncGlobalStylesUserConfig } from './hooks';
 export * from './types';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/73759

## Proposed Changes

* This PR is focusing on removing the outer padding on each preview. Also, setting the background color in the large preview so that it's consistent with the color variation

https://user-images.githubusercontent.com/13596067/222632328-a171de54-3069-44f9-8d47-20082e889288.mov

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/sidebar-revamp,pattern-assembler/color-and-fonts`
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Choose a color variation first and the background color is not white so that we're easy to notice where the padding is.
  * Browser header/sections/footer patterns and ensure the outer padding is gone
  * Select header, sections, and footer, and ensure
    * The outer padding is gone
    * There is padding between the header and sections, and the background color is the same as the selected color variation
    * There is padding between the footer and sections, and the background color is the same as the selected color variation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
