### PR TITLE
Blaze: Add source to the widget so that we can track the origin of the campain

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -21,6 +21,7 @@ export type BlazePressPromotionProps = {
 	siteId: string | number;
 	postId: string | number;
 	keyValue: string;
+	source?: string;
 };
 
 type BlazePressTranslatable = ( original: string, extra?: TranslateOptionsText ) => string;
@@ -75,12 +76,14 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 				if ( props.siteId === null || props.postId === null ) {
 					return;
 				}
+				const source = props.source || 'blazepress';
 
 				await showDSP(
 					selectedSiteSlug,
 					props.siteId,
 					props.postId,
 					onClose,
+					source,
 					( original: string, options?: TranslateOptionsText ): string => {
 						if ( options ) {
 							// This is a special case where we re-use the translate in another application

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -26,12 +26,9 @@ declare global {
 				showDialog?: boolean;
 				setShowCancelButton?: ( show: boolean ) => void;
 				uploadImageLabel?: string;
-<<<<<<< HEAD
 				showGetStartedMessage?: boolean;
 				onGetStartedMessageClose?: ( dontShowAgain: boolean ) => void;
-=======
 				source?: string;
->>>>>>> 97dc728c20 (Blaze: Add source to the widget so that we can better track where the blazes are created from on the app side.)
 			} ) => void;
 			strings: any;
 		};

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -26,8 +26,12 @@ declare global {
 				showDialog?: boolean;
 				setShowCancelButton?: ( show: boolean ) => void;
 				uploadImageLabel?: string;
+<<<<<<< HEAD
 				showGetStartedMessage?: boolean;
 				onGetStartedMessageClose?: ( dontShowAgain: boolean ) => void;
+=======
+				source?: string;
+>>>>>>> 97dc728c20 (Blaze: Add source to the widget so that we can better track where the blazes are created from on the app side.)
 			} ) => void;
 			strings: any;
 		};
@@ -53,6 +57,7 @@ export async function showDSP(
 	siteId: number | string,
 	postId: number | string,
 	onClose: () => void,
+	source?: string,
 	translateFn: ( value: string, options?: any ) => string,
 	domNodeOrId?: HTMLElement | string | null,
 	setShowCancelButton?: ( show: boolean ) => void,
@@ -79,6 +84,7 @@ export async function showDSP(
 				uploadImageLabel: isWpMobileApp() ? __( 'Tap to add image' ) : undefined,
 				showGetStartedMessage: ! isWpMobileApp(), // Don't show the GetStartedMessage in the mobile app.
 				onGetStartedMessageClose: onGetStartedMessageClose,
+				source: source,
 			} );
 		} else {
 			reject( false );

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -54,7 +54,7 @@ export async function showDSP(
 	siteId: number | string,
 	postId: number | string,
 	onClose: () => void,
-	source?: string,
+	source: string,
 	translateFn: ( value: string, options?: any ) => string,
 	domNodeOrId?: HTMLElement | string | null,
 	setShowCancelButton?: ( show: boolean ) => void,

--- a/client/my-sites/promote-post/components/posts-list/index.tsx
+++ b/client/my-sites/promote-post/components/posts-list/index.tsx
@@ -1,9 +1,11 @@
 import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import BlazePressWidget from 'calypso/components/blazepress-widget';
 import EmptyContent from 'calypso/components/empty-content';
 import usePromoteParams from 'calypso/data/promote-post/use-promote-params';
 import PostItem, { Post } from 'calypso/my-sites/promote-post/components/post-item';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import './style.scss';
 
 interface Props {
@@ -13,6 +15,8 @@ interface Props {
 
 export default function PostsList( { content, isLoading }: Props ) {
 	const { isModalOpen, selectedSiteId, selectedPostId, keyValue } = usePromoteParams();
+	const currentQuery = useSelector( getCurrentQueryArguments );
+	const source = currentQuery?.[ 'source' ];
 
 	const isEmpty = ! content || ! content.length;
 	return (
@@ -46,6 +50,7 @@ export default function PostsList( { content, isLoading }: Props ) {
 					siteId={ selectedSiteId }
 					postId={ selectedPostId }
 					keyValue={ keyValue }
+					source={ source }
 				/>
 			) }
 		</>

--- a/client/my-sites/promote-post/components/posts-list/index.tsx
+++ b/client/my-sites/promote-post/components/posts-list/index.tsx
@@ -16,7 +16,8 @@ interface Props {
 export default function PostsList( { content, isLoading }: Props ) {
 	const { isModalOpen, selectedSiteId, selectedPostId, keyValue } = usePromoteParams();
 	const currentQuery = useSelector( getCurrentQueryArguments );
-	const source = currentQuery?.[ 'source' ];
+	const sourceQuery = currentQuery?.[ 'source' ];
+	const source = sourceQuery ? sourceQuery.toString() : undefined;
 
 	const isEmpty = ! content || ! content.length;
 	return (


### PR DESCRIPTION
## Proposed Changes

* Add a `source` attribute to the widget that gets passed in the URL which then gets passed into every track event.
- Related pe7hp4-b3-p2#webviews  the tumblr changes are now live.

## Testing Instructions

Load up the calypso PR. 
Navigate to /advertising/example.com?blazepress-widget=post-9&source=hello - notice the source query parameter. 
Notice that this value gets passed into track events. Which will make it easier to track the entry point of the creation flow. 

See:

<img width="1828" alt="Screenshot_2023-03-08_at_10_47_03_AM" src="https://user-images.githubusercontent.com/115071/223807539-8376d575-a37e-4b03-9117-eee7dae0f9ac.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?