### PR TITLE
Theme Showcase: Scale out web preview to display desktop view in the Theme Detail page

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -70,6 +70,7 @@ body.is-section-theme-i4 {
 					@include breakpoint-deprecated( "<960px" ) {
 						margin-top: 0;
 						position: relative;
+						top: auto !important;
 					}
 				}
 
@@ -499,6 +500,13 @@ body.is-section-theme-i4 {
 	@include breakpoint-deprecated( ">960px" ) {
 		height: calc(100vh - 128px);
 		pointer-events: all;
+
+		.theme-preview__frame-wrapper .theme-preview__frame {
+			height: 200%;
+			max-width: 200%;
+			transform: scale(0.5) !important;
+			width: 200%;
+		}
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

This PR scales the iframe that renders the theme preview to display the desktop view instead of the mobile view. This change is to prevent desktop users seeing a mobile theme preview.

| Before | After | 
| --- | --- |
| ![Screenshot 2023-03-03 at 3 49 07 PM](https://user-images.githubusercontent.com/797888/222662343-4f400004-3a4e-485e-93ee-f281c3c49622.png) | ![Screenshot 2023-03-03 at 3 49 21 PM](https://user-images.githubusercontent.com/797888/222662357-6634f48f-fe08-486a-acd8-8e8e931bb04a.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Select a theme with style variations, such as Twenty Twenty-Three.
* Ensure that the theme preview is scaled out as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
