### PR TITLE
Migrate spt store from registerStore to register

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.tsx
@@ -2,8 +2,7 @@ import { initializeTracksWithIdentity, PatternDefinition } from '@automattic/pag
 import { dispatch } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
 import { PagePatternsPlugin } from './page-patterns-plugin';
-
-import './store';
+import { pageLayoutStore } from './store';
 import './index.scss';
 
 declare global {
@@ -29,7 +28,7 @@ if ( tracksUserData ) {
 
 // Open plugin only if we are creating new page.
 if ( screenAction === 'add' ) {
-	dispatch( 'automattic/starter-page-layouts' ).setOpenState( 'OPEN_FROM_ADD_PAGE' );
+	dispatch( pageLayoutStore ).setOpenState( 'OPEN_FROM_ADD_PAGE' );
 }
 
 // Always register ability to open from document sidebar.

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-patterns-plugin.tsx
@@ -3,8 +3,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { addFilter, removeFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
-import { selectors as starterPageTemplatesSelectors } from '../starter-page-templates/store';
-import type { SelectFromMap } from '@automattic/data-stores';
+import { pageLayoutStore } from './store';
 import '@wordpress/nux';
 
 const INSERTING_HOOK_NAME = 'isInsertingPagePattern';
@@ -13,7 +12,6 @@ const INSERTING_HOOK_NAMESPACE = 'automattic/full-site-editing/inserting-pattern
 interface PagePatternsPluginProps {
 	patterns: PatternDefinition[];
 }
-type StarterPageTemplatesSelectors = SelectFromMap< typeof starterPageTemplatesSelectors >;
 type CoreEditorPlaceholder = {
 	getBlocks: ( ...args: unknown[] ) => Array< { name: string; clientId: string } >;
 	getEditedPostAttribute: ( ...args: unknown[] ) => unknown;
@@ -26,7 +24,7 @@ type CoreNuxPlaceholder = {
 };
 
 export function PagePatternsPlugin( props: PagePatternsPluginProps ) {
-	const { setOpenState } = useDispatch( 'automattic/starter-page-layouts' );
+	const { setOpenState } = useDispatch( pageLayoutStore );
 	const { setUsedPageOrPatternsModal } = useDispatch( 'automattic/wpcom-welcome-guide' );
 	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
 	const { editPost } = useDispatch( 'core/editor' );
@@ -34,9 +32,7 @@ export function PagePatternsPlugin( props: PagePatternsPluginProps ) {
 	const { disableTips } = useDispatch( 'core/nux' );
 
 	const selectProps = useSelect( ( select ) => {
-		const { isOpen, isPatternPicker }: StarterPageTemplatesSelectors = select(
-			'automattic/starter-page-layouts'
-		);
+		const { isOpen, isPatternPicker } = select( pageLayoutStore );
 		return {
 			isOpen: isOpen(),
 			isWelcomeGuideActive: (

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/store.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/store.ts
@@ -1,4 +1,4 @@
-import { registerStore } from '@wordpress/data';
+import { register, createReduxStore } from '@wordpress/data';
 import type { Reducer } from 'redux';
 
 type OpenState = 'CLOSED' | 'OPEN_FROM_ADD_PAGE' | 'OPEN_FOR_BLANK_CANVAS';
@@ -19,14 +19,9 @@ export const selectors = {
 	isPatternPicker: ( state: OpenState ): boolean => 'OPEN_FOR_BLANK_CANVAS' === state,
 };
 
-const STORE_KEY = 'automattic/starter-page-layouts';
-
-registerStore( STORE_KEY, {
-	// In reality the store can dispatch any action, however `reducer` has a
-	// strongly typed action type to make the typings inside the function
-	// easier to work with.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	reducer: reducer as any,
+export const pageLayoutStore = createReduxStore( 'automattic/starter-page-layouts', {
+	reducer,
 	actions,
 	selectors,
 } );
+register( pageLayoutStore );


### PR DESCRIPTION
## Proposed Changes
Experiments with migrating a store from `registerStore` to `createReduxStore` + `register`. The first reason to do it is because `registerStore` is deprecated. The main benefit we get is built-in type inference without any extra work, which ultimately simplifies existing code.

This depends on the `@wordpress/data` update in #73890 being merged first.

## Testing Instructions
1. install this branch's ETK build on your sandbox
2. Sandbox a test site and create a new page
3. verify the page layout store works
4. TBD: verify interactions with other parts of ETK, like the welcome modals.
