### PR TITLE
Billing History: Add Card displaying link to Taxamo receipt

### DIFF
--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -121,8 +121,6 @@ export function ReceiptBody( {
 	const moment = useLocalizedMoment();
 	const title = translate( 'Visit %(url)s', { args: { url: transaction.url }, textOnly: true } );
 	const serviceLink = <a href={ transaction.url } title={ title } />;
-	const link = 'https://google.com';
-	const labelContent = translate( 'View tax invoice' );
 
 	return (
 		<div>
@@ -172,15 +170,28 @@ export function ReceiptBody( {
 					</Button>
 				</div>
 			</Card>
-			<CompactCard
-				href={ link }
-				rel="noopener noreferrer"
-				target="_blank"
-				className="billing-history__tax-receipt-link"
-			>
-				{ labelContent }
-			</CompactCard>
+			{ transaction.tax_external_id && transaction.tax_external_id.length > 0 && (
+				<ReceiptExternalLink transaction={ transaction } />
+			) }
 		</div>
+	);
+}
+
+function ReceiptExternalLink( { transaction }: { transaction: BillingTransaction } ) {
+	const translate = useTranslate();
+	const externalTaxlink =
+		'https://invoicestaxamo.s3.amazonaws.com/' + transaction.tax_external_id + '/invoice.html';
+	const labelContent = translate( 'View tax invoice' );
+
+	return (
+		<CompactCard
+			href={ externalTaxlink }
+			rel="noopener noreferrer"
+			target="_blank"
+			className="billing-history__tax-receipt-link"
+		>
+			{ labelContent }
+		</CompactCard>
 	);
 }
 

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { Button, Card } from '@automattic/components';
+import { Button, Card, CompactCard } from '@automattic/components';
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -121,6 +121,8 @@ export function ReceiptBody( {
 	const moment = useLocalizedMoment();
 	const title = translate( 'Visit %(url)s', { args: { url: transaction.url }, textOnly: true } );
 	const serviceLink = <a href={ transaction.url } title={ title } />;
+	const link = 'https://google.com';
+	const labelContent = translate( 'View tax invoice' );
 
 	return (
 		<div>
@@ -170,6 +172,14 @@ export function ReceiptBody( {
 					</Button>
 				</div>
 			</Card>
+			<CompactCard
+				href={ link }
+				rel="noopener noreferrer"
+				target="_blank"
+				className="billing-history__tax-receipt-link"
+			>
+				{ labelContent }
+			</CompactCard>
 		</div>
 	);
 }

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -476,3 +476,9 @@ textarea.billing-history__billing-details-editable {
 		left: 170px;
 	}
 }
+
+@media ( min-width: 480px ) {
+	.billing-history__tax-receipt-link {
+		margin-top: 16px;
+	}
+}

--- a/client/state/billing-transactions/types.ts
+++ b/client/state/billing-transactions/types.ts
@@ -14,7 +14,7 @@ export interface BillingTransaction {
 	address: string;
 	amount: string;
 	tax_country_code: string;
-	tax_external_id: string;
+	tax_external_id?: string;
 	cc_email: string;
 	cc_name: string;
 	cc_num: string;

--- a/client/state/billing-transactions/types.ts
+++ b/client/state/billing-transactions/types.ts
@@ -14,6 +14,7 @@ export interface BillingTransaction {
 	address: string;
 	amount: string;
 	tax_country_code: string;
+	tax_external_id: string;
 	cc_email: string;
 	cc_name: string;
 	cc_num: string;


### PR DESCRIPTION
### Summary:

We need to add a link to the Taxamo tax invoice to the bottom of a user's individual receipt in billing history. We will use the external link card component  for this purpose.


![T2YSYk.png](https://user-images.githubusercontent.com/552016/225376978-416377f0-44de-4f92-929a-267596c26741.png)


Related to [#](https://github.com/Automattic/payments-shilling/issues/1341)

## Proposed Changes

* Add a separate card component that will have the link to the taxamo link from the Billing page.
* Requires D104748-code to attach tax_external_id to receipts
* Important: ensure that the order object does have the ` [tax_external_id]` set up as only then it will display the card component with the link to the external receipt page. You can confirm this by viewing the order object for that receipt from payments admin.

## Testing Instructions
1. Before applying the patch, you should not see a card component with the link to the tax receipt like this ![A0mUlK.png](https://user-images.githubusercontent.com/552016/225156589-0d466726-7f7c-4a18-a4bb-3acc1259587b.png)
2. Apply this Patch along with the backend diff D104748-code
1. Visit a specific receipt page from `/me/purchases/billing/{receipt}` for a receipt that has vat id saved and for a country that is eligible for taxes.
3. You should now see a `View tax invoice` card component like this:   ![NrkhSj.png](https://user-images.githubusercontent.com/552016/225156826-37c1bb56-cedc-468a-8244-bb2ed09ba53b.png)
4. Clicking that view tax invoice link should open an external tax receipt that looks like this ![cJulqI.png](https://user-images.githubusercontent.com/552016/225153361-b23df380-f6a7-4894-ba5f-2d977d21811b.png)