### PR TITLE
Launchpad: Remove unused Sensei code

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -1,12 +1,6 @@
 import { FEATURE_VIDEO_UPLOADS, planHasFeature } from '@automattic/calypso-products';
 import { DEVICE_TYPES } from '@automattic/components';
-import {
-	FREE_FLOW,
-	NEWSLETTER_FLOW,
-	BUILD_FLOW,
-	WRITE_FLOW,
-	SENSEI_FLOW,
-} from '@automattic/onboarding';
+import { FREE_FLOW, NEWSLETTER_FLOW, BUILD_FLOW, WRITE_FLOW } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import WebPreview from 'calypso/components/web-preview/component';
@@ -28,7 +22,6 @@ const LaunchpadSitePreview = ( {
 	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 	const site = useSite();
 	const isInVideoPressFlow = isVideoPressFlow( flow );
-	const isSenseiFlow = SENSEI_FLOW === flow;
 
 	let previewUrl = siteSlug ? 'https://' + siteSlug : null;
 	const devicesToShow: Device[] = [ DEVICE_TYPES.COMPUTER, DEVICE_TYPES.PHONE ];
@@ -37,7 +30,7 @@ const LaunchpadSitePreview = ( {
 		components: { strong: <strong /> },
 	} );
 
-	if ( isInVideoPressFlow || isSenseiFlow ) {
+	if ( isInVideoPressFlow ) {
 		const windowWidth = window.innerWidth;
 		defaultDevice = windowWidth >= 1000 ? DEVICE_TYPES.COMPUTER : DEVICE_TYPES.PHONE;
 		const productSlug = site?.plan?.product_slug;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -316,27 +316,6 @@ export function getEnhancedTasks(
 						},
 					};
 					break;
-				case 'sensei_setup':
-					taskData = {
-						title: translate( 'Set up Course Site' ),
-						completed: true,
-					};
-					break;
-				case 'sensei_publish_first_course':
-					taskData = {
-						title: translate( 'Publish your first Course' ),
-						completed:
-							site?.options?.launchpad_checklist_tasks_statuses?.publish_first_course || false,
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.assign(
-								addQueryArgs( `${ site?.URL }/wp-admin/post-new.php?`, {
-									post_type: 'course',
-								} )
-							);
-						},
-					};
-					break;
 				case 'domain_upsell':
 					taskData = {
 						title: translate( 'Choose a domain' ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -71,18 +71,6 @@ export const tasks: Task[] = [
 		disabled: true,
 	},
 	{
-		id: 'sensei_setup',
-		completed: true,
-		taskType: 'blog',
-		disabled: true,
-	},
-	{
-		id: 'sensei_publish_first_course',
-		completed: false,
-		taskType: 'blog',
-		disabled: false,
-	},
-	{
 		id: 'setup_free',
 		completed: true,
 		disabled: false,
@@ -156,5 +144,4 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 		'site_launched',
 	],
 	videopress: [ 'videopress_setup', 'plan_selected', 'videopress_upload', 'videopress_launched' ],
-	sensei: [ 'sensei_setup', 'plan_selected', 'sensei_publish_first_course' ],
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -3,7 +3,6 @@ import {
 	LINK_IN_BIO_TLD_FLOW,
 	NEWSLETTER_FLOW,
 	VIDEOPRESS_FLOW,
-	SENSEI_FLOW,
 	FREE_FLOW,
 } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
@@ -45,11 +44,6 @@ export function getLaunchpadTranslations( flow: string | null ): TranslatedLaunc
 			translatedStrings.flowName = translate( 'Video' );
 			translatedStrings.title = translate( 'Your site is almost ready!' );
 			translatedStrings.launchTitle = translate( 'Your site is almost ready!' );
-			break;
-		case SENSEI_FLOW:
-			translatedStrings.flowName = translate( 'Sensei' );
-			translatedStrings.title = translate( 'Your Course Site is ready to launch!' );
-			translatedStrings.launchTitle = translate( 'Your Course Site is ready to launch!' );
 			break;
 	}
 


### PR DESCRIPTION
### Proposed Changes

The Sensei flow no longer uses the launchpad screen. This PR simply removed unused, Sensei-related code from Launchpad files. 

### Testing

**Review Time: Short**
**Testing Time: Short**

There should be no differences in Launchpad behavior before and after this PR. 

For review, confirm that Sensei related code has been removed cleanly, in a way that will not impact other flows. 

For testing, pick 1-2 flows (link in bio, newsletter, free, videopress, write, build, etc), and go through them to smoke test and confirm no issues. 
