### PR TITLE
Design picker: Updated tracking for pattern based virtual themes in onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -44,6 +44,7 @@ export function recordSelectedDesign( {
 		recordTracksEvent( 'calypso_signup_select_design', {
 			...getDesignEventProps( { flow, intent, design, styleVariation } ),
 			...getDesignTypeProps( design ),
+			...getVirtualDesignProps( design, styleVariation ),
 			...optionalProps,
 		} );
 
@@ -76,13 +77,6 @@ export function getDesignEventProps( {
 	const is_style_variation = styleVariation && styleVariation.slug !== 'default';
 	const variationSlugSuffix = is_style_variation ? `-${ styleVariation.slug }` : '';
 
-	/**
-	 * If the design is virtual, and it has a recipe with pattern_ids,
-	 * then we assume that it's a pattern based virtual theme.
-	 */
-	const virtual_theme_pattern =
-		design.is_virtual && design.recipe?.pattern_ids ? design.recipe?.pattern_ids[ 0 ] : null;
-
 	return {
 		flow,
 		intent,
@@ -94,7 +88,6 @@ export function getDesignEventProps( {
 		is_premium: design.is_premium,
 		has_style_variations: ( design.style_variations || [] ).length > 0,
 		is_style_variation: is_style_variation,
-		virtual_theme_pattern,
 	};
 }
 
@@ -114,7 +107,9 @@ export function getVirtualDesignProps( design: Design, styleVariation?: StyleVar
 	 * then we assume that it's a pattern based virtual theme.
 	 */
 	const virtual_theme_pattern =
-		design.is_virtual && design.recipe?.pattern_ids ? design.recipe?.pattern_ids[ 0 ] : null;
+		design.is_virtual && design.recipe?.pattern_ids?.length
+			? design.recipe?.pattern_ids[ 0 ]
+			: null;
 
 	return {
 		slug: design.slug + variationSlugSuffix,

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -76,6 +76,13 @@ export function getDesignEventProps( {
 	const is_style_variation = styleVariation && styleVariation.slug !== 'default';
 	const variationSlugSuffix = is_style_variation ? `-${ styleVariation.slug }` : '';
 
+	/**
+	 * If the design is virtual, and it has a recipe with pattern_ids,
+	 * then we assume that it's a pattern based virtual theme.
+	 */
+	const virtual_theme_pattern =
+		design.is_virtual && design.recipe?.pattern_ids ? design.recipe?.pattern_ids[ 0 ] : null;
+
 	return {
 		flow,
 		intent,
@@ -87,6 +94,7 @@ export function getDesignEventProps( {
 		is_premium: design.is_premium,
 		has_style_variations: ( design.style_variations || [] ).length > 0,
 		is_style_variation: is_style_variation,
+		virtual_theme_pattern,
 	};
 }
 
@@ -101,9 +109,17 @@ export function getVirtualDesignProps( design: Design, styleVariation?: StyleVar
 		variationSlugSuffix = `-${ design.preselected_style_variation.slug }`;
 	}
 
+	/**
+	 * If the design is virtual, and it has a recipe with pattern_ids,
+	 * then we assume that it's a pattern based virtual theme.
+	 */
+	const virtual_theme_pattern =
+		design.is_virtual && design.recipe?.pattern_ids ? design.recipe?.pattern_ids[ 0 ] : null;
+
 	return {
 		slug: design.slug + variationSlugSuffix,
 		is_virtual: design.is_virtual,
 		is_style_variation: is_style_variation,
+		virtual_theme_pattern,
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1776

## Proposed Changes

* Add a new property called `virtual_theme_pattern` in the `calypso_signup_design_preview_select` and `calypso_signup_select_design` tracking events

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link from the comments and go to `setup/site-setup/designSetup?siteSlug=bogdanu91devpremium.wordpress.com&flags=virtual-themes/onboarding`
* Make sure that when you click on a pattern based theme a `calypso_signup_design_preview_select` event is triggered with a prop `virtual_theme_pattern` prop. The value of this prop is pattern_id-site_id (e.g. `"3851-174455321"`), where the site id is the pattern's source site id.
* After clicking on the theme, click on the `Start` button from the upper right corner
* Make sure that `calypso_signup_select_design` event contains `virtual_theme_pattern` prop with the same value 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
