### PR TITLE
Odyssey Stats: Use content hashing for chunk names

### DIFF
--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -56,6 +56,7 @@ module.exports = {
 	output: {
 		path: outputPath,
 		filename: 'build.min.js',
+		chunkFilename: '[contenthash].js',
 	},
 	optimization: {
 		minimize: ! isDevelopment,
@@ -123,6 +124,7 @@ module.exports = {
 		} ),
 		...SassConfig.plugins( {
 			filename: 'build.min.css',
+			chunkFilename: '[contenthash].css',
 			minify: ! isDevelopment,
 		} ),
 		new DependencyExtractionWebpackPlugin( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See this incident: p1HpG7-l6v-p2

## Proposed Changes

* Changes our chunk filename pattern to [use content-aware hashing instead of relying on chunk IDs](https://webpack.js.org/configuration/output/#template-strings).
* This should fix a current production incident where clients are requesting and receiving outdated chunk assets that are being rejected by Odyssey's main JS bundle.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this change to your local Jetpack test site using these instructions: PejTkB-3N-p2.
* Ensure that the Odyssey Stats interface load as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?