### PR TITLE
VAT: add AU, CH, and JP tax vendor info

### DIFF
--- a/client/me/purchases/billing-history/vat-vendor-details.tsx
+++ b/client/me/purchases/billing-history/vat-vendor-details.tsx
@@ -44,10 +44,10 @@ function getVatVendorInfo(
 		};
 	}
 
-	if ( country === 'GB' ) {
+	if ( country === 'AU' ) {
 		return {
 			country,
-			taxName: translate( 'VAT', { textOnly: true } ),
+			taxName: translate( 'GST', { textOnly: true } ),
 			address: [
 				'Aut O’Mattic Ltd.',
 				'c/o Noone Casey',
@@ -55,7 +55,7 @@ function getVatVendorInfo(
 				'Dublin, D02 AY86',
 				'Ireland',
 			],
-			vatId: 'UK 376 1703 88',
+			vatId: 'ARN: 3000 1650 1438',
 		};
 	}
 
@@ -71,6 +71,51 @@ function getVatVendorInfo(
 				'Ireland',
 			],
 			vatId: '790004303',
+		};
+	}
+
+	if ( country === 'CH' ) {
+		return {
+			country,
+			taxName: translate( 'GST', { textOnly: true } ),
+			address: [
+				'Aut O’Mattic Ltd.',
+				'c/o Noone Casey',
+				'Grand Canal Dock, 25 Herbert Pl',
+				'Dublin, D02 AY86',
+				'Ireland',
+			],
+			vatId: 'CHE-259.584.214 MWST',
+		};
+	}
+
+	if ( country === 'GB' ) {
+		return {
+			country,
+			taxName: translate( 'VAT', { textOnly: true } ),
+			address: [
+				'Aut O’Mattic Ltd.',
+				'c/o Noone Casey',
+				'Grand Canal Dock, 25 Herbert Pl',
+				'Dublin, D02 AY86',
+				'Ireland',
+			],
+			vatId: 'UK 376 1703 88',
+		};
+	}
+
+	if ( country === 'JP' ) {
+		return {
+			country,
+			taxName: translate( 'VAT', { textOnly: true } ),
+			address: [
+				'Aut O’Mattic Ltd.',
+				'c/o Noone Casey',
+				'Grand Canal Dock, 25 Herbert Pl',
+				'Dublin, D02 AY86',
+				'Ireland',
+			],
+			vatId: '4700150101102',
 		};
 	}
 

--- a/client/me/purchases/billing-history/vat-vendor-details.tsx
+++ b/client/me/purchases/billing-history/vat-vendor-details.tsx
@@ -29,17 +29,19 @@ function getVatVendorInfo(
 	date: string,
 	translate: ReturnType< typeof useTranslate >
 ): VatVendorInfo | undefined {
+	const automatticVatAddress = [
+		'Aut O’Mattic Ltd.',
+		'c/o Noone Casey',
+		'Grand Canal Dock, 25 Herbert Pl',
+		'Dublin, D02 AY86',
+		'Ireland',
+	];
+
 	if ( isCountryInEu( country, date ) ) {
 		return {
 			country,
 			taxName: translate( 'VAT', { textOnly: true } ),
-			address: [
-				'Aut O’Mattic Ltd.',
-				'c/o Noone Casey',
-				'Grand Canal Dock, 25 Herbert Pl',
-				'Dublin, D02 AY86',
-				'Ireland',
-			],
+			address: automatticVatAddress,
 			vatId: 'IE3255131SH',
 		};
 	}
@@ -48,13 +50,7 @@ function getVatVendorInfo(
 		return {
 			country,
 			taxName: translate( 'GST', { textOnly: true } ),
-			address: [
-				'Aut O’Mattic Ltd.',
-				'c/o Noone Casey',
-				'Grand Canal Dock, 25 Herbert Pl',
-				'Dublin, D02 AY86',
-				'Ireland',
-			],
+			address: automatticVatAddress,
 			vatId: 'ARN: 3000 1650 1438',
 		};
 	}
@@ -63,13 +59,7 @@ function getVatVendorInfo(
 		return {
 			country,
 			taxName: translate( 'GST', { textOnly: true } ),
-			address: [
-				'Aut O’Mattic Ltd.',
-				'c/o Noone Casey',
-				'Grand Canal Dock, 25 Herbert Pl',
-				'Dublin, D02 AY86',
-				'Ireland',
-			],
+			address: automatticVatAddress,
 			vatId: '790004303',
 		};
 	}
@@ -78,13 +68,7 @@ function getVatVendorInfo(
 		return {
 			country,
 			taxName: translate( 'GST', { textOnly: true } ),
-			address: [
-				'Aut O’Mattic Ltd.',
-				'c/o Noone Casey',
-				'Grand Canal Dock, 25 Herbert Pl',
-				'Dublin, D02 AY86',
-				'Ireland',
-			],
+			address: automatticVatAddress,
 			vatId: 'CHE-259.584.214 MWST',
 		};
 	}
@@ -93,13 +77,7 @@ function getVatVendorInfo(
 		return {
 			country,
 			taxName: translate( 'VAT', { textOnly: true } ),
-			address: [
-				'Aut O’Mattic Ltd.',
-				'c/o Noone Casey',
-				'Grand Canal Dock, 25 Herbert Pl',
-				'Dublin, D02 AY86',
-				'Ireland',
-			],
+			address: automatticVatAddress,
 			vatId: 'UK 376 1703 88',
 		};
 	}
@@ -108,13 +86,7 @@ function getVatVendorInfo(
 		return {
 			country,
 			taxName: translate( 'VAT', { textOnly: true } ),
-			address: [
-				'Aut O’Mattic Ltd.',
-				'c/o Noone Casey',
-				'Grand Canal Dock, 25 Herbert Pl',
-				'Dublin, D02 AY86',
-				'Ireland',
-			],
+			address: automatticVatAddress,
 			vatId: '4700150101102',
 		};
 	}


### PR DESCRIPTION
This add the tax vendor info for Switzerland, Australia, and Japan. It also abstracts the Aut O'Mattic address into a variable so that it only needs to be updated in a single place.

See: https://github.com/Automattic/payments-shilling/issues/1448

To test:
- with Store sandboxed
- visit Checkout and make a purchase using the Swiss VAT details in D104290-code
- visit Purchases > Billing History and view the receipt for the most recent purchase
- verify that the correct Swiss VAT number (`CHE-259.584.214 MWST`) is shown with the Aut O'Mattic Irish vendor address