### PR TITLE
Jetpack Settings: Display notice for Atomic sites when navigating to settings/jetpack

### DIFF
--- a/client/my-sites/site-settings/settings-jetpack/main.jsx
+++ b/client/my-sites/site-settings/settings-jetpack/main.jsx
@@ -33,7 +33,9 @@ const SiteSettingsJetpack = ( {
 	retention,
 	storagePurchased,
 } ) => {
-	if ( ! siteIsJetpack || site.is_wpcom_atomic ) {
+	// Sites hosted on WordPress.com cannot modify Jetpack credentials
+	const managedJetpackCreds = ! siteIsJetpack || site.is_wpcom_atomic;
+	if ( managedJetpackCreds ) {
 		return (
 			<EmptyContent
 				action={ translate( 'Manage general settings for %(site)s', {

--- a/client/my-sites/site-settings/settings-jetpack/main.jsx
+++ b/client/my-sites/site-settings/settings-jetpack/main.jsx
@@ -34,7 +34,7 @@ const SiteSettingsJetpack = ( {
 	storagePurchased,
 } ) => {
 	//todo: this check makes sense in Jetpack section?
-	if ( ! siteIsJetpack ) {
+	if ( ! siteIsJetpack || site.is_wpcom_atomic ) {
 		return (
 			<EmptyContent
 				action={ translate( 'Manage general settings for %(site)s', {

--- a/client/my-sites/site-settings/settings-jetpack/main.jsx
+++ b/client/my-sites/site-settings/settings-jetpack/main.jsx
@@ -33,7 +33,6 @@ const SiteSettingsJetpack = ( {
 	retention,
 	storagePurchased,
 } ) => {
-	//todo: this check makes sense in Jetpack section?
 	if ( ! siteIsJetpack || site.is_wpcom_atomic ) {
 		return (
 			<EmptyContent

--- a/client/my-sites/site-settings/settings-jetpack/main.jsx
+++ b/client/my-sites/site-settings/settings-jetpack/main.jsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { WPCOM_FEATURES_SCAN } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import AdvancedCredentials from 'calypso/components/advanced-credentials';
 import BackupRetentionManagement from 'calypso/components/backup-retention-management';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -18,6 +18,7 @@ import SiteSettingsNavigation from 'calypso/my-sites/site-settings/navigation';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import isRewindActive from 'calypso/state/selectors/is-rewind-active';
 import isSiteFailedMigrationSource from 'calypso/state/selectors/is-site-failed-migration-source';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -34,7 +35,8 @@ const SiteSettingsJetpack = ( {
 	storagePurchased,
 } ) => {
 	// Sites hosted on WordPress.com cannot modify Jetpack credentials
-	const managedJetpackCreds = ! siteIsJetpack || site.is_wpcom_atomic;
+	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
+	const managedJetpackCreds = ! siteIsJetpack || isAtomic;
 	if ( managedJetpackCreds ) {
 		return (
 			<EmptyContent


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72983
Related to https://github.com/Automattic/jetpack/pull/29268

## Proposed Changes

* A PR has been submitted to remove the Jetpack submenu item from the Settings menu in Calypso on Atomic sites: https://github.com/Automattic/jetpack/pull/29268

* This PR compliments that fix by displaying a notice to users who may try navigating to the slug `settings/jetpack/SITEURL` manually. Currently if an Atomic user navigates to this slug, they will see the Jetpack credentials screen as reported in #72983 
* Code already exists to display a notice to users who navigate to this slug for a site that is not a Jetpack site. Since Atomic sites are also Jetpack sites, Atomic users do not see this notice. Adding an additional condition will now display the following notice to Atomic users as well:

<img width="695" alt="image" src="https://user-images.githubusercontent.com/65082164/222633796-3b8083bf-5752-4864-9577-3b25d93ba7c7.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Testing on Atomic
* Ensure you have an Atomic site to test
* Navigate to https://wordpress.com/settings/jetpack/ATOMIC_SITE_URL and confirm that the notice is displayed

## Testing on Simple
* Navigate to a https://wordpress.com/settings/jetpack/SIMPLE_SITE_URL and confirm that the notice is displayed

## Testing on self hosted Jetpack connected sites
* Ensure you have a Jurassic Ninja site with a Jetpack Backup plan, or a self hosted Jetpack connected site with the Jetpack backup plan
* Navigate to a https://wordpress.com/settings/jetpack/JETPACK_SITE_URL and confirm that the correct Jetpack credentials page displays as outlined [here](https://jetpack.com/support/backup/backups-via-the-jetpack-plugin/adding-credentials-to-jetpack/#add-your-credentials)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
