### PR TITLE
[POC] Theme Showcase: Update back button UI in the Theme Detail page

### DIFF
--- a/client/components/header-cake/index.jsx
+++ b/client/components/header-cake/index.jsx
@@ -17,6 +17,7 @@ export default class HeaderCake extends Component {
 			actionHref,
 			actionOnClick,
 			alwaysShowActionText,
+			alwaysShowBackText,
 		} = this.props;
 		const classes = classNames( 'header-cake', this.props.className, {
 			'is-compact': this.props.isCompact,
@@ -24,7 +25,12 @@ export default class HeaderCake extends Component {
 
 		return (
 			<Card className={ classes }>
-				<HeaderCakeBack text={ backText } href={ backHref } onClick={ this.props.onClick } />
+				<HeaderCakeBack
+					text={ backText }
+					href={ backHref }
+					onClick={ this.props.onClick }
+					alwaysShowActionText={ alwaysShowBackText }
+				/>
 
 				<div className="header-cake__title" role="presentation" onClick={ this.props.onTitleClick }>
 					{ this.props.children }
@@ -58,9 +64,11 @@ HeaderCake.propTypes = {
 	actionIcon: PropTypes.string,
 	actionOnClick: PropTypes.func,
 	alwaysShowActionText: PropTypes.bool,
+	alwaysShowBackText: PropTypes.bool,
 };
 
 HeaderCake.defaultProps = {
 	isCompact: false,
 	alwaysShowActionText: false,
+	alwaysShowBackText: false,
 };

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -285,17 +285,6 @@ class ThemeSheet extends Component {
 		this.trackButtonClick( 'next_theme' );
 	};
 
-	renderBackButton = () => {
-		const { translate } = this.props;
-
-		return (
-			<Button className="theme__sheet-back-button" borderless onClick={ this.goBack }>
-				<Gridicon icon="chevron-left" size={ 18 } />
-				{ translate( 'Back to themes' ) }
-			</Button>
-		);
-	};
-
 	renderBar = () => {
 		const { author, name, translate, softLaunched } = this.props;
 
@@ -1307,22 +1296,23 @@ class ThemeSheet extends Component {
 				<ThanksModal source="details" themeId={ this.props.themeId } />
 				<AutoLoadingHomepageModal source="details" />
 				{ ! isNewDetailsAndPreview && pageUpsellBanner }
-				{ ! isNewDetailsAndPreview && (
-					<HeaderCake
-						className="theme__sheet-action-bar"
-						backText={ translate( 'All Themes' ) }
-						onClick={ this.goBack }
-					>
-						{ ! retired &&
-							! hasWpOrgThemeUpsellBanner &&
-							! isWPForTeamsSite &&
-							this.renderButton() }
-					</HeaderCake>
-				) }
+				<HeaderCake
+					className="theme__sheet-action-bar"
+					backText={
+						isNewDetailsAndPreview ? translate( 'Back to themes' ) : translate( 'All Themes' )
+					}
+					onClick={ this.goBack }
+					alwaysShowBackText={ isNewDetailsAndPreview }
+				>
+					{ ! isNewDetailsAndPreview &&
+						! retired &&
+						! hasWpOrgThemeUpsellBanner &&
+						! isWPForTeamsSite &&
+						this.renderButton() }
+				</HeaderCake>
 				<div className={ columnsClassName }>
 					{ isNewDetailsAndPreview && (
 						<div className="theme__sheet-column-header">
-							{ this.renderBackButton() }
 							{ pageUpsellBanner }
 							{ this.renderHeader() }
 						</div>

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -20,6 +20,14 @@ body.is-section-theme-i4 {
 		}
 	}
 
+	.theme__sheet-action-bar {
+		margin: 0;
+
+		@include breakpoint-deprecated( "<960px" ) {
+			margin: 0 0 16px 0;
+		}
+	}
+
 	.theme__sheet-columns {
 		display: grid;
 		gap: 0 32px;


### PR DESCRIPTION
## Proposed Changes

| Before | After |
| --- | --- |
| ![Screenshot 2023-03-06 at 5 46 25 PM](https://user-images.githubusercontent.com/797888/223081691-9868d968-5ee8-4970-b102-9c8c14432b8a.png) | ![Screenshot 2023-03-06 at 6 15 04 PM](https://user-images.githubusercontent.com/797888/223081728-6280d55c-6abc-43ed-89af-056f3936a690.png)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
