### PR TITLE
Developer UX: remove feature flag and deploy SMP submenu

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -285,7 +285,7 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 	const hasFeatureSFTP = useSafeSiteHasFeature( site.ID, FEATURE_SFTP );
 	const displayUpsell = ! hasFeatureSFTP;
 	const submenuItems = useSubmenuItems( site );
-	const developerSubmenuProps = useSubmenuPopoverProps< HTMLDivElement >( {
+	const submenuProps = useSubmenuPopoverProps< HTMLDivElement >( {
 		offsetTop: -8,
 	} );
 
@@ -294,7 +294,7 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 	}
 
 	return (
-		<div { ...developerSubmenuProps.parent }>
+		<div { ...submenuProps.parent }>
 			<TrackComponentView
 				eventName="calypso_sites_dashboard_site_action_hosting_config_view"
 				eventProperties={ {
@@ -310,7 +310,7 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 				{ __( 'Hosting configuration' ) } <MenuItemGridIcon icon="chevron-right" size={ 18 } />
 			</MenuItemLink>
 			<SubmenuPopover
-				{ ...developerSubmenuProps.submenu }
+				{ ...submenuProps.submenu }
 				focusOnMount={ displayUpsell ? false : 'firstElement' }
 			>
 				{ displayUpsell ? (

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_SFTP,
 	WPCOM_FEATURES_MANAGE_PLUGINS,
@@ -108,26 +107,9 @@ const ManagePluginsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 					has_manage_plugins_feature: hasManagePluginsFeature,
 				} )
 			}
-			info={
-				isEnabled( 'dev/developer-ux' ) &&
-				! hasManagePluginsFeature &&
-				__( 'Requires a Business Plan' )
-			}
+			info={ ! hasManagePluginsFeature && __( 'Requires a Business Plan' ) }
 		>
 			{ label }
-		</MenuItemLink>
-	);
-};
-
-const HostingConfigItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
-	const { __ } = useI18n();
-
-	return (
-		<MenuItemLink
-			href={ getHostingConfigUrl( site.slug ) }
-			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_hosting_config_click' ) }
-		>
-			{ __( 'Hosting configuration' ) }
 		</MenuItemLink>
 	);
 };
@@ -407,13 +389,8 @@ export const SitesEllipsisMenu = ( {
 				<SiteMenuGroup>
 					{ ! isLaunched && <LaunchItem { ...props } /> }
 					<SettingsItem { ...props } />
-					{ isEnabled( 'dev/developer-ux' ) && hasHostingPage && (
-						<HostingConfigurationSubmenu { ...props } />
-					) }
+					{ hasHostingPage && <HostingConfigurationSubmenu { ...props } /> }
 					{ ! isP2Site( site ) && <ManagePluginsItem { ...props } /> }
-					{ ! isEnabled( 'dev/developer-ux' ) && hasHostingPage && (
-						<HostingConfigItem { ...props } />
-					) }
 					{ site.is_coming_soon && <PreviewSiteModalItem { ...props } /> }
 					{ shouldShowSiteCopyItem && <CopySiteItem { ...props } onClick={ startSiteCopy } /> }
 					<MenuItemLink

--- a/config/development.json
+++ b/config/development.json
@@ -40,7 +40,6 @@
 		"desktop-promo": true,
 		"dev/auth-helper": true,
 		"dev/account-settings-helper": true,
-		"dev/developer-ux": true,
 		"dev/features-helper": true,
 		"dev/preferences-helper": true,
 		"dev/react-query-devtools": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -28,7 +28,6 @@
 		"desktop-promo": true,
 		"dev/auth-helper": true,
 		"dev/account-settings-helper": true,
-		"dev/developer-ux": true,
 		"dev/preferences-helper": true,
 		"devdocs": true,
 		"devdocs/color-scheme-picker": true,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1852
Previously https://github.com/Automattic/wp-calypso/pull/73998

## Proposed Changes

Removes the feature flag for the new Hosting Configuration submenu.

### Personal

<img width="736" alt="image" src="https://user-images.githubusercontent.com/36432/222792126-70ec4104-b70a-493f-aad9-dec55bb9858c.png">

### Business 

<img width="737" alt="image" src="https://user-images.githubusercontent.com/36432/222792278-78e472bc-cc60-402c-bdd8-3d9476b9e433.png">

### P2

<img width="536" alt="image" src="https://user-images.githubusercontent.com/36432/222792314-b76d24b9-1915-4cbd-8d38-be51b77fae4d.png">


## Testing Instructions

* Go to `/sites`
* Click on the actions menu on any site
* Observe the Hosting Configuration is visible and it show the correct content. Upsell for free sites and Submenu items for Business+.