### PR TITLE
Checkout: Increase timeout to 12s for all checkout tests using `it.each`

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -181,7 +181,6 @@ export default function CheckoutMain( {
 	const {
 		applyCoupon,
 		replaceProductInCart,
-		replaceProductsInCart,
 		isLoading: isLoadingCart,
 		isPendingUpdate: isCartPendingUpdate,
 		responseCart,
@@ -200,7 +199,6 @@ export default function CheckoutMain( {
 		couponCodeFromUrl,
 		applyCoupon,
 		addProductsToCart,
-		replaceProductsInCart,
 	} );
 
 	useRecordCartLoaded( {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -4,7 +4,6 @@ import type {
 	RequestCartProduct,
 	ApplyCouponToCart,
 	AddProductsToCart,
-	ReplaceProductsInCart,
 } from '@automattic/shopping-cart';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-add-products-from-url' );
@@ -28,7 +27,6 @@ export default function useAddProductsFromUrl( {
 	couponCodeFromUrl,
 	applyCoupon,
 	addProductsToCart,
-	replaceProductsInCart,
 }: {
 	isLoadingCart: boolean;
 	isCartPendingUpdate: boolean;
@@ -37,7 +35,6 @@ export default function useAddProductsFromUrl( {
 	couponCodeFromUrl: string | null | undefined;
 	applyCoupon: ApplyCouponToCart;
 	addProductsToCart: AddProductsToCart;
-	replaceProductsInCart: ReplaceProductsInCart;
 } ): isPendingAddingProductsFromUrl {
 	const isMounted = useRef( true );
 	useEffect( () => {
@@ -112,7 +109,6 @@ export default function useAddProductsFromUrl( {
 		applyCoupon,
 		productsForCart,
 		addProductsToCart,
-		replaceProductsInCart,
 	] );
 
 	debug( 'useAddProductsFromUrl isLoading', isLoading );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-autocomplete.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-autocomplete.tsx
@@ -32,6 +32,13 @@ jest.mock( 'calypso/lib/analytics/utils/refresh-country-code-cookie-gdpr' );
 jest.mock( 'calypso/state/products-list/selectors/is-marketplace-product' );
 jest.mock( 'calypso/lib/navigate' );
 
+// These tests seem to be particularly slow (it might be because of using
+// it.each; it's not clear but the timeout might apply to the whole loop
+// rather that each iteration?), so we need to increase the timeout for their
+// operation. The standard timeout (at the time of writing) is 5 seconds so
+// we are increasing this to 12 seconds.
+jest.setTimeout( 12000 );
+
 describe( 'Checkout contact step', () => {
 	const mainCartKey = 'foo.com' as CartKey;
 	const initialCart = getBasicCart();

--- a/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
@@ -38,8 +38,8 @@ jest.mock( 'calypso/lib/navigate' );
 // it.each; it's not clear but the timeout might apply to the whole loop
 // rather that each iteration?), so we need to increase the timeout for their
 // operation. The standard timeout (at the time of writing) is 5 seconds so
-// we are increasing this to 8 seconds.
-jest.setTimeout( 8000 );
+// we are increasing this to 12 seconds.
+jest.setTimeout( 12000 );
 
 describe( 'Checkout contact step extra tax fields', () => {
 	const mainCartKey: CartKey = 'foo.com' as CartKey;

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker-dropdown.tsx
@@ -39,6 +39,13 @@ jest.mock( 'calypso/state/sites/domains/selectors' );
 jest.mock( 'calypso/state/sites/plans/selectors/get-plans-by-site' );
 jest.mock( 'calypso/state/sites/selectors' );
 
+// These tests seem to be particularly slow (it might be because of using
+// it.each; it's not clear but the timeout might apply to the whole loop
+// rather that each iteration?), so we need to increase the timeout for their
+// operation. The standard timeout (at the time of writing) is 5 seconds so
+// we are increasing this to 12 seconds.
+jest.setTimeout( 12000 );
+
 /* eslint-disable jest/no-conditional-expect */
 
 describe( 'CheckoutMain with a variant picker', () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker-radio.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker-radio.tsx
@@ -39,6 +39,13 @@ jest.mock( 'calypso/state/sites/domains/selectors' );
 jest.mock( 'calypso/state/sites/plans/selectors/get-plans-by-site' );
 jest.mock( 'calypso/state/sites/selectors' );
 
+// These tests seem to be particularly slow (it might be because of using
+// it.each; it's not clear but the timeout might apply to the whole loop
+// rather that each iteration?), so we need to increase the timeout for their
+// operation. The standard timeout (at the time of writing) is 5 seconds so
+// we are increasing this to 12 seconds.
+jest.setTimeout( 12000 );
+
 /* eslint-disable jest/no-conditional-expect */
 
 describe( 'CheckoutMain with a variant picker', () => {


### PR DESCRIPTION
## Proposed Changes

There are several checkout tests which use Jest's `it.each()` (aka `test.each()`) architecture to iterate over test cases. It's not totally clear but it's possible that the default timeout for a test applies to the whole loop of tests and not a single iteration. In any case, these tests seem to time out frequently, so this PR increases the timeout to 12 seconds for those test files.

## Testing Instructions

Do automated tests pass?