### PR TITLE
Subscription Manager: Adding formatted title with a subtitle to the manager

### DIFF
--- a/client/my-sites/subscriptions/index.tsx
+++ b/client/my-sites/subscriptions/index.tsx
@@ -1,11 +1,11 @@
 import config from '@automattic/calypso-config';
-import { SubscriptionManagerContainer } from '@automattic/subscription-manager';
+import SubscriptionManager from '@automattic/subscription-manager';
 import page, { Callback } from 'page';
 import { createElement } from 'react';
 import { makeLayout, render } from 'calypso/controller';
 
 const createSubscriptions: Callback = ( context, next ) => {
-	context.primary = createElement( SubscriptionManagerContainer );
+	context.primary = createElement( SubscriptionManager );
 	next();
 };
 

--- a/packages/subscription-manager/package.json
+++ b/packages/subscription-manager/package.json
@@ -30,6 +30,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
+		"@automattic/typography": "workspace:^",
 		"typescript": "^4.5.5"
 	},
 	"peerDependencies": {

--- a/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
+++ b/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
@@ -2,19 +2,29 @@
 /**
  * External dependencies
  */
+import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import './styles.scss';
 
 export type SubscriptionManagerContainerProps = {
 	children?: React.ReactNode;
 };
 
 const SubscriptionManagerContainer = ( { children }: SubscriptionManagerContainerProps ) => {
+	const translate = useTranslate();
 	return (
-		<Main className="site-settings">
+		<Main className="subscription-manager-container">
 			<DocumentHead title="Subscriptions" />
-			<FormattedHeader brandFont headerText="Subscriptions" align="left" />
+			<FormattedHeader
+				brandFont
+				headerText={ translate( 'Subscription management' ) }
+				subHeaderText={ translate(
+					'Manage your WordPress.com newsletter and blog subscriptions.'
+				) }
+				align="left"
+			/>
 			{ children }
 		</Main>
 	);

--- a/packages/subscription-manager/src/components/SubscriptionManagerContainer/styles.scss
+++ b/packages/subscription-manager/src/components/SubscriptionManagerContainer/styles.scss
@@ -1,0 +1,51 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@wordpress/base-styles/breakpoints";
+
+.wpcom-site {
+	background-color: $studio-white;
+
+	.layout__content {
+		padding: 48px 62px;
+
+		.main {
+			max-width: 1440px;
+
+			.formatted-header {
+				margin: 0;
+
+				.formatted-header__title {
+					font-size: $font-headline-medium !important;
+					line-height: $font-headline-large;
+					color: $studio-gray-100;
+					margin-bottom: 16px;
+				}
+
+				.formatted-header__subtitle {
+					font-size: $font-body !important;
+					line-height: $font-title-medium;
+					color: $studio-gray-60;
+				}
+			}
+		}
+
+	}
+
+
+	@media screen and ( max-width: $break-medium ) {
+		.layout__content {
+			padding: 4px 24px;
+
+			.main {
+				.formatted-header {
+					.formatted-header__title {
+						font-size: $font-title-medium !important;
+						line-height: $font-title-large;
+						margin-bottom: 8px;
+					}
+				}
+			}
+		}
+	}
+
+}
+

--- a/packages/subscription-manager/src/components/SubscriptionManagerContainer/styles.scss
+++ b/packages/subscription-manager/src/components/SubscriptionManagerContainer/styles.scss
@@ -13,14 +13,14 @@
 			.formatted-header {
 				margin: 0;
 
-				.formatted-header__title {
+				&__title {
 					font-size: $font-headline-medium !important;
 					line-height: $font-headline-large;
 					color: $studio-gray-100;
 					margin-bottom: 16px;
 				}
 
-				.formatted-header__subtitle {
+				&__subtitle {
 					font-size: $font-body !important;
 					line-height: $font-title-medium;
 					color: $studio-gray-60;
@@ -37,7 +37,7 @@
 
 			.subscription-manager-container {
 				.formatted-header {
-					.formatted-header__title {
+					&__title {
 						font-size: $font-title-medium !important;
 						line-height: $font-title-large;
 						margin-bottom: 8px;

--- a/packages/subscription-manager/src/components/SubscriptionManagerContainer/styles.scss
+++ b/packages/subscription-manager/src/components/SubscriptionManagerContainer/styles.scss
@@ -7,7 +7,7 @@
 	.layout__content {
 		padding: 48px 62px;
 
-		.main {
+		.subscription-manager-container {
 			max-width: 1440px;
 
 			.formatted-header {
@@ -35,7 +35,7 @@
 		.layout__content {
 			padding: 4px 24px;
 
-			.main {
+			.subscription-manager-container {
 				.formatted-header {
 					.formatted-header__title {
 						font-size: $font-title-medium !important;

--- a/packages/subscription-manager/src/index.tsx
+++ b/packages/subscription-manager/src/index.tsx
@@ -1,1 +1,3 @@
-export { SubscriptionManagerContainer } from './components/SubscriptionManagerContainer';
+import { SubscriptionManagerContainer as SubscriptionManager } from './components/SubscriptionManagerContainer';
+
+export default SubscriptionManager;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,6 +1563,7 @@ __metadata:
   resolution: "@automattic/subscription-manager@workspace:packages/subscription-manager"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/typography": "workspace:^"
     typescript: ^4.5.5
   peerDependencies:
     "@wordpress/data": ^6.1.5


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #74074

## Proposed Changes

* Introduce a formatted title to the SubscriptionManager that reads as "Subscription management"
  * used translate callback
* Introduce a formatted subtitle to the SubscriptionManager that reads as "Manage your WordPress.com newsletter and blog subscriptions."
  * used translate callback

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open incognito browser window (where you are logged out of wpcom)
* Go to http://calypso.localhost:3000/subscriptions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


![calypso localhost_3000_subscriptions](https://user-images.githubusercontent.com/2019970/223980963-1afef229-a398-4767-bec5-357cb869b85e.png)

![calypso localhost_3000_subscriptions (1)](https://user-images.githubusercontent.com/2019970/223980961-1e0f5c71-491a-4b7f-b202-22b46771442a.png)
