### PR TITLE
Remove lodash trim on post header from the Reader

### DIFF
--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -18,7 +18,7 @@ const ReaderFullPostHeader = ( { post, referralPost } ) => {
 	};
 
 	const classes = { 'reader-full-post__header': true };
-	if ( ! post.title || post.title?.trim().length < 1 ) {
+	if ( ! post.title || post.title.trim().length < 1 ) {
 		classes[ 'is-missing-title' ] = true;
 	}
 

--- a/client/blocks/reader-full-post/header.jsx
+++ b/client/blocks/reader-full-post/header.jsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames';
-import { trim } from 'lodash';
 import PropTypes from 'prop-types';
 import TagsList from 'calypso/blocks/reader-post-card/tags-list';
 import AutoDirection from 'calypso/components/auto-direction';
@@ -19,7 +18,7 @@ const ReaderFullPostHeader = ( { post, referralPost } ) => {
 	};
 
 	const classes = { 'reader-full-post__header': true };
-	if ( ! post.title || trim( post.title ).length < 1 ) {
+	if ( ! post.title || post.title?.trim().length < 1 ) {
 		classes[ 'is-missing-title' ] = true;
 	}
 


### PR DESCRIPTION
## Proposed Changes

* This PR will remove the usage of the Lodash `trim()` function, and use the [built-in String method `trim()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim). 

### Ensure `post.title` is not empty or undefined? 

While working on this PR, I was not sure if we should check and ensure that the `trim()` method is not called when `post.title` is `undefined`. This is only happening when the post is being loaded, and during that time, with this code proposal, there are no JS errors on the console. 

In this case, if we need to ensure that the method is not running while the post is being loaded, we can add the following to the comparison:

`typeof post.title?.trim()?.length === 'undefined' ? 0 : post.title?.trim()?.length `. 

But I'm unsure if I'm overthinking this, and only adding the optional chaining on the string `post.title` is enough. 

What do you think about it? 

## Testing Instructions

* Checkout this branch locally `update/remove-trim-lodash-reader-post-header`.
* Follow the test site or site you are going to publish the post.
* Post a post with a space as a title and with no title.
* Visit the Reader, and click on the post that has been published.
* Check that no JS errors were thrown. 
* Check that the post header (`reader-full-post__header`) gets the `is-missing-title` CSS class.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
