### PR TITLE
Add redirects for expired eCommerce trials

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { PLAN_FREE, PLAN_JETPACK_FREE } from '@automattic/calypso-products';
 import { removeQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
 import { some, startsWith } from 'lodash';
@@ -62,9 +63,16 @@ import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isStagingSite from 'calypso/state/selectors/is-staging-site';
+import wasEcommerceTrialSite from 'calypso/state/selectors/was-ecommerce-trial-site';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
-import { getSite, getSiteId, getSiteOption, getSiteSlug } from 'calypso/state/sites/selectors';
+import {
+	getSite,
+	getSiteId,
+	getSiteOption,
+	getSitePlanSlug,
+	getSiteSlug,
+} from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { setSelectedSiteId, setAllSitesSelected } from 'calypso/state/ui/actions';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
@@ -282,6 +290,30 @@ function onSelectedSiteAvailable( context ) {
 	if ( isMigrationInProgress && ! startsWith( context.pathname, '/migrate/' ) ) {
 		page.redirect( `/migrate/${ selectedSite.slug }` );
 		return false;
+	}
+
+	// If we had an eCommerce trial, and the user doesn't have an active paid plan,
+	// redirect to
+	if ( wasEcommerceTrialSite( state, selectedSite.ID ) ) {
+		// Use getSitePlanSlug() as it ignores expired plans.
+		const currentPlanSlug = getSitePlanSlug( state, selectedSite.ID );
+
+		if ( [ PLAN_FREE, PLAN_JETPACK_FREE ].includes( currentPlanSlug ) ) {
+			const permittedPathPrefixes = [
+				'/checkout/',
+				'/domains/',
+				'/email/',
+				'/plans/my-plan/trial-expired/',
+				'/purchases/',
+			];
+
+			if ( ! permittedPathPrefixes.some( ( prefix ) => context.pathname.startsWith( prefix ) ) ) {
+				page.redirect( `/plans/my-plan/trial-expired/${ selectedSite.slug }` );
+				return false;
+			}
+
+			context.hideLeftNavigation = true;
+		}
 	}
 
 	const primaryDomain = getPrimaryDomainBySiteId( state, selectedSite.ID );
@@ -601,7 +633,9 @@ export function redirectToPrimary( context, primarySiteSlug ) {
 
 export function navigation( context, next ) {
 	// Render the My Sites navigation in #secondary
-	context.secondary = createNavigation( context );
+	if ( ! context.hideLeftNavigation ) {
+		context.secondary = createNavigation( context );
+	}
 	next();
 }
 

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -70,11 +70,13 @@ export default function () {
 		p2RedirectToHubPlans,
 		currentPlan
 	);
-	trackedPage( '/plans/my-plan/trial-expired/:domain', siteSelection, trialExpired );
+	trackedPage( '/plans/my-plan/trial-expired/:domain',
+		...commonHandlers,
+		trialExpired 
+	);
 	trackedPage(
 		'/plans/my-plan/trial-upgraded/:domain',
-		stagingSiteNotSupportedRedirect,
-		siteSelection,
+		...commonHandlers,
 		trialUpgradeConfirmation
 	);
 	trackedPage(

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -70,10 +70,7 @@ export default function () {
 		p2RedirectToHubPlans,
 		currentPlan
 	);
-	trackedPage( '/plans/my-plan/trial-expired/:domain',
-		...commonHandlers,
-		trialExpired 
-	);
+	trackedPage( '/plans/my-plan/trial-expired/:domain', ...commonHandlers, trialExpired );
 	trackedPage(
 		'/plans/my-plan/trial-upgraded/:domain',
 		...commonHandlers,

--- a/client/state/selectors/was-ecommerce-trial-site.ts
+++ b/client/state/selectors/was-ecommerce-trial-site.ts
@@ -1,0 +1,8 @@
+import getRawSite from 'calypso/state/selectors/get-raw-site';
+import type { AppState } from 'calypso/types';
+
+export default function wasEcommerceTrialSite( state: AppState, siteId: number ) {
+	const site = getRawSite( state, siteId );
+
+	return site?.was_ecommerce_trial === true;
+}

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -22,6 +22,7 @@ export const SITE_REQUEST_FIELDS = [
 	'is_core_site_editor_enabled',
 	'is_wpcom_atomic',
 	'is_wpcom_staging_site',
+	'was_ecommerce_trial',
 	'description',
 	'user_interactions',
 ].join();

--- a/client/state/sites/selectors/get-site-plan.ts
+++ b/client/state/sites/selectors/get-site-plan.ts
@@ -1,3 +1,4 @@
+import { PLAN_FREE, PLAN_JETPACK_FREE } from '@automattic/calypso-products';
 import getRawSite from 'calypso/state/selectors/get-raw-site';
 import type { AppState } from 'calypso/types';
 
@@ -39,7 +40,7 @@ export default function getSitePlan(
 		if ( site.jetpack && ! site.is_wpcom_atomic ) {
 			return {
 				product_id: 2002,
-				product_slug: 'jetpack_free',
+				product_slug: PLAN_JETPACK_FREE,
 				product_name_short: 'Free',
 				free_trial: false,
 				expired: false,
@@ -48,7 +49,7 @@ export default function getSitePlan(
 
 		return {
 			product_id: 1,
-			product_slug: 'free_plan',
+			product_slug: PLAN_FREE,
 			product_name_short: 'Free',
 			free_trial: false,
 			expired: false,

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -129,6 +129,7 @@ export interface SiteDetails {
 	site_owner?: number;
 	slug: string;
 	visible?: boolean;
+	was_ecommerce_trial?: boolean;
 	wpcom_url?: string;
 	user_interactions?: string[];
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* Automattic/wc-calypso-bridge#1005
* Automattic/jetpack#29423
* https://github.com/Automattic/wp-calypso/pull/74392

## Proposed Changes

* This PR tackles a few related problems as a starting point for showing an expiration page when the free eCommerce trial has expired for a site:
  - It adds Calypso support for a new `was_ecommerce_trial` property of the site object, which is being added in Automattic/jetpack#29423
  - It wires in checks that do the following if the site was an eCommerce trial _and_ the plan has expired:
    * If the requested route is for a subscription management path (`/domains/`, `/email/`, `/purchases/`), or checkout, or the new trial expired UI, we let the request continue, and we attempt to hide the left nav** for pages that we show by setting `context.hideLeftNavigation`
    * If the requested route is for any other path, we redirect the user to the new trial expired UI

** I had some issues with this previously, but I suspect the issue was related to a subtle improvement I made in the Jetpack PR

## Testing Instructions

* Ensure that you have the changes from Automattic/jetpack#29423 running on your WordPress.com developer system, and that `public-api.wordpress.com` is calling your development system
   - See the instructions in that PR if the changes haven't landed yet
   - Note that this is necessary to get the `was_ecommerce_trial` flag populated
* Ensure that you have sites in the following states:
   a. A site with an expired eCommerce trial and no other plan
   b. A site with a valid eCommerce trial
   c. A site that started with an eCommerce trial and then upgraded to a paid plan
   d. A free site that has never had an eCommerce trial
   e. A site with a paid plan that has never had an eCommerce trial
 * Run this branch locally or via the Calypso.live branch
 * For the sites in `c.`, `d.`, and `e.` above, verify that you can navigate to site-specific parts of Calypso without any issues, e.g. `/hosting-config/:site`, `/plugins/:site`, `/email/:site`, etc. We want to test that the changes don't break any existing logic
 * For the current eCommerce trial site (case `b.`), verify that you can navigate around the expected pages accessible to users on the eCommerce trial (this excludes site-specific `/plugins/*` paths for now)
 * For the expired eCommerce trial site, verify that accessing any site-specific path _except_ the following is redirected to `/plans/my-plan/trial-expired/:siteSlug`:
    - `/checkout/*`
    - `/domains/*`
    - `/email/*`
    - `/purchases/*`
 * Now verify that trying to visit any paths above for the eCommerce site (e.g. `/email/:siteSlug` or `/purchases/subscriptions/:siteSlug`) shows the relevant content, but does not show the left nav
  - Also verify that switching sites once in the no-nav state correctly shows the nav after rendering the new site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?