### PR TITLE
Theme Showcase: Add global style upgrade modal in the theme preview

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -76,7 +76,6 @@ import {
 	getThemeRequestErrors,
 	getThemeForumUrl,
 	getThemeDemoUrl,
-	getThemePreviewThemeOptions,
 	shouldShowTryAndCustomize,
 	isExternallyManagedTheme as getIsExternallyManagedTheme,
 	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
@@ -340,7 +339,8 @@ class ThemeSheet extends Component {
 		this.props.setThemePreviewOptions(
 			this.props.themeId,
 			this.props.defaultOption,
-			this.props.secondaryOption
+			this.props.secondaryOption,
+			this.getSelectedStyleVariation()
 		);
 		return preview.action( this.props.themeId );
 	};
@@ -351,8 +351,14 @@ class ThemeSheet extends Component {
 	}
 
 	shouldRenderUnlockStyleButton() {
-		const { selectedStyleVariationSlug, shouldLimitGlobalStyles, styleVariations } = this.props;
-		return shouldLimitGlobalStyles && styleVariations.length > 0 && !! selectedStyleVariationSlug;
+		const { defaultOption, selectedStyleVariationSlug, shouldLimitGlobalStyles, styleVariations } =
+			this.props;
+		return (
+			shouldLimitGlobalStyles &&
+			defaultOption?.key === 'activate' &&
+			styleVariations.length > 0 &&
+			!! selectedStyleVariationSlug
+		);
 	}
 
 	isThemeCurrentOne() {
@@ -1483,7 +1489,6 @@ export default connect(
 		return {
 			...theme,
 			themeId,
-			themeOptions: getThemePreviewThemeOptions( state ),
 			price: getPremiumThemePrice( state, themeId, siteId ),
 			error,
 			siteId,

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -1,14 +1,18 @@
 import { Button } from '@automattic/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
+import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
 import PulsingDot from 'calypso/components/pulsing-dot';
 import WebPreview from 'calypso/components/web-preview';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
+import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { hideThemePreview } from 'calypso/state/themes/actions';
 import {
 	getThemeDemoUrl,
@@ -20,6 +24,9 @@ import {
 } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { connectOptions } from './theme-options';
+
+const DEFAULT_VARIATION_SLUG = 'default';
+const isDefaultVariationSlug = ( slug ) => ! slug || slug === DEFAULT_VARIATION_SLUG;
 
 class ThemePreview extends Component {
 	static displayName = 'ThemePreview';
@@ -38,6 +45,7 @@ class ThemePreview extends Component {
 
 	state = {
 		showActionIndicator: false,
+		showUnlockStyleUpgradeModal: false,
 	};
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
@@ -58,6 +66,47 @@ class ThemePreview extends Component {
 	getSecondaryOption = () => {
 		const { isActive } = this.props;
 		return isActive ? null : this.props.themeOptions.secondary;
+	};
+
+	getStyleVariationOption = () => {
+		return this.props.themeOptions?.styleVariation;
+	};
+
+	getPremiumGlobalStylesEventProps = () => {
+		const { themeId } = this.props;
+		const styleVariationOption = this.getStyleVariationOption();
+		return {
+			theme: themeId,
+			style_variation: styleVariationOption?.slug,
+		};
+	};
+
+	appendStyleVariationOptionToUrl = ( url ) => {
+		const styleVariationOption = this.getStyleVariationOption();
+		if ( ! styleVariationOption ) {
+			return url;
+		}
+
+		const [ base, query ] = url.split( '?' );
+		const params = new URLSearchParams( query );
+		params.set( 'style_variation', styleVariationOption.title );
+
+		return `${ base }?${ params.toString() }`;
+	};
+
+	shouldShowUnlockStyleButton = () => {
+		const { options, shouldLimitGlobalStyles, themeOptions } = this.props;
+		if ( ! themeOptions ) {
+			return false;
+		}
+
+		const primaryOption = this.getPrimaryOption();
+		const styleVariationOption = this.getStyleVariationOption();
+		return (
+			shouldLimitGlobalStyles &&
+			primaryOption?.key === options.activate.key &&
+			! isDefaultVariationSlug( styleVariationOption?.slug )
+		);
 	};
 
 	onPrimaryButtonClick = () => {
@@ -86,6 +135,47 @@ class ThemePreview extends Component {
 		! this.props.isJetpack && this.props.hideThemePreview();
 	};
 
+	onUnlockStyleButtonClick = () => {
+		this.props.recordTracksEvent(
+			'calypso_theme_preview_global_styles_gating_modal_show',
+			this.getPremiumGlobalStylesEventProps()
+		);
+
+		this.setState( { showUnlockStyleUpgradeModal: true } );
+	};
+
+	onPremiumGlobalStylesUpgradeModalCheckout = () => {
+		this.props.recordTracksEvent(
+			'calypso_theme_preview_global_styles_gating_modal_checkout_button_click',
+			this.getPremiumGlobalStylesEventProps()
+		);
+
+		const params = new URLSearchParams();
+		params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );
+
+		this.setState( { showUnlockStyleUpgradeModal: false } );
+		page( `/checkout/${ this.props.siteSlug || '' }/premium?${ params.toString() }` );
+	};
+
+	onPremiumGlobalStylesUpgradeModalTryStyle = () => {
+		this.props.recordTracksEvent(
+			'calypso_theme_preview_global_styles_gating_modal_try_button_click',
+			this.getPremiumGlobalStylesEventProps()
+		);
+
+		this.setState( { showUnlockStyleUpgradeModal: false } );
+		this.onPrimaryButtonClick();
+	};
+
+	onPremiumGlobalStylesUpgradeModalClose = () => {
+		this.props.recordTracksEvent(
+			'calypso_theme_preview_global_styles_gating_modal_close_button_click',
+			this.getPremiumGlobalStylesEventProps()
+		);
+
+		this.setState( { showUnlockStyleUpgradeModal: false } );
+	};
+
 	renderPrimaryButton = () => {
 		const primaryOption = this.getPrimaryOption();
 		const buttonHref = primaryOption.getUrl ? primaryOption.getUrl( this.props.themeId ) : null;
@@ -112,9 +202,17 @@ class ThemePreview extends Component {
 		);
 	};
 
+	renderUnlockStyleButton = () => {
+		return (
+			<Button primary onClick={ this.onUnlockStyleButtonClick }>
+				{ this.props.translate( 'Unlock this style' ) }
+			</Button>
+		);
+	};
+
 	render() {
 		const { themeId, siteId, demoUrl, children, isWPForTeamsSite } = this.props;
-		const { showActionIndicator } = this.state;
+		const { showActionIndicator, showUnlockStyleUpgradeModal } = this.state;
 
 		if ( ! themeId || isWPForTeamsSite ) {
 			return null;
@@ -130,19 +228,41 @@ class ThemePreview extends Component {
 						showExternal={ false }
 						showSEO={ false }
 						onClose={ this.props.hideThemePreview }
-						previewUrl={ this.props.demoUrl + '?demo=true&iframe=true&theme_preview=true' }
-						externalUrl={ this.props.demoUrl }
+						previewUrl={ this.appendStyleVariationOptionToUrl(
+							demoUrl + '?demo=true&iframe=true&theme_preview=true'
+						) }
+						externalUrl={ demoUrl }
 						belowToolbar={ this.props.belowToolbar }
 					>
 						{ showActionIndicator && <PulsingDot active={ true } /> }
 						{ ! showActionIndicator && this.renderSecondaryButton() }
-						{ ! showActionIndicator && this.renderPrimaryButton() }
+						{ ! showActionIndicator &&
+							( this.shouldShowUnlockStyleButton()
+								? this.renderUnlockStyleButton()
+								: this.renderPrimaryButton() ) }
 					</WebPreview>
+				) }
+				{ showUnlockStyleUpgradeModal && (
+					<PremiumGlobalStylesUpgradeModal
+						checkout={ this.onPremiumGlobalStylesUpgradeModalCheckout }
+						tryStyle={ this.onPremiumGlobalStylesUpgradeModalTryStyle }
+						closeModal={ this.onPremiumGlobalStylesUpgradeModalClose }
+						isOpen
+					/>
 				) }
 			</div>
 		);
 	}
 }
+
+const withSiteGlobalStylesStatus = createHigherOrderComponent(
+	( Wrapped ) => ( props ) => {
+		const { siteId } = props;
+		const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteId || -1 );
+		return <Wrapped { ...props } shouldLimitGlobalStyles={ shouldLimitGlobalStyles } />;
+	},
+	'withSiteGlobalStylesStatus'
+);
 
 // make all actions available to preview.
 const ConnectedThemePreview = connectOptions( ThemePreview );
@@ -155,11 +275,13 @@ export default connect(
 		}
 
 		const siteId = getSelectedSiteId( state );
+		const siteSlug = getSiteSlug( state, siteId );
 		const isJetpack = isJetpackSite( state, siteId );
 		const themeOptions = getThemePreviewThemeOptions( state );
 		return {
 			themeId,
 			siteId,
+			siteSlug,
 			isJetpack,
 			themeOptions,
 			isInstalling: isInstallingTheme( state, themeId, siteId ),
@@ -183,4 +305,4 @@ export default connect(
 		};
 	},
 	{ hideThemePreview, recordTracksEvent }
-)( localize( ConnectedThemePreview ) );
+)( withSiteGlobalStylesStatus( localize( ConnectedThemePreview ) ) );


### PR DESCRIPTION
## Proposed Changes

This PR updates the theme preview component so that when users select a premium style variation in a free plan, the action button is updated to "Unlock this style". Clicking the button will open the premium plan upsell modal.

![Screenshot 2023-03-06 at 11 08 11 AM](https://user-images.githubusercontent.com/797888/223010578-814e1d87-c9e5-41c6-8768-bdf84766d675.png)

![Screenshot 2023-03-06 at 11 08 29 AM](https://user-images.githubusercontent.com/797888/223010620-4537e1db-d3ba-42c9-a114-4fada92cb797.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Select a free theme with style variations, such as Twenty Twenty-Three.
* Select a style variation that's not the default, and click on the button "Open live demo".
* Ensure that the theme preview modal has the action button "Unlock this style".
* Ensure that clicking the "Unlock this style" button opens the premium plan upsell modal.
* Ensure that in the premium plan upsell modal, clicking on the "Try it out first" button will have the same behavior as the original action button.
* Ensure that in the premium plan upsell modal, clicking on the "Upgrade plan" button will redirect users to the checkout page with the Premium plan pre-selected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
