### PR TITLE
Ensure that upgrades from the trial Plans pages show post-purchase UI

### DIFF
--- a/client/lib/ecommerce-trial/get-ecommerce-trial-checkout-url.ts
+++ b/client/lib/ecommerce-trial/get-ecommerce-trial-checkout-url.ts
@@ -1,0 +1,16 @@
+import { addQueryArgs } from 'calypso/lib/url';
+
+interface ECommerceTrialCheckoutUrlArguments {
+	productSlug: string;
+	siteSlug: string;
+}
+
+export function getECommerceTrialCheckoutUrl( {
+	productSlug,
+	siteSlug,
+}: ECommerceTrialCheckoutUrlArguments ): string {
+	return addQueryArgs(
+		{ redirect_to: `/plans/my-plan/trial-upgraded/${ siteSlug }` },
+		`/checkout/${ siteSlug }/${ productSlug }`
+	);
+}

--- a/client/my-sites/plans/current-plan/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/current-plan/ecommerce-trial/index.tsx
@@ -19,6 +19,7 @@ import shipping from 'calypso/assets/images/plans/wpcom/ecommerce-trial/shipping
 import simpleCustomization from 'calypso/assets/images/plans/wpcom/ecommerce-trial/simple-customization.svg';
 import unlimitedProducts from 'calypso/assets/images/plans/wpcom/ecommerce-trial/unlimited-products.svg';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import { getECommerceTrialCheckoutUrl } from 'calypso/lib/ecommerce-trial/get-ecommerce-trial-checkout-url';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ECommerceTrialBanner from '../../ecommerce-trial/ecommerce-trial-banner';
 import FeatureIncludedCard from '../feature-included-card';
@@ -50,7 +51,13 @@ const ECommerceTrialCurrentPlan = () => {
 		recordTracksEvent( `calypso_wooexpress_my_plan_cta`, {
 			cta_position: ctaPosition,
 		} );
-		page.redirect( `/checkout/${ selectedSite?.slug }/${ PLAN_ECOMMERCE_MONTHLY }` );
+
+		const checkoutUrl = getECommerceTrialCheckoutUrl( {
+			productSlug: PLAN_ECOMMERCE_MONTHLY,
+			siteSlug: selectedSite?.slug ?? '',
+		} );
+
+		page.redirect( checkoutUrl );
 	};
 
 	// TODO: translate when final copy is available

--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -13,6 +13,7 @@ import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import SegmentedControl from 'calypso/components/segmented-control';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import { getECommerceTrialCheckoutUrl } from 'calypso/lib/ecommerce-trial/get-ecommerce-trial-checkout-url';
 import { getPlanRawPrice, getPlan } from 'calypso/state/plans/selectors';
 import { getECommerceFeatureSets } from './ecommerce-features';
 import ECommerceTrialBanner from './ecommerce-trial-banner';
@@ -54,7 +55,10 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 				location: tracksLocation,
 			} );
 
-			const checkoutUrl = `/checkout/${ siteSlug }/${ targetECommercePlan.getStoreSlug() }`;
+			const checkoutUrl = getECommerceTrialCheckoutUrl( {
+				productSlug: targetECommercePlan.getStoreSlug(),
+				siteSlug,
+			} );
 
 			page.redirect( checkoutUrl );
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* #73500
* #74064 - this PR needs to be merged before this one, as we need the links in that page to be active!

## Proposed Changes

* This PR ensures that when users start the upgrade process from the Plans or My Plan/Free trial pages, we redirect them to the post-purchase screen.
  - At an implementation level, this leverages a standalone `getECommerceTrialCheckoutUrl()` function so the logic can be shared across the pages where we'll be triggering upgrades

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via the calypso.live branch
* For a site on the free eCommerce trial, navigate to _Upgrades_ -> _Plans_
* Switch to the "Free trials" tab at the top of the screen
* Click on the "Upgrade now" CTA in the main banner on the screen
* Verify that you're taken to checkout with the eCommerce plan in your cart
* Verify that the checkout URL includes the following URL parameter: `redirect_to=%2Fplans%2Fmy-plan%2Ftrial-upgraded%2F:siteSlug`
* Click on the "Remove from cart" link for the eCommerce plan, and then click on the "Continue" button to confirm removal of the item
* This should return you to the My Plan/Free trials page
* Click on the "Plans" tab at the top of the page
* Click on the "Upgrade now" CTA in the pricing section
* Verify that you're taken to checkout with the eCommerce plan in your cart
* Verify that the checkout URL includes the following URL parameter: `redirect_to=%2Fplans%2Fmy-plan%2Ftrial-upgraded%2F:siteSlug`
* Click on the "Remove from cart" link for the eCommerce plan, and then click on the "Continue" button to confirm removal of the item
* This should return you to the Plans page
* Scroll down to the bottom of the page and click on the "Upgrade now" CTA at the bottom of the page
* Verify that you're taken to checkout with the eCommerce plan in your cart
* Verify that the checkout URL includes the following URL parameter: `redirect_to=%2Fplans%2Fmy-plan%2Ftrial-upgraded%2F:siteSlug`
* This time, complete the purchase
* Verify that you're redirected to the trial upgrade confirmation page at `/plans/my-plan/trial-upgraded/:siteSlug`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?