### PR TITLE
Update domain upsell globe icon

### DIFF
--- a/client/components/domains/domain-upsell-callout/index.jsx
+++ b/client/components/domains/domain-upsell-callout/index.jsx
@@ -11,6 +11,7 @@ import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { globe } from '@wordpress/icons';
 
 import './style.scss';
 
@@ -54,7 +55,7 @@ const DomainUpsellCallout = ( { trackEvent } ) => {
 			<div className="domain-upsell-callout">
 				<div className="domain-upsell-callout__content">
 					<div className="domain-upsell-callout__content-text">
-						<Gridicon icon="globe" size={ 16 } className="domain-upsell-callout__icon" />
+						{ globe }
 						<span className="domain-upsell-callout__domain-name">{ site.domain }</span>
 						<button className="domain-upsell-callout__button" onClick={ getCtaClickHandler }>
 							<span className="domain-upsell-callout__button-text-desktop">

--- a/client/components/domains/domain-upsell-callout/index.jsx
+++ b/client/components/domains/domain-upsell-callout/index.jsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isFreePlanProduct } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
+import { globe } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
 import { useCallback } from 'react';
@@ -11,7 +12,6 @@ import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { globe } from '@wordpress/icons';
 
 import './style.scss';
 

--- a/client/components/domains/domain-upsell-callout/index.jsx
+++ b/client/components/domains/domain-upsell-callout/index.jsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isFreePlanProduct } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
-import { globe } from '@wordpress/icons';
+import { globe, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
 import { useCallback } from 'react';
@@ -55,7 +55,7 @@ const DomainUpsellCallout = ( { trackEvent } ) => {
 			<div className="domain-upsell-callout">
 				<div className="domain-upsell-callout__content">
 					<div className="domain-upsell-callout__content-text">
-						{ globe }
+						<Icon icon={ globe } size={ 16 } />
 						<span className="domain-upsell-callout__domain-name">{ site.domain }</span>
 						<button className="domain-upsell-callout__button" onClick={ getCtaClickHandler }>
 							<span className="domain-upsell-callout__button-text-desktop">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/73727

## Proposed Changes

* Change the globe icon from GridIcon to Gutenberg version.

Before | After
--|--
<img width="1460" alt="globe-before" src="https://user-images.githubusercontent.com/140841/223490858-37001da2-c1b3-471f-bc9f-6ad4ef810945.png">  |  <img width="1344" alt="globe-after" src="https://user-images.githubusercontent.com/140841/223569612-8df34811-8da4-4162-8993-33bb7a165df9.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- With a free site without a custom domain, go to /posts
- Click on a post to edit
- You should see the upsell callout with the updated globe icon
- Check the icon looks ok in Safari, Chrome, and FireFox.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
