### PR TITLE
Disable Help Center in support sites

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -211,7 +211,9 @@ class Help_Center {
 	 * Returns true if the current site is a support site.
 	 */
 	public function is_support_site() {
-		return defined( 'WPCOM_SUPPORT_BLOG_IDS' ) && in_array( get_current_blog_id(), WPCOM_SUPPORT_BLOG_IDS, true );
+		// Disable the Help Center in support sites for now. It may be causing issues with notifications.
+		return false;
+		// Disable for now: `return defined( 'WPCOM_SUPPORT_BLOG_IDS' ) && in_array( get_current_blog_id(), WPCOM_SUPPORT_BLOG_IDS, true )`.
 	}
 
 	/**


### PR DESCRIPTION
The Help Center **_may be_** interfering with enqueuing a few scripts in the support site. We can't reproduce while sandboxed, even with forced concatenation. This is an attempt to deploy support sites without the Help Center to see if it is the root cause.