### PR TITLE
Add GR to the lists of EU countries and countries supporting VAT

### DIFF
--- a/client/me/purchases/is-country-in-eu.ts
+++ b/client/me/purchases/is-country-in-eu.ts
@@ -14,6 +14,7 @@ export function isCountryInEu( country: string, date?: string ): boolean {
 		'ES',
 		'FI',
 		'FR',
+		'GR',
 		'HR',
 		'HU',
 		'IE',

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -26,6 +26,7 @@ const countriesSupportingVat = [
 	'FI',
 	'FR',
 	'GB',
+	'GR',
 	'HR',
 	'HU',
 	'IE',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/payments-shilling#1436

## Proposed Changes

It turns out that there are two two letter country codes in use for Greece: GR (from  ISO 3166) and EL ([used in the EU](https://publications.europa.eu/code/pdf/370000en.htm)). EL is used in various places to whether to display e.g. the inline vat form, but the checkout code supplies GR instead. 

This adds Greece's 2 letter country code (GR rather than EL) to the list of countries that show the inline VAT details form in checkout. It also adds it to the list of EU countries for displaying the Automattic VAT details. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This will need D103796-code and D104012-code applied to a wpcom sandbox to work completely. 
* Go to checkout and set the billing country to Greece. You should see the inline form to add vat details appear. 
* With the two backend diffs applied, adding a valid Greek VAT number here should reduce the tax to zero.
(Without the two backend diffs the form will still show, but there will be no tax displayed and you will be unable to save a Greek VAT number.)
<img width="898" alt="Screenshot 2023-03-08 at 16 54 43" src="https://user-images.githubusercontent.com/7126226/223778326-a11b0464-afc7-4863-ae9f-602125f71f0f.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?