### PR TITLE
Site Assembler: Add action bar to large preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -362,6 +362,7 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 
 	const onDeleteSection = ( position: number ) => {
 		deleteSection( position );
+		setSectionPosition( null );
 	};
 
 	const onMoveUpSection = ( position: number ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -373,6 +373,10 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 		moveDownSection( position );
 	};
 
+	const onDeleteHeader = () => onSelect( 'header', null );
+
+	const onDeleteFooter = () => onSelect( 'footer', null );
+
 	const stepContent = (
 		<div className="pattern-assembler__wrapper" ref={ wrapperRef } tabIndex={ -1 }>
 			<NavigatorProvider className="pattern-assembler__sidebar" initialPath="/">
@@ -394,9 +398,9 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 							onMoveUpSection={ onMoveUpSection }
 							onMoveDownSection={ onMoveDownSection }
 							onAddHeader={ () => trackEventPatternAdd( 'header' ) }
-							onDeleteHeader={ () => updateHeader( null ) }
+							onDeleteHeader={ onDeleteHeader }
 							onAddFooter={ () => trackEventPatternAdd( 'footer' ) }
-							onDeleteFooter={ () => updateFooter( null ) }
+							onDeleteFooter={ onDeleteFooter }
 							onContinueClick={ onContinueClick }
 						/>
 					) }
@@ -481,6 +485,8 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 				onDeleteSection={ onDeleteSection }
 				onMoveUpSection={ onMoveUpSection }
 				onMoveDownSection={ onMoveDownSection }
+				onDeleteHeader={ onDeleteHeader }
+				onDeleteFooter={ onDeleteFooter }
 			/>
 			<PremiumGlobalStylesUpgradeModal { ...globalStylesUpgradeModalProps } />
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -477,6 +477,9 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 				sections={ sections }
 				footer={ footer }
 				activePosition={ activePosition }
+				onDeleteSection={ onDeleteSection }
+				onMoveUpSection={ onMoveUpSection }
+				onMoveDownSection={ onMoveDownSection }
 			/>
 			<PremiumGlobalStylesUpgradeModal { ...globalStylesUpgradeModalProps } />
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.scss
@@ -1,0 +1,43 @@
+.pattern-assembler {
+	.pattern-action-bar {
+		display: flex;
+		opacity: 0;
+		align-items: center;
+		position: absolute;
+		height: 27px;
+		right: 0;
+
+		.pattern-action-bar__block {
+			flex-direction: column;
+			display: flex;
+			align-items: center;
+		}
+
+		.pattern-action-bar__action {
+			padding: 0;
+			min-width: 30px;
+			max-width: 30px;
+
+			svg {
+				fill: #2c3338;
+
+				&:hover {
+					transform: scale(1.05);
+					transition: transform 0.1s ease-in;
+					transform-origin: center;
+				}
+			}
+
+			&:not(:disabled):hover svg {
+				fill: var(--studio-blue-50);
+			}
+
+			&--move-up,
+			&--move-down {
+				height: 13px;
+				display: flex;
+				align-items: center;
+			}
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.scss
@@ -19,7 +19,7 @@
 			max-width: 30px;
 
 			svg {
-				fill: #2c3338;
+				fill: var(--studio-gray-80);
 
 				&:hover {
 					transform: scale(1.05);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
@@ -2,15 +2,15 @@ import { Button } from '@wordpress/components';
 import { chevronUp, chevronDown, closeSmall, edit } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import './pattern-action-bar.scss';
 
 type PatternActionBarProps = {
-	onReplace: () => void;
+	onReplace?: () => void;
 	onDelete: () => void;
 	onMoveUp?: () => void;
 	onMoveDown?: () => void;
 	disableMoveUp?: boolean;
 	disableMoveDown?: boolean;
-	enableMoving?: boolean;
 	patternType: string;
 };
 
@@ -21,7 +21,6 @@ const PatternActionBar = ( {
 	onMoveDown,
 	disableMoveUp,
 	disableMoveDown,
-	enableMoving,
 	patternType,
 }: PatternActionBarProps ) => {
 	const translate = useTranslate();
@@ -31,7 +30,7 @@ const PatternActionBar = ( {
 			role="menubar"
 			aria-label={ translate( 'Pattern actions' ) }
 		>
-			{ enableMoving && (
+			{ onMoveUp && onMoveDown && (
 				<div className="pattern-action-bar__block">
 					<Button
 						className="pattern-action-bar__action pattern-action-bar__action--move-up"
@@ -59,19 +58,21 @@ const PatternActionBar = ( {
 					/>
 				</div>
 			) }
-			<Button
-				className="pattern-action-bar__block pattern-action-bar__action"
-				role="menuitem"
-				label={ translate( 'Replace' ) }
-				onClick={ () => {
-					recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_replace_click', {
-						pattern_type: patternType,
-					} );
-					onReplace();
-				} }
-				icon={ edit }
-				iconSize={ 20 }
-			/>
+			{ onReplace && (
+				<Button
+					className="pattern-action-bar__block pattern-action-bar__action"
+					role="menuitem"
+					label={ translate( 'Replace' ) }
+					onClick={ () => {
+						recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_replace_click', {
+							pattern_type: patternType,
+						} );
+						onReplace();
+					} }
+					icon={ edit }
+					iconSize={ 20 }
+				/>
+			) }
 			<Button
 				className="pattern-action-bar__block pattern-action-bar__action"
 				role="menuitem"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { chevronUp, chevronDown, closeSmall, edit } from '@wordpress/icons';
+import { chevronUp, chevronDown, close, edit } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import './pattern-action-bar.scss';
@@ -83,7 +83,7 @@ const PatternActionBar = ( {
 					} );
 					onDelete();
 				} }
-				icon={ closeSmall }
+				icon={ close }
 				iconSize={ 23 }
 			/>
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -33,10 +33,11 @@
 
 	.pattern-action-bar {
 		position: absolute;
-		top: 15px;
-		right: 15px;
+		top: 16px;
+		left: 16px;
+		right: unset;
 		padding: 6px;
-		border: 1px solid #dcdcde;
+		border: 1px solid #1e1e1e;
 		border-radius: 4px;
 		background-color: #fff;
 		opacity: 0;
@@ -48,12 +49,26 @@
 		}
 	}
 
+	&::after {
+		content: "";
+		position: absolute;
+		left: 2px;
+		right: 2px;
+		top: 2px;
+		bottom: 2px;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 10px;
+	}
+
 	&:hover,
 	&:focus,
 	&:focus-within {
 		.pattern-action-bar {
-			animation: slideInShort 0.2s forwards, fadeIn 0.3s forwards;
-			animation-timing-function: cubic-bezier(0.445, 0.05, 0.55, 0.95);
+			opacity: 1;
+		}
+
+		&::after {
+			box-shadow: 0 0 0 2px var(--studio-blue-50);
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -1,3 +1,5 @@
+@import "./keyframes";
+
 .pattern-large-preview {
 	flex: 1;
 	position: relative;
@@ -20,8 +22,39 @@
 	.pattern-large-preview__pattern-header {
 		margin-block-end: var(--pattern-large-preview-block-gap);
 	}
+
 	.pattern-large-preview__pattern-footer {
 		margin-block-start: var(--pattern-large-preview-block-gap);
+	}
+}
+
+.pattern-large-preview__pattern {
+	position: relative;
+
+	.pattern-action-bar {
+		position: absolute;
+		top: 15px;
+		right: 15px;
+		padding: 6px;
+		border: 1px solid #dcdcde;
+		border-radius: 4px;
+		background-color: #fff;
+		opacity: 0;
+
+		> .pattern-action-bar__action {
+			min-width: 28px;
+			height: 28px;
+			padding: 2px;
+		}
+	}
+
+	&:hover,
+	&:focus,
+	&:focus-within {
+		.pattern-action-bar {
+			animation: slideInShort 0.2s forwards, fadeIn 0.3s forwards;
+			animation-timing-function: cubic-bezier(0.445, 0.05, 0.55, 0.95);
+		}
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -29,6 +29,7 @@
 }
 
 .pattern-large-preview__pattern {
+	$pattern-large-preview-outer-border-radius: calc(var(--device-switcher-border-radius) / 2);
 	position: relative;
 
 	.pattern-action-bar {
@@ -38,7 +39,7 @@
 		right: unset;
 		padding: 6px;
 		border: 1px solid #1e1e1e;
-		border-radius: 4px;
+		border-radius: 2px;
 		background-color: #fff;
 		opacity: 0;
 
@@ -56,8 +57,17 @@
 		right: 2px;
 		top: 2px;
 		bottom: 2px;
-		/* stylelint-disable-next-line scales/radii */
-		border-radius: 10px;
+		border-radius: 2px;
+	}
+
+	&:first-child::after {
+		border-top-left-radius: $pattern-large-preview-outer-border-radius;
+		border-top-right-radius: $pattern-large-preview-outer-border-radius;
+	}
+
+	&:last-child::after {
+		border-bottom-left-radius: $pattern-large-preview-outer-border-radius;
+		border-bottom-right-radius: $pattern-large-preview-outer-border-radius;
 	}
 
 	&:hover,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -43,6 +43,7 @@
 		gap: 6px;
 		background-color: #fff;
 		opacity: 0;
+		z-index: 1;
 
 		> .pattern-action-bar__action {
 			position: relative;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -29,7 +29,7 @@
 }
 
 .pattern-large-preview__pattern {
-	$pattern-large-preview-outer-border-radius: calc(var(--device-switcher-border-radius) / 2);
+	$pattern-large-preview-outer-border-radius: calc(var(--device-switcher-border-radius) - var(--device-switcher-border-width));
 	position: relative;
 
 	.pattern-action-bar {
@@ -40,13 +40,24 @@
 		padding: 6px;
 		border: 1px solid #1e1e1e;
 		border-radius: 2px;
+		gap: 6px;
 		background-color: #fff;
 		opacity: 0;
 
 		> .pattern-action-bar__action {
+			position: relative;
 			min-width: 28px;
 			height: 28px;
 			padding: 2px;
+
+			&::before {
+				content: "";
+				position: absolute;
+				left: -6px;
+				right: -6px;
+				top: -6px;
+				bottom: -6px;
+			}
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -19,6 +19,8 @@ interface Props {
 	onDeleteSection: ( position: number ) => void;
 	onMoveUpSection: ( position: number ) => void;
 	onMoveDownSection: ( position: number ) => void;
+	onDeleteHeader: () => void;
+	onDeleteFooter: () => void;
 }
 
 // The pattern renderer element has 1px min height before the pattern is loaded
@@ -32,6 +34,8 @@ const PatternLargePreview = ( {
 	onDeleteSection,
 	onMoveUpSection,
 	onMoveDownSection,
+	onDeleteHeader,
+	onDeleteFooter,
 }: Props ) => {
 	const translate = useTranslate();
 	const hasSelectedPattern = header || sections.length || footer;
@@ -47,13 +51,28 @@ const PatternLargePreview = ( {
 
 	const renderPattern = ( type: string, pattern: Pattern, position = -1 ) => {
 		const key = type === 'section' ? pattern.key : type;
+		const getActionBarProps = () => {
+			if ( type === 'header' ) {
+				return { onDelete: onDeleteHeader };
+			} else if ( type === 'footer' ) {
+				return { onDelete: onDeleteFooter };
+			}
+
+			return {
+				disableMoveUp: position === 0,
+				disableMoveDown: sections?.length === position + 1,
+				onDelete: () => onDeleteSection( position ),
+				onMoveUp: () => onMoveUpSection( position ),
+				onMoveDown: () => onMoveDownSection( position ),
+			};
+		};
 
 		return (
 			<li
 				key={ key }
 				className={ classnames(
 					'pattern-large-preview__pattern',
-					`pattern-large-preview__pattern-${ key }`
+					`pattern-large-preview__pattern-${ type }`
 				) }
 			>
 				<PatternRenderer
@@ -62,16 +81,7 @@ const PatternLargePreview = ( {
 					// Disable default max-height
 					maxHeight="none"
 				/>
-				{ type === 'section' && (
-					<PatternActionBar
-						patternType={ type }
-						disableMoveUp={ position === 0 }
-						disableMoveDown={ sections?.length === position + 1 }
-						onDelete={ () => onDeleteSection( position ) }
-						onMoveUp={ () => onMoveUpSection( position ) }
-						onMoveDown={ () => onMoveDownSection( position ) }
-					/>
-				) }
+				<PatternActionBar patternType={ type } { ...getActionBarProps() } />
 			</li>
 		);
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -2,9 +2,11 @@ import { PatternRenderer } from '@automattic/block-renderer';
 import { DeviceSwitcher } from '@automattic/components';
 import { useStyle } from '@automattic/global-styles';
 import { Icon, layout } from '@wordpress/icons';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useEffect, useState, CSSProperties } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import PatternActionBar from './pattern-action-bar';
 import { encodePatternId } from './utils';
 import type { Pattern } from './types';
 import './pattern-large-preview.scss';
@@ -14,12 +16,23 @@ interface Props {
 	sections: Pattern[];
 	footer: Pattern | null;
 	activePosition: number;
+	onDeleteSection: ( position: number ) => void;
+	onMoveUpSection: ( position: number ) => void;
+	onMoveDownSection: ( position: number ) => void;
 }
 
 // The pattern renderer element has 1px min height before the pattern is loaded
 const PATTERN_RENDERER_MIN_HEIGHT = 1;
 
-const PatternLargePreview = ( { header, sections, footer, activePosition }: Props ) => {
+const PatternLargePreview = ( {
+	header,
+	sections,
+	footer,
+	activePosition,
+	onDeleteSection,
+	onMoveUpSection,
+	onMoveDownSection,
+}: Props ) => {
 	const translate = useTranslate();
 	const hasSelectedPattern = header || sections.length || footer;
 	const frameRef = useRef< HTMLDivElement | null >( null );
@@ -32,16 +45,36 @@ const PatternLargePreview = ( { header, sections, footer, activePosition }: Prop
 		'--pattern-large-preview-background': backgroundColor,
 	} as CSSProperties );
 
-	const renderPattern = ( key: string, pattern: Pattern ) => (
-		<li key={ key } className={ `pattern-large-preview__pattern-${ key }` }>
-			<PatternRenderer
-				patternId={ encodePatternId( pattern.id ) }
-				viewportHeight={ viewportHeight || frameRef.current?.clientHeight }
-				// Disable default max-height
-				maxHeight="none"
-			/>
-		</li>
-	);
+	const renderPattern = ( type: string, pattern: Pattern, position = -1 ) => {
+		const key = type === 'section' ? pattern.key : type;
+
+		return (
+			<li
+				key={ key }
+				className={ classnames(
+					'pattern-large-preview__pattern',
+					`pattern-large-preview__pattern-${ key }`
+				) }
+			>
+				<PatternRenderer
+					patternId={ encodePatternId( pattern.id ) }
+					viewportHeight={ viewportHeight || frameRef.current?.clientHeight }
+					// Disable default max-height
+					maxHeight="none"
+				/>
+				{ type === 'section' && (
+					<PatternActionBar
+						patternType={ type }
+						disableMoveUp={ position === 0 }
+						disableMoveDown={ sections?.length === position + 1 }
+						onDelete={ () => onDeleteSection( position ) }
+						onMoveUp={ () => onMoveUpSection( position ) }
+						onMoveDown={ () => onMoveDownSection( position ) }
+					/>
+				) }
+			</li>
+		);
+	};
 
 	const updateViewportHeight = () => {
 		setViewportHeight( frameRef.current?.clientHeight );
@@ -112,7 +145,7 @@ const PatternLargePreview = ( { header, sections, footer, activePosition }: Prop
 					ref={ listRef }
 				>
 					{ header && renderPattern( 'header', header ) }
-					{ sections.map( ( pattern ) => renderPattern( pattern.key!, pattern ) ) }
+					{ sections.map( ( pattern, i ) => renderPattern( 'section', pattern, i ) ) }
 					{ footer && renderPattern( 'footer', footer ) }
 				</ul>
 			) : (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -93,7 +93,6 @@ const PatternLayout = ( {
 												onDelete={ () => onDeleteSection( index ) }
 												onMoveUp={ () => onMoveUpSection( index ) }
 												onMoveDown={ () => onMoveDownSection( index ) }
-												enableMoving={ true }
 												disableMoveUp={ index === 0 }
 												disableMoveDown={ sections?.length === index + 1 }
 											/>
@@ -159,7 +158,6 @@ const PatternLayout = ( {
 											onDelete={ () => onDeleteSection( index ) }
 											onMoveUp={ () => onMoveUpSection( index ) }
 											onMoveDown={ () => onMoveDownSection( index ) }
-											enableMoving={ true }
 											disableMoveUp={ index === 0 }
 											disableMoveDown={ sections?.length === index + 1 }
 										/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pattern-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pattern-list.tsx
@@ -1,7 +1,12 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
-import { __experimentalNavigatorBackButton as NavigatorBackButton } from '@wordpress/components';
+import {
+	__experimentalNavigatorBackButton as NavigatorBackButton,
+	__experimentalUseNavigator as useNavigator,
+} from '@wordpress/components';
+import { usePrevious } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import NavigatorHeader from './navigator-header';
 import PatternSelector from './pattern-selector';
 import { useSectionPatterns } from './patterns-data';
@@ -17,11 +22,23 @@ interface Props {
 const ScreenPatternList = ( { selectedPattern, onSelect, onBack, onDoneClick }: Props ) => {
 	const translate = useTranslate();
 	const patterns = useSectionPatterns();
+	const navigator = useNavigator();
+	const prevSelectedPattern = usePrevious( selectedPattern );
 	const isSidebarRevampEnabled = isEnabled( 'pattern-assembler/sidebar-revamp' );
+
+	useEffect( () => {
+		if ( prevSelectedPattern && ! selectedPattern ) {
+			navigator.goBack();
+		}
+	}, [ prevSelectedPattern, selectedPattern ] );
 
 	return (
 		<>
-			{ isSidebarRevampEnabled && <NavigatorHeader title={ translate( 'Add patterns' ) } /> }
+			{ isSidebarRevampEnabled && (
+				<NavigatorHeader
+					title={ selectedPattern ? translate( 'Replace a pattern' ) : translate( 'Add patterns' ) }
+				/>
+			) }
 			<div className="screen-container__body">
 				<PatternSelector
 					title={ ! isSidebarRevampEnabled ? translate( 'Add sections' ) : undefined }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -64,48 +64,6 @@ $font-family: "SF Pro Text", $sans;
 			background-color: transparent;
 		}
 
-		.pattern-action-bar {
-			display: flex;
-			opacity: 0;
-			align-items: center;
-			position: absolute;
-			height: 27px;
-			right: 0;
-
-			.pattern-action-bar__block {
-				flex-direction: column;
-				display: flex;
-				align-items: center;
-			}
-
-			.pattern-action-bar__action {
-				padding: 0;
-				min-width: 30px;
-				max-width: 30px;
-
-				svg {
-					fill: #2c3338;
-
-					&:hover {
-						transform: scale(1.05);
-						transition: transform 0.1s ease-in;
-						transform-origin: center;
-					}
-				}
-
-				&:not(:disabled):hover svg {
-					fill: var(--studio-blue-50);
-				}
-
-				&--move-up,
-				&--move-down {
-					height: 13px;
-					display: flex;
-					align-items: center;
-				}
-			}
-		}
-
 		.pattern-layout__list {
 			list-style: none;
 			font-family: Inter, sans-serif;

--- a/packages/components/src/device-switcher/device-switcher.scss
+++ b/packages/components/src/device-switcher/device-switcher.scss
@@ -28,10 +28,11 @@
 
 	.device-switcher__container--frame-bordered & {
 		$frame-border-width: 10px;
+		border-radius: var(--device-switcher-border-radius);
 
 		@include break-small {
+			--device-switcher-border-radius: 40px; /* stylelint-disable-line scales/radii */
 			border: $frame-border-width solid var(--color-print);
-			border-radius: 40px; /* stylelint-disable-line scales/radii */
 			box-sizing: border-box;
 			box-shadow:
 				0 5px 15px rgb(0 0 0 / 7%),
@@ -39,8 +40,8 @@
 		}
 
 		@include break-large {
+			--device-switcher-border-radius: 20px; /* stylelint-disable-line scales/radii */
 			border: $frame-border-width solid var(--color-print);
-			border-radius: 20px; /* stylelint-disable-line scales/radii */
 			box-shadow:
 				0 15px 20px rgb(0 0 0 / 4%),
 				0 13px 10px rgb(0 0 0 / 3%),
@@ -54,9 +55,9 @@
 	}
 
 	.device-switcher__container--is-phone & {
+		--device-switcher-border-radius: 40px; /* stylelint-disable-line scales/radii */
 		max-width: 340px;
 		max-height: 680px;
-		border-radius: 40px; /* stylelint-disable-line scales/radii */
 		box-shadow:
 			0 76px 65px rgb(0 0 0 / 4%),
 			0 50px 40px rgb(0 0 0 / 3%),

--- a/packages/components/src/device-switcher/device-switcher.scss
+++ b/packages/components/src/device-switcher/device-switcher.scss
@@ -27,12 +27,12 @@
 	isolation: isolate;
 
 	.device-switcher__container--frame-bordered & {
-		$frame-border-width: 10px;
+		--device-switcher-border-width: 10px;
 		border-radius: var(--device-switcher-border-radius);
 
 		@include break-small {
 			--device-switcher-border-radius: 40px; /* stylelint-disable-line scales/radii */
-			border: $frame-border-width solid var(--color-print);
+			border: var(--device-switcher-border-width) solid var(--color-print);
 			box-sizing: border-box;
 			box-shadow:
 				0 5px 15px rgb(0 0 0 / 7%),
@@ -41,7 +41,7 @@
 
 		@include break-large {
 			--device-switcher-border-radius: 20px; /* stylelint-disable-line scales/radii */
-			border: $frame-border-width solid var(--color-print);
+			border: var(--device-switcher-border-width) solid var(--color-print);
 			box-shadow:
 				0 15px 20px rgb(0 0 0 / 4%),
 				0 13px 10px rgb(0 0 0 / 3%),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbxlJb-3d0-p2#comment-2393

## Proposed Changes

* This PR is focusing on adding the action bar to the large preview. I don't add the `replace` action since people might click the `replace` action when they're adding patterns. It might be a bit weird (at least for me).

https://user-images.githubusercontent.com/13596067/223116333-e2f28f63-a0a6-4a4b-98d0-9cf2417252eb.mov

![image](https://user-images.githubusercontent.com/13596067/226547946-31e63b2a-67b8-48b1-b2d6-c86a2e7dfc8a.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/color-and-fonts`
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen, select "Homepage"
  * Select any patterns
  * Reorder/Remove the pattern from the large preview
  * Replace a pattern from the sidebar, and remove it from the large preview. Ensure the sidebar will go back to the "Homepage" screen


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?