### PR TITLE
Staging Sites: Improve progress indicator text

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -155,11 +155,7 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 			{ ( addingStagingSite || ( showManageStagingSite && ! isStagingSiteTransferComplete ) ) && (
 				<>
 					<StyledLoadingBar progress={ progress } />
-					<p>
-						{ __(
-							'Feel free to continue working while we create your staging site. We’ll email you once it is ready.'
-						) }
-					</p>
+					<p>{ __( 'We are setting up your staging site. We’ll email you once it is ready.' ) }</p>
 				</>
 			) }
 		</Card>


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/1758

## Proposed Changes

Tweaks the text on the progress indicator screen:

![CleanShot 2023-03-08 at 14 17 54@2x](https://user-images.githubusercontent.com/36432/223864278-7631e76c-7e3f-4688-a33d-bc8b909f445c.png)

## Testing Instructions

1. Create a new Business site and take it Atomic.
2. Create a staging site.
3. Verify the text appears as presented.