### PR TITLE
My home upsell: Update copy for yearly plans

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -5,7 +5,6 @@ import { useDomainSuggestions } from '@automattic/domain-picker/src';
 import { useLocale } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useMemo } from '@wordpress/element';
-import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useState } from 'react';
@@ -108,7 +107,7 @@ export function RenderDomainUpsell( {
 	dismissPreference,
 } ) {
 	const translate = useTranslate();
-	const { hasTranslation } = useI18n();
+
 	const tracksContext = isProfileUpsell ? 'profile' : 'my_home';
 
 	const dispatch = useDispatch();
@@ -186,25 +185,15 @@ export function RenderDomainUpsell( {
 	};
 
 	const cardTitle =
-		// eslint-disable-next-line no-nested-ternary
 		! isFreePlan && ! isMonthlyPlan
-			? hasTranslation( 'Make your mark online with a memorable domain name' ) || locale === 'en'
-				? translate( 'Make your mark online with a memorable domain name' )
-				: translate( 'You still have a free domain to claim!' )
+			? translate( 'Make your mark online with a memorable domain name' )
 			: translate( 'Own your online identity with a custom domain' );
 
 	const cardSubtitle =
-		// eslint-disable-next-line no-nested-ternary
 		! isFreePlan && ! isMonthlyPlan
-			? hasTranslation(
+			? translate(
 					'Your plan includes a free domain for the first year. Stake your claim on the web with a domain name that boosts your brand.'
-			  ) || locale === 'en'
-				? translate(
-						'Your plan includes a free domain for the first year. Stake your claim on the web with a domain name that boosts your brand.'
-				  )
-				: translate(
-						'Own your online identity giving your site a memorable domain name. Your plan includes one for free for one year, so you can still claim it.'
-				  )
+			  )
 			: translate(
 					"Stake your claim on your corner of the web with a site address that's easy to find, share, and follow."
 			  );

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -5,6 +5,7 @@ import { useDomainSuggestions } from '@automattic/domain-picker/src';
 import { useLocale } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useMemo } from '@wordpress/element';
+import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useState } from 'react';
@@ -107,7 +108,7 @@ export function RenderDomainUpsell( {
 	dismissPreference,
 } ) {
 	const translate = useTranslate();
-
+	const { hasTranslation } = useI18n();
 	const tracksContext = isProfileUpsell ? 'profile' : 'my_home';
 
 	const dispatch = useDispatch();
@@ -185,15 +186,25 @@ export function RenderDomainUpsell( {
 	};
 
 	const cardTitle =
+		// eslint-disable-next-line no-nested-ternary
 		! isFreePlan && ! isMonthlyPlan
-			? translate( 'Make your mark online with a memorable domain name' )
+			? hasTranslation( 'Make your mark online with a memorable domain name' ) || locale === 'en'
+				? translate( 'Make your mark online with a memorable domain name' )
+				: translate( 'You still have a free domain to claim!' )
 			: translate( 'Own your online identity with a custom domain' );
 
 	const cardSubtitle =
+		// eslint-disable-next-line no-nested-ternary
 		! isFreePlan && ! isMonthlyPlan
-			? translate(
+			? hasTranslation(
 					'Your plan includes a free domain for the first year. Stake your claim on the web with a domain name that boosts your brand.'
-			  )
+			  ) || locale === 'en'
+				? translate(
+						'Your plan includes a free domain for the first year. Stake your claim on the web with a domain name that boosts your brand.'
+				  )
+				: translate(
+						'Own your online identity giving your site a memorable domain name. Your plan includes one for free for one year, so you can still claim it.'
+				  )
 			: translate(
 					"Stake your claim on your corner of the web with a site address that's easy to find, share, and follow."
 			  );

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -186,13 +186,13 @@ export function RenderDomainUpsell( {
 
 	const cardTitle =
 		! isFreePlan && ! isMonthlyPlan
-			? translate( 'You still have a free domain to claim!' )
+			? translate( 'Make your mark online with a memorable domain name' )
 			: translate( 'Own your online identity with a custom domain' );
 
 	const cardSubtitle =
 		! isFreePlan && ! isMonthlyPlan
 			? translate(
-					'Own your online identity giving your site a memorable domain name. Your plan includes one for free for one year, so you can still claim it.'
+					'Your plan includes a free domain for the first year. Stake your claim on the web with a domain name that boosts your brand.'
 			  )
 			: translate(
 					"Stake your claim on your corner of the web with a site address that's easy to find, share, and follow."

--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -72,7 +72,7 @@ jest.mock( '@automattic/domain-picker/src', () => {
 let pageLink = '';
 jest.mock( 'page', () => ( link ) => ( pageLink = link ) );
 
-const domainUpsellHeadingPaidPlan = 'You still have a free domain to claim!';
+const domainUpsellHeadingPaidPlan = 'Make your mark online with a memorable domain name';
 const domainUpsellHeadingFreePlan = 'Own your online identity with a custom domain';
 const buyThisDomainCta = 'Buy this domain';
 const searchForDomainCta = 'Search for another domain';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/1949

## Proposed Changes

Update the copy of the My home upsell for yearly plans.

Title: `Make your mark online with a memorable domain name`
Description: `Your plan includes a free domain for the first year. Stake your claim on the web with a domain name that boosts your brand.`

## Screenshots
| Before | After |
| --- | --- |
| ![Image](https://user-images.githubusercontent.com/402286/224171619-5d5e950e-088e-4e9c-adaa-0258e0c1487d.png) | ![image](https://user-images.githubusercontent.com/402286/224820282-ee85d104-474f-4ec7-8a3f-d1f1e21efb0f.png) |

## Testing Instructions
- Using a yearly plan site without custom domains
- You should see the upsell on the home
- The copy should match the suggested

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
