### PR TITLE
Server Bundler: Enable cache for assets on the development env

### DIFF
--- a/client/server/bundler/index.js
+++ b/client/server/bundler/index.js
@@ -100,7 +100,15 @@ function middleware( app ) {
 	}
 
 	app.use( waitForCompiler );
-	app.use( webpackMiddleware( compiler ) );
+	app.use(
+		webpackMiddleware( compiler, {
+			headers: ( req, res ) => {
+				if ( /\.(?:gif|jpg|jpeg|png|svg)$/i.test( req.originalUrl ) ) {
+					res.setHeader( 'Cache-Control', 'max-age=3600' );
+				}
+			},
+		} )
+	);
 }
 
 module.exports = middleware;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Enable cache for file assets so that those assets won't request every time. This is especially for the `gridicon` since the calypso will request svg and it leads the icon might become white when you are back and forth between different pages.

![image](https://user-images.githubusercontent.com/13596067/224072019-fc97407e-b525-4127-a324-6e6c93520969.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/site-setup?siteSlug=<your_site>`
* Back and forth between different steps, and ensure the back icon, `<`, on the top-left corner won't be flashing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
