### PR TITLE
Checkout: Show actual VAT validation error messages

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -397,12 +397,7 @@ export default function WPCheckout( {
 								reduxDispatch( removeNotice( 'vat_info_notice' ) );
 								if ( shouldShowContactDetailsValidationErrors ) {
 									reduxDispatch(
-										errorNotice(
-											translate(
-												'Your Business Tax ID details are not valid. Please check each field and try again.'
-											),
-											{ id: 'vat_info_notice' }
-										)
+										errorNotice( ( error as Error ).message, { id: 'vat_info_notice' } )
 									);
 								}
 								return false;


### PR DESCRIPTION
## Proposed Changes

When validating VAT info during checkout, we always display a generic failure message no matter what the server returns. However, this can be confusing for users if the message isn't a validation error (see https://github.com/Automattic/payments-shilling/issues/1451).

In this PR, we change checkout to display the raw error message returned by the server instead.

Before:

<img width="1096" alt="Screenshot 2023-03-12 at 1 14 34 PM" src="https://user-images.githubusercontent.com/2036909/224562033-ea75a015-5397-494f-95c8-33fa1aaccf66.png">

After:

<img width="1097" alt="Screenshot 2023-03-12 at 1 33 27 PM" src="https://user-images.githubusercontent.com/2036909/224562022-1ad867f3-cfb4-40e8-a37f-38427296a637.png">

Note that once D104452-code is merged, the "After" screenshot will be identical to the "Before".

## Testing Instructions

- Add a product to your cart and visit checkout.
- Select a country in the billing details step that allows VAT details (eg: the United Kingdom).
- Check the box to add VAT details.
- Enter invalid VAT details into the form and press submit.
- Verify that you see a raw error message from the server displayed. Before D104452-code that will be `The provided VAT information is not valid`, but after that diff it will be identical to the current message, `Your Business Tax ID details are not valid. Please check each field and try again.`.