### PR TITLE
App Banner: Fix style regressions

### DIFF
--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -72,7 +72,6 @@ body.app-banner-is-visible {
 }
 
 .app-banner__text-content {
-	width: 100%;
 	letter-spacing: -0.4px;
 	margin: 36px auto 0;
 }
@@ -100,7 +99,6 @@ body.app-banner-is-visible {
 }
 
 .app-banner__buttons {
-	width: 100%;
 	margin-top: 36px;
 
 	.button {

--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -115,11 +115,17 @@ body.app-banner-is-visible {
 }
 
 .button.app-banner__open-button {
-	background-color: var(--color-jetpack);
+	background-color: var(--studio-jetpack-green-40);
 	border: 0;
 	border-radius: 4px;
 	margin-right: 10px;
 	margin-bottom: 12px;
+
+	&:hover,
+	&:focus {
+		background-color: var(--studio-jetpack-green-60);
+		border-color: var(--studio-jetpack-green-60);
+	}
 }
 
 .button.app-banner__no-thanks-button {

--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -118,7 +118,6 @@ body.app-banner-is-visible {
 	background-color: var(--studio-jetpack-green-40);
 	border: 0;
 	border-radius: 4px;
-	margin-right: 10px;
 	margin-bottom: 12px;
 
 	&:hover,


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/74284

Following the refactoring/removal of some redundant code in https://github.com/Automattic/wp-calypso/pull/74284, a couple of style regressions were noted in [this comment](https://github.com/Automattic/wp-calypso/pull/74284#issuecomment-1464025631). This PR fixes those regressions.

## Proposed Changes

* To address the incorrect hover/focus colours, those button states have been targeted. `--studio-jetpack-green-60` has been used as the hover/focus colour, and the colour for the default state has been set to `--studio-jetpack-green-40 `. This is in keeping with how Jetpack's colour are utilised for other links throughout Calypso ([example](https://github.com/Automattic/wp-calypso/blob/888c6680c5496c1117b59e8cbf7e48b3f4a587fc/client/blocks/get-apps/style.scss#L48-L65)).
* The button alignment issue on larger screens has been addressed by removing `margin-right` from the main button (as this was not needed and creating the unwanted padding). 
* The width has also been removed from the `app-banner__text-content` and `app-banner__buttons` containers, as this was causing the containers to overflow the screen on larger devices, which left the icon appearing off-centre in some cases.

## Testing Instructions

_Prerequisite:_ The app banner can be viewed via the mobile web (which can also be [emulated using browser tools](https://developer.chrome.com/docs/devtools/device-mode/#viewport)) when navigating directly to the Reader, Stats, Notifications, or the editor.

The following should be confirmed for both iOS and Android:

* Verify that the banner appears as expected when navigating to the Reader, Stats, Notifications, and the editor.
* The banners should look and function the same with the changes in this PR as they do in production.
* In your browser with the banner already displayed, increase the size of the window to ensure that the content of the banners should always be centred, with no screen overflow.

> **Note**
> The banners themselves only display on mobile devices (not tablets), so it should be rare that the alignment issue is encountered through everyday browsing. However, it's still useful to fix in case there may be larger mobile devices used in landscape mode.

### Hover/focus colours

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/224410118-4add6f78-672e-4cf0-aed1-9b2a1b0190ec.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/224410264-1a39ca50-6623-4f02-8246-e968f5d25b91.png" width="100%"> |

### Alignment on larger devices

**Before:**

<img width="616" alt="Screenshot 2023-03-10 at 19 52 55" src="https://user-images.githubusercontent.com/2998162/224414550-4d3a64a8-0799-48b7-ab2b-27f0115dfa23.png">

**After:**

<img width="529" alt="Screenshot 2023-03-10 at 19 57 32" src="https://user-images.githubusercontent.com/2998162/224415459-65603ec1-b835-4ab5-ace5-9a604af118da.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
