### PR TITLE
Virtual themes i2: Update Pattern Assembler CTA copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -647,10 +647,14 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			selectedDesign.is_virtual && selectedDesign.recipe?.pattern_ids?.length;
 		const patternAssemblerCTA = showPatternAssemblerCTA && (
 			<PatternAssemblerCta
+				compact={ true }
 				hasPrimaryButton={ false }
 				onButtonClick={ () => pickBlankCanvasDesign( selectedDesign, true ) }
 				showEditorFallback={ false }
-				compact={ true }
+				showHeading={ false }
+				text={ translate(
+					'You can also start from scratch and build your own homepage with our library of patterns.'
+				) }
 			/>
 		);
 

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -55,29 +55,25 @@ export function useStarterDesignsQuery(
 	queryParams: StarterDesignsQueryParams,
 	{ select, shouldLimitGlobalStyles, ...queryOptions }: Options = {}
 ): UseQueryResult< StarterDesigns > {
-	return useQuery(
-		[ 'starter-designs-__', queryParams ],
-		() => fetchStarterDesigns( queryParams ),
-		{
-			select: ( response: StarterDesignsResponse ) => {
-				const allDesigns = {
-					generated: {
-						designs: response.generated?.designs?.map( apiStarterDesignsGeneratedToDesign ),
-					},
-					static: {
-						designs: response.static?.designs?.map( ( design ) =>
-							apiStarterDesignsStaticToDesign( design, shouldLimitGlobalStyles )
-						),
-					},
-				};
+	return useQuery( [ 'starter-designs', queryParams ], () => fetchStarterDesigns( queryParams ), {
+		select: ( response: StarterDesignsResponse ) => {
+			const allDesigns = {
+				generated: {
+					designs: response.generated?.designs?.map( apiStarterDesignsGeneratedToDesign ),
+				},
+				static: {
+					designs: response.static?.designs?.map( ( design ) =>
+						apiStarterDesignsStaticToDesign( design, shouldLimitGlobalStyles )
+					),
+				},
+			};
 
-				return select ? select( allDesigns ) : allDesigns;
-			},
-			refetchOnMount: 'always',
-			staleTime: Infinity,
-			...queryOptions,
-		}
-	);
+			return select ? select( allDesigns ) : allDesigns;
+		},
+		refetchOnMount: 'always',
+		staleTime: Infinity,
+		...queryOptions,
+	} );
 }
 
 function fetchStarterDesigns(

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -55,25 +55,29 @@ export function useStarterDesignsQuery(
 	queryParams: StarterDesignsQueryParams,
 	{ select, shouldLimitGlobalStyles, ...queryOptions }: Options = {}
 ): UseQueryResult< StarterDesigns > {
-	return useQuery( [ 'starter-designs', queryParams ], () => fetchStarterDesigns( queryParams ), {
-		select: ( response: StarterDesignsResponse ) => {
-			const allDesigns = {
-				generated: {
-					designs: response.generated?.designs?.map( apiStarterDesignsGeneratedToDesign ),
-				},
-				static: {
-					designs: response.static?.designs?.map( ( design ) =>
-						apiStarterDesignsStaticToDesign( design, shouldLimitGlobalStyles )
-					),
-				},
-			};
+	return useQuery(
+		[ 'starter-designs-__', queryParams ],
+		() => fetchStarterDesigns( queryParams ),
+		{
+			select: ( response: StarterDesignsResponse ) => {
+				const allDesigns = {
+					generated: {
+						designs: response.generated?.designs?.map( apiStarterDesignsGeneratedToDesign ),
+					},
+					static: {
+						designs: response.static?.designs?.map( ( design ) =>
+							apiStarterDesignsStaticToDesign( design, shouldLimitGlobalStyles )
+						),
+					},
+				};
 
-			return select ? select( allDesigns ) : allDesigns;
-		},
-		refetchOnMount: 'always',
-		staleTime: Infinity,
-		...queryOptions,
-	} );
+				return select ? select( allDesigns ) : allDesigns;
+			},
+			refetchOnMount: 'always',
+			staleTime: Infinity,
+			...queryOptions,
+		}
+	);
 }
 
 function fetchStarterDesigns(

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -10,6 +10,8 @@ type PatternAssemblerCtaProps = {
 	hasPrimaryButton?: boolean;
 	onButtonClick: ( shouldGoToAssemblerStep: boolean ) => void;
 	showEditorFallback?: boolean;
+	showHeading?: boolean;
+	text?: string;
 };
 
 const PatternAssemblerCta = ( {
@@ -17,6 +19,8 @@ const PatternAssemblerCta = ( {
 	hasPrimaryButton = true,
 	onButtonClick,
 	showEditorFallback = true,
+	showHeading = true,
+	text: customText,
 }: PatternAssemblerCtaProps ) => {
 	const translate = useTranslate();
 	const isDesktop = useViewportMatch( 'large' );
@@ -31,21 +35,26 @@ const PatternAssemblerCta = ( {
 		return null;
 	}
 
+	let text = customText;
+	if ( ! text ) {
+		text = shouldGoToAssemblerStep
+			? translate(
+					"Can't find something you like? Start with a blank canvas and design your own homepage using our library of patterns."
+			  )
+			: translate(
+					"Can't find something you like? Jump right into the editor to design your homepage from scratch."
+			  );
+	}
+
 	return (
 		<div className={ classnames( 'pattern-assembler-cta-wrapper', { 'is-compact': compact } ) }>
 			<div className="pattern-assembler-cta__image-wrapper">
 				<img className="pattern-assembler-cta__image" src={ blankCanvasImage } alt="Blank Canvas" />
 			</div>
-			<h3 className="pattern-assembler-cta__title">{ translate( 'Design your own' ) }</h3>
-			<p className="pattern-assembler-cta__subtitle">
-				{ shouldGoToAssemblerStep
-					? translate(
-							"Can't find something you like? Start with a blank canvas and design your own homepage using our library of patterns."
-					  )
-					: translate(
-							"Can't find something you like? Jump right into the editor to design your homepage from scratch."
-					  ) }
-			</p>
+			{ showHeading && (
+				<h3 className="pattern-assembler-cta__title">{ translate( 'Design your own' ) }</h3>
+			) }
+			<p className="pattern-assembler-cta__subtitle">{ text }</p>
 			<Button
 				className="pattern-assembler-cta__button"
 				onClick={ handleButtonClick }

--- a/packages/design-picker/src/components/pattern-assembler-cta/style.scss
+++ b/packages/design-picker/src/components/pattern-assembler-cta/style.scss
@@ -57,5 +57,13 @@
 		.pattern-assembler-cta__image {
 			width: 100px;
 		}
+
+		.pattern-assembler-cta__subtitle {
+			font-size: 0.875rem;
+		}
+
+		.pattern-assembler-cta__button {
+			margin-top: 16px;
+		}
 	}
 }


### PR DESCRIPTION
See paYJgx-34n-p2#comment-3317

## Proposed Changes

Trims down the copy of the Pattern Assembler CTA displayed in the sidebar when a virtual theme is being previewed so it feels less wordier.

Before | After
--- | ---
<img width="272" alt="Screenshot 2023-03-13 at 12 59 42" src="https://user-images.githubusercontent.com/1233880/224695753-d87601ef-4780-4b4a-8b31-7d5a08e92088.png"> | <img width="340" alt="Screenshot 2023-03-13 at 12 57 01" src="https://user-images.githubusercontent.com/1233880/224695775-a9a31e43-e504-4e54-ab17-fdceb47146d6.png">

## Testing Instructions
- Use the Calypso live link below
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMSIN>&flags=virtual-themes/onboarding`
- Select a pattern-based virtual theme
- Check the sidebar
- Make sure the Pattern Assembler CTA copy looks good