### PR TITLE
Remove redundant feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -76,7 +76,6 @@
 		"inline-help": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/api-cache": true,
-		"jetpack/app-branding": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/cancel-through-main-flow": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -45,7 +45,6 @@
 		"i18n/translation-scanner": true,
 		"inline-help": true,
 		"jetpack/api-cache": true,
-		"jetpack/app-branding": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/cancel-through-main-flow": true,

--- a/config/production.json
+++ b/config/production.json
@@ -48,7 +48,6 @@
 		"inline-help": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/api-cache": false,
-		"jetpack/app-branding": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/cancel-through-main-flow": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -45,7 +45,6 @@
 		"inline-help": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/api-cache": true,
-		"jetpack/app-branding": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/cancel-through-main-flow": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -56,7 +56,6 @@
 		"inline-help": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/api-cache": true,
-		"jetpack/app-branding": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/cancel-through-main-flow": true,
 		"jetpack/concierge-sessions": false,


### PR DESCRIPTION
The `jetpack/app-branding` feature flag originally added in https://github.com/Automattic/wp-calypso/pull/6681 has since been set to `true` across all environments. We also don't have future plans that will make it necessary or useful to set the flag to `false`. Therefore, in the following series of PRs, all redundant code associated with the flag was removed:

* `Get Apps`: https://github.com/Automattic/wp-calypso/pull/74263
* `Customer Home`: https://github.com/Automattic/wp-calypso/pull/74290
* `Apps Badge`: https://github.com/Automattic/wp-calypso/pull/74296
* `Apps Banner`: https://github.com/Automattic/wp-calypso/pull/74284
* `Apps Promo Sidebar`: https://github.com/Automattic/wp-calypso/pull/74288

## Proposed Changes

* As all code relying on `jetpack/app-branding` has been removed, and the flag is always set to true, it can be removed.

## Testing Instructions

* Search the codebase for `jetpack/app-branding` to ensure there are no remaining references.
* Visit the areas of Calypso that mention the Jetpack mobile app to ensure there are no changes to their design or functionality. This was also covered as part of the reviews for each of the linked PRs above, and more thorough testing steps can be found in each of those individual PRs.   

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
