### PR TITLE
Theme Showcase: Logged-out header

### DIFF
--- a/client/components/search-themes/index.tsx
+++ b/client/components/search-themes/index.tsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { __experimentalUseFocusOutside as useFocusOutside } from '@wordpress/compose';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
@@ -119,7 +120,9 @@ const SearchThemes: React.FC< SearchThemesProps > = ( { query, onSearch, recordT
 	return (
 		<div ref={ wrapperRef } { ...useFocusOutside( closeSearch ) }>
 			<div
-				className="search-themes-card"
+				className={ classnames( 'search-themes-card', {
+					'is-suggestions-open': isSearchOpen,
+				} ) }
 				role="presentation"
 				data-tip-target="search-themes-card"
 				onClick={ focusOnInput }

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -7,7 +7,7 @@ import ThemeShowcase from './theme-showcase';
 const ConnectedThemeShowcase = connectOptions( ThemeShowcase );
 
 export default ( props ) => (
-	<Main fullWidthLayout className="themes">
+	<Main fullWidthLayout isLoggedOut className="themes">
 		<BodySectionCssClass
 			bodyClass={ [
 				...( isEnabled( 'themes/showcase-i4/details-and-preview' )

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -478,7 +478,6 @@ class ThemeShowcase extends Component {
 		const tabFilters = this.getTabFilters();
 		const tiers = this.getTiers();
 
-		// FIXME: Logged-in title should only be 'Themes'
 		return (
 			<div className="theme-showcase">
 				<DocumentHead title={ title } meta={ metas } />
@@ -487,53 +486,72 @@ class ThemeShowcase extends Component {
 					title={ this.props.analyticsPageTitle }
 					properties={ { is_logged_in: isLoggedIn } }
 				/>
-				{ isLoggedIn && (
-					<ThemesHeader
-						description={ translate(
-							'Select or update the visual design for your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-							{
-								components: {
-									learnMoreLink: <InlineSupportLink supportContext="themes" showIcon={ false } />,
-								},
-							}
-						) }
-					>
-						<div className="themes__install-theme-button-container">
-							<InstallThemeButton />
-						</div>
-						<ScreenOptionsTab wpAdminPath="themes.php" />
-					</ThemesHeader>
-				) }
+				<ThemesHeader
+					title={
+						isLoggedIn
+							? translate( 'Themes' )
+							: translate( 'Find the perfect theme for your website' )
+					}
+					description={
+						isLoggedIn
+							? translate(
+									'Select or update the visual design for your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+									{
+										components: {
+											learnMoreLink: (
+												<InlineSupportLink supportContext="themes" showIcon={ false } />
+											),
+										},
+									}
+							  )
+							: translate(
+									'Beautiful and responsive WordPress.com themes. Choose from free and premium options for all types of websites. Then, install the one that is right for you.'
+							  )
+					}
+				>
+					{ isLoggedIn && (
+						<>
+							<div className="themes__install-theme-button-container">
+								<InstallThemeButton />
+							</div>
+							<ScreenOptionsTab wpAdminPath="themes.php" />
+						</>
+					) }
+				</ThemesHeader>
 				<div className="themes__content" ref={ this.scrollRef }>
 					<QueryThemeFilters />
-					<SearchThemes
-						query={ filterString + search }
-						onSearch={ this.doSearch }
-						recordTracksEvent={ this.recordSearchThemesTracksEvent }
-					/>
-					{ tabFilters && (
-						<div className="theme__filters">
-							<ThemesToolbarGroup
-								items={ Object.values( tabFilters ) }
-								selectedKey={ this.state.tabFilter.key }
-								onSelect={ ( key ) =>
-									this.onFilterClick(
-										Object.values( tabFilters ).find( ( tabFilter ) => tabFilter.key === key )
-									)
-								}
-							/>
-							{ premiumThemesEnabled && ! isMultisite && (
-								<SimplifiedSegmentedControl
-									key={ tier }
-									initialSelected={ tier || 'all' }
-									options={ tiers }
-									onSelect={ this.onTierSelect }
+					<div className="themes__controls">
+						<SearchThemes
+							query={ filterString + search }
+							onSearch={ this.doSearch }
+							recordTracksEvent={ this.recordSearchThemesTracksEvent }
+						/>
+						{ tabFilters && (
+							<div className="theme__filters">
+								<ThemesToolbarGroup
+									items={ Object.values( tabFilters ) }
+									selectedKey={ this.state.tabFilter.key }
+									onSelect={ ( key ) =>
+										this.onFilterClick(
+											Object.values( tabFilters ).find( ( tabFilter ) => tabFilter.key === key )
+										)
+									}
 								/>
-							) }
-						</div>
-					) }
-					{ this.renderBanner() }
-					{ this.renderThemes( themeProps ) }
+								{ premiumThemesEnabled && ! isMultisite && (
+									<SimplifiedSegmentedControl
+										key={ tier }
+										initialSelected={ tier || 'all' }
+										options={ tiers }
+										onSelect={ this.onTierSelect }
+									/>
+								) }
+							</div>
+						) }
+					</div>
+					<div className="themes__showcase">
+						{ this.renderBanner() }
+						{ this.renderThemes( themeProps ) }
+					</div>
 					{ siteId && <QuerySitePlans siteId={ siteId } /> }
 					{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 					<QueryProductsList />

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -184,6 +184,119 @@ body.is-section-themes {
 	}
 }
 
+.is-logged-out {
+	.themes__header::before,
+	.themes__controls::before {
+		background-color: #e5f4ff;
+		content: "";
+		left: 0;
+		height: 100%;
+		position: absolute;
+		top: 0;
+		width: 100%;
+		z-index: -1;
+	}
+
+	.themes__header {
+		border: none;
+		margin: 0;
+		position: relative;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			padding: 64px 32px 16px;
+		}
+
+		h1 {
+			color: var(--studio-blue-50);
+			font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+			font-size: 2.75rem;
+			line-height: 1.15;
+			margin-bottom: 16px;
+		}
+
+		.page-sub-header {
+			font-size: 1rem;
+		}
+	}
+
+	.themes__content {
+		position: relative;
+
+		.themes__controls,
+		.themes__showcase {
+			padding: 0 16px;
+			position: relative;
+
+			@include breakpoint-deprecated( ">660px" ) {
+				padding: 0 32px;
+			}
+		}
+	}
+
+	.search-themes-card {
+		border-radius: 4px;
+		max-width: 450px;
+		transition: max-width 0.2s ease-out;
+
+		&.is-suggestions-open {
+			max-width: 100%;
+		}
+
+		.search,
+		.keyed-suggestions {
+			border: none;
+			box-shadow:
+				0 0 0 0 rgba(38, 19, 19, 0.03),
+				0 1px 2px 0 rgba(38, 19, 19, 0.03),
+				0 4px 4px 0 rgba(38, 19, 19, 0.03),
+				0 9px 5px 0 rgba(38, 19, 19, 0.02),
+				0 16px 6px 0 rgba(38, 19, 19, 0),
+				0 25px 7px 0 rgba(38, 19, 19, 0);
+			margin: 0;
+		}
+
+		.keyed-suggestions__category {
+			background-color: var(--studio-blue-5);
+		}
+
+		.keyed-suggestions__value.is-selected {
+			background-color: rgba(var(--studio-blue-rgb), 0.1);
+		}
+	}
+
+	.themes-toolbar-group.responsive-toolbar-group__dropdown .components-toolbar .components-button,
+	.themes-toolbar-group.responsive-toolbar-group__swipe .components-toolbar .components-button {
+		&:not(.is-pressed) {
+			color: var(--studio-blue-90);
+
+			&:hover::before {
+				background-color: rgba(var(--studio-blue-rgb), 0.1);
+			}
+		}
+
+		&.is-pressed {
+			color: var(--color-text-inverted);
+
+			&::before {
+				background-color: var(--studio-blue-50);
+			}
+		}
+	}
+
+	.theme__filters {
+		margin: 0;
+		padding: 72px 0 24px;
+
+		.segmented-control {
+			background-color: var(--studio-blue-5);
+
+			.segmented-control__text {
+				color: var(--studio-gray-80);
+			}
+		}
+	}
+}
+
 .theme-showcase {
 	.themes__selection .themes-list {
 		margin: 32px -16px 0;
@@ -307,16 +420,11 @@ body.is-section-themes {
 .themes__content {
 	min-height: 100vh;
 
-	@include breakpoint-deprecated( "<660px" ) {
-		margin: 16px 16px 0;
-	}
-}
-
-.is-section-themes.has-no-sidebar .themes__content {
-	padding: 0 0 32px;
-
-	@include breakpoint-deprecated( ">480px" ) {
-		padding: 32px;
+	.themes__controls,
+	.themes__showcase {
+		@include breakpoint-deprecated( "<660px" ) {
+			padding: 0 16px;
+		}
 	}
 }
 

--- a/client/my-sites/themes/themes-header.tsx
+++ b/client/my-sites/themes/themes-header.tsx
@@ -1,17 +1,16 @@
-import { translate } from 'i18n-calypso';
-
 import './themes-header.scss';
 
 interface Props {
+	title: string;
 	description: string;
 	children: any;
 }
 
-const ThemesHeader = ( { description, children }: Props ) => {
+const ThemesHeader = ( { title, description, children }: Props ) => {
 	return (
 		<div className="themes__header">
 			<div className="themes__page-heading">
-				<h1>{ translate( 'Themes' ) }</h1>
+				<h1>{ title }</h1>
 				<p className="page-sub-header">{ description }</p>
 			</div>
 			{ children }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73266

## Proposed Changes

This PR updates the Theme Showcase logged-out header as described in #73266. The update is only for the logged-out header, so the logged-in header should remain unchanged.

| Before | After |
| --- | --- |
| ![Screenshot 2023-03-09 at 11 50 23 AM](https://user-images.githubusercontent.com/797888/223912088-462e585d-5803-4d03-8d26-c47e6a6be8d3.png) | ![Screenshot 2023-03-10 at 2 01 00 PM](https://user-images.githubusercontent.com/797888/224239033-4929e545-39d6-46c4-badc-43b7deafd1ca.png) |


| Before | After |
| --- | --- |
| ![Screenshot 2023-03-09 at 11 51 54 AM](https://user-images.githubusercontent.com/797888/223912337-0966aab1-53e0-47a2-98e8-a158bd42ce46.png) | ![Screenshot 2023-03-10 at 2 01 12 PM](https://user-images.githubusercontent.com/797888/224239079-3f6321e6-94e5-4341-972d-a976e0f6aada.png) |


@davewhitley  @vinimotaa  @david-gonzalez-a8c 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-out Theme Showcase and ensure that the header is as described above.
* Ensure that the logged-in Theme Showcase header works the same as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
