### PR TITLE
Launchpad: add onboarding signup goals default site intent v3

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -199,7 +199,7 @@ const siteSetupFlow: Flow = {
 					if ( typeof siteId === 'number' ) {
 						pendingActions.push(
 							saveSiteSettings( siteId, {
-								launchpad_screen: isLaunchpadIntent( intent ) ? 'full' : 'off',
+								launchpad_screen: isLaunchpadIntent( siteIntent ) ? 'full' : 'off',
 							} )
 						);
 					}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -123,6 +123,7 @@ const siteSetupFlow: Flow = {
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
 		const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
+		const { getIntent } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 		const goals = useSelect( ( select ) => select( ONBOARD_STORE ).getGoals() );
 		const selectedDesign = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 		const startingPoint = useSelect( ( select ) => select( ONBOARD_STORE ).getStartingPoint() );
@@ -151,7 +152,7 @@ const siteSetupFlow: Flow = {
 			( select ) => site && select( SITE_STORE ).isSiteAtomic( site.ID )
 		);
 		const storeType = useSelect( ( select ) => select( ONBOARD_STORE ).getStoreType() );
-		const { setPendingAction, setStepProgress, resetOnboardStoreWithSkipFlags } =
+		const { setPendingAction, setStepProgress, resetOnboardStoreWithSkipFlags, setIntent } =
 			useDispatch( ONBOARD_STORE );
 		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite, saveSiteSettings } =
 			useDispatch( SITE_STORE );
@@ -178,12 +179,13 @@ const siteSetupFlow: Flow = {
 						return;
 					}
 
+					const siteIntent = getIntent();
 					const siteId = site?.ID;
 					const pendingActions = [
-						setIntentOnSite( siteSlug, intent ),
+						setIntentOnSite( siteSlug, siteIntent ),
 						setGoalsOnSite( siteSlug, goals ),
 					];
-					if ( intent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
+					if ( siteIntent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
 						pendingActions.push(
 							setThemeOnSite(
 								siteSlug,
@@ -216,7 +218,7 @@ const siteSetupFlow: Flow = {
 			navigate( 'processing' );
 
 			// Clean-up the store so that if onboard for new site will be launched it will be launched with no preselected values
-			resetOnboardStoreWithSkipFlags( [ 'skipPendingAction' ] );
+			resetOnboardStoreWithSkipFlags( [ 'skipPendingAction', 'skipIntent' ] );
 		};
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) {
@@ -545,6 +547,7 @@ const siteSetupFlow: Flow = {
 
 				case 'goals':
 					// Skip to dashboard must have been pressed
+					setIntent( SiteIntent.Build );
 					return exitFlow( `/home/${ siteSlug }` );
 
 				case 'vertical':

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -207,7 +207,7 @@ const siteSetupFlow: Flow = {
 					let redirectionUrl = to;
 
 					// Forcing cache invalidation to retrieve latest launchpad_screen option value
-					if ( isLaunchpadIntent( intent ) ) {
+					if ( isLaunchpadIntent( siteIntent ) ) {
 						redirectionUrl = addQueryArgs( { showLaunchpad: true }, to );
 					}
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -177,12 +177,17 @@ const siteSetupFlow: Flow = {
 					if ( ! siteSlug ) {
 						return;
 					}
+
+					// If user clicks "Skip to Dashboard" on goals step,
+					// Default site_intent to "build"
+					const updatedSiteIntent = intent ? intent : SiteIntent.Build;
+
 					const siteId = site?.ID;
 					const pendingActions = [
-						setIntentOnSite( siteSlug, intent ),
+						setIntentOnSite( siteSlug, updatedSiteIntent ),
 						setGoalsOnSite( siteSlug, goals ),
 					];
-					if ( intent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
+					if ( updatedSiteIntent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
 						pendingActions.push(
 							setThemeOnSite(
 								siteSlug,

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -178,16 +178,12 @@ const siteSetupFlow: Flow = {
 						return;
 					}
 
-					// If user clicks "Skip to Dashboard" on goals step,
-					// Default site_intent to "build"
-					const updatedSiteIntent = intent ? intent : SiteIntent.Build;
-
 					const siteId = site?.ID;
 					const pendingActions = [
-						setIntentOnSite( siteSlug, updatedSiteIntent ),
+						setIntentOnSite( siteSlug, intent ),
 						setGoalsOnSite( siteSlug, goals ),
 					];
-					if ( updatedSiteIntent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
+					if ( intent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
 						pendingActions.push(
 							setThemeOnSite(
 								siteSlug,

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -307,6 +307,9 @@ const intent: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_INTENT' ) {
 		return action.intent;
 	}
+	if ( action.type === 'RESET_ONBOARD_STORE' && action?.skipFlags?.includes( 'skipIntent' ) ) {
+		return state;
+	}
 	if ( [ 'RESET_INTENT', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
 		return '';
 	}

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -77,7 +77,7 @@ describe(
 				await startSiteFlow.clickButton( 'Skip to dashboard' );
 			} );
 
-			it( 'Skip the Launchpad', async function () {
+			it( 'Skip Launchpad', async function () {
 				await Promise.all( [
 					page.waitForNavigation( { url: /.*\/view\/.*/ } ),
 					await page.click( 'button:text("Skip to dashboard")' ),

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -79,7 +79,7 @@ describe(
 
 			it( 'Skip Launchpad', async function () {
 				await Promise.all( [
-					page.waitForNavigation( { url: /.*\/view\/.*/ } ),
+					page.waitForNavigation( { url: /.*\/view\/.*/, timeout: 30 * 1000 } ),
 					await page.click( 'button:text("Skip to dashboard")' ),
 				] );
 			} );

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -72,11 +72,15 @@ describe(
 				await cartCheckoutPage.purchase( { timeout: 60 * 1000 } );
 			} );
 
-			it( 'Skip to dashboard', async function () {
+			it( 'Skip Onboarding', async function () {
 				const startSiteFlow = new StartSiteFlow( page );
+				await startSiteFlow.clickButton( 'Skip to dashboard' );
+			} );
+
+			it( 'Skip the Launchpad', async function () {
 				await Promise.all( [
-					page.waitForNavigation( { url: /.*\/home\/.*/ } ),
-					startSiteFlow.clickButton( 'Skip to dashboard' ),
+					page.waitForNavigation( { url: /.*\/view\/.*/ } ),
+					await page.click( 'button:text("Skip to dashboard")' ),
 				] );
 			} );
 		} );


### PR DESCRIPTION
#### Testing/Review instructions

Test: short
Review: short

#### Proposed Changes

Currently, users that click the `Skip to dashboard` link on the top right-hand corner of the Goals onboarding step will be navigated to the home screen with the following site options:

`site_intent` = ""
`launchpad_screen` = false

The changes in this PR will set the `site_intent` site option to `build` if the user clicks `Skip to dashboard` on the Goals page. This will also enable the launchpad and set the `launchpad_screen` site option to `full` before the user is navigated to the home screen.

P2 post to give heads up: paYE8P-2yP-p2

Goals step:
<img width="1508" alt="image" src="https://user-images.githubusercontent.com/10482592/216123805-a7a15a5a-2a92-4d50-8750-373a4516f835.png">


#### Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Navigate to the onboarding flow (Click `< Switch Site` on the Calypso sidebar and then click `Add a new site`)
* Create your free site and you should land on the Goals step.
* Do not select a goal and click `Skip to dashboard`. The `site_intent` and `launchpad_screen` values should be updated. The home screen should redirect you to the launchpad screen (There may be a bug that requires multiple refreshes before you redirected - )
* Create a new site and test another goal such as `Write & Publish` to verify the correct `site_intent` value is set

#### Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72870 and https://github.com/Automattic/wp-calypso/pull/72883