### PR TITLE
Staging Sites: Hide the domain upsell and 'Add domain' link on My Home

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -20,6 +20,7 @@ import { getPreference } from 'calypso/state/preferences/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedEditor } from 'calypso/state/selectors/get-selected-editor';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import isWpcomStagingSite from 'calypso/state/selectors/is-staging-site';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import {
 	getSiteFrontPage,
@@ -41,6 +42,7 @@ export const QuickLinks = ( {
 	canModerateComments,
 	customizeUrl,
 	isAtomic,
+	isStagingSite,
 	isStaticHomePage,
 	canAddEmail,
 	menusUrl,
@@ -158,7 +160,7 @@ export const QuickLinks = ( {
 					materialIcon="view_quilt"
 				/>
 			) }
-			{ canManageSite && (
+			{ canManageSite && ! isStagingSite && (
 				<>
 					{ canAddEmail ? (
 						<ActionBox
@@ -414,6 +416,7 @@ const mapStateToProps = ( state ) => {
 		isStaticHomePage,
 		editHomePageUrl,
 		isAtomic: isSiteAtomic( state, siteId ),
+		isStagingSite: isWpcomStagingSite( state, siteId ),
 		isExpanded: getPreference( state, 'homeQuickLinksToggleStatus' ) !== 'collapsed',
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 	};

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -14,7 +14,7 @@ import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { addQueryArgs } from 'calypso/lib/url';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import { isNotAtomicJetpack, isP2Site } from 'calypso/sites-dashboard/utils';
+import { isNotAtomicJetpack, isP2Site, isStagingSite } from 'calypso/sites-dashboard/utils';
 import { getCurrentUser, isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
@@ -69,7 +69,12 @@ export default function DomainUpsell( { context } ) {
 
 	const shouldNotShowMyHomeUpsell = ! isProfileUpsell && ( siteDomainsLength || ! isEmailVerified );
 
-	if ( shouldNotShowUpselDismissed || shouldNotShowProfileUpsell || shouldNotShowMyHomeUpsell ) {
+	if (
+		shouldNotShowUpselDismissed ||
+		shouldNotShowProfileUpsell ||
+		shouldNotShowMyHomeUpsell ||
+		isStagingSite( selectedSite )
+	) {
 		return null;
 	}
 

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -40,6 +40,10 @@ export const isP2Site = ( site: SiteExcerptNetworkData ) => {
 	return site.options?.is_wpforteams_site;
 };
 
+export const isStagingSite = ( site: SiteExcerptNetworkData ) => {
+	return site.is_wpcom_staging_site;
+};
+
 export const SMALL_MEDIA_QUERY = 'screen and ( max-width: 600px )';
 
 export const MEDIA_QUERIES = {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1934

## Proposed Changes

Hides the My Home domain upsell and 'Add domain' link for staging sites:

<img width="1258" alt="image" src="https://user-images.githubusercontent.com/36432/224743705-58d8617c-7591-4365-819e-d085cc445349.png">

## Testing Instructions

1. Create a new Business site and take it Atomic.
2. SSH into the site to disable the Launchpad: `wp option delete launchpad_screen`.
3. Visit My Home and verify the Domain upsell and 'Add domain' link still appears.
4. Create a staging site.
5. Visit My Home and verify the Domain upsell and 'Add domain' link don't appear.