### PR TITLE
Virtual themes i2: Create custom homepage template

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -43,6 +43,7 @@ import {
 	getVirtualDesignProps,
 } from '../../analytics/record-design';
 import StepperLoader from '../../components/stepper-loader';
+import { PLACEHOLDER_SITE_ID } from '../pattern-assembler/constants';
 import { getCategorizationOptions } from './categories';
 import { DEFAULT_VARIATION_SLUG, RETIRING_DESIGN_SLUGS, STEP_NAME } from './constants';
 import DesignPickerDesignTitle from './design-picker-design-title';
@@ -453,7 +454,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 	// ********** Logic for submitting the selected design
 
-	const { setDesignOnSite } = useDispatch( SITE_STORE );
+	const { setDesignOnSite, applyThemeWithPatterns } = useDispatch( SITE_STORE );
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 
 	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
@@ -467,12 +468,20 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 					( design ) => design.slug === _selectedDesign.slug
 				);
 			}
-			setPendingAction( () =>
-				setDesignOnSite( siteSlugOrId, _selectedDesign, {
+			setPendingAction( () => {
+				if ( _selectedDesign.is_virtual && _selectedDesign.recipe?.pattern_ids?.length ) {
+					return applyThemeWithPatterns(
+						siteSlugOrId,
+						_selectedDesign,
+						null,
+						PLACEHOLDER_SITE_ID
+					).then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) );
+				}
+				return setDesignOnSite( siteSlugOrId, _selectedDesign, {
 					styleVariation: selectedStyleVariation,
 					verticalId: siteVerticalId,
-				} ).then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) )
-			);
+				} ).then( () => reduxDispatch( requestActiveTheme( site?.ID || -1 ) ) );
+			} );
 
 			handleSubmit(
 				{

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -516,7 +516,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 	function* applyThemeWithPatterns(
 		siteSlug: string,
 		design: Design,
-		globalStyles: GlobalStyles,
+		globalStyles: GlobalStyles | null,
 		sourceSiteId: number
 	) {
 		const stylesheet = design?.recipe?.stylesheet || '';
@@ -527,7 +527,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		// modified Home template.
 		yield setThemeOnSite( siteSlug, theme, undefined, false );
 
-		if ( isEnabled( 'pattern-assembler/color-and-fonts' ) ) {
+		if ( isEnabled( 'pattern-assembler/color-and-fonts' ) && globalStyles ) {
 			yield setGlobalStyles( siteSlug, stylesheet, globalStyles );
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1912
Requires https://github.com/Automattic/wp-calypso/pull/73944

## Proposed Changes

Ensures that the activation of patter-based virtual themes creates a new Home template instead of updating the existing Index template.

## Testing Instructions

- Use the Calypso live link below
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_SLUG>&flags=virtual-themes/onboarding`
- Pick a pattern-based virtual theme
- Go to the site editor and select the Home template
- Make sure it contains the patterns included in the virtual theme