### PR TITLE
Fixing coblock style e2e test by adding a button click.

### DIFF
--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -66,6 +66,11 @@ describe( DataHelper.createSuiteTitle( 'CoBlocks: Extensions: Cover Styles' ), (
 		await editorPage.openSettings();
 	} );
 
+	it( 'Click on the Styles button', async () => {
+		const stylesButton = await editorWindowLocator.locator( `button[aria-label="Styles"]` );
+		await stylesButton?.click();
+	} );
+
 	it.each( CoverBlock.coverStyles )( 'Verify "%s" style is available', async ( style ) => {
 		await editorWindowLocator.locator( `button[aria-label="${ style }"]` ).waitFor();
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Adding a click on the Styles button to open the styles selection menu.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts should pass on desktop and mobile.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
