### PR TITLE
i18n: Add context for Jetpack `Security` strings

### DIFF
--- a/client/jetpack-cloud/sections/comparison/table/useComparisonData.tsx
+++ b/client/jetpack-cloud/sections/comparison/table/useComparisonData.tsx
@@ -34,7 +34,7 @@ export const useComparisonData = () => {
 		() => [
 			{
 				sectionId: 'security',
-				sectionName: translate( 'Security' ),
+				sectionName: translate( 'Security', { context: 'Jetpack product name' } ),
 				icon: LockIcon,
 				features: [
 					{

--- a/client/jetpack-cloud/sections/comparison/table/useProductsToCompare.ts
+++ b/client/jetpack-cloud/sections/comparison/table/useProductsToCompare.ts
@@ -25,7 +25,7 @@ export const useProductsToCompare = () => {
 			},
 			{
 				id: 'SECURITY',
-				name: translate( 'Security' ),
+				name: translate( 'Security', { context: 'Jetpack product name' } ),
 				productSlug: PLAN_JETPACK_SECURITY_T1_YEARLY,
 			},
 			{

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -52,7 +52,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 				id: 'products',
 				items: [
 					{
-						label: translate( 'Security' ),
+						label: translate( 'Security', { context: 'Jetpack product name' } ),
 						tagline: translate( 'Protect your site' ),
 						href: `${ JETPACK_COM_BASE_URL }/features/security/`,
 						items: [
@@ -148,7 +148,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 					href: `${ JETPACK_COM_BASE_URL }/complete/`,
 				},
 				{
-					label: translate( 'Security' ),
+					label: translate( 'Security', { context: 'Jetpack product name' } ),
 					tagline: translate( 'Comprehensive site security' ),
 					href: `${ JETPACK_COM_BASE_URL }/features/security/`,
 				},

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1606,7 +1606,7 @@ const getPlanJetpackSecurityT1Details = (): IncompleteJetpackPlan => ( {
 	...getJetpackCommonPlanDetails(),
 	group: GROUP_JETPACK,
 	type: TYPE_SECURITY_T1,
-	getTitle: () => translate( 'Security' ),
+	getTitle: () => translate( 'Security', { context: 'Jetpack product name' } ),
 	availableFor: ( plan ) => [ PLAN_JETPACK_FREE, ...JETPACK_LEGACY_PLANS ].includes( plan ),
 	getDescription: () =>
 		translate(

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -42,7 +42,7 @@ export default function JetpackUpsellCard( {
 				iconUrl: SecurityIcon,
 				isFree: false,
 				slug: 'security',
-				title: translate( 'Security' ),
+				title: translate( 'Security', { context: 'Jetpack product name' } ),
 			},
 			{
 				description: translate(

--- a/packages/data-stores/src/contextual-help/contextual-help.tsx
+++ b/packages/data-stores/src/contextual-help/contextual-help.tsx
@@ -1,5 +1,5 @@
 import { localizeUrl } from '@automattic/i18n-utils';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { RESULT_TOUR, RESULT_VIDEO, SELL_INTENT } from './constants';
 
 export type LinksForSection = {
@@ -1115,7 +1115,7 @@ export const contextLinksForSection: Record< string, LinksForSection | LinksForS
 			},
 			post_id: 10977,
 			get title() {
-				return __( 'Security', __i18n_text_domain__ );
+				return _x( 'Security', 'Jetpack product name', __i18n_text_domain__ );
 			},
 			get description() {
 				return __(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 579-gh-Automattic/issues

## Proposed Changes

* Add context `Jetpack product name` to Jetpack `Security` strings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review changes.
* Inspect `calypso-strings.pot` build artifact and confirm the updated `Security` with context are included.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
