### PR TITLE
Subscription Management: Router idea

### DIFF
--- a/client/my-sites/subscriptions/index.tsx
+++ b/client/my-sites/subscriptions/index.tsx
@@ -4,8 +4,28 @@ import page, { Callback } from 'page';
 import { createElement } from 'react';
 import { makeLayout, render } from 'calypso/controller';
 
+const SubscriptionManagementPage = () => {
+	return (
+		<SubscriptionManager>
+			<SubscriptionManager.Tabs>
+				<SubscriptionManager.Tab path="/subscriptions/sites">Sites</SubscriptionManager.Tab>
+				<SubscriptionManager.Tab path="/subscriptions/settings">Settings</SubscriptionManager.Tab>
+			</SubscriptionManager.Tabs>
+
+			{ /* <SubscriptionManager.Router>
+				<SubscriptionManager.Route path="/subscriptions/sites">
+					Sites content here
+				</SubscriptionManager.Route>
+				<SubscriptionManager.Route path="/subscriptions/settings">
+					Settings content here
+				</SubscriptionManager.Route>
+			</SubscriptionManager.Router> */ }
+		</SubscriptionManager>
+	);
+};
+
 const createSubscriptions: Callback = ( context, next ) => {
-	context.primary = createElement( SubscriptionManager );
+	context.primary = createElement( SubscriptionManagementPage );
 	next();
 };
 

--- a/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
+++ b/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
@@ -6,6 +6,10 @@ import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import { useCurrentRoute } from 'calypso/components/route';
+import SectionNav from 'calypso/components/section-nav';
+import NavTabItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
 import './styles.scss';
 
 export type SubscriptionManagerContainerProps = {
@@ -14,6 +18,7 @@ export type SubscriptionManagerContainerProps = {
 
 const SubscriptionManagerContainer = ( { children }: SubscriptionManagerContainerProps ) => {
 	const translate = useTranslate();
+	const { currentRoute } = useCurrentRoute();
 	return (
 		<Main className="subscription-manager-container">
 			<DocumentHead title="Subscriptions" />

--- a/packages/subscription-manager/src/components/Tabs/Tab.tsx
+++ b/packages/subscription-manager/src/components/Tabs/Tab.tsx
@@ -1,0 +1,22 @@
+/* eslint-disable no-restricted-imports */
+/**
+ * External dependencies
+ */
+import { useCurrentRoute } from 'calypso/components/route';
+import NavTabItem from 'calypso/components/section-nav/item';
+
+type TabProps = {
+	path: string;
+	children?: React.ReactNode;
+};
+
+const Tab = ( { path, children }: TabProps ) => {
+	const { currentRoute } = useCurrentRoute();
+	return (
+		<NavTabItem path={ path } selected={ currentRoute === path }>
+			{ children }
+		</NavTabItem>
+	);
+};
+
+export default Tab;

--- a/packages/subscription-manager/src/components/Tabs/Tabs.tsx
+++ b/packages/subscription-manager/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,21 @@
+/* eslint-disable no-restricted-imports */
+/**
+ * External dependencies
+ */
+import SectionNav from 'calypso/components/section-nav';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import Tab from './Tab';
+
+type TabsProps = {
+	children?: typeof Tab | typeof Tab[];
+};
+
+const Tabs = ( { children }: TabsProps ) => {
+	return (
+		<SectionNav>
+			<NavTabs>{ children }</NavTabs>
+		</SectionNav>
+	);
+};
+
+export default Tabs;

--- a/packages/subscription-manager/src/components/Tabs/index.ts
+++ b/packages/subscription-manager/src/components/Tabs/index.ts
@@ -1,0 +1,2 @@
+export { default as Tabs } from './Tabs';
+export { default as Tab } from './Tab';

--- a/packages/subscription-manager/src/components/index.d.ts
+++ b/packages/subscription-manager/src/components/index.d.ts
@@ -41,3 +41,51 @@ declare module 'calypso/components/main' {
 	} >;
 	export default Main;
 }
+
+declare module 'calypso/components/section-nav' {
+	const SectionNav: React.FC< {
+		selectedText?: string;
+		selectedCount?: number;
+		hasPinnedItems?: boolean;
+		onMobileNavPanelOpen?: () => void;
+		className?: string;
+		allowDropdown?: boolean;
+	} >;
+	export default SectionNav;
+}
+
+declare module 'calypso/components/section-nav/tabs' {
+	const NavTabs: React.FC< {
+		selectedText?: TranslatableString;
+		selectedCount?: number;
+		label?: string;
+		hasSiblingControls?: boolean;
+	} >;
+	export default NavTabs;
+}
+
+declare module 'calypso/components/section-nav/item' {
+	const SectionNavItem: React.FC< {
+		itemType?: 'button' | 'link';
+		path?: string;
+		selected?: boolean;
+		tabIndex?: number;
+		onClick?: ( event: React.MouseEvent< HTMLAnchorElement > ) => void;
+		onKeyPress?: ( event: React.KeyboardEvent< HTMLAnchorElement > ) => void;
+		isExternalLink?: boolean;
+		disabled?: boolean;
+		count?: number | boolean;
+		compactCount?: boolean;
+		className?: string;
+		preloadSectionName?: string;
+	} >;
+	export default SectionNavItem;
+}
+
+declare module 'calypso/components/route' {
+	export const useCurrentRoute: () => {
+		currentSection: boolean;
+		currentRoute: string;
+		currentQuery: boolean;
+	};
+}

--- a/packages/subscription-manager/src/index.tsx
+++ b/packages/subscription-manager/src/index.tsx
@@ -1,3 +1,7 @@
 import { SubscriptionManagerContainer as SubscriptionManager } from './components/SubscriptionManagerContainer';
+import { Tab, Tabs } from './components/Tabs';
 
-export default SubscriptionManager;
+export default Object.assign( SubscriptionManager, {
+	Tab,
+	Tabs,
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
