### PR TITLE
Revert "Plugins: Redirect to /plans when on the commerce trial (#73953)"

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -7,9 +7,7 @@ import { getSiteFragment, sectionify } from 'calypso/lib/route';
 import { navigation } from 'calypso/my-sites/controller';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
-import { fetchSitePlans } from 'calypso/state/sites/plans/actions';
-import { isSiteOnECommerceTrial, getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { ALLOWED_CATEGORIES } from './categories/use-categories';
 import PlanSetup from './jetpack-plugins-setup';
 import PluginListComponent from './main';
@@ -137,44 +135,6 @@ export function jetpackCanUpdate( context, next ) {
 			return;
 		}
 	}
-	next();
-}
-
-function waitForState( context ) {
-	return new Promise( ( resolve ) => {
-		const unsubscribe = context.store.subscribe( () => {
-			const state = context.store.getState();
-
-			const siteId = getSelectedSiteId( state );
-			if ( ! siteId ) {
-				return;
-			}
-
-			const currentPlan = getCurrentPlan( state, siteId );
-			if ( ! currentPlan ) {
-				return;
-			}
-			unsubscribe();
-			resolve();
-		} );
-		// Trigger a `store.subscribe()` callback
-		context.store.dispatch( fetchSitePlans( getSelectedSiteId( context.store.getState() ) ) );
-	} );
-}
-
-export async function redirectTrialSites( context, next ) {
-	const { store } = context;
-	// Make sure state is populated with plan info
-	await waitForState( context );
-	const state = store.getState();
-	const selectedSite = getSelectedSite( state );
-
-	// If the site is on an ecommerce trial, redirect to the plans page
-	if ( isSiteOnECommerceTrial( state, selectedSite?.ID ) ) {
-		page.redirect( `/plans/${ selectedSite.slug }` );
-		return false;
-	}
-
 	next();
 }
 

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -14,7 +14,6 @@ import {
 	renderProvisionPlugins,
 	jetpackCanUpdate,
 	plugins,
-	redirectTrialSites,
 	scrollTopIfNoHash,
 	navigationIfLoggedIn,
 	maybeRedirectLoggedOut,
@@ -42,7 +41,6 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		renderProvisionPlugins,
-		redirectTrialSites,
 		makeLayout,
 		clientRender
 	);
@@ -54,7 +52,6 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigationIfLoggedIn,
-		redirectTrialSites,
 		browsePlugins,
 		makeLayout,
 		clientRender
@@ -77,7 +74,6 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
-		redirectTrialSites,
 		upload,
 		makeLayout,
 		clientRender
@@ -103,7 +99,6 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
-		redirectTrialSites,
 		plans,
 		makeLayout,
 		clientRender
@@ -116,7 +111,6 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
-		redirectTrialSites,
 		plugins,
 		makeLayout,
 		clientRender
@@ -129,7 +123,6 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
-		redirectTrialSites,
 		jetpackCanUpdate,
 		plugins,
 		makeLayout,
@@ -143,7 +136,6 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigationIfLoggedIn,
-		redirectTrialSites,
 		browsePluginsOrPlugin,
 		makeLayout,
 		clientRender
@@ -156,7 +148,6 @@ export default function ( router ) {
 		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
-		redirectTrialSites,
 		renderPluginWarnings,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
This reverts commit e8f649cb199af8594afbd7672a785278de7202d5.

Context: p1678204038150439-slack-C029JEQRVRT

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?