### PR TITLE
Jetpack Connection: fix checkout flow for new WPCOM users

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -128,6 +128,16 @@ export function redirectLoggedOut( context, next ) {
 		loginParameters.locale = login_locale;
 	}
 
+	const queryParams = Object.fromEntries( new URLSearchParams( window.location.search ) );
+	if (
+		'1' === queryParams?.unlinked &&
+		loginParameters.redirectTo &&
+		loginParameters.redirectTo.startsWith( '/checkout/' )
+	) {
+		loginParameters.isJetpack = true;
+		loginParameters.redirectTo = 'https://wordpress.com' + loginParameters.redirectTo;
+	}
+
 	// force full page reload to avoid SSR hydration issues.
 	window.location = login( loginParameters );
 	return;

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -128,9 +128,8 @@ export function redirectLoggedOut( context, next ) {
 		loginParameters.locale = login_locale;
 	}
 
-	const queryParams = Object.fromEntries( new URLSearchParams( window.location.search ) );
 	if (
-		'1' === queryParams?.unlinked &&
+		'1' === context.query?.unlinked &&
 		loginParameters.redirectTo &&
 		loginParameters.redirectTo.startsWith( '/checkout/' )
 	) {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -441,15 +441,22 @@ export function siteSelection( context, next ) {
 	const currentUser = getCurrentUser( getState() );
 	const hasOneSite = currentUser && currentUser.visible_site_count === 1;
 
+	// Making sure non-connected users get redirected to user connection flow.
+	// Details: p9dueE-6Hf-p2
+	const isUnlinkedCheckout =
+		'1' === context.query?.unlinked &&
+		context.pathname.match( /^\/checkout\/[^/]+\/jetpack_/i ) &&
+		! context.pathname.includes( 'jetpack_boost' );
+
 	// The user doesn't have any sites: render `NoSitesMessage`
-	if ( currentUser && currentUser.site_count === 0 ) {
+	if ( currentUser && currentUser.site_count === 0 && ! isUnlinkedCheckout ) {
 		renderEmptySites( context );
 		recordNoSitesPageView( context, siteFragment );
 		return;
 	}
 
 	// The user has all sites set as hidden: render help message with how to make them visible
-	if ( currentUser && currentUser.visible_site_count === 0 ) {
+	if ( currentUser && currentUser.visible_site_count === 0 && ! isUnlinkedCheckout ) {
 		renderNoVisibleSites( context );
 		recordNoVisibleSitesPageView( context, siteFragment );
 		return;
@@ -500,13 +507,6 @@ export function siteSelection( context, next ) {
 	}
 
 	const siteId = getSiteId( getState(), siteFragment );
-
-	// Making sure non-connected users get redirected to user connection flow.
-	// Details: p9dueE-6Hf-p2
-	const isUnlinkedCheckout =
-		'1' === context.query?.unlinked &&
-		context.pathname.match( /^\/checkout\/[^/]+\/jetpack_/i ) &&
-		! context.pathname.includes( 'jetpack_boost' );
 
 	if ( siteId && ! isUnlinkedCheckout ) {
 		// onSelectedSiteAvailable might render an error page about domain-only sites or redirect


### PR DESCRIPTION
## Proposed Changes
Connection-signup-checkout flow is broken for Jetpack standalone plugins.
This PR modifies Calypso code to overcome the problem, and redirect users where needed so they would stay in the flow.

The discussion: p1678203806521239-slack-C0299DMPG

## Testing Instructions
It's a bit hard to test, so hold on to your seat.

1. Log out of both wordpress.com and http://calypso.localhost:3000/
2. Disconnect your Jetpack site, install Jetpack Backup plugin.
3. Open JS file `wp-content/plugins/jetpack-backup/jetpack_vendor/automattic/jetpack-backup/build/index.js` and replace `https://wordpress.com/checkout/` with `http://calypso.localhost:3000/checkout/`.
4. Go to Jetpack Backup dashboard, click "Get VaultPress Backup". Confirm that you got redirected to the page `/log-in/jetpack`.
5. Enter a new email for a new WPCOM account, submit the form. You should see the "Check your email" screen.
6. Follow the link from the email, on WPCOM go to "Profile -> Security" and set a password.
7. Load `http://calypso.localhost:3000` and login under that user.
8. Open this URL (fill your domain name in two places):
```
calypso.localhost:3000/checkout/your-domain-name.com/jetpack_backup_t1_yearly?redirect_to=admin.php%3Fpage%3Djetpack-backup&unlinked=1&site=your-domain-name.com
```
9. You should see the "Approve" screen, click "Approve".
10. You should end up on the wp-admin Dashboard. This is fine, you'll get redirected to checkout after the PR is deployed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
