### PR TITLE
Jetpack Connection: fix the checkout flow for Jetpack Boost

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -444,9 +444,7 @@ export function siteSelection( context, next ) {
 	// Making sure non-connected users get redirected to user connection flow.
 	// Details: p9dueE-6Hf-p2
 	const isUnlinkedCheckout =
-		'1' === context.query?.unlinked &&
-		context.pathname.match( /^\/checkout\/[^/]+\/jetpack_/i ) &&
-		! context.pathname.includes( 'jetpack_boost' );
+		'1' === context.query?.unlinked && context.pathname.match( /^\/checkout\/[^/]+\/jetpack_/i );
 
 	// The user doesn't have any sites: render `NoSitesMessage`
 	if ( currentUser && currentUser.site_count === 0 && ! isUnlinkedCheckout ) {
@@ -508,7 +506,10 @@ export function siteSelection( context, next ) {
 
 	const siteId = getSiteId( getState(), siteFragment );
 
-	if ( siteId && ! isUnlinkedCheckout ) {
+	const isUnlinkedCheckoutNotBoost =
+		isUnlinkedCheckout && ! context.pathname.includes( 'jetpack_boost' );
+
+	if ( siteId && ! isUnlinkedCheckoutNotBoost ) {
 		// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
 		// to wp-admin. In that case, don't continue handling the route.
 		dispatch( setSelectedSiteId( siteId ) );
@@ -543,7 +544,7 @@ export function siteSelection( context, next ) {
 
 				// If the user is presumably not connected to WPCOM, we ignore the site ID we found.
 				// Details: p9dueE-6Hf-p2
-				if ( freshSiteId && ! isUnlinkedCheckout ) {
+				if ( freshSiteId && ! isUnlinkedCheckoutNotBoost ) {
 					// onSelectedSiteAvailable might render an error page about domain-only sites or redirect
 					// to wp-admin. In that case, don't continue handling the route.
 					dispatch( setSelectedSiteId( freshSiteId ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74177

## Proposed Changes
* Improve the solution in #74177 to include the Jetpack Boost plugin.

## Testing Instructions
Same as #74177, but for Jetpack Boost

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
