### PR TITLE
Fix some WooCommerce colours

### DIFF
--- a/client/assets/images/onboarding/woo-commerce.svg
+++ b/client/assets/images/onboarding/woo-commerce.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" data-name="Layer 1" width="24" height="24" viewBox="0 0 148.5 148.5">
    <defs>
-      <style>.cls-1{fill:#9b5c8f;}.cls-2{fill:#fff;}</style>
+      <style>.cls-1{fill:#7f54b3;}.cls-2{fill:#fff;}</style>
    </defs>
    <rect class="cls-1" width="148.5" height="148.5" rx="15" />
    <path class="cls-2" d="M26.08,42.22H123A11.08,11.08,0,0,1,134,53.31v37A11.08,11.08,0,0,1,123,101.38H88.21L93,113.06,72,101.38H26.13A11.08,11.08,0,0,1,15,90.29v-37A11,11,0,0,1,26.08,42.22Z" transform="translate(-0.89 -0.9)" />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.scss
@@ -9,6 +9,7 @@
 		margin-left: 10px;
 	}
 	.woocommerce-bundled-badge {
+		font-family: $sans;
 		margin-left: 10px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
@@ -1,11 +1,11 @@
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
-import { PremiumBadge } from '@automattic/design-picker';
+import { PremiumBadge, WooCommerceBundledBadge } from '@automattic/design-picker';
 import { useSelect } from '@wordpress/data';
-import WooCommerceBundledBadge from '../../../../../../../packages/design-picker/src/components/woocommerce-bundled-badge';
 import { useSite } from '../../../../hooks/use-site';
 import { SITE_STORE } from '../../../../stores';
 import type { Design } from '@automattic/design-picker';
 import type { FC } from 'react';
+
 import './design-picker-design-title.scss';
 
 type Props = {

--- a/packages/design-picker/src/components/woocommerce-bundled-badge/style.scss
+++ b/packages/design-picker/src/components/woocommerce-bundled-badge/style.scss
@@ -1,5 +1,5 @@
 .woocommerce-bundled-badge {
-	--woo-purple-50: #7f54b3;
+	--woocommerce-purple-50: #7f54b3;
 
 	display: inline-flex;
 	align-items: center;
@@ -10,7 +10,7 @@
 	box-sizing: border-box;
 	font-size: 0.75rem;
 	color: var(--studio-white);
-	background: var(--woo-purple-50);
+	background: var(--woocommerce-purple-50);
 	z-index: 1;
 
 	svg {
@@ -18,7 +18,7 @@
 		margin-right: 5px;
 
 		.cls-1 {
-			fill: var(--woo-purple-50);
+			fill: var(--woocommerce-purple-50);
 		}
 
 		.cls-2 {

--- a/packages/design-picker/src/components/woocommerce-bundled-badge/style.scss
+++ b/packages/design-picker/src/components/woocommerce-bundled-badge/style.scss
@@ -1,4 +1,6 @@
 .woocommerce-bundled-badge {
+	--woo-purple-50: #7f54b3;
+
 	display: inline-flex;
 	align-items: center;
 	height: 20px;
@@ -8,7 +10,7 @@
 	box-sizing: border-box;
 	font-size: 0.75rem;
 	color: var(--studio-white);
-	background: #9b5c8f;
+	background: var(--woo-purple-50);
 	z-index: 1;
 
 	svg {
@@ -16,7 +18,7 @@
 		margin-right: 5px;
 
 		.cls-1 {
-			fill: #9b5c8f;
+			fill: var(--woo-purple-50);
 		}
 
 		.cls-2 {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #73434

## Proposed Changes

* This PR updates two SVG images to use the newer WooCommerce purple, `#7f54b3`:
  - The background colour used in the WooCommerce badge in the theme showcase
  - The "Woo" logo used in the following locations:
    * The upgrade modal shown in design setup step when selecting a theme that bundles WooCommerce and the user doesn't have a Business plan or higher
    * The store features step, which isn't currently used in any flows
* This PR also makes two small changes to the design picker title component used for a specific theme:
  - The import path for the WooCommerce badge now uses the named package export rather than a relative path
  - The font for the WooCommerce badge is no longer using the WordPress.com title font (Recoleta), but our standard sans-serif fonts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live
* For a site on a Premium or lower plan, navigate to `/setup/site-setup/designSetup?siteSlug=[yoursite]`
   - If you are running this locally, also append `&flags=-themes/subscription-purchases` to the URL - we need this flag disabled to see the logo in the upgrade modal
* Browse through the available themes, and confirm that the WooCommerce badges have the new background colour
* Select one of the themes and view more details
* Verify that the WooCommerce badge in the title looks OK and has a sans-serif font
* Click on the "Unlock theme" button in the top right corner
* Verify that the "Woo" logo in the modal is using the new purple colour
* Now navigate to _Appearance_ themes for a site
* Verify that the WooCommerce badges for themes are using the correct purple

### Screenshots

##### Design picker
<img width="1594" alt="Screenshot 2023-03-08 at 09 30 54" src="https://user-images.githubusercontent.com/3376401/223652493-d49fc8ff-3bbc-47ae-8e3c-5d3e55f87927.png">

##### Design picker theme title
<img width="939" alt="Screenshot 2023-03-08 at 09 51 33" src="https://user-images.githubusercontent.com/3376401/223653500-46008c4b-8915-4e88-9e2b-a58929febbbb.png">

##### Upgrade modal
<img width="788" alt="Screenshot 2023-03-08 at 09 29 53" src="https://user-images.githubusercontent.com/3376401/223652470-9e18e92e-3f83-4501-a96b-0f53e6c4b6ff.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
