### PR TITLE
BackupRetention: Update disclaimer and remove current site size additional buffer

### DIFF
--- a/client/components/backup-retention-management/constants.ts
+++ b/client/components/backup-retention-management/constants.ts
@@ -2,7 +2,7 @@ import type { RetentionPeriod } from 'calypso/state/rewind/retention/types';
 
 export const RETENTION_OPTIONS = [ 7, 30, 120, 365 ] as RetentionPeriod[];
 
-export const STORAGE_ESTIMATION_ADDITIONAL_BUFFER = 0.25;
+export const STORAGE_ESTIMATION_ADDITIONAL_BUFFER = 0;
 
 export const STORAGE_RETENTION_LEARN_MORE_LINK =
 	'https://jetpack.com/support/backup/#how-is-storage-usage-calculated';

--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -319,7 +319,7 @@ const BackupRetentionManagement: FunctionComponent< OwnProps > = ( {
 						/>
 						<div className="retention-form__disclaimer">
 							{ translate(
-								'*We estimate the space you need based on your current site size and the selected number of days.'
+								'*We estimate the space you need based on your current site size. If your site size increases, we may need to reduce the number of days of backups that are saved.'
 							) }
 						</div>
 						{ storageUpgradeRequired && (


### PR DESCRIPTION
## Proposed Changes

* Update setting disclaimer
* Remove current site size 25% additional buffer

## Screenshots

### Adjusted disclaimer
![image](https://user-images.githubusercontent.com/1488641/222806474-dcd51249-20e7-41cf-9b64-3c52a13796fb.png)

### Current site size additional buffer

| Before (including 25% buffer) | After (without additional buffer) |
|---|---|
| ![image](https://user-images.githubusercontent.com/1488641/222806775-e3932f03-1a79-44e7-941e-b9432ef054b7.png) | ![image](https://user-images.githubusercontent.com/1488641/222806720-d7cca8f1-31f4-4d79-827f-9333923864b5.png) |

## Discussion

peaFOp-11T-p2#comment-908

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a Calypso live branch
* Navigate to Jetpack settings in Jetpack Cloud or Calypso Blue using a site with Jetpack VaultPress Backup plan.
* Ensure you see the new disclaimer as the screenshot provided below.
* Ensure the current site size is smaller (-25%) to the one you see in production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?