### PR TITLE
Creating conversion experiment on paid media signup flow (biannual option)

### DIFF
--- a/client/signup/steps/plans-pm/index.jsx
+++ b/client/signup/steps/plans-pm/index.jsx
@@ -33,7 +33,7 @@ export class PlansStepPM extends Component {
 		);
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
 
-		loadExperimentAssignment( 'paid_media_signup_2023_02_hide_monthly' ).then(
+		loadExperimentAssignment( 'paid_media_signup_2023_03_biannual_toggle_hide_free' ).then(
 			( experimentName ) => {
 				this.setState( { experiment: experimentName } );
 				this.setState( { experimentIsLoading: false } );
@@ -74,7 +74,7 @@ export class PlansStepPM extends Component {
 					isAllPaidPlansShown={ true }
 					isInSignup={ true }
 					shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
-					shouldHideMonthlyToggle={ this.state.experiment?.variationName === 'treatment' }
+					showBiannualToggle={ this.state.experiment?.variationName === 'treatment' }
 				/>
 			</div>
 		);
@@ -99,6 +99,14 @@ export class PlansStepPM extends Component {
 		const freePlanButton = (
 			<Button onClick={ () => buildUpgradeFunction( this.props, null ) } borderless />
 		);
+
+		if ( this.state.experiment?.variationName === 'treatment' ) {
+			if ( this.state.isDesktop ) {
+				return translate( "Pick one that's right for you and unlock features that help you grow." );
+			}
+
+			return translate( 'Choose a plan.' );
+		}
 
 		if ( this.state.isDesktop ) {
 			return translate(

--- a/client/signup/steps/plans-pm/plans-features-main-pm.jsx
+++ b/client/signup/steps/plans-pm/plans-features-main-pm.jsx
@@ -158,18 +158,17 @@ export class PlansFeaturesMainPM extends Component {
 	}
 
 	getPlanTypeSelector() {
-		const { shouldHideMonthlyToggle } = this.props;
 		const planTypeSelector = {
 			basePlansPath: this.props.basePlansPath,
 			customerType: 'personal',
 			eligibleForWpcomMonthlyPlans: true,
 			isInSignup: this.props.isInSignup,
 			intervalType: this.props.intervalType,
+			showBiannualToggle: this.props.showBiannualToggle,
 		};
 		const plans = this.getPlans();
-		if ( shouldHideMonthlyToggle === false ) {
-			return <PlanTypeSelector { ...planTypeSelector } kind="interval" plans={ plans } />;
-		}
+
+		return <PlanTypeSelector { ...planTypeSelector } kind="interval" plans={ plans } />;
 	}
 
 	render() {
@@ -189,14 +188,14 @@ PlansFeaturesMainPM.propTypes = {
 	customerType: PropTypes.string,
 	flowName: PropTypes.string,
 	hideFreePlan: PropTypes.bool,
-	intervalType: PropTypes.oneOf( [ 'monthly', 'yearly' ] ),
+	intervalType: PropTypes.oneOf( [ 'monthly', 'yearly', '2yearly' ] ),
 	isInSignup: PropTypes.bool,
 	isReskinned: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
 	plansWithScroll: PropTypes.bool,
 	planTypeSelector: PropTypes.string,
 	redirectToAddDomainFlow: PropTypes.bool,
-	shouldHideMonthlyToggle: PropTypes.bool,
+	showBiannualToggle: PropTypes.bool,
 	shouldShowPlansFeatureComparison: PropTypes.bool,
 	showFAQ: PropTypes.bool,
 };
@@ -210,7 +209,7 @@ PlansFeaturesMainPM.defaultProps = {
 	plansWithScroll: false,
 	planTypeSelector: 'interval',
 	showFAQ: true,
-	shouldHideMonthlyToggle: false,
+	showBiannualToggle: false,
 	shouldShowPlansFeatureComparison: true,
 };
 


### PR DESCRIPTION
Related: #74207 

## Proposed Changes

* Replaces the test setup in #72968 with a followup test that replaces the Monthly option with Bi-annually, and removes the Free plan link.
* The experiment name is `paid_media_signup_2023_03_biannual_toggle_hide_free`
* This experiment affects only the paid media signup flow (`onboarding-pm`)

Here's are screenshots showing the page for both tab options:

![CleanShot 2023-03-09 at 13 36 11@2x](https://user-images.githubusercontent.com/35781181/224122980-eb5af743-dfa1-47a6-b628-3cc8566323eb.png)


## Testing Instructions

* Checkout this PR and start Calypso locally.
* Navigate to the paid media signup flow (`/start/onboarding-pm`)
* Proceed to the Plans step of the signup flow without assigning yourself to a variant.
* Confirm that you see that Plans step with Annual and Monthly toggle options as well as the Free link (note: `onboarding-pm` doesn't use the 2023 design)
* Confirm that you can select a plan and make it to the checkout page as expected.
* Assign yourself to the treatment variant of this experiment and repeat the flow.
* Confirm that you see 1 year and 2 years tab options.
* Click the tabs and confirm that you see the correct prices.
* Click choose a variety of plans and confirm that the correct plan appears on the checkout page.
* Test the `onboarding` flow at `/start` and confirm that the updates to the shared tab code hasn't affected the other flows.
