### PR TITLE
Site Assembler: Global styles adjustment

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/index.tsx
@@ -1,4 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
+import { PremiumBadge } from '@automattic/design-picker';
 import {
 	__experimentalHStack as HStack,
 	__experimentalNavigatorBackButton as NavigatorBackButton,
@@ -11,10 +12,11 @@ interface Props {
 	title: string;
 	description?: string;
 	hideBack?: boolean;
+	isPremium?: boolean;
 	onBack?: () => void;
 }
 
-const NavigatorHeader = ( { title, description, hideBack, onBack }: Props ) => {
+const NavigatorHeader = ( { title, description, hideBack, isPremium, onBack }: Props ) => {
 	const translate = useTranslate();
 
 	return (
@@ -34,6 +36,7 @@ const NavigatorHeader = ( { title, description, hideBack, onBack }: Props ) => {
 						</NavigatorBackButton>
 					) }
 					<h2>{ title }</h2>
+					{ isPremium && <PremiumBadge shouldHideTooltip /> }
 				</HStack>
 				{ description && <p className="navigator-header__description">{ description }</p> }
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/style.scss
@@ -17,6 +17,10 @@
 		.button.is-borderless .gridicon {
 			top: 4px;
 		}
+
+		.premium-badge {
+			margin-inline-start: 20px;
+		}
 	}
 
 	.navigator-header__description {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
@@ -27,6 +27,7 @@ const ScreenColorPalettes = ( {
 			<NavigatorHeader
 				title={ translate( 'Colors' ) }
 				description={ translate( 'Foreground and background colors used throughout your site.' ) }
+				isPremium
 			/>
 			<div className="screen-container__body">
 				<ColorPaletteVariations

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
@@ -26,7 +26,9 @@ const ScreenColorPalettes = ( {
 		<>
 			<NavigatorHeader
 				title={ translate( 'Colors' ) }
-				description={ translate( 'Foreground and background colors used throughout your site.' ) }
+				description={ translate(
+					'Select from our curated color palettes or tweak to your heart’s content when you upgrade to the Premium plan or higher.'
+				) }
 				isPremium
 			/>
 			<div className="screen-container__body">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
@@ -29,6 +29,7 @@ const ScreenFontPairings = ( {
 				description={ translate(
 					'We’ve hand picked a selection of font pairings that you can customize later.'
 				) }
+				isPremium
 			/>
 			<div className="screen-container__body">
 				<FontPairingVariations

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
@@ -27,7 +27,7 @@ const ScreenFontPairings = ( {
 			<NavigatorHeader
 				title={ translate( 'Fonts' ) }
 				description={ translate(
-					'We’ve hand picked a selection of font pairings that you can customize later.'
+					'Select from our hand-picked font pairings or expanded library when you upgrade to the Premium plan or higher.'
 				) }
 				isPremium
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -92,10 +92,8 @@ const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Pr
 			<div className="screen-container__footer">
 				<span className="screen-container__description">
 					{ shouldUnlockGlobalStyles
-						? translate( 'You’ve selected Premium fonts or colors for your site' )
-						: translate(
-								'Open the editor where you can further customize your homepage as desired'
-						  ) }
+						? translate( 'You’ve selected Premium fonts or colors for your site.' )
+						: translate( 'Click Continue to further customize your site.' ) }
 				</span>
 				<Button className="pattern-assembler__button" onClick={ onContinueClick } primary>
 					{ shouldUnlockGlobalStyles ? translate( 'Unlock this style' ) : translate( 'Continue' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -1,9 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
+import { englishLocales, useLocale } from '@automattic/i18n-utils';
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalDivider as Divider,
 } from '@wordpress/components';
+import { hasTranslation } from '@wordpress/i18n';
 import { header, footer, layout, styles, typography } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { NavigationButtonAsItem } from './navigator-buttons';
@@ -17,6 +19,12 @@ interface Props {
 
 const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Props ) => {
 	const translate = useTranslate();
+	const locale = useLocale();
+	const defaultCTADescription =
+		englishLocales.includes( locale ) ||
+		hasTranslation( 'Click Continue to further customize your site.' )
+			? translate( 'Click Continue to further customize your site.' )
+			: '';
 
 	return (
 		<>
@@ -93,7 +101,7 @@ const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Pr
 				<span className="screen-container__description">
 					{ shouldUnlockGlobalStyles
 						? translate( 'You’ve selected Premium fonts or colors for your site.' )
-						: translate( 'Click Continue to further customize your site.' ) }
+						: defaultCTADescription }
 				</span>
 				<Button className="pattern-assembler__button" onClick={ onContinueClick } primary>
 					{ shouldUnlockGlobalStyles ? translate( 'Unlock this style' ) : translate( 'Continue' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -90,6 +90,13 @@ const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Pr
 				</ItemGroup>
 			</div>
 			<div className="screen-container__footer">
+				<span className="screen-container__description">
+					{ shouldUnlockGlobalStyles
+						? translate( 'You’ve selected Premium fonts or colors for your site' )
+						: translate(
+								'Open the editor where you can further customize your homepage as desired'
+						  ) }
+				</span>
 				<Button className="pattern-assembler__button" onClick={ onContinueClick } primary>
 					{ shouldUnlockGlobalStyles ? translate( 'Unlock this style' ) : translate( 'Continue' ) }
 				</Button>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -1,11 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
-import { englishLocales, useLocale } from '@automattic/i18n-utils';
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalDivider as Divider,
 } from '@wordpress/components';
-import { hasTranslation } from '@wordpress/i18n';
 import { header, footer, layout, styles, typography } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { NavigationButtonAsItem } from './navigator-buttons';
@@ -19,12 +17,6 @@ interface Props {
 
 const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Props ) => {
 	const translate = useTranslate();
-	const locale = useLocale();
-	const defaultCTADescription =
-		englishLocales.includes( locale ) ||
-		hasTranslation( 'Click Continue to further customize your site.' )
-			? translate( 'Click Continue to further customize your site.' )
-			: '';
 
 	return (
 		<>
@@ -101,7 +93,7 @@ const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Pr
 				<span className="screen-container__description">
 					{ shouldUnlockGlobalStyles
 						? translate( 'You’ve selected Premium fonts or colors for your site.' )
-						: defaultCTADescription }
+						: '' }
 				</span>
 				<Button className="pattern-assembler__button" onClick={ onContinueClick } primary>
 					{ shouldUnlockGlobalStyles ? translate( 'Unlock this style' ) : translate( 'Continue' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -23,7 +23,7 @@ const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Pr
 			<NavigatorHeader
 				title={ translate( 'Let’s get creative' ) }
 				description={ translate(
-					'Use our library of styles and patterns to design your own theme.'
+					'Use our library of styles and patterns to design your own homepage.'
 				) }
 				hideBack
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -307,6 +307,14 @@ $font-family: "SF Pro Text", $sans;
 		margin-top: auto;
 	}
 
+	.screen-container__description {
+		display: inline-block;
+		padding-bottom: 8px;
+		font-size: $font-body-small;
+		letter-spacing: -0.15px;
+		color: var(--color-neutral-60);
+	}
+
 	/**
 	 * Gutenberg Components
 	 */

--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -62,7 +62,7 @@ const ColorPaletteVariation = ( {
 		>
 			<div className="global-styles-variation__item-preview">
 				<GlobalStylesContext.Provider value={ context }>
-					<ColorPaletteVariationPreview />
+					<ColorPaletteVariationPreview title={ colorPaletteVariation.title } />
 				</GlobalStylesContext.Provider>
 			</div>
 		</div>

--- a/packages/global-styles/src/components/color-palette-variations/preview.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/preview.tsx
@@ -32,6 +32,7 @@ const ColorPaletteVariationPreview = ( { title }: Props ) => {
 	const [ themeColors ] = useSetting( 'color.palette.theme' );
 	const [ containerResizeListener, { width } ] = useResizeObserver();
 	const ratio = width ? width / STYLE_PREVIEW_WIDTH : 1;
+	const normalizedHeight = Math.ceil( STYLE_PREVIEW_HEIGHT * ratio );
 	const normalizedSwatchSize = STYLE_PREVIEW_COLOR_SWATCH_SIZE * ratio * 2;
 
 	const uniqueColors = [ ...new Set< string >( themeColors.map( ( { color }: Color ) => color ) ) ];
@@ -45,12 +46,13 @@ const ColorPaletteVariationPreview = ( { title }: Props ) => {
 	return (
 		<GlobalStylesVariationContainer
 			width={ width }
-			ratio={ ratio }
+			height={ normalizedHeight }
 			containerResizeListener={ containerResizeListener }
 		>
 			<div
 				style={ {
-					height: STYLE_PREVIEW_HEIGHT * ratio,
+					// Apply the normalized height only when the width is available
+					height: width ? normalizedHeight : 0,
 					width: '100%',
 					background: gradientValue ?? backgroundColor,
 					cursor: 'pointer',

--- a/packages/global-styles/src/components/color-palette-variations/preview.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/preview.tsx
@@ -22,10 +22,11 @@ const ColorPaletteVariationPreview = () => {
 	const [ containerResizeListener, { width } ] = useResizeObserver();
 	const ratio = width ? width / STYLE_PREVIEW_WIDTH : 1;
 
-	const highlightedColors: Color[] = themeColors
+	const uniqueColors = [ ...new Set< string >( themeColors.map( ( { color }: Color ) => color ) ) ];
+	const highlightedColors = uniqueColors
 		.filter(
 			// we exclude background color because it is already visible in the preview.
-			( { color }: Color ) => color !== backgroundColor
+			( color ) => color !== backgroundColor
 		)
 		.slice( 0, 2 );
 
@@ -58,7 +59,7 @@ const ColorPaletteVariationPreview = () => {
 						} }
 					>
 						<VStack spacing={ 4 * ratio }>
-							{ highlightedColors.map( ( { color }, index ) => (
+							{ highlightedColors.map( ( color, index ) => (
 								<div
 									key={ index }
 									style={ {

--- a/packages/global-styles/src/components/color-palette-variations/preview.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/preview.tsx
@@ -7,6 +7,7 @@ import {
 	useSetting,
 	useStyle,
 } from '@wordpress/edit-site/build-module/components/global-styles/hooks';
+import { translate } from 'i18n-calypso';
 import {
 	STYLE_PREVIEW_WIDTH,
 	STYLE_PREVIEW_HEIGHT,
@@ -15,7 +16,17 @@ import {
 import GlobalStylesVariationContainer from '../global-styles-variation-container';
 import type { Color } from '../../types';
 
-const ColorPaletteVariationPreview = () => {
+interface Props {
+	title?: string;
+}
+
+const ColorPaletteVariationPreview = ( { title }: Props ) => {
+	const [ fontWeight ] = useStyle( 'typography.fontWeight' );
+	const [ fontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
+	const [ headingFontFamily = fontFamily ] = useStyle( 'elements.h1.typography.fontFamily' );
+	const [ headingFontWeight = fontWeight ] = useStyle( 'elements.h1.typography.fontWeight' );
+	const [ textColor = 'black' ] = useStyle( 'color.text' );
+	const [ headingColor = textColor ] = useStyle( 'elements.h1.color.text' );
 	const [ backgroundColor = 'white' ] = useStyle( 'color.background' );
 	const [ gradientValue ] = useStyle( 'color.gradient' );
 	const [ themeColors ] = useSetting( 'color.palette.theme' );
@@ -50,28 +61,54 @@ const ColorPaletteVariationPreview = () => {
 						overflow: 'hidden',
 					} }
 				>
-					<HStack
-						spacing={ 10 * ratio }
-						justify="center"
-						style={ {
-							height: '100%',
-							overflow: 'hidden',
-						} }
-					>
-						<VStack spacing={ 4 * ratio }>
-							{ highlightedColors.map( ( color, index ) => (
-								<div
-									key={ index }
-									style={ {
-										height: STYLE_PREVIEW_COLOR_SWATCH_SIZE * ratio,
-										width: STYLE_PREVIEW_COLOR_SWATCH_SIZE * ratio,
-										background: color,
-										borderRadius: ( STYLE_PREVIEW_COLOR_SWATCH_SIZE * ratio ) / 2,
-									} }
-								/>
-							) ) }
+					{ title ? (
+						<HStack
+							spacing={ 10 * ratio }
+							justify="center"
+							style={ {
+								height: '100%',
+								overflow: 'hidden',
+							} }
+						>
+							<VStack spacing={ 4 * ratio }>
+								{ highlightedColors.map( ( color, index ) => (
+									<div
+										key={ index }
+										style={ {
+											height: STYLE_PREVIEW_COLOR_SWATCH_SIZE * ratio,
+											width: STYLE_PREVIEW_COLOR_SWATCH_SIZE * ratio,
+											background: color,
+											borderRadius: ( STYLE_PREVIEW_COLOR_SWATCH_SIZE * ratio ) / 2,
+										} }
+									/>
+								) ) }
+							</VStack>
+						</HStack>
+					) : (
+						<VStack
+							spacing={ 3 * ratio }
+							justify="center"
+							style={ {
+								height: '100%',
+								overflow: 'hidden',
+								padding: 10 * ratio,
+								boxSizing: 'border-box',
+							} }
+						>
+							<div
+								style={ {
+									fontSize: 40 * ratio,
+									fontFamily: headingFontFamily,
+									color: headingColor,
+									fontWeight: headingFontWeight,
+									lineHeight: '1em',
+									textAlign: 'center',
+								} }
+							>
+								{ translate( 'Default' ) }
+							</div>
 						</VStack>
-					</HStack>
+					) }
 				</div>
 			</div>
 		</GlobalStylesVariationContainer>

--- a/packages/global-styles/src/components/color-palette-variations/preview.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/preview.tsx
@@ -32,6 +32,7 @@ const ColorPaletteVariationPreview = ( { title }: Props ) => {
 	const [ themeColors ] = useSetting( 'color.palette.theme' );
 	const [ containerResizeListener, { width } ] = useResizeObserver();
 	const ratio = width ? width / STYLE_PREVIEW_WIDTH : 1;
+	const normalizedSwatchSize = STYLE_PREVIEW_COLOR_SWATCH_SIZE * ratio * 2;
 
 	const uniqueColors = [ ...new Set< string >( themeColors.map( ( { color }: Color ) => color ) ) ];
 	const highlightedColors = uniqueColors
@@ -70,19 +71,17 @@ const ColorPaletteVariationPreview = ( { title }: Props ) => {
 								overflow: 'hidden',
 							} }
 						>
-							<VStack spacing={ 4 * ratio }>
-								{ highlightedColors.map( ( color, index ) => (
-									<div
-										key={ index }
-										style={ {
-											height: STYLE_PREVIEW_COLOR_SWATCH_SIZE * ratio,
-											width: STYLE_PREVIEW_COLOR_SWATCH_SIZE * ratio,
-											background: color,
-											borderRadius: ( STYLE_PREVIEW_COLOR_SWATCH_SIZE * ratio ) / 2,
-										} }
-									/>
-								) ) }
-							</VStack>
+							{ highlightedColors.map( ( color, index ) => (
+								<div
+									key={ index }
+									style={ {
+										height: normalizedSwatchSize,
+										width: normalizedSwatchSize,
+										background: color,
+										borderRadius: normalizedSwatchSize / 2,
+									} }
+								/>
+							) ) }
 						</HStack>
 					) : (
 						<VStack

--- a/packages/global-styles/src/components/color-palette-variations/style.scss
+++ b/packages/global-styles/src/components/color-palette-variations/style.scss
@@ -1,14 +1,18 @@
 .color-palette-variations {
 	display: grid;
 	gap: 12px;
-	grid-template-columns: repeat(2, 1fr);
+	grid-template-columns: repeat(3, 1fr);
 	width: 100%;
 	box-sizing: border-box;
+
+	.global-styles-variation-container__iframe {
+		max-height: 50px;
+	}
 }
 
 .global-styles-variation__item {
 	position: relative;
-	margin: 3px;
+	margin: 2px;
 	cursor: pointer;
 
 	&:hover,
@@ -16,14 +20,14 @@
 	&.is-active {
 		&::after {
 			border-radius: 3px; /* stylelint-disable-line scales/radii */
-			bottom: -3px;
+			bottom: -2px;
 			content: "";
 			display: block;
-			left: -3px;
+			left: -2px;
 			pointer-events: none;
 			position: absolute;
-			right: -3px;
-			top: -3px;
+			right: -2px;
+			top: -2px;
 		}
 	}
 

--- a/packages/global-styles/src/components/font-pairing-variations/font-families-loader.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/font-families-loader.tsx
@@ -3,6 +3,7 @@ import type { FontFamily } from '../../types';
 
 interface Props {
 	fontFamilies: FontFamily[];
+	onLoad?: () => void;
 }
 
 // See https://developers.google.com/fonts/docs/css2
@@ -10,15 +11,11 @@ const FONT_API_BASE = 'https://fonts-api.wp.com/css2';
 
 const FONT_AXIS = 'ital,wght@0,400;0,700;1,400;1,700';
 
-const SYSTEM_FONT_SLUG = 'system-font';
-
-const FontFamiliesLoader = ( { fontFamilies }: Props ) => {
+const FontFamiliesLoader = ( { fontFamilies, onLoad }: Props ) => {
 	const params = useMemo(
 		() =>
 			new URLSearchParams( [
-				...fontFamilies
-					.filter( ( { slug } ) => slug !== SYSTEM_FONT_SLUG )
-					.map( ( { fontFamily } ) => [ 'family', `${ fontFamily }:${ FONT_AXIS }` ] ),
+				...fontFamilies.map( ( { fontFamily } ) => [ 'family', `${ fontFamily }:${ FONT_AXIS }` ] ),
 				[ 'display', 'swap' ],
 			] ),
 		fontFamilies
@@ -28,7 +25,14 @@ const FontFamiliesLoader = ( { fontFamilies }: Props ) => {
 		return null;
 	}
 
-	return <link rel="stylesheet" type="text/css" href={ `${ FONT_API_BASE }?${ params }` } />;
+	return (
+		<link
+			rel="stylesheet"
+			type="text/css"
+			href={ `${ FONT_API_BASE }?${ params }` }
+			onLoad={ onLoad }
+		/>
+	);
 };
 
 export default FontFamiliesLoader;

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -55,7 +55,7 @@ const FontPairingVariation = ( {
 				aria-current={ isActive }
 			>
 				<div className="global-styles-variation__item-preview">
-					<FontPairingVariationPreview />
+					<FontPairingVariationPreview title={ fontPairingVariation.title } />
 				</div>
 			</div>
 		</GlobalStylesContext.Provider>

--- a/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/preview.tsx
@@ -7,6 +7,7 @@ import {
 	useSetting,
 	useStyle,
 } from '@wordpress/edit-site/build-module/components/global-styles/hooks';
+import { translate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { STYLE_PREVIEW_WIDTH, STYLE_PREVIEW_HEIGHT } from '../../constants';
 import GlobalStylesVariationContainer from '../global-styles-variation-container';
@@ -19,7 +20,11 @@ const DEFAULT_FONT_STYLES: React.CSSProperties = {
 	textOverflow: 'ellipsis',
 };
 
-const FontPairingVariationPreview = () => {
+interface Props {
+	title?: string;
+}
+
+const FontPairingVariationPreview = ( { title }: Props ) => {
 	const [ fontFamilies ] = useSetting( 'typography.fontFamilies' );
 	const [ textFontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
 	const [ headingFontFamily = textFontFamily ] = useStyle(
@@ -67,43 +72,69 @@ const FontPairingVariationPreview = () => {
 							overflow: 'hidden',
 						} }
 					>
-						<HStack
-							spacing={ 10 * ratio }
-							justify="flex-start"
-							style={ {
-								height: '100%',
-								overflow: 'hidden',
-							} }
-						>
-							<VStack spacing={ 4 * ratio } style={ { margin: '16px' } }>
+						{ title ? (
+							<HStack
+								spacing={ 10 * ratio }
+								justify="flex-start"
+								style={ {
+									height: '100%',
+									overflow: 'hidden',
+								} }
+							>
+								<VStack spacing={ 4 * ratio } style={ { margin: '16px' } }>
+									<div
+										title={ headingFontFamilyName }
+										aria-label={ headingFontFamilyName }
+										style={ {
+											...DEFAULT_FONT_STYLES,
+											color: '#000000',
+											fontSize: '16px',
+											fontWeight: 400,
+											fontFamily: headingFontFamily,
+										} }
+									>
+										{ headingFontFamilyName }
+									</div>
+									<div
+										title={ textFontFamilyName }
+										aria-label={ textFontFamilyName }
+										style={ {
+											...DEFAULT_FONT_STYLES,
+											color: '#444444',
+											fontSize: '12px',
+											fontWeight: 400,
+											fontFamily: textFontFamily,
+										} }
+									>
+										{ textFontFamilyName }
+									</div>
+								</VStack>
+							</HStack>
+						) : (
+							<HStack
+								align="center"
+								justify="flex-start"
+								style={ {
+									height: '100%',
+									overflow: 'hidden',
+									padding: '16px',
+									boxSizing: 'border-box',
+								} }
+							>
 								<div
-									title={ headingFontFamilyName }
-									aria-label={ headingFontFamilyName }
 									style={ {
-										...DEFAULT_FONT_STYLES,
+										fontFamily: headingFontFamily,
 										color: '#000000',
 										fontSize: '16px',
 										fontWeight: 400,
-										fontFamily: headingFontFamily,
+										lineHeight: '1em',
+										textAlign: 'center',
 									} }
 								>
-									{ headingFontFamilyName }
+									{ translate( 'Default' ) }
 								</div>
-								<div
-									title={ textFontFamilyName }
-									aria-label={ textFontFamilyName }
-									style={ {
-										...DEFAULT_FONT_STYLES,
-										color: '#444444',
-										fontSize: '12px',
-										fontWeight: 400,
-										fontFamily: textFontFamily,
-									} }
-								>
-									{ textFontFamilyName }
-								</div>
-							</VStack>
-						</HStack>
+							</HStack>
+						) }
 					</div>
 				</div>
 				<FontFamiliesLoader fontFamilies={ fontFamilies } />

--- a/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/preview.tsx
@@ -8,8 +8,8 @@ import {
 	useStyle,
 } from '@wordpress/edit-site/build-module/components/global-styles/hooks';
 import { translate } from 'i18n-calypso';
-import { useMemo } from 'react';
-import { STYLE_PREVIEW_WIDTH, STYLE_PREVIEW_HEIGHT } from '../../constants';
+import { useMemo, useState } from 'react';
+import { STYLE_PREVIEW_WIDTH, STYLE_PREVIEW_HEIGHT, SYSTEM_FONT_SLUG } from '../../constants';
 import GlobalStylesVariationContainer from '../global-styles-variation-container';
 import FontFamiliesLoader from './font-families-loader';
 import type { FontFamily } from '../../types';
@@ -25,19 +25,18 @@ interface Props {
 }
 
 const FontPairingVariationPreview = ( { title }: Props ) => {
-	const [ fontFamilies ] = useSetting( 'typography.fontFamilies' );
+	const [ fontFamilies ] = useSetting( 'typography.fontFamilies' ) as [ FontFamily[] ];
 	const [ textFontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
 	const [ headingFontFamily = textFontFamily ] = useStyle(
 		'elements.heading.typography.fontFamily'
 	);
 	const [ containerResizeListener, { width } ] = useResizeObserver();
 	const ratio = width ? width / STYLE_PREVIEW_WIDTH : 1;
+	const externalFontFamilies = fontFamilies.filter( ( { slug } ) => slug !== SYSTEM_FONT_SLUG );
+	const [ isLoaded, setIsLoaded ] = useState( ! externalFontFamilies.length );
 
 	const getFontFamilyName = ( targetFontFamily: string ) => {
-		const fontFamily = fontFamilies.find(
-			( { fontFamily }: FontFamily ) => fontFamily === targetFontFamily
-		);
-
+		const fontFamily = fontFamilies.find( ( { fontFamily } ) => fontFamily === targetFontFamily );
 		return fontFamily ? fontFamily.name : targetFontFamily;
 	};
 
@@ -51,6 +50,8 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 		[ headingFontFamily, fontFamilies ]
 	);
 
+	const handleOnLoad = () => setIsLoaded( true );
+
 	return (
 		<GlobalStylesVariationContainer
 			width={ width }
@@ -63,6 +64,7 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 						height: STYLE_PREVIEW_HEIGHT * ratio,
 						width: '100%',
 						background: 'white',
+						opacity: isLoaded ? 1 : 0,
 						cursor: 'pointer',
 					} }
 				>
@@ -137,7 +139,7 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 						) }
 					</div>
 				</div>
-				<FontFamiliesLoader fontFamilies={ fontFamilies } />
+				<FontFamiliesLoader fontFamilies={ externalFontFamilies } onLoad={ handleOnLoad } />
 			</>
 		</GlobalStylesVariationContainer>
 	);

--- a/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/preview.tsx
@@ -32,6 +32,7 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 	);
 	const [ containerResizeListener, { width } ] = useResizeObserver();
 	const ratio = width ? width / STYLE_PREVIEW_WIDTH : 1;
+	const normalizedHeight = Math.ceil( STYLE_PREVIEW_HEIGHT * ratio );
 	const externalFontFamilies = fontFamilies.filter( ( { slug } ) => slug !== SYSTEM_FONT_SLUG );
 	const [ isLoaded, setIsLoaded ] = useState( ! externalFontFamilies.length );
 
@@ -55,13 +56,14 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 	return (
 		<GlobalStylesVariationContainer
 			width={ width }
-			ratio={ ratio }
+			height={ normalizedHeight }
 			containerResizeListener={ containerResizeListener }
 		>
 			<>
 				<div
 					style={ {
-						height: STYLE_PREVIEW_HEIGHT * ratio,
+						// Apply the normalized height only when the width is available
+						height: width ? normalizedHeight : 0,
 						width: '100%',
 						background: 'white',
 						opacity: isLoaded ? 1 : 0,

--- a/packages/global-styles/src/components/font-pairing-variations/style.scss
+++ b/packages/global-styles/src/components/font-pairing-variations/style.scss
@@ -4,6 +4,10 @@
 	grid-template-columns: repeat(2, 1fr);
 	width: 100%;
 	box-sizing: border-box;
+
+	.global-styles-variation-container__iframe {
+		max-height: 79px;
+	}
 }
 
 .global-styles-variation__item {

--- a/packages/global-styles/src/components/global-styles-variation-container/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variation-container/index.tsx
@@ -4,19 +4,18 @@ import {
 } from '@wordpress/block-editor';
 import { useGlobalStylesOutput } from '@wordpress/edit-site/build-module/components/global-styles/use-global-styles-output';
 import { useMemo } from 'react';
-import { STYLE_PREVIEW_HEIGHT } from '../../constants';
 import './style.scss';
 
 interface Props {
 	width: number | null;
-	ratio: number;
+	height: number;
 	containerResizeListener: JSX.Element;
 	children: JSX.Element;
 }
 
 const GlobalStylesVariationContainer = ( {
 	width,
-	ratio,
+	height,
 	containerResizeListener,
 	children,
 	...props
@@ -43,8 +42,8 @@ const GlobalStylesVariationContainer = ( {
 			className="global-styles-variation-container__iframe"
 			head={ <EditorStyles styles={ editorStyles } /> }
 			style={ {
-				height: Math.ceil( STYLE_PREVIEW_HEIGHT * ratio ),
-				visibility: ! width ? 'hidden' : 'visible',
+				height,
+				visibility: width ? 'visible' : 'hidden',
 			} }
 			tabIndex={ -1 }
 			{ ...props }

--- a/packages/global-styles/src/constants.ts
+++ b/packages/global-styles/src/constants.ts
@@ -1,3 +1,5 @@
 export const STYLE_PREVIEW_WIDTH = 248;
 export const STYLE_PREVIEW_HEIGHT = 152;
 export const STYLE_PREVIEW_COLOR_SWATCH_SIZE = 32;
+
+export const SYSTEM_FONT_SLUG = 'system-font';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1678141059396239/1677729706.837199-slack-CRWCHQGUB

## Proposed Changes

This PR is focusing on the refinement of the global styles on pattern assembler screen
* Added the copy to the above "Continue"/"Unlock this style" button
* Added the premium badge on the color & fonts screen
* Updated the style of the default variation
* Updated the style of the color variation, and avoided showing duplicate colors
* Updated descriptions on the color & fonts screen
* Delayed showing the font variation when the external fonts are loaded

https://user-images.githubusercontent.com/13596067/223389237-a263d499-6a36-4623-bbfe-eacb09fd807f.mov

![image](https://user-images.githubusercontent.com/13596067/223616437-174ec9be-92f2-4672-a0ef-2aacb6f6cbed.png)

![image](https://user-images.githubusercontent.com/13596067/223616541-c5598efa-e6a1-4439-89b8-43ab4f6c2322.png)

![image](https://user-images.githubusercontent.com/13596067/223616571-54788846-5bc8-4a64-adcb-91a417a8833c.png)

![image](https://user-images.githubusercontent.com/13596067/223616658-94b294fb-3b7a-4065-8970-492edae646ea.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/sidebar-revamp,pattern-assembler/color-and-fonts`
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Ensure there is a short description above the "Continue" button. Select any color or font variation, and ensure the description is changed.
  * Select "Change colors"
    * Ensure the premium badge is next to the title
    * Ensure the description is "Select from our curated color palettes or tweak to your heart’s content when you upgrade to the Premium plan or higher."
    * Ensure the default variation shows "Default"
    * Ensure the non-default variations show the new style
  * Select "Change fonts"
    * Ensure the premium badge is next to the title
    * Ensure the description is "Select from our hand-picked font pairings or expanded library when you upgrade to the Premium plan or higher."
    * Ensure you won't see the unstyled font family
    * Ensure the default variation shows "Default"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?