### PR TITLE
Jetpack Pro Dashboard: show small/large screen based on the content.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
@@ -12,18 +12,13 @@
 
 .toggle-activate-monitoring__toggle-button {
 	@extend .inline-flex-align-centre;
+	width: max-content;
 
 	.components-toggle-control .components-base-control__field {
 		margin-bottom: 0;
 
 		.components-form-toggle {
-			@include break-xlarge {
-				margin-right: 4px;
-			}
-
-			@include break-xlarge {
-				margin-right: 12px;
-			}
+			margin-right: 4px;
 		}
 	}
 
@@ -38,6 +33,10 @@
 .toggle-activate-monitoring__duration {
 	button {
 		@extend .inline-flex-align-centre;
+	}
+
+	img {
+		width: 24px;
 	}
 
 	span {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -6,7 +6,7 @@ import { getQueryArg, removeQueryArgs, addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useContext, useEffect, useState, useMemo } from 'react';
+import { useContext, useEffect, useState, useMemo, createRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Count from 'calypso/components/count';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -43,6 +43,8 @@ export default function SitesOverview() {
 	const isMobile = useMobileBreakpoint();
 	const jetpackSiteDisconnected = useSelector( checkIfJetpackSiteGotDisconnected );
 	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
+
+	const containerRef = createRef< any >();
 
 	const selectedLicenses = useSelector( getSelectedLicenses );
 	const selectedLicensesSiteId = useSelector( getSelectedLicensesSiteId );
@@ -268,7 +270,7 @@ export default function SitesOverview() {
 					</div>
 				</div>
 				<div className="sites-overview__content">
-					<div className="sites-overview__content-wrapper">
+					<div ref={ containerRef } className="sites-overview__content-wrapper">
 						{ ( ! showEmptyState || hasAppliedFilter ) && (
 							<SiteSearchFilterContainer
 								searchQuery={ search }
@@ -286,6 +288,7 @@ export default function SitesOverview() {
 								isLoading={ isLoading }
 								currentPage={ currentPage }
 								isFavoritesTab={ isFavoritesTab }
+								ref={ containerRef }
 							/>
 						) }
 					</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/style.scss
@@ -20,19 +20,12 @@
 	position: absolute;
 	right: 16px;
 	display: inline;
-	@include break-xlarge() {
-		display: none;
-	}
 }
 .site-actions__all-actions {
 	vertical-align: middle;
 	display: flex;
 	color: var(--studio-gray-40);
 	margin: 0 0.1em;
-	@include break-large() {
-		display: inline-flex;
-		height: 100%;
-	}
 }
 a.site-actions__menu-item {
 	margin: 0 -1px;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -1,11 +1,12 @@
 import { Card } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import page from 'page';
-import { useContext } from 'react';
+import { useContext, forwardRef, createRef } from 'react';
 import Pagination from 'calypso/components/pagination';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { addQueryArgs } from 'calypso/lib/route';
 import EditButton from '../../dashboard-bulk-actions/edit-button';
+import { useDashboardShowLargeScreen } from '../../hooks';
 import SitesOverviewContext from '../context';
 import SiteBulkSelect from '../site-bulk-select';
 import SiteCard from '../site-card';
@@ -27,8 +28,9 @@ interface Props {
 	isFavoritesTab: boolean;
 }
 
-export default function SiteContent( { data, isLoading, currentPage, isFavoritesTab }: Props ) {
+const SiteContent = ( { data, isLoading, currentPage, isFavoritesTab }: Props, ref: any ) => {
 	const isMobile = useMobileBreakpoint();
+
 	const { isBulkManagementActive } = useContext( SitesOverviewContext );
 
 	const sites = formatSites( data?.sites );
@@ -37,44 +39,51 @@ export default function SiteContent( { data, isLoading, currentPage, isFavorites
 		addPageArgs( pageNumber );
 	};
 
+	const siteTableRef = createRef< HTMLTableElement >();
+
+	const isLargeScreen = useDashboardShowLargeScreen( siteTableRef, ref );
+
 	return (
 		<>
-			{
-				// We are using CSS to hide/show add email content on mobile/large screen view instead of the breakpoint
-				// hook since the hook returns true only when the width > some value, and we have some
-				// styles applied using the CSS breakpoint which is true for width >= some value
-			 }
-			<div className="site-content__large-screen-view">
-				<SiteTable isLoading={ isLoading } columns={ siteColumns } items={ sites } />
-			</div>
-			<div className="site-content__small-screen-view">
-				<Card className="site-content__bulk-select">
-					{ isBulkManagementActive ? (
-						<SiteBulkSelect sites={ sites } isLoading={ isLoading } />
-					) : (
-						<>
-							<span className="site-content__bulk-select-label">{ siteColumns[ 0 ].title }</span>
-							<EditButton sites={ sites } />
-						</>
-					) }
-				</Card>
-				<div className="site-content__mobile-view">
-					<>
-						{ isLoading ? (
-							<Card>
-								<TextPlaceholder />
-							</Card>
+			{ isLargeScreen ? (
+				<div className="site-content__large-screen-view">
+					<SiteTable
+						ref={ siteTableRef }
+						isLoading={ isLoading }
+						columns={ siteColumns }
+						items={ sites }
+					/>
+				</div>
+			) : (
+				<div className="site-content__small-screen-view">
+					<Card className="site-content__bulk-select">
+						{ isBulkManagementActive ? (
+							<SiteBulkSelect sites={ sites } isLoading={ isLoading } />
 						) : (
 							<>
-								{ sites.length > 0 &&
-									sites.map( ( rows, index ) => (
-										<SiteCard key={ index } columns={ siteColumns } rows={ rows } />
-									) ) }
+								<span className="site-content__bulk-select-label">{ siteColumns[ 0 ].title }</span>
+								<EditButton sites={ sites } />
 							</>
 						) }
-					</>
+					</Card>
+					<div className="site-content__mobile-view">
+						<>
+							{ isLoading ? (
+								<Card>
+									<TextPlaceholder />
+								</Card>
+							) : (
+								<>
+									{ sites.length > 0 &&
+										sites.map( ( rows, index ) => (
+											<SiteCard key={ index } columns={ siteColumns } rows={ rows } />
+										) ) }
+								</>
+							) }
+						</>
+					</div>
 				</div>
-			</div>
+			) }
 
 			{ data && data?.total > 0 && (
 				<Pagination
@@ -87,4 +96,6 @@ export default function SiteContent( { data, isLoading, currentPage, isFavorites
 			) }
 		</>
 	);
-}
+};
+
+export default forwardRef( SiteContent );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -2,15 +2,67 @@
 @import "@wordpress/base-styles/mixins";
 
 .site-content__large-screen-view {
-	display: none;
-	@include break-xlarge {
-		display: block;
+	.site-set-favorite__favorite-icon {
+		visibility: hidden;
+		color: var(--color-primary);
 	}
-}
 
-.site-content__small-screen-view {
-	@include break-xlarge {
+	.sites-overview__status-count {
 		display: none;
+	}
+
+	.sites-overview__row-text {
+		margin-inline-start: 55px;
+		width: calc(100% - 55px);
+		font-size: 0.875rem !important;
+	}
+
+	.sites-overview__overlay {
+		inset-inline-end: 0;
+	}
+
+	.sites-overview__error-container {
+		margin: 0;
+		height: inherit;
+	}
+
+	.sites-overview__error-icon {
+		width: auto;
+		padding: 16px;
+	}
+
+	.sites-overview__status-critical {
+		display: none;
+	}
+
+	.sites-overview__critical {
+		color: var(--studio-white);
+	}
+
+	.sites-overview__column-content {
+		max-width: fit-content;
+	}
+
+	.site-select-checkbox {
+		input[type="checkbox"] {
+			@include break-wide {
+				inset-inline-start: 10px;
+			}
+
+			@include break-huge {
+				inset-inline-start: 16px;
+			}
+		}
+	}
+
+	.toggle-activate-monitoring__toggle-button .components-toggle-control
+	.components-base-control__field .components-form-toggle {
+		margin-right: 12px;
+	}
+
+	.site-actions__all-actions {
+		display: inline-flex;
+		height: 100%;
 	}
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
@@ -13,6 +13,7 @@ import SiteContent from '../index';
 jest.mock( '@automattic/viewport-react', () => ( {
 	useDesktopBreakpoint: () => true,
 	useMobileBreakpoint: () => false,
+	useBreakpoint: () => true,
 } ) );
 
 describe( '<SiteContent>', () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search-filter-container/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search-filter-container/style.scss
@@ -27,9 +27,6 @@
 		box-shadow: none;
 		.search__open-icon {
 			width: 40px;
-			@include break-wide() {
-				width: 60px;
-			}
 		}
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/style.scss
@@ -8,13 +8,5 @@
 		inset-block-start: 50%;
 		transform: translateY(-50%);
 		inset-inline-start: 16px;
-
-		@include break-xlarge {
-			inset-inline-start: 8px;
-		}
-
-		@include break-wide {
-			inset-inline-start: 16px;
-		}
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/style.scss
@@ -5,15 +5,10 @@
 	position: absolute;
 	top: 6px;
 	color: var(--studio-gray-20) !important;
-
-	@include break-xlarge {
-		visibility: hidden;
-		color: var(--color-primary) !important;
-	}
 }
 
 .site-set-favorite__favorite-icon-active {
-	visibility: visible;
+	visibility: visible !important;
 	color: var(--color-primary) !important;
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -266,7 +266,9 @@ export default function SiteStatusContent( {
 	}
 
 	if ( disabledStatus ) {
-		updatedContent = <span className="sites-overview__disabled">{ content } </span>;
+		updatedContent = (
+			<span className="sites-overview__disabled sites-overview__row-status">{ content } </span>
+		);
 	}
 
 	return (
@@ -295,7 +297,7 @@ export default function SiteStatusContent( {
 					</Tooltip>
 				</>
 			) : (
-				updatedContent
+				<span className="sites-overview__row-status">{ updatedContent }</span>
 			) }
 		</>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -54,8 +54,6 @@ export default function SiteTableRow( { columns, item, setExpanded, isExpanded }
 
 	const isExpandedContentEnabled = isEnabled( 'jetpack/pro-dashboard-expandable-block' );
 
-	const isExpandedBlockEnabled = isEnabled( 'jetpack/pro-dashboard-expandable-block' );
-
 	return (
 		<Fragment>
 			<tr
@@ -116,7 +114,7 @@ export default function SiteTableRow( { columns, item, setExpanded, isExpanded }
 				<td
 					className={ classNames( 'site-table__actions', {
 						'site-table__td-without-border-bottom': isExpanded,
-						'site-table__actions-button': isExpandedBlockEnabled,
+						'site-table__actions-button': isExpandedContentEnabled,
 					} ) }
 					// If there is an error, we need to span the whole row because we don't show the expand buttons.
 					colSpan={ hasSiteError && isExpandedContentEnabled ? 2 : 1 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
@@ -33,13 +33,28 @@
 
 td.site-table__actions {
 	padding: 0;
-	width: 50px;
+
+	@include break-wide {
+		width: 30px;
+	}
+
+	@include break-huge {
+		width: 50px;
+	}
 }
 
 td.site-table__actions-button {
 	border-right: none;
 	button {
-		margin-inline-end: 15px;
+		@include break-wide {
+			margin-inline-start: 8px;
+			margin-inline-end: 8px;
+		}
+
+		@include break-huge {
+			margin-inline-start: 0;
+			margin-inline-end: 15px;
+		}
 	}
 }
 
@@ -54,8 +69,12 @@ td.site-table__td-without-border-bottom {
 .site-table__expandable-button {
 	display: flex;
 	position: relative;
-	right: -10px;
 	top: 2px;
+
+	@include break-huge {
+		right: -10px;
+	}
+
 }
 
 td.site-table__error {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Icon, starFilled } from '@wordpress/icons';
 import classNames from 'classnames';
-import { useContext, useState } from 'react';
+import { useContext, useState, forwardRef, Ref } from 'react';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import './style.scss';
 import EditButton from '../../dashboard-bulk-actions/edit-button';
@@ -16,7 +16,7 @@ interface Props {
 	items: Array< SiteData >;
 }
 
-export default function SiteTable( { isLoading, columns, items }: Props ) {
+const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableElement > ) => {
 	const { isBulkManagementActive } = useContext( SitesOverviewContext );
 
 	const [ expandedRow, setExpandedRow ] = useState< number | null >( null );
@@ -29,6 +29,7 @@ export default function SiteTable( { isLoading, columns, items }: Props ) {
 
 	return (
 		<table
+			ref={ ref }
 			className={ classNames( 'site-table__table', {
 				'site-table__table-v2': isExpandedBlockEnabled,
 			} ) }
@@ -91,4 +92,6 @@ export default function SiteTable( { isLoading, columns, items }: Props ) {
 			</tbody>
 		</table>
 	);
-}
+};
+
+export default forwardRef( SiteTable );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -355,7 +355,6 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	vertical-align: middle;
-	max-width: 70px;
 }
 
 .sites-overview__warning {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -1,6 +1,12 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.sites-overview__large-screen {
+	.site-search-filter-container__search .search.is-open .search__open-icon {
+		width: 60px;
+	}
+}
+
 .sites-overview {
 	.current-section {
 		padding: 0 16px;
@@ -98,7 +104,8 @@
 	}
 }
 .sites-overview__status-select-license,
-.sites-overview__status-unselect-license, {
+.sites-overview__status-unselect-license {
+	max-width: 100%;
 	display: inline-flex;
 	flex-direction: row;
 	justify-content: center;
@@ -161,11 +168,6 @@
 		margin-inline-end: 5px;
 		font-size: 1rem !important;
 	}
-	@include break-xlarge {
-		width: calc(100% - 55px);
-		margin-inline-start: 55px;
-		font-size: 0.875rem !important;
-	}
 }
 .sites-overview__overlay {
 	display: block;
@@ -175,9 +177,6 @@
 	background: linear-gradient(to right, rgba(255, 255, 255, 0.8) 30%, rgba(255, 255, 255, 1) 100%);
 	inset-block-start: 0;
 	inset-inline-end: 75px;
-	@include break-xlarge {
-		inset-inline-end: 0;
-	}
 }
 .sites-overview__vertical-align-middle {
 	vertical-align: middle;
@@ -189,10 +188,6 @@
 	align-items: center;
 	height: 40px;
 	position: relative;
-	@include break-xlarge {
-		margin: 0;
-		height: inherit;
-	}
 }
 .sites-overview__error-icon {
 	background: #d94f4f;
@@ -202,10 +197,6 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	@include break-xlarge {
-		width: auto;
-		padding: 16px;
-	}
 }
 .sites-overview__error-message {
 	font-size: 0.75rem;
@@ -215,13 +206,13 @@
 }
 .sites-overview__error-message-large-screen {
 	display: none;
-	@include break-xlarge {
+	@include break-wide {
 		display: inline-block;
 	}
 }
 .sites-overview__error-message-small-screen {
 	display: inline-block;
-	@include break-xlarge {
+	@include break-wide {
 		display: none;
 	}
 }
@@ -240,7 +231,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	vertical-align: middle;
-	@include break-xlarge {
+	@include break-wide {
 		max-width: 70px;
 	}
 	@include break-wide() {
@@ -268,9 +259,6 @@
 	inset-block-start: 50%;
 	transform: translateY(-50%);
 	display: inline-flex;
-	@include break-xlarge {
-		display: none;
-	}
 }
 .sites-overview__status-count {
 	position: absolute;
@@ -286,9 +274,6 @@
 	font-size: 0.75rem;
 	line-height: 20px;
 	box-sizing: border-box;
-	@include break-xlarge {
-		display: none;
-	}
 }
 .sites-overview__status-failed {
 	background-color: var(--studio-red-50);
@@ -370,12 +355,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	vertical-align: middle;
-	@include break-xlarge {
-		max-width: 70px;
-	}
-	@include break-wide() {
-		max-width: fit-content;
-	}
+	max-width: 70px;
 }
 
 .sites-overview__warning {
@@ -392,8 +372,4 @@
 	@extend .sites-overview__column-content;
 	padding: 15px;
 	color: var(--studio-red-50);
-
-	@include break-xlarge {
-		color: var(--studio-white);
-	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/utils.ts
@@ -61,6 +61,11 @@ describe( 'utils', () => {
 					trend_change: 0,
 				},
 			},
+			jetpack_boost_scores: {
+				overall: 100,
+				mobile: 50,
+				desktop: 50,
+			},
 		};
 		const rows: SiteData = {
 			site: {
@@ -84,22 +89,28 @@ describe( 'utils', () => {
 				threats: 4,
 				type: 'scan',
 				status: 'failed',
-				value: translate(
-					'%(threats)d Threat',
-					'%(threats)d Threats', // plural version of the string
-					{
-						count: scanThreats,
-						args: {
-							threats: scanThreats,
-						},
-					}
-				),
+				value: translate( '%(threats)d Threat', '%(threats)d Threats', {
+					count: scanThreats,
+					args: {
+						threats: scanThreats,
+					},
+				} ),
 			},
 			plugin: {
 				updates: pluginUpdates.length,
 				type: 'plugin',
 				value: `${ pluginUpdates.length } ${ translate( 'Available' ) }`,
 				status: 'warning',
+			},
+			stats: {
+				status: 'active',
+				type: 'stats',
+				value: siteObj.site_stats,
+			},
+			boost: {
+				status: 'active',
+				type: 'boost',
+				value: siteObj.jetpack_boost_scores,
 			},
 		};
 		test( 'should return the meta data for the feature type', () => {
@@ -214,6 +225,7 @@ describe( 'utils', () => {
 						value: sites[ 0 ].site_stats,
 					},
 					boost: {
+						status: 'active',
 						type: 'boost',
 						value: sites[ 0 ].jetpack_boost_scores,
 					},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -82,6 +82,7 @@ export interface StatsNode {
 
 export interface BoostNode {
 	type: AllowedTypes;
+	status: AllowedStatusTypes;
 	value: BoostData;
 }
 export interface BackupNode {
@@ -113,6 +114,7 @@ export interface MonitorNode {
 export interface SiteData {
 	site: SiteNode;
 	stats: StatsNode;
+	boost: BoostNode;
 	backup: BackupNode;
 	scan: ScanNode;
 	plugin: PluginNode;
@@ -123,7 +125,7 @@ export interface SiteData {
 
 export interface RowMetaData {
 	row: {
-		value: Site | SiteStats | ReactChild;
+		value: Site | SiteStats | BoostData | ReactChild;
 		status: AllowedStatusTypes | string;
 		error?: boolean;
 	};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -330,6 +330,7 @@ const formatStatsData = ( site: Site ) => {
 
 const formatBoostData = ( site: Site ) => {
 	const boostData: BoostNode = {
+		status: 'active',
 		type: 'boost',
 		value: site.jetpack_boost_scores,
 	};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -12,11 +12,11 @@ import type {
 	StatusTooltip,
 	RowMetaData,
 	StatsNode,
+	BoostNode,
 	BackupNode,
 	ScanNode,
 	MonitorNode,
 	SiteColumns,
-	BoostNode,
 } from './types';
 
 const INITIAL_UNIX_EPOCH = '1970-01-01 00:00:00';


### PR DESCRIPTION
Related to 1203940061556608-as-1204052758732571

## Proposed Changes

This PR implements 
- A custom hook to detect if the table content is overflowing.
- Switch to the small screen if the content is overflowing.
- CSS enhancements 
- Switch to the large screen when the screen width is >1280px

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_**  Boost column is added to be able to test the implementation when the expandable block is enabled. 

**Instructions**

1. Run `git checkout update/enhance-table-responsiveness` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that a small screen is shown if the content of the table is very large and is overflowing. We will show the large screen when the width is  >1280px, but it'll switch to a small screen if the content is overflowing. 
4. Open the dev tool and switch to screen size > 1280px, make sure the content is large, and verify the small screen view is shown. Tip: You can change the text of the column values to any random large text if the content is not large enough. 
5. Switch to any view <1280px and verify the small screen view is shown.
6. Open the live link and verify steps 3,4 & 5 when the expandable block is not enabled. You can also set `jetpack/pro-dashboard-expandable-block` to false in `jetpack-cloud-development.json` instead of using the live link. 
7. Verify the dashboard looks good on all screen sizes(375px, 768px, 1024px, 1280px, 1440px etc).
8. Please note you'll have to refresh the page after the small screen view is shown even when you are viewing 1700px

---------

**When the expandable block is not enabled(this is how it'll look/function in production after merging)**

Large screen view with large texts

<img width="1455" alt="Screenshot 2023-03-13 at 6 09 40 PM" src="https://user-images.githubusercontent.com/10586875/224705267-648dfe0c-3be2-4275-8d78-2d327e46d55f.png">

When the content is overflowing(1282px)

<img width="1003" alt="Screenshot 2023-03-13 at 6 10 37 PM" src="https://user-images.githubusercontent.com/10586875/224705286-ca23849a-aa03-425e-a700-39ce3156e024.png">

<img width="1456" alt="Screenshot 2023-03-13 at 6 14 40 PM" src="https://user-images.githubusercontent.com/10586875/224705553-3bb5053b-32b9-4204-98e8-53e51ac02ff7.png">

Mobile view

<img width="366" alt="Screenshot 2023-03-13 at 6 15 55 PM" src="https://user-images.githubusercontent.com/10586875/224705911-ddbadfac-2a5e-4580-898a-d3008ea0597c.png">

Tablet view

<img width="823" alt="Screenshot 2023-03-13 at 6 16 02 PM" src="https://user-images.githubusercontent.com/10586875/224705923-7b3dc7d1-ed6b-40ae-9f56-1312a1c145a6.png">

---------

**When the expandable block is enabled**

Large screen view with large texts

<img width="1455" alt="Screenshot 2023-03-13 at 6 20 26 PM" src="https://user-images.githubusercontent.com/10586875/224706888-fd152423-aeb0-44bc-ba0d-836075d55207.png">

When the content is overflowing(1470px)

<img width="1214" alt="Screenshot 2023-03-13 at 6 20 52 PM" src="https://user-images.githubusercontent.com/10586875/224706973-a37bc48d-b831-4642-9df1-b1703ce97cd5.png">

Mobile view

<img width="384" alt="Screenshot 2023-03-13 at 6 21 55 PM" src="https://user-images.githubusercontent.com/10586875/224707090-87216dc9-1994-419d-95b9-8f650d467cb8.png">

Tablet view

<img width="845" alt="Screenshot 2023-03-13 at 6 21 48 PM" src="https://user-images.githubusercontent.com/10586875/224707131-c534c912-d191-470f-8cef-17f1c0827c8d.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?