### PR TITLE
Add ref for reader signup link

### DIFF
--- a/client/blocks/follow-button/index.jsx
+++ b/client/blocks/follow-button/index.jsx
@@ -32,7 +32,7 @@ class FollowButtonContainer extends Component {
 	handleFollowToggle = ( following ) => {
 		if ( ! this.props.isLoggedIn ) {
 			const { pathname } = getUrlParts( window.location.href );
-			return navigate( createAccountUrl( { redirectTo: pathname } ) );
+			return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
 		}
 		if ( following ) {
 			const followData = omitBy(

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -48,7 +48,7 @@ class LikeButton extends PureComponent {
 	toggleLiked( event ) {
 		if ( ! this.props.isLoggedIn ) {
 			const { pathname } = getUrlParts( window.location.href );
-			return navigate( createAccountUrl( { redirectTo: pathname } ) );
+			return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
 		}
 		if ( event ) {
 			event.preventDefault();

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -148,7 +148,7 @@ export function redirectLoggedOutToSignup( context, next ) {
 		return;
 	}
 
-	return page.redirect( createAccountUrl( { redirectTo: context.path } ) );
+	return page.redirect( createAccountUrl( { redirectTo: context.path, ref: 'reader-lp' } ) );
 }
 
 /**

--- a/client/lib/paths/index.js
+++ b/client/lib/paths/index.js
@@ -22,6 +22,6 @@ export function newPost( site ) {
 	return '/post' + sitePath;
 }
 
-export function createAccountUrl( { redirectTo } ) {
-	return `/start/account?redirect_to=${ redirectTo }`;
+export function createAccountUrl( { redirectTo, ref } ) {
+	return `/start/account?redirect_to=${ redirectTo }&ref=${ ref }`;
 }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -80,7 +80,7 @@ class TagStream extends Component {
 
 		if ( ! this.props.isLoggedIn ) {
 			const { pathname } = getUrlParts( window.location.href );
-			return navigate( createAccountUrl( { redirectTo: pathname } ) );
+			return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
 		}
 
 		toggleAction( decodedTagSlug );


### PR DESCRIPTION
As part of making reader tag pages public, we want to track what impact this has on wordpress.com signups.

> Figure out a way to create a funnel report of folks coming from logged out tag pages that then lead to signup. Could be tricky since initially they’ll be logged out.

It will work with this tracks funnel pe7F0s-A6-p2#comment-684

## Proposed Changes

Adds `?ref=lp-reader` to redirects for logged out reader.
`?ref=lp-reader` was chosen because this is already appended to the signup link in the header. It stands for "landing-page-reader" and is the same convention used by `/themes` and other logged out pages.

## Testing Instructions

The following situations should redirect you to /start/account/user?redirect_to=/tag/fishing`&ref=reader-lp`
* Clicking action buttons
* Clicking follow tag
* Clicking a users profile to go to their feed
* The signup button in the header