### PR TITLE
Backup: Update backup storage FAQs links

### DIFF
--- a/client/components/backup-retention-management/constants.ts
+++ b/client/components/backup-retention-management/constants.ts
@@ -5,4 +5,4 @@ export const RETENTION_OPTIONS = [ 7, 30, 120, 365 ] as RetentionPeriod[];
 export const STORAGE_ESTIMATION_ADDITIONAL_BUFFER = 0;
 
 export const STORAGE_RETENTION_LEARN_MORE_LINK =
-	'https://jetpack.com/support/backup/#how-is-storage-usage-calculated';
+	'https://jetpack.com/support/jetpack-vaultpress-backup-storage-and-retention/';

--- a/client/components/backup-storage-space/storage-usage-help-tooltip.tsx
+++ b/client/components/backup-storage-space/storage-usage-help-tooltip.tsx
@@ -71,7 +71,7 @@ const StorageHelpTooltip: React.FC< OwnProps > = ( { className, bytesAvailable }
 					components: {
 						a: (
 							<a
-								href="https://jetpack.com/support/backup/#how-is-storage-usage-calculated"
+								href="https://jetpack.com/support/jetpack-vaultpress-backup-storage-and-retention/"
 								target="_blank"
 								rel="external noreferrer noopener"
 							/>

--- a/client/components/backup-storage-space/style.scss
+++ b/client/components/backup-storage-space/style.scss
@@ -138,7 +138,7 @@
 
 .storage-usage-help-tooltip {
 
-	&__tooltip.popover {
+	&__tooltip.tooltip.popover {
 		&.is-right .popover__arrow {
 			border-right-color: #fff;
 		}
@@ -160,7 +160,7 @@
 
 			p {
 				padding-right: 24px;
-				font-size: $font-body;
+				font-size: $font-body-small;
 				color: var(--studio-gray-60);
 				margin: 0;
 			}
@@ -170,7 +170,7 @@
 			}
 
 			a {
-				font-size: $font-body;
+				font-size: $font-body-small;
 				text-decoration: underline;
 			}
 		}


### PR DESCRIPTION
## Proposed Changes

* Update the `Learn more...` link on Backup and Jetpack Settings page to https://jetpack.com/support/jetpack-vaultpress-backup-storage-and-retention/
* Adjusted styling to be consistent with the paragraph font size on the Jetpack Settings page tooltip and Backup page tooltip.
* Adjusted Backup page tooltip CSS selector to prevent another component impacting the tooltip style. This is because there are some rare cases where the tooltip goes greyed out like this:
  <img width="525" alt="image" src="https://user-images.githubusercontent.com/1488641/224402600-fad5d78d-a43b-4d24-a399-fd42c76023ff.png">


## Screenshots
| Page | Screenshot |
|---|---|
| Backup page | <img width="532" alt="image" src="https://user-images.githubusercontent.com/1488641/224402934-b9258c93-c50c-450a-994a-608a77c08b86.png"> |
| Jetpack Settings page | <img width="520" alt="image" src="https://user-images.githubusercontent.com/1488641/224403000-dfa9e50c-354b-4369-99fe-cc1ac21fd42d.png"> |

## Testing Instructions

* Start Calypso Live and Jetpack Cloud Live and validate the `Learn more...` link in Backup and Jetpack Settings page in Calypso Blue and Jetpack Cloud are pointing to https://jetpack.com/support/jetpack-vaultpress-backup-storage-and-retention/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
