### PR TITLE
Contact form: change the query sent to the Q&A endpoint

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -151,7 +151,7 @@ export class HelpContactForm extends PureComponent {
 		} );
 	};
 
-	getSibylQuery = () => ( this.state.subject + ' ' + this.state.message ).trim();
+	getSibylQuery = () => this.state.message.trim();
 
 	doRequestSite = () => {
 		if ( resemblesUrl( this.state.userDeclaredUrl ) ) {


### PR DESCRIPTION
## Proposed Changes

* In the support contact form: don't send the message subject as part of the q&a search.
Results seem to be worse than when only the message itself is sent (see pbvpgB-2MS-p2)

## Testing Instructions
* Visit /help/contact
* Fill in the subject and message
* Check the network request going to the `help/qanda` endpoint only contains the message string.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?