### PR TITLE
Gardening: add Kitkat notification mechanism

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
     types: [opened, reopened, synchronize, edited, labeled, closed]
   issues: # For auto-triage of issues.
-    types: [opened, reopened, edited, closed]
+    types: [opened, labeled, reopened, edited, closed]
   issue_comment: # To gather support references in issue comments.
     types: [created]
 concurrency:
@@ -44,4 +44,5 @@ jobs:
          slack_team_channel: ${{ secrets.SLACK_TEAM_CHANNEL }}
          slack_he_triage_channel: ${{ secrets.SLACK_HE_TRIAGE_CHANNEL }}
          slack_quality_channel: ${{ secrets.SLACK_QUALITY_CHANNEL }}
-         tasks: 'assignIssues,cleanLabels,notifyDesign,notifyEditorial,flagOss,triageNewIssues,gatherSupportReferences,replyToCustomersReminder'
+         slack_kitkat_channel: ${{ secrets.SLACK_KITKAT_CHANNEL }}
+         tasks: 'assignIssues,cleanLabels,notifyDesign,notifyEditorial,flagOss,triageNewIssues,gatherSupportReferences,replyToCustomersReminder,notifyKitKat'


### PR DESCRIPTION
## Proposed Changes

This builds on top of https://github.com/Automattic/jetpack/pull/28904/

It will allow us to send Slack notifications to the Kitkat team with issues are labeled as high priority.

## Testing Instructions

* Not much to test here, this will only be available once this is merged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
