### PR TITLE
BBE Content Form: Allow uppercase file extensions

### DIFF
--- a/client/signup/steps/website-content/wordpress-media-upload.tsx
+++ b/client/signup/steps/website-content/wordpress-media-upload.tsx
@@ -173,7 +173,7 @@ export function WordpressMediaUpload( {
 		const fileParts = fileName.split( '.' );
 		const extension = fileParts[ fileParts.length - 1 ];
 
-		if ( allowedFileTypes.includes( extension ) ) {
+		if ( allowedFileTypes.includes( extension?.toLowerCase() ) ) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1525

## Proposed Changes

* The current BBE content form does not allow users to upload files with valid file extensions if the extension is in uppercase. This PR removes the restriction.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`, proceed through the flow steps and complete the purchase.
* On the website content form, try uploading an image/video file with an uppercase file extension. Confirm that you can upload it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
