### PR TITLE
Fix domain-only flow when selecting a free plan

### DIFF
--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -300,8 +300,8 @@ export default function getThankYouPageUrl( {
 		receiptIdOrPlaceholder
 	) {
 		if ( urlFromCookie.includes( '/setup/setup-site' ) ) {
-			const noticeType = getNoticeType( cart );
-			return getUrlWithQueryParam( urlFromCookie, noticeType );
+			debug( 'domain only signup with free site selection' );
+			return urlFromCookie;
 		}
 		if ( ! urlFromCookie.includes( '/start/setup-site' ) ) {
 			clearSignupCompleteFlowName();

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -297,13 +297,18 @@ export default function getThankYouPageUrl( {
 		( cart?.create_new_blog || signupFlowName === 'domain' ) &&
 		! isDomainOnly &&
 		urlFromCookie &&
-		receiptIdOrPlaceholder &&
-		! urlFromCookie.includes( '/start/setup-site' )
+		receiptIdOrPlaceholder
 	) {
-		clearSignupCompleteFlowName();
-		const newBlogReceiptUrl = `${ urlFromCookie }/${ receiptIdOrPlaceholder }`;
-		debug( 'new blog created, so returning', newBlogReceiptUrl );
-		return newBlogReceiptUrl;
+		if ( urlFromCookie.includes( '/setup/setup-site' ) ) {
+			const noticeType = getNoticeType( cart );
+			return getUrlWithQueryParam( urlFromCookie, noticeType );
+		}
+		if ( ! urlFromCookie.includes( '/start/setup-site' ) ) {
+			clearSignupCompleteFlowName();
+			const newBlogReceiptUrl = `${ urlFromCookie }/${ receiptIdOrPlaceholder }`;
+			debug( 'new blog created, so returning', newBlogReceiptUrl );
+			return newBlogReceiptUrl;
+		}
 	}
 
 	// disable upsell for tailored signup users

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -89,9 +89,13 @@ function getLaunchDestination( dependencies ) {
 	return `/home/${ dependencies.siteSlug }`;
 }
 
-function getDomainSignupFlowDestination( { domainItem, cartItem, siteId, designType, siteSlug } ) {
-	if ( domainItem && cartItem && designType !== 'existing-site' ) {
-		return addQueryArgs( { siteId }, '/start/setup-site' );
+function getDomainSignupFlowDestination( { siteId, designType, siteSlug, refParameter } ) {
+	if ( designType === 'page' ) {
+		const queryParam = { siteId };
+		if ( refParameter ) {
+			queryParam.ref = refParameter;
+		}
+		return addQueryArgs( queryParam, '/setup/setup-site' );
 	} else if ( designType === 'existing-site' ) {
 		return `/checkout/thank-you/${ siteSlug }`;
 	}


### PR DESCRIPTION
Related to #74068 

## Proposed Changes

This PR fixes domain only flow when the user select "New site -> Add free plan" option.

The error mentioned in the above issue happens because after adding a free plan, a regular site is created (instead of domain only shadow site). After the checkout we should directly redirect the user to the site setup page instead of showing the regular domain only thank you page (since the site has already been created).

## Testing Instructions

Apply this patch locally or use the link below.

- Navigate to `start/domain`
- Enter a domain in the search field
- In "Choose how to use your domain" step, select "New site"
- In "Choose a plan", select "Start with a free plan"
- Complete the checkout and verify that the thank you page with the Setup is properly displayed (see screenshot below)

![thankyou](https://user-images.githubusercontent.com/2797601/224025566-b1d66939-decd-4345-9fbf-20e670a14c44.png)

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
