### PR TITLE
Inline Help: Prefer title over link value for React keys.

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -142,7 +142,7 @@ function HelpSearchResults( {
 		};
 
 		return (
-			<Fragment key={ link ?? title }>
+			<Fragment key={ title ?? link }>
 				<li className="inline-help__results-item">
 					<div className="inline-help__results-cell">
 						<a


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Prefer the title value over the link value when setting up results listing so as to avoid collisions when the URL is the same.

This fixes a console error on the Stats page due to two of the surfaced help articles having the same URL. Testing across top-level pages doesn’t reveal any further key collisions.

See #72545 for details on reproducing the error.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Launch the Calypso Live link. (The error message isn't printed in production.)
2. Visit any P2 page starting on My Home.
3. Open the dev console.
4. Switch to the Stats page.
5. Confirm the React error is no longer present in the console.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
