### PR TITLE
Fix the FSE template edit e2e test

### DIFF
--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -51,6 +51,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 
 		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Back' );
+		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Back' );
+		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Templates' );
 		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Page' );
 		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Edit' );
 	} );

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -50,7 +50,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	it( 'Open the Page template', async function () {
 		fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
 
-		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Templates' );
+		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Back' );
 		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Page' );
 		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Edit' );
 	} );


### PR DESCRIPTION
Noticed this test permafailing on trunk. Looks like the editor loads differently on the new gutenberg version, where it's zoomed into the index template instead of starting more zoomed out. As a result, to edit the "page" template, we need to click the "back" button first.

Note that on the e2e test site, it seems to start zoomed into the "navigation" submenu, which is kinda weird. I'm not sure how sustainable this test will be, but it's breaking everywhere right now so a quick fix seems prudent.

## Testing Instructions
e2e should pass