### PR TITLE
Theme Showcase: Update Theme Detail page back button

### DIFF
--- a/client/components/header-cake/index.jsx
+++ b/client/components/header-cake/index.jsx
@@ -17,6 +17,7 @@ export default class HeaderCake extends Component {
 			actionHref,
 			actionOnClick,
 			alwaysShowActionText,
+			alwaysShowBackText,
 		} = this.props;
 		const classes = classNames( 'header-cake', this.props.className, {
 			'is-compact': this.props.isCompact,
@@ -24,7 +25,12 @@ export default class HeaderCake extends Component {
 
 		return (
 			<Card className={ classes }>
-				<HeaderCakeBack text={ backText } href={ backHref } onClick={ this.props.onClick } />
+				<HeaderCakeBack
+					text={ backText }
+					href={ backHref }
+					onClick={ this.props.onClick }
+					alwaysShowActionText={ alwaysShowBackText }
+				/>
 
 				<div className="header-cake__title" role="presentation" onClick={ this.props.onTitleClick }>
 					{ this.props.children }
@@ -58,9 +64,11 @@ HeaderCake.propTypes = {
 	actionIcon: PropTypes.string,
 	actionOnClick: PropTypes.func,
 	alwaysShowActionText: PropTypes.bool,
+	alwaysShowBackText: PropTypes.bool,
 };
 
 HeaderCake.defaultProps = {
 	isCompact: false,
 	alwaysShowActionText: false,
+	alwaysShowBackText: false,
 };

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -284,17 +284,6 @@ class ThemeSheet extends Component {
 		this.trackButtonClick( 'next_theme' );
 	};
 
-	renderBackButton = () => {
-		const { translate } = this.props;
-
-		return (
-			<Button className="theme__sheet-back-button" borderless onClick={ this.goBack }>
-				<Gridicon icon="chevron-left" size={ 18 } />
-				{ translate( 'Back to themes' ) }
-			</Button>
-		);
-	};
-
 	renderBar = () => {
 		const { author, name, translate, softLaunched } = this.props;
 
@@ -1313,22 +1302,25 @@ class ThemeSheet extends Component {
 				<ThanksModal source="details" themeId={ this.props.themeId } />
 				<AutoLoadingHomepageModal source="details" />
 				{ ! isNewDetailsAndPreview && pageUpsellBanner }
-				{ ! isNewDetailsAndPreview && (
+				<div className="theme__sheet-action-bar-container">
 					<HeaderCake
 						className="theme__sheet-action-bar"
-						backText={ translate( 'All Themes' ) }
+						backText={
+							isNewDetailsAndPreview ? translate( 'Back to themes' ) : translate( 'All Themes' )
+						}
 						onClick={ this.goBack }
+						alwaysShowBackText={ isNewDetailsAndPreview }
 					>
-						{ ! retired &&
+						{ ! isNewDetailsAndPreview &&
+							! retired &&
 							! hasWpOrgThemeUpsellBanner &&
 							! isWPForTeamsSite &&
 							this.renderButton() }
 					</HeaderCake>
-				) }
+				</div>
 				<div className={ columnsClassName }>
 					{ isNewDetailsAndPreview && (
 						<div className="theme__sheet-column-header">
-							{ this.renderBackButton() }
 							{ pageUpsellBanner }
 							{ this.renderHeader() }
 						</div>

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -1,5 +1,7 @@
 @import "@automattic/onboarding/styles/mixins";
 
+$theme-sheet-content-max-width: 1462px;
+
 body.is-section-theme-i4 {
 	&.theme-default.color-scheme {
 		--color-surface-backdrop: var(--studio-white);
@@ -20,6 +22,28 @@ body.is-section-theme-i4 {
 		}
 	}
 
+	.theme__sheet-action-bar-container {
+		box-shadow: 0 1px var(--color-border-subtle);
+	}
+
+	.theme__sheet-action-bar {
+		box-shadow: none;
+		box-sizing: content-box;
+		margin: 0 auto;
+		max-width: $theme-sheet-content-max-width;
+		min-height: 70px;
+		padding: 0 20px;
+		position: relative;
+
+		@include breakpoint-deprecated( "<960px" ) {
+			margin: 0 0 32px 0;
+		}
+
+		@include breakpoint-deprecated( "<960px" ) {
+			min-height: 60px;
+		}
+	}
+
 	.theme__sheet-columns {
 		display: grid;
 		gap: 0 32px;
@@ -28,7 +52,7 @@ body.is-section-theme-i4 {
 			"content preview";
 		grid-template-columns: 1fr 1fr;
 		grid-template-rows: auto 1fr;
-		max-width: 1462px;
+		max-width: $theme-sheet-content-max-width;
 		padding: 48px 20px;
 
 		h2,


### PR DESCRIPTION
## Proposed Changes

This PR updates the Theme Detail page's back button to be more aligned with the design in `/plugins`. See p1678096033821669-slack-C048CUFRGFQ for more discussion. 

| Before | After |
| --- | --- |
| ![Screenshot 2023-03-07 at 5 11 31 PM](https://user-images.githubusercontent.com/797888/223376421-22afed63-aaa9-497c-b0bb-bf2f1c3c0eb4.png) | ![Screenshot 2023-03-07 at 5 02 37 PM](https://user-images.githubusercontent.com/797888/223376439-8dfdfb36-bf7d-4536-be6d-404b19f9218b.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase `/themes/${site_slug}`. If using calypso.live, the flag `themes/showcase-i4/details-and-preview` is required.
* Ensure that the back button is as shown above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x]  Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?