### PR TITLE
Fix event recording for `calypso_plan_features_upgrade_click`

### DIFF
--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -14,7 +14,7 @@ import classNames from 'classnames';
 import { localize, TranslateResult, useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import { WPCOM_PLANS_UI_STORE } from './store';
@@ -278,7 +278,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 
 		if ( ! freePlan ) {
 			recordTracksEvent( 'calypso_plan_features_upgrade_click', {
-				current_plan: null,
+				current_plan: currentSitePlanSlug,
 				upgrading_to: planType,
 			} );
 		}

--- a/client/my-sites/plan-features-comparison/actions.jsx
+++ b/client/my-sites/plan-features-comparison/actions.jsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useState } from 'react';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 const noop = () => {};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1678294085915499-slack-CFFF01Q4V

## Proposed Changes

* The `calypso_plan_features_upgrade_click` event is not recorded correctly. This is because the `recordTracksEvent` function imported from `calypso/state/analytics/actions` is an action generator meant to be used along with `dispatch`. This PR changes the import so that the function is imported from `calypso/lib/analytics/tracks`, which does not need to be wrapped in `dispatch`.
* While working on this, I noticed that the `current_plan` event prop was passed as `null`. This change also replaces `null` with the actual current plan slug.

This change is a "band-aid" solution and does not fix the root problem - it is easy to use the `recordTracksEvent` from the wrong file. The proper fix is to probably rename the `recordTracksEvent` from `calypso/state/analytics/actions`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/<site slug>` where the selected site is on any plan lower than the eCommerce plan. (free is also okay)
* Open the network inspector and switch to the "Images/Img" tab.
* Click on the "Upgrade" button for any plan.
* Confirm that you see a network request to `pixel.wp.com`.
* Open the network request and confirm that the payload contains the correct event props.
<img width="415" alt="image" src="https://user-images.githubusercontent.com/5436027/224020761-5196cabf-6cdb-4cbc-927f-90348d5221df.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?