### PR TITLE
Site Assembler: Introduce feature flag to use inline styles

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
@@ -1,4 +1,5 @@
 import { BlockRendererProvider, PatternsRendererProvider } from '@automattic/block-renderer';
+import { isEnabled } from '@automattic/calypso-config';
 import { PLACEHOLDER_SITE_ID } from './constants';
 import type { SiteInfo } from '@automattic/block-renderer';
 
@@ -17,7 +18,11 @@ const PatternAssemblerContainer = ( {
 	children,
 	siteInfo,
 }: Props ) => (
-	<BlockRendererProvider siteId={ siteId } stylesheet={ stylesheet }>
+	<BlockRendererProvider
+		siteId={ siteId }
+		stylesheet={ stylesheet }
+		useInlineStyles={ isEnabled( 'pattern-assembler/inline-styles' ) }
+	>
 		<PatternsRendererProvider
 			// Site used to render site-related things on the previews,
 			// such as the logo, title, and tagline.

--- a/config/development.json
+++ b/config/development.json
@@ -135,6 +135,7 @@
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/sidebar-revamp": true,
 		"pattern-assembler/write-flow": true,
+		"pattern-assembler/inline-styles": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -86,6 +86,7 @@
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/sidebar-revamp": false,
 		"pattern-assembler/write-flow": true,
+		"pattern-assembler/inline-styles": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/production.json
+++ b/config/production.json
@@ -100,6 +100,7 @@
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/sidebar-revamp": false,
 		"pattern-assembler/write-flow": true,
+		"pattern-assembler/inline-styles": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -98,6 +98,7 @@
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/sidebar-revamp": false,
 		"pattern-assembler/write-flow": true,
+		"pattern-assembler/inline-styles": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -109,6 +109,7 @@
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/sidebar-revamp": false,
 		"pattern-assembler/write-flow": true,
+		"pattern-assembler/inline-styles": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/packages/block-renderer/src/components/block-renderer-provider.tsx
+++ b/packages/block-renderer/src/components/block-renderer-provider.tsx
@@ -7,10 +7,15 @@ export interface Props {
 	siteId: number | string;
 	stylesheet?: string;
 	children: JSX.Element;
+	useInlineStyles?: boolean;
 }
 
-const useBlockRendererContext = ( siteId: number | string, stylesheet: string ) => {
-	const { data: settings } = useBlockRendererSettings( siteId, stylesheet );
+const useBlockRendererContext = (
+	siteId: number | string,
+	stylesheet: string,
+	useInlineStyles = false
+) => {
+	const { data: settings } = useBlockRendererSettings( siteId, stylesheet, useInlineStyles );
 
 	const [ globalStyles ] = useGlobalStylesOutput();
 
@@ -36,8 +41,13 @@ const useBlockRendererContext = ( siteId: number | string, stylesheet: string ) 
 	return context;
 };
 
-const BlockRendererProvider = ( { siteId, stylesheet = '', children }: Props ) => {
-	const context = useBlockRendererContext( siteId, stylesheet );
+const BlockRendererProvider = ( {
+	siteId,
+	stylesheet = '',
+	children,
+	useInlineStyles = false,
+}: Props ) => {
+	const context = useBlockRendererContext( siteId, stylesheet, useInlineStyles );
 
 	if ( ! context.isReady ) {
 		return null;

--- a/packages/block-renderer/src/hooks/use-block-renderer-settings.ts
+++ b/packages/block-renderer/src/hooks/use-block-renderer-settings.ts
@@ -5,14 +5,16 @@ import type { BlockRendererSettings } from '../types';
 const useBlockRendererSettings = (
 	siteId: number | string,
 	stylesheet: string,
+	useInlineStyles = false,
 	queryOptions: UseQueryOptions< unknown, unknown, BlockRendererSettings > = {}
 ): UseQueryResult< BlockRendererSettings > => {
 	const params = new URLSearchParams( {
 		stylesheet,
+		use_inline_styles: useInlineStyles.toString(),
 	} );
 
 	return useQuery< any, unknown, BlockRendererSettings >(
-		[ siteId, 'block-renderer', stylesheet ],
+		[ siteId, 'block-renderer', stylesheet, useInlineStyles ],
 		() =>
 			wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId ) }/block-renderer/settings`,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72548

## Proposed Changes

* Introduce a feature flag to enable `use_inline_styles` on development to test the performance and whether any side effects.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/sidebar-revamp,pattern-assembler/color-and-fonts,pattern-assembler/inline-styles`
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen, ensure the styles of patterns look good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
