### PR TITLE
SMP: update submenu popover dimensions calculation

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -302,11 +302,7 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 					product_slug: site.plan?.product_slug,
 				} }
 			/>
-			<MenuItemLink
-				href={ getHostingConfigUrl( site.slug ) }
-				onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_hosting_config_click' ) }
-				info={ displayUpsell && __( 'Requires a Business Plan' ) }
-			>
+			<MenuItemLink info={ displayUpsell && __( 'Requires a Business Plan' ) }>
 				{ __( 'Hosting configuration' ) } <MenuItemGridIcon icon="chevron-right" size={ 18 } />
 			</MenuItemLink>
 			<SubmenuPopover


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/1896

## Proposed Changes

* Calculate the right space submenu dynamically to avoid cutting the SMP upsell 
* Remove the Hosting configuration submenu link on SMP. It was conflicting on mobile platforms and keyboard navigation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set your browser's width to `2000px`.
* Navigate to `/sites`.
* Find a free site.
* Click on the actions menu (three dots).
* Put the mouse over the Hosting configuration.
* Observe the upsell submenu appears on the left. On the right would overflow the screen.
* Click on Hosting configuration.
* Observe you are not redirected.

### Screenshots

| **Before** | **After** |
|---|---|
| <img width="434" alt="before-submenu-right-space" src="https://user-images.githubusercontent.com/779993/223462327-96fd8851-ef7c-486b-9cc0-6f5c1d0f5265.png"> | <img width="654" alt="after-submenu-right-space" src="https://user-images.githubusercontent.com/779993/223462313-9a9983d4-f9f4-462e-8da1-d657a373beb4.png"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
