### PR TITLE
Signup: hide progress indicator for onboarding flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -126,6 +126,7 @@ export function generateFlows( {
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
 			lastModified: '2020-12-10',
 			showRecaptcha: true,
+			hideProgressIndicator: true,
 		},
 		{
 			name: 'onboarding-2023-pricing-grid',
@@ -214,6 +215,7 @@ export function generateFlows( {
 			description: 'Allow new Pressable users to grant permission to server credentials',
 			lastModified: '2017-11-20',
 			disallowResume: true,
+			hideProgressIndicator: true,
 		},
 		{
 			name: 'rewind-switch',
@@ -332,6 +334,7 @@ export function generateFlows( {
 			disallowResume: true,
 			lastModified: '2022-02-15',
 			showRecaptcha: true,
+			hideProgressIndicator: true,
 		},
 		{
 			name: 'add-domain',
@@ -454,6 +457,7 @@ export function generateFlows( {
 				return translate( 'Set up your site' );
 			},
 			enableBranchSteps: true,
+			hideProgressIndicator: true,
 		},
 		{
 			name: 'do-it-for-me',

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -6,11 +6,7 @@ import {
 	is2023PricingGridActivePage,
 } from '@automattic/calypso-products';
 import { isBlankCanvasDesign } from '@automattic/design-picker';
-import {
-	isNewsletterOrLinkInBioFlow,
-	isNewsletterFlow,
-	LINK_IN_BIO_TLD_FLOW,
-} from '@automattic/onboarding';
+import { isNewsletterOrLinkInBioFlow, isNewsletterFlow } from '@automattic/onboarding';
 import debugModule from 'debug';
 import {
 	clone,
@@ -124,15 +120,8 @@ function removeLoadingScreenClassNamesFromBody() {
 }
 
 function showProgressIndicator( flowName ) {
-	const DISABLED_PROGRESS_INDICATOR_FLOWS = [
-		'pressable-nux',
-		'setup-site',
-		'importer',
-		'domain',
-		LINK_IN_BIO_TLD_FLOW,
-	];
-
-	return ! DISABLED_PROGRESS_INDICATOR_FLOWS.includes( flowName );
+	const flow = flows.getFlow( flowName );
+	return ! flow.hideProgressIndicator;
 }
 
 class Signup extends Component {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1615

## Proposed Changes

* This change removes the progress indicator from the onboarding flow.
* Also involves a small refactor of the `showProgressIndicator` function so that we move away from hardcoded flow names in the code. Related discussion: https://github.com/Automattic/wp-calypso/pull/56311/files#r713614799

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start`. Confirm that the progress indicator is not shown. 
<img width="1430" alt="image" src="https://user-images.githubusercontent.com/5436027/224337507-85df774c-99f9-48f8-93e6-839328c3515b.png">
* Confirm that the progress indicator is not shown on the 'pressable-nux', 'domain' and 'setup-site' flows.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
