### PR TITLE
My home upsell: Add dismiss button

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -52,7 +52,7 @@ export default function DomainUpsell( { context } ) {
 		[ siteDomains ]
 	);
 
-	const dismissPreference = `calypso_my_home_domain_upsell_dismiss-${ site.ID }`;
+	const dismissPreference = `calypso_my_home_domain_upsell_dismiss-${ site?.ID }`;
 	const hasPreferences = useSelector( hasReceivedRemotePreferences );
 	const isDismissed = useSelector( ( state ) => getPreference( state, dismissPreference ) );
 

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -194,7 +194,7 @@ export function RenderDomainUpsell( {
 			<div>
 				<div className="domain-upsell__card-dismiss">
 					<button onClick={ getDismissClickHandler }>
-						<Gridicon icon="cross" />
+						<Gridicon icon="cross" width={ 18 } />
 					</button>
 				</div>
 				<h3>{ cardTitle }</h3>

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { isFreePlanProduct } from '@automattic/calypso-products';
-import { Button, Card, Spinner } from '@automattic/components';
+import { getPlan, isFreePlanProduct, getIntervalTypeForTerm } from '@automattic/calypso-products';
+import { Button, Card, Gridicon, Spinner } from '@automattic/components';
 import { useDomainSuggestions } from '@automattic/domain-picker/src';
 import { useLocale } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
@@ -8,7 +8,7 @@ import { useMemo } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -16,9 +16,12 @@ import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopp
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isNotAtomicJetpack, isP2Site } from 'calypso/sites-dashboard/utils';
 import { getCurrentUser, isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
 import isSiteOnMonthlyPlan from 'calypso/state/selectors/is-site-on-monthly-plan';
 import { getDomainsBySite } from 'calypso/state/sites/domains/selectors';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -38,6 +41,7 @@ export default function DomainUpsell( { context } ) {
 	const site = isProfileUpsell ? primarySite : selectedSite;
 
 	const isMonthlyPlan = useSelector( ( state ) => isSiteOnMonthlyPlan( state, site?.ID ) );
+
 	const isFreePlan = isFreePlanProduct( site?.plan );
 
 	const siteDomains = useSelector( ( state ) => getDomainsBySite( state, site ) );
@@ -45,6 +49,12 @@ export default function DomainUpsell( { context } ) {
 		() => siteDomains.filter( ( domain ) => ! domain.isWPCOMDomain ).length,
 		[ siteDomains ]
 	);
+
+	const dismissPreference = `calypso_my_home_domain_upsell_dismiss-${ site.ID }`;
+	const hasPreferences = useSelector( hasReceivedRemotePreferences );
+	const isDismissed = useSelector( ( state ) => getPreference( state, dismissPreference ) );
+
+	const shouldNotShowUpselDismissed = ! hasPreferences || isDismissed;
 
 	const shouldNotShowProfileUpsell =
 		isProfileUpsell &&
@@ -57,7 +67,7 @@ export default function DomainUpsell( { context } ) {
 
 	const shouldNotShowMyHomeUpsell = ! isProfileUpsell && ( siteDomainsLength || ! isEmailVerified );
 
-	if ( shouldNotShowProfileUpsell || shouldNotShowMyHomeUpsell ) {
+	if ( shouldNotShowUpselDismissed || shouldNotShowProfileUpsell || shouldNotShowMyHomeUpsell ) {
 		return null;
 	}
 
@@ -71,6 +81,7 @@ export default function DomainUpsell( { context } ) {
 				isProfileUpsell={ isProfileUpsell }
 				searchTerm={ searchTerm }
 				siteSlug={ isProfileUpsell ? primarySiteSlug : selectedSiteSlug }
+				dismissPreference={ dismissPreference }
 			/>
 		</CalypsoShoppingCartProvider>
 	);
@@ -82,11 +93,13 @@ export function RenderDomainUpsell( {
 	isProfileUpsell,
 	searchTerm,
 	siteSlug,
+	dismissPreference,
 } ) {
 	const translate = useTranslate();
 
 	const tracksContext = isProfileUpsell ? 'profile' : 'my_home';
 
+	const dispatch = useDispatch();
 	const locale = useLocale();
 	const { allDomainSuggestions } =
 		useDomainSuggestions( searchTerm, 3, undefined, locale, {
@@ -131,6 +144,11 @@ export function RenderDomainUpsell( {
 					},
 					`/plans/yearly/${ siteSlug }`
 			  );
+
+	const getDismissClickHandler = () => {
+		recordTracksEvent( 'calypso_my_home_domain_upsell_dismiss_click' );
+		dispatch( savePreference( dismissPreference, 1 ) );
+	};
 	const [ ctaIsBusy, setCtaIsBusy ] = useState( false );
 	const getCtaClickHandler = async () => {
 		setCtaIsBusy( true );
@@ -172,6 +190,11 @@ export function RenderDomainUpsell( {
 		<Card className="domain-upsell__card customer-home__card">
 			<TrackComponentView eventName={ 'calypso_' + tracksContext + '_domain_upsell_impression' } />
 			<div>
+				<div className="domain-upsell__card-dismiss">
+					<button onClick={ getDismissClickHandler }>
+						<Gridicon icon="cross" />
+					</button>
+				</div>
 				<h3>{ cardTitle }</h3>
 				<p>{ cardSubtitle }</p>
 				<div className="suggested-domain-name">

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -19,7 +19,6 @@ import { getCurrentUser, isCurrentUserEmailVerified } from 'calypso/state/curren
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
-import isSiteOnMonthlyPlan from 'calypso/state/selectors/is-site-on-monthly-plan';
 import { getDomainsBySite } from 'calypso/state/sites/domains/selectors';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
@@ -40,7 +39,10 @@ export default function DomainUpsell( { context } ) {
 	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
 	const site = isProfileUpsell ? primarySite : selectedSite;
 
-	const isMonthlyPlan = useSelector( ( state ) => isSiteOnMonthlyPlan( state, site?.ID ) );
+	const currentPlan = useSelector( ( state ) => getCurrentPlan( state, site?.ID ) );
+	const currentPlanIntervalType = getIntervalTypeForTerm(
+		getPlan( currentPlan?.productSlug )?.term
+	);
 
 	const isFreePlan = isFreePlanProduct( site?.plan );
 
@@ -77,7 +79,7 @@ export default function DomainUpsell( { context } ) {
 		<CalypsoShoppingCartProvider>
 			<RenderDomainUpsell
 				isFreePlan={ isFreePlan }
-				isMonthlyPlan={ isMonthlyPlan }
+				isMonthlyPlan={ currentPlanIntervalType === 'monthly' }
 				isProfileUpsell={ isProfileUpsell }
 				searchTerm={ searchTerm }
 				siteSlug={ isProfileUpsell ? primarySiteSlug : selectedSiteSlug }

--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -37,6 +37,23 @@ body .customer-home__layout .domain-upsell__card {
 		margin-top: 8px;
 	}
 
+	&-dismiss {
+		position: absolute;
+		width: 18px;
+		height: 18px;
+		top: 16px;
+		right: 16px;
+		color: var(--color-text-subtle);
+		button {
+			cursor: pointer;
+		}
+
+		@include break-small {
+			width: 24px;
+			height: 24px;
+		}
+	}
+
 	.suggested-domain-name {
 		span {
 			font-size: rem(14px);

--- a/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/style.scss
@@ -46,12 +46,9 @@ body .customer-home__layout .domain-upsell__card {
 		color: var(--color-text-subtle);
 		button {
 			cursor: pointer;
+			height: 18px;
 		}
 
-		@include break-small {
-			width: 24px;
-			height: 24px;
-		}
 	}
 
 	.suggested-domain-name {

--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -36,6 +36,11 @@ const initialState = {
 			},
 		},
 	},
+	preferences: {
+		remoteValues: {
+			'calypso_my_home_domain_upsell_dismiss-1': false,
+		},
+	},
 	ui: {
 		selectedSiteId: 1,
 	},


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/73956

## Proposed Changes

Add an `X` to dismiss the My Home Upsell, and it should act like the post editor upsell (each site is independent & the same amount of time).
Also, it tracks the dismiss click with `calypso_my_home_domain_upsell_dismiss_click`

![image](https://user-images.githubusercontent.com/402286/223451403-805d0992-cb90-4291-bc2b-5fdc8cd2f856.png)

## Testing Instructions

- Use a site that shows the My Home Upsell (no custom domain, free or yearly plan for now).
- Go to `/home`
- The domain upsell should show an `X` on the top right corner
- Clicking should track `calypso_my_home_domain_upsell_dismiss_click` & dismiss the upsell.

To re-show the banner, you should post this (with your site id), to `https://public-api.wordpress.com/rest/v1.1/me/preferences?http_envelope=1`
```
{
    "calypso_preferences": {
        "calypso_my_home_domain_upsell_dismiss-YOURSITEID": false,
    }
}
```

## Pre-merge Checklist
- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
