### PR TITLE
Jetpack Agency Dashboard: Remove Beta from Social Advanced during license issuing

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -180,7 +180,9 @@ export function formatApiPartner( partner: APIPartner ): Partner {
  * @returns Product title
  */
 export function getProductTitle( product: string ): string {
-	return product.replace( /(?:Jetpack\s|[)(])/gi, '' );
+	return product
+		.replace( /(?:Jetpack\s|[)(])/gi, '' )
+		.replace( 'Social Advanced Beta', 'Social Advanced' );
 }
 
 export function selectProductOptions( families: APIProductFamily[] ): APIProductFamilyProduct[] {


### PR DESCRIPTION
## Proposed Changes

* This PR string replaces the word "Beta" from "Social Advanced Beta" in the Jetpack Pro Dashboard.

## Testing Instructions

* Load up the license issuing page in the Jetpack Pro Dashboard and ensure that "Beta" is removed from "Social Advanced" as a product.

![Screen Shot 2023-03-09 at 2 31 58 PM](https://user-images.githubusercontent.com/5528445/224134343-cda6af29-5ae4-4d3a-b300-964af7670259.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
