### PR TITLE
Add Tracks event for CTA clicks in eCommerce trial Plans page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -48,13 +48,18 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 		( 1 - eCommercePlanPrices.annualPlanMonthlyPrice / eCommercePlanPrices.monthlyPlanPrice ) * 100
 	);
 
-	const redirectToCheckoutForPlan = useCallback( ( tracksLocation: string ) => {
-		recordTracksEvent( 'calypso_wooexpress_plans_page_upgrade_cta_clicked', { location: tracksLocation } );
+	const redirectToCheckoutForPlan = useCallback(
+		( tracksLocation: string ) => {
+			recordTracksEvent( 'calypso_wooexpress_plans_page_upgrade_cta_clicked', {
+				location: tracksLocation,
+			} );
 
-		const checkoutUrl = `/checkout/${ siteSlug }/${ targetECommercePlan.getStoreSlug() }`;
+			const checkoutUrl = `/checkout/${ siteSlug }/${ targetECommercePlan.getStoreSlug() }`;
 
-		page.redirect( checkoutUrl );
-	}, [ siteSlug, targetECommercePlan ] );
+			page.redirect( checkoutUrl );
+		},
+		[ siteSlug, targetECommercePlan ]
+	);
 
 	const eCommercePlanFeatureSets = useMemo( () => {
 		return getECommerceFeatureSets( { translate } );

--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import {
 	getPlans,
 	plansLink,
@@ -47,7 +48,9 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 		( 1 - eCommercePlanPrices.annualPlanMonthlyPrice / eCommercePlanPrices.monthlyPlanPrice ) * 100
 	);
 
-	const redirectToCheckoutForPlan = useCallback( () => {
+	const redirectToCheckoutForPlan = useCallback( ( tracksLocation: string ) => {
+		recordTracksEvent( 'calypso_wooexpress_plans_page_upgrade_cta_clicked', { location: tracksLocation } );
+
 		const checkoutUrl = `/checkout/${ siteSlug }/${ targetECommercePlan.getStoreSlug() }`;
 
 		page.redirect( checkoutUrl );
@@ -156,7 +159,7 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 					<Button
 						className="e-commerce-trial-plans__price-card-cta"
 						primary
-						onClick={ redirectToCheckoutForPlan }
+						onClick={ () => redirectToCheckoutForPlan( 'main-price-card' ) }
 					>
 						{ translate( 'Upgrade now' ) }
 					</Button>
@@ -171,7 +174,7 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 			<div className="e-commerce-trial-plans__cta-wrapper">
 				<Button
 					className="e-commerce-trial-plans__cta is-primary"
-					onClick={ redirectToCheckoutForPlan }
+					onClick={ () => redirectToCheckoutForPlan( 'footer' ) }
 				>
 					{ translate( 'Upgrade now' ) }
 				</Button>


### PR DESCRIPTION
## Proposed Changes

* This PR ensures that we trigger a new `calypso_wooexpress_plans_page_upgrade_cta_clicked` Tracks event when a user on the free trial clicks on an upgrade CTA on the Plans page. The new event includes a `location` event property to identify the location of the CTA that was clicked. The current values for the `location` property are:
  - `main-price-card` - the CTA in the main price card on the page
  - `footer` - the CTA below the page content

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure you are able to inspect Tracks events easily -- the easiest way to do that is via [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension)
* Run this branch locally or via the calypso.live branch
* Navigate to _Upgrades_ -> _Plans_ for a site on the free eCommerce trial
* Click on the "Upgrade now" button in the pricing card
* Verify that you see a `calypso_wooexpress_plans_page_upgrade_cta_clicked` Tracks event logged with `location` set to `main-price-card`
* Click on the _Remove from cart_ link below the eCommerce plan item that was added to your cart, and click on "Continue" to remove the item from the cart and return to the plans page
* Switch the billing interval via the _Pay Monthly | Pay Annually_ toggle
* Click on the "Upgrade now" button in the pricing card
* Verify that you see a `calypso_wooexpress_plans_page_upgrade_cta_clicked` Tracks event logged with the `location` event property set to `main-price-card`
* Click on the _Remove from cart_ link below the eCommerce plan item that was added to your cart, and click on "Continue" to remove the item from the cart and return to the plans page
* Scroll down to the bottom of the plans page
* Click on the "Upgrade now" button at the bottom of the page
* Verify that you see a `calypso_wooexpress_plans_page_upgrade_cta_clicked` Tracks event logged with the `location` event property set to `footer`
* Click on the _Remove from cart_ link below the eCommerce plan item that was added to your cart, and click on "Continue" to remove the item from the cart and return to the plans page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
