### PR TITLE
Plans 2023: Fix old grid showing on admin route changes

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -718,7 +718,8 @@ export default connect(
 		) {
 			customerType = 'business';
 		}
-		const is2023PricingGridVisible = is2023PricingGridActivePage( window );
+		const is2023PricingGridVisible =
+			props.is2023PricingGridVisible ?? is2023PricingGridActivePage( window );
 		const planTypeSelectorProps = {
 			basePlansPath: props.basePlansPath,
 			isInSignup: props.isInSignup,

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -1,3 +1,4 @@
+import { is2023PricingGridActivePage } from '@automattic/calypso-products/src/plans-utilities';
 import page from 'page';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
 import { productSelect } from 'calypso/my-sites/plans/jetpack-plans/controller';
@@ -38,6 +39,7 @@ export function plans( context, next ) {
 					: undefined
 			}
 			domainAndPlanPackage={ context.query.domainAndPlanPackage }
+			is2023PricingGridVisible={ is2023PricingGridActivePage( null, context.pathname ) }
 		/>
 	);
 	next();

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -6,6 +6,7 @@ import {
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	isFreePlanProduct,
 } from '@automattic/calypso-products';
+import { is2023PricingGridActivePage } from '@automattic/calypso-products/src/plans-utilities';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -400,7 +401,8 @@ const ConnectedPlans = connect( ( state, props ) => {
 		isSiteEligibleForMonthlyPlan: isEligibleForWpComMonthlyPlan( state, selectedSiteId ),
 		showTreatmentPlansReorderTest: isTreatmentPlansReorderTest( state ),
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
-		is2023PricingGridVisible: props.is2023PricingGridVisible,
+		is2023PricingGridVisible:
+			props.is2023PricingGridVisible ?? is2023PricingGridActivePage( window ),
 		isDomainAndPlanPackageFlow: !! getCurrentQueryArguments( state )?.domainAndPlanPackage,
 		isJetpackNotAtomic: isJetpackSite( state, selectedSiteId, { treatAtomicAsJetpackSite: false } ),
 		isDomainUpsell:

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -6,7 +6,6 @@ import {
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	isFreePlanProduct,
 } from '@automattic/calypso-products';
-import { is2023PricingGridActivePage } from '@automattic/calypso-products/src/plans-utilities';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -225,7 +224,13 @@ class Plans extends Component {
 	};
 
 	renderPlansMain() {
-		const { currentPlan, selectedSite, isWPForTeamsSite, currentPlanIntervalType } = this.props;
+		const {
+			currentPlan,
+			selectedSite,
+			isWPForTeamsSite,
+			currentPlanIntervalType,
+			is2023PricingGridVisible,
+		} = this.props;
 
 		if ( ! this.props.plansLoaded || ! currentPlan ) {
 			// Maybe we should show a loading indicator here?
@@ -244,8 +249,7 @@ class Plans extends Component {
 			);
 		}
 
-		const hideFreePlan =
-			! is2023PricingGridActivePage( window ) || this.props.isDomainAndPlanPackageFlow;
+		const hideFreePlan = ! is2023PricingGridVisible || this.props.isDomainAndPlanPackageFlow;
 
 		const hidePlanTypeSelector =
 			this.props.domainAndPlanPackage &&
@@ -267,6 +271,7 @@ class Plans extends Component {
 				plansWithScroll={ false }
 				showTreatmentPlansReorderTest={ this.props.showTreatmentPlansReorderTest }
 				hidePlansFeatureComparison={ this.props.isDomainAndPlanPackageFlow }
+				is2023PricingGridVisible={ is2023PricingGridVisible }
 			/>
 		);
 	}
@@ -377,14 +382,13 @@ class Plans extends Component {
 	}
 }
 
-const ConnectedPlans = connect( ( state ) => {
+const ConnectedPlans = connect( ( state, props ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 
 	const currentPlan = getCurrentPlan( state, selectedSiteId );
 	const currentPlanIntervalType = getIntervalTypeForTerm(
 		getPlan( currentPlan?.productSlug )?.term
 	);
-	const is2023PricingGridVisible = is2023PricingGridActivePage( window );
 
 	return {
 		currentPlan,
@@ -396,7 +400,7 @@ const ConnectedPlans = connect( ( state ) => {
 		isSiteEligibleForMonthlyPlan: isEligibleForWpComMonthlyPlan( state, selectedSiteId ),
 		showTreatmentPlansReorderTest: isTreatmentPlansReorderTest( state ),
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
-		is2023PricingGridVisible,
+		is2023PricingGridVisible: props.is2023PricingGridVisible,
 		isDomainAndPlanPackageFlow: !! getCurrentQueryArguments( state )?.domainAndPlanPackage,
 		isJetpackNotAtomic: isJetpackSite( state, selectedSiteId, { treatAtomicAsJetpackSite: false } ),
 		isDomainUpsell:

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -57,9 +57,10 @@ export const is2023PricingGridEnabled = (): boolean => {
  * @returns true if the pricing grid maybe shown in a given page
  */
 export const is2023PricingGridActivePage = (
-	browserWindow: Window & typeof globalThis
+	browserWindow?: Window & typeof globalThis,
+	pathname?: string
 ): boolean => {
-	const currentRoutePath = browserWindow.location.pathname ?? '';
+	const currentRoutePath = pathname ?? browserWindow?.location.pathname ?? '';
 	const isPricingGridEnabled = is2023PricingGridEnabled();
 
 	// Is this the internal plans page /plans/<site-slug> ?


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74098, https://github.com/Automattic/wp-calypso/pull/73481
Fixes https://github.com/Automattic/wp-calypso/issues/74098

## Proposed Changes

Fixes a bug in Calypso admin that would always render and override the old plans grid when visiting `/plans` page, causing a brief flicker between old and new plans. The changes force the predicate `is2023PricingGridActivePage` check to happen earlier from the `/plans` controller. 

This may need revisiting to clean up, but should hopefully patch the problem now. 

See:

https://user-images.githubusercontent.com/1705499/223739689-3e7d71a4-3278-4bf2-81c4-75fe3eb0cdd2.mov


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Calypso admin (anywhere)
* do a route switch into the plans page e.g. click on "My Home" then on "Upgrades -> Plans".
* there should be no flicker between old & new plans as visible in the media above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
