### PR TITLE
Stepper Framework: Show WordPress logo instead of white screen when a step is loading

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/index.tsx
@@ -1,0 +1,12 @@
+import classnames from 'classnames';
+import WordPressLogo from 'calypso/components/wordpress-logo';
+import './style.scss';
+
+const StepperLoader = () => {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return (
+		<WordPressLogo size={ 72 } className={ classnames( 'wpcom-site__logo', 'stepper-loader' ) } />
+	);
+};
+
+export default StepperLoader;

--- a/client/landing/stepper/declarative-flow/internals/components/stepper-loader/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/components/stepper-loader/style.scss
@@ -1,0 +1,3 @@
+.stepper-loader {
+	animation: loading-fade 1.6s ease-in-out infinite;
+}

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -10,7 +10,6 @@ import { useEffect, useState, useCallback } from 'react';
 import Modal from 'react-modal';
 import { Switch, Route, Redirect, generatePath, useHistory, useLocation } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
-import WordPressLogo from 'calypso/components/wordpress-logo';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
 import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
@@ -19,6 +18,7 @@ import { recordSignupStart } from 'calypso/lib/analytics/signup';
 import SignupHeader from 'calypso/signup/signup-header';
 import { ONBOARD_STORE } from '../../stores';
 import recordStepStart from './analytics/record-step-start';
+import StepperLoader from './components/stepper-loader';
 import VideoPressIntroBackground from './steps-repository/intro/videopress-intro-background';
 import { AssertConditionState, Flow, StepperStep } from './types';
 import './global.scss';
@@ -125,7 +125,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		switch ( assertCondition.state ) {
 			case AssertConditionState.CHECKING:
 				/* eslint-disable wpcalypso/jsx-classname-namespace */
-				return <WordPressLogo size={ 72 } className="wpcom-site__logo" />;
+				return <StepperLoader />;
 			/* eslint-enable wpcalypso/jsx-classname-namespace */
 			case AssertConditionState.FAILURE:
 				throw new Error( assertCondition.message ?? 'An error has occurred.' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -41,6 +41,7 @@ import {
 	recordSelectedDesign,
 	getVirtualDesignProps,
 } from '../../analytics/record-design';
+import StepperLoader from '../../components/stepper-loader';
 import { getCategorizationOptions } from './categories';
 import { DEFAULT_VARIATION_SLUG, RETIRING_DESIGN_SLUGS, STEP_NAME } from './constants';
 import DesignPickerDesignTitle from './design-picker-design-title';
@@ -584,7 +585,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 	// Don't render until we've done fetching all the data needed for initial render.
 	if ( ! site || isLoadingSiteVertical || isLoadingDesigns || isLoadingVirtualThemesExperiment ) {
-		return null;
+		return <StepperLoader />;
 	}
 
 	if ( selectedDesign && isPreviewingDesign ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
@@ -1,5 +1,6 @@
 import { BlockRendererProvider, PatternsRendererProvider } from '@automattic/block-renderer';
 import { isEnabled } from '@automattic/calypso-config';
+import StepperLoader from '../../components/stepper-loader';
 import { PLACEHOLDER_SITE_ID } from './constants';
 import type { SiteInfo } from '@automattic/block-renderer';
 
@@ -22,6 +23,7 @@ const PatternAssemblerContainer = ( {
 		siteId={ siteId }
 		stylesheet={ stylesheet }
 		useInlineStyles={ isEnabled( 'pattern-assembler/inline-styles' ) }
+		placeholder={ <StepperLoader /> }
 	>
 		<PatternsRendererProvider
 			// Site used to render site-related things on the previews,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/with-global-styles-provider.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/with-global-styles-provider.tsx
@@ -5,6 +5,7 @@ import { useSelect } from '@wordpress/data';
 import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { ONBOARD_STORE } from '../../../../stores';
+import StepperLoader from '../../components/stepper-loader';
 
 const withGlobalStylesProvider = createHigherOrderComponent(
 	< OuterProps, >( InnerComponent: React.ComponentType< OuterProps > ) => {
@@ -16,7 +17,7 @@ const withGlobalStylesProvider = createHigherOrderComponent(
 			const stylesheet = selectedDesign?.recipe?.stylesheet;
 
 			if ( ! siteSlugOrId || ! stylesheet ) {
-				return null;
+				return <StepperLoader />;
 			}
 
 			if ( ! isEnabled( 'pattern-assembler/color-and-fonts' ) ) {
@@ -25,7 +26,11 @@ const withGlobalStylesProvider = createHigherOrderComponent(
 
 			// TODO: We might need to lazy load the GlobalStylesProvider
 			return (
-				<GlobalStylesProvider siteId={ siteSlugOrId } stylesheet={ stylesheet }>
+				<GlobalStylesProvider
+					siteId={ siteSlugOrId }
+					stylesheet={ stylesheet }
+					placeholder={ <StepperLoader /> }
+				>
 					<InnerComponent { ...props } />
 				</GlobalStylesProvider>
 			);

--- a/packages/block-renderer/src/components/block-renderer-provider.tsx
+++ b/packages/block-renderer/src/components/block-renderer-provider.tsx
@@ -8,6 +8,7 @@ export interface Props {
 	stylesheet?: string;
 	children: JSX.Element;
 	useInlineStyles?: boolean;
+	placeholder?: JSX.Element | null;
 }
 
 const useBlockRendererContext = (
@@ -46,11 +47,12 @@ const BlockRendererProvider = ( {
 	stylesheet = '',
 	children,
 	useInlineStyles = false,
+	placeholder = null,
 }: Props ) => {
 	const context = useBlockRendererContext( siteId, stylesheet, useInlineStyles );
 
 	if ( ! context.isReady ) {
-		return null;
+		return placeholder;
 	}
 
 	return (

--- a/packages/global-styles/src/components/global-styles-provider/index.tsx
+++ b/packages/global-styles/src/components/global-styles-provider/index.tsx
@@ -81,13 +81,14 @@ interface Props {
 	siteId: number | string;
 	stylesheet: string;
 	children: JSX.Element;
+	placeholder: JSX.Element | null;
 }
 
-const GlobalStylesProvider = ( { siteId, stylesheet, children }: Props ) => {
+const GlobalStylesProvider = ( { siteId, stylesheet, children, placeholder = null }: Props ) => {
 	const context = useGlobalStylesContext( siteId, stylesheet );
 
 	if ( ! context.isReady ) {
-		return null;
+		return placeholder;
 	}
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Instead of rendering `null` when a step is loading, show the WordPress logo to improve the experience

https://user-images.githubusercontent.com/13596067/222715640-f97a323f-6b85-496a-b872-4a22b028d42d.mov

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Navigate between steps and ensure you will see the WordPress logo with loading animation instead of white screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
