### PR TITLE
Virtual themes i2: Show description and Pattern Assembler CTA

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -21,6 +21,7 @@ import UnifiedDesignPickerStep from '../unified-design-picker';
 jest.mock( '@wordpress/compose', () => ( {
 	...jest.requireActual( '@wordpress/compose' ),
 	useViewportMatch: jest.fn( () => false ),
+	useMediaQuery: jest.fn( () => true ),
 } ) );
 
 jest.mock( 'react-router-dom', () => ( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -7,6 +7,7 @@ import {
 	useCategorization,
 	getDesignPreviewUrl,
 	isBlankCanvasDesign,
+	PatternAssemblerCta,
 } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
@@ -603,18 +604,29 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			vertical_id: selectedDesign.verticalizable ? siteVerticalId : undefined,
 		} );
 
+		const hasMoreInfo = selectedDesignHasStyleVariations || selectedDesign.is_virtual;
+
 		const pickDesignText =
-			selectedDesign.design_type === 'vertical' || selectedDesignHasStyleVariations
+			selectedDesign.design_type === 'vertical' || hasMoreInfo
 				? translate( 'Continue' )
 				: translate( 'Start with %(designTitle)s', { args: { designTitle } } );
 
 		const actionButtons = (
 			<>
-				{ selectedDesignHasStyleVariations && (
-					<div className="action-buttons__title">{ headerDesignTitle }</div>
-				) }
+				{ hasMoreInfo && <div className="action-buttons__title">{ headerDesignTitle }</div> }
 				<div>{ getPrimaryActionButton( pickDesignText ) }</div>
 			</>
+		);
+
+		const showPatternAssemblerCTA =
+			selectedDesign.is_virtual && selectedDesign.recipe?.pattern_ids?.length;
+		const patternAssemblerCTA = showPatternAssemblerCTA && (
+			<PatternAssemblerCta
+				hasPrimaryButton={ false }
+				onButtonClick={ () => pickBlankCanvasDesign( selectedDesign, true ) }
+				showSiteEditorFallback={ false }
+				compact={ true }
+			/>
 		);
 
 		const stepContent = (
@@ -631,7 +643,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 					isOpen={ showPremiumGlobalStylesModal }
 					tryStyle={ tryPremiumGlobalStyles }
 				/>
-				{ selectedDesignHasStyleVariations ? (
+				{ hasMoreInfo ? (
 					<AsyncLoad
 						require="@automattic/design-preview"
 						placeholder={ null }
@@ -644,6 +656,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 						actionButtons={ actionButtons }
 						recordDeviceClick={ recordDeviceClick }
 						showGlobalStylesPremiumBadge={ shouldLimitGlobalStyles }
+						patternAssemblerCTA={ patternAssemblerCTA }
 					/>
 				) : (
 					<WebPreview
@@ -669,7 +682,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			</>
 		);
 
-		return selectedDesignHasStyleVariations ? (
+		return hasMoreInfo ? (
 			<StepContainer
 				stepName={ STEP_NAME }
 				stepContent={ stepContent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -11,7 +11,7 @@ import {
 } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
-import { useViewportMatch } from '@wordpress/compose';
+import { useViewportMatch, useMediaQuery } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { ReactChild, useRef, useState, useEffect } from 'react';
@@ -70,6 +70,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	const locale = useLocale();
 
 	const isMobile = ! useViewportMatch( 'small' );
+	const isXLargeScreen = useMediaQuery( '(min-width: 1080px)' );
 
 	const intent = useSelect( ( select ) => select( ONBOARD_STORE ).getIntent() );
 
@@ -604,7 +605,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			vertical_id: selectedDesign.verticalizable ? siteVerticalId : undefined,
 		} );
 
-		const hasMoreInfo = selectedDesignHasStyleVariations || selectedDesign.is_virtual;
+		const hasMoreInfo =
+			selectedDesignHasStyleVariations || ( selectedDesign.is_virtual && isXLargeScreen );
 
 		const pickDesignText =
 			selectedDesign.design_type === 'vertical' || hasMoreInfo
@@ -624,7 +626,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			<PatternAssemblerCta
 				hasPrimaryButton={ false }
 				onButtonClick={ () => pickBlankCanvasDesign( selectedDesign, true ) }
-				showSiteEditorFallback={ false }
+				showEditorFallback={ false }
 				compact={ true }
 			/>
 		);

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -55,7 +55,7 @@ export function useStarterDesignsQuery(
 	queryParams: StarterDesignsQueryParams,
 	{ select, shouldLimitGlobalStyles, ...queryOptions }: Options = {}
 ): UseQueryResult< StarterDesigns > {
-	return useQuery( [ 'starter-designs-7', queryParams ], () => fetchStarterDesigns( queryParams ), {
+	return useQuery( [ 'starter-designs', queryParams ], () => fetchStarterDesigns( queryParams ), {
 		select: ( response: StarterDesignsResponse ) => {
 			const allDesigns = {
 				generated: {

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -55,7 +55,7 @@ export function useStarterDesignsQuery(
 	queryParams: StarterDesignsQueryParams,
 	{ select, shouldLimitGlobalStyles, ...queryOptions }: Options = {}
 ): UseQueryResult< StarterDesigns > {
-	return useQuery( [ 'starter-designs', queryParams ], () => fetchStarterDesigns( queryParams ), {
+	return useQuery( [ 'starter-designs-7', queryParams ], () => fetchStarterDesigns( queryParams ), {
 		select: ( response: StarterDesignsResponse ) => {
 			const allDesigns = {
 				generated: {

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -1,14 +1,23 @@
 import { Button } from '@automattic/components';
 import { useViewportMatch } from '@wordpress/compose';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import blankCanvasImage from '../assets/images/blank-canvas-cta.svg';
 import './style.scss';
 
 type PatternAssemblerCtaProps = {
+	compact?: boolean;
+	hasPrimaryButton?: boolean;
 	onButtonClick: ( shouldGoToAssemblerStep: boolean ) => void;
+	showEditorFallback?: boolean;
 };
 
-const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
+const PatternAssemblerCta = ( {
+	compact = false,
+	hasPrimaryButton = true,
+	onButtonClick,
+	showEditorFallback = true,
+}: PatternAssemblerCtaProps ) => {
 	const translate = useTranslate();
 	const isDesktop = useViewportMatch( 'large' );
 
@@ -18,8 +27,12 @@ const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 		onButtonClick( shouldGoToAssemblerStep );
 	};
 
+	if ( ! shouldGoToAssemblerStep && ! showEditorFallback ) {
+		return null;
+	}
+
 	return (
-		<div className="pattern-assembler-cta-wrapper">
+		<div className={ classnames( 'pattern-assembler-cta-wrapper', { 'is-compact': compact } ) }>
 			<div className="pattern-assembler-cta__image-wrapper">
 				<img className="pattern-assembler-cta__image" src={ blankCanvasImage } alt="Blank Canvas" />
 			</div>
@@ -33,7 +46,11 @@ const PatternAssemblerCta = ( { onButtonClick }: PatternAssemblerCtaProps ) => {
 							"Can't find something you like? Jump right into the editor to design your homepage from scratch."
 					  ) }
 			</p>
-			<Button className="pattern-assembler-cta__button" onClick={ handleButtonClick } primary>
+			<Button
+				className="pattern-assembler-cta__button"
+				onClick={ handleButtonClick }
+				primary={ hasPrimaryButton }
+			>
 				{ shouldGoToAssemblerStep
 					? translate( 'Start designing' )
 					: translate( 'Open the editor' ) }

--- a/packages/design-picker/src/components/pattern-assembler-cta/style.scss
+++ b/packages/design-picker/src/components/pattern-assembler-cta/style.scss
@@ -45,4 +45,17 @@
 	.pattern-assembler-cta__image {
 		width: 200px;
 	}
+
+	&.is-compact {
+		margin-top: 32px;
+		padding: 32px;
+
+		.pattern-assembler-cta__title {
+			margin-top: 16px;
+		}
+
+		.pattern-assembler-cta__image {
+			width: 100px;
+		}
+	}
 }

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -19,6 +19,7 @@ interface PreviewProps {
 	actionButtons: React.ReactNode;
 	recordDeviceClick: ( device: string ) => void;
 	showGlobalStylesPremiumBadge: boolean;
+	patternAssemblerCTA?: React.ReactNode;
 }
 
 const INJECTED_CSS = `body{ transition: background-color 0.2s linear, color 0.2s linear; };`;
@@ -41,6 +42,7 @@ const Preview: React.FC< PreviewProps > = ( {
 	actionButtons,
 	recordDeviceClick,
 	showGlobalStylesPremiumBadge,
+	patternAssemblerCTA,
 } ) => {
 	const sitePreviewInlineCss = useMemo( () => {
 		if ( selectedVariation ) {
@@ -69,6 +71,7 @@ const Preview: React.FC< PreviewProps > = ( {
 				onClickCategory={ onClickCategory }
 				actionButtons={ actionButtons }
 				showGlobalStylesPremiumBadge={ showGlobalStylesPremiumBadge }
+				patternAssemblerCTA={ patternAssemblerCTA }
 			/>
 			<SitePreview
 				url={ previewUrl }

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { useState } from '@wordpress/element';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import StyleVariationPreviews from './style-variation';
 import type { Category, StyleVariation } from '@automattic/design-picker/src/types';
 
@@ -37,6 +37,7 @@ interface SidebarProps {
 	onClickCategory?: ( category: Category ) => void;
 	actionButtons: React.ReactNode;
 	showGlobalStylesPremiumBadge: boolean;
+	patternAssemblerCTA?: React.ReactNode;
 }
 
 const Sidebar: React.FC< SidebarProps > = ( {
@@ -52,7 +53,9 @@ const Sidebar: React.FC< SidebarProps > = ( {
 	onClickCategory,
 	actionButtons,
 	showGlobalStylesPremiumBadge,
+	patternAssemblerCTA,
 } ) => {
+	const translate = useTranslate();
 	const [ isShowFullDescription, setIsShowFullDescription ] = useState( false );
 	const isShowDescriptionToggle = shortDescription && description !== shortDescription;
 
@@ -116,6 +119,7 @@ const Sidebar: React.FC< SidebarProps > = ( {
 			{ actionButtons && (
 				<div className="design-preview__sidebar-action-buttons">{ actionButtons }</div>
 			) }
+			{ patternAssemblerCTA }
 		</div>
 	);
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1908
Requires D103960-code

## Proposed Changes

Changes the `designPreview` step for pattern-based virtual themes to show a theme description that sets better expectations for users about which theme will actually be activated.

It also displays a CTA to start the Pattern Assembler.

<img width="1267" alt="Screenshot 2023-03-08 at 13 33 03" src="https://user-images.githubusercontent.com/1233880/223735233-09bcc8ff-4881-4a3c-b8e9-bfaf2c74fcc7.png">

## Testing Instructions

- Use the Calypso live link below
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_SLUG>&flags=virtual-themes/onboarding`
- Select a pattern-based virtual theme
- Make sure you see a design description in the sidebar. Make sure it's clear and doesn't have typos.
  - If you don't see it, you might need to clear the `useQuery` cache by applying this change and running the PR locally:
```diff
diff --git a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
index 6a056f8777..e895422ef3 100644
--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -55,7 +55,7 @@ export function useStarterDesignsQuery(
 	queryParams: StarterDesignsQueryParams,
 	{ select, shouldLimitGlobalStyles, ...queryOptions }: Options = {}
 ): UseQueryResult< StarterDesigns > {
-	return useQuery( [ 'starter-designs', queryParams ], () => fetchStarterDesigns( queryParams ), {
+	return useQuery( [ 'starter-designs*', queryParams ], () => fetchStarterDesigns( queryParams ), {
 		select: ( response: StarterDesignsResponse ) => {
 			const allDesigns = {
 				generated: {
```
- Make sure you see a CTA to open the Pattern Assembler
- Make sure neither the description nor the CTA are visible on smaller screens
- Make sure the CTA starts the Pattern Assembler