### PR TITLE
Odyssey: black segment controls all around

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -124,13 +124,13 @@
 	}
 	// Black segmented controls.
 	.is-section-stats .segmented-control .segmented-control__item {
+		.segmented-control__link:hover {
+			background-color: var(--color-neutral-0);
+		}
 		&.is-selected .segmented-control__link,
 		&.is-selected .segmented-control__link:hover {
 			background-color: var(--studio-black);
 			border-color: var(--studio-black);
-		}
-		.segmented-control__link:hover {
-			background-color: var(--color-neutral-0);
 		}
 		&.is-selected + .segmented-control__item .segmented-control__link {
 			border-left-color: var(--studio-black);

--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -122,14 +122,19 @@
 			margin-left: 32px;
 		}
 	}
-	// Black period segmented control.
-	.segmented-control.is-primary .segmented-control__item.is-selected .segmented-control__link,
-	.segmented-control.is-primary .segmented-control__item.is-selected .segmented-control__link:hover {
-		background-color: var(--studio-black);
-		border-color: var(--studio-black);
-	}
-	.segmented-control.is-primary .segmented-control__item.is-selected + .segmented-control__item .segmented-control__link {
-		border-left-color: var(--studio-black);
+	// Black segmented controls.
+	.is-section-stats .segmented-control .segmented-control__item {
+		&.is-selected .segmented-control__link,
+		&.is-selected .segmented-control__link:hover {
+			background-color: var(--studio-black);
+			border-color: var(--studio-black);
+		}
+		.segmented-control__link:hover {
+			background-color: var(--color-neutral-0);
+		}
+		&.is-selected + .segmented-control__item .segmented-control__link {
+			border-left-color: var(--studio-black);
+		}
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

The PR proposes to change selected segment controls to be black background for all the places.

## Testing Instructions

* Apply this change to your Odyssey Stats instance using option 1 or 2 from PejTkB-3E-p2.
* Ensure you see all the segment controls like the following

<img width="832" alt="image" src="https://user-images.githubusercontent.com/1425433/222641436-a4e11ae8-a743-4bbe-a19b-249822a95678.png">
<img width="837" alt="image" src="https://user-images.githubusercontent.com/1425433/222641479-46382a3e-008d-49eb-a6fe-cd43922471f9.png">
<img width="416" alt="image" src="https://user-images.githubusercontent.com/1425433/222641521-ed2c8845-6f66-48a1-9faf-d70fdddfc104.png">
<img width="811" alt="image" src="https://user-images.githubusercontent.com/1425433/222641597-c571e871-4c70-44c2-be6b-19c23f920f75.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
