### PR TITLE
Fix Public API Connect Signup from Highlander Comment form

### DIFF
--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -52,6 +52,14 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 	const wccomFrom = get( currentQuery, 'wccom-from' );
 	const isFromMigrationPlugin = includes( redirectTo, 'wpcom-migration' );
 
+	/**
+	 *  Include redirects to public.api/connect/?action=verify&service={some service}
+	 *  If the signup is from the Highlander Comments flow, the signup page will be in a popup modal
+	 *  We need to redirect back to public.api/connect/ to do an external login and close modal
+	 *  Ref: PCYsg-Hfw-p2
+	 */
+	const isFromPublicAPIConnectFlow = includes( redirectTo, 'public.api/connect/?action=verify' );
+
 	if (
 		// Match locales like `/log-in/jetpack/es`
 		startsWith( currentRoute, '/log-in/jetpack' )
@@ -119,6 +127,7 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 
 	if (
 		isFromMigrationPlugin ||
+		isFromPublicAPIConnectFlow ||
 		( includes( redirectTo, 'action=jetpack-sso' ) && includes( redirectTo, 'sso_nonce=' ) )
 	) {
 		const params = new URLSearchParams( {


### PR DESCRIPTION
This fixes a bug in the highlander (jetpack) comments form, that uses WPCOM public api connect to allow a user that is logged out to either login or create a new account.

The bug is when a user chooses to create a new account, the modal does not close and instead redirects to reader.

What should happen, is after the user creates a new account, the modal communicates with the parent page and does an external login and then close the modal.

The fix here is to include the redirect URL to the public api connect verify URL when rendering the signup URL, so that once the signup is complete, the user will be automatically redirected to the public api connect verify, the user will be externally logged in and the modal should close.

### Testing
* Sandbox public-api.wordpress.com
* Sandbox a test site, i.e. https://eoigaltestwp.wordpress.com/
* Apply patch code-D103968 (this just makes sure the popup modal loads calypso.localhost:3000
* Go to a comment form on test site (https://eoigaltestwp.wordpress.com/2020/02/20/example-post/) and do the following steps;

https://user-images.githubusercontent.com/5560595/223714308-bbdbbb7c-1097-4162-822b-fc5780d5b303.mov

Ref: https://github.com/Automattic/jetpack/issues/29321
