### PR TITLE
Add Woo Express Performance to the cart from the trial plans page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -1,9 +1,12 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import config from '@automattic/calypso-config';
 import {
 	getPlans,
 	plansLink,
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_MONTHLY,
+	PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
+	PLAN_WOOEXPRESS_MEDIUM,
 } from '@automattic/calypso-products';
 import { Button, Card } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
@@ -26,6 +29,13 @@ interface ECommerceTrialPlansPageProps {
 	siteSlug: string;
 }
 
+interface PlanPrices {
+	annualPlanPrice: number;
+	annualPlanMonthlyPrice: number;
+	monthlyPlanPrice: number;
+	currencyCode: string;
+}
+
 const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 	const interval = props.interval ?? 'monthly';
 	const siteSlug = props.siteSlug;
@@ -34,6 +44,8 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 
 	const eCommercePlanAnnual = getPlans()[ PLAN_ECOMMERCE ];
 	const eCommercePlanMonthly = getPlans()[ PLAN_ECOMMERCE_MONTHLY ];
+	const wooexpressMediumMonthly = getPlans()[ PLAN_WOOEXPRESS_MEDIUM_MONTHLY ];
+	const wooexpressMediumYearly = getPlans()[ PLAN_WOOEXPRESS_MEDIUM ];
 
 	const eCommercePlanPrices = useSelector( ( state ) => ( {
 		annualPlanPrice: getPlanRawPrice( state, eCommercePlanAnnual.getProductId(), false ) || 0,
@@ -42,8 +54,19 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 		currencyCode: getPlan( state, eCommercePlanAnnual.getProductId() )?.currency_code || '',
 	} ) );
 
+	const wooexpressPlanPrices = useSelector( ( state ) => ( {
+		monthlyPlanPrice: getPlanRawPrice( state, wooexpressMediumMonthly.getProductId() ) || 0,
+		annualPlanPrice: getPlanRawPrice( state, wooexpressMediumYearly.getProductId() ) || 0,
+		annualPlanMonthlyPrice:
+			getPlanRawPrice( state, wooexpressMediumYearly.getProductId(), true ) || 0,
+		currencyCode: getPlan( state, wooexpressMediumMonthly.getProductId() )?.currency_code || '',
+	} ) );
+
 	const isAnnualSubscription = interval === 'yearly';
 	const targetECommercePlan = isAnnualSubscription ? eCommercePlanAnnual : eCommercePlanMonthly;
+	const targetWooExpressMediumPlan = isAnnualSubscription
+		? wooexpressMediumYearly
+		: wooexpressMediumMonthly;
 
 	const percentageSavings = Math.floor(
 		( 1 - eCommercePlanPrices.annualPlanMonthlyPrice / eCommercePlanPrices.monthlyPlanPrice ) * 100
@@ -55,14 +78,18 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 				location: tracksLocation,
 			} );
 
+			const productSlug = config.isEnabled( 'plans/wooexpress-medium' )
+				? targetWooExpressMediumPlan.getStoreSlug()
+				: targetECommercePlan.getStoreSlug();
+
 			const checkoutUrl = getECommerceTrialCheckoutUrl( {
-				productSlug: targetECommercePlan.getStoreSlug(),
+				productSlug,
 				siteSlug,
 			} );
 
 			page.redirect( checkoutUrl );
 		},
-		[ siteSlug, targetECommercePlan ]
+		[ siteSlug, targetECommercePlan, targetWooExpressMediumPlan ]
 	);
 
 	const eCommercePlanFeatureSets = useMemo( () => {
@@ -72,44 +99,106 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 	const monthlyPriceWrapper = <span className="e-commerce-trial-plans__price-card-value" />;
 	const priceDescription = <span className="e-commerce-trial-plans__price-card-interval" />;
 
-	const priceContent = isAnnualSubscription
-		? translate(
-				'{{monthlyPriceWrapper}}%(monthlyPrice)s{{/monthlyPriceWrapper}} {{priceDescription}}per month, %(annualPrice)s billed annually{{/priceDescription}}',
-				{
-					args: {
-						monthlyPrice: formatCurrency(
-							eCommercePlanPrices.annualPlanMonthlyPrice,
-							eCommercePlanPrices.currencyCode,
-							{ stripZeros: true }
-						),
-						annualPrice: formatCurrency(
-							eCommercePlanPrices.annualPlanPrice,
-							eCommercePlanPrices.currencyCode,
-							{ stripZeros: true }
-						),
-					},
-					components: {
-						monthlyPriceWrapper,
-						priceDescription,
-					},
-				}
-		  )
-		: translate(
-				'{{monthlyPriceWrapper}}%(monthlyPrice)s{{/monthlyPriceWrapper}} {{priceDescription}}per month{{/priceDescription}}',
-				{
-					args: {
-						monthlyPrice: formatCurrency(
-							eCommercePlanPrices.monthlyPlanPrice,
-							eCommercePlanPrices.currencyCode,
-							{ stripZeros: true }
-						),
-					},
-					components: {
-						monthlyPriceWrapper,
-						priceDescription,
-					},
-				}
-		  );
+	const getPriceContent = ( planPrices: PlanPrices ) => {
+		return isAnnualSubscription
+			? translate(
+					'{{monthlyPriceWrapper}}%(monthlyPrice)s{{/monthlyPriceWrapper}} {{priceDescription}}per month, %(annualPrice)s billed annually{{/priceDescription}}',
+					{
+						args: {
+							monthlyPrice: formatCurrency(
+								planPrices.annualPlanMonthlyPrice,
+								planPrices.currencyCode,
+								{ stripZeros: true }
+							),
+							annualPrice: formatCurrency( planPrices.annualPlanPrice, planPrices.currencyCode, {
+								stripZeros: true,
+							} ),
+						},
+						components: {
+							monthlyPriceWrapper,
+							priceDescription,
+						},
+					}
+			  )
+			: translate(
+					'{{monthlyPriceWrapper}}%(monthlyPrice)s{{/monthlyPriceWrapper}} {{priceDescription}}per month{{/priceDescription}}',
+					{
+						args: {
+							monthlyPrice: formatCurrency( planPrices.monthlyPlanPrice, planPrices.currencyCode, {
+								stripZeros: true,
+							} ),
+						},
+						components: {
+							monthlyPriceWrapper,
+							priceDescription,
+						},
+					}
+			  );
+	};
+
+	const priceContent = config.isEnabled( 'plans/wooexpress-medium' )
+		? getPriceContent( wooexpressPlanPrices )
+		: getPriceContent( eCommercePlanPrices );
+
+	const eCommercePlanUpgradeCard = () => {
+		return (
+			<Card className="e-commerce-trial-plans__price-card">
+				<div className="e-commerce-trial-plans__price-card-text">
+					<span className="e-commerce-trial-plans__price-card-title">
+						{ targetECommercePlan.getTitle() }
+					</span>
+					<span className="e-commerce-trial-plans__price-card-subtitle">
+						{ translate( 'Accelerate your growth with advanced features.' ) }
+					</span>
+				</div>
+				<div className="e-commerce-trial-plans__price-card-conditions">
+					{ priceContent }
+					{ isAnnualSubscription && (
+						<span className="e-commerce-trial-plans__price-card-savings">
+							{ translate( 'Save %(percentageSavings)s%% by paying annually', {
+								args: { percentageSavings },
+							} ) }
+						</span>
+					) }
+				</div>
+				<div className="e-commerce-trial-plans__price-card-cta-wrapper">
+					<Button
+						className="e-commerce-trial-plans__price-card-cta"
+						primary
+						onClick={ () => redirectToCheckoutForPlan( 'main-price-card' ) }
+					>
+						{ translate( 'Upgrade now' ) }
+					</Button>
+				</div>
+			</Card>
+		);
+	};
+
+	const wooexpressMediumMonthlyPlanUpgradeCard = () => {
+		return (
+			<Card className="e-commerce-trial-plans__price-card">
+				<div className="e-commerce-trial-plans__price-card-text">
+					<span className="e-commerce-trial-plans__price-card-title">
+						{ targetWooExpressMediumPlan.getTitle() }
+					</span>
+					<span className="e-commerce-trial-plans__price-card-subtitle">
+						{ /* TODO - Is this the right copy? */ }
+						{ translate( 'Accelerate your growth with advanced features.' ) }
+					</span>
+				</div>
+				<div className="e-commerce-trial-plans__price-card-conditions">{ priceContent }</div>
+				<div className="e-commerce-trial-plans__price-card-cta-wrapper">
+					<Button
+						className="e-commerce-trial-plans__price-card-cta"
+						primary
+						onClick={ () => redirectToCheckoutForPlan( 'main-price-card' ) }
+					>
+						{ translate( 'Upgrade now' ) }
+					</Button>
+				</div>
+			</Card>
+		);
+	};
 
 	return (
 		<>
@@ -145,35 +234,9 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 				</SegmentedControl>
 			</div>
 
-			<Card className="e-commerce-trial-plans__price-card">
-				<div className="e-commerce-trial-plans__price-card-text">
-					<span className="e-commerce-trial-plans__price-card-title">
-						{ targetECommercePlan.getTitle() }
-					</span>
-					<span className="e-commerce-trial-plans__price-card-subtitle">
-						{ translate( 'Accelerate your growth with advanced features.' ) }
-					</span>
-				</div>
-				<div className="e-commerce-trial-plans__price-card-conditions">
-					{ priceContent }
-					{ isAnnualSubscription && (
-						<span className="e-commerce-trial-plans__price-card-savings">
-							{ translate( 'Save %(percentageSavings)s%% by paying annually', {
-								args: { percentageSavings },
-							} ) }
-						</span>
-					) }
-				</div>
-				<div className="e-commerce-trial-plans__price-card-cta-wrapper">
-					<Button
-						className="e-commerce-trial-plans__price-card-cta"
-						primary
-						onClick={ () => redirectToCheckoutForPlan( 'main-price-card' ) }
-					>
-						{ translate( 'Upgrade now' ) }
-					</Button>
-				</div>
-			</Card>
+			{ config.isEnabled( 'plans/wooexpress-medium' )
+				? wooexpressMediumMonthlyPlanUpgradeCard()
+				: eCommercePlanUpgradeCard() }
 
 			<div className="e-commerce-trial-plans__features-wrapper">
 				{ eCommercePlanFeatureSets.map( ( featureSet ) => (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #74201

## Proposed Changes

When clicking "Upgrade now" from the `/plans` or `/plans/my-plans` page on an eCommerce trial site, the Woo Express Performance (Medium) plan will be added to the cart.

## Testing Instructions

The easiest way to test this is on calypso.localhost after checking out this branch. You will need to enable the `plans/wooexpress-medium` feature flag to see the change on calypso.live.

With the feature flag disabled, you will see the normal "Commerce" upgrade nudge instead.

* After checking out this branch, visit `/plans/:siteSlug` for an ecommerce trial site.
* You should see the following upgrade nudges for monthly and annual, respectively
<img width="916" alt="image" src="https://user-images.githubusercontent.com/917632/224154036-7bf5a00e-9722-4310-8e53-fc81a7bc2224.png">
<img width="923" alt="image" src="https://user-images.githubusercontent.com/917632/224154064-c3c74d45-1c1f-4307-b9e2-4323edbb3bd4.png">
* Clicking the either of "Upgrade now" buttons will add either the monthly or annual Medium plan to the cart, depending on your selection above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
