### PR TITLE
Site Assembler: Sidebar revamp adjustment

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -414,7 +414,6 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 				<NavigatorScreen path="/homepage">
 					<ScreenHomepage
 						patterns={ sections }
-						onDoneClick={ () => onDoneClick( 'section' ) }
 						onAddSection={ onAddSection }
 						onReplaceSection={ onReplaceSection }
 						onDeleteSection={ onDeleteSection }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/index.tsx
@@ -1,17 +1,40 @@
+import { Button, Gridicon } from '@automattic/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalNavigatorBackButton as NavigatorBackButton,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import './style.scss';
 
 interface Props {
 	title: string;
 	description?: string;
+	hideBack?: boolean;
+	onBack?: () => void;
 }
 
-const NavigatorHeader = ( { title, description }: Props ) => {
+const NavigatorHeader = ( { title, description, hideBack, onBack }: Props ) => {
+	const translate = useTranslate();
+
 	return (
 		<>
 			<DocumentHead title={ title } />
 			<div className="navigator-header">
-				<h2 className="navigator-header__title">{ title }</h2>
+				<HStack className="navigator-header__heading" spacing={ 2 } justify="flex-start">
+					{ ! hideBack && (
+						<NavigatorBackButton
+							as={ Button }
+							title={ translate( 'Back' ) }
+							borderless={ true }
+							aria-label={ translate( 'Navigate to the previous view' ) }
+							onClick={ onBack }
+						>
+							<Gridicon icon="chevron-left" size={ 16 } />
+						</NavigatorBackButton>
+					) }
+					<h2>{ title }</h2>
+				</HStack>
 				{ description && <p className="navigator-header__description">{ description }</p> }
 			</div>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/style.scss
@@ -13,6 +13,10 @@
 			line-height: 40px;
 			letter-spacing: -0.32px;
 		}
+
+		.button.is-borderless .gridicon {
+			top: 4px;
+		}
 	}
 
 	.navigator-header__description {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/style.scss
@@ -1,15 +1,18 @@
 @import "@automattic/typography/styles/fonts";
 
 .pattern-assembler {
-	.navigator-header__title {
-		font-family: Recoleta, sans-serif;
-		font-style: normal;
-		font-weight: 400;
-		font-size: $font-title-large;
-		line-height: 40px;
-		letter-spacing: -0.32px;
-		color: var(--color-neutral-100);
+	.navigator-header__heading {
 		margin-bottom: 8px;
+		color: var(--color-neutral-100);
+
+		h2 {
+			font-family: Recoleta, sans-serif;
+			font-style: normal;
+			font-weight: 400;
+			font-size: $font-title-large;
+			line-height: 40px;
+			letter-spacing: -0.32px;
+		}
 	}
 
 	.navigator-header__description {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -1,8 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Button, Popover } from '@automattic/components';
-import { Icon, plus, header, footer, group } from '@wordpress/icons';
+import { Button } from '@automattic/components';
+import { Icon, header, footer, group } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useRef } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import PatternActionBar from './pattern-action-bar';
 import type { Pattern } from './types';
@@ -44,8 +43,6 @@ const PatternLayout = ( {
 	onDeleteFooter = noop,
 }: PatternLayoutProps ) => {
 	const translate = useTranslate();
-	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
-	const addButtonContainerRef = useRef< HTMLDivElement | null >( null );
 	const isSidebarRevampEnabled = isEnabled( 'pattern-assembler/sidebar-revamp' );
 
 	if ( ! isSidebarRevampEnabled ) {
@@ -173,25 +170,10 @@ const PatternLayout = ( {
 					) }
 				</AsyncLoad>
 			) }
-			<div
-				className="pattern-layout__add-button-container"
-				ref={ addButtonContainerRef }
-				onMouseEnter={ () => setIsPopoverVisible( true ) }
-				onMouseLeave={ () => setIsPopoverVisible( false ) }
-			>
-				<Button className="pattern-layout__add-button" onClick={ () => onAddSection() }>
-					<Icon icon={ plus } size={ 32 } />
-				</Button>
-				<Popover
-					className="pattern-layout__add-button-popover"
-					context={ addButtonContainerRef.current }
-					isVisible={ isPopoverVisible }
-					position="right"
-					focusOnShow
-				>
-					{ translate( 'Add your next pattern' ) }
-				</Popover>
-			</div>
+			<Button className="pattern-layout__add-button" onClick={ () => onAddSection() }>
+				<span className="pattern-layout__add-button-icon">+</span>
+				{ translate( 'Add patterns' ) }
+			</Button>
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -10,7 +10,6 @@ type PatternSelectorProps = {
 	patterns: Pattern[];
 	onSelect: ( selectedPattern: Pattern | null ) => void;
 	onBack: () => void;
-	onDoneClick: () => void;
 	selectedPattern: Pattern | null;
 	emptyPatternText?: string;
 };
@@ -20,7 +19,6 @@ const PatternSelector = ( {
 	patterns,
 	onSelect,
 	onBack,
-	onDoneClick,
 	selectedPattern,
 	emptyPatternText,
 }: PatternSelectorProps ) => {
@@ -53,16 +51,6 @@ const PatternSelector = ( {
 						onSelect={ onSelect }
 					/>
 				</div>
-			</div>
-			<div className="pattern-selector__footer">
-				<NavigatorBackButton
-					as={ Button }
-					className="pattern-assembler__button"
-					onClick={ onDoneClick }
-					primary
-				>
-					{ translate( 'Done' ) }
-				</NavigatorBackButton>
 			</div>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
@@ -25,6 +25,7 @@ const ScreenFooter = ( { selectedPattern, onSelect, onBack, onDoneClick }: Props
 					description={ translate(
 						'Your footer will be added to all pages and can be used to show information or links that will help visitors take the next step.'
 					) }
+					onBack={ onBack }
 				/>
 			) }
 			<div className="screen-container__body">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
@@ -1,4 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { Button } from '@automattic/components';
+import { __experimentalNavigatorBackButton as NavigatorBackButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import NavigatorHeader from './navigator-header';
 import PatternSelector from './pattern-selector';
@@ -34,10 +36,19 @@ const ScreenFooter = ( { selectedPattern, onSelect, onBack, onDoneClick }: Props
 					patterns={ patterns }
 					onSelect={ onSelect }
 					onBack={ onBack }
-					onDoneClick={ onDoneClick }
 					selectedPattern={ selectedPattern }
 					emptyPatternText={ isSidebarRevampEnabled ? translate( 'No Footer' ) : undefined }
 				/>
+			</div>
+			<div className="screen-container__footer">
+				<NavigatorBackButton
+					as={ Button }
+					className="pattern-assembler__button"
+					primary
+					onClick={ onDoneClick }
+				>
+					{ translate( 'Done' ) }
+				</NavigatorBackButton>
 			</div>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
@@ -25,6 +25,7 @@ const ScreenHeader = ( { selectedPattern, onSelect, onBack, onDoneClick }: Props
 					description={ translate(
 						'Your header will be added to all pages and is usually where your site navigation lives.'
 					) }
+					onBack={ onBack }
 				/>
 			) }
 			<div className="screen-container__body">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
@@ -1,4 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { Button } from '@automattic/components';
+import { __experimentalNavigatorBackButton as NavigatorBackButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import NavigatorHeader from './navigator-header';
 import PatternSelector from './pattern-selector';
@@ -34,10 +36,19 @@ const ScreenHeader = ( { selectedPattern, onSelect, onBack, onDoneClick }: Props
 					patterns={ patterns }
 					onSelect={ onSelect }
 					onBack={ onBack }
-					onDoneClick={ onDoneClick }
 					selectedPattern={ selectedPattern }
 					emptyPatternText={ isSidebarRevampEnabled ? translate( 'No Header' ) : undefined }
 				/>
+			</div>
+			<div className="screen-container__footer">
+				<NavigatorBackButton
+					as={ Button }
+					className="pattern-assembler__button"
+					primary
+					onClick={ onDoneClick }
+				>
+					{ translate( 'Done' ) }
+				</NavigatorBackButton>
 			</div>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-homepage.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-homepage.tsx
@@ -10,7 +10,6 @@ import type { Pattern } from './types';
 
 interface Props {
 	patterns: Pattern[];
-	onDoneClick: () => void;
 	onAddSection: () => void;
 	onReplaceSection: ( position: number ) => void;
 	onDeleteSection: ( position: number ) => void;
@@ -20,7 +19,6 @@ interface Props {
 
 const ScreenHomepage = ( {
 	patterns,
-	onDoneClick,
 	onAddSection,
 	onReplaceSection,
 	onDeleteSection,
@@ -56,12 +54,7 @@ const ScreenHomepage = ( {
 				/>
 			</div>
 			<div className="screen-container__footer">
-				<NavigatorBackButton
-					as={ Button }
-					className="pattern-assembler__button"
-					onClick={ onDoneClick }
-					primary
-				>
+				<NavigatorBackButton as={ Button } className="pattern-assembler__button" primary>
 					{ translate( 'Done' ) }
 				</NavigatorBackButton>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main-deprecated.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main-deprecated.tsx
@@ -52,6 +52,7 @@ const ScreenMainDeprecated = ( {
 				description={ translate(
 					'Choose from our library of patterns to quickly put together the structure of your homepage.'
 				) }
+				hideBack
 			/>
 			<div className="screen-container__body">
 				<PatternLayout

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -24,6 +24,7 @@ const ScreenMain = ( { onSelect, onContinueClick }: Props ) => {
 				description={ translate(
 					'Use our library of styles and patterns to design your own theme.'
 				) }
+				hideBack
 			/>
 			<div className="screen-container__body">
 				<ItemGroup>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pattern-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pattern-list.tsx
@@ -1,4 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { Button } from '@automattic/components';
+import { __experimentalNavigatorBackButton as NavigatorBackButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import NavigatorHeader from './navigator-header';
 import PatternSelector from './pattern-selector';
@@ -26,9 +28,18 @@ const ScreenPatternList = ( { selectedPattern, onSelect, onBack, onDoneClick }: 
 					patterns={ patterns }
 					onSelect={ onSelect }
 					onBack={ onBack }
-					onDoneClick={ onDoneClick }
 					selectedPattern={ selectedPattern }
 				/>
+			</div>
+			<div className="screen-container__footer">
+				<NavigatorBackButton
+					as={ Button }
+					className="pattern-assembler__button"
+					primary
+					onClick={ onDoneClick }
+				>
+					{ translate( 'Done' ) }
+				</NavigatorBackButton>
 			</div>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -256,11 +256,6 @@ $font-family: "SF Pro Text", $sans;
 			}
 		}
 
-		.pattern-selector__footer {
-			position: sticky;
-			bottom: 0;
-		}
-
 		.pattern-selector__block-list {
 			button {
 				display: block;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -193,6 +193,8 @@ $font-family: "SF Pro Text", $sans;
 			&:hover,
 			&:focus,
 			&:focus-within {
+				color: var(--color-link-dark);
+
 				.pattern-layout__add-button-icon {
 					background-color: var(--color-link-dark);
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -167,22 +167,21 @@ $font-family: "SF Pro Text", $sans;
 			height: 100%;
 		}
 
-		.pattern-layout__add-button-container {
-			position: relative;
-			margin-right: auto;
-		}
-
 		.pattern-layout__icon {
 			margin-right: 16px;
 		}
 
 		.pattern-layout__add-button {
-			width: 100%;
-			height: 100%;
+			flex-shrink: 0;
 			gap: 16px;
+			font-family: Inter, sans-serif;
 
-			.pattern-layout__add-button-icon,
-			svg {
+			.pattern-layout__add-button-icon {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				width: 24px;
+				height: 24px;
 				padding: 6px;
 				border-radius: 2px;
 				box-sizing: border-box;
@@ -191,23 +190,10 @@ $font-family: "SF Pro Text", $sans;
 				transition: background-color 0.2s ease-in;
 			}
 
-			.pattern-layout__add-button-icon {
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				width: 24px;
-				height: 24px;
-			}
-
-			svg {
-				fill: currentColor;
-			}
-
 			&:hover,
 			&:focus,
 			&:focus-within {
-				.pattern-layout__add-button-icon,
-				svg {
+				.pattern-layout__add-button-icon {
 					background-color: var(--color-link-dark);
 				}
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbxlJb-3d0-p2#comment-2391

## Proposed Changes

* Add the `<` button to the `NavigationHeader`
* Align the `Done` button to the bottom of each screen
* Revamp the `+` button to `+ Add patterns"

![image](https://user-images.githubusercontent.com/13596067/223085683-89a98895-aab3-4505-b14a-7c8633467dea.png)

![image](https://user-images.githubusercontent.com/13596067/223085889-3dc2005e-529b-45ec-a2b4-3d8a325816de.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/sidebar-revamp,pattern-assembler/color-and-fonts`
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
   * Select any actions, and ensure the `<` is shown on the left of the title and the `Done` button is always at the bottom
   * Select `Create your homepage`, and ensure the `+` button is replaced with `+ Add patterns`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?