### PR TITLE
Add reader manage link to top of P2 and A8c Reader feeds

### DIFF
--- a/client/reader/a8c/main.jsx
+++ b/client/reader/a8c/main.jsx
@@ -28,6 +28,9 @@ export default function A8CFollowing( props ) {
 				<Button compact onClick={ markAllAsSeen } disabled={ ! feedsInfo.unseenCount }>
 					{ translate( 'Mark all as seen' ) }
 				</Button>
+				<Button primary compact className="following__manage" href="/following/manage">
+					{ translate( 'Manage' ) }
+				</Button>
 			</SectionHeader>
 		</Stream>
 	);

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -171,6 +171,12 @@ class FollowingManage extends Component {
 		}
 	}
 
+	goBack() {
+		if ( typeof window !== 'undefined' ) {
+			window.history.back();
+		}
+	}
+
 	render() {
 		const {
 			sitesQuery,
@@ -204,7 +210,7 @@ class FollowingManage extends Component {
 		return (
 			<Fragment>
 				<div className="following-manage__header">
-					<HeaderCake backHref="/read">
+					<HeaderCake onClick={ this.goBack }>
 						<h1>{ translate( 'Manage Followed Sites' ) }</h1>
 					</HeaderCake>
 				</div>

--- a/client/reader/p2/main.jsx
+++ b/client/reader/p2/main.jsx
@@ -26,6 +26,9 @@ export default function P2Following( props ) {
 				<Button compact onClick={ markAllAsSeen } disabled={ ! feedsInfo.unseenCount }>
 					{ translate( 'Mark all as seen' ) }
 				</Button>
+				<Button primary compact className="following__manage" href="/following/manage">
+					{ translate( 'Manage' ) }
+				</Button>
 			</SectionHeader>
 		</Stream>
 	);


### PR DESCRIPTION
## Description

@andrewspittle highlighted that there was no easy way to manage P2s that you had followed from the P2 reader feed. I thought we had removed the button, but it turns out that there never was a button there. :-) 

I went ahead and added one to the top of the P2 feed and to the A8c specific feed. I also updated the back button come once you're on the Manage page so it works with all three screens.

### Before

![before](https://user-images.githubusercontent.com/5634774/224418334-1dba25f5-3b8b-4711-9099-e171d5ff3145.gif)

### After

![after](https://user-images.githubusercontent.com/5634774/224418356-8445b5e4-1d79-4ec8-8748-8ca03c10c7a1.gif)

### Testing Instructions

- Apply this PR
- Go to http://calypso.localhost:3000/read/p2
- Click the new "Manage" button
- Click the "Back Button 
- Repeat with http://calypso.localhost:3000/read/a8c