### PR TITLE
Revert "Flaky E2E: disable shared memory on Chromium."

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -112,10 +112,9 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 		);
 		const logFilePath = path.join( this.testArtifactsPath, `${ this.testFilename }.log` );
 
-		// Start the browser and sets launch options.
+		// Start the browser.
 		const browser = await browserType.launch( {
 			...config.launchOptions,
-			args: [ browserType.name() === 'chromium' ? '--disable-dev-shm-usage' : '' ],
 			logger: {
 				log: async ( name: string, severity: string, message: string ) => {
 					await fs.appendFile(


### PR DESCRIPTION
Reverts Automattic/wp-calypso#73503

I don't think the previous change above did much to address the crashes; in fact, I suspect the incidence has increased. Take a look at the trend recently below:

![image](https://user-images.githubusercontent.com/6549265/224185623-fc1448e0-2cb3-4805-bda0-0c7cdcfc542e.png)
