### PR TITLE
Storage Upgrade: Enable multiple products

### DIFF
--- a/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-available-storage-upgrade-products.ts
+++ b/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-available-storage-upgrade-products.ts
@@ -10,7 +10,7 @@ import { TIER_1_SLUGS, TIER_2_SLUGS } from 'calypso/my-sites/plans/jetpack-plans
 import { getSlugInTerm } from 'calypso/my-sites/plans/jetpack-plans/convert-slug-terms';
 import getPurchasedStorageSubscriptions from 'calypso/my-sites/plans/jetpack-plans/get-purchased-storage-subscriptions';
 import { Duration, SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
-import useGetStorageUpgradeProduct from './use-get-storage-upgrade-product';
+import useGetStorageUpgradeProducts from './use-get-storage-upgrade-products';
 
 const useAvailableStorageUpgradeProducts = (
 	siteId: number,
@@ -19,7 +19,7 @@ const useAvailableStorageUpgradeProducts = (
 	const purchasedStorageSlugs = useSelector( ( state ) =>
 		getPurchasedStorageSubscriptions( state, siteId )
 	).map( ( { productSlug } ) => productSlug );
-	const getStorageUpgradeProduct = useGetStorageUpgradeProduct();
+	const getStorageUpgradeProducts = useGetStorageUpgradeProducts();
 
 	const sameDurationFilter = ( p: SelectorProduct ) => p.term === duration;
 
@@ -50,10 +50,14 @@ const useAvailableStorageUpgradeProducts = (
 			! allDurationsSubscriptions.includes( productSlug );
 	}, [ purchasedStorageSlugs ] );
 
-	return [
-		...TIER_1_SLUGS.map( getStorageUpgradeProduct ),
-		...TIER_2_SLUGS.map( getStorageUpgradeProduct ),
-	]
+	const allUpgradeProducts: SelectorProduct[] = [ ...TIER_1_SLUGS, ...TIER_2_SLUGS ].reduce(
+		( acc: SelectorProduct[], slug: string ) => {
+			return [ ...acc, ...( getStorageUpgradeProducts( slug ) as SelectorProduct[] ) ];
+		},
+		[]
+	);
+
+	return allUpgradeProducts
 		.filter( ( product ): product is SelectorProduct => !! product )
 		.filter( sameDurationFilter )
 		.filter( sameProductType )

--- a/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-get-storage-upgrade-products.ts
+++ b/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-get-storage-upgrade-products.ts
@@ -10,7 +10,7 @@ import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-
 import type { ProductSlug, PlanSlug } from '@automattic/calypso-products';
 import type { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 
-type StorageUpgradeGetter = ( slug: string ) => SelectorProduct;
+type StorageUpgradeGetter = ( slug: string ) => SelectorProduct[];
 
 function getDisclaimerLink() {
 	const backupStorageFaqId = 'backup-storage-limits-faq';
@@ -30,14 +30,14 @@ function getDisclaimerLink() {
 		: `https://cloud.jetpack.com/pricing#${ backupStorageFaqId }`;
 }
 
-export const useGetTier1UpgradeProduct = (): StorageUpgradeGetter => {
+export const useGetTier1UpgradeProducts = (): StorageUpgradeGetter => {
 	const translate = useTranslate();
 
 	// Security and Backup share the same per-tier storage limits
 	const storageAmount = useJetpack10GbStorageAmountText();
 
 	return useCallback(
-		( slug: string ): SelectorProduct => {
+		( slug: string ): SelectorProduct[] => {
 			const features = {
 				items: [
 					{
@@ -64,32 +64,34 @@ export const useGetTier1UpgradeProduct = (): StorageUpgradeGetter => {
 			};
 			const product = slugToSelectorProduct( slug );
 
-			return {
-				...product,
-				displayName: storageAmount,
-				subheader: translate( 'of backup storage' ),
-				buttonLabel: translate( 'Upgrade storage' ),
-				// description: <the default description of the product being upgraded>,
-				features: features,
-				disclaimer: getJetpackProductDisclaimer(
-					product?.productSlug as ProductSlug | PlanSlug,
-					features.items,
-					getDisclaimerLink()
-				),
-			} as SelectorProduct;
+			return [
+				{
+					...product,
+					displayName: storageAmount,
+					subheader: translate( 'of backup storage' ),
+					buttonLabel: translate( 'Upgrade storage' ),
+					// description: <the default description of the product being upgraded>,
+					features: features,
+					disclaimer: getJetpackProductDisclaimer(
+						product?.productSlug as ProductSlug | PlanSlug,
+						features.items,
+						getDisclaimerLink()
+					),
+				} as SelectorProduct,
+			];
 		},
 		[ storageAmount, translate ]
 	);
 };
 
-export const useGetTier2UpgradeProduct = (): StorageUpgradeGetter => {
+export const useGetTier2UpgradeProducts = (): StorageUpgradeGetter => {
 	const translate = useTranslate();
 
 	// Security and Backup share the same per-tier storage limits
 	const storageAmount = useJetpack1TbStorageAmountText();
 
 	return useCallback(
-		( slug: string ): SelectorProduct => {
+		( slug: string ): SelectorProduct[] => {
 			const features = {
 				items: [
 					{
@@ -118,45 +120,48 @@ export const useGetTier2UpgradeProduct = (): StorageUpgradeGetter => {
 				],
 			};
 			const product = slugToSelectorProduct( slug );
-			return {
-				...product,
-				displayName: storageAmount,
-				subheader: translate( 'of backup storage' ),
-				buttonLabel: translate( 'Upgrade storage' ),
-				description: translate(
-					'Go back in time and recover all your information for up to a year, with %(storageAmount)s storage space.',
-					{ args: { storageAmount } }
-				),
-				features: features,
-				disclaimer: getJetpackProductDisclaimer(
-					product?.productSlug as ProductSlug | PlanSlug,
-					features.items,
-					getDisclaimerLink()
-				),
-			} as SelectorProduct;
+
+			return [
+				{
+					...product,
+					displayName: storageAmount,
+					subheader: translate( 'of backup storage' ),
+					buttonLabel: translate( 'Upgrade storage' ),
+					description: translate(
+						'Go back in time and recover all your information for up to a year, with %(storageAmount)s storage space.',
+						{ args: { storageAmount } }
+					),
+					features: features,
+					disclaimer: getJetpackProductDisclaimer(
+						product?.productSlug as ProductSlug | PlanSlug,
+						features.items,
+						getDisclaimerLink()
+					),
+				} as SelectorProduct,
+			];
 		},
 		[ storageAmount, translate ]
 	);
 };
 
-const useGetStorageUpgradeProduct = () => {
-	const getTier1Upgrade = useGetTier1UpgradeProduct();
-	const getTier2Upgrade = useGetTier2UpgradeProduct();
+const useGetStorageUpgradeProducts = () => {
+	const getTier1Upgrades = useGetTier1UpgradeProducts();
+	const getTier2Upgrades = useGetTier2UpgradeProducts();
 
 	return useCallback(
-		( slug: string ): SelectorProduct | null => {
+		( slug: string ): SelectorProduct[] | null => {
 			if ( TIER_1_SLUGS.includes( slug ) ) {
-				return getTier1Upgrade( slug );
+				return getTier1Upgrades( slug );
 			}
 
 			if ( TIER_2_SLUGS.includes( slug ) ) {
-				return getTier2Upgrade( slug );
+				return getTier2Upgrades( slug );
 			}
 
 			return null;
 		},
-		[ getTier1Upgrade, getTier2Upgrade ]
+		[ getTier1Upgrades, getTier2Upgrades ]
 	);
 };
 
-export default useGetStorageUpgradeProduct;
+export default useGetStorageUpgradeProducts;

--- a/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-purchased-storage-upgrade-products.ts
+++ b/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-purchased-storage-upgrade-products.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import getPurchasedStorageSubscriptions from 'calypso/my-sites/plans/jetpack-plans/get-purchased-storage-subscriptions';
 import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
-import useGetStorageUpgradeProduct from './use-get-storage-upgrade-product';
+import useGetStorageUpgradeProducts from './use-get-storage-upgrade-products';
 
 const usePurchasedStorageUpgradeProducts = ( siteId: number ): SelectorProduct[] => {
 	const purchasedStorageSlugs = useSelector( ( state ) =>
@@ -16,15 +16,15 @@ const usePurchasedStorageUpgradeProducts = ( siteId: number ): SelectorProduct[]
 	const mostImportantSlug =
 		purchasedStorageSlugs.find( isJetpackSecuritySlug ) ?? purchasedStorageSlugs?.[ 0 ];
 
-	const getStorageUpgradeProduct = useGetStorageUpgradeProduct();
+	const getStorageUpgradeProducts = useGetStorageUpgradeProducts();
 
 	return useMemo( () => {
 		if ( ! mostImportantSlug ) {
 			return [];
 		}
 
-		return [ getStorageUpgradeProduct( mostImportantSlug ) ] as SelectorProduct[];
-	}, [ mostImportantSlug, getStorageUpgradeProduct ] );
+		return [ ...( getStorageUpgradeProducts( mostImportantSlug ) as SelectorProduct[] ) ];
+	}, [ mostImportantSlug, getStorageUpgradeProducts ] );
 };
 
 export default usePurchasedStorageUpgradeProducts;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR enables having multiple upgrade products in the storage upgrade page. It's prerequisite work for 1182633034225700-as-1204031357952912.

### Testing instructions

- Make sure you have a Jetpack site with Backup or Security T1
- Spin up Calypso locally or by using a live link below
- Open the dev console
- Visit `/plans/storage/:site`
- Check there's no JS error
- Check that the page behaves as in production

### Screenshots

_Storage upgrade page_
<img width="500" alt="Screenshot 2023-03-09 at 4 54 40 PM" src="https://user-images.githubusercontent.com/1620183/224177264-6d977024-cce6-42c5-a883-66f3b0434e35.png">
