### PR TITLE
App Banner: Delete unused/redundant code in App Banner component

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -125,14 +125,10 @@ export class AppBanner extends Component {
 		const { currentRoute, currentSection } = this.props;
 
 		if ( this.isAndroid() ) {
-			const displayJetpackAppBranding = config.isEnabled( 'jetpack/app-branding' );
-			const scheme = displayJetpackAppBranding ? 'jetpack' : 'wordpress';
-			const packageName = displayJetpackAppBranding
-				? 'com.jetpack.android'
-				: 'org.wordpress.android';
+			const scheme = 'jetpack';
+			const packageName = 'com.jetpack.android';
 			const utmDetails = `utm_source%3Dcalypso%26utm_campaign%3Dcalypso-mobile-banner`;
 
-			//TODO: update when section deep links are available.
 			switch ( currentSection ) {
 				case GUTENBERG:
 					return `intent://details?id=${ packageName }&url=${ scheme }://post&referrer=${ utmDetails }#Intent;scheme=market;action=android.intent.action.VIEW;package=com.android.vending;end`;

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button, Card } from '@automattic/components';
 import { compose } from '@wordpress/compose';
 import classNames from 'classnames';
@@ -156,57 +155,6 @@ export class AppBanner extends Component {
 		return (
 			<div className={ classNames( 'app-banner-overlay' ) } ref={ this.preventNotificationsClose }>
 				<Card
-					className={ classNames( 'app-banner', 'is-compact', currentSection, 'jetpack' ) }
-					ref={ this.preventNotificationsClose }
-				>
-					<TrackComponentView
-						eventName="calypso_mobile_app_banner_impression"
-						eventProperties={ {
-							page: currentSection,
-						} }
-						statGroup="calypso_mobile_app_banner"
-						statName="impression"
-					/>
-					<AnimatedIcon className="app-banner__icon" icon={ icon } />
-					<div className="app-banner__text-content jetpack">
-						<div className="app-banner__title jetpack">
-							<span> { title } </span>
-						</div>
-						<div className="app-banner__copy jetpack">
-							<span> { copy } </span>
-						</div>
-					</div>
-					<div className="app-banner__buttons jetpack">
-						<Button
-							primary
-							className="app-banner__open-button jetpack"
-							onClick={ this.openApp }
-							href={ this.getDeepLink() }
-						>
-							{ translate( 'Open in the Jetpack app' ) }
-						</Button>
-						<Button className="app-banner__no-thanks-button jetpack" onClick={ this.dismiss }>
-							{ translate( 'Continue in browser' ) }
-						</Button>
-					</div>
-				</Card>
-			</div>
-		);
-	};
-
-	getWordpressAppBanner = ( { translate, currentSection } ) => {
-		const { title, copy } = getAppBannerData( translate, currentSection );
-
-		// This conditional will be unnecessary once the 'jetpack/app-branding'
-		// feature flag is removed and its features are made the default
-		// experience, as getAppBannerData will then not include conditionals.
-		if ( ! title || ! copy ) {
-			return null;
-		}
-
-		return (
-			<div className={ classNames( 'app-banner-overlay' ) } ref={ this.preventNotificationsClose }>
-				<Card
 					className={ classNames( 'app-banner', 'is-compact', currentSection ) }
 					ref={ this.preventNotificationsClose }
 				>
@@ -218,9 +166,7 @@ export class AppBanner extends Component {
 						statGroup="calypso_mobile_app_banner"
 						statName="impression"
 					/>
-					<div className="app-banner__circle is-top-left is-yellow" />
-					<div className="app-banner__circle is-top-right is-blue" />
-					<div className="app-banner__circle is-bottom-right is-red" />
+					<AnimatedIcon className="app-banner__icon" icon={ icon } />
 					<div className="app-banner__text-content">
 						<div className="app-banner__title">
 							<span> { title } </span>
@@ -236,10 +182,10 @@ export class AppBanner extends Component {
 							onClick={ this.openApp }
 							href={ this.getDeepLink() }
 						>
-							{ translate( 'Open in app' ) }
+							{ translate( 'Open in the Jetpack app' ) }
 						</Button>
 						<Button className="app-banner__no-thanks-button" onClick={ this.dismiss }>
-							{ translate( 'No thanks' ) }
+							{ translate( 'Continue in browser' ) }
 						</Button>
 					</div>
 				</Card>
@@ -252,11 +198,7 @@ export class AppBanner extends Component {
 			return null;
 		}
 
-		const displayJetpackAppBranding = config.isEnabled( 'jetpack/app-branding' );
-
-		return displayJetpackAppBranding
-			? this.getJetpackAppBanner( this.props )
-			: this.getWordpressAppBanner( this.props );
+		return this.getJetpackAppBanner( this.props );
 	}
 }
 

--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -25,18 +25,13 @@ body.app-banner-is-visible {
 	left: 0;
 	width: 100%;
 	background-color: var(--color-surface);
-	color: var(--color-primary-80);
-	padding: 20px;
+	color: var(--color-neutral-100);
+	padding: 30px 24px;
 	margin-bottom: 0;
 	box-shadow: 3px -2px 24px 4px rgba(0, 0, 0, 0.29);
 	overflow: hidden;
-
-	&.jetpack {
-		color: var(--color-neutral-100);
-		padding: 30px 24px;
-		text-align: center;
-		font-family: "SF Pro Text", $sans;
-	}
+	text-align: center;
+	font-family: "SF Pro Text", $sans;
 }
 
 .app-banner__circle {
@@ -78,78 +73,57 @@ body.app-banner-is-visible {
 
 .app-banner__text-content {
 	width: 100%;
-
-	&.jetpack {
-		letter-spacing: -0.4px;
-		margin: 36px auto 0;
-	}
+	letter-spacing: -0.4px;
+	margin: 36px auto 0;
 }
 
 .app-banner__title {
-	font-size: rem(22px); //typography-exception
-	font-family: $brand-serif;
+	font-size: rem(28px); //typography-exception
 	line-height: 30px;
-
-	&.jetpack {
-		font-size: rem(28px); //typography-exception
-		font-weight: 500;
-		max-width: 18em;
-		margin-left: auto;
-		margin-right: auto;
-		-webkit-font-smoothing: auto;
-		-moz-osx-font-smoothing: initial;
-		text-rendering: auto;
-		@extend .wp-brand-font;
-	}
+	font-weight: 500;
+	max-width: 18em;
+	margin-left: auto;
+	margin-right: auto;
+	-webkit-font-smoothing: auto;
+	-moz-osx-font-smoothing: initial;
+	text-rendering: auto;
+	@extend .wp-brand-font;
 }
 
 .app-banner__copy {
-	margin-top: 12px;
-	font-size: rem(15px); //typography-exception
-
-	&.jetpack {
-		font-size: rem(16px); //typography-exception
-		line-height: 21px;
-		max-width: 18em;
-		margin-left: auto;
-		margin-right: auto;
-		margin-top: 18px;
-	}
+	font-size: rem(16px); //typography-exception
+	line-height: 21px;
+	max-width: 18em;
+	margin-left: auto;
+	margin-right: auto;
+	margin-top: 18px;
 }
 
 .app-banner__buttons {
 	width: 100%;
 	margin-top: 36px;
+
+	.button {
+		width: 100%;
+		min-width: 110px;
+		max-width: 366px;
+		margin: auto;
+		display: block;
+		padding: 15px 18px;
+		font-size: rem(18px); //typography-exception;
+	}
 }
 
 .button.app-banner__open-button {
-	background-color: var(--color-accent-40);
+	background-color: var(--color-jetpack);
 	border: 0;
 	border-radius: 4px;
 	margin-right: 10px;
-
-	&.jetpack {
-		background-color: var(--color-jetpack);
-		margin-bottom: 12px;
-	}
+	margin-bottom: 12px;
 }
 
 .button.app-banner__no-thanks-button {
 	background: none;
 	border: 0;
-	color: var(--color-text-subtle);
-
-	&.jetpack {
-		color: var(--color-text);
-	}
-}
-
-.button.jetpack {
-	width: 100%;
-	min-width: 110px;
-	max-width: 366px;
-	margin: auto;
-	display: block;
-	padding: 15px 18px;
-	font-size: rem(18px); //typography-exception;
+	color: var(--color-text);
 }

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { get, includes, reduce } from 'lodash';
 
 export const APP_BANNER_DISMISS_TIMES_PREFERENCE = 'appBannerDismissTimes';
@@ -22,8 +21,6 @@ const emptyBanner = {
 };
 
 export function getAppBannerData( translate, sectionName, isRTL ) {
-	const displayJetpackAppBranding = config.isEnabled( 'jetpack/app-branding' );
-
 	switch ( sectionName ) {
 		case GUTENBERG:
 			return {
@@ -54,17 +51,11 @@ export function getAppBannerData( translate, sectionName, isRTL ) {
 				icon: `/calypso/animations/app-promo/jp-stats${ isRTL ? '-rtl' : '' }.json`,
 			};
 		case HOME:
-			if ( displayJetpackAppBranding ) {
-				return {
-					title: translate( 'The Jetpack app makes WordPress better.' ),
-					copy: translate(
-						'Everything you need to write, publish, and manage a world-class site.'
-					),
-					icon: `/calypso/animations/app-promo/wp-to-jp${ isRTL ? '-rtl' : '' }.json`,
-				};
-			}
-
-			return emptyBanner;
+			return {
+				title: translate( 'The Jetpack app makes WordPress better.' ),
+				copy: translate( 'Everything you need to write, publish, and manage a world-class site.' ),
+				icon: `/calypso/animations/app-promo/wp-to-jp${ isRTL ? '-rtl' : '' }.json`,
+			};
 		default:
 			return emptyBanner;
 	}


### PR DESCRIPTION
A `jetpack/app-branding` feature flag was added in https://github.com/Automattic/wp-calypso/pull/6681 in order to conditionally replace mentions of the WordPress app with the Jetpack app. As the flag is now set to `true` across all environments, we can safely remove all code that mentions the WordPress app, as it is now redundant.

This PR is one of multiple planned that will eventually allow us to remove the `jetpack/app-branding` feature flag.

## Proposed Changes

* Redundant/unused code has been removed from the App Banner component.

## Testing Instructions

_Prerequisite:_ The app banner can be viewed via the mobile web (which can also be [emulated using browser tools](https://developer.chrome.com/docs/devtools/device-mode/#viewport)) when navigating directly to the Reader, Stats, Notifications, or the editor.

The following should be confirmed for both iOS and Android:

* Verify that the banner appears as expected when navigating to the Reader, Stats, Notifications, and the editor.
* The banners should look and function the same with the changes in this PR as they do in production.

| Reader  | Stats |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/224121313-742cdf16-e0c0-4525-9631-47b460d603be.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/224121545-96f79aa6-5dea-42eb-be84-e017d2600081.png" width="100%"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
