### PR TITLE
Plans 2023: Enable for all locales

### DIFF
--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -1,5 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { getLocaleSlug } from 'i18n-calypso';
 import {
 	JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN,
 	BEST_VALUE_PLANS,
@@ -43,18 +42,11 @@ export const redirectCheckoutToWpAdmin = (): boolean => !! JETPACK_REDIRECT_CHEC
 
 /**
  * Returns if the 2023 Pricing grid feature has been enabled.
- * Currently this depends on the feature flag and on the locale the user is on
+ * Currently this depends on the feature flag.
  *
  */
 export const is2023PricingGridEnabled = (): boolean => {
-	const isFeatureFlagEnabled = (): boolean => isEnabled( 'onboarding/2023-pricing-grid' );
-
-	const isLocaleSupported = (): boolean => {
-		const supportedLocales = [ 'en', 'en-gb', 'es' ];
-		return supportedLocales.includes( getLocaleSlug() ?? '' );
-	};
-
-	return isFeatureFlagEnabled() && isLocaleSupported();
+	return isEnabled( 'onboarding/2023-pricing-grid' );
 };
 
 /**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1577

## Proposed Changes

* Removes the locale filter and enables the new pricing grid for all locales.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch your locale to any locale other than English and Spanish. 
* Go to `/start` and proceed to the plans step.
* Confirm that you can see the new pricing grid.
* Go to `/plans/<site slug>` and confirm that you can see the new pricing grid.
* Do a spot check of translations on both pages.
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/5436027/223060761-2bd1fc52-2e3c-4d5b-a581-7822d270056a.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
