### PR TITLE
Add logic to skip onboarding launchpad_screen option update for e2e t…

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -1,4 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { Design, isBlankCanvasDesign } from '@automattic/design-picker';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -7,6 +7,7 @@ import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
 import { ImporterMainPlatform } from 'calypso/blocks/import/types';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { addQueryArgs } from 'calypso/lib/route';
+import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
@@ -163,7 +164,25 @@ const siteSetupFlow: Flow = {
 			setStepProgress( flowProgress );
 		}
 
-		const exitFlow = ( to: string ) => {
+		const fetchSiteBlogStickers = async ( siteId: number ) => {
+			let blogStickers: string[] = [];
+			try {
+				await wpcom.req.get( `/sites/${ siteId }/blog-stickers` ).then( ( result: string[] ) => {
+					blogStickers = result;
+				} );
+			} catch ( e ) {
+				return blogStickers;
+			}
+			return blogStickers;
+		};
+
+		const exitFlow = async ( to: string ) => {
+			let blogStickers: string[] = [];
+
+			if ( site?.ID && config( 'env_id' ) === 'wpcalypso' ) {
+				blogStickers = await fetchSiteBlogStickers( site?.ID );
+			}
+
 			setPendingAction( () => {
 				/**
 				 * This implementation seems very hacky.
@@ -192,20 +211,31 @@ const siteSetupFlow: Flow = {
 						);
 					}
 
-					// Update Launchpad option based on site intent
-					if ( typeof siteId === 'number' ) {
-						pendingActions.push(
-							saveSiteSettings( siteId, {
-								launchpad_screen: isLaunchpadIntent( intent ) ? 'full' : 'off',
-							} )
-						);
-					}
-
 					let redirectionUrl = to;
 
-					// Forcing cache invalidation to retrieve latest launchpad_screen option value
-					if ( isLaunchpadIntent( intent ) ) {
-						redirectionUrl = addQueryArgs( { showLaunchpad: true }, to );
+					// The e2e test sites can include one (or both) of the blog stickers below:
+					// 'a8c-e2e-test-blog' or 'a8c-test-blog'
+					// If the test site includes one of these blog stickers,
+					// then we do not set the 'launchpad_screen' option to 'full'.
+					// This will temporarily prevent the launchpad_screen site option update
+					// on e2e test accounts to ensure e2e test cases continue to pass until we update them.
+					if (
+						! blogStickers.includes( 'a8c-e2e-test-blog' ) &&
+						! blogStickers.includes( 'a8c-test-blog' )
+					) {
+						// Update Launchpad option based on site intent
+						if ( typeof siteId === 'number' ) {
+							pendingActions.push(
+								saveSiteSettings( siteId, {
+									launchpad_screen: isLaunchpadIntent( intent ) ? 'full' : 'off',
+								} )
+							);
+						}
+
+						// Forcing cache invalidation to retrieve latest launchpad_screen option value
+						if ( isLaunchpadIntent( intent ) ) {
+							redirectionUrl = addQueryArgs( { showLaunchpad: true }, to );
+						}
 					}
 
 					Promise.all( pendingActions ).then( () => window.location.assign( redirectionUrl ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73405

## Proposed Changes

- E2E pre-release tests are not accounting for the Launchpad.
- Because of this, when we merge changes to general onboarding that would otherwise enable the Launchpad, it causes pre-release test failures ( launchpad screen loads when the e2e specs expect the home page )
- In this PR, we don't enable Launchpad for test sites in the wpcalypso pre-release testing environment

**Note:**
It's important to call out that this is a temporary stopgap. The ideal solution is to update pre-release tests to account for Launchpad since it's an actual feature that #cylon is implementing and releasing to a general audience.releasing to a general audience. We're taking this approach to have a quick patch in production, and to avoid any more interruptions to other teams' workflows

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Create a new site and stop at the onboarding flow goals page wordpress.com/start
* SSH into your sandbox and run this command to add the `a8c-test-blog` blog sticker to your new site: `wp blog-stickers add --sticker=a8c-test-blog --blog_id={siteId} --who={yourUserName}`
* Go back to Calypso (goals page) and select `Write & Publish` , `Promote myself or business` or `Other` then click continue. Pause there.
* Change the 'wpcalypso' string to 'development' to test locally https://github.com/Automattic/wp-calypso/pull/74065/files#diff-614cccce787b17e46e84a16af7865700992dfd374e701239023fd2e1feaa12a1R182
* Return to the goals page and switch the origin to calypso.localhost:3000. Continue through the rest of the onboarding flow.
* Confirm that you are not redirected to the launchpad screen
* Run this command to remove the blog sticker from your test site: `wp blog-stickers remove --sticker=a8c-test-blog --who={yourUserName} --blog_id={siteId}`
* Navigate back to the goals page using the same test site: `/setup/site-setup/goals?siteSlug={siteSlug}`, select `Write & Publish` , `Promote myself or business` or `Other` then continue through the rest of the flow.
* Confirm that you are redirected to the launchpad screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
