### PR TITLE
Marketplace: Update the Thank you page to only retry the request of not fetched items

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -74,8 +74,10 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 				);
 			} )
 	);
-	const areWporgPluginsFetched: Array< boolean > = useSelector( ( state ) =>
-		areFetched( state, productSlugs )
+	const areWporgPluginsFetched: Array< boolean > = useSelector(
+		( state ) => areFetched( state, productSlugs ),
+		( newValues: Array< boolean >, oldValues: Array< boolean > ) =>
+			newValues.every( ( newValue, i ) => newValue === oldValues[ i ] )
 	);
 	const areWporgPluginsFetching: Array< boolean > = useSelector( ( state ) =>
 		areFetching( state, productSlugs )
@@ -143,14 +145,11 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 				}
 			} );
 		}
-	}, [
-		areAllWporgPluginsFetched,
-		areWporgPluginsFetched,
-		areWporgPluginsFetching,
-		productSlugs,
-		dispatch,
-		wporgPlugins,
-	] );
+
+		// We don't want it to run at every change of areWporgPluginsFetching,
+		// we only rerun when areWporgPluginsFetched changes
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ areAllWporgPluginsFetched, areWporgPluginsFetched, productSlugs, dispatch, wporgPlugins ] );
 
 	// Site is already Atomic (or just transferred).
 	// Poll the plugin installation status.

--- a/client/state/plugins/wporg/selectors.js
+++ b/client/state/plugins/wporg/selectors.js
@@ -17,6 +17,10 @@ export function isFetching( state, pluginSlug ) {
 	return state?.plugins.wporg.fetchingItems[ pluginSlug ] ?? false;
 }
 
+export function areFetching( state, pluginSlugs ) {
+	return pluginSlugs.map( ( pluginSlug ) => isFetching( state, pluginSlug ) );
+}
+
 export function hasError( state, pluginSlug ) {
 	const plugin = getPlugin( state, pluginSlug );
 	return plugin?.error ?? null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #74228

## Proposed Changes

Only retry the request of .org plugins not fetched yet.

Before this change, if at least a plugin was not fetched, a request was being sent for each slug.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install a .org plugin. Ex: `/plugins/worker`
* Clear your cache
* Update the thank you page to add a not valid .org plugin. Ex: `/marketplace/thank-you/worker,abc/:site` 
* Open the network tab, filter by `api.wordpress.org` and check if the valid plugin request is made only once.

<img width="1278" alt="CleanShot 2023-03-08 at 17 38 45@2x" src="https://user-images.githubusercontent.com/5039531/223844429-741e6ce7-54f1-4108-85a5-9fe17a909ce2.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
