### PR TITLE
Site editor & site preview domain upsell: disable for p2s

### DIFF
--- a/client/components/domains/domain-upsell-callout/index.jsx
+++ b/client/components/domains/domain-upsell-callout/index.jsx
@@ -6,6 +6,7 @@ import page from 'page';
 import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { isP2Site } from 'calypso/sites-dashboard/utils';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
@@ -43,7 +44,8 @@ const DomainUpsellCallout = ( { trackEvent } ) => {
 		isDismissed ||
 		siteDomains.length > 1 ||
 		! isEmailVerified ||
-		! isFreePlanProduct( site.plan )
+		! isFreePlanProduct( site.plan ) ||
+		isP2Site
 	) {
 		return null;
 	}

--- a/client/components/domains/domain-upsell-callout/index.jsx
+++ b/client/components/domains/domain-upsell-callout/index.jsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isFreePlanProduct } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
+import { useMemo } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
 import { useCallback } from 'react';
@@ -24,6 +25,10 @@ const DomainUpsellCallout = ( { trackEvent } ) => {
 	const dismissPreference = `${ trackEvent }-${ site?.ID }`;
 	const isEmailVerified = useSelector( ( state ) => isCurrentUserEmailVerified( state ) );
 	const siteDomains = useSelector( ( state ) => getDomainsBySiteId( state, site?.ID ) );
+	const siteDomainsLength = useMemo(
+		() => siteDomains.filter( ( domain ) => ! domain.isWPCOMDomain ).length,
+		[ siteDomains ]
+	);
 	const hasPreferences = useSelector( hasReceivedRemotePreferences );
 	const isDismissed = useSelector( ( state ) => getPreference( state, dismissPreference ) );
 	const { __ } = useI18n();
@@ -42,10 +47,10 @@ const DomainUpsellCallout = ( { trackEvent } ) => {
 		! site ||
 		! hasPreferences ||
 		isDismissed ||
-		siteDomains.length > 1 ||
+		siteDomainsLength ||
 		! isEmailVerified ||
 		! isFreePlanProduct( site.plan ) ||
-		isP2Site
+		isP2Site( site )
 	) {
 		return null;
 	}

--- a/client/components/domains/domain-upsell-callout/test/index.js
+++ b/client/components/domains/domain-upsell-callout/test/index.js
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import DomainUpsellCallout from '../index';
+
+// Test that the DomainUpsellCallout component renders null when isP2Site is true
+const mockProps = {
+	TrackEvent: '',
+};
+
+describe( 'domain-upsell-callout', () => {
+	test( 'should render null when isP2Site is true', () => {
+		const testProps = {
+			...mockProps,
+			isP2Site: true,
+		};
+
+		renderWithProvider( <DomainUpsellCallout { ...testProps } /> );
+
+		expect( screen.getByText( 'Customize your domain' ) ).not.toBeVisible();
+	} );
+} );

--- a/client/components/domains/domain-upsell-callout/test/index.js
+++ b/client/components/domains/domain-upsell-callout/test/index.js
@@ -1,24 +1,164 @@
 /**
  * @jest-environment jsdom
  */
-import { screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import DomainUpsellCallout from '../index';
 
 // Test that the DomainUpsellCallout component renders null when isP2Site is true
-const mockProps = {
-	TrackEvent: '',
+const initialState = {
+	sites: {
+		items: {
+			1: {
+				ID: 1,
+				URL: 'example.wordpress.com',
+				plan: {
+					product_slug: 'free_plan',
+				},
+				options: {
+					is_wpforteams_site: false,
+				},
+			},
+		},
+		domains: {
+			items: {
+				1: [
+					{
+						domain: 'example.wordpress.com',
+						isWPCOMDomain: true,
+					},
+				],
+			},
+		},
+		plans: {
+			1: {
+				product_slug: 'free_plan',
+			},
+		},
+	},
+	ui: {
+		selectedSiteId: 1,
+	},
+	currentUser: {
+		id: 12,
+		user: {
+			email_verified: true,
+			site_count: 1,
+			primary_blog: 1,
+		},
+	},
+	preferences: {
+		remoteValues: {
+			calypso__dismiss: false,
+		},
+	},
 };
 
 describe( 'domain-upsell-callout', () => {
-	test( 'should render null when isP2Site is true', () => {
-		const testProps = {
-			...mockProps,
-			isP2Site: true,
+	test( 'Should not render on P2 sites', () => {
+		const newInitialState = {
+			...initialState,
+			sites: {
+				...initialState.sites,
+				items: {
+					1: {
+						...initialState.sites.items[ 1 ],
+						options: {
+							is_wpforteams_site: true,
+						},
+					},
+				},
+			},
 		};
 
-		renderWithProvider( <DomainUpsellCallout { ...testProps } /> );
+		const mockStore = configureStore();
+		const store = mockStore( newInitialState );
 
-		expect( screen.getByText( 'Customize your domain' ) ).not.toBeVisible();
+		const { container } = renderWithProvider(
+			<Provider store={ store }>
+				<DomainUpsellCallout trackEvent="" />
+			</Provider>
+		);
+
+		expect( container.getElementsByClassName( 'domain-upsell-callout' ) ).toHaveLength( 0 );
+	} );
+
+	test( 'Should render on free sites without custom domain', () => {
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+
+		const { container } = renderWithProvider(
+			<Provider store={ store }>
+				<DomainUpsellCallout trackEvent="" />
+			</Provider>
+		);
+
+		expect( container.getElementsByClassName( 'domain-upsell-callout' ) ).toHaveLength( 1 );
+	} );
+
+	test( 'Should not render on free sites with custom domain', () => {
+		const newInitialState = {
+			...initialState,
+			sites: {
+				...initialState.sites,
+				domains: {
+					items: {
+						...initialState.sites.domains.items,
+						1: [
+							...initialState.sites.domains.items[ 1 ],
+							{
+								domain: 'example.com',
+								isWPCOMDomain: false,
+							},
+						],
+					},
+				},
+			},
+		};
+
+		const mockStore = configureStore();
+		const store = mockStore( newInitialState );
+
+		const { container } = renderWithProvider(
+			<Provider store={ store }>
+				<DomainUpsellCallout trackEvent="" />
+			</Provider>
+		);
+
+		expect( container.getElementsByClassName( 'domain-upsell-callout' ) ).toHaveLength( 0 );
+	} );
+
+	test( 'Should not render on non free sites', () => {
+		const newInitialState = {
+			...initialState,
+			sites: {
+				...initialState.sites,
+				items: {
+					1: {
+						...initialState.sites.items[ 1 ],
+						plan: {
+							product_slug: 'business-bundle',
+						},
+					},
+				},
+				plans: {
+					1: {
+						product_slug: 'business-bundle',
+					},
+				},
+			},
+		};
+
+		const mockStore = configureStore();
+		const store = mockStore( newInitialState );
+
+		const { container } = renderWithProvider(
+			<Provider store={ store }>
+				<DomainUpsellCallout trackEvent="" />
+			</Provider>
+		);
+
+		expect( container.getElementsByClassName( 'domain-upsell-callout' ) ).toHaveLength( 0 );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Fixes https://github.com/Automattic/dotcom-forge/issues/1858

## Proposed Changes

* Don't show the upsell if it's a p2 site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a p2 site and edit or create a post.
* Confirm that you see the upsell.
* Apply these changes and confirm that the upsell doesn't appear.
* Confirm that the upsell also doesn't appear on site preview (/posts list, click three dots and then View).
* Check that the upsell still appears on free, non-p2 sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
