### PR TITLE
Fix intense behavior of style variations in Pattern Assembler

### DIFF
--- a/packages/global-styles/src/components/global-styles-variation-container/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variation-container/index.tsx
@@ -29,7 +29,7 @@ const GlobalStylesVariationContainer = ( {
 			return [
 				...styles,
 				{
-					css: 'html{overflow:hidden}body{min-width: 0;padding: 0;border: none;}',
+					css: 'html{overflow:hidden}body{min-width: 0;padding: 0;border: none;transform:scale(1);}',
 					isGlobalStyles: true,
 				},
 			];

--- a/packages/global-styles/src/components/global-styles-variation-container/style.scss
+++ b/packages/global-styles/src/components/global-styles-variation-container/style.scss
@@ -6,7 +6,5 @@
 	box-shadow: 0 0 0 1px rgb(0 0 0 / 10%);
 	border: 0;
 	display: block;
-	max-height: 77.2258px;
 	max-width: 100%;
-	overflow: hidden;
 }


### PR DESCRIPTION
## Proposed Changes

Fixes the "intense" Firefox behavior of the style variations displayed in the Pattern Assembler. Changes are based on https://github.com/Automattic/wp-calypso/pull/72729 which fixed a similar issue in the Design Preview.

Before

https://user-images.githubusercontent.com/1233880/224017564-955485ed-dea6-4994-926d-b358c0e3313b.mov


After

https://user-images.githubusercontent.com/1233880/224017433-ca4326a8-1c4c-4c72-a7e2-b2185b511b7f.mov



## Testing Instructions

- Use the Calypso live link below in Firefox
- Open the Pattern Assembler
- Select "Change colors" or "Change fonts"
- Make sure you don't get the "intense" behavior
- Make sure the container are rendered as expected
