### PR TITLE
Site Assembler: Enable pattern-assembler/sidebar-revamp flag on production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -83,7 +83,7 @@
 		"p2/p2-plus": true,
 		"pattern-assembler/color-and-fonts": false,
 		"pattern-assembler/logged-out-showcase": true,
-		"pattern-assembler/sidebar-revamp": false,
+		"pattern-assembler/sidebar-revamp": true,
 		"pattern-assembler/write-flow": true,
 		"pattern-assembler/inline-styles": false,
 		"plans/personal-plan": true,

--- a/config/production.json
+++ b/config/production.json
@@ -98,7 +98,7 @@
 		"p2/p2-plus": true,
 		"pattern-assembler/color-and-fonts": false,
 		"pattern-assembler/logged-out-showcase": true,
-		"pattern-assembler/sidebar-revamp": false,
+		"pattern-assembler/sidebar-revamp": true,
 		"pattern-assembler/write-flow": true,
 		"pattern-assembler/inline-styles": false,
 		"plans/personal-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -96,7 +96,7 @@
 		"page/export": true,
 		"pattern-assembler/color-and-fonts": false,
 		"pattern-assembler/logged-out-showcase": true,
-		"pattern-assembler/sidebar-revamp": false,
+		"pattern-assembler/sidebar-revamp": true,
 		"pattern-assembler/write-flow": true,
 		"pattern-assembler/inline-styles": false,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -106,7 +106,7 @@
 		"p2/p2-plus": true,
 		"pattern-assembler/color-and-fonts": false,
 		"pattern-assembler/logged-out-showcase": true,
-		"pattern-assembler/sidebar-revamp": false,
+		"pattern-assembler/sidebar-revamp": true,
 		"pattern-assembler/write-flow": true,
 		"pattern-assembler/inline-styles": false,
 		"plans/personal-plan": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-1eO-p2

## Proposed Changes

* Deploy the sidebar revamp to users

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the Testing section from pdtkmj-1eO-p2

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?