### PR TITLE
Add page for expired eCommerce trials

### DIFF
--- a/client/my-sites/plans-features-main/plan-interval-selector/index.tsx
+++ b/client/my-sites/plans-features-main/plan-interval-selector/index.tsx
@@ -1,0 +1,53 @@
+import classNames from 'classnames';
+import SegmentedControl from 'calypso/components/segmented-control';
+import type { ReactNode } from 'react';
+
+import './style.scss';
+
+type PlanInterval = {
+	content: ReactNode;
+	interval: string;
+	onClick?: () => void;
+	path?: string;
+	selected: boolean;
+};
+
+type PlanIntervalSelectorProps = {
+	className: string;
+	intervals: PlanInterval[];
+	isPlansInsideStepper: boolean;
+	use2023PricingGridStyles: boolean;
+};
+
+const PlanIntervalSelector = ( {
+	className,
+	intervals,
+	isPlansInsideStepper,
+	use2023PricingGridStyles,
+}: PlanIntervalSelectorProps ) => {
+	const pricingGridStyles = {
+		'plan-interval-selector__2023-pricing-grid': use2023PricingGridStyles,
+	};
+
+	return (
+		<SegmentedControl
+			compact
+			className={ classNames( 'plan-interval-selector', pricingGridStyles, className ) }
+			primary={ true }
+		>
+			{ intervals.map( ( planInterval ) => (
+				<SegmentedControl.Item
+					key={ planInterval.interval }
+					selected={ planInterval.selected }
+					path={ planInterval.path }
+					onClick={ planInterval.onClick }
+					isPlansInsideStepper={ isPlansInsideStepper }
+				>
+					{ planInterval.content }
+				</SegmentedControl.Item>
+			) ) }
+		</SegmentedControl>
+	);
+};
+
+export default PlanIntervalSelector;

--- a/client/my-sites/plans-features-main/plan-interval-selector/style.scss
+++ b/client/my-sites/plans-features-main/plan-interval-selector/style.scss
@@ -1,0 +1,70 @@
+@import "@wordpress/base-styles/breakpoints";
+
+.plan-interval-selector.plan-interval-selector__2023-pricing-grid.segmented-control {
+	background-color: #f2f2f2;
+	border-color: var(--studio-gray-5);
+	border-radius: 6px; /* stylelint-disable-line scales/radii */
+	width: 414px; // width of mobile plans grid
+	margin: 0 auto;
+
+	@media ( min-width: $break-medium ) {
+		max-width: fit-content;
+		width: auto;
+	}
+
+	.segmented-control__link {
+		padding: 6px 11px;
+	}
+
+	li.segmented-control__item {
+		border: 6px;
+		border-color: var(--studio-gray-5);
+		border-radius: 6px; /* stylelint-disable-line scales/radii */
+		color: var(--color-text);
+		padding: 2px;
+
+		.segmented-control__text {
+			color: var(--color-text);
+		}
+
+		a.segmented-control__link {
+			padding: 6px 11px;
+		}
+
+		&:not(.is-selected) {
+			border: 6px;
+			padding: 2px;
+			font-weight: 500;
+
+			a.segmented-control__link {
+				border: 1px solid #f2f2f2;
+				border-radius: 5px; /* stylelint-disable-line scales/radii */
+
+				&:hover {
+					border-color: var(--studio-gray-10);
+					background: unset;
+				}
+				&:focus {
+					box-shadow: 0 0 0 1px var(--studio-gray-90);
+					outline: none;
+				}
+			}
+		}
+
+		&.is-selected {
+			padding: 1px 0 0 1px;
+
+			a.segmented-control__link {
+				border: 0.5px solid rgba(0, 0, 0, 0.04);
+				border-radius: 6px; /* stylelint-disable-line scales/radii */
+				box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12), 0 3px 1px rgba(0, 0, 0, 0.04);
+				background-color: var(--studio-white);
+
+				&:hover {
+					background-color: var(--studio-white);
+					border-color: rgba(0, 0, 0, 0.04);
+				}
+			}
+		}
+	}
+}

--- a/client/my-sites/plans/components/ecommerce-plan-features/index.tsx
+++ b/client/my-sites/plans/components/ecommerce-plan-features/index.tsx
@@ -10,10 +10,10 @@ import { Button, Card } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import SegmentedControl from 'calypso/components/segmented-control';
 import { getECommerceTrialCheckoutUrl } from 'calypso/lib/ecommerce-trial/get-ecommerce-trial-checkout-url';
+import PlanIntervalSelector from 'calypso/my-sites/plans-features-main/plan-interval-selector';
 import { getPlanRawPrice, getPlan } from 'calypso/state/plans/selectors';
 import TrialFeatureCard from './trial-feature-card';
 import type { WooExpressMediumPlanFeatureSet } from './trial-feature-card';
@@ -128,26 +128,38 @@ const ECommercePlanFeatures = ( {
 		[ siteSlug, targetPlan, triggerTracksEvent ]
 	);
 
+	const planIntervals = useMemo( () => {
+		return [
+			{
+				interval: 'monthly',
+				...monthlyControlProps,
+				content: <span>{ translate( 'Pay Monthly' ) }</span>,
+				selected: interval === 'monthly',
+			},
+			{
+				interval: 'yearly',
+				...yearlyControlProps,
+				content: (
+					<span>
+						{ translate( 'Pay Annually (Save %(percentageSavings)s%%)', {
+							args: { percentageSavings },
+						} ) }
+					</span>
+				),
+				selected: interval === 'yearly',
+			},
+		];
+	}, [ interval, monthlyControlProps, percentageSavings, translate, yearlyControlProps ] );
+
 	return (
 		<div className="ecommerce-plan-features">
 			<div className="ecommerce-plan-features__interval-toggle-wrapper">
-				<SegmentedControl
-					compact
-					primary={ true }
+				<PlanIntervalSelector
 					className="ecommerce-plan-features__interval-toggle price-toggle"
-				>
-					<SegmentedControl.Item selected={ interval === 'monthly' } { ...monthlyControlProps }>
-						<span>{ translate( 'Pay Monthly' ) }</span>
-					</SegmentedControl.Item>
-
-					<SegmentedControl.Item selected={ interval === 'yearly' } { ...yearlyControlProps }>
-						<span>
-							{ translate( 'Pay Annually (Save %(percentageSavings)s%%)', {
-								args: { percentageSavings },
-							} ) }
-						</span>
-					</SegmentedControl.Item>
-				</SegmentedControl>
+					intervals={ planIntervals }
+					isPlansInsideStepper={ false }
+					use2023PricingGridStyles={ true }
+				/>
 			</div>
 
 			<Card className="ecommerce-plan-features__price-card">

--- a/client/my-sites/plans/components/ecommerce-plan-features/index.tsx
+++ b/client/my-sites/plans/components/ecommerce-plan-features/index.tsx
@@ -17,6 +17,7 @@ import { getECommerceTrialCheckoutUrl } from 'calypso/lib/ecommerce-trial/get-ec
 import { getPlanRawPrice, getPlan } from 'calypso/state/plans/selectors';
 import TrialFeatureCard from './trial-feature-card';
 import type { WooExpressMediumPlanFeatureSet } from './trial-feature-card';
+import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
 
@@ -29,7 +30,8 @@ interface ECommercePlanFeaturesProps {
 	interval: 'monthly' | 'yearly';
 	monthlyControlProps: SegmentedOptionProps;
 	planFeatureSets: WooExpressMediumPlanFeatureSet[];
-	siteSlug: string;
+	priceCardSubtitle?: TranslateResult;
+	siteSlug?: string | null;
 	triggerTracksEvent: ( tracksLocation: string ) => void;
 	yearlyControlProps: SegmentedOptionProps;
 }
@@ -38,6 +40,7 @@ const ECommercePlanFeatures = ( {
 	interval,
 	monthlyControlProps,
 	planFeatureSets,
+	priceCardSubtitle,
 	siteSlug,
 	triggerTracksEvent,
 	yearlyControlProps,
@@ -111,6 +114,10 @@ const ECommercePlanFeatures = ( {
 		( tracksLocation: string ) => {
 			triggerTracksEvent( tracksLocation );
 
+			if ( ! siteSlug ) {
+				return;
+			}
+
 			const checkoutUrl = getECommerceTrialCheckoutUrl( {
 				productSlug: targetPlan.getStoreSlug(),
 				siteSlug,
@@ -149,7 +156,9 @@ const ECommercePlanFeatures = ( {
 						{ targetPlan.getTitle() }
 					</span>
 					<span className="ecommerce-plan-features__price-card-subtitle">
-						{ translate( 'Accelerate your growth with advanced features.' ) }
+						{ priceCardSubtitle
+							? priceCardSubtitle
+							: translate( 'Accelerate your growth with advanced features.' ) }
 					</span>
 				</div>
 				<div className="ecommerce-plan-features__price-card-conditions">
@@ -166,6 +175,7 @@ const ECommercePlanFeatures = ( {
 					<Button
 						className="ecommerce-plan-features__price-card-cta"
 						primary
+						disabled={ ! siteSlug }
 						onClick={ () => redirectToCheckoutForPlan( 'main-price-card' ) }
 					>
 						{ translate( 'Upgrade now' ) }
@@ -181,6 +191,7 @@ const ECommercePlanFeatures = ( {
 			<div className="ecommerce-plan-features__cta-wrapper">
 				<Button
 					className="ecommerce-plan-features__cta is-primary"
+					disabled={ ! siteSlug }
 					onClick={ () => redirectToCheckoutForPlan( 'footer' ) }
 				>
 					{ translate( 'Upgrade now' ) }

--- a/client/my-sites/plans/ecommerce-trial/controller.jsx
+++ b/client/my-sites/plans/ecommerce-trial/controller.jsx
@@ -1,4 +1,10 @@
+import ECommerceTrialExpired from './ecommerce-trial-expired';
 import TrialUpgradeConfirmation from './upgrade-confirmation';
+
+export function trialExpired( context, next ) {
+	context.primary = <ECommerceTrialExpired />;
+	next();
+}
 
 export function trialUpgradeConfirmation( context, next ) {
 	context.primary = <TrialUpgradeConfirmation />;

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
@@ -1,0 +1,81 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import QueryPlans from 'calypso/components/data/query-plans';
+import Main from 'calypso/components/main';
+import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import ECommercePlanFeatures from 'calypso/my-sites/plans/components/ecommerce-plan-features';
+import { getExpiredTrialWooExpressMediumFeatureSets } from 'calypso/my-sites/plans/ecommerce-trial/wx-medium-features';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+import './style.scss';
+
+const ECommerceTrialExpired = (): JSX.Element => {
+	const translate = useTranslate();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const [ interval, setInterval ] = useState( 'monthly' as 'monthly' | 'yearly' );
+
+	const { monthlyControlProps, yearlyControlProps } = useMemo( () => {
+		return {
+			monthlyControlProps: {
+				onClick: () => setInterval( 'monthly' ),
+			},
+			yearlyControlProps: {
+				onClick: () => setInterval( 'yearly' ),
+			},
+		};
+	}, [ setInterval ] );
+
+	const expiredTrialWooExpressMediumPlanFeatureSets = useMemo( () => {
+		return getExpiredTrialWooExpressMediumFeatureSets( { translate } );
+	}, [ translate ] );
+
+	const triggerTracksEvent = useCallback( ( tracksLocation: string ) => {
+		recordTracksEvent( 'calypso_wooexpress_expired_trial_upgrade_cta_clicked', {
+			location: tracksLocation,
+		} );
+	}, [] );
+
+	return (
+		<>
+			<QueryPlans />
+			<BodySectionCssClass bodyClass={ [ 'is-ecommerce-trial-plan' ] } />
+			<Main wideLayout>
+				<PageViewTracker
+					path="/plans/my-plan/trial-expired/:site"
+					title="Plans > Ecommerce Trial Expired"
+				/>
+				<div className="ecommerce-trial-expired__content">
+					<div className="ecommerce-trial-expired__header">
+						<h1 className="ecommerce-trial-expired__title">
+							{ translate( 'Your free trial has ended' ) }
+						</h1>
+						<div className="ecommerce-trial-expired__subtitle">
+							{ translate(
+								'Don’t lose all that hard work! Upgrade to a paid plan to continue working on your store.' +
+									'Unlock more features, launch and start selling, and make your business venture a reality.'
+							) }
+						</div>
+					</div>
+				</div>
+
+				<ECommercePlanFeatures
+					interval={ interval }
+					monthlyControlProps={ monthlyControlProps }
+					planFeatureSets={ expiredTrialWooExpressMediumPlanFeatureSets }
+					priceCardSubtitle={ translate(
+						'Kickstart your growth with the world’s most-trusted ecommerce platform.'
+					) }
+					siteSlug={ siteSlug }
+					triggerTracksEvent={ triggerTracksEvent }
+					yearlyControlProps={ yearlyControlProps }
+				/>
+			</Main>
+		</>
+	);
+};
+
+export default ECommerceTrialExpired;

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
@@ -6,11 +6,26 @@ body.is-section-plans.is-expired-ecommerce-trial-plan {
 		--color-surface-backdrop: var(--color-surface);
 	}
 
+	.main.is-wide-layout {
+		@media ( max-width: $break-medium ) {
+			padding-left: 20px;
+			padding-right: 20px;
+		}
+	}
+
 	.ecommerce-trial-expired__content {
 		text-align: center;
 
+		@media ( max-width: $break-medium ) {
+			padding-top: 40px;
+		}
+
 		.ecommerce-trial-expired__title {
-			font-size: $woo-font-title-large;
+			font-size: $woo-font-title-medium;
+
+			@media ( min-width: $break-medium ) {
+				font-size: $woo-font-title-large;
+			}
 		}
 
 		.ecommerce-trial-expired__subtitle {

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
@@ -1,5 +1,29 @@
+@import "@automattic/typography/styles/woo-commerce";
+@import "@wordpress/base-styles/breakpoints";
+
 body.is-section-plans.is-expired-ecommerce-trial-plan {
 	&.color-scheme {
 		--color-surface-backdrop: var(--color-surface);
+	}
+
+	.ecommerce-trial-expired__content {
+		text-align: center;
+
+		.ecommerce-trial-expired__title {
+			font-size: $woo-font-title-large;
+		}
+
+		.ecommerce-trial-expired__subtitle {
+			margin: 16px auto 0;
+
+			@media ( min-width: $break-medium ) {
+				max-width: 580px;
+			}
+		}
+
+		.ecommerce-trial-expired__manage-purchases {
+			font-size: $woo-font-body-extra-small;
+			margin-top: 16px;
+		}
 	}
 }

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
@@ -1,0 +1,5 @@
+body.is-section-plans.is-expired-ecommerce-trial-plan {
+	&.color-scheme {
+		--color-surface-backdrop: var(--color-surface);
+	}
+}

--- a/client/my-sites/plans/ecommerce-trial/wx-medium-features.ts
+++ b/client/my-sites/plans/ecommerce-trial/wx-medium-features.ts
@@ -11,6 +11,12 @@ type WooExpressMediumFeatureSetProps = {
 	translate: typeof i18nTranslate;
 };
 
+/*
+ * Note that this file includes multiple sets of features:
+ *  - getWooExpressMediumFeatureSets: the features for upsells while in the trial.
+ *  - getWooExpressMediumFeatureSetsAfterTrial: the features for upsells after the trial has expired.
+ */
+
 export const getWooExpressMediumFeatureSets = ( {
 	translate,
 }: WooExpressMediumFeatureSetProps ): WooExpressMediumPlanFeatureSet[] => {
@@ -210,6 +216,272 @@ export const getWooExpressMediumFeatureSets = ( {
 			items: [
 				{
 					title: translate( 'Print shipping labels', { textOnly: true } ),
+					subtitle: translate( 'Print shipping labels from your store to save time and money.' ),
+				},
+				{
+					title: translate( 'Offer shipment tracking', { textOnly: true } ),
+					subtitle: translate( 'Provide customers with an easy way to track their shipment.' ),
+				},
+				{
+					title: translate( 'Customize shipping rates', { textOnly: true } ),
+					subtitle: translate(
+						'Define multiple shipping rates based on location, price, weight, or other criteria.'
+					),
+				},
+				{
+					title: translate( 'Set conditional shipping', { textOnly: true } ),
+					subtitle: translate( 'Restrict shipping and payment options using conditional logic.' ),
+				},
+				{
+					title: translate( 'Simplify returns and exchanges', { textOnly: true } ),
+					subtitle: translate(
+						'Manage the RMA process, add warranties to products and let customers request/manage returns from their account.'
+					),
+				},
+			],
+		},
+	];
+};
+
+export const getExpiredTrialWooExpressMediumFeatureSets = ( {
+	translate,
+}: WooExpressMediumFeatureSetProps ): WooExpressMediumPlanFeatureSet[] => {
+	return [
+		{
+			expanded: true,
+			illustration: generalFeatures,
+			title: translate( 'Get everything you need for success', { textOnly: true } ),
+			subtitle: translate( 'All the tools you need to start growing your business are included.' ),
+			items: [
+				{
+					title: translate( 'Start making sales', { textOnly: true } ),
+					subtitle: translate(
+						'Purchase a plan to keep building and launch when you’re ready, or publish your store immediately. '
+					),
+				},
+				{
+					title: translate( 'Priority support 24/7', { textOnly: true } ),
+					subtitle: translate(
+						'Need help? Reach out to our Woo specialists anytime via email or chat.'
+					),
+				},
+				{
+					title: translate( 'Get unlimited admin accounts', { textOnly: true } ),
+					subtitle: translate(
+						'Add as many staff accounts as you need to help run your business.'
+					),
+				},
+				{
+					title: translate( 'Customize your look with premium themes and simple editing.', {
+						textOnly: true,
+					} ),
+					subtitle: translate(
+						'Choose from a selection of beautiful themes, then customize without touching a line of code.'
+					),
+				},
+				{
+					title: translate( 'Get found online', { textOnly: true } ),
+					subtitle: translate(
+						'Promote and sell your products on popular social media platforms and marketplaces.'
+					),
+				},
+				{
+					title: translate( 'Sell in person', { textOnly: true } ),
+					subtitle: translate(
+						'Use a mobile card reader to take payments in a store, at a popup, or wherever your business takes you.'
+					),
+				},
+				{
+					title: translate( 'Automate your marketing', { textOnly: true } ),
+					subtitle: translate(
+						'Build custom email automations to keep customers and prospects engaged.'
+					),
+				},
+				{
+					title: translate( 'Simplify shipping', { textOnly: true } ),
+					subtitle: translate( 'Print shipping labels from your store to save time and money.' ),
+				},
+				{
+					title: translate( 'Own your store forever', { textOnly: true } ),
+					subtitle: translate(
+						'Your site is open source, meaning you’re always in control of your business.'
+					),
+				},
+			],
+		},
+		{
+			illustration: payments,
+			title: translate( 'Payments', { textOnly: true } ),
+			subtitle: translate( 'Quickly and easily accept payments.' ),
+			items: [
+				{
+					title: translate( 'Give your customers more ways to pay.', { textOnly: true } ),
+					subtitle: translate(
+						'Accept all major credit and debit cards, plus popular options like Apple Pay and Google Pay.'
+					),
+				},
+				{
+					title: translate( 'Go global', { textOnly: true } ),
+					subtitle: translate(
+						'Sell in 60+ countries and take payments in more than 100 currencies.'
+					),
+				},
+				{
+					title: translate( 'Offer subscriptions', { textOnly: true } ),
+					subtitle: translate(
+						'Add a subscription for any product or service, including the ability to set subscription discounts, signup fees, free trials, or expiration periods.'
+					),
+				},
+				{
+					title: translate( 'Automate tax collection', { textOnly: true } ),
+					subtitle: translate(
+						'Automatically calculate how much sales tax should be collected at checkout.'
+					),
+				},
+				{
+					title: translate( 'Sell in person', { textOnly: true } ),
+					subtitle: translate(
+						'Use a mobile card reader to take payments in a store, at a popup, or wherever your business takes you.'
+					),
+				},
+			],
+		},
+		{
+			illustration: productManagement,
+			title: translate( 'Product management', { textOnly: true } ),
+			subtitle: translate( 'Simplify the way you manage, sell and promote your products.' ),
+			items: [
+				{
+					title: translate( 'Manage on the go', { textOnly: true } ),
+					subtitle: translate(
+						'Process orders and manage your store anywhere with the WooCommerce Mobile App.'
+					),
+				},
+				{
+					title: translate( 'Unlimited products', { textOnly: true } ),
+					subtitle: translate( 'Add as many products as you want to your store.' ),
+				},
+				{
+					title: translate( 'Offer gift cards', { textOnly: true } ),
+					subtitle: translate( 'Sell and accept pre-paid, multi-purpose e-gift vouchers.' ),
+				},
+				{
+					title: translate( 'Send back in stock notifications', { textOnly: true } ),
+					subtitle: translate( 'Notify customers when your products are restocked.' ),
+				},
+				{
+					title: translate( 'Set order limits', { textOnly: true } ),
+					subtitle: translate( 'Specify min and max allowed product quantities for orders.' ),
+				},
+				{
+					title: translate( 'Sell product bundles', { textOnly: true } ),
+					subtitle: translate( 'Offer personalized product packages and bulk discounts.' ),
+				},
+				{
+					title: translate( 'Offer customizable product kits', { textOnly: true } ),
+					subtitle: translate(
+						'Use Composite Products to add product kit building functionality with inventory management.'
+					),
+				},
+				{
+					title: translate( 'Quickly import products', { textOnly: true } ),
+					subtitle: translate( 'Import, merge, and export products using a CSV file.' ),
+				},
+				{
+					title: translate( 'Sell product add-ons', { textOnly: true } ),
+					subtitle: translate( 'Enable gift wrapping/messages or custom pricing.' ),
+				},
+				{
+					title: translate( 'Unlimited images', { textOnly: true } ),
+					subtitle: translate( 'Add any number of images to your product variations.' ),
+				},
+				{
+					title: translate( 'Product recommendations', { textOnly: true } ),
+					subtitle: translate(
+						'Earn more revenue with automated upsell and cross-sell product recommendations.'
+					),
+				},
+				{
+					title: translate( 'Take pre-orders', { textOnly: true } ),
+					subtitle: translate( 'Let customers order products before they’re available.' ),
+				},
+			],
+		},
+		{
+			illustration: customization,
+			title: translate( 'Themes and customization', { textOnly: true } ),
+			subtitle: translate( 'Bring your brand to life with a fully customizable storefront.' ),
+			items: [
+				{
+					title: translate( 'Premium themes', { textOnly: true } ),
+					subtitle: translate(
+						'Tap into a diverse selection of beautifully designed premium themes.'
+					),
+				},
+				{
+					title: translate( 'Simple customization', { textOnly: true } ),
+					subtitle: translate(
+						"Take control over your store's layout without touching a line of code."
+					),
+				},
+				{
+					title: translate( 'Cart and checkout optimization', { textOnly: true } ),
+					subtitle: translate(
+						'Streamline your checkout and boost conversions with simplified editing of your shopping cart and checkout pages.'
+					),
+				},
+			],
+		},
+		{
+			illustration: growth,
+			title: translate( 'Marketing and growth', { textOnly: true } ),
+			subtitle: translate(
+				'Optimize your store for sales by adding in email and social integrations.'
+			),
+			items: [
+				{
+					title: translate( 'Sell everywhere', { textOnly: true } ),
+					subtitle: translate(
+						'Promote and sell your products on popular social media platforms and marketplaces.'
+					),
+				},
+				{
+					title: translate( 'Automate your marketing', { textOnly: true } ),
+					subtitle: translate(
+						'Build custom email automations to keep customers and prospects engaged.'
+					),
+				},
+				{
+					title: translate( 'Recover abandoned carts', { textOnly: true } ),
+					subtitle: translate(
+						'Drive more sales by automatically emailing customers who leave your store without checking out.'
+					),
+				},
+				{
+					title: translate( 'Encourage referrals', { textOnly: true } ),
+					subtitle: translate(
+						'Offer free gifts or coupons when your customers refer new shoppers.'
+					),
+				},
+				{
+					title: translate( 'Send birthday coupons', { textOnly: true } ),
+					subtitle: translate(
+						'Automatically email your customers a birthday discount to keep them coming back.'
+					),
+				},
+				{
+					title: translate( 'Drive loyalty', { textOnly: true } ),
+					subtitle: translate( 'Keep your loyal customers loyal with a rewards program.' ),
+				},
+			],
+		},
+		{
+			illustration: shipping,
+			title: translate( 'Shipping', { textOnly: true } ),
+			subtitle: translate( 'Streamline your fulfillment with integrated shipping.' ),
+			items: [
+				{
+					title: translate( 'Shipping labels, simplified', { textOnly: true } ),
 					subtitle: translate( 'Print shipping labels from your store to save time and money.' ),
 				},
 				{

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -19,7 +19,7 @@ import {
 	redirectToPlansIfNotJetpack,
 } from './controller';
 import { currentPlan } from './current-plan/controller';
-import { trialUpgradeConfirmation } from './ecommerce-trial/controller';
+import { trialExpired, trialUpgradeConfirmation } from './ecommerce-trial/controller';
 
 const trackedPage = ( url, ...rest ) => {
 	page( url, ...rest, makeLayout, clientRender );
@@ -70,6 +70,7 @@ export default function () {
 		p2RedirectToHubPlans,
 		currentPlan
 	);
+	trackedPage( '/plans/my-plan/trial-expired/:domain', siteSelection, trialExpired );
 	trackedPage(
 		'/plans/my-plan/trial-upgraded/:domain',
 		stagingSiteNotSupportedRedirect,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* Automattic/wc-calypso-bridge#1005
* #74387

## Proposed Changes

* This change implements a new page for expired eCommerce trials
* For now, this doesn't include the header image, but the PR does include all the recommended copy and styles beyond that, including mobile styles

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via the Calypso.live branch
* Ensure you can inspect Tracks events (e.g. by using Tracks Vigilante)
* For an eCommerce trial site without any purchases other than the free eCommerce trial, navigate to `/plans/my-plan/trial-expired/:siteSlug`
* Verify that you see the trial expired page, and you don't see a link to manage your previous purchases
* Verify that we logged a `calypso_page_view` event for the page load
* Compare the layout in desktop and mobile screens to the designs in lD0gTB4IqGsmSmsnjZNaP6-fi-2232%3A21618, and the copy matches the content from p1678485569139339/1678450383.291469-slack-C03Q87XT1QF
* Verify that toggling the interval works
* Verify that clicking on the CTAs adds the appropriate product to your cart, and triggers a `calypso_wooexpress_expired_trial_upgrade_cta_clicked` Tracks event with the `location` event prop set to `footer` or `main-price-card`
* Now make a purchase on the site, such as a third party premium theme subscription
* Refresh the page, and verify that you see the "Manage your previous purchases" link
* Verify that clicking on the link takes you to manage your purchases for the current site

### Screenshots

<img width="1127" alt="Screenshot 2023-03-15 at 18 23 21" src="https://user-images.githubusercontent.com/3376401/225375477-2542bebe-a19d-47f2-b833-dcc6ac5b922c.png">
<img width="1055" alt="Screenshot 2023-03-15 at 18 23 56" src="https://user-images.githubusercontent.com/3376401/225375489-5d7442b7-c75a-413d-89f6-ad0c20135a20.png">
<img width="1054" alt="Screenshot 2023-03-15 at 18 24 19" src="https://user-images.githubusercontent.com/3376401/225375488-5d12504e-eba7-4f8d-a78b-dd18eb87c77f.png">
<img width="1054" alt="Screenshot 2023-03-15 at 18 24 33" src="https://user-images.githubusercontent.com/3376401/225375484-0fbf5d82-f2c6-4c65-8a60-a9f3aadf8aa1.png">
<img width="1054" alt="Screenshot 2023-03-15 at 18 24 54" src="https://user-images.githubusercontent.com/3376401/225375481-6fef7437-9d37-4fae-9096-7143e8466664.png">
<img width="1054" alt="Screenshot 2023-03-15 at 18 25 06" src="https://user-images.githubusercontent.com/3376401/225375479-631b9f34-b850-4e78-b43d-2adfc4fde94e.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?