### PR TITLE
WooExpress Trial: Pass incoming profiler data to the ecommerce trial endpoint.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -29,6 +29,9 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
 		[]
 	);
+	const profilerData = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect).getProfilerData()
+	) || {};
 
 	useEffect( () => {
 		if ( submit ) {
@@ -42,7 +45,8 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 						`/sites/${ data?.siteSlug }/ecommerce-trial/add/ecommerce-trial-bundle-monthly`,
 						{
 							apiVersion: '1.1',
-						}
+						},
+						profilerData
 					);
 
 					submit?.( { siteSlug: data?.siteSlug }, AssignTrialResult.SUCCESS );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -29,9 +29,8 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
 		[]
 	);
-	const profilerData = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect).getProfilerData()
-	) || {};
+	const profilerData =
+		useSelect( ( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getProfilerData() ) || {};
 
 	useEffect( () => {
 		if ( submit ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -46,7 +46,9 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 						{
 							apiVersion: '1.1',
 						},
-						profilerData
+						{
+							wpcom_woocommerce_onboarding: profilerData,
+						}
 					);
 
 					submit?.( { siteSlug: data?.siteSlug }, AssignTrialResult.SUCCESS );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -30,7 +30,8 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 		[]
 	);
 	const profilerData =
-		useSelect( ( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getProfilerData() ) || {};
+		useSelect( ( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getProfilerData(), [] ) ||
+		{};
 
 	useEffect( () => {
 		if ( submit ) {

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -30,6 +30,7 @@ const wooexpress: Flow = {
 		];
 	},
 	useAssertConditions(): AssertConditionResult {
+		const { setProfilerData } = useDispatch( ONBOARD_STORE );
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
@@ -38,6 +39,17 @@ const wooexpress: Flow = {
 
 		const flowName = this.name;
 		const locale = useLocale();
+
+		const queryParams = new URLSearchParams( window.location.search );
+		const profilerData = queryParams.get( 'profilerdata' );
+
+		if ( profilerData ) {
+			const decodedProfilerData = JSON.parse(
+				decodeURIComponent( escape( window.atob( profilerData ) ) )
+			);
+
+			setProfilerData( decodedProfilerData );
+		}
 
 		const getStartUrl = () => {
 			let hasFlowParams = false;

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -44,11 +44,14 @@ const wooexpress: Flow = {
 		const profilerData = queryParams.get( 'profilerdata' );
 
 		if ( profilerData ) {
-			const decodedProfilerData = JSON.parse(
-				decodeURIComponent( escape( window.atob( profilerData ) ) )
-			);
+			try {
+				const decodedProfilerData = JSON.parse(
+					decodeURIComponent( escape( window.atob( profilerData ) ) )
+				);
 
-			setProfilerData( decodedProfilerData );
+				setProfilerData( decodedProfilerData );
+				// Ignore any bad/invalid data and prevent it from causing downstream issues.
+			} catch {}
 		}
 
 		const getStartUrl = () => {

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -5,6 +5,7 @@ import { STORE_KEY as SITE_STORE } from '../site';
 import { CreateSiteParams, Visibility, NewSiteBlogDetails } from '../site/types';
 import { FeatureId } from '../wpcom-features/types';
 import { SiteGoal, STORE_KEY } from './constants';
+import { ProfilerData } from './types';
 import type { State } from '.';
 import type { DomainSuggestion } from '../domain-suggestions';
 // somewhat hacky, but resolves the circular dependency issue
@@ -464,6 +465,11 @@ export const setPluginsToVerify = ( pluginSlugs: string[] ) => ( {
 	pluginSlugs,
 } );
 
+export const setProfilerData = ( profilerData: ProfilerData ) => ( {
+	type: 'SET_PROFILER_DATA' as const,
+	profilerData,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -481,6 +487,7 @@ export type OnboardAction = ReturnType<
 	| typeof setLastLocation
 	| typeof setPlanProductId
 	| typeof setPluginsToVerify
+	| typeof setProfilerData
 	| typeof setRandomizedDesigns
 	| typeof setSelectedDesign
 	| typeof setSelectedStyleVariation

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@wordpress/data';
 import { SiteGoal } from './constants';
 import type { OnboardAction } from './actions';
-import type { DomainForm } from './types';
+import type { DomainForm, ProfilerData } from './types';
 import type { DomainSuggestion } from '../domain-suggestions';
 import type { FeatureId } from '../wpcom-features/types';
 // somewhat hacky, but resolves the circular dependency issue
@@ -496,6 +496,19 @@ const pluginsToVerify: Reducer< string[] | undefined, OnboardAction > = ( state,
 	return state;
 };
 
+export const profilerData: Reducer< ProfilerData | undefined, OnboardAction > = (
+	state,
+	action
+) => {
+	if ( action.type === 'SET_PROFILER_DATA' ) {
+		return action.profilerData;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return undefined;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	anchorPodcastId,
 	anchorEpisodeId,
@@ -540,6 +553,7 @@ const reducer = combineReducers( {
 	productCartItems,
 	isMigrateFromWp,
 	pluginsToVerify,
+	profilerData,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -64,3 +64,4 @@ export const getDomainCartItem = ( state: State ) => state.domainCartItem;
 export const getHideFreePlan = ( state: State ) => state.hideFreePlan;
 export const getIsMigrateFromWp = ( state: State ) => state.isMigrateFromWp;
 export const getPluginsToVerify = ( state: State ) => state.pluginsToVerify;
+export const getProfilerData = ( state: State ) => state.profilerData;

--- a/packages/data-stores/src/onboard/test/actions.ts
+++ b/packages/data-stores/src/onboard/test/actions.ts
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { setProfilerData } from '../actions';
+import { ProfilerData } from '../types';
+
+describe( 'actions', () => {
+	const expectedProfilerData = {
+		industry: 'clothing_and_accessories',
+		persona: 'im_already_selling_online',
+		platforms: [ 'shopify' ],
+		store_location: 'us',
+		store_name: 'Beautifully Handmade, 手工精美',
+	} as ProfilerData;
+
+	it( 'should return a SET_PROFILER_DATA action', () => {
+		const expected = {
+			type: 'SET_PROFILER_DATA',
+			profilerData: expectedProfilerData,
+		};
+
+		expect( setProfilerData( expectedProfilerData ) ).toEqual( expected );
+	} );
+} );

--- a/packages/data-stores/src/onboard/test/reducers.ts
+++ b/packages/data-stores/src/onboard/test/reducers.ts
@@ -1,0 +1,26 @@
+import { profilerData } from '../reducer';
+import { ProfilerData } from '../types';
+
+describe( 'reducer', () => {
+	it( 'returns the correct default state', () => {
+		const state = profilerData( undefined, { type: 'TEST_ACTION' } );
+		expect( state ).toEqual( undefined );
+	} );
+
+	it( 'returns the profiler data', () => {
+		const expectedProfilerData = {
+			industry: 'clothing_and_accessories',
+			persona: 'im_already_selling_online',
+			platforms: [ 'shopify' ],
+			store_location: 'us',
+			store_name: 'Beautifully Handmade, 手工精美',
+		} as ProfilerData;
+
+		const state = profilerData( undefined, {
+			type: 'SET_PROFILER_DATA',
+			profilerData: expectedProfilerData,
+		} );
+
+		expect( state ).toEqual( expectedProfilerData );
+	} );
+} );

--- a/packages/data-stores/src/onboard/test/selectors.ts
+++ b/packages/data-stores/src/onboard/test/selectors.ts
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { getProfilerData } from '../selectors';
+import type { State } from '../reducer';
+
+describe( 'selectors', () => {
+	it( 'should return the profiler data', () => {
+		const expectedProfilerData = {
+			industry: 'clothing_and_accessories',
+			persona: 'im_already_selling_online',
+			platforms: [ 'shopify' ],
+			store_location: 'us',
+			store_name: 'Beautifully Handmade, 手工精美',
+		};
+		const state: State = {
+			profilerData: expectedProfilerData,
+		};
+		expect( getProfilerData( state ) ).toEqual( expectedProfilerData );
+	} );
+} );

--- a/packages/data-stores/src/onboard/types.ts
+++ b/packages/data-stores/src/onboard/types.ts
@@ -7,3 +7,7 @@ export type DomainForm = {
 	searchResults?: DomainSuggestion[] | null;
 	hideInitialQuery?: boolean;
 };
+
+export interface ProfilerData {
+	[ key: string ]: string | number | boolean | string[] | number[];
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #72717

## Proposed Changes

Pass incoming profiler data to the ecommerce trial api
    
If we get the `profilerdata` parameter passed in, we store in the `ONBOARD_STORE`. Then we retrieve it and pass it along to to ecommerce trial api.

Since this implementation is tied to only the ecommerce trial, it seemed OK to store the incoming data directly rather than key it off site id/slug.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

After applying this branch, run the onboard data store tests

```
yarn run test-packages packages/data-stores/src/onboard/test/
```

#### Verifying that invalid data is ignored

* Ensure you have your network inspector tab available
* Visit http://calypso.localhost:3000/setup/wooexpress?eyJibG9nbmFtZSI6IuaJi+W3peeyvue+jiIsIndvb2NvbW1lcmNlX2RlZmF1bHRfY291bnRyeSI6IlRIOlRILTg1Iiwid29vY29tbWVyY2Vfb25ib2FyZGluZ19wcm9maWxlIjp7ImluZHVzdHJ5IjpbeyJzbHVnIjoiaGVhbHRoLWJlYXV0eSJ9XSwiaXNfc3RvcmVfY291bnRyeV9zZXQiOnRydWUsInNlbGxpbmdfdmVudWVzIjoib3RoZXIiLCJvdGhlcl9wbGF0Zm9ybSI6Im90aGVyIiwib3RoZXJfcGxhdGZvcm1fbmFtZSI6IkJpZyBDYXJ0ZWwiLCJza2lwcGVkIjp0cnVlfX0=
* Verify that the flow completes and the API call to `https://public-api.wordpress.com/rest/v1.1/sites/:siteSlug/ecommerce-trial/add/ecommerce-trial-bundle-monthly?http_envelope=1` includes an empty `wpcom_woocommerce_onboarding` object.

The above content includes incorrectly encoded data that will trigger an exception in the decode logic. (The `+` symbols need to be URL-encoded.)

#### Verify that valid data is passed through

* Ensure you have your network inspector tab available 
* Then visit: http://calypso.localhost:3000/setup/wooexpress?profilerdata=eyJibG9nbmFtZSI6IuaJi%2BW3peeyvue%2BjiIsIndvb2NvbW1lcmNlX2RlZmF1bHRfY291bnRyeSI6IlRIOlRILTg1Iiwid29vY29tbWVyY2Vfb25ib2FyZGluZ19wcm9maWxlIjp7ImluZHVzdHJ5IjpbeyJzbHVnIjoiaGVhbHRoLWJlYXV0eSJ9XSwiaXNfc3RvcmVfY291bnRyeV9zZXQiOnRydWUsInNlbGxpbmdfdmVudWVzIjoib3RoZXIiLCJvdGhlcl9wbGF0Zm9ybSI6Im90aGVyIiwib3RoZXJfcGxhdGZvcm1fbmFtZSI6IkJpZyBDYXJ0ZWwiLCJza2lwcGVkIjp0cnVlfX0=
  - The above url contains the following `profilerdata` payload:
```
{
	"blogname": "手工精美",
	"woocommerce_default_country": "TH:TH-85",
	"woocommerce_onboarding_profile": {
		"industry": [
			{
				"slug": "health-beauty"
			}
		],
		"is_store_country_set": true,
		"selling_venues": "other",
		"other_platform": "other",
		"other_platform_name": "Big Cartel",
		"skipped":true
	}
}
```
* Verify that the flow completes and the API call to `https://public-api.wordpress.com/rest/v1.1/sites/:siteSlug/ecommerce-trial/add/ecommerce-trial-bundle-monthly?http_envelope=1` includes the values above in the `wpcom_woocommerce_onboarding` object sent to the API.
* When you get to the home page, verify that the store title is set correctly
* Open the store details task, and verify that the country has been set appropriately
* Once the site has been created, locate the blog id for the site (`https://wordpress.com/wp-admin/network/sites.php?s=:siteSlug`).
* Then ssh into your sandbox and run `wpsh`.
* In `wpsh`, run `return get_blog_option( :blogId, 'woocommerce_onboarding_profile' );` and verify the result matches the payload above.
  - Note that we have a filter running on the sites that currently prevents this field from being returned -- see Automattic/wc-calypso-bridge#997

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?