### PR TITLE
Theme Showcase: Remove style variation upsell banner in the Theme Detail page

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -397,18 +397,6 @@ class ThemeSheet extends Component {
 		return isAtomic && isPremium && ! canUserUploadThemes && ! hasUnlimitedPremiumThemes;
 	}
 
-	hasSiteGlobalStyleUpsellBanner() {
-		const { shouldLimitGlobalStyles } = this.props;
-
-		// Show theme upsell banner on a Free theme with global style gating.
-		// Don't show if other upsell banners are displayed.
-		return (
-			! this.hasWpComThemeUpsellBanner() &&
-			! this.hasThemeUpsellBannerAtomic() &&
-			shouldLimitGlobalStyles
-		);
-	}
-
 	// Render "Open Live Demo" pseudo-button for mobiles.
 	// This is a legacy hack that shows the button under the preview screenshot for mobiles
 	// but not for desktop (becomes hidden behind the screenshot).
@@ -1017,10 +1005,6 @@ class ThemeSheet extends Component {
 				return translate( 'Upgrade to a Business plan and subscribe to this theme!' );
 			}
 			return translate( 'Subscribe to this premium theme!' );
-		} else if ( this.hasSiteGlobalStyleUpsellBanner() ) {
-			return translate(
-				'Upgrade to the Premium plan to get access to all additional styles, colors, and fonts!'
-			);
 		}
 
 		return translate( 'Access this theme for FREE with a Premium or Business plan!' );
@@ -1046,8 +1030,6 @@ class ThemeSheet extends Component {
 				);
 			}
 			return translate( 'Subscribe to this premium theme and unlock all its features.' );
-		} else if ( this.hasSiteGlobalStyleUpsellBanner() ) {
-			return '';
 		}
 
 		return translate(
@@ -1214,8 +1196,6 @@ class ThemeSheet extends Component {
 		const hasWpOrgThemeUpsellBanner = this.hasWpOrgThemeUpsellBanner();
 		// Show theme upsell banner on Atomic sites.
 		const hasThemeUpsellBannerAtomic = this.hasThemeUpsellBannerAtomic();
-		// Show theme upsell banner on an active Free theme with global style gating.
-		const hasSiteGlobalStyleUpsellBanner = this.hasSiteGlobalStyleUpsellBanner();
 
 		const hasUpsellBanner =
 			hasWpComThemeUpsellBanner || hasWpOrgThemeUpsellBanner || hasThemeUpsellBannerAtomic;
@@ -1232,7 +1212,7 @@ class ThemeSheet extends Component {
 			'theme__page-upsell-disabled': this.isLoading(),
 		} );
 
-		if ( hasWpComThemeUpsellBanner || hasSiteGlobalStyleUpsellBanner ) {
+		if ( hasWpComThemeUpsellBanner ) {
 			const forceDisplay =
 				( isBundledSoftwareSet && ! isSiteBundleEligible ) ||
 				( isExternallyManagedTheme &&


### PR DESCRIPTION
## Proposed Changes

This PR removes the style variation upsell banner introduced in #73526, in favor of #74029 which updates the primary action button to "Unlock this style" when selecting a premium style variation in a free plan.

![Screenshot 2023-03-06 at 11 32 22 AM](https://user-images.githubusercontent.com/797888/223013538-f36b6e0b-3efd-4138-850d-2b0691baa266.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Select a free theme with style variations, such as Twenty Twenty-Three.
* Ensure that the style variation upsell banner is no longer displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
