### PR TITLE
Users management: Add subscriptions activation banner

### DIFF
--- a/client/my-sites/people/subscribers/banner-activation.tsx
+++ b/client/my-sites/people/subscribers/banner-activation.tsx
@@ -3,6 +3,7 @@ import { Notice } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import useBannerDismissReducer from 'calypso/my-sites/people/subscribers/hooks/use-banner-dismiss-reducer';
 import useSubscriptionBanner from 'calypso/my-sites/people/subscribers/hooks/use-subscription-banner';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
@@ -18,6 +19,12 @@ export default function BannerActivation() {
 
 	function onEnableSubscriptionsModule() {
 		dispatch( activateModule( site?.ID, 'subscriptions' ) );
+		recordTracksEvent( 'calypso_subscriptions_module_enable' );
+	}
+
+	function onNoticeDismiss() {
+		bannerDispatch( { type: 'dismiss', payload: true } );
+		recordTracksEvent( 'calypso_subscriptions_banner_dismiss' );
 	}
 
 	return (
@@ -27,7 +34,7 @@ export default function BannerActivation() {
 				<Card className="people-subscription-banner">
 					<Notice
 						status="info"
-						onRemove={ () => bannerDispatch( { type: 'dismiss', payload: true } ) }
+						onRemove={ onNoticeDismiss }
 						actions={ [
 							{
 								label: translate( 'Enable' ),

--- a/client/my-sites/people/subscribers/banner-activation.tsx
+++ b/client/my-sites/people/subscribers/banner-activation.tsx
@@ -1,35 +1,79 @@
 import { Card } from '@automattic/components';
 import { Notice } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect, useRef, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import useBannerDismissReducer from 'calypso/my-sites/people/subscribers/hooks/use-banner-dismiss-reducer';
 import useSubscriptionBanner from 'calypso/my-sites/people/subscribers/hooks/use-subscription-banner';
+import { getFormSettings } from 'calypso/my-sites/site-settings/form-discussion';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
+import { saveJetpackSettings } from 'calypso/state/jetpack/settings/actions';
+import getJetpackSettings from 'calypso/state/selectors/get-jetpack-settings';
+import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 export default function BannerActivation() {
+	const moduleSlug = 'subscriptions';
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const siteId = site?.ID as number;
+	const siteJetpackSettings = useSelector( ( state ) => getJetpackSettings( state, siteId ) );
+	const isModuleActive = useSelector( ( state ) =>
+		isJetpackModuleActive( state, siteId, moduleSlug )
+	);
+	const isModuleActiveRef = useRef( isModuleActive );
 	const [ bannerState, bannerDispatch ] = useBannerDismissReducer();
-	const showSubscriptionBanner = useSubscriptionBanner( site?.ID as number, bannerState.dismissed );
+	const showSubscriptionBanner = useSubscriptionBanner( siteId, bannerState.dismissed );
 
-	function onEnableSubscriptionsModule() {
-		dispatch( activateModule( site?.ID, 'subscriptions' ) );
+	/**
+	 * Callbacks
+	 */
+	const prepareModuleSettings = useCallback( () => {
+		return Object.assign( {}, getFormSettings( siteJetpackSettings ), {
+			stb_enabled: true,
+			stc_enabled: true,
+		} );
+	}, [ getFormSettings, siteJetpackSettings ] );
+
+	const onEnableSubscriptionsModule = useCallback( () => {
+		dispatch( activateModule( siteId, moduleSlug ) );
 		recordTracksEvent( 'calypso_subscriptions_module_enable' );
-	}
+	}, [ siteId ] );
 
-	function onNoticeDismiss() {
+	const onNoticeDismiss = useCallback( () => {
 		bannerDispatch( { type: 'dismiss', payload: true } );
 		recordTracksEvent( 'calypso_subscriptions_banner_dismiss' );
-	}
+	}, [] );
 
+	const onModuleActivationTransition = useCallback( () => {
+		const settings = prepareModuleSettings();
+		dispatch( saveJetpackSettings( siteId, settings ) );
+	}, [ siteId, prepareModuleSettings ] );
+
+	const detectModuleActivationTransition = useCallback( () => {
+		if ( ! isModuleActiveRef.current && isModuleActive ) {
+			onModuleActivationTransition();
+		}
+	}, [ isModuleActive ] );
+
+	/**
+	 * Effects
+	 */
+	useEffect( detectModuleActivationTransition, [ detectModuleActivationTransition ] );
+	useEffect( () => {
+		isModuleActiveRef.current = isModuleActive;
+	}, [ isModuleActive ] );
+
+	/**
+	 * Templates
+	 */
 	return (
 		<>
-			{ site?.ID && <QueryJetpackModules siteId={ site.ID } /> }
+			{ siteId && <QueryJetpackModules siteId={ siteId } /> }
 			{ showSubscriptionBanner && (
 				<Card className="people-subscription-banner">
 					<Notice

--- a/client/my-sites/people/subscribers/banner-activation.tsx
+++ b/client/my-sites/people/subscribers/banner-activation.tsx
@@ -1,0 +1,49 @@
+import { Card } from '@automattic/components';
+import { Notice } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch, useSelector } from 'react-redux';
+import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
+import useBannerDismissReducer from 'calypso/my-sites/people/subscribers/hooks/use-banner-dismiss-reducer';
+import useSubscriptionBanner from 'calypso/my-sites/people/subscribers/hooks/use-subscription-banner';
+import { activateModule } from 'calypso/state/jetpack/modules/actions';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+export default function BannerActivation() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const [ bannerState, bannerDispatch ] = useBannerDismissReducer();
+	const showSubscriptionBanner = useSubscriptionBanner( site?.ID as number, bannerState.dismissed );
+
+	function onEnableSubscriptionsModule() {
+		dispatch( activateModule( site?.ID, 'subscriptions' ) );
+	}
+
+	return (
+		<>
+			{ site?.ID && <QueryJetpackModules siteId={ site.ID } /> }
+			{ showSubscriptionBanner && (
+				<Card className="people-subscription-banner">
+					<Notice
+						status="info"
+						onRemove={ () => bannerDispatch( { type: 'dismiss', payload: true } ) }
+						actions={ [
+							{
+								label: translate( 'Enable' ),
+								className: 'is-compact is-primary',
+								onClick: onEnableSubscriptionsModule,
+							},
+						] }
+					>
+						<strong>
+							{ translate(
+								"Activate post and comment subscriptions to ensure your site visitors don't miss a thing"
+							) }
+						</strong>
+					</Notice>
+				</Card>
+			) }
+		</>
+	);
+}

--- a/client/my-sites/people/subscribers/hooks/use-banner-dismiss-reducer.ts
+++ b/client/my-sites/people/subscribers/hooks/use-banner-dismiss-reducer.ts
@@ -1,0 +1,34 @@
+import { useReducer } from 'react';
+
+const JP_SUBSCRIPTION_BANNER_DISMISSED = 'jp_subscription_banner_dismissed';
+
+export interface BannerDismissState {
+	dismissed: boolean;
+}
+
+export interface BannerDismissAction {
+	type: 'dismiss';
+	payload?: boolean;
+}
+
+function reducer( state: BannerDismissState, action: BannerDismissAction ): BannerDismissState {
+	switch ( action.type ) {
+		case 'dismiss': {
+			const dismissed = !! action.payload;
+			sessionStorage.setItem( JP_SUBSCRIPTION_BANNER_DISMISSED, dismissed.toString() );
+
+			return { dismissed };
+		}
+		default: {
+			throw new Error();
+		}
+	}
+}
+
+export default function useBannerDismissReducer() {
+	const initialState = {
+		dismissed: sessionStorage.getItem( JP_SUBSCRIPTION_BANNER_DISMISSED ) === 'true',
+	};
+
+	return useReducer( reducer, initialState );
+}

--- a/client/my-sites/people/subscribers/hooks/use-subscription-banner.ts
+++ b/client/my-sites/people/subscribers/hooks/use-subscription-banner.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import isActivatingJetpackModule from 'calypso/state/selectors/is-activating-jetpack-module';
+import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+
+export default function useSubscriptionBanner( siteId: number, isDismissed?: boolean ) {
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isSubscriptionsModuleActive = useSelector( ( state ) =>
+		isJetpackModuleActive( state, siteId, 'subscriptions' )
+	);
+	const isSubscriptionsModuleActivating = useSelector( ( state ) =>
+		isActivatingJetpackModule( state, siteId, 'subscriptions' )
+	);
+
+	const [ showSubscriptionBanner, setShowSubscriptionBanner ] = useState( false );
+
+	const shouldShowSubscriptionBanner = useCallback(
+		() =>
+			!! isJetpack &&
+			! isDismissed &&
+			! isSubscriptionsModuleActivating &&
+			isSubscriptionsModuleActive === false,
+		[ isJetpack, isDismissed, isSubscriptionsModuleActive, isSubscriptionsModuleActivating ]
+	);
+
+	useEffect(
+		() => setShowSubscriptionBanner( shouldShowSubscriptionBanner() ),
+		[ shouldShowSubscriptionBanner ]
+	);
+
+	return showSubscriptionBanner;
+}

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -12,6 +12,7 @@ import PeopleListItem from 'calypso/my-sites/people/people-list-item';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PeopleListSectionHeader from '../people-list-section-header';
+import BannerActivation from './banner-activation';
 import type { FollowersQuery } from './types';
 import type { Member } from '../types';
 
@@ -85,6 +86,8 @@ function Subscribers( props: Props ) {
 		case 'loading':
 			return (
 				<>
+					<BannerActivation />
+
 					<PeopleListSectionHeader
 						isPlaceholder={ isLoading }
 						label={ translate(
@@ -105,6 +108,7 @@ function Subscribers( props: Props ) {
 							</PopoverMenuItem>
 						</EllipsisMenu>
 					</PeopleListSectionHeader>
+
 					<Card className="people-subscribers-list">
 						{ isLoading && renderPlaceholders() }
 						<InfiniteList

--- a/client/my-sites/people/subscribers/style.scss
+++ b/client/my-sites/people/subscribers/style.scss
@@ -9,6 +9,37 @@
 	}
 }
 
+.people-subscription-banner {
+	padding: 0;
+
+	.components-notice {
+		margin: 0;
+		padding-right: 12px;
+	}
+
+	.components-notice__content {
+		display: flex;
+		align-items: start;
+		justify-content: space-between;
+		margin-right: 0;
+		font-size: 0.875rem;
+	}
+
+	.components-notice__actions .components-button {
+		height: auto;
+		color: var(--color-text-inverted);
+		box-shadow: none;
+		background: var(--wp-admin-theme-color);
+
+		&:hover,
+		&:focus {
+			box-shadow: none;
+			color: var(--color-text-inverted);
+			background: var(--wp-admin-theme-color-darker-10);
+		}
+	}
+}
+
 .add-subscriber .add-subscriber__form--container label.add-subscriber__form-label-emails {
 	margin-top: 0;
 }

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -618,7 +618,7 @@ const connectComponent = connect( ( state ) => {
 	};
 } );
 
-const getFormSettings = ( settings ) => {
+export const getFormSettings = ( settings ) => {
 	return pick( settings, [
 		'default_pingback_flag',
 		'default_ping_status',

--- a/client/my-sites/site-settings/subscriptions.jsx
+++ b/client/my-sites/site-settings/subscriptions.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
@@ -23,6 +24,10 @@ const Subscriptions = ( {
 	subscriptionsModuleActive,
 	translate,
 } ) => {
+	const viewFollowersSubscribersLink = ! isEnabled( 'user-management-revamp' )
+		? `/people/email-followers/${ selectedSiteSlug }`
+		: `/people/subscribers/${ selectedSiteSlug }`;
+
 	return (
 		<div>
 			<QueryJetpackConnection siteId={ selectedSiteId } />
@@ -74,7 +79,7 @@ const Subscriptions = ( {
 				</FormFieldset>
 			</CompactCard>
 
-			<CompactCard href={ '/people/email-followers/' + selectedSiteSlug }>
+			<CompactCard href={ viewFollowersSubscribersLink }>
 				{ translate( 'View your email followers' ) }
 			</CompactCard>
 


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/1466

## Proposed Changes

* Introduced banner for enabling subscriptions module
* Fixed issue with wrong link to the email followers

## Testing Instructions

* Go to `/settings/discussion/{JETPACK_CONNECTED_SLUG}`
* Make sure that "Let visitors subscribe to new posts and comments via email" option is disabled
  * Disable two nested options as well
* Go to `/people/subscribers/{JETPACK_CONNECTED_SLUG}`
* Check if there is a banner
* Click on "X" dismiss button
* Check if the banner disappears
* Open "Dev Tool / Application tab / Session storage / Edit: `jp_subscription_banner_dismissed` field to `false`
* Check if the banner appears again
* Click on the `Enable` button
* Go back to `/settings/discussion/{JETPACK_CONNECTED_SLUG}`
* Check if the subscriptions module with nested options are enabled again

Bug fix testing scenario:
* Go to `/settings/discussion/{JETPACK_CONNECTED_SLUG}`
* Click on `View your email followers`
* Check if it redirects to `/people/subscribers/{SITE_SLUG}` route

<img width="749" alt="Screenshot 2023-03-10 at 15 48 48" src="https://user-images.githubusercontent.com/1241413/224346396-ab48f5d7-a844-4690-a17a-936d9afcce7f.png">

<img width="796" alt="Screenshot 2023-03-08 at 10 18 33" src="https://user-images.githubusercontent.com/1241413/223750180-ec8f62b7-327e-4d92-8bb6-4b141c7f0bfc.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
