### PR TITLE
Pricing page: Fix "Manage Subscription" buttons when products are included in plan or owned.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
@@ -83,7 +83,8 @@ export const getProductsToDisplay = ( {
 
 	const purchasedSlugs = purchasedProductsWithoutAddOn
 		?.map( ( p ) => p?.productSlug )
-		?.filter( ( slug ) => slug );
+		// Remove null or empty product slugs
+		?.filter( Boolean );
 
 	// Products that have not been directly purchased must honor the current filter
 	// selection since they exist in both monthly and yearly version.
@@ -106,9 +107,8 @@ export const getProductsToDisplay = ( {
 			return true;
 		} );
 	return (
-		[ ...purchasedProductsWithoutAddOn, ...filteredProducts ]
-			// Make sure we don't allow any null or invalid products
-			.filter( ( product ): product is SelectorProduct => !! product )
+		// Remove null or empty products
+		[ ...purchasedProductsWithoutAddOn, ...filteredProducts ].filter( Boolean )
 	);
 };
 

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-products-to-display.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-products-to-display.ts
@@ -13,14 +13,16 @@ export const useProductsToDisplay = ( { siteId, duration }: ItemToDisplayProps )
 		useGetPlansGridProducts( siteId );
 
 	return useMemo( () => {
-		const crmIncludedOrPurchased = [ ...purchasedProducts, ...includedInPlanProducts ].some(
-			( p ) => ( JETPACK_CRM_PRODUCTS as ReadonlyArray< string > ).includes( p.productSlug )
-		);
+		const crmPurchasedOrIncluded = [ ...purchasedProducts, ...includedInPlanProducts ]
+			.filter( ( p ) => Boolean( p?.productSlug ) )
+			.some( ( p ) =>
+				( JETPACK_CRM_PRODUCTS as ReadonlyArray< string > ).includes( p.productSlug )
+			);
 
 		const allAvailableProducts: SelectorProduct[] = [ ...availableProducts ];
 
 		// Guard against double-including CRM in the list of products
-		if ( ! crmIncludedOrPurchased ) {
+		if ( ! crmPurchasedOrIncluded ) {
 			const externalCrmProducts = JETPACK_CRM_PRODUCTS.map(
 				slugToSelectorProduct
 			) as SelectorProduct[];

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-products-to-display.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-products-to-display.ts
@@ -12,15 +12,22 @@ export const useProductsToDisplay = ( { siteId, duration }: ItemToDisplayProps )
 	const { availableProducts, purchasedProducts, includedInPlanProducts } =
 		useGetPlansGridProducts( siteId );
 
-	const allAvailableProducts = useMemo( () => {
-		const moreAvailableProducts = [ ...JETPACK_CRM_PRODUCTS ].map(
-			slugToSelectorProduct
-		) as SelectorProduct[];
-
-		return [ ...availableProducts, ...moreAvailableProducts ] as SelectorProduct[];
-	}, [ availableProducts ] );
-
 	return useMemo( () => {
+		const crmIncludedOrPurchased = [ ...purchasedProducts, ...includedInPlanProducts ].some(
+			( p ) => ( JETPACK_CRM_PRODUCTS as ReadonlyArray< string > ).includes( p.productSlug )
+		);
+
+		const allAvailableProducts: SelectorProduct[] = [ ...availableProducts ];
+
+		// Guard against double-including CRM in the list of products
+		if ( ! crmIncludedOrPurchased ) {
+			const externalCrmProducts = JETPACK_CRM_PRODUCTS.map(
+				slugToSelectorProduct
+			) as SelectorProduct[];
+
+			allAvailableProducts.push( ...externalCrmProducts );
+		}
+
 		const allItems = getProductsToDisplay( {
 			duration,
 			availableProducts: allAvailableProducts,
@@ -29,5 +36,5 @@ export const useProductsToDisplay = ( { siteId, duration }: ItemToDisplayProps )
 		} );
 
 		return isolatePopularItems( allItems, MOST_POPULAR_PRODUCTS );
-	}, [ duration, allAvailableProducts, purchasedProducts, includedInPlanProducts ] );
+	}, [ duration, availableProducts, purchasedProducts, includedInPlanProducts ] );
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -7,12 +7,15 @@ import {
 	TERM_ANNUALLY,
 	TERM_MONTHLY,
 	isSupersedingJetpackItem,
+	JETPACK_COMPLETE_PLANS,
+	JETPACK_SECURITY_PLANS,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 import reactNodeToString from 'calypso/lib/react-node-to-string';
 import OwnerInfo from 'calypso/me/purchases/purchase-item/owner-info';
@@ -130,9 +133,21 @@ export const useStoreItemInfo = ( {
 
 	const getIsIncludedInPlan = useCallback(
 		( item: SelectorProduct ) => {
+			// If user owns the Jetpack Complete Plan/bundle, then JetPack Security plan/bundle should
+			// be considered as included in the Complete plan ("Part of the current plan").
+			const siteHasCompletePlan =
+				sitePlan?.product_slug &&
+				( JETPACK_COMPLETE_PLANS as ReadonlyArray< string > ).includes( sitePlan.product_slug );
+			const itemIsSecurity = ( JETPACK_SECURITY_PLANS as ReadonlyArray< string > ).includes(
+				item.productSlug
+			);
+
+			if ( siteHasCompletePlan && itemIsSecurity ) {
+				return true;
+			}
 			return ! getIsOwned( item ) && getIsPlanFeature( item );
 		},
-		[ getIsOwned, getIsPlanFeature ]
+		[ getIsOwned, getIsPlanFeature, sitePlan ]
 	);
 
 	const getIsSuperseded = useCallback(
@@ -193,8 +208,15 @@ export const useStoreItemInfo = ( {
 					//navigate to checkout
 					return buildCheckoutURL( siteSlug || '', '' );
 				}
+				// If the product is owned or included in the current plan, return the "Manage plan/Subscription"
+				// URL (`/me/purchases/:site/:productId`)
+				if ( getIsOwned( item ) || getIsIncludedInPlan( item ) ) {
+					return createCheckoutURL?.( item, getIsUpgradeableToYearly( item ), getPurchase( item ) );
+				}
+				// Otherwise no URL is returned and we will end up dispatching adding product to cart on click event.
 				return '';
 			}
+
 			return createCheckoutURL?.( item, getIsUpgradeableToYearly( item ), getPurchase( item ) );
 		},
 
@@ -204,6 +226,8 @@ export const useStoreItemInfo = ( {
 			getIsUpgradeableToYearly,
 			getPurchase,
 			getIsProductInCart,
+			getIsOwned,
+			getIsIncludedInPlan,
 			siteSlug,
 		]
 	);
@@ -218,6 +242,15 @@ export const useStoreItemInfo = ( {
 					} );
 					return;
 				}
+				// If the product is owned or included in the current plan, we are navigating to the
+				// "Manage plan/Subscription" URL (`/me/purchases/:site/:productId`) - handled by getCheckoutURL.
+				if ( getIsOwned( item ) || getIsIncludedInPlan( item ) ) {
+					recordTracksEvent( 'calypso_pricing_manage_owned_product_click', {
+						productSlug: item.productSlug,
+					} );
+					return;
+				}
+
 				shoppingCartTracker( 'calypso_jetpack_shopping_cart_add_product', {
 					productSlug: item.productSlug,
 				} );
@@ -225,10 +258,15 @@ export const useStoreItemInfo = ( {
 				const addedToCartText = translate( 'added to cart' );
 				const productName = reactNodeToString( item.displayName );
 				dispatch( successNotice( `${ productName } ${ addedToCartText }`, { duration: 5000 } ) );
-
 				return addProductsToCart( [ { product_slug: item.productSlug } ] );
 			}
 
+			if ( item.type === 'item-type-plan' ) {
+				recordTracksEvent( 'calypso_pricing_purchase_bundle_click', {
+					productSlug: item.productSlug,
+				} );
+				return;
+			}
 			return onClickPurchase?.( item, getIsUpgradeableToYearly( item ), getPurchase( item ) );
 		},
 		[
@@ -237,10 +275,12 @@ export const useStoreItemInfo = ( {
 			getIsUpgradeableToYearly,
 			getPurchase,
 			getIsProductInCart,
+			getIsOwned,
+			getIsIncludedInPlan,
 			shoppingCartTracker,
-			addProductsToCart,
-			dispatch,
 			translate,
+			dispatch,
+			addProductsToCart,
 		]
 	);
 

--- a/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
+++ b/client/my-sites/plans/jetpack-plans/use-get-plans-grid-products.ts
@@ -24,6 +24,8 @@ import slugToSelectorProduct from './slug-to-selector-product';
 import type { PlanGridProducts, SelectorProduct } from './types';
 
 const useSelectorPageProducts = ( siteId: number | null ): PlanGridProducts => {
+	// Available products are products that have not been purchased,
+	// and are not included as part of an active subscription
 	let availableProducts: string[] = [];
 
 	// Products/features included in the current plan


### PR DESCRIPTION
See #74231 -- this PR is meant to solve the original issue outlined there, but which failed due to a crashing bug on Jetpack.com's pricing page. Original instructions are included inline for your convenience.

**NOTE:** In addition to the testing instructions below, check that visiting `/pricing/:site` does not result in a blank white page.

---

When a site owns a bundle (Complete or Security), the individual products that are labeled as "Included in the current plan" with display a "Manage Subscription" CTA button, instead of allowing you to purchase the product (because it is already included as part of the "Plan" subscription).  However the "Manage Subscription: buttons were not working correctly and were actually adding the products into the shopping cart, when instead they should have been linking to the product purchase management page (`/me/purchases/:site/:productId`) instead.  This PR Fixes this issue

Note t**his issue appears only when user is logged into wordpress.com and site is selected** (It is this criteria that also allows the pricing page shopping cart to be enabled and available on the page (Just fyi).

Asana Task: M-Origin: 1202858161751496-as-1204050913154767/f


## Testing Instructions

### To view/experience the regression:

-make sure you are logged-in to your A8C Wordpress.com account.
- Create a JN site, connect it, and purchase one of the Bundles/Plans. (Jetpack Complete recommended because it will show the most products that are included with the plan).
- From the wp-admin Jetpack Dashboard click on "**My Plan**" link in the top nav, just to confirm that your site ownes/has subscription to _Jetpack Complete_.
- Now click on the "Plans" link in the top nav. Verify you are taken to the Jetpack Cloud pricing page.
- On the pricing page, Verify that the _Complete plan_ says, "**Active on your site**" and notice that many of the individual product cards are saying, "**Included in the current plan**" and displaying the CTA button that says "**Manage Subscription**":. 
**Note:** (you may need to make sure you are logged-in/authorized into Jetpack Cloud Staging.. If you don't see the shopping cart, or any of the above mentioned features, click the "Log in" button on the top right corner of the page and authorize login with your wordpress.com account.
- Now, notice the bug/regression that when clicking on any of the "Manage Subscription" buttons, **the product is added to the shopping cart**, _instead_ of linking to the product/plan 'manage purchase' page (`/me/purchases/:site/:productId`) .

**(See the "Before the fix" video below:**


https://user-images.githubusercontent.com/11078128/223843545-f2abaf59-6e1c-4634-8a0a-6660e431d553.mov


### Now to test that the issue is fixed and works as expected:

* boot up this PR 
    * Run `git fetch && git checkout fix/logged-in-pricing-cards-cta-buttons-behavior`
    * Run `yarn start-jetpack-cloud`
* OR use the Jetpack Cloud Live (direct link) provided below
* Go to `http://jetpack.cloud.localhost:3000/pricing/${siteSlug}`  (Replace `${siteSlug}` with the slug of the JN site you created and has the Jetpack Complete subscription)
**OR** if using the Jetpack Cloud Live link, add/append `/pricing/${siteSlug}` to the container hostname (ie.- https://mycontainer.calypso.live`
- Verify that the product CTA button(s) that say "Manage Subscription" on all the products that are "Included in the current plan" are now pointing correctly to the product purchase page at page (`/me/purchases/:site/:productId`) .
- Verify that everything else looks and works good. Verify non-owned (or non-included in plan) products still get added to the cart properly.

**(See the "After the fix" video below:**


https://user-images.githubusercontent.com/11078128/223843625-92d95162-8767-4b2c-a9d3-cf1578da86e9.mov


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1204050913154767