### PR TITLE
Implementing new term length toggle option for the plans step

### DIFF
--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -35,7 +35,7 @@ export type PlanTypeSelectorProps = {
 	siteSlug?: string | null;
 	selectedPlan?: string;
 	selectedFeature?: string;
-	shortestTermOption?: 'monthly' | '1year';
+	showBiannualToggle?: boolean;
 	isInSignup: boolean;
 	plans: string[];
 	eligibleForWpcomMonthlyPlans?: boolean;
@@ -124,7 +124,7 @@ export type IntervalTypeProps = Pick<
 	| 'isPlansInsideStepper'
 	| 'hideDiscountLabel'
 	| 'redirectTo'
-	| 'shortestTermOption'
+	| 'showBiannualToggle'
 >;
 
 export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
@@ -134,7 +134,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		isInSignup,
 		eligibleForWpcomMonthlyPlans,
 		hideDiscountLabel,
-		shortestTermOption,
+		showBiannualToggle,
 	} = props;
 	const [ spanRef, setSpanRef ] = useState< HTMLSpanElement >();
 	const segmentClasses = classNames( 'plan-features__interval-type', 'price-toggle', {
@@ -154,8 +154,8 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 	const isDomainAndPlanPackageFlow = new URLSearchParams( window.location.search ).get(
 		'domainAndPlanPackage'
 	);
-	const shouldHideMonthly = shortestTermOption === '1year';
-	const intervalTabs = shouldHideMonthly ? [ 'yearly', '2yearly' ] : [ 'monthly', 'yearly' ];
+
+	const intervalTabs = showBiannualToggle ? [ 'yearly', '2yearly' ] : [ 'monthly', 'yearly' ];
 
 	return (
 		<IntervalTypeToggleWrapper
@@ -177,11 +177,11 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 					>
 						<span ref={ intervalType === 'monthly' ? ( ref ) => ref && setSpanRef( ref ) : null }>
 							{ interval === 'monthly' ? translate( 'Pay monthly' ) : null }
-							{ interval === 'yearly' && ! shouldHideMonthly ? translate( 'Pay annually' ) : null }
-							{ interval === 'yearly' && shouldHideMonthly ? translate( 'Pay 1 year' ) : null }
+							{ interval === 'yearly' && ! showBiannualToggle ? translate( 'Pay annually' ) : null }
+							{ interval === 'yearly' && showBiannualToggle ? translate( 'Pay 1 year' ) : null }
 							{ interval === '2yearly' ? translate( 'Pay 2 years' ) : null }
 						</span>
-						{ ! shouldHideMonthly && hideDiscountLabel ? null : (
+						{ ! showBiannualToggle && hideDiscountLabel ? null : (
 							<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
 								{ translate(
 									'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -35,6 +35,7 @@ export type PlanTypeSelectorProps = {
 	siteSlug?: string | null;
 	selectedPlan?: string;
 	selectedFeature?: string;
+	shortestTermOption?: 'monthly' | '1year';
 	isInSignup: boolean;
 	plans: string[];
 	eligibleForWpcomMonthlyPlans?: boolean;
@@ -123,11 +124,18 @@ export type IntervalTypeProps = Pick<
 	| 'isPlansInsideStepper'
 	| 'hideDiscountLabel'
 	| 'redirectTo'
+	| 'shortestTermOption'
 >;
 
 export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
 	const translate = useTranslate();
-	const { intervalType, isInSignup, eligibleForWpcomMonthlyPlans, hideDiscountLabel } = props;
+	const {
+		intervalType,
+		isInSignup,
+		eligibleForWpcomMonthlyPlans,
+		hideDiscountLabel,
+		shortestTermOption,
+	} = props;
 	const [ spanRef, setSpanRef ] = useState< HTMLSpanElement >();
 	const segmentClasses = classNames( 'plan-features__interval-type', 'price-toggle', {
 		'is-signup': isInSignup,
@@ -146,6 +154,8 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 	const isDomainAndPlanPackageFlow = new URLSearchParams( window.location.search ).get(
 		'domainAndPlanPackage'
 	);
+	const shouldHideMonthly = shortestTermOption === '1year';
+	const intervalTabs = shouldHideMonthly ? [ 'yearly', '2yearly' ] : [ 'monthly', 'yearly' ];
 
 	return (
 		<IntervalTypeToggleWrapper
@@ -153,42 +163,37 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 			isInSignup={ isInSignup }
 		>
 			<SegmentedControl compact className={ segmentClasses } primary={ true }>
-				<SegmentedControl.Item
-					selected={ intervalType === 'monthly' }
-					path={ generatePath( props, {
-						intervalType: 'monthly',
-						domain: isDomainUpsellFlow,
-						domainAndPlanPackage: isDomainAndPlanPackageFlow,
-						...additionalPathProps,
-					} ) }
-					isPlansInsideStepper={ props.isPlansInsideStepper }
-				>
-					<span>{ translate( 'Pay monthly' ) }</span>
-				</SegmentedControl.Item>
-
-				<SegmentedControl.Item
-					selected={ intervalType === 'yearly' }
-					path={ generatePath( props, {
-						intervalType: 'yearly',
-						domain: isDomainUpsellFlow,
-						domainAndPlanPackage: isDomainAndPlanPackageFlow,
-						...additionalPathProps,
-					} ) }
-					isPlansInsideStepper={ props.isPlansInsideStepper }
-				>
-					<span ref={ ( ref ) => ref && setSpanRef( ref ) }>{ translate( 'Pay annually' ) }</span>
-					{ hideDiscountLabel ? null : (
-						<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
-							{ translate(
-								'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',
-								{
-									args: { maxDiscount },
-									comment: 'Will be like "Save up to 30% by paying annually..."',
-								}
-							) }
-						</PopupMessages>
-					) }
-				</SegmentedControl.Item>
+				{ intervalTabs.map( ( interval ) => (
+					<SegmentedControl.Item
+						key={ interval }
+						selected={ intervalType === interval }
+						path={ generatePath( props, {
+							intervalType: interval,
+							domain: isDomainUpsellFlow,
+							domainAndPlanPackage: isDomainAndPlanPackageFlow,
+							...additionalPathProps,
+						} ) }
+						isPlansInsideStepper={ props.isPlansInsideStepper }
+					>
+						<span ref={ intervalType === 'monthly' ? ( ref ) => ref && setSpanRef( ref ) : null }>
+							{ interval === 'monthly' ? translate( 'Pay monthly' ) : null }
+							{ interval === 'yearly' && ! shouldHideMonthly ? translate( 'Pay annually' ) : null }
+							{ interval === 'yearly' && shouldHideMonthly ? translate( 'Pay 1 year' ) : null }
+							{ interval === '2yearly' ? translate( 'Pay 2 years' ) : null }
+						</span>
+						{ ! shouldHideMonthly && hideDiscountLabel ? null : (
+							<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
+								{ translate(
+									'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',
+									{
+										args: { maxDiscount },
+										comment: 'Will be like "Save up to 30% by paying annually..."',
+									}
+								) }
+							</PopupMessages>
+						) }
+					</SegmentedControl.Item>
+				) ) }
 			</SegmentedControl>
 		</IntervalTypeToggleWrapper>
 	);

--- a/client/signup/steps/plans/util.ts
+++ b/client/signup/steps/plans/util.ts
@@ -10,7 +10,7 @@ export const getIntervalType = (): string => {
 	const urlParts = getUrlParts( typeof window !== 'undefined' ? window.location?.href : '' );
 	const intervalType = urlParts?.searchParams.get( 'intervalType' ) || '';
 
-	if ( [ 'yearly', 'monthly' ].includes( intervalType ) ) {
+	if ( [ 'yearly', '2yearly', 'monthly' ].includes( intervalType ) ) {
 		return intervalType;
 	}
 


### PR DESCRIPTION
Related to #74131 

## Proposed Changes

* This implements the changes discussed at pdgrnI-28f-p2.
* Creates a second set of term length tab options - the choices are now either `[ Monthly, Yearly ]` or `[ 1 Year, 2 Years]`
* This PR does not implement maxDiscount calculations for the new two year option, so it doesn't display that modal for the new set.

Screen shots:

<img width="984" alt="Screenshot 2023-03-08 at 8 11 11 AM" src="https://user-images.githubusercontent.com/35781181/223721856-97e175bf-d7da-4c74-8031-2acf94f2aa54.png">

<img width="984" alt="Screenshot 2023-03-08 at 8 06 30 AM" src="https://user-images.githubusercontent.com/35781181/223721880-a7941f1f-7e93-49e0-b3ad-e56e560c87da.png">

## Testing Instructions

* Checkout this PR
* Force a plans step to show the two year option by adding `shortestTermOption="1year"` as a prop to the `PlanTypeSelector` component (e.g., [here](https://github.com/Automattic/wp-calypso/blob/8b72626d660c1cf6566fc38796da1261aa59323c/client/my-sites/plans-features-main/index.jsx#L623))
* Confirm that the default is still [Monthly, Yearly]
