### PR TITLE
Stats: fix chart flickering

### DIFF
--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -58,7 +58,7 @@ export default class ChartBar extends PureComponent {
 
 	getScaleY() {
 		const scaleY = this.props.data.value / this.props.max;
-		// Hack: We use an invisible but non-zero value here, becaue zero scaleY-ed bars grows to max and then disappear when combined with container animation in Chrome.
+		// Hack: We use an invisible but non-zero value here, becaue zero scaleY-ed bars grows to max and then disappear when combined with container animation on initialization in Chrome.
 		return scaleY < 1e-4 ? '0.0001' : scaleY.toFixed( 4 );
 	}
 

--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -56,8 +56,9 @@ export default class ChartBar extends PureComponent {
 		} );
 	}
 
-	getPercentage() {
-		return Math.ceil( ( this.props.data.value / this.props.max ) * 10000 ) / 100;
+	getScaleY() {
+		const scaleY = this.props.data.value / this.props.max;
+		return scaleY < 1e-4 ? '0.0001' : scaleY.toFixed( 4 );
 	}
 
 	getNestedPercentage() {
@@ -86,13 +87,12 @@ export default class ChartBar extends PureComponent {
 	}
 
 	renderBar() {
-		const percentage = this.getPercentage();
 		return (
 			<div
 				ref={ this.setRef }
 				key="value"
 				className="chart__bar-section is-bar"
-				style={ { transform: `scaleY( ${ percentage / 100 } )` } }
+				style={ { transform: `scaleY( ${ this.getScaleY() } )` } }
 			>
 				{ this.renderNestedBar() }
 			</div>

--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -58,6 +58,7 @@ export default class ChartBar extends PureComponent {
 
 	getScaleY() {
 		const scaleY = this.props.data.value / this.props.max;
+		// Hack: We use an invisible but non-zero value here, becaue zero scaleY-ed bars grows to max and then disappear when combined with container animation in Chrome.
 		return scaleY < 1e-4 ? '0.0001' : scaleY.toFixed( 4 );
 	}
 

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -137,77 +137,71 @@ function Chart( {
 
 	const { isTooltipVisible, tooltipContext, tooltipPosition, tooltipData } = tooltip;
 
-	return (
-		<>
-			{
-				// This is a hack to avoid the flickering on page load.
-				// The component listens on the resize event of its own, which would resize on initialization.
-				// The hack renders an empty div, which triggers the resize event, and then the actual component would be rendered.
-			 }
-			{ width <= 0 && <div ref={ resizeRef }></div> }
-			{ width > 0 && (
-				<div
-					ref={ resizeRef }
-					className={ classNames( 'chart', { 'is-placeholder': isPlaceholder } ) }
-				>
-					<div className="chart__y-axis-markers">
-						<div className="chart__y-axis-marker is-hundred" />
-						<div className="chart__y-axis-marker is-fifty" />
-						<div className="chart__y-axis-marker is-zero" />
+	// This is a hack to avoid the flickering on page load.
+	// The component listens on the resize event of its own, which would resize on initialization.
+	// The hack renders an empty div, which triggers the resize event, and then the actual component would be rendered.
+	if ( width <= 0 ) {
+		return <div ref={ resizeRef }></div>;
+	}
 
-						{ ( isPlaceholder || isEmptyChart ) && (
-							<div className="chart__empty">
-								{ children || (
-									<Notice
-										className="chart__empty-notice"
-										status="is-warning"
-										isCompact
-										text={ translate( 'No activity this period', {
-											context: 'Message on empty bar chart in Stats',
-											comment: 'Should be limited to 32 characters to prevent wrapping',
-										} ) }
-										showDismiss={ false }
-									/>
-								) }
-							</div>
+	return (
+		<div ref={ resizeRef } className={ classNames( 'chart', { 'is-placeholder': isPlaceholder } ) }>
+			<div className="chart__y-axis-markers">
+				<div className="chart__y-axis-marker is-hundred" />
+				<div className="chart__y-axis-marker is-fifty" />
+				<div className="chart__y-axis-marker is-zero" />
+
+				{ ( isPlaceholder || isEmptyChart ) && (
+					<div className="chart__empty">
+						{ children || (
+							<Notice
+								className="chart__empty-notice"
+								status="is-warning"
+								isCompact
+								text={ translate( 'No activity this period', {
+									context: 'Message on empty bar chart in Stats',
+									comment: 'Should be limited to 32 characters to prevent wrapping',
+								} ) }
+								showDismiss={ false }
+							/>
 						) }
 					</div>
-					{ ! isPlaceholder && (
-						<div ref={ yAxisRef } className="chart__y-axis">
-							<div className="chart__y-axis-width-fix">{ numberFormat( 1e5 ) }</div>
-							<div className="chart__y-axis-label is-hundred">
-								{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, 2 ) }
-							</div>
-							<div className="chart__y-axis-label is-fifty">
-								{ yMax > 1 ? numberFormat( yMax / 2 ) : numberFormat( yMax / 2, 2 ) }
-							</div>
-							<div className="chart__y-axis-label is-zero">{ numberFormat( 0 ) }</div>
-						</div>
-					) }
-					<BarContainer
-						barClick={ barClick }
-						chartWidth={ width }
-						data={ chartData }
-						isPlaceholder={ isPlaceholder }
-						isRtl={ isRtl }
-						isTouch={ hasTouch() }
-						setTooltip={ handleTooltipChange }
-						yAxisMax={ yMax }
-					/>
-					{ isTooltipVisible && (
-						<Tooltip
-							className="chart__tooltip"
-							id="popover__chart-bar"
-							context={ tooltipContext }
-							isVisible={ isTooltipVisible }
-							position={ tooltipPosition }
-						>
-							<ul>{ tooltipData }</ul>
-						</Tooltip>
-					) }
+				) }
+			</div>
+			{ ! isPlaceholder && (
+				<div ref={ yAxisRef } className="chart__y-axis">
+					<div className="chart__y-axis-width-fix">{ numberFormat( 1e5 ) }</div>
+					<div className="chart__y-axis-label is-hundred">
+						{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, 2 ) }
+					</div>
+					<div className="chart__y-axis-label is-fifty">
+						{ yMax > 1 ? numberFormat( yMax / 2 ) : numberFormat( yMax / 2, 2 ) }
+					</div>
+					<div className="chart__y-axis-label is-zero">{ numberFormat( 0 ) }</div>
 				</div>
 			) }
-		</>
+			<BarContainer
+				barClick={ barClick }
+				chartWidth={ width }
+				data={ chartData }
+				isPlaceholder={ isPlaceholder }
+				isRtl={ isRtl }
+				isTouch={ hasTouch() }
+				setTooltip={ handleTooltipChange }
+				yAxisMax={ yMax }
+			/>
+			{ isTooltipVisible && (
+				<Tooltip
+					className="chart__tooltip"
+					id="popover__chart-bar"
+					context={ tooltipContext }
+					isVisible={ isTooltipVisible }
+					position={ tooltipPosition }
+				>
+					<ul>{ tooltipData }</ul>
+				</Tooltip>
+			) }
+		</div>
 	);
 }
 

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -58,7 +58,7 @@ function Chart( {
 	onChangeMaxBars,
 } ) {
 	const [ tooltip, setTooltip ] = useState( { isTooltipVisible: false } );
-	const [ sizing, setSizing ] = useState( { clientWidth: 650, hasResized: false } );
+	const [ sizing, setSizing ] = useState( { clientWidth: 0, hasResized: false } );
 	const [ yAxisSize, setYAxisSize ] = useState( { clientWidth: 0, hasResized: false } );
 
 	// Callback to handle tooltip changes.
@@ -138,63 +138,76 @@ function Chart( {
 	const { isTooltipVisible, tooltipContext, tooltipPosition, tooltipData } = tooltip;
 
 	return (
-		<div ref={ resizeRef } className={ classNames( 'chart', { 'is-placeholder': isPlaceholder } ) }>
-			<div className="chart__y-axis-markers">
-				<div className="chart__y-axis-marker is-hundred" />
-				<div className="chart__y-axis-marker is-fifty" />
-				<div className="chart__y-axis-marker is-zero" />
+		<>
+			{
+				// This is a hack to avoid the flickering on page load.
+				// The component listens on the resize event of its own, which would resize on initialization.
+				// The hack renders an empty div, which triggers the resize event, and then the actual component would be rendered.
+			 }
+			{ width <= 0 && <div ref={ resizeRef }></div> }
+			{ width > 0 && (
+				<div
+					ref={ resizeRef }
+					className={ classNames( 'chart', { 'is-placeholder': isPlaceholder } ) }
+				>
+					<div className="chart__y-axis-markers">
+						<div className="chart__y-axis-marker is-hundred" />
+						<div className="chart__y-axis-marker is-fifty" />
+						<div className="chart__y-axis-marker is-zero" />
 
-				{ ( isPlaceholder || isEmptyChart ) && (
-					<div className="chart__empty">
-						{ children || (
-							<Notice
-								className="chart__empty-notice"
-								status="is-warning"
-								isCompact
-								text={ translate( 'No activity this period', {
-									context: 'Message on empty bar chart in Stats',
-									comment: 'Should be limited to 32 characters to prevent wrapping',
-								} ) }
-								showDismiss={ false }
-							/>
+						{ ( isPlaceholder || isEmptyChart ) && (
+							<div className="chart__empty">
+								{ children || (
+									<Notice
+										className="chart__empty-notice"
+										status="is-warning"
+										isCompact
+										text={ translate( 'No activity this period', {
+											context: 'Message on empty bar chart in Stats',
+											comment: 'Should be limited to 32 characters to prevent wrapping',
+										} ) }
+										showDismiss={ false }
+									/>
+								) }
+							</div>
 						) }
 					</div>
-				) }
-			</div>
-			{ ! isPlaceholder && (
-				<div ref={ yAxisRef } className="chart__y-axis">
-					<div className="chart__y-axis-width-fix">{ numberFormat( 1e5 ) }</div>
-					<div className="chart__y-axis-label is-hundred">
-						{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, 2 ) }
-					</div>
-					<div className="chart__y-axis-label is-fifty">
-						{ yMax > 1 ? numberFormat( yMax / 2 ) : numberFormat( yMax / 2, 2 ) }
-					</div>
-					<div className="chart__y-axis-label is-zero">{ numberFormat( 0 ) }</div>
+					{ ! isPlaceholder && (
+						<div ref={ yAxisRef } className="chart__y-axis">
+							<div className="chart__y-axis-width-fix">{ numberFormat( 1e5 ) }</div>
+							<div className="chart__y-axis-label is-hundred">
+								{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, 2 ) }
+							</div>
+							<div className="chart__y-axis-label is-fifty">
+								{ yMax > 1 ? numberFormat( yMax / 2 ) : numberFormat( yMax / 2, 2 ) }
+							</div>
+							<div className="chart__y-axis-label is-zero">{ numberFormat( 0 ) }</div>
+						</div>
+					) }
+					<BarContainer
+						barClick={ barClick }
+						chartWidth={ width }
+						data={ chartData }
+						isPlaceholder={ isPlaceholder }
+						isRtl={ isRtl }
+						isTouch={ hasTouch() }
+						setTooltip={ handleTooltipChange }
+						yAxisMax={ yMax }
+					/>
+					{ isTooltipVisible && (
+						<Tooltip
+							className="chart__tooltip"
+							id="popover__chart-bar"
+							context={ tooltipContext }
+							isVisible={ isTooltipVisible }
+							position={ tooltipPosition }
+						>
+							<ul>{ tooltipData }</ul>
+						</Tooltip>
+					) }
 				</div>
 			) }
-			<BarContainer
-				barClick={ barClick }
-				chartWidth={ width }
-				data={ chartData }
-				isPlaceholder={ isPlaceholder }
-				isRtl={ isRtl }
-				isTouch={ hasTouch() }
-				setTooltip={ handleTooltipChange }
-				yAxisMax={ yMax }
-			/>
-			{ isTooltipVisible && (
-				<Tooltip
-					className="chart__tooltip"
-					id="popover__chart-bar"
-					context={ tooltipContext }
-					isVisible={ isTooltipVisible }
-					position={ tooltipPosition }
-				>
-					<ul>{ tooltipData }</ul>
-				</Tooltip>
-			) }
-		</div>
+		</>
 	);
 }
 

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -201,7 +201,7 @@ $y-axis-padding: 0 20px;
 	bottom: 0; // 1
 	left: 16%; // 1
 	height: 100%;
-	transform: scaleY(0); // 2
+	transform: scaleY(0.01); // 2
 	transition: transform 0.3s ease-in-out; // 3
 	transform-origin: 0% 100%; // 4
 	z-index: z-index("root", ".chart__bar-section");

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -201,7 +201,7 @@ $y-axis-padding: 0 20px;
 	bottom: 0; // 1
 	left: 16%; // 1
 	height: 100%;
-	transform: scaleY(0.01); // 2
+	transform: scaleY(0); // 2
 	transition: transform 0.3s ease-in-out; // 3
 	transform-origin: 0% 100%; // 4
 	z-index: z-index("root", ".chart__bar-section");


### PR DESCRIPTION
Related to #73699 

## Proposed Changes

The PR fixes two flickering issue of Chart.

### Chart resizing

The flickering issue is caused by the initial resize event triggered by the Chart component itself. The Chart component listens on resize event of its own, so the first rendering uses the default size (The component hasn't been rendered yet) . As a result, it needs to re-render itself with an actual size afterwards, which causes the flickering.

The PR proposes to render an empty div when there's no size info, which then would trigger the resize event for the component and render the actually component.

https://user-images.githubusercontent.com/6869813/220807763-22acdac6-df75-4ee6-8b01-ae1e174d27c6.mov

### Chrome bug(?)

When switching periods or on page load, zero scaleY-ed bars grows to max and then disappear. This only happens in Chrome. When we apply a super small invisible `scaleY`, the issue is gone.

https://user-images.githubusercontent.com/1425433/223000217-b8d91a70-5e25-46e4-871b-31fe8ad95a49.mov

## Testing Instructions

* Open Live Branch
* Navigate to `/stats/week/{site-slug}?tab=views`
* Refresh the page on different window width
* Ensure there's not flickering described in #73699
* Ensure in Chrome there's no zero height bar flickering

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
