### PR TITLE
Stats: fix chart flickering caused by Y Axis resize event

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -161,10 +161,7 @@ function Chart( {
 	// The hack renders an empty div, which triggers the resize event, and then the actual component would be rendered.
 	if ( sizing.clientWidth <= 0 || yAxisSize.clientWidth <= 0 ) {
 		return (
-			<div
-				ref={ resizeRef }
-				className={ classNames( 'chart', { 'is-placeholder': isPlaceholder } ) }
-			>
+			<div ref={ resizeRef } className="chart">
 				<ChartYAxis />
 			</div>
 		);

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -143,11 +143,31 @@ function Chart( {
 
 	const { isTooltipVisible, tooltipContext, tooltipPosition, tooltipData } = tooltip;
 
+	const ChartYAxis = () => (
+		<div ref={ yAxisRef } className="chart__y-axis">
+			<div className="chart__y-axis-width-fix">{ numberFormat( 1e5 ) }</div>
+			<div className="chart__y-axis-label is-hundred">
+				{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, 2 ) }
+			</div>
+			<div className="chart__y-axis-label is-fifty">
+				{ yMax > 1 ? numberFormat( yMax / 2 ) : numberFormat( yMax / 2, 2 ) }
+			</div>
+			<div className="chart__y-axis-label is-zero">{ numberFormat( 0 ) }</div>
+		</div>
+	);
+
 	// This is a hack to avoid the flickering on page load.
 	// The component listens on the resize event of its own, which would resize on initialization.
 	// The hack renders an empty div, which triggers the resize event, and then the actual component would be rendered.
-	if ( width <= 0 ) {
-		return <div ref={ resizeRef }></div>;
+	if ( sizing.clientWidth <= 0 || yAxisSize.clientWidth <= 0 ) {
+		return (
+			<div
+				ref={ resizeRef }
+				className={ classNames( 'chart', { 'is-placeholder': isPlaceholder } ) }
+			>
+				<ChartYAxis />
+			</div>
+		);
 	}
 
 	return (
@@ -174,18 +194,7 @@ function Chart( {
 					</div>
 				) }
 			</div>
-			{ ! isPlaceholder && (
-				<div ref={ yAxisRef } className="chart__y-axis">
-					<div className="chart__y-axis-width-fix">{ numberFormat( 1e5 ) }</div>
-					<div className="chart__y-axis-label is-hundred">
-						{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, 2 ) }
-					</div>
-					<div className="chart__y-axis-label is-fifty">
-						{ yMax > 1 ? numberFormat( yMax / 2 ) : numberFormat( yMax / 2, 2 ) }
-					</div>
-					<div className="chart__y-axis-label is-zero">{ numberFormat( 0 ) }</div>
-				</div>
-			) }
+			{ ! isPlaceholder && <ChartYAxis /> }
 			<BarContainer
 				barClick={ barClick }
 				chartWidth={ width }

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -137,11 +137,31 @@ function Chart( {
 
 	const { isTooltipVisible, tooltipContext, tooltipPosition, tooltipData } = tooltip;
 
+	const ChartYAxis = () => (
+		<div ref={ yAxisRef } className="chart__y-axis">
+			<div className="chart__y-axis-width-fix">{ numberFormat( 1e5 ) }</div>
+			<div className="chart__y-axis-label is-hundred">
+				{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, 2 ) }
+			</div>
+			<div className="chart__y-axis-label is-fifty">
+				{ yMax > 1 ? numberFormat( yMax / 2 ) : numberFormat( yMax / 2, 2 ) }
+			</div>
+			<div className="chart__y-axis-label is-zero">{ numberFormat( 0 ) }</div>
+		</div>
+	);
+
 	// This is a hack to avoid the flickering on page load.
 	// The component listens on the resize event of its own, which would resize on initialization.
 	// The hack renders an empty div, which triggers the resize event, and then the actual component would be rendered.
-	if ( width <= 0 ) {
-		return <div ref={ resizeRef }></div>;
+	if ( sizing.clientWidth <= 0 || yAxisSize.clientWidth <= 0 ) {
+		return (
+			<div
+				ref={ resizeRef }
+				className={ classNames( 'chart', { 'is-placeholder': isPlaceholder } ) }
+			>
+				<ChartYAxis />
+			</div>
+		);
 	}
 
 	return (
@@ -168,18 +188,7 @@ function Chart( {
 					</div>
 				) }
 			</div>
-			{ ! isPlaceholder && (
-				<div ref={ yAxisRef } className="chart__y-axis">
-					<div className="chart__y-axis-width-fix">{ numberFormat( 1e5 ) }</div>
-					<div className="chart__y-axis-label is-hundred">
-						{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, 2 ) }
-					</div>
-					<div className="chart__y-axis-label is-fifty">
-						{ yMax > 1 ? numberFormat( yMax / 2 ) : numberFormat( yMax / 2, 2 ) }
-					</div>
-					<div className="chart__y-axis-label is-zero">{ numberFormat( 0 ) }</div>
-				</div>
-			) }
+			{ ! isPlaceholder && <ChartYAxis /> }
 			<BarContainer
 				barClick={ barClick }
 				chartWidth={ width }

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -72,8 +72,11 @@ function Chart( {
 	}, [] );
 
 	const handleYAxisSizeChange = ( contentRect ) => {
+		if ( ! contentRect ) {
+			return;
+		}
 		setYAxisSize( ( prevSizing ) => {
-			const clientWidth = contentRect.width;
+			const clientWidth = contentRect?.width;
 			if ( ! prevSizing.hasResized || clientWidth !== prevSizing.clientWidth ) {
 				return { clientWidth, hasResized: true };
 			}
@@ -87,6 +90,9 @@ function Chart( {
 	// Needs to be memoized to avoid causing the `useWindowResizeCallback` custom hook to re-subscribe.
 	const handleContentRectChange = useCallback(
 		( contentRect ) => {
+			if ( ! contentRect ) {
+				return;
+			}
 			setSizing( ( prevSizing ) => {
 				const effectiveYAxisSize =
 					yAxisRef && yAxisRef.current ? yAxisRef.current.clientWidth : yAxisSize.clientWidth;
@@ -137,28 +143,11 @@ function Chart( {
 
 	const { isTooltipVisible, tooltipContext, tooltipPosition, tooltipData } = tooltip;
 
-	const ChartYAxis = () => (
-		<div ref={ yAxisRef } className="chart__y-axis">
-			<div className="chart__y-axis-width-fix">{ numberFormat( 1e5 ) }</div>
-			<div className="chart__y-axis-label is-hundred">
-				{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, 2 ) }
-			</div>
-			<div className="chart__y-axis-label is-fifty">
-				{ yMax > 1 ? numberFormat( yMax / 2 ) : numberFormat( yMax / 2, 2 ) }
-			</div>
-			<div className="chart__y-axis-label is-zero">{ numberFormat( 0 ) }</div>
-		</div>
-	);
-
 	// This is a hack to avoid the flickering on page load.
 	// The component listens on the resize event of its own, which would resize on initialization.
 	// The hack renders an empty div, which triggers the resize event, and then the actual component would be rendered.
-	if ( sizing.clientWidth <= 0 || yAxisSize.clientWidth <= 0 ) {
-		return (
-			<div ref={ resizeRef } className="chart">
-				<ChartYAxis />
-			</div>
-		);
+	if ( width <= 0 ) {
+		return <div ref={ resizeRef }></div>;
 	}
 
 	return (
@@ -185,7 +174,18 @@ function Chart( {
 					</div>
 				) }
 			</div>
-			{ ! isPlaceholder && <ChartYAxis /> }
+			{ ! isPlaceholder && (
+				<div ref={ yAxisRef } className="chart__y-axis">
+					<div className="chart__y-axis-width-fix">{ numberFormat( 1e5 ) }</div>
+					<div className="chart__y-axis-label is-hundred">
+						{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, 2 ) }
+					</div>
+					<div className="chart__y-axis-label is-fifty">
+						{ yMax > 1 ? numberFormat( yMax / 2 ) : numberFormat( yMax / 2, 2 ) }
+					</div>
+					<div className="chart__y-axis-label is-zero">{ numberFormat( 0 ) }</div>
+				</div>
+			) }
 			<BarContainer
 				barClick={ barClick }
 				chartWidth={ width }

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -76,7 +76,7 @@ function Chart( {
 			return;
 		}
 		setYAxisSize( ( prevSizing ) => {
-			const clientWidth = contentRect?.width;
+			const clientWidth = contentRect.width;
 			if ( ! prevSizing.hasResized || clientWidth !== prevSizing.clientWidth ) {
 				return { clientWidth, hasResized: true };
 			}

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -155,10 +155,7 @@ function Chart( {
 	// The hack renders an empty div, which triggers the resize event, and then the actual component would be rendered.
 	if ( sizing.clientWidth <= 0 || yAxisSize.clientWidth <= 0 ) {
 		return (
-			<div
-				ref={ resizeRef }
-				className={ classNames( 'chart', { 'is-placeholder': isPlaceholder } ) }
-			>
+			<div ref={ resizeRef } className="chart">
 				<ChartYAxis />
 			</div>
 		);


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/73699#issuecomment-1457170819

## Proposed Changes

Render Y Axis in mocked Chart container to avoid resize event triggered by the Y Axis component.

## Testing Instructions

* Open Calypso Live
* Test with different size of screens (especially small screens)
* Ensure there's no flickering described in https://github.com/Automattic/wp-calypso/issues/73699#issuecomment-1457170819

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
