### PR TITLE
Signup: Filter signup progress by flowName

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -43,7 +43,10 @@ import {
 	processStep,
 } from 'calypso/state/signup/progress/actions';
 import { ProgressState } from 'calypso/state/signup/progress/schema';
-import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
+import {
+	getSignupProgress,
+	getSignupProgressByFlow,
+} from 'calypso/state/signup/progress/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import type { Flow, Dependencies } from '../../signup/types';
 
@@ -325,8 +328,9 @@ export default class SignupFlowController {
 
 	_process() {
 		const currentSteps = this._getFlowSteps();
-		const signupProgress = filter( getSignupProgress( this._reduxStore.getState() ), ( step ) =>
-			includes( currentSteps, step.stepName )
+		const signupProgress = filter(
+			getSignupProgressByFlow( this._reduxStore.getState(), this._flowName ),
+			( step ) => includes( currentSteps, step.stepName )
 		);
 		const pendingSteps = filter( signupProgress, { status: 'pending' } );
 		const completedSteps = filter( signupProgress, { status: 'completed' } );
@@ -354,7 +358,7 @@ export default class SignupFlowController {
 		const dependenciesSatisfied = dependencies.length === keys( dependenciesFound ).length;
 		const currentSteps = this._getFlowSteps();
 		const signupProgress = filter(
-			getSignupProgress( this._reduxStore.getState() ),
+			getSignupProgressByFlow( this._reduxStore.getState(), this._flowName ),
 			( { stepName } ) => includes( currentSteps, stepName )
 		);
 		const allStepsSubmitted =
@@ -469,7 +473,7 @@ export default class SignupFlowController {
 		);
 
 		return reduce(
-			getSignupProgress( this._reduxStore.getState() ),
+			getSignupProgressByFlow( this._reduxStore.getState(), this._flowName ),
 			( current, step ) => ( {
 				...current,
 				...pick( step.providedDependencies, requiredDependencies ),

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -18,6 +18,10 @@ jest.mock( 'calypso/signup/config/flows-pure', () =>
 jest.mock( 'calypso/signup/config/steps', () => require( './mocks/signup/config/steps' ) );
 jest.mock( 'calypso/signup/config/steps-pure', () => require( './mocks/signup/config/steps' ) );
 
+function getInitialStateForFlowName( flowName ) {
+	return { signup: { flow: { currentFlowName: flowName } } };
+}
+
 function createSignupStore( initialState ) {
 	return createStore(
 		combineReducers( { signup: signupReducer } ),
@@ -82,9 +86,9 @@ describe( 'flow-controller', () => {
 	} );
 
 	describe( 'controlling a simple flow', () => {
-		test( 'should run the onComplete callback with the flow destination when the flow is completed', () => {
+		test( 'should run the onComplete callback with the flow destination when the flow is completed', () => {
 			return new Promise( ( done ) => {
-				const store = createSignupStore();
+				const store = createSignupStore( getInitialStateForFlowName( 'simple_flow' ) );
 
 				signupFlowController = new SignupFlowController( {
 					flowName: 'simple_flow',
@@ -104,7 +108,7 @@ describe( 'flow-controller', () => {
 	describe( 'controlling a flow w/ an asynchronous step', () => {
 		let store;
 		beforeEach( () => {
-			store = createSignupStore();
+			store = createSignupStore( getInitialStateForFlowName( 'flow_with_async' ) );
 			signupFlowController = new SignupFlowController( {
 				flowName: 'flow_with_async',
 				reduxStore: store,
@@ -141,7 +145,7 @@ describe( 'flow-controller', () => {
 	describe( 'controlling a flow w/ dependencies', () => {
 		test( 'should call the apiRequestFunction callback with its dependencies', () => {
 			return new Promise( ( done ) => {
-				const store = createSignupStore();
+				const store = createSignupStore( getInitialStateForFlowName( 'flow_with_dependencies' ) );
 				signupFlowController = new SignupFlowController( {
 					flowName: 'flow_with_dependencies',
 					onComplete: function ( dependencies, destination ) {
@@ -168,7 +172,7 @@ describe( 'flow-controller', () => {
 	describe( 'controlling a flow w/ a delayed step', () => {
 		test( 'should submit steps with the delayApiRequestUntilComplete once the flow is complete', () => {
 			return new Promise( ( done ) => {
-				const store = createSignupStore();
+				const store = createSignupStore( getInitialStateForFlowName( 'flowWithDelay' ) );
 				signupFlowController = new SignupFlowController( {
 					flowName: 'flowWithDelay',
 					onComplete: () => done(),
@@ -191,7 +195,7 @@ describe( 'flow-controller', () => {
 
 		test( 'should not submit delayed steps if some steps are in-progress', () => {
 			return new Promise( ( done ) => {
-				const store = createSignupStore();
+				const store = createSignupStore( getInitialStateForFlowName( 'flowWithDelay' ) );
 				signupFlowController = new SignupFlowController( {
 					flowName: 'flowWithDelay',
 					onComplete: () => done(),
@@ -220,7 +224,9 @@ describe( 'flow-controller', () => {
 	describe( 'controlling a flow w/ dependencies provided in query', () => {
 		test( 'should throw an error if the given flow requires dependencies from query but none are given', () => {
 			expect( () => {
-				const store = createSignupStore();
+				const store = createSignupStore(
+					getInitialStateForFlowName( 'flowWithProvidedDependencies' )
+				);
 				signupFlowController = new SignupFlowController( {
 					flowName: 'flowWithProvidedDependencies',
 					reduxStore: store,
@@ -231,7 +237,9 @@ describe( 'flow-controller', () => {
 		// eslint-disable-next-line jest/expect-expect
 		test( 'should run `onComplete` once all steps are submitted without an error', () => {
 			return new Promise( ( done ) => {
-				const store = createSignupStore();
+				const store = createSignupStore(
+					getInitialStateForFlowName( 'flowWithProvidedDependencies' )
+				);
 				signupFlowController = new SignupFlowController( {
 					flowName: 'flowWithProvidedDependencies',
 					providedDependencies: { siteSlug: 'foo' },
@@ -248,7 +256,9 @@ describe( 'flow-controller', () => {
 		// eslint-disable-next-line jest/expect-expect
 		test( 'should run `onComplete` once all steps are submitted, including optional dependency', () => {
 			return new Promise( ( done ) => {
-				const store = createSignupStore();
+				const store = createSignupStore(
+					getInitialStateForFlowName( 'flowWithSiteTopicWithOptionalTheme' )
+				);
 				signupFlowController = new SignupFlowController( {
 					flowName: 'flowWithSiteTopicWithOptionalTheme',
 					onComplete: () => done(),
@@ -274,7 +284,9 @@ describe( 'flow-controller', () => {
 		// eslint-disable-next-line jest/expect-expect
 		test( 'should run `onComplete` once all steps are submitted, excluding optional dependency', () => {
 			return new Promise( ( done ) => {
-				const store = createSignupStore();
+				const store = createSignupStore(
+					getInitialStateForFlowName( 'flowWithSiteTopicWithOptionalTheme' )
+				);
 				signupFlowController = new SignupFlowController( {
 					flowName: 'flowWithSiteTopicWithOptionalTheme',
 					onComplete: () => done(),
@@ -297,7 +309,9 @@ describe( 'flow-controller', () => {
 		} );
 
 		test( "should throw if step doesn't provide required dependency", () => {
-			const store = createSignupStore();
+			const store = createSignupStore(
+				getInitialStateForFlowName( 'flowWithSiteTopicWithOptionalTheme' )
+			);
 			signupFlowController = new SignupFlowController( {
 				flowName: 'flowWithSiteTopicWithOptionalTheme',
 				onComplete: () => {},

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -12,7 +12,7 @@ import { updateDependencies } from 'calypso/state/signup/actions';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { setCurrentFlowName, setPreviousFlowName } from 'calypso/state/signup/flow/actions';
 import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
-import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
+import { getSignupProgressByFlow } from 'calypso/state/signup/progress/selectors';
 import { setSiteType } from 'calypso/state/signup/steps/site-type/actions';
 import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import { requestSite } from 'calypso/state/sites/actions';
@@ -154,7 +154,7 @@ export default {
 		const flowName = getFlowName( context.params, userLoggedIn );
 		const localeFromParams = context.params.lang;
 		const localeFromStore = ! userLoggedIn ? store.get( 'signup-locale' ) : '';
-		const signupProgress = getSignupProgress( context.store.getState() );
+		const signupProgress = getSignupProgressByFlow( context.store.getState(), flowName );
 
 		// Special case for the user step which may use oauth2 redirect flow
 		// Check if there is a valid flow in progress to resume

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -65,7 +65,7 @@ import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isUserRegistrationDaysWithinRange from 'calypso/state/selectors/is-user-registration-days-within-range';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { submitSignupStep, removeStep, addStep } from 'calypso/state/signup/progress/actions';
-import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
+import { getSignupProgressByFlow } from 'calypso/state/signup/progress/selectors';
 import { submitSiteType } from 'calypso/state/signup/steps/site-type/actions';
 import { getSiteType } from 'calypso/state/signup/steps/site-type/selectors';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
@@ -919,7 +919,7 @@ class Signup extends Component {
 }
 
 export default connect(
-	( state ) => {
+	( state, ownProps ) => {
 		const signupDependencies = getSignupDependencyStore( state );
 
 		// Use selectedSiteId which was set by setSelectedSiteForSignup of controller
@@ -935,7 +935,7 @@ export default connect(
 				? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS ) // this is intentional, not a mistake
 				: true,
 			isDomainOnlySite: isDomainOnlySite( state, siteId ),
-			progress: getSignupProgress( state ),
+			progress: getSignupProgressByFlow( state, ownProps.flowName ),
 			signupDependencies,
 			isLoggedIn: isUserLoggedIn( state ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -10,7 +10,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { submitSignupStep } from 'calypso/state/signup/progress/actions';
-import { getSignupProgress } from 'calypso/state/signup/progress/selectors';
+import { getSignupProgressByFlow } from 'calypso/state/signup/progress/selectors';
 import { getFilteredSteps } from '../utils';
 import './style.scss';
 
@@ -197,12 +197,12 @@ export class NavigationLink extends Component {
 }
 
 export default connect(
-	( state ) => {
+	( state, ownProps ) => {
 		const { intent } = getSignupDependencyStore( state );
 
 		return {
 			userLoggedIn: isUserLoggedIn( state ),
-			signupProgress: getSignupProgress( state ),
+			signupProgress: getSignupProgressByFlow( state, ownProps.flowName ),
 			intent,
 		};
 	},

--- a/client/state/signup/progress/schema.ts
+++ b/client/state/signup/progress/schema.ts
@@ -31,6 +31,7 @@ export interface StepState {
 	providedDependencies?: Dependencies;
 	status: 'completed' | 'processing' | 'pending' | 'in-progress' | 'invalid';
 	stepName: string;
+	lastKnownFlow: string;
 	wasSkipped?: boolean;
 }
 

--- a/client/state/signup/progress/selectors.ts
+++ b/client/state/signup/progress/selectors.ts
@@ -1,12 +1,28 @@
-import { get } from 'lodash';
 import { getStepModuleName } from 'calypso/signup/config/step-components';
 import { ProgressState } from './schema';
 import 'calypso/state/signup/init';
 
 const initialState: ProgressState = {};
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function getSignupProgress( state: any ): ProgressState {
-	return get( state, 'signup.progress', initialState );
+type SignupProgressState = {
+	signup: {
+		progress: ProgressState;
+	};
+};
+
+export function getSignupProgress( state: SignupProgressState ): ProgressState {
+	return state?.signup?.progress || initialState;
+}
+
+export function getSignupProgressByFlow(
+	state: SignupProgressState,
+	flowName: string
+): ProgressState {
+	const progress = state?.signup?.progress || initialState;
+	return Object.keys( progress )
+		.filter( ( key ) => progress[ key ]?.lastKnownFlow === flowName )
+		.reduce( ( acc, key ) => {
+			return { ...acc, [ key ]: progress[ key ] };
+		}, {} );
 }
 
 /**
@@ -15,8 +31,7 @@ export function getSignupProgress( state: any ): ProgressState {
  * @param   {Object}  state The current client state
  * @returns  {boolean} denoting whether the plans step existed AND it was skipped
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const isPlanStepExistsAndSkipped = ( state: any ) => {
+export const isPlanStepExistsAndSkipped = ( state: SignupProgressState ) => {
 	const { signup: { progress = {} } = {} } = state;
 	const planName =
 		Object.keys( progress ).find( ( stepName ) => getStepModuleName( stepName ) === 'plans' ) ?? '';

--- a/client/state/signup/progress/test/selectors.js
+++ b/client/state/signup/progress/test/selectors.js
@@ -1,4 +1,8 @@
-import { getSignupProgress, isPlanStepExistsAndSkipped } from '../selectors';
+import {
+	getSignupProgress,
+	getSignupProgressByFlow,
+	isPlanStepExistsAndSkipped,
+} from '../selectors';
 
 describe( 'selectors', () => {
 	test( 'should return empty, plain object as a default state', () => {
@@ -16,6 +20,24 @@ describe( 'selectors', () => {
 		const state = { signup: { progress } };
 
 		expect( getSignupProgress( state ) ).toEqual( progress );
+	} );
+
+	test( 'should select progress steps from state, filtered by flowName', () => {
+		const progress = {
+			stepA: {
+				status: 'completed',
+				stepName: 'stepA',
+				lastKnownFlow: 'test-flow',
+			},
+			stepB: {
+				status: 'completed',
+				stepName: 'stepB',
+				lastKnownFlow: 'test-flow-2',
+			},
+		};
+		const state = { signup: { progress } };
+
+		expect( getSignupProgressByFlow( state, 'test-flow' ) ).toEqual( { stepA: progress.stepA } );
 	} );
 
 	test( 'isPlanStepExistsAndSkipped : An aliased skipped step should return true', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1677084219872039-slack-C040UAN6TPS

## Proposed Changes

The original bug can be reproduced by the following steps:

- Clear out indexeddb for https://wpcalypso.wordpress.com
- Go to https://wpcalypso.wordpress.com/start/
- Search for any domain name and proceed to the plans page.
- Don’t select a plan. In the same tab, go to https://wpcalypso.wordpress.com/start/free
- You should now see the infinite loading screen.

This happens because the persisted signup progress contains the `domains` step in the `pending` state.

In #73711, we attempted to remove the persistence of this state slice completely, but it caused undesired product changes. 

This PR adds a new selector, `getSignupProgressByFlow`, which filters steps by their `lastKnownFlow` key. This ensures that saved steps from other flows have no effect on the current flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Testing would involve:
* Testing a few signup flows like `/start`, `/start/launch-site/`, `/start/free`, `/start/domain`, etc. More can be found here: 2f4ae-pb/#plain
* Test back, forward and reload behaviours.
* E2E tests.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?