### PR TITLE
Marketplace: Retrieve themes data on the Thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -101,7 +101,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	// Retrieve theme information
 	const wpComThemes = useSelector( ( state ) => getThemes( state, 'wpcom', productSlugs ) );
 
-	const isAllDataFetched =
+	const areAllProductsFetched =
 		!! pluginsOnSite.length &&
 		pluginsOnSite.every( ( pluginOnSite, index ) => !! pluginOnSite || !! wpComThemes[ index ] );
 
@@ -167,7 +167,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		}
 
 		// Update the menu after the plugin has been installed, since that might change some menu items.
-		if ( isAllDataFetched ) {
+		if ( areAllProductsFetched ) {
 			dispatch( requestAdminMenu( siteId ) );
 			return;
 		}
@@ -177,7 +177,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		}
 	}, [
 		isRequestingPlugins,
-		isAllDataFetched,
+		areAllProductsFetched,
 		dispatch,
 		siteId,
 		transferStatus,
@@ -191,7 +191,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 			return;
 		}
 
-		setShowProgressBar( ! isAllDataFetched );
+		setShowProgressBar( ! areAllProductsFetched );
 
 		// Sites already transferred to Atomic or self-hosted Jetpack sites no longer need to change the current step.
 		if ( isJetpack ) {
@@ -207,7 +207,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		} else if ( transferStatus === transferStates.COMPLETE ) {
 			setCurrentStep( 3 );
 		}
-	}, [ transferStatus, isAllDataFetched, showProgressBar, isJetpack ] );
+	}, [ transferStatus, areAllProductsFetched, showProgressBar, isJetpack ] );
 
 	const steps = useMemo(
 		() =>
@@ -323,7 +323,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 			<MasterbarStyled
 				onClick={ () => page( `/plugins/${ siteSlug }` ) }
 				backText={ translate( 'Back to plugins' ) }
-				canGoBack={ isAllDataFetched }
+				canGoBack={ areAllProductsFetched }
 			/>
 			{ productSlugs.map( ( productSlug, index ) => (
 				<QueryTheme key={ 'query-theme-' + index } siteId="wpcom" themeId={ productSlug } />

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -55,7 +55,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 
 	// retrieve WPCom plugin data
 	const wpComPluginsDataResults = useWPCOMPlugins( productSlugs );
-	const wpComPluginsData = wpComPluginsDataResults.map(
+	const wpComPluginsData: Plugin[] = wpComPluginsDataResults.map(
 		( wpComPluginData ) => wpComPluginData.data
 	);
 	const softwareSlugs = wpComPluginsData.map( ( wpComPluginData, i ) =>
@@ -119,7 +119,13 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 					...pluginOnSite,
 					...dotComThemes[ index ],
 					...dotOrgThemes[ index ],
-					product_type: getProductType( dotComThemes, dotOrgThemes, index ),
+					product_type: getProductType(
+						dotComThemes,
+						dotOrgThemes,
+						wpComPluginsData,
+						wporgPlugins,
+						index
+					),
 				} );
 
 				return productsList;
@@ -371,19 +377,31 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 };
 
 /**
- * Returns the type of the product, having 'plugin' as default
+ * Returns the type of the product
  *
  * @param dotComThemes list of WordPress.com themes
  * @param dotOrgThemes list of WordPress.org themes
+ * @param dotComPlugins list of WordPress.com plugins
+ * @param dotOrgPlugins list of WordPress.org plugins
  * @param index current index to search on the list
- * @returns 'theme'| 'plugin' the type of the product
+ * @returns 'theme'| 'plugin' | undefined the type of the product
  */
-function getProductType( dotComThemes: [], dotOrgThemes: [], index: number ): 'theme' | 'plugin' {
+function getProductType(
+	dotComThemes: [],
+	dotOrgThemes: [],
+	dotComPlugins: Array< Plugin >,
+	dotOrgPlugins: Array< Plugin >,
+	index: number
+): 'theme' | 'plugin' | undefined {
 	if ( dotComThemes[ index ] || dotOrgThemes[ index ] ) {
 		return 'theme';
 	}
 
-	return 'plugin';
+	if ( dotComPlugins[ index ] || dotOrgPlugins[ index ]?.fetched ) {
+		return 'plugin';
+	}
+
+	return undefined;
 }
 
 function FooterIcon( { icon }: { icon: string } ) {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -108,16 +108,15 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	// Consolidate the plugin information from the .org and .com sources in a single list
 	const productInformationList = useMemo( () => {
 		return pluginsOnSite.reduce(
-			( pluginsList: Array< any >, pluginOnSite: Plugin, index: number ) => {
-				pluginsList.push( {
-					...pluginOnSite,
+			( productsList: Array< any >, pluginOnSite: Plugin, index: number ) => {
+				productsList.push( {
 					...wpComPluginsData[ index ],
 					...wporgPlugins[ index ],
 					...wpComThemes[ index ],
 					isTheme: !! wpComThemes[ index ],
 				} );
 
-				return pluginsList;
+				return productsList;
 			},
 			[]
 		);

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -55,7 +55,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 
 	// retrieve WPCom plugin data
 	const wpComPluginsDataResults = useWPCOMPlugins( productSlugs );
-	const wpComPluginsData: Plugin[] = wpComPluginsDataResults.map(
+	const wpComPluginsData: Array< any > = wpComPluginsDataResults.map(
 		( wpComPluginData ) => wpComPluginData.data
 	);
 	const softwareSlugs = wpComPluginsData.map( ( wpComPluginData, i ) =>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -113,7 +113,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 					...wpComPluginsData[ index ],
 					...wporgPlugins[ index ],
 					...wpComThemes[ index ],
-					isTheme: !! wpComThemes[ index ],
+					product_type: getProductType( wpComThemes, index ),
 				} );
 
 				return productsList;
@@ -227,7 +227,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	const pluginsSection: ThankYouSectionProps = {
 		sectionKey: 'plugin_information',
 		nextSteps: productInformationList
-			.filter( ( product ) => product.isTheme === false )
+			.filter( ( product ) => product.product_type === 'plugin' )
 			.map( ( plugin: any ) => ( {
 				stepKey: `plugin_information_${ plugin.slug }`,
 				stepSection: <ThankYouPluginSection plugin={ plugin } />,
@@ -360,6 +360,21 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		</ThemeProvider>
 	);
 };
+
+/**
+ * Returns the type of the product, having 'plugin' as default
+ *
+ * @param themes list of themes
+ * @param index current index to search on the list
+ * @returns 'theme'| 'plugin' the type of the product
+ */
+function getProductType( themes: [], index: number ): 'theme' | 'plugin' {
+	if ( themes[ index ] ) {
+		return 'theme';
+	}
+
+	return 'plugin';
+}
 
 function FooterIcon( { icon }: { icon: string } ) {
 	return (

--- a/client/state/themes/selectors/get-themes.js
+++ b/client/state/themes/selectors/get-themes.js
@@ -1,0 +1,7 @@
+import { getTheme } from 'calypso/state/themes/selectors/get-theme';
+
+import 'calypso/state/themes/init';
+
+export function getThemes( state, siteId, themeIds ) {
+	return themeIds.map( ( themeId ) => getTheme( state, siteId, themeId ) );
+}

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -15,6 +15,7 @@ export { getPurchasedThemes } from 'calypso/state/themes/selectors/get-purchased
 export { getRecommendedThemes } from 'calypso/state/themes/selectors/get-recommended-themes';
 export { getTrendingThemes } from 'calypso/state/themes/selectors/get-trending-themes';
 export { getTheme } from 'calypso/state/themes/selectors/get-theme';
+export { getThemes } from 'calypso/state/themes/selectors/get-themes';
 export { getThemeCustomizeUrl } from 'calypso/state/themes/selectors/get-theme-customize-url';
 export { getThemeDemoUrl } from 'calypso/state/themes/selectors/get-theme-demo-url';
 export { getThemeDetailsUrl } from 'calypso/state/themes/selectors/get-theme-details-url';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73838

## Proposed Changes

* Retrieve themes data when a theme slug is passed on the Marketplace Thank You page URL. 

* A new selector was added to get data from more than 1 theme.

## Testing Instructions
* This PR shouldn't change any behavior from the prod version
* Install and purchase plugins to make sure everything still working as expected
* Update the URL to add a theme slug and check if still working as expected. From `/marketplace/thank-you/:plugin-slug/:site` to `/marketplace/thank-you/:plugin-slug,:theme-slug/:site`. Ex: `/marketplace/thank-you/woocommerce-subscriptions,yuna/www.test.com.br`

PS: The marketplace theme purchase is not redirecting to the Marketplace Thank you page yet and cannot be tested.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
