### PR TITLE
Developer UX: refactor submenu events and add upsell events

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -419,9 +419,7 @@ export const SitesEllipsisMenu = ( {
 					<MenuItemLink
 						href={ `/settings/performance/${ site.slug }` }
 						onClick={ () =>
-							recordTracks(
-								'calypso_sites_dashboard_site_action_submenu_performance_settings_click'
-							)
+							recordTracks( 'calypso_sites_dashboard_site_action_performance_settings_click' )
 						}
 					>
 						{ __( 'Performance settings' ) }
@@ -430,7 +428,7 @@ export const SitesEllipsisMenu = ( {
 						<MenuItemLink
 							href={ `/settings/general/${ site.slug }#site-privacy-settings` }
 							onClick={ () =>
-								recordTracks( 'calypso_sites_dashboard_site_action_submenu_privacy_settings_click' )
+								recordTracks( 'calypso_sites_dashboard_site_action_privacy_settings_click' )
 							}
 						>
 							{ __( 'Privacy settings' ) }
@@ -440,7 +438,7 @@ export const SitesEllipsisMenu = ( {
 						<MenuItemLink
 							href={ `/domains/manage/${ site.slug }/dns/${ site.slug }` }
 							onClick={ () =>
-								recordTracks( 'calypso_sites_dashboard_site_action_submenu_dns_records_click' )
+								recordTracks( 'calypso_sites_dashboard_site_action_dns_records_click' )
 							}
 						>
 							{ __( 'Domains and DNS' ) }

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -261,37 +261,37 @@ function useSubmenuItems( site: SiteExcerptData ) {
 	const { __ } = useI18n();
 	const siteSlug = site.slug;
 
-	return useMemo< { label: string; href: string; eventName: string }[] >( () => {
+	return useMemo< { label: string; href: string; sectionName: string }[] >( () => {
 		return [
 			{
 				label: __( 'SFTP/SSH credentials' ),
 				href: `/hosting-config/${ siteSlug }#sftp-credentials`,
-				eventName: 'calypso_sites_dashboard_site_action_submenu_sftp_credentials_click',
+				sectionName: 'sftp_credentials',
 			},
 			{
 				label: __( 'Database access' ),
 				href: `/hosting-config/${ siteSlug }#database-access`,
-				eventName: 'calypso_sites_dashboard_site_action_submenu_database_access_click',
+				sectionName: 'database_access',
 			},
 			{
 				label: __( 'Deploy from GitHub' ),
 				href: `/hosting-config/${ siteSlug }#connect-github`,
-				eventName: 'calypso_sites_dashboard_site_action_submenu_connect_github_click',
+				sectionName: 'connect_github',
 			},
 			{
 				label: __( 'Web server settings' ),
 				href: `/hosting-config/${ siteSlug }#web-server-settings`,
-				eventName: 'calypso_sites_dashboard_site_action_submenu_web_server_settings_click',
+				sectionName: 'web_server_settings',
 			},
 			{
 				label: __( 'Clear cache' ),
 				href: `/hosting-config/${ siteSlug }#cache`,
-				eventName: 'calypso_sites_dashboard_site_action_submenu_cache_click',
+				sectionName: 'cache',
 			},
 			{
 				label: __( 'Web server logs' ),
 				href: `/hosting-config/${ siteSlug }#web-server-logs`,
-				eventName: 'calypso_sites_dashboard_site_action_submenu_logs_click',
+				sectionName: 'logs',
 			},
 		];
 	}, [ __, siteSlug ] );
@@ -337,7 +337,11 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 						<MenuItemLink
 							key={ item.label }
 							href={ item.href }
-							onClick={ () => recordTracks( item.eventName ) }
+							onClick={ () =>
+								recordTracks( 'calypso_sites_dashboard_site_action_hosting_config_submenu_click', {
+									section: item.sectionName,
+								} )
+							}
 						>
 							{ item.label }
 						</MenuItemLink>

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -299,21 +299,26 @@ function useSubmenuItems( site: SiteExcerptData ) {
 
 function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps ) {
 	const { __ } = useI18n();
+	const hasFeatureSFTP = useSafeSiteHasFeature( site.ID, FEATURE_SFTP );
+	const displayUpsell = ! hasFeatureSFTP;
 	const submenuItems = useSubmenuItems( site );
 	const onSubmenuIsVisible = useCallback( () => {
-		recordTracks( 'calypso_sites_dashboard_site_action_hosting_config_submenu_open' );
-	}, [ recordTracks ] );
+		recordTracks( 'calypso_sites_dashboard_site_action_hosting_config_submenu_open', {
+			display_upsell: displayUpsell,
+			product_slug: site.plan?.product_slug,
+		} );
+	}, [ displayUpsell, recordTracks, site.plan?.product_slug ] );
 	const developerSubmenuProps = useSubmenuPopoverProps< HTMLDivElement >( {
 		offsetTop: -8,
 		onVisible: onSubmenuIsVisible,
 	} );
-	const hasFeatureSFTP = useSafeSiteHasFeature( site.ID, FEATURE_SFTP );
 
 	useEffect( () => {
 		recordTracks( 'calypso_sites_dashboard_site_action_hosting_config_view', {
+			display_upsell: displayUpsell,
 			product_slug: site.plan?.product_slug,
 		} );
-	}, [ recordTracks, site.plan?.product_slug ] );
+	}, [ displayUpsell, recordTracks, site.plan?.product_slug ] );
 
 	if ( submenuItems.length === 0 ) {
 		return null;
@@ -324,15 +329,15 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 			<MenuItemLink
 				href={ getHostingConfigUrl( site.slug ) }
 				onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_hosting_config_click' ) }
-				info={ ! hasFeatureSFTP && __( 'Requires a Business Plan' ) }
+				info={ ! displayUpsell && __( 'Requires a Business Plan' ) }
 			>
 				{ __( 'Hosting configuration' ) } <MenuItemGridIcon icon="chevron-right" size={ 18 } />
 			</MenuItemLink>
 			<SubmenuPopover
 				{ ...developerSubmenuProps.submenu }
-				focusOnMount={ hasFeatureSFTP ? 'firstElement' : false }
+				focusOnMount={ displayUpsell ? 'firstElement' : false }
 			>
-				{ hasFeatureSFTP ? (
+				{ displayUpsell ? (
 					submenuItems.map( ( item ) => (
 						<MenuItemLink
 							key={ item.label }

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -329,29 +329,15 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 			<MenuItemLink
 				href={ getHostingConfigUrl( site.slug ) }
 				onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_hosting_config_click' ) }
-				info={ ! displayUpsell && __( 'Requires a Business Plan' ) }
+				info={ displayUpsell && __( 'Requires a Business Plan' ) }
 			>
 				{ __( 'Hosting configuration' ) } <MenuItemGridIcon icon="chevron-right" size={ 18 } />
 			</MenuItemLink>
 			<SubmenuPopover
 				{ ...developerSubmenuProps.submenu }
-				focusOnMount={ displayUpsell ? 'firstElement' : false }
+				focusOnMount={ displayUpsell ? false : 'firstElement' }
 			>
 				{ displayUpsell ? (
-					submenuItems.map( ( item ) => (
-						<MenuItemLink
-							key={ item.label }
-							href={ item.href }
-							onClick={ () =>
-								recordTracks( 'calypso_sites_dashboard_site_action_hosting_config_submenu_click', {
-									section: item.sectionName,
-								} )
-							}
-						>
-							{ item.label }
-						</MenuItemLink>
-					) )
-				) : (
 					<UpsellMenuGroup>
 						{ __(
 							'Upgrade to the Business Plan to enable SFTP & SSH, database access, GitHub deploys, and more…'
@@ -367,6 +353,20 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 							{ __( 'Check full feature list' ) }
 						</Button>
 					</UpsellMenuGroup>
+				) : (
+					submenuItems.map( ( item ) => (
+						<MenuItemLink
+							key={ item.label }
+							href={ item.href }
+							onClick={ () =>
+								recordTracks( 'calypso_sites_dashboard_site_action_hosting_config_submenu_click', {
+									section: item.sectionName,
+								} )
+							}
+						>
+							{ item.label }
+						</MenuItemLink>
+					) )
 				) }
 			</SubmenuPopover>
 		</div>

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -352,7 +352,7 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 								} )
 							}
 						>
-							{ __( 'Check full feature list' ) }
+							{ __( 'See full feature list' ) }
 						</Button>
 					</UpsellMenuGroup>
 				) : (

--- a/packages/components/src/submenu-popover/index.tsx
+++ b/packages/components/src/submenu-popover/index.tsx
@@ -1,5 +1,5 @@
 import { Popover } from '@wordpress/components';
-import { LegacyRef, useCallback, useMemo, useRef, useState } from 'react';
+import { LegacyRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 interface SubmenuPopoverProps extends Popover.Props {
 	isVisible?: boolean;
@@ -63,13 +63,19 @@ function useHasRightSpace( element: HTMLElement | undefined ): boolean {
 }
 
 export function useSubmenuPopoverProps< T extends HTMLElement >(
-	options: { offsetTop?: number } = {}
+	options: { offsetTop?: number; onVisible?: () => void } = {}
 ) {
 	const { offsetTop = 0 } = options;
 	const [ isVisible, setIsVisible ] = useState( false );
 	const anchor = useRef< T >();
 	const hasRightSpace = useHasRightSpace( anchor?.current );
 	const closeSubmenuA11y = useCloseSubmenuA11y();
+
+	useEffect( () => {
+		if ( isVisible ) {
+			options.onVisible?.();
+		}
+	}, [ isVisible, options, options.onVisible ] );
 
 	const submenu: Partial< SubmenuPopoverProps > = {
 		isVisible,

--- a/packages/components/src/submenu-popover/index.tsx
+++ b/packages/components/src/submenu-popover/index.tsx
@@ -1,5 +1,5 @@
 import { Popover } from '@wordpress/components';
-import { LegacyRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { LegacyRef, useCallback, useMemo, useRef, useState } from 'react';
 
 interface SubmenuPopoverProps extends Popover.Props {
 	isVisible?: boolean;
@@ -63,19 +63,13 @@ function useHasRightSpace( element: HTMLElement | undefined ): boolean {
 }
 
 export function useSubmenuPopoverProps< T extends HTMLElement >(
-	options: { offsetTop?: number; onVisible?: () => void } = {}
+	options: { offsetTop?: number } = {}
 ) {
 	const { offsetTop = 0 } = options;
 	const [ isVisible, setIsVisible ] = useState( false );
 	const anchor = useRef< T >();
 	const hasRightSpace = useHasRightSpace( anchor?.current );
 	const closeSubmenuA11y = useCloseSubmenuA11y();
-
-	useEffect( () => {
-		if ( isVisible ) {
-			options.onVisible?.();
-		}
-	}, [ isVisible, options, options.onVisible ] );
 
 	const submenu: Partial< SubmenuPopoverProps > = {
 		isVisible,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/1897

## Proposed Changes

* Add upsell events on view and on click
* Refactor submenu item events to use the same event.

This PR needs to change the tracks events repository.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable event logs in Chrome dev tools: `localStorage.setItem( 'debug', 'calypso:analytics*' );`
* Go to `/sites`
* Open the actions menu on a free site
* Observe the event `calypso_sites_dashboard_site_action_hosting_config_view` is triggered
* Put the mouse over the Hosting Configuration to display the submenu
* Observe the event `calypso_sites_dashboard_site_action_hosting_config_upsell_view` is triggered
* Click on the CTA `Check full feature list`
* Observe the event `calypso_sites_dashboard_site_action_hosting_config_upsell_click` is triggered
* Go back to `/sites`
* Open the actions menu on a business site
* Put the mouse over the Hosting Configuration to display the submenu
* Click on any submenu item
* Observe the event `calypso_sites_dashboard_site_action_hosting_config_submenu_click` is triggered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
