### PR TITLE
Checkout: Do not validate VAT details in checkout if unchanged

### DIFF
--- a/client/me/purchases/vat-info/are-vat-details-same.ts
+++ b/client/me/purchases/vat-info/are-vat-details-same.ts
@@ -1,0 +1,17 @@
+import type { VatDetails } from '@automattic/wpcom-checkout';
+
+export function areVatDetailsSame( a: VatDetails, b: VatDetails ): boolean {
+	if ( a.id !== b.id ) {
+		return false;
+	}
+	if ( a.country !== b.country ) {
+		return false;
+	}
+	if ( a.name !== b.name ) {
+		return false;
+	}
+	if ( a.address !== b.address ) {
+		return false;
+	}
+	return true;
+}

--- a/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
@@ -35,6 +35,13 @@ jest.mock( 'calypso/state/products-list/selectors/is-marketplace-product' );
 jest.mock( 'calypso/lib/navigate' );
 
 describe( 'Checkout contact step extra tax fields', () => {
+	// These tests seem to be particularly slow (it might be because of using
+	// it.each; it's not clear but the timeout might apply to the whole loop
+	// rather that each iteration?), so we need to increase the timeout for their
+	// operation. The standard timeout (at the time of writing) is 5 seconds so
+	// we are increasing this to 8 seconds.
+	jest.setTimeout( 8000 );
+
 	const mainCartKey: CartKey = 'foo.com' as CartKey;
 	const initialCart = getBasicCart();
 	const defaultPropsForMockCheckout = {

--- a/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
@@ -34,14 +34,14 @@ jest.mock( 'calypso/lib/analytics/utils/refresh-country-code-cookie-gdpr' );
 jest.mock( 'calypso/state/products-list/selectors/is-marketplace-product' );
 jest.mock( 'calypso/lib/navigate' );
 
-describe( 'Checkout contact step extra tax fields', () => {
-	// These tests seem to be particularly slow (it might be because of using
-	// it.each; it's not clear but the timeout might apply to the whole loop
-	// rather that each iteration?), so we need to increase the timeout for their
-	// operation. The standard timeout (at the time of writing) is 5 seconds so
-	// we are increasing this to 8 seconds.
-	jest.setTimeout( 8000 );
+// These tests seem to be particularly slow (it might be because of using
+// it.each; it's not clear but the timeout might apply to the whole loop
+// rather that each iteration?), so we need to increase the timeout for their
+// operation. The standard timeout (at the time of writing) is 5 seconds so
+// we are increasing this to 8 seconds.
+jest.setTimeout( 8000 );
 
+describe( 'Checkout contact step extra tax fields', () => {
 	const mainCartKey: CartKey = 'foo.com' as CartKey;
 	const initialCart = getBasicCart();
 	const defaultPropsForMockCheckout = {


### PR DESCRIPTION
## Proposed Changes

In checkout, if you fill out the VAT details form (for a country that supports VAT), the details are always validated and saved to the server via the `/me/vat-info` endpoint. However, you're only allowed to save those details once, and they are always validated before saving. So there's really no need to validate them on every use within checkout. (In fact, if validation fails a second time this presents quite a UX problem since the user cannot edit them after that point!)

In this PR we modify the billing step validation so that it does not submit the details for validation if they are unchanged.

<img width="573" alt="Screenshot 2023-02-15 at 5 46 27 PM" src="https://user-images.githubusercontent.com/2036909/223858971-77b321ad-90bd-42e1-9537-4622c9b137b1.png">

## Testing Instructions

- Open the network panel of your browser's devtools.
- Save a VAT ID to your test account (either using `/me/purchases/vat-details` or Payments Admin or checkout itself).
- Add a product to your cart and visit checkout.
- Edit the billing details step if it's not already active.
- Make sure you select a country which supports VAT.
- Make sure the "Add Business Tax ID details" checkbox is checked and the VAT details are pre-filled.
- Click "Continue" to complete the step. We need to do this once first to prepare for the test.

Now for the actual test...

- Edit the step again.
- Click "Continue" to complete the step.
- Verify that there is **no POST request** made to the `/me/vat-info` endpoint.
- Edit the step again and change one of the VAT fields like "Address for tax ID" and click "Continue".
- Verify that there is **a successful POST request** made to the `/me/vat-info` endpoint with the updated address.