### PR TITLE
Domains List: Update domains list actions

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain-header/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain-header/style.scss
@@ -54,6 +54,9 @@
 
 	@include break-mobile {
 		display: flex;
+		.ellipsis-menu__toggle.button.is-borderless {
+			padding: 0 15px 10px 15px;
+		}
 	}
 }
 

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -1,4 +1,4 @@
-import { Button, Gridicon, Spinner } from '@automattic/components';
+import { Button, Spinner } from '@automattic/components';
 import { Icon, home, info, redo, plus } from '@wordpress/icons';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -379,7 +379,6 @@ class DomainRow extends PureComponent {
 					disabled={ disabled || isBusy }
 					onClick={ this.stopPropagation }
 					toggleTitle={ translate( 'Options' ) }
-					icon={ <Gridicon icon="ellipsis" className="gridicon" /> }
 					popoverClassName="domain-row__popover"
 					position="bottom"
 				>

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -29,6 +29,8 @@ import TransferConnectedDomainNudge from 'calypso/my-sites/domains/domain-manage
 import {
 	domainManagementList,
 	createSiteFromDomainOnly,
+	domainManagementEditContactInfo,
+	domainManagementDns,
 	domainUseMyDomain,
 } from 'calypso/my-sites/domains/paths';
 import {
@@ -335,6 +337,16 @@ class DomainRow extends PureComponent {
 		page( emailPath );
 	};
 
+	goToEditContactInfo = () => {
+		const { currentRoute, domain, site } = this.props;
+		page( domainManagementEditContactInfo( site.slug, domain.domain, currentRoute ) );
+	};
+
+	goToDNSManagement = () => {
+		const { currentRoute, domain, site } = this.props;
+		page( domainManagementDns( site.slug, domain.domain, currentRoute ) );
+	};
+
 	renderEllipsisMenu() {
 		const {
 			disabled,
@@ -375,6 +387,12 @@ class DomainRow extends PureComponent {
 						{ domain.type === domainTypes.TRANSFER
 							? translate( 'View transfer' )
 							: translate( 'View settings' ) }
+					</PopoverMenuItem>
+					<PopoverMenuItem icon="info-outline" onClick={ this.goToDNSManagement }>
+						{ translate( 'Manage DNS' ) }
+					</PopoverMenuItem>
+					<PopoverMenuItem icon="book" onClick={ this.goToEditContactInfo }>
+						{ translate( 'Manage Contact Info' ) }
 					</PopoverMenuItem>
 					{ canSetAsPrimary( domain, isManagingAllSites, shouldUpgradeToMakePrimary ) &&
 						! isRecentlyRegisteredAndDoesNotPointToWpcom( domain ) && (

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -1,5 +1,5 @@
-import { Button, Spinner } from '@automattic/components';
-import { Icon, home, info, moreVertical, redo, plus } from '@wordpress/icons';
+import { Button, Gridicon, Spinner } from '@automattic/components';
+import { Icon, home, info, redo, plus } from '@wordpress/icons';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
@@ -379,7 +379,7 @@ class DomainRow extends PureComponent {
 					disabled={ disabled || isBusy }
 					onClick={ this.stopPropagation }
 					toggleTitle={ translate( 'Options' ) }
-					icon={ <Icon icon={ moreVertical } size={ 28 } className="gridicon" /> }
+					icon={ <Gridicon icon="ellipsis" className="gridicon" /> }
 					popoverClassName="domain-row__popover"
 					position="bottom"
 				>

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -345,10 +345,6 @@
 		padding: 0;
 	}
 
-	.gridicon {
-		transform: rotate(90deg);
-	}
-
 	@include break-mobile {
 		flex: 6 6 0;
 		margin: 0;

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -345,6 +345,10 @@
 		padding: 0;
 	}
 
+	.gridicon {
+		transform: rotate(90deg);
+	}
+
 	@include break-mobile {
 		flex: 6 6 0;
 		margin: 0;

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -350,7 +350,7 @@
 		margin: 0;
 
 		.button.is-borderless {
-			padding: 10px 15px 10px 15px;
+			padding: 0 15px 10px 15px;
 		}
 	}
 }

--- a/client/my-sites/domains/domain-management/list/domain-row.scss
+++ b/client/my-sites/domains/domain-management/list/domain-row.scss
@@ -350,7 +350,7 @@
 		margin: 0;
 
 		.button.is-borderless {
-			padding: 0 0 10px 30px;
+			padding: 10px 15px 10px 15px;
 		}
 	}
 }
@@ -370,11 +370,5 @@
 		svg {
 			fill: var(--studio-white);
 		}
-	}
-}
-
-.domain-table-header {
-	.list__action-cell {
-		padding: 0 0 0 30px;
 	}
 }

--- a/client/my-sites/domains/domain-management/list/free-domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/free-domain-item.jsx
@@ -3,7 +3,7 @@
 import { Spinner } from '@automattic/components';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, edit, home, moreVertical } from '@wordpress/icons';
+import { Icon, edit, home } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import { createElement } from 'react';
 import SiteAddressChanger from 'calypso/blocks/site-address-changer';
@@ -65,7 +65,6 @@ export default function FreeDomainItem( {
 				<EllipsisMenu
 					disabled={ disabled }
 					toggleTitle={ __( 'Free WordPress address options' ) }
-					icon={ <Icon icon={ moreVertical } size={ 28 } className="gridicon" /> }
 					popoverClassName="free-domain-item__popover"
 					position="bottom"
 				>

--- a/client/my-sites/domains/domain-management/list/free-domain-item.scss
+++ b/client/my-sites/domains/domain-management/list/free-domain-item.scss
@@ -66,6 +66,10 @@
 	& .ellipsis-menu {
 		transform: translateY(-6px);
 		height: 20px;
+
+		.button.is-borderless {
+			padding: 0 15px 10px 15px;
+		}
 	}
 
 	& .ellipsis-menu__toggle {

--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -2,13 +2,14 @@
 
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
-import { Icon, moreVertical, plus, search } from '@wordpress/icons';
+import { Icon, plus, search } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { createRef, Component, Fragment } from 'react';
 import { connect } from 'react-redux';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { domainAddNew, domainUseMyDomain } from 'calypso/my-sites/domains/paths';
@@ -94,11 +95,7 @@ class AddDomainButton extends Component {
 	};
 
 	renderLabel() {
-		const { ellipsisButton, specificSiteActions, translate } = this.props;
-
-		if ( ellipsisButton ) {
-			return <Icon icon={ moreVertical } className="options-domain-button__ellipsis gridicon" />;
-		}
+		const { specificSiteActions, translate } = this.props;
 
 		let label = translate( 'Other domain options' );
 		if ( specificSiteActions ) {
@@ -116,6 +113,14 @@ class AddDomainButton extends Component {
 	render() {
 		const { specificSiteActions, ellipsisButton, borderless } = this.props;
 		const classes = classNames( 'options-domain-button', ellipsisButton && 'ellipsis' );
+
+		if ( ellipsisButton ) {
+			return (
+				<EllipsisMenu popoverClassName="options-domain-button__popover" position="bottom">
+					{ this.renderOptions() }
+				</EllipsisMenu>
+			);
+		}
 
 		return (
 			<Fragment>

--- a/client/my-sites/domains/domain-management/list/site-domains.jsx
+++ b/client/my-sites/domains/domain-management/list/site-domains.jsx
@@ -168,7 +168,7 @@ export class SiteDomains extends Component {
 			},
 			{ name: 'auto-renew', label: translate( 'Auto-renew' ) },
 			{ name: 'email', label: translate( 'Email' ) },
-			{ name: 'action', label: null },
+			{ name: 'action', label: translate( 'Actions' ) },
 		];
 
 		return (


### PR DESCRIPTION
## Estimated Time to Test / Review:
- Test -> Short
- Review -> Short

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add "Actions" column header label
* Center align the actions icon
* Make actions icon bolder
* Align with existing ellipses conventions and make icon horizontal
* Make actions icon click area larger
* Add actions manage dns and edit contact info popover menu items

## Screenshots
### Before
<img width="1496" alt="Screenshot 2023-03-09 at 1 04 02 AM" src="https://user-images.githubusercontent.com/5414230/223972970-ef9485d0-189a-4a58-8f35-600decba13f1.png">

### After
![Screenshot 2023-03-09 at 2 57 26 AM copy](https://user-images.githubusercontent.com/5414230/224004089-8f5fde80-75ce-49e0-a967-da532852cc3a.jpg)

![Screenshot 2023-03-09 at 3 00 32 AM copy](https://user-images.githubusercontent.com/5414230/224004458-826c06ca-9695-4178-9e79-2e613b9aad75.jpg)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch and run `yarn start` in a terminal
* Navigate to the domains list page of a test site that has a custom domain
* Verify that the domains action icon layout behaves as expected
* Verify that the "Manage DNS" item navigates to http://calypso.localhost:3000/domains/manage/{SITE_SLUG}/dns/{SITE_SLUG}
* Verify that the "Manage Contact Info" item navigates to http://calypso.localhost:3000/domains/manage/{SITE_SLUG}/edit-contact-info/{SITE_SLUG}
* Verify that the free domain item ellipses at the bottom of the list continue to work as expected
* Verify that the domain header ellipses at the top of the page continue to work as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
