### PR TITLE
e2e: Fix flaky I18n Tests

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-welcome-tour-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-welcome-tour-component.ts
@@ -20,11 +20,11 @@ export class EditorWelcomeTourComponent {
 	}
 
 	/**
-	 * Force dismisses the welcome tour using Redux state/actions.
+	 * Force shows or dismisses the welcome tour using Redux state/actions.
 	 *
 	 * @see {@link https://github.com/Automattic/wp-calypso/issues/57660}
 	 */
-	async forceDismissWelcomeTour(): Promise< void > {
+	async forceToggleWelcomeTour( show = true ): Promise< void > {
 		// Locator API doesn't have waitForFunction yet. We need a Frame for now.
 		const editorElement = await this.editor.elementHandle( {
 			timeout: EXTENDED_EDITOR_WAIT_TIMEOUT,
@@ -45,7 +45,7 @@ export class EditorWelcomeTourComponent {
 			return await welcomeGuide.isWelcomeGuideStatusLoaded();
 		} );
 
-		await editorFrame.waitForFunction( async () => {
+		await editorFrame.waitForFunction( async ( show ) => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			const welcomeGuide = ( window as any )?.wp?.data?.dispatch(
 				'automattic/wpcom-welcome-guide'
@@ -55,8 +55,23 @@ export class EditorWelcomeTourComponent {
 				return false;
 			}
 
-			const actionPayload = await welcomeGuide.setShowWelcomeGuide( false );
-			return actionPayload.show === false;
-		} );
+			const actionPayload = await welcomeGuide.setShowWelcomeGuide( show );
+
+			return actionPayload.show === show;
+		}, show );
+	}
+
+	/**
+	 * Force shows the welcome tour using Redux state/actions.
+	 */
+	async forceShowWelcomeTour(): Promise< void > {
+		await this.forceToggleWelcomeTour( true );
+	}
+
+	/**
+	 * Force dismisses the welcome tour using Redux state/actions.
+	 */
+	async forceDismissWelcomeTour(): Promise< void > {
+		await this.forceToggleWelcomeTour( false );
 	}
 }

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -275,7 +275,7 @@ describe( 'I18N: Editor', function () {
 	describe.each( locales )( `Locale: %s`, function ( locale ) {
 		beforeAll( async function () {
 			await restAPIClient.setMySettings( { language: locale } );
-			await page.reload( { waitUntil: 'networkidle', timeout: 20 * 1000 } );
+			await page.reload();
 		} );
 
 		describe( 'Editing Toolkit Plugin', function () {

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -9,6 +9,7 @@ import {
 	getTestAccountByFeature,
 	envToFeatureKey,
 	RestAPIClient,
+	EditorWelcomeTourComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser, Locator } from 'playwright';
 import type { LanguageSlug } from '@automattic/languages';
@@ -284,14 +285,25 @@ describe( 'I18N: Editor', function () {
 			} );
 
 			it( 'Translations for Welcome Guide', async function () {
+				// Abort API request to fetch the Welcome Tour status in order to avoid
+				// overwriting the current state when the request finishes.
+				await page.route( '**/block-editor/nux*', ( route ) => {
+					route.abort();
+				} );
+
 				const editorWindowLocator = editorPage.getEditorWindowLocator();
+				const editorWelcomeTourComponent = new EditorWelcomeTourComponent(
+					page,
+					editorWindowLocator
+				);
 
 				// We know these are all defined because of the filtering above. Non-null asserting is safe here.
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				const etkTranslations = translations[ locale ]!.etkPlugin!;
 
-				await editorPage.openEditorOptionsMenu();
-				await editorWindowLocator.locator( etkTranslations.welcomeGuide.openGuideSelector ).click();
+				// Ensure the Welcome Guide component is shown.
+				await editorWelcomeTourComponent.forceShowWelcomeTour();
+
 				await editorWindowLocator
 					.locator( etkTranslations.welcomeGuide.welcomeTitleSelector )
 					.waitFor();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Remove page reload `waitUntil` param after changing the language in i18n editor spec.
* Fix flaky ETK translations test caused by Welcome Tour current state being overwritten by initial state fetched from the API.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run custom I18N Tests build in TeamCity for this branch and confirm no test are ignored and all tests pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
