### PR TITLE
StatModuleFollowers: Wrap the time period strings for translation

### DIFF
--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -82,6 +82,8 @@ class StatModuleFollowers extends Component {
 	}
 
 	calculateOffset( pastValue ) {
+		const { translate } = this.props;
+
 		const now = new Date();
 		const value = new Date( pastValue );
 		const difference = now.getTime() - value.getTime();
@@ -94,11 +96,11 @@ class StatModuleFollowers extends Component {
 		let result = '';
 
 		if ( days > 0 ) {
-			result = days + ' days';
+			result = translate( '%d days', { args: days } );
 		} else if ( hours > 0 ) {
-			result = hours + ' hours';
+			result = translate( '%d hours', { args: hours } );
 		} else if ( minutes > 0 ) {
-			result = minutes + ' minutes';
+			result = translate( '%d minutes', { args: minutes } );
 		}
 
 		return result;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 580-gh-Automattic/i18n-issues

## Proposed Changes

In the Subscribers card at the bottom of the `/stats/insights/[site]` page, the time period strings have been wrapped for translation. The originals already exist and are translated, so the translations should appear right away.

| Before | After |
| --- | --- |
|![image](https://user-images.githubusercontent.com/75777864/222687016-77113273-9857-4d3a-bbb6-8b0561d58c60.png)|![image](https://user-images.githubusercontent.com/75777864/222687264-b9b1ea2b-681d-49e7-9c36-9c81e61a488e.png)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a non-English language.
* Visit `/stats/insights/[site]` and verify that the time offset appears translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
