### PR TITLE
Updates to ecommerce trial features

### DIFF
--- a/client/my-sites/plans/current-plan/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/current-plan/ecommerce-trial/index.tsx
@@ -4,25 +4,15 @@ import { Button } from '@automattic/components';
 import { useMediaQuery } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
-import bestInClassHosting from 'calypso/assets/images/plans/wpcom/ecommerce-trial/best-in-class-hosting.svg';
-import connect from 'calypso/assets/images/plans/wpcom/ecommerce-trial/connect.png';
-import googleAnalytics from 'calypso/assets/images/plans/wpcom/ecommerce-trial/google-analytics.svg';
-import launch from 'calypso/assets/images/plans/wpcom/ecommerce-trial/launch.png';
-import premiumThemes from 'calypso/assets/images/plans/wpcom/ecommerce-trial/premium-themes.svg';
-import prioritySupport from 'calypso/assets/images/plans/wpcom/ecommerce-trial/priority-support.svg';
-import promote from 'calypso/assets/images/plans/wpcom/ecommerce-trial/promote.png';
-import securityPerformance from 'calypso/assets/images/plans/wpcom/ecommerce-trial/security-performance.svg';
-import seoTools from 'calypso/assets/images/plans/wpcom/ecommerce-trial/seo-tools.svg';
-import shipping from 'calypso/assets/images/plans/wpcom/ecommerce-trial/shipping2.png';
-import simpleCustomization from 'calypso/assets/images/plans/wpcom/ecommerce-trial/simple-customization.svg';
-import unlimitedProducts from 'calypso/assets/images/plans/wpcom/ecommerce-trial/unlimited-products.svg';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ECommerceTrialBanner from '../../ecommerce-trial/ecommerce-trial-banner';
 import FeatureIncludedCard from '../feature-included-card';
 import FeatureNotIncludedCard from '../feature-not-included-card';
+import { includedFeatures, notIncludedFeatures } from './trial-features';
+import type { GetFeatureHrefProps } from './trial-features';
 
 import './style.scss';
 
@@ -36,6 +26,8 @@ const ECommerceTrialCurrentPlan = () => {
 
 	const viewAllIncludedFeatures = () => {
 		setShowAllTrialFeaturesInMobileView( true );
+
+		recordTracksEvent( 'calypso_wooexpress_my_plan_view_all_features_click' );
 	};
 
 	const isMobile = useMediaQuery( '(max-width: 480px)' );
@@ -53,104 +45,14 @@ const ECommerceTrialCurrentPlan = () => {
 		page.redirect( `/checkout/${ selectedSite?.slug }/${ PLAN_ECOMMERCE_MONTHLY }` );
 	};
 
-	// TODO: translate when final copy is available
-	const allIncludedFeatures = [
-		{
-			title: translate( 'Priority support' ),
-			text: translate( 'Need help? Reach out to us anytime, anywhere.' ),
-			illustration: prioritySupport,
-			showButton: true,
-			buttonText: translate( 'Ask a question' ),
-		},
-		{
-			title: translate( 'Premium themes' ),
-			text: translate( 'Choose from a wide selection of beautifully designed themes.' ),
-			illustration: premiumThemes,
-			showButton: true,
-			buttonText: translate( 'Browse premium themes' ),
-		},
-		{
-			title: translate( 'Simple customization' ),
-			text: translate(
-				"Change your store's look and feel, update your cart and checkout pages, and more."
-			),
-			illustration: simpleCustomization,
-			showButton: true,
-			buttonText: translate( 'Design your store' ),
-		},
-		{
-			title: translate( 'Unlimited products' ),
-			text: translate(
-				"Create as many products or services as you'd like, including subscriptions."
-			),
-			illustration: unlimitedProducts,
-			showButton: true,
-			buttonText: translate( 'Add a product' ),
-		},
-		{
-			title: translate( 'Security & performance' ),
-			text: translate( 'Get auto real-time backups, malware scans, and spam protection.' ),
-			illustration: securityPerformance,
-			showButton: true,
-			buttonText: translate( 'Keep your store safe' ),
-		},
-		{
-			title: translate( 'SEO tools' ),
-			text: translate(
-				'Boost traffic with tools that make your content more findable on search engines.'
-			),
-			illustration: seoTools,
-			showButton: true,
-			buttonText: translate( 'Increase visibility' ),
-		},
-		{
-			title: translate( 'Google Analytics' ),
-			text: translate( "See where your visitors come from and what they're doing on your store." ),
-			illustration: googleAnalytics,
-			showButton: true,
-			buttonText: translate( 'Connect Google Analytics' ),
-		},
-		{
-			title: translate( 'Best-in-class hosting' ),
-			text: translate( 'We take care of hosting your store so you can focus on selling.' ),
-			illustration: bestInClassHosting,
-			showButton: false,
-		},
-	];
+	const allIncludedFeatures = useMemo( () => includedFeatures( { translate } ), [ translate ] );
 
 	const whatsIncluded = displayAllIncluded
 		? allIncludedFeatures
 		: // Show only first 4 items
 		  allIncludedFeatures.slice( 0, 4 );
 
-	const whatsNotIncluded = [
-		{
-			title: translate( 'Launch your store to the world' ),
-			text: translate( 'Once you upgrade, you can publish your store and start taking orders.' ),
-			illustration: launch,
-		},
-		{
-			title: translate( 'Promote your products' ),
-			text: translate(
-				'Advertise and sell on popular marketplaces and social media platforms using your product catalog.'
-			),
-			illustration: promote,
-		},
-		{
-			title: translate( 'Connect with your customers' ),
-			text: translate(
-				'Get access to email features that let you communicate with your customers and prospects.'
-			),
-			illustration: connect,
-		},
-		{
-			title: translate( 'Integrate top shipping carriers' ),
-			text: translate(
-				'Customize your shipping rates, print labels right from your store, and more.'
-			),
-			illustration: shipping,
-		},
-	];
+	const whatsNotIncluded = useMemo( () => notIncludedFeatures( { translate } ), [ translate ] );
 
 	const bannerCallToAction = (
 		<Button
@@ -161,6 +63,15 @@ const ECommerceTrialCurrentPlan = () => {
 			{ translate( 'Upgrade now' ) }
 		</Button>
 	);
+
+	const siteUrlDetails = useMemo( (): GetFeatureHrefProps => {
+		return {
+			siteSlug: selectedSite?.slug ?? '',
+			wpAdminUrl:
+				selectedSite?.options?.admin_url ??
+				( selectedSite?.URL ? selectedSite.URL + '/wp-admin/' : '' ),
+		};
+	}, [ selectedSite ] );
 
 	return (
 		<>
@@ -176,12 +87,9 @@ const ECommerceTrialCurrentPlan = () => {
 			<div className="e-commerce-trial-current-plan__included-wrapper">
 				{ whatsIncluded.map( ( feature ) => (
 					<FeatureIncludedCard
-						key={ feature.title }
-						illustration={ feature.illustration }
-						title={ feature.title }
-						text={ feature.text }
-						showButton={ feature.showButton }
-						buttonText={ feature.buttonText }
+						key={ feature.id }
+						{ ...feature }
+						{ ...siteUrlDetails }
 					></FeatureIncludedCard>
 				) ) }
 

--- a/client/my-sites/plans/current-plan/ecommerce-trial/trial-features.ts
+++ b/client/my-sites/plans/current-plan/ecommerce-trial/trial-features.ts
@@ -1,0 +1,153 @@
+import { HelpCenter } from '@automattic/data-stores';
+import { dispatch as dataStoreDispatch } from '@wordpress/data';
+import { translate as i18nTranslate } from 'i18n-calypso';
+import bestInClassHosting from 'calypso/assets/images/plans/wpcom/ecommerce-trial/best-in-class-hosting.svg';
+import connect from 'calypso/assets/images/plans/wpcom/ecommerce-trial/connect.png';
+import googleAnalytics from 'calypso/assets/images/plans/wpcom/ecommerce-trial/google-analytics.svg';
+import launch from 'calypso/assets/images/plans/wpcom/ecommerce-trial/launch.png';
+import premiumThemes from 'calypso/assets/images/plans/wpcom/ecommerce-trial/premium-themes.svg';
+import prioritySupport from 'calypso/assets/images/plans/wpcom/ecommerce-trial/priority-support.svg';
+import promote from 'calypso/assets/images/plans/wpcom/ecommerce-trial/promote.png';
+import securityPerformance from 'calypso/assets/images/plans/wpcom/ecommerce-trial/security-performance.svg';
+import seoTools from 'calypso/assets/images/plans/wpcom/ecommerce-trial/seo-tools.svg';
+import shipping from 'calypso/assets/images/plans/wpcom/ecommerce-trial/shipping2.png';
+import simpleCustomization from 'calypso/assets/images/plans/wpcom/ecommerce-trial/simple-customization.svg';
+import unlimitedProducts from 'calypso/assets/images/plans/wpcom/ecommerce-trial/unlimited-products.svg';
+import type { TranslateResult } from 'i18n-calypso';
+
+interface TrialFeaturesProps {
+	translate: typeof i18nTranslate;
+}
+
+export interface GetFeatureHrefProps {
+	siteSlug: string;
+	wpAdminUrl: string;
+}
+
+export interface IncludedFeatures {
+	id: string;
+	title: TranslateResult;
+	text: TranslateResult;
+	illustration: string;
+	showButton: boolean;
+	buttonText?: TranslateResult;
+	onButtonClick?: () => void;
+	getHref?: ( getHrefProps: GetFeatureHrefProps ) => string;
+}
+
+export const includedFeatures = ( { translate }: TrialFeaturesProps ): IncludedFeatures[] => {
+	return [
+		{
+			id: 'support',
+			title: translate( 'Priority support' ),
+			text: translate( 'Need help? Reach out to us anytime, anywhere.' ),
+			illustration: prioritySupport,
+			showButton: true,
+			buttonText: translate( 'Ask a question' ),
+			onButtonClick: () => {
+				const HELP_CENTER_STORE = HelpCenter.register();
+				dataStoreDispatch( HELP_CENTER_STORE ).setShowHelpCenter( true );
+			},
+		},
+		{
+			id: 'premium-themes',
+			title: translate( 'Premium themes' ),
+			text: translate( 'Choose from a wide selection of beautifully designed themes.' ),
+			illustration: premiumThemes,
+			showButton: true,
+			buttonText: translate( 'Browse premium themes' ),
+			getHref: ( { siteSlug }: GetFeatureHrefProps ) => `/themes/${ siteSlug }`,
+		},
+		{
+			id: 'customization',
+			title: translate( 'Simple customization' ),
+			text: translate(
+				"Change your store's look and feel, update your cart and checkout pages, and more."
+			),
+			illustration: simpleCustomization,
+			showButton: true,
+			buttonText: translate( 'Design your store' ),
+			getHref: ( { wpAdminUrl }: GetFeatureHrefProps ) => `${ wpAdminUrl }site-editor.php`,
+		},
+		{
+			id: 'unlimited-products',
+			title: translate( 'Unlimited products' ),
+			text: translate(
+				"Create as many products or services as you'd like, including subscriptions."
+			),
+			illustration: unlimitedProducts,
+			showButton: true,
+			buttonText: translate( 'Add a product' ),
+			getHref: ( { wpAdminUrl }: GetFeatureHrefProps ) =>
+				`${ wpAdminUrl }post-new.php?post_type=product&tutorial=true`,
+		},
+		{
+			id: 'security-backups',
+			title: translate( 'Security & performance' ),
+			text: translate( 'Get auto real-time backups, malware scans, and spam protection.' ),
+			illustration: securityPerformance,
+			showButton: true,
+			buttonText: translate( 'Keep your store safe' ),
+			getHref: ( { siteSlug }: GetFeatureHrefProps ) => `/backup/${ siteSlug }`,
+		},
+		{
+			id: 'seo-tools',
+			title: translate( 'SEO tools' ),
+			text: translate(
+				'Boost traffic with tools that make your content more findable on search engines.'
+			),
+			illustration: seoTools,
+			showButton: true,
+			buttonText: translate( 'Increase visibility' ),
+			getHref: ( { siteSlug }: GetFeatureHrefProps ) => `/marketing/traffic/${ siteSlug }`,
+		},
+		{
+			id: 'google-analytics',
+			title: translate( 'Google Analytics' ),
+			text: translate( "See where your visitors come from and what they're doing on your store." ),
+			illustration: googleAnalytics,
+			showButton: true,
+			buttonText: translate( 'Connect Google Analytics' ),
+			getHref: ( { siteSlug }: GetFeatureHrefProps ) =>
+				`/marketing/traffic/${ siteSlug }#analytics`,
+		},
+		{
+			id: 'hosting',
+			title: translate( 'Best-in-class hosting' ),
+			text: translate( 'We take care of hosting your store so you can focus on selling.' ),
+			illustration: bestInClassHosting,
+			showButton: false,
+		},
+	];
+};
+
+export const notIncludedFeatures = ( { translate }: TrialFeaturesProps ) => {
+	return [
+		{
+			title: translate( 'Launch your store to the world' ),
+			text: translate( 'Once you upgrade, you can publish your store and start taking orders.' ),
+			illustration: launch,
+		},
+		{
+			title: translate( 'Promote your products' ),
+			text: translate(
+				'Advertise and sell on popular marketplaces and social media platforms using your product catalog.'
+			),
+			illustration: promote,
+		},
+		{
+			title: translate( 'Connect with your customers' ),
+			text: translate(
+				'Get access to email features that let you communicate with your customers and prospects.'
+			),
+			illustration: connect,
+		},
+		{
+			title: translate( 'Integrate top shipping carriers' ),
+			text: translate(
+				'Customize your shipping rates, print labels right from your store, and more.'
+			),
+			illustration: shipping,
+		},
+	];
+};

--- a/client/my-sites/plans/current-plan/ecommerce-trial/trial-features.ts
+++ b/client/my-sites/plans/current-plan/ecommerce-trial/trial-features.ts
@@ -3,15 +3,11 @@ import { dispatch as dataStoreDispatch } from '@wordpress/data';
 import { translate as i18nTranslate } from 'i18n-calypso';
 import bestInClassHosting from 'calypso/assets/images/plans/wpcom/ecommerce-trial/best-in-class-hosting.svg';
 import connect from 'calypso/assets/images/plans/wpcom/ecommerce-trial/connect.png';
-import googleAnalytics from 'calypso/assets/images/plans/wpcom/ecommerce-trial/google-analytics.svg';
 import launch from 'calypso/assets/images/plans/wpcom/ecommerce-trial/launch.png';
 import premiumThemes from 'calypso/assets/images/plans/wpcom/ecommerce-trial/premium-themes.svg';
 import prioritySupport from 'calypso/assets/images/plans/wpcom/ecommerce-trial/priority-support.svg';
 import promote from 'calypso/assets/images/plans/wpcom/ecommerce-trial/promote.png';
-import securityPerformance from 'calypso/assets/images/plans/wpcom/ecommerce-trial/security-performance.svg';
-import seoTools from 'calypso/assets/images/plans/wpcom/ecommerce-trial/seo-tools.svg';
 import shipping from 'calypso/assets/images/plans/wpcom/ecommerce-trial/shipping2.png';
-import simpleCustomization from 'calypso/assets/images/plans/wpcom/ecommerce-trial/simple-customization.svg';
 import unlimitedProducts from 'calypso/assets/images/plans/wpcom/ecommerce-trial/unlimited-products.svg';
 import type { TranslateResult } from 'i18n-calypso';
 
@@ -38,42 +34,21 @@ export interface IncludedFeatures {
 export const includedFeatures = ( { translate }: TrialFeaturesProps ): IncludedFeatures[] => {
 	return [
 		{
-			id: 'support',
-			title: translate( 'Priority support' ),
-			text: translate( 'Need help? Reach out to us anytime, anywhere.' ),
-			illustration: prioritySupport,
-			showButton: true,
-			buttonText: translate( 'Ask a question' ),
-			onButtonClick: () => {
-				const HELP_CENTER_STORE = HelpCenter.register();
-				dataStoreDispatch( HELP_CENTER_STORE ).setShowHelpCenter( true );
-			},
-		},
-		{
 			id: 'premium-themes',
 			title: translate( 'Premium themes' ),
-			text: translate( 'Choose from a wide selection of beautifully designed themes.' ),
+			text: translate(
+				'Find a theme that fits your business from our premium selection, and customize it to reflect your brand.'
+			),
 			illustration: premiumThemes,
 			showButton: true,
-			buttonText: translate( 'Browse premium themes' ),
+			buttonText: translate( 'Browse themes' ),
 			getHref: ( { siteSlug }: GetFeatureHrefProps ) => `/themes/${ siteSlug }`,
 		},
 		{
-			id: 'customization',
-			title: translate( 'Simple customization' ),
+			id: 'product-customization',
+			title: translate( 'Product customization' ),
 			text: translate(
-				"Change your store's look and feel, update your cart and checkout pages, and more."
-			),
-			illustration: simpleCustomization,
-			showButton: true,
-			buttonText: translate( 'Design your store' ),
-			getHref: ( { wpAdminUrl }: GetFeatureHrefProps ) => `${ wpAdminUrl }site-editor.php`,
-		},
-		{
-			id: 'unlimited-products',
-			title: translate( 'Unlimited products' ),
-			text: translate(
-				"Create as many products or services as you'd like, including subscriptions."
+				'Get ready for launch by adding products with powerful tools like bundling and smart, data-driven upsells.'
 			),
 			illustration: unlimitedProducts,
 			showButton: true,
@@ -82,34 +57,37 @@ export const includedFeatures = ( { translate }: TrialFeaturesProps ): IncludedF
 				`${ wpAdminUrl }post-new.php?post_type=product&tutorial=true`,
 		},
 		{
-			id: 'security-backups',
-			title: translate( 'Security & performance' ),
-			text: translate( 'Get auto real-time backups, malware scans, and spam protection.' ),
-			illustration: securityPerformance,
-			showButton: true,
-			buttonText: translate( 'Keep your store safe' ),
-			getHref: ( { siteSlug }: GetFeatureHrefProps ) => `/backup/${ siteSlug }`,
-		},
-		{
-			id: 'seo-tools',
-			title: translate( 'SEO tools' ),
+			id: 'accept-payments',
+			title: translate( 'Get ready to accept payments' ),
 			text: translate(
-				'Boost traffic with tools that make your content more findable on search engines.'
+				'Set up one (or more!) payment methods and get your checkout process ready for launch.'
 			),
-			illustration: seoTools,
+			illustration: '',
 			showButton: true,
-			buttonText: translate( 'Increase visibility' ),
-			getHref: ( { siteSlug }: GetFeatureHrefProps ) => `/marketing/traffic/${ siteSlug }`,
+			buttonText: translate( 'Get ready to take payments' ),
+			getHref: ( { wpAdminUrl }: GetFeatureHrefProps ) =>
+				`${ wpAdminUrl }admin.php?page=wc-admin&task=payments`,
 		},
 		{
-			id: 'google-analytics',
-			title: translate( 'Google Analytics' ),
-			text: translate( "See where your visitors come from and what they're doing on your store." ),
-			illustration: googleAnalytics,
+			id: 'email-automation',
+			title: translate( 'Email automation' ),
+			text: translate(
+				'Get your automated customer emails set up and ready to send for when you launch.'
+			),
+			illustration: '',
 			showButton: true,
-			buttonText: translate( 'Connect Google Analytics' ),
-			getHref: ( { siteSlug }: GetFeatureHrefProps ) =>
-				`/marketing/traffic/${ siteSlug }#analytics`,
+			buttonText: translate( 'Set up emails' ),
+			getHref: ( { wpAdminUrl }: GetFeatureHrefProps ) =>
+				`${ wpAdminUrl }edit.php?post_type=aw_workflow#presets`,
+		},
+		{
+			id: 'ecommerce-toolkit',
+			title: translate( 'Your full ecommerce toolkit' ),
+			text: translate(
+				'Everything you need to create a beautiful store and be ready to sell anything, anywhere.'
+			),
+			illustration: '',
+			showButton: false,
 		},
 		{
 			id: 'hosting',
@@ -117,6 +95,29 @@ export const includedFeatures = ( { translate }: TrialFeaturesProps ): IncludedF
 			text: translate( 'We take care of hosting your store so you can focus on selling.' ),
 			illustration: bestInClassHosting,
 			showButton: false,
+		},
+		{
+			id: 'own-store',
+			title: translate( 'A store you own' ),
+			text: translate(
+				'Run your store however you’d like, customize every part of it, and even move it – it’s yours.'
+			),
+			illustration: '',
+			showButton: false,
+		},
+		{
+			id: 'support',
+			title: translate( 'Priority support' ),
+			text: translate(
+				'Need a helping hand? Our friendly team of experts are on hand, 24 hours a day, 7 days a week.'
+			),
+			illustration: prioritySupport,
+			showButton: true,
+			buttonText: translate( 'Ask a question' ),
+			onButtonClick: () => {
+				const HELP_CENTER_STORE = HelpCenter.register();
+				dataStoreDispatch( HELP_CENTER_STORE ).setShowHelpCenter( true );
+			},
 		},
 	];
 };

--- a/client/my-sites/plans/current-plan/feature-included-card/index.tsx
+++ b/client/my-sites/plans/current-plan/feature-included-card/index.tsx
@@ -1,27 +1,58 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, Card } from '@automattic/components';
+import { useCallback, useMemo } from 'react';
+import type { GetFeatureHrefProps, IncludedFeatures } from '../ecommerce-trial/trial-features';
 
 import './style.scss';
 
-interface Props {
-	title: string;
-	text: string;
-	illustration: string;
-	showButton: boolean;
-	buttonText?: string;
-	buttonClick?: () => void;
-}
+interface FeatureIncludedCardProps extends IncludedFeatures, GetFeatureHrefProps {}
 
-const FeatureIncludedCard = ( props: Props ) => {
-	const { illustration, title, text, showButton, buttonText, buttonClick } = props;
+const FeatureIncludedCard = ( {
+	buttonText,
+	getHref,
+	id,
+	illustration,
+	onButtonClick,
+	showButton,
+	siteSlug,
+	text,
+	title,
+	wpAdminUrl,
+}: FeatureIncludedCardProps ) => {
+	const onCardLinkClick = useCallback( () => {
+		if ( ! showButton ) {
+			return;
+		}
+
+		recordTracksEvent( 'calypso_wooexpress_included_feature_cta_clicked', { feature: id } );
+
+		onButtonClick?.();
+	}, [ id, onButtonClick, showButton ] );
+
+	const cardLinkHref = useMemo( () => {
+		if ( ! showButton || ! getHref ) {
+			return '';
+		}
+
+		return getHref( { siteSlug, wpAdminUrl } );
+	}, [ id, getHref, showButton, siteSlug, wpAdminUrl ] );
 
 	return (
 		<Card className="feature-included-card__card">
-			<img className="feature-included-card__illustration" alt={ title } src={ illustration } />
+			<img
+				className="feature-included-card__illustration"
+				alt={ String( title ) }
+				src={ illustration }
+			/>
 			<div className="feature-included-card__content">
 				<p className="feature-included-card__title">{ title }</p>
 				<p className="feature-included-card__text">{ text }</p>
 				{ showButton && (
-					<Button className="feature-included-card__link" onClick={ buttonClick }>
+					<Button
+						className="feature-included-card__link"
+						href={ cardLinkHref }
+						onClick={ onCardLinkClick }
+					>
 						{ buttonText }
 					</Button>
 				) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR actually tackles multiple items related to the included and not-included features on the Free trial page for eCommerce trials:
  - Refactor the included and not included features into a new `trial-features` file
  - Update the list of included features and CTAs to include as per this discussion: p1677878624899229/1677604360.597229-slack-C04ANV80KRT
  - Add click tracking for the features that include links/CTAs via the `calypso_wooexpress_included_feature_cta_clicked` Tracks event, where we record the feature's identifier in the `feature` event property
  - For full clarity/visibility, the CTAs and ids are:
     * `premium-themes` - _Browse themes_ -> `/themes/:siteSlug` i.e. _Appearance_ -> _Themes_
     * `product-customization` - _Add a product_ -> `/wp-admin/post-new.php?post_type=product&tutorial=true` i.e. _Products_ -> _Add New_ with the tutorial/suggestion mode enabled
     * `accept-payments` - _Get ready to take payments_ -> `/wp-admin/admin.php?page=wc-admin&task=payments` -> _My Home_ -> _Set up payment_ task
     * `email-automation` - _Set up emails) -> `/wp-admin/edit.php?post_type=aw_workflow#presets` -> _AutomateWoo_ -> _Workflows_ -> "Browse presets" tab -- this is only available on more recently-created trial sites
     * `support` - _Ask a question_ -> Opens help center modal in-screen

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?