### PR TITLE
Add Draft Post notification setting

### DIFF
--- a/client/me/notification-settings/blogs-settings/blog.jsx
+++ b/client/me/notification-settings/blogs-settings/blog.jsx
@@ -67,6 +67,7 @@ class BlogSettings extends Component {
 			'mentions',
 			'scheduled_publicize',
 			'blogging_prompt',
+			'draft_post_prompt',
 		];
 
 		if ( site.options.woocommerce_is_active ) {

--- a/client/me/notification-settings/settings-form/constants.js
+++ b/client/me/notification-settings/settings-form/constants.js
@@ -1,3 +1,4 @@
 export const NOTIFICATIONS_EXCEPTIONS = {
+	timeline: [ 'draft_post_prompt' ],
 	email: [ 'achievement', 'scheduled_publicize', 'store_order' ],
 };

--- a/client/me/notification-settings/settings-form/locales.js
+++ b/client/me/notification-settings/settings-form/locales.js
@@ -16,6 +16,7 @@ export const settingLabels = {
 	mentions: () => i18n.translate( 'Username mentions' ),
 	scheduled_publicize: () => i18n.translate( 'Post Publicized' ),
 	blogging_prompt: () => i18n.translate( 'Daily Writing Prompts' ),
+	draft_post_prompt: () => i18n.translate( 'Draft Post Prompts' ),
 	store_order: () => i18n.translate( 'New order' ),
 };
 

--- a/client/me/notification-settings/settings-form/stream-options.jsx
+++ b/client/me/notification-settings/settings-form/stream-options.jsx
@@ -27,7 +27,8 @@ export default class extends PureComponent {
 					const isException =
 						( this.props.stream in NOTIFICATIONS_EXCEPTIONS &&
 							NOTIFICATIONS_EXCEPTIONS[ this.props.stream ].indexOf( setting ) >= 0 ) ||
-						( setting === 'blogging_prompt' && this.isDeviceStream() );
+						( [ 'blogging_prompt', 'draft_post_prompt' ].includes( setting ) &&
+							this.isDeviceStream() );
 					return (
 						<li className="notification-settings-form-stream-options__item" key={ index }>
 							{ isException ? null : (


### PR DESCRIPTION
This adds a setting to allow users to disable the `Draft Post Prompts` email notification.

<img width="1025" alt="Screenshot 2023-03-10 at 11 08 17" src="https://user-images.githubusercontent.com/5560595/224300878-7f1bb680-80d3-41d8-a17c-f8ec4d95e309.png">

### Testing

Disable the `Draft Post Prompts` email notification and click the `Save settings` button, refresh and make sure the setting is disabled. Enable, refresh and make sure setting is enabled successfully.

Ref - pe7F0s-zI-p2
