### PR TITLE
Plans 2023: Ability to dismiss notices on new /plans page

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -162,6 +162,7 @@ type PlanFeatures2023GridType = PlanFeatures2023GridProps &
 
 type PlanFeatures2023GridState = {
 	showPlansComparisonGrid: boolean;
+	noticeDismissed: boolean;
 };
 
 type ServiceLogoProps = {
@@ -255,9 +256,14 @@ export class PlanFeatures2023Grid extends Component<
 > {
 	state = {
 		showPlansComparisonGrid: false,
+		noticeDismissed: false,
 	};
 
 	plansComparisonGridContainerRef = createRef< HTMLDivElement >();
+
+	handleDismissNotice = () => {
+		this.setState( { noticeDismissed: true } );
+	};
 
 	componentDidMount() {
 		this.props.recordTracksEvent( 'calypso_wp_plans_test_view' );
@@ -839,12 +845,18 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderNotice() {
-		return (
-			this.renderUpgradeDisabledNotice() ||
-			this.renderDiscountNotice() ||
-			this.renderCreditNotice() ||
-			this.renderMarketingMessage()
-		);
+		const { noticeDismissed } = this.state;
+
+		if ( ! noticeDismissed ) {
+			return (
+				this.renderUpgradeDisabledNotice() ||
+				this.renderDiscountNotice() ||
+				this.renderCreditNotice() ||
+				this.renderMarketingMessage()
+			);
+		}
+
+		return this.renderMarketingMessage();
 	}
 
 	renderMarketingMessage() {
@@ -869,13 +881,16 @@ export class PlanFeatures2023Grid extends Component<
 
 		const bannerContainer = this.getBannerContainer();
 		const activeDiscount = getDiscountByName( this.props.withDiscount );
+
 		if ( ! bannerContainer || ! activeDiscount ) {
 			return false;
 		}
+
 		return ReactDOM.createPortal(
 			<Notice
 				className="plan-features__notice-credits"
-				showDismiss={ false }
+				showDismiss={ true }
+				onDismissClick={ this.handleDismissNotice }
 				icon="info-outline"
 				status="is-success"
 			>
@@ -903,7 +918,12 @@ export class PlanFeatures2023Grid extends Component<
 			return false;
 		}
 		return ReactDOM.createPortal(
-			<Notice className="plan-features__notice" showDismiss={ false } status="is-info">
+			<Notice
+				className="plan-features__notice"
+				showDismiss={ true }
+				onDismissClick={ this.handleDismissNotice }
+				status="is-info"
+			>
 				{ translate(
 					'This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner.'
 				) }
@@ -938,7 +958,8 @@ export class PlanFeatures2023Grid extends Component<
 		return ReactDOM.createPortal(
 			<Notice
 				className="plan-features__notice-credits"
-				showDismiss={ false }
+				showDismiss={ true }
+				onDismissClick={ this.handleDismissNotice }
 				icon="info-outline"
 				status="is-success"
 			>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -243,7 +243,7 @@ export class PlanFeatures extends Component {
 		return ReactDOM.createPortal(
 			<Notice
 				className="plan-features__notice-credits"
-				showDismiss={ true }
+				showDismiss={ false }
 				icon="info-outline"
 				status="is-success"
 			>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -243,7 +243,7 @@ export class PlanFeatures extends Component {
 		return ReactDOM.createPortal(
 			<Notice
 				className="plan-features__notice-credits"
-				showDismiss={ false }
+				showDismiss={ true }
 				icon="info-outline"
 				status="is-success"
 			>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1528

## Proposed Changes

This adds a handler to dismiss the notices in the new `/plans` page. Part of addressing https://github.com/Automattic/martech/issues/1528

I think these changes raise some questions:

1. We have a form of prioritization of notices on the page, combined with a marketing message at the bottom of the list. Is this the desired behavior going forward? I'm assuming it is, but some possible alternatives: (1) show multiple notices on the page (with "dismiss all" functionality), or (2) show notices back-to-back as the user dismisses each.
2. Do we still show the marketing message, if set, when a notice is dismissed? The current logic will show the marketing message if the user dismisses the notice. It also looks like we never render the marketing message placeholder in the new pricing grid, so this may be subject to cleanup/removal altogether (?).
3. What happens on page/browser reloads and route changes (clicking around the UI and back to the plans page)? The current changes will show the notice again in both cases.

## Media

<img width="700" alt="Screenshot 2023-03-06 at 3 34 37 PM" src="https://user-images.githubusercontent.com/1705499/223132822-4392c90a-95c9-4252-8b04-98d79be94b34.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There are three types of notices. The changes are the same and apply to all three. I guess testing one of them should suffice:

- go to /plans/[SITE] with a paid plan to get the "pro-rated" credit (I believe that's the case?)
- ensure the notice shows with a dismiss button. click to dismiss the notice
- (if we decide on keeping/re-introducing the marketing message) activate the marketing message and ensure it shows after notice is dismissed (assuming again this is the functionality we want - see comments above)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
