### PR TITLE
Odyssey Stats: Rename app name to "odyssey-stats"

### DIFF
--- a/apps/odyssey-stats/package.json
+++ b/apps/odyssey-stats/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "@automattic/calypso-stats",
+	"name": "@automattic/odyssey-stats",
 	"version": "0.1.0",
-	"description": "WordPress.com Stats.",
+	"description": "Calypso Stats served within wp-admin via the Jetpack plugin",
 	"main": "dist/build.min.js",
 	"sideEffects": true,
 	"repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -353,50 +353,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/calypso-stats@workspace:apps/odyssey-stats":
-  version: 0.0.0-use.local
-  resolution: "@automattic/calypso-stats@workspace:apps/odyssey-stats"
-  dependencies:
-    "@automattic/babel-plugin-transform-wpcalypso-async": "workspace:^"
-    "@automattic/calypso-apps-builder": "workspace:^"
-    "@automattic/calypso-babel-config": "workspace:^"
-    "@automattic/calypso-build": "workspace:^"
-    "@automattic/calypso-config": "workspace:^"
-    "@automattic/calypso-eslint-overrides": "workspace:^"
-    "@automattic/calypso-polyfills": "workspace:^"
-    "@automattic/calypso-url": "workspace:^"
-    "@automattic/languages": "workspace:^"
-    "@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^"
-    "@automattic/webpack-inline-constant-exports-plugin": "workspace:^"
-    "@automattic/wp-babel-makepot": "workspace:^"
-    "@wordpress/dependency-extraction-webpack-plugin": ^4.4.0
-    autoprefixer: ^10.2.5
-    calypso: "workspace:^"
-    classnames: ^2.3.1
-    debug: ^4.3.4
-    gettext-parser: ^6.0.0
-    html-webpack-plugin: ^5.0.0-beta.4
-    jest: ^27.2.4
-    lodash: ^4.17.21
-    mkdirp: ^1.0.4
-    node-fetch: ^2.6.6
-    page: ^1.11.5
-    path-browserify: ^1.0.1
-    postcss: ^8.3.11
-    prop-types: ^15.8.1
-    react: ^17.0.2
-    react-dom: ^17.0.2
-    react-query: ^3.32.1
-    react-redux: ^7.2.6
-    redux: ^4.1.2
-    redux-thunk: ^2.3.0
-    webpack: ^5.68.0
-    webpack-bundle-analyzer: ^4.5.0
-    wpcom: "workspace:^"
-    wpcom-proxy-request: "workspace:^"
-  languageName: unknown
-  linkType: soft
-
 "@automattic/calypso-storybook@workspace:^, @automattic/calypso-storybook@workspace:packages/calypso-storybook":
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-storybook@workspace:packages/calypso-storybook"
@@ -1204,6 +1160,50 @@ __metadata:
     reakit-utils: ^0.15.1
     redux: ^4.1.2
     webpack: ^5.68.0
+  languageName: unknown
+  linkType: soft
+
+"@automattic/odyssey-stats@workspace:apps/odyssey-stats":
+  version: 0.0.0-use.local
+  resolution: "@automattic/odyssey-stats@workspace:apps/odyssey-stats"
+  dependencies:
+    "@automattic/babel-plugin-transform-wpcalypso-async": "workspace:^"
+    "@automattic/calypso-apps-builder": "workspace:^"
+    "@automattic/calypso-babel-config": "workspace:^"
+    "@automattic/calypso-build": "workspace:^"
+    "@automattic/calypso-config": "workspace:^"
+    "@automattic/calypso-eslint-overrides": "workspace:^"
+    "@automattic/calypso-polyfills": "workspace:^"
+    "@automattic/calypso-url": "workspace:^"
+    "@automattic/languages": "workspace:^"
+    "@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^"
+    "@automattic/webpack-inline-constant-exports-plugin": "workspace:^"
+    "@automattic/wp-babel-makepot": "workspace:^"
+    "@wordpress/dependency-extraction-webpack-plugin": ^4.4.0
+    autoprefixer: ^10.2.5
+    calypso: "workspace:^"
+    classnames: ^2.3.1
+    debug: ^4.3.4
+    gettext-parser: ^6.0.0
+    html-webpack-plugin: ^5.0.0-beta.4
+    jest: ^27.2.4
+    lodash: ^4.17.21
+    mkdirp: ^1.0.4
+    node-fetch: ^2.6.6
+    page: ^1.11.5
+    path-browserify: ^1.0.1
+    postcss: ^8.3.11
+    prop-types: ^15.8.1
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    react-query: ^3.32.1
+    react-redux: ^7.2.6
+    redux: ^4.1.2
+    redux-thunk: ^2.3.0
+    webpack: ^5.68.0
+    webpack-bundle-analyzer: ^4.5.0
+    wpcom: "workspace:^"
+    wpcom-proxy-request: "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Proposed Changes

* Rename the Odyssey Stats app from "@automattic/calypso-stats" to "@automattic/odyssey-stats".

## Testing Instructions

* N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
