### PR TITLE
Site Assembler - Pattern action tooltips overlap the icon 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -118,6 +118,8 @@ $font-family: "SF Pro Text", $sans;
 			overflow-y: auto;
 			overflow-x: hidden;
 			scrollbar-width: none;
+			// Fix for tooltip position issue
+			padding-bottom: 25px;
 
 			&::-webkit-scrollbar {
 				display: none;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -360,7 +360,8 @@ $font-family: "SF Pro Text", $sans;
 .pattern-assembler.pattern-assembler__sidebar-revamp {
 	.pattern-layout {
 		.pattern-layout__list {
-			margin: 0 0 16px;
+			// Fix for tooltip position issue
+			margin: 0 0 -9px;
 		}
 
 		.pattern-action-bar {


### PR DESCRIPTION
Related https://github.com/Automattic/wp-calypso/issues/74266 https://github.com/Automattic/wp-calypso/pull/74190 

## Proposed Changes

* Add a 25px padding-bottom to the `<ul>` to allow space for the tooltip
* Keep the same distance between the list and the `Add patterns` button

|Before|After|
|---|---|
|<img width="319" alt="Screenshot 2566-03-09 at 21 11 36" src="https://user-images.githubusercontent.com/1881481/224051176-77fdc2e8-061a-417a-a1df-ccc461020d44.png">|<img width="321" alt="Screenshot 2566-03-09 at 21 10 15" src="https://user-images.githubusercontent.com/1881481/224051193-1937b9c9-1b90-404d-bb1f-556dd3f01e0f.png">|

## Remaining issue
The issue remains on the last pattern when there is scroll.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Access the assembler
- Create your homepage
- Add one pattern
- Hover over the pattern on the list to show the action bar
- Add two patterns
- Hover over the last pattern
- Add as many patterns as required to trigger the scroll
- Scroll down and hover over the last pattern to verify the issue still remains

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
