### PR TITLE
happy-blocks: Add missing slash for translations filepath

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/index.php
+++ b/apps/happy-blocks/block-library/pricing-plans/index.php
@@ -113,8 +113,8 @@ function happyblocks_pricing_plans_normalize_translations_filepath( $file, $hand
 	}
 	// Fix the filepath to use the correct location for the translation file.
 	if ( 'happy-blocks' === $domain ) {
-		$old_path = WP_LANG_DIR . 'happy-blocks';
-		$new_path = WP_LANG_DIR . 'a8c-plugins/happy-blocks';
+		$old_path = WP_LANG_DIR . '/happy-blocks';
+		$new_path = WP_LANG_DIR . '/a8c-plugins/happy-blocks';
 		$file     = str_replace( $old_path, $new_path, $file );
 	}
 	return $file;


### PR DESCRIPTION
Related to 563-gh-Automattic/i18n-issues

## Proposed Changes

* Add missing slash in filepath for pricing plan translations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `install-plugin.sh happy-blocks fix/happy-blocks-translation-filepath-slash` on your sandbox.
* Enable staticized subdomains on your sandbox.
* Sandbox `wordpress.com`.
* Open `https://wordpress.com/de/forums/?new=1` and add a `pricing-plans` block.
* Confirm block translations are rendered as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
