### PR TITLE
I18N: Localize the labels (categories / description) into the user lo…

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -7,6 +7,8 @@
 
 namespace A8C\FSE;
 
+use function A8C\FSE\Common\get_iso_639_locale;
+
 /**
  * Class Starter_Page_Templates
  */
@@ -42,9 +44,11 @@ class Starter_Page_Templates {
 	/**
 	 * Gets the cache key for templates array, after setting it if it hasn't been set yet.
 	 *
+	 * @param string $locale The templates locale.
+	 *
 	 * @return string
 	 */
-	public function get_templates_cache_key() {
+	public function get_templates_cache_key( string $locale ) {
 		if ( empty( $this->templates_cache_key ) ) {
 			$this->templates_cache_key = implode(
 				'_',
@@ -52,11 +56,11 @@ class Starter_Page_Templates {
 					'starter_page_templates',
 					A8C_ETK_PLUGIN_VERSION,
 					get_option( 'site_vertical', 'default' ),
-					$this->get_verticals_locale(),
 				)
 			);
 		}
-		return $this->templates_cache_key;
+
+		return $this->templates_cache_key . '_' . $locale;
 	}
 
 	/**
@@ -138,7 +142,8 @@ class Starter_Page_Templates {
 	 * Enqueue block editor assets.
 	 */
 	public function enqueue_assets() {
-		$screen = get_current_screen();
+		$screen      = get_current_screen();
+		$user_locale = get_iso_639_locale( get_user_locale() );
 
 		// Return early if we don't meet conditions to show templates.
 		if ( 'page' !== $screen->id ) {
@@ -146,7 +151,25 @@ class Starter_Page_Templates {
 		}
 
 		// Load templates for this site.
-		$page_templates = $this->get_page_templates();
+		$page_templates = $this->get_page_templates( $this->get_verticals_locale() );
+		if ( $user_locale !== $this->get_verticals_locale() ) {
+			// If the user locale is not the blog locale, we should show labels in the user locale.
+			$user_page_templates_indexed = array();
+			$user_page_templates         = $this->get_page_templates( $user_locale );
+			foreach ( $user_page_templates as $page_template ) {
+				if ( ! empty( $page_template['ID'] ) ) {
+					$user_page_templates_indexed[ $page_template['ID'] ] = $page_template;
+				}
+			}
+			foreach ( $page_templates as $key => $page_template ) {
+				if ( isset( $user_page_templates_indexed[ $page_template['ID'] ]['categories'] ) ) {
+					$page_templates[ $key ]['categories'] = $user_page_templates_indexed[ $page_template['ID'] ]['categories'];
+				}
+				if ( isset( $user_page_templates_indexed[ $page_template['ID'] ]['description'] ) ) {
+					$page_templates[ $key ]['description'] = $user_page_templates_indexed[ $page_template['ID'] ]['description'];
+				}
+			}
+		}
 
 		if ( empty( $page_templates ) ) {
 			$this->pass_error_to_frontend( __( 'No data received from the vertical API. Skipped showing modal window with template selection.', 'full-site-editing' ) );
@@ -205,11 +228,12 @@ class Starter_Page_Templates {
 	/**
 	 * Get page templates from the patterns API or return cached version if available.
 	 *
+	 * @param string $locale The templates locale.
+	 *
 	 * @return array Containing page templates or nothing if an error occurred.
 	 */
-	public function get_page_templates() {
-		$page_template_data = get_transient( $this->get_templates_cache_key() );
-
+	public function get_page_templates( string $locale ) {
+		$page_template_data   = get_transient( $this->get_templates_cache_key( $locale ) );
 		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
 
 		// Load fresh data if we don't have any or vertical_id doesn't match.
@@ -222,7 +246,7 @@ class Starter_Page_Templates {
 						'tags'         => 'layout',
 						'pattern_meta' => 'is_web',
 					),
-					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->get_verticals_locale()
+					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $locale
 				)
 			);
 
@@ -242,7 +266,7 @@ class Starter_Page_Templates {
 
 			// Only save to cache if we have not overridden the source site.
 			if ( false === $override_source_site ) {
-				set_transient( $this->get_templates_cache_key(), $page_template_data, DAY_IN_SECONDS );
+				set_transient( $this->get_templates_cache_key( $locale ), $page_template_data, DAY_IN_SECONDS );
 			}
 
 			return $page_template_data;
@@ -267,7 +291,7 @@ class Starter_Page_Templates {
 	 * Deletes cached templates data when theme switches.
 	 */
 	public function clear_templates_cache() {
-		delete_transient( $this->get_templates_cache_key() );
+		delete_transient( $this->get_templates_cache_key( $this->get_verticals_locale() ) );
 	}
 
 	/**
@@ -276,6 +300,6 @@ class Starter_Page_Templates {
 	private function get_verticals_locale() {
 		// Make sure to get blog locale, not user locale.
 		$language = function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_locale();
-		return \A8C\FSE\Common\get_iso_639_locale( $language );
+		return get_iso_639_locale( $language );
 	}
 }


### PR DESCRIPTION
## Context
When selecting "Add new page" in WP.com, the names of the categories/patterns appear in the site language, along with the actual pattern that's going to be inserted. It'd make more sense to use the user locale to display the pattern names/description, while still inserting the pattern in the site language.

![image](https://user-images.githubusercontent.com/23708351/222741938-984f4d36-d565-43e2-a990-f8b70ccffe11.png)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/i18n-issues#531

## Proposed Changes

* When the user locale differs from the blog locale, we also fetch the pattern templates in the user locale, and we replace the categories/description in the original data with the ones in the user locale. 
* This approach requires no API changes and should not interfere with any caching mechanism present on the end-point.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Select a simple site, update your user locale to be different from the site locale
* Trigger the Add new page pop-up and confirm that the categories and descriptions are shown in the user locale, while the content inserted by the templates is in the site locale. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
