### PR TITLE
Site Editor: fix template sidebar navigation

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -698,7 +698,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 		}
 	} );
 	const popoverSlotElem = document.querySelector( '.interface-interface-skeleton ~ .popover-slot' );
-	popoverSlotObserver.observe( popoverSlotElem, { childList: true } );
+	popoverSlotElem && popoverSlotObserver.observe( popoverSlotElem, { childList: true } );
 
 	// Sidebar might already be open before this script is executed.
 	// post and site editors

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1037,7 +1037,7 @@ function handleSiteEditorBackButton( calypsoPort ) {
 	// have to do this event delegation style because the Editor isn't fully initialized yet.
 	document.getElementById( 'wpwrap' ).addEventListener( 'click', ( event ) => {
 		const dashboardLink = select( 'core/edit-site' )?.getSettings?.().__experimentalDashboardLink;
-		// The link has changed. Pray it doesn't change again.
+		// The link has changed. Pray it doesn't change any further.
 		// This is how to find it in Gutenberg 15.2.
 		const isDashboardLink = traverseToFindLink( event.target, dashboardLink );
 


### PR DESCRIPTION
The fix in #74026 introduced a bug where no matter the level of nesting in the Site Editor nav sidebar, clicking the arrow button returns us to Calypso:

https://user-images.githubusercontent.com/195089/223567740-d20b8217-8edf-44c8-a253-4268616e37b0.mov



## Proposed Changes

* better handling of link detection
* get rid of old outdated forms of link detection
* unrelated fix I saw while testing in 9213231abc9eb0c563dfde99cfda7139c175f70a

## Testing Instructions

0. sandbox `widgets.wp.com` and the site whose Site Editor you will test
1. Run `install-plugin.sh wbe fix/site-editor-template-sidebar-navigation` on your sandbox.
2. Click into the nav sidebar as in the video above. Only the top-level link should take you back to the Calypso dashboard.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
