### PR TITLE
Fix/wpcc login

### DIFF
--- a/client/blocks/follow-button/index.jsx
+++ b/client/blocks/follow-button/index.jsx
@@ -1,7 +1,11 @@
+import { getUrlParts } from '@automattic/calypso-url';
 import { omitBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { navigate } from 'calypso/lib/navigate';
+import { createAccountUrl } from 'calypso/lib/paths';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { follow, unfollow } from 'calypso/state/reader/follows/actions';
 import { isFollowing } from 'calypso/state/reader/follows/selectors';
 import FollowButton from './button';
@@ -26,6 +30,10 @@ class FollowButtonContainer extends Component {
 	};
 
 	handleFollowToggle = ( following ) => {
+		if ( ! this.props.isLoggedIn ) {
+			const { pathname } = getUrlParts( window.location.href );
+			return navigate( createAccountUrl( { redirectTo: pathname } ) );
+		}
 		if ( following ) {
 			const followData = omitBy(
 				{
@@ -63,6 +71,7 @@ class FollowButtonContainer extends Component {
 export default connect(
 	( state, ownProps ) => ( {
 		following: isFollowing( state, { feedUrl: ownProps.siteUrl } ),
+		isLoggedIn: isUserLoggedIn( state ),
 	} ),
 	{
 		follow,

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -1,10 +1,14 @@
+import { getUrlParts } from '@automattic/calypso-url';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { omitBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { createElement, PureComponent } from 'react';
+import { connect } from 'react-redux';
+import { navigate } from 'calypso/lib/navigate';
+import { createAccountUrl } from 'calypso/lib/paths';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import LikeIcons from './icons';
-
 import './style.scss';
 
 class LikeButton extends PureComponent {
@@ -42,6 +46,10 @@ class LikeButton extends PureComponent {
 	}
 
 	toggleLiked( event ) {
+		if ( ! this.props.isLoggedIn ) {
+			const { pathname } = getUrlParts( window.location.href );
+			return navigate( createAccountUrl( { redirectTo: pathname } ) );
+		}
 		if ( event ) {
 			event.preventDefault();
 		}
@@ -102,4 +110,6 @@ class LikeButton extends PureComponent {
 	}
 }
 
-export default localize( LikeButton );
+export default connect( ( state ) => ( {
+	isLoggedIn: isUserLoggedIn( state ),
+} ) )( localize( LikeButton ) );

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -16,6 +16,7 @@ import { READER_POST_OPTIONS_MENU } from 'calypso/reader/follow-sources';
 import { canBeMarkedAsSeen, isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import * as stats from 'calypso/reader/stats';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import * as PostUtils from 'calypso/state/posts/utils';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { hasReaderFollowOrganization } from 'calypso/state/reader/follows/selectors';
@@ -251,6 +252,7 @@ class ReaderPostEllipsisMenu extends Component {
 			isWPForTeamsItem,
 			currentRoute,
 			hasOrganization,
+			isLoggedIn,
 		} = this.props;
 
 		const { ID: postId, site_ID: siteId } = post;
@@ -259,6 +261,10 @@ class ReaderPostEllipsisMenu extends Component {
 		const isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
 
 		let isBlockPossible = false;
+
+		if ( ! isLoggedIn ) {
+			return null;
+		}
 
 		// Should we show the 'block' option?
 		if (
@@ -360,6 +366,7 @@ export default connect(
 		return Object.assign(
 			{ currentRoute: getCurrentRoute( state ) },
 			{ isWPForTeamsItem: isSiteWPForTeams( state, siteId ) || isFeedWPForTeams( state, feedId ) },
+			{ isLoggedIn: isUserLoggedIn( state ) },
 			{
 				hasOrganization: hasReaderFollowOrganization( state, feedId, siteId ),
 			}

--- a/client/components/data/sync-reader-follows/index.js
+++ b/client/components/data/sync-reader-follows/index.js
@@ -1,11 +1,12 @@
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { requestFollows } from 'calypso/state/reader/follows/actions';
 import shouldSyncReaderFollows from 'calypso/state/selectors/should-sync-reader-follows';
 
 class SyncReaderFollows extends Component {
 	check() {
-		if ( this.props.shouldSync ) {
+		if ( this.props.isLoggedIn && this.props.shouldSync ) {
 			this.props.requestFollows();
 		}
 	}
@@ -26,6 +27,7 @@ class SyncReaderFollows extends Component {
 export default connect(
 	( state ) => ( {
 		shouldSync: shouldSyncReaderFollows( state ),
+		isLoggedIn: isUserLoggedIn( state ),
 	} ),
 	{ requestFollows }
 )( SyncReaderFollows );

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -75,6 +75,7 @@ export const ssrSetupLocale = ssrSetupLocaleMiddleware();
  * These functions are not used by Node. It is here to provide an APi compatible with `./index.web.js`
  */
 export const redirectLoggedOut = () => {};
+export const redirectLoggedOutToSignup = () => {};
 export const redirectWithoutLocaleParamIfLoggedIn = () => {};
 // eslint-disable-next-line no-unused-vars
 export const render = ( context ) => {};

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -10,7 +10,7 @@ import MomentProvider from 'calypso/components/localized-moment/provider';
 import { RouteProvider } from 'calypso/components/route';
 import Layout from 'calypso/layout';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
-import { login } from 'calypso/lib/paths';
+import { login, createAccountUrl } from 'calypso/lib/paths';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import { getSiteFragment } from 'calypso/lib/route';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -130,6 +130,25 @@ export function redirectLoggedOut( context, next ) {
 
 	// force full page reload to avoid SSR hydration issues.
 	window.location = login( loginParameters );
+	return;
+}
+
+/**
+ * Middleware to redirect logged out users to create an account.
+ * Designed for use in situations where no site is selected, such as the reader.
+ *
+ * @param   {Object}   context Context object
+ * @param   {Function} next    Calls next middleware
+ * @returns {void}
+ */
+export function redirectLoggedOutToSignup( context, next ) {
+	const state = context.store.getState();
+	if ( isUserLoggedIn( state ) ) {
+		next();
+		return;
+	}
+
+	window.location = createAccountUrl( { redirectTo: context.path } );
 	return;
 }
 

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -100,9 +100,12 @@ const LayoutLoggedOut = ( {
 		}
 	} else if ( config.isEnabled( 'jetpack-cloud' ) || isWpMobileApp() || isJetpackThankYou ) {
 		masterbar = null;
-	} else if ( sectionName === 'plugins' ) {
-		masterbar = <UniversalNavbarHeader />;
-	} else if ( sectionName === 'themes' || sectionName === 'theme' ) {
+	} else if (
+		sectionName === 'plugins' ||
+		sectionName === 'themes' ||
+		sectionName === 'theme' ||
+		sectionName === 'reader'
+	) {
 		masterbar = <UniversalNavbarHeader />;
 	} else {
 		masterbar = (

--- a/client/layout/universal-navbar-header/nav-style.scss
+++ b/client/layout/universal-navbar-header/nav-style.scss
@@ -29,7 +29,8 @@ $studio-blue-30: #0675c4;
 }
 
 .is-section-themes,
-.is-section-theme {
+.is-section-theme,
+.is-section-reader {
 	&.has-no-sidebar {
 		.masterbar {
 			height: 56px;

--- a/client/layout/universal-navbar-header/nav-style.scss
+++ b/client/layout/universal-navbar-header/nav-style.scss
@@ -32,15 +32,23 @@ $studio-blue-30: #0675c4;
 .is-section-theme,
 .is-section-reader {
 	&.has-no-sidebar {
-		.masterbar {
-			height: 56px;
-			position: relative;
-			background: $studio-blue-15;
-			border-bottom: 1px solid $studio-blue-15;
-			.x-nav {
+		.masterbar-menu {
+			.masterbar {
 				height: 56px;
+				position: relative;
+				background: $studio-blue-15;
+				border-bottom: 1px solid $studio-blue-15;
+				.x-nav {
+					height: 56px;
+				}
 			}
 		}
+	}
+}
+
+.is-section-themes,
+.is-section-theme {
+	&.has-no-sidebar {
 		.layout__content {
 			overflow: visible;
 		}

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -123,6 +123,19 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 		signupUrl = `/start/account?${ params.toString() }`;
 	}
 
+	/**
+	 *  Include redirects to public.api/connect/?action=verify&service={some service}
+	 *  If the signup is from the Highlander Comments flow, the signup page will be in a popup modal
+	 *  We need to redirect back to public.api/connect/ to do an external login and close modal
+	 *  Ref: PCYsg-Hfw-p2
+	 */
+	if ( includes( redirectTo, 'public.api/connect/?action=verify' ) ) {
+		const params = new URLSearchParams( {
+			redirect_to: redirectTo,
+		} );
+		signupUrl = `/start/account?${ params.toString() }`;
+	}
+
 	return signupUrl;
 }
 

--- a/client/lib/paths/index.js
+++ b/client/lib/paths/index.js
@@ -21,3 +21,7 @@ export function newPost( site ) {
 	const sitePath = editorPathFromSite( site );
 	return '/post' + sitePath;
 }
+
+export function createAccountUrl( { redirectTo } ) {
+	return `/start/account?redirect_to=${ redirectTo }`;
+}

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -9,6 +9,7 @@ import StreamComponent from 'calypso/reader/following/main';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { getPrettyFeedUrl, getPrettySiteUrl } from 'calypso/reader/route';
 import { recordTrack } from 'calypso/reader/stats';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getLastPath } from 'calypso/state/reader-ui/selectors';
 import { toggleReaderSidebarFollowing } from 'calypso/state/reader-ui/sidebar/actions';
 import { isFollowingOpen } from 'calypso/state/reader-ui/sidebar/selectors';
@@ -96,9 +97,12 @@ export function incompleteUrlRedirects( context, next ) {
 }
 
 export function sidebar( context, next ) {
-	context.secondary = (
-		<AsyncLoad require="calypso/reader/sidebar" path={ context.path } placeholder={ null } />
-	);
+	const state = context.store.getState();
+	if ( isUserLoggedIn( state ) ) {
+		context.secondary = (
+			<AsyncLoad require="calypso/reader/sidebar" path={ context.path } placeholder={ null } />
+		);
+	}
 
 	next();
 }

--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -1,5 +1,5 @@
 import page from 'page';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'calypso/controller';
+import { makeLayout, redirectLoggedOutToSignup, render as clientRender } from 'calypso/controller';
 import { updateLastRoute, unmountSidebar, blogDiscoveryByFeedId } from 'calypso/reader/controller';
 import { blogPost, feedPost } from './controller';
 
@@ -8,7 +8,7 @@ export default function () {
 	page(
 		'/read/feeds/:feed/posts/:post',
 		blogDiscoveryByFeedId,
-		redirectLoggedOut,
+		redirectLoggedOutToSignup,
 		updateLastRoute,
 		unmountSidebar,
 		feedPost,
@@ -19,7 +19,7 @@ export default function () {
 	// Blog full post
 	page(
 		'/read/blogs/:blog/posts/:post',
-		redirectLoggedOut,
+		redirectLoggedOutToSignup,
 		updateLastRoute,
 		unmountSidebar,
 		blogPost,

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -1,7 +1,12 @@
 import config from '@automattic/calypso-config';
 import page from 'page';
 import { addMiddleware } from 'redux-dynamic-middlewares';
-import { makeLayout, redirectLoggedOut, render as clientRender } from 'calypso/controller';
+import {
+	makeLayout,
+	redirectLoggedOut,
+	redirectLoggedOutToSignup,
+	render as clientRender,
+} from 'calypso/controller';
 import {
 	blogListing,
 	feedDiscovery,
@@ -40,7 +45,7 @@ export default async function () {
 	if ( config.isEnabled( 'reader' ) ) {
 		page(
 			'/read',
-			redirectLoggedOut,
+			redirectLoggedOutToSignup,
 			updateLastRoute,
 			sidebar,
 			following,
@@ -62,7 +67,7 @@ export default async function () {
 		page(
 			'/read/feeds/:feed_id',
 			blogDiscoveryByFeedId,
-			redirectLoggedOut,
+			redirectLoggedOutToSignup,
 			updateLastRoute,
 			prettyRedirects,
 			sidebar,
@@ -77,7 +82,7 @@ export default async function () {
 		page( '/read/blogs/:blog_id/posts', incompleteUrlRedirects );
 		page(
 			'/read/blogs/:blog_id',
-			redirectLoggedOut,
+			redirectLoggedOutToSignup,
 			updateLastRoute,
 			prettyRedirects,
 			sidebar,

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -1,3 +1,4 @@
+import { getUrlParts } from '@automattic/calypso-url';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
@@ -6,10 +7,13 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryReaderFollowedTags from 'calypso/components/data/query-reader-followed-tags';
 import QueryReaderTag from 'calypso/components/data/query-reader-tag';
+import { navigate } from 'calypso/lib/navigate';
+import { createAccountUrl } from 'calypso/lib/paths';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import HeaderBack from 'calypso/reader/header-back';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import Stream from 'calypso/reader/stream';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { requestFollowTag, requestUnfollowTag } from 'calypso/state/reader/tags/items/actions';
 import { getReaderTags, getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
@@ -73,6 +77,12 @@ class TagStream extends Component {
 		const { decodedTagSlug, unfollowTag, followTag } = this.props;
 		const isFollowing = this.isSubscribed(); // this is the current state, not the new state
 		const toggleAction = isFollowing ? unfollowTag : followTag;
+
+		if ( ! this.props.isLoggedIn ) {
+			const { pathname } = getUrlParts( window.location.href );
+			return navigate( createAccountUrl( { redirectTo: pathname } ) );
+		}
+
 		toggleAction( decodedTagSlug );
 		recordAction( isFollowing ? 'unfollowed_topic' : 'followed_topic' );
 		recordGaEvent(
@@ -152,6 +162,7 @@ export default connect(
 	( state ) => ( {
 		followedTags: getReaderFollowedTags( state ),
 		tags: getReaderTags( state ),
+		isLoggedIn: isUserLoggedIn( state ),
 	} ),
 	{
 		followTag: requestFollowTag,

--- a/client/sections.js
+++ b/client/sections.js
@@ -339,6 +339,7 @@ const sections = [
 		paths: [ '/tags', '/tag' ],
 		module: 'calypso/reader/tag-stream',
 		group: 'reader',
+		enableLoggedOut: true,
 		trackLoadPerformance: true,
 	},
 	{


### PR DESCRIPTION
This fixes a bug in the highlander (jetpack) comments form, that uses WPCOM public api connect to allow a user that is logged out to either login or create a new account.

The bug is when a user chooses to create a new account, the modal does not close and instead redirects to reader.

What should happen, is after the user creates a new account, the modal communicates with the parent page and does an external login and then close the modal.

The fix here is to include the redirect URL to the public api connect verify URL when rendering the signup URL, so that once the signup is complete, the user will be automatically redirected to the public api connect verify, the user will be externally logged in and the modal should close.

### Testing
* Sandbox public-api.wordpress.com
* Sandbox a test site, i.e. https://eoigaltestwp.wordpress.com/
* Apply patch code-D103968 (this just makes sure the popup modal loads calypso.localhost:3000
* Go to a comment form on test site (https://eoigaltestwp.wordpress.com/2020/02/20/example-post/) and do the following steps;

https://user-images.githubusercontent.com/5560595/223714308-bbdbbb7c-1097-4162-822b-fc5780d5b303.mov

Ref: https://github.com/Automattic/jetpack/issues/29321
