### PR TITLE
My home domain upsell: Select first domain instead of .com on e2e

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -4,6 +4,7 @@ import { reloadAndRetry } from '../../element-helper';
 const selectors = {
 	searchInput: `.search-component__input`,
 	resultItem: ( keyword: string ) => `.domain-suggestion__content:has-text("${ keyword }")`,
+	firstResultItem: `.domain-suggestion:first-child .domain-suggestion__content`,
 };
 
 /**
@@ -74,6 +75,23 @@ export class DomainSearchComponent {
 	 */
 	async selectDomain( keyword: string ): Promise< string > {
 		const targetItem = await this.page.waitForSelector( selectors.resultItem( keyword ) );
+		// Heading element inside a given result contains the full domain name string.
+		const selectedDomain = await targetItem
+			.waitForSelector( 'h3' )
+			.then( ( el ) => el.innerText() );
+
+		await Promise.all( [ this.page.waitForNavigation(), targetItem.click() ] );
+
+		return selectedDomain;
+	}
+
+	/**
+	 * Select the first domain suggestion.
+	 *
+	 * @returns {string} Domain that was selected.
+	 */
+	async selectFirstSuggestion(): Promise< string > {
+		const targetItem = await this.page.waitForSelector( selectors.firstResultItem );
 		// Heading element inside a given result contains the full domain name string.
 		const selectedDomain = await targetItem
 			.waitForSelector( 'h3' )

--- a/test/e2e/specs/domain-upsell/domain-upsell__sidebar.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__sidebar.ts
@@ -68,8 +68,8 @@ describe( DataHelper.createSuiteTitle( 'Sidebar: Domain upsell' ), function () {
 		await domainSearchComponent.search( blogName + '.com' );
 	} );
 
-	it( 'Choose the .com TLD', async function () {
-		selectedDomain = await domainSearchComponent.selectDomain( '.com' );
+	it( 'Choose the the first suggestion', async function () {
+		selectedDomain = await domainSearchComponent.selectFirstSuggestion();
 	} );
 
 	it( 'View available plans', async function () {


### PR DESCRIPTION
Related to p1678363478775119-slack-C02DQP0FP

## Proposed Changes

As sometimes there is no `.com` suggestion, we choose the first suggestion instead.

## Testing Instructions

Run `yarn workspace wp-e2e-tests test -- domain-upsell`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~