### PR TITLE
VAT Info: Strip leading CHE from Swiss VAT ID

### DIFF
--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -36,6 +36,19 @@ async function setVatDetails( vatDetails: VatDetails ): Promise< VatDetails > {
 	} );
 }
 
+// Some countries prefix the VAT ID with the country code, but that's not
+// part of the ID as we need it formatted, so here we strip the country
+// code out if it is there.
+function stripCountryCodeFromVatId( id: string, country: string | undefined | null ): string {
+	const first2UppercasedChars = id.slice( 0, 2 ).toUpperCase();
+
+	if ( isNaN( Number( first2UppercasedChars ) ) && first2UppercasedChars === country ) {
+		return id.slice( 2 );
+	}
+
+	return id;
+}
+
 const emptyVatDetails = {};
 
 export default function useVatDetails(): VatDetailsManager {
@@ -50,11 +63,7 @@ export default function useVatDetails(): VatDetailsManager {
 		const { country, id } = data;
 
 		if ( !! id && id?.length > 1 ) {
-			const first2UppercasedChars = id.slice( 0, 2 ).toUpperCase();
-
-			if ( isNaN( Number( first2UppercasedChars ) ) && first2UppercasedChars === country ) {
-				return { ...data, id: id.slice( 2 ) };
-			}
+			return { ...data, id: stripCountryCodeFromVatId( id, country ) };
 		}
 
 		return data;

--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -40,9 +40,14 @@ async function setVatDetails( vatDetails: VatDetails ): Promise< VatDetails > {
 // part of the ID as we need it formatted, so here we strip the country
 // code out if it is there.
 function stripCountryCodeFromVatId( id: string, country: string | undefined | null ): string {
-	const first2UppercasedChars = id.slice( 0, 2 ).toUpperCase();
+	// Switzerland often uses the prefix 'CHE-' instead of just `CH`.
+	const swissCodeRegexp = /^CHE-?/i;
+	if ( country === 'CH' && swissCodeRegexp.test( id ) ) {
+		return id.replace( swissCodeRegexp, '' );
+	}
 
-	if ( isNaN( Number( first2UppercasedChars ) ) && first2UppercasedChars === country ) {
+	const first2UppercasedChars = id.slice( 0, 2 ).toUpperCase();
+	if ( first2UppercasedChars === country ) {
 		return id.slice( 2 );
 	}
 

--- a/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
@@ -247,6 +247,125 @@ describe( 'Checkout contact step VAT form', () => {
 		} );
 	} );
 
+	it( 'sends ID to the VAT endpoint without prefixed country code when completing the step', async () => {
+		const vatId = '12345';
+		const vatName = 'Test company';
+		const vatAddress = '123 Main Street';
+		const countryCode = 'GB';
+		const mockVatEndpoint = mockSetVatInfoEndpoint();
+		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
+		const user = userEvent.setup();
+		const cartChanges = { products: [ planWithoutDomain ] };
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
+
+		// Wait for the cart to load
+		await screen.findByLabelText( 'Continue with the entered contact details' );
+
+		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.type(
+			await screen.findByLabelText( 'Business Tax ID Number' ),
+			countryCode + vatId
+		);
+		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+		await user.click( screen.getByText( 'Continue' ) );
+		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
+		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
+			id: vatId,
+			name: vatName,
+			country: countryCode,
+			address: vatAddress,
+		} );
+	} );
+
+	it( 'sends ID to the VAT endpoint without prefixed Swiss country code and hyphen when completing the step', async () => {
+		const vatId = '12345';
+		const vatName = 'Test company';
+		const vatAddress = '123 Main Street';
+		const countryCode = 'CH';
+		const mockVatEndpoint = mockSetVatInfoEndpoint();
+		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
+		const user = userEvent.setup();
+		const cartChanges = { products: [ planWithoutDomain ] };
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
+
+		// Wait for the cart to load
+		await screen.findByLabelText( 'Continue with the entered contact details' );
+
+		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), 'CHE-' + vatId );
+		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+		await user.click( screen.getByText( 'Continue' ) );
+		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
+		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
+			id: vatId,
+			name: vatName,
+			country: countryCode,
+			address: vatAddress,
+		} );
+	} );
+
+	it( 'sends ID to the VAT endpoint without prefixed Swiss country code when completing the step', async () => {
+		const vatId = '12345';
+		const vatName = 'Test company';
+		const vatAddress = '123 Main Street';
+		const countryCode = 'CH';
+		const mockVatEndpoint = mockSetVatInfoEndpoint();
+		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
+		const user = userEvent.setup();
+		const cartChanges = { products: [ planWithoutDomain ] };
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
+
+		// Wait for the cart to load
+		await screen.findByLabelText( 'Continue with the entered contact details' );
+
+		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), 'CHE' + vatId );
+		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+		await user.click( screen.getByText( 'Continue' ) );
+		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
+		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
+			id: vatId,
+			name: vatName,
+			country: countryCode,
+			address: vatAddress,
+		} );
+	} );
+
+	it( 'sends ID to the VAT endpoint without prefixed lowercase Swiss country code when completing the step', async () => {
+		const vatId = '12345';
+		const vatName = 'Test company';
+		const vatAddress = '123 Main Street';
+		const countryCode = 'CH';
+		const mockVatEndpoint = mockSetVatInfoEndpoint();
+		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
+		const user = userEvent.setup();
+		const cartChanges = { products: [ planWithoutDomain ] };
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
+
+		// Wait for the cart to load
+		await screen.findByLabelText( 'Continue with the entered contact details' );
+
+		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
+		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), 'che' + vatId );
+		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+		await user.click( screen.getByText( 'Continue' ) );
+		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
+		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
+			id: vatId,
+			name: vatName,
+			country: countryCode,
+			address: vatAddress,
+		} );
+	} );
+
 	it( 'when there is a cached contact country that differs from the cached VAT country, the contact country is sent to the VAT endpoint', async () => {
 		nock.cleanAll();
 		const cachedContactCountry = 'ES';


### PR DESCRIPTION
## Proposed Changes

It looks like the default VAT number format for Switzerland includes 'CHE-' at the front. It's optional, but if people are going to try it by default we should probably validate numbers with it there.

This PR modifies the code that submits VAT ID numbers to also strip a leading `CHE-` (in addition to the existing behavior which is to strip a leading `CH`, or whatever the country code is). Without this change, we actually will submit the ID with a leading `E-` (what's left after stripping the `CH`).

## Testing Instructions

Automated tests are included.