### PR TITLE
Pattern Assembler - Remove flag pattern-assembler/write-flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -56,11 +56,7 @@ import type { StarterDesigns } from '@automattic/data-stores';
 import type { Design, StyleVariation } from '@automattic/design-picker';
 
 const SiteIntent = Onboard.SiteIntent;
-const SITE_ASSEMBLER_AVAILABLE_INTENTS: string[] = [ SiteIntent.Build ];
-
-if ( isEnabled( 'pattern-assembler/write-flow' ) ) {
-	SITE_ASSEMBLER_AVAILABLE_INTENTS.push( SiteIntent.Write );
-}
+const SITE_ASSEMBLER_AVAILABLE_INTENTS: string[] = [ SiteIntent.Build, SiteIntent.Write ];
 
 const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const { goBack, submit, exitFlow } = navigation;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Onboard } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -20,15 +19,11 @@ const useHeaderPatterns = () => {
 				category: header,
 				category_slug: 'header',
 			},
-			/*
-		Discarded because there is a menu option named Blog
-		and for now the blogger flow is not supported
-		{
-			id: 5608,
-			name: 'Centered header with logo and navigation',
-			category: header,
-		},
-		*/
+			{
+				id: 5608,
+				name: 'Centered header with logo and navigation',
+				category: header,
+			},
 			{
 				id: 5582,
 				name: 'Simple header',
@@ -542,24 +537,20 @@ const useSectionPatterns = () => {
 				category_slug: 'posts',
 			},
 		];
-		if ( isEnabled( 'pattern-assembler/write-flow' ) ) {
-			if ( intent === SiteIntent.Write ) {
-				// In the Write flow, move posts patterns to the first position
-				patterns = patterns.sort( ( a, b ) => {
-					if ( a.category === b.category ) {
-						return 0;
-					} else if ( a.category === posts ) {
-						return -1;
-					} else if ( b.category === posts ) {
-						return 1;
-					}
 
+		if ( intent === SiteIntent.Write ) {
+			// In the Write flow, move posts patterns to the first position
+			patterns = patterns.sort( ( a, b ) => {
+				if ( a.category === b.category ) {
 					return 0;
-				} );
-			}
-		} else {
-			// Remove posts patterns
-			patterns = patterns.filter( ( { category } ) => category !== posts );
+				} else if ( a.category === posts ) {
+					return -1;
+				} else if ( b.category === posts ) {
+					return 1;
+				}
+
+				return 0;
+			} );
 		}
 
 		return patterns;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -23,6 +23,7 @@ const useHeaderPatterns = () => {
 				id: 5608,
 				name: 'Centered header with logo and navigation',
 				category: header,
+				category_slug: 'header',
 			},
 			{
 				id: 5582,

--- a/config/development.json
+++ b/config/development.json
@@ -131,7 +131,6 @@
 		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/sidebar-revamp": true,
-		"pattern-assembler/write-flow": true,
 		"pattern-assembler/inline-styles": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -83,7 +83,6 @@
 		"pattern-assembler/color-and-fonts": false,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/sidebar-revamp": true,
-		"pattern-assembler/write-flow": true,
 		"pattern-assembler/inline-styles": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,

--- a/config/production.json
+++ b/config/production.json
@@ -98,7 +98,6 @@
 		"pattern-assembler/color-and-fonts": false,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/sidebar-revamp": true,
-		"pattern-assembler/write-flow": true,
 		"pattern-assembler/inline-styles": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -96,7 +96,6 @@
 		"pattern-assembler/color-and-fonts": false,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/sidebar-revamp": true,
-		"pattern-assembler/write-flow": true,
 		"pattern-assembler/inline-styles": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -106,7 +106,6 @@
 		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/sidebar-revamp": true,
-		"pattern-assembler/write-flow": true,
 		"pattern-assembler/inline-styles": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/72144 https://github.com/Automattic/wp-calypso/pull/74060

## Proposed Changes

* Remove pattern-assembler/write-flow 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click on the Calypso live link on the first comment
* Create a new site
* On the goals screen, choose `Write and publish`
* Continue until the Design Picker and scroll down to click `Start designing`
* Add sections
* Check that posts patterns are in the first position
* Go back to the goals screen and don't choose any goal
* Verify that the posts patterns aren't in the first position 
* Continue to verify that patterns are added to a Home template on your site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?