### PR TITLE
Odyssey Stats: Prepare post details from "post" or "postFallback"

### DIFF
--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -18,21 +18,13 @@ type PostThumbnail = {
 	URL: string;
 };
 
-type PostDiscussion = {
-	comment_count: number;
-	comment_status: string;
-	comments_open: boolean;
-	ping_status: string;
-	pings_open: boolean;
-};
-
 type Post = {
-	date: string;
+	date: string | null;
 	title: string;
-	type: string;
-	like_count: number;
+	type: string | null;
+	like_count: number | null;
 	post_thumbnail: PostThumbnail | null;
-	discussion: PostDiscussion;
+	comment_count: number | null;
 };
 
 const POST_STATS_CARD_TITLE_LIMIT = 48;
@@ -97,7 +89,7 @@ export default function PostDetailHighlightsSection( {
 						likeCount={ post?.like_count || 0 }
 						post={ postData }
 						viewCount={ viewCount }
-						commentCount={ post?.discussion?.comment_count || 0 }
+						commentCount={ post?.comment_count || 0 }
 					/>
 
 					<Card className="highlight-card">

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -106,32 +106,34 @@ class StatsPostDetail extends Component {
 	getPost() {
 		const { isPostHomepage, post, postFallback } = this.props;
 
+		const postBase = {
+			title: this.getTitle(),
+			type: isPostHomepage ? 'page' : 'post',
+		};
+
+		// Check if post is valid.
 		if ( typeof post === 'object' && post?.title.length ) {
-			return {
-				title: this.getTitle(),
+			return Object.assign( postBase, {
 				date: post?.date,
 				post_thumbnail: post?.post_thumbnail,
 				like_count: post?.like_count,
 				comment_count: post?.discussion?.comment_count,
 				type: post?.type,
-			};
+			} );
 		}
 
+		// Check if postFallback is valid.
 		if ( typeof postFallback === 'object' && postFallback?.post_title.length ) {
-			return {
-				title: this.getTitle(),
+			return Object.assign( postBase, {
 				date: postFallback?.post_date_gmt,
 				post_thumbnail: null,
 				like_count: null,
 				comment_count: parseInt( postFallback?.comment_count, 10 ),
 				type: postFallback?.post_type,
-			};
+			} );
 		}
 
-		return {
-			title: this.getTitle(),
-			type: isPostHomepage ? 'page' : 'post',
-		};
+		return postBase;
 	}
 
 	render() {

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -92,15 +92,46 @@ class StatsPostDetail extends Component {
 			return translate( 'Home page / Archives' );
 		}
 
-		if ( typeof post?.title === 'string' && post.title.length ) {
+		if ( typeof post?.title === 'string' && post?.title.length ) {
 			return decodeEntities( stripHTML( post.title ) );
 		}
 
-		if ( typeof postFallback?.post_title === 'string' && postFallback.post_title.length ) {
+		if ( typeof postFallback?.post_title === 'string' && postFallback?.post_title.length ) {
 			return decodeEntities( stripHTML( postFallback.post_title ) );
 		}
 
 		return null;
+	}
+
+	getPost() {
+		const { isPostHomepage, post, postFallback } = this.props;
+
+		if ( typeof post === 'object' && post?.title.length ) {
+			return {
+				title: this.getTitle(),
+				date: post?.date,
+				post_thumbnail: post?.post_thumbnail,
+				like_count: post?.like_count,
+				comment_count: post?.discussion?.comment_count,
+				type: post?.type,
+			};
+		}
+
+		if ( typeof postFallback === 'object' && postFallback?.post_title.length ) {
+			return {
+				title: this.getTitle(),
+				date: postFallback?.post_date_gmt,
+				post_thumbnail: null,
+				like_count: null,
+				comment_count: parseInt( postFallback?.comment_count, 10 ),
+				type: postFallback?.post_type,
+			};
+		}
+
+		return {
+			title: this.getTitle(),
+			type: isPostHomepage ? 'page' : 'post',
+		};
 	}
 
 	render() {
@@ -108,8 +139,6 @@ class StatsPostDetail extends Component {
 			isPostHomepage,
 			isRequestingStats,
 			countViews,
-			post,
-			postFallback,
 			postId,
 			siteId,
 			translate,
@@ -117,9 +146,13 @@ class StatsPostDetail extends Component {
 			showViewLink,
 			previewUrl,
 		} = this.props;
+
 		const isLoading = isRequestingStats && ! countViews;
 
-		const postType = post && post.type !== null ? post.type : 'post';
+		// Prepare post details to PostStatsCard from post or postFallback.
+		const passedPost = this.getPost();
+
+		const postType = passedPost && passedPost.type !== null ? passedPost.type : 'post';
 		let actionLabel;
 		let noViewsLabel;
 
@@ -130,12 +163,6 @@ class StatsPostDetail extends Component {
 			actionLabel = translate( 'View Post' );
 			noViewsLabel = translate( 'Your post has not received any views yet!' );
 		}
-
-		// Make title to PostStatsCard for Homepage
-		const passedPost = post ||
-			postFallback || {
-				title: this.getTitle(),
-			};
 
 		return (
 			<Main fullWidthLayout>

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -92,11 +92,11 @@ class StatsPostDetail extends Component {
 			return translate( 'Home page / Archives' );
 		}
 
-		if ( typeof post?.title === 'string' && post?.title.length ) {
+		if ( typeof post?.title === 'string' && post.title.length ) {
 			return decodeEntities( stripHTML( post.title ) );
 		}
 
-		if ( typeof postFallback?.post_title === 'string' && postFallback?.post_title.length ) {
+		if ( typeof postFallback?.post_title === 'string' && postFallback.post_title.length ) {
 			return decodeEntities( stripHTML( postFallback.post_title ) );
 		}
 
@@ -113,24 +113,26 @@ class StatsPostDetail extends Component {
 
 		// Check if post is valid.
 		if ( typeof post === 'object' && post?.title.length ) {
-			return Object.assign( postBase, {
+			return {
+				...postBase,
 				date: post?.date,
 				post_thumbnail: post?.post_thumbnail,
 				like_count: post?.like_count,
 				comment_count: post?.discussion?.comment_count,
 				type: post?.type,
-			} );
+			};
 		}
 
 		// Check if postFallback is valid.
 		if ( typeof postFallback === 'object' && postFallback?.post_title.length ) {
-			return Object.assign( postBase, {
+			return {
+				...postBase,
 				date: postFallback?.post_date_gmt,
 				post_thumbnail: null,
 				like_count: null,
 				comment_count: parseInt( postFallback?.comment_count, 10 ),
 				type: postFallback?.post_type,
-			} );
+			};
 		}
 
 		return postBase;

--- a/packages/components/src/post-stats-card/index.tsx
+++ b/packages/components/src/post-stats-card/index.tsx
@@ -12,7 +12,7 @@ type PostStatsCardProps = {
 	likeCount: number | null;
 	viewCount: number | null;
 	post: {
-		date: string;
+		date: string | null;
 		post_thumbnail: string | null;
 		title: string;
 	};
@@ -30,7 +30,10 @@ export default function PostStatsCard( {
 	uploadHref,
 }: PostStatsCardProps ) {
 	const translate = useTranslate();
-	const parsedDate = useMemo( () => new Date( post?.date ).toLocaleDateString(), [ post?.date ] );
+	const parsedDate = useMemo(
+		() => ( post?.date ? new Date( post?.date ).toLocaleDateString() : '' ),
+		[ post?.date ]
+	);
 	const TitleTag = titleLink ? 'a' : 'div';
 
 	const recordClickOnUploadImageButton = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Generate the post passed to the `PostStatsCard` from the existing `post` or `postFallback` since the `post` would be `null` on Odyssey Stats.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify Odyssey Stats with Option 1 in `PejTkB-3E-p2`.
* Navigate to the Post Details page on Odyssey Stats.
* Ensure the post title and date are displayed as Calypso Stats.

### Calypso Stats
<img width="1265" alt="截圖 2023-03-11 上午12 51 25" src="https://user-images.githubusercontent.com/6869813/224376584-4ddcaf5e-4735-4ee4-a3f2-243cd2ea81f7.png">

### Odyssey Stats
|Before|After|
|-|-|
|<img width="1260" alt="截圖 2023-03-11 上午12 51 03" src="https://user-images.githubusercontent.com/6869813/224376376-f3cb3ae1-7ff5-47a9-880b-37e1a5bea14c.png">|<img width="1260" alt="截圖 2023-03-11 上午12 50 30" src="https://user-images.githubusercontent.com/6869813/224376439-a90367ec-59d8-498f-8855-89d4ba9a4e60.png">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
