### PR TITLE
Odyssey: rename has-background-color to avoid style conflict

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -59,10 +59,9 @@
 	& .is-section-stats .has-fixed-nav {
 		padding-top: 64px;
 	}
-	& .highlight-cards.has-background-color,
-	& .inner-notice-container.has-background-color {
-		color: inherit !important;
-		background-color: var(--jetpack-white-off) !important;
+	& .highlight-cards.has-odyssey-stats-bg-color,
+	& .inner-notice-container.has-odyssey-stats-bg-color {
+		background-color: var(--jetpack-white-off);
 	}
 	#wpcontent {
 		padding-left: 1px;

--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -61,7 +61,8 @@
 	}
 	& .highlight-cards.has-background-color,
 	& .inner-notice-container.has-background-color {
-		background-color: var(--jetpack-white-off);
+		color: var(--jp-black) !important;
+		background-color: var(--jetpack-white-off) !important;
 	}
 	#wpcontent {
 		padding-left: 1px;

--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -61,7 +61,7 @@
 	}
 	& .highlight-cards.has-background-color,
 	& .inner-notice-container.has-background-color {
-		color: var(--jp-black) !important;
+		color: inherit !important;
 		background-color: var(--jetpack-white-off) !important;
 	}
 	#wpcontent {

--- a/client/my-sites/stats/annual-highlights-section/index.tsx
+++ b/client/my-sites/stats/annual-highlights-section/index.tsx
@@ -105,7 +105,7 @@ export default function AnnualHighlightsSection( { siteId }: { siteId: number } 
 				titleHref={ viewMoreHref }
 				year={ year }
 				navigation={ navigation }
-				className="has-background-color"
+				className="has-odyssey-stats-bg-color"
 			/>
 		</>
 	);

--- a/client/my-sites/stats/highlights-section/index.tsx
+++ b/client/my-sites/stats/highlights-section/index.tsx
@@ -34,7 +34,7 @@ export default function HighlightsSection( { siteId }: { siteId: number } ) {
 
 	return (
 		<HighlightCards
-			className="has-background-color"
+			className="has-odyssey-stats-bg-color"
 			counts={ counts }
 			previousCounts={ previousCounts }
 			showValueTooltip={ true }

--- a/client/my-sites/stats/stats-notices/index.jsx
+++ b/client/my-sites/stats/stats-notices/index.jsx
@@ -40,7 +40,7 @@ export default function StatsNotices( { siteId } ) {
 	return (
 		<>
 			{ showOptOutNotice && (
-				<div className="inner-notice-container has-background-color">
+				<div className="inner-notice-container has-odyssey-stats-bg-color">
 					<NoticeBanner
 						level="success"
 						title={ translate( 'Welcome to the new Jetpack Stats!' ) }
@@ -61,7 +61,7 @@ export default function StatsNotices( { siteId } ) {
 				</div>
 			) }
 			{ showFeedbackNotice && (
-				<div className="inner-notice-container has-background-color">
+				<div className="inner-notice-container has-odyssey-stats-bg-color">
 					<NoticeBanner
 						level="info"
 						title={ translate( "We'd love to hear your thoughts on the new Stats" ) }

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -148,7 +148,7 @@ export default function HighlightsSection( props ) {
 	const highlights = getHighlights( earningsData );
 	const notices = payoutNotices( earningsData );
 	return (
-		<div className="highlight-cards wordads has-background-color">
+		<div className="highlight-cards wordads has-odyssey-stats-bg-color">
 			<HighlightsSectionHeader notices={ notices } />
 			<HighlightsListing highlights={ highlights } />
 		</div>


### PR DESCRIPTION
## Proposed Changes

Explicitly set foreground color for highlight cards to override 3rd party styles which make the text invisible.

Discussion: p1678677751120659-slack-C0438NHCLSY

## Testing Instructions

* Install https://de.wordpress.org/plugins/redux-framework/ along with Jetpack
* Open Odyssey Stats Traffic page
* Ensure Highlights Card works well
* Open Insights page
* Ensure Highlights Card works well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?