### PR TITLE
Check for expired eCommerce trials in the Marketplace upgrade nudge

### DIFF
--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -28,7 +28,9 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 const UpgradeNudge = ( { siteSlug, paidPlugins } ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
-	const isEcommerceTrial = sitePlan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
+
+	// Use selectedSite.plan because getSitePlan() doesn't return expired plans.
+	const isEcommerceTrial = selectedSite?.plan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 	const jetpackNonAtomic = useSelector(
 		( state ) =>
 			isJetpackSite( state, selectedSite?.ID ) && ! isAtomicSite( state, selectedSite?.ID )
@@ -126,7 +128,7 @@ const UpgradeNudge = ( { siteSlug, paidPlugins } ) => {
 				callToAction={ translate( 'Upgrade now' ) }
 				icon="notice-outline"
 				showIcon={ true }
-				href={ `/checkout/${ siteSlug }/${ PLAN_ECOMMERCE_MONTHLY }` }
+				href={ `/plans/${ siteSlug }` }
 				feature={ FEATURE_INSTALL_PLUGINS }
 				plan={ PLAN_ECOMMERCE_MONTHLY }
 				title={ translate( 'To install additional plugins, please upgrade to a paid plan.' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* #73953
* #73753

## Proposed Changes

* This PR fixes the logic for the upsell nudge in the WordPress.com plugins marketplace to use the correct text after the eCommerce trial plan has expired.
* This PR also modifies the upsell to point the user to the Plans page rather than adding a product directly to the cart.

Note that this PR will likely be moot while #73953 is causing this page to redirect to the plans page, but I think we should fix this regardless, as we do want to re-enable access to the marketplace at some point.

## Testing Instructions

* Find a site where you have added the eCommerce trial _and_ that plan has expired
* Open `/plugins/:siteSlug` via the main WordPress.com site -- verify that the upsell promotes the Business plan explicitly
* Run this branch locally or via Calypso.live
* Open `/plugins/:siteSlug`
* Verify that the upsell banner doesn't specify the plan in the copy
* Click on the CTA in the banner, and verify that you're taken to the plans page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?