### PR TITLE
Apps Badge: Delete redundant conditional

### DIFF
--- a/client/blocks/get-apps/apps-badge.jsx
+++ b/client/blocks/get-apps/apps-badge.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { startsWith } from 'lodash';
@@ -7,7 +6,6 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import TranslatableString from 'calypso/components/translatable/proptype';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
-import userAgent from 'calypso/lib/user-agent';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './apps-badge.scss';
@@ -19,16 +17,10 @@ const APP_STORE_BADGE_URLS = {
 		defaultSrc: '/calypso/images/me/get-apps-ios-store.svg',
 		src: 'https://linkmaker.itunes.apple.com/assets/shared/badges/{localeSlug}/appstore-lrg.svg',
 		tracksEvent: 'calypso_app_download_ios_click',
-		getStoreLink: ( utm_source, _utm_medium, _utm_campaign, displayJetpackAppBranding ) => {
-			const appId = displayJetpackAppBranding
-				? '1565481562' // Jetpack
-				: '335703880'; // WordPress
-			return `https://apps.apple.com/app/apple-store/id${ appId }?pt=299112&ct=${ utm_source }&mt=8`;
+		getStoreLink: ( utm_source ) => {
+			return `https://apps.apple.com/app/apple-store/id$1565481562?pt=299112&ct=${ utm_source }&mt=8`;
 		},
-		getTitleText: ( displayJetpackAppBranding ) =>
-			displayJetpackAppBranding
-				? translate( 'Download the Jetpack iOS mobile app.' )
-				: translate( 'Download the WordPress iOS mobile app.' ),
+		getTitleText: () => translate( 'Download the Jetpack iOS mobile app.' ),
 		getAltText: () => translate( 'Apple App Store download badge' ),
 		getLocaleSlug: function () {
 			const localeSlug = getLocaleSlug();
@@ -43,16 +35,11 @@ const APP_STORE_BADGE_URLS = {
 		getStoreLink: (
 			utm_source,
 			utm_medium = 'web',
-			utm_campaign = 'mobile-download-promo-pages',
-			displayJetpackAppBranding
+			utm_campaign = 'mobile-download-promo-pages'
 		) => {
-			const appId = displayJetpackAppBranding ? 'com.jetpack.android' : 'org.wordpress.android';
-			return `https://play.google.com/store/apps/details?id=${ appId }&referrer=utm_source%3D%${ utm_source }%26utm_medium%3D${ utm_medium }%26utm_campaign%3D${ utm_campaign }`;
+			return `https://play.google.com/store/apps/details?id=com.jetpack.android&referrer=utm_source%3D%${ utm_source }%26utm_medium%3D${ utm_medium }%26utm_campaign%3D${ utm_campaign }`;
 		},
-		getTitleText: ( displayJetpackAppBranding ) =>
-			displayJetpackAppBranding
-				? translate( 'Download the Jetpack Android mobile app.' )
-				: translate( 'Download the WordPress Android mobile app.' ),
+		getTitleText: () => translate( 'Download the Jetpack Android mobile app.' ),
 		getAltText: () => translate( 'Google Play Store download badge' ),
 		getLocaleSlug,
 	},
@@ -92,11 +79,6 @@ export class AppsBadge extends PureComponent {
 			this.image = null;
 			this.loadImage();
 		}
-
-		const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
-		const isIos = isiPad || isiPod || isiPhone;
-		this.displayJetpackAppBranding =
-			config.isEnabled( 'jetpack/app-branding' ) && ( isIos || isAndroid );
 	}
 
 	loadImage() {
@@ -142,14 +124,7 @@ export class AppsBadge extends PureComponent {
 			<figure className={ figureClassNames }>
 				<a
 					href={
-						storeLink
-							? storeLink
-							: badge.getStoreLink(
-									utm_source,
-									utm_medium,
-									utm_campaign,
-									this.displayJetpackAppBranding
-							  )
+						storeLink ? storeLink : badge.getStoreLink( utm_source, utm_medium, utm_campaign )
 					}
 					onClick={ this.onLinkClick }
 					target="_blank"
@@ -157,7 +132,7 @@ export class AppsBadge extends PureComponent {
 				>
 					<img
 						src={ imageSrc }
-						title={ titleText ? titleText : badge.getTitleText( this.displayJetpackAppBranding ) }
+						title={ titleText ? titleText : badge.getTitleText() }
 						alt={ altText ? altText : badge.getAltText() }
 					/>
 				</a>


### PR DESCRIPTION
A `jetpack/app-branding` feature flag was added in https://github.com/Automattic/wp-calypso/pull/6681 in order to conditionally replace mentions of the WordPress app with the Jetpack app. As the flag is now set to `true` across all environments, we can safely remove all code that mentions the WordPress app, as it is now redundant.

This PR is part of a series that will eventually allow us to remove the `jetpack/app-branding` feature flag.

## Proposed Changes

* As `jetpack/app-branding` is always true, this PR removes that conditional and all associated (redundant) functionality associated with it from the Apps Badge component.

## Testing Instructions

* In a mobile browser, navigate to _Me_ → _Apps_ and confirm that there are no changes to the style or functionality of the app badges. The Google Play badge should display for Android devices and the App Store badge for iOS devices.

| Android  | iOS |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/224302812-37f6a194-1464-4ff6-b087-f4e69061d9ee.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/224303003-67bdfdb1-869c-4992-9414-5b926db60f69.png" width="100%"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
