### PR TITLE
Flaky E2E: additional fixes to ensure the launchpad is skipped correctly.

### DIFF
--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -73,14 +73,18 @@ describe(
 			} );
 
 			it( 'Skip Onboarding', async function () {
+				await page.waitForURL( /setup\/site-setup\/goals/, { waitUntil: 'networkidle' } );
 				const startSiteFlow = new StartSiteFlow( page );
-				await startSiteFlow.clickButton( 'Skip to dashboard' );
+				await Promise.all( [
+					page.waitForURL( /build\/launchpad/, { waitUntil: 'networkidle' } ),
+					startSiteFlow.clickButton( 'Skip to dashboard' ),
+				] );
 			} );
 
 			it( 'Skip Launchpad', async function () {
 				await Promise.all( [
-					page.waitForNavigation( { url: /.*\/view\/.*/, timeout: 30 * 1000 } ),
-					await page.click( 'button:text("Skip to dashboard")' ),
+					page.waitForURL( /view/ ),
+					page.getByRole( 'button', { name: 'Skip to dashboard' } ).click( { timeout: 20 * 1000 } ),
 				] );
 			} );
 		} );

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -73,10 +73,10 @@ describe(
 			} );
 
 			it( 'Skip Onboarding', async function () {
-				await page.waitForURL( /setup\/site-setup\/goals/, { waitUntil: 'networkidle' } );
+				await page.waitForURL( /setup\/site-setup\/goals/ );
 				const startSiteFlow = new StartSiteFlow( page );
 				await Promise.all( [
-					page.waitForURL( /build\/launchpad/, { waitUntil: 'networkidle' } ),
+					page.waitForURL( /build\/launchpad/ ),
 					startSiteFlow.clickButton( 'Skip to dashboard' ),
 				] );
 			} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/74389.

## Proposed Changes

This PR adds waits for URL and network load state and removes usage of deprecated `waitForNavigation` call in the `Signup: Business` spec.

Context: p1678737506278029-slack-CHN6J22MP and https://github.com/Automattic/wp-calypso/pull/74082.

The fix previously added in https://github.com/Automattic/wp-calypso/pull/74082 worked well, but there was one instance where the click on `Skip to dashboard` failed because the click happened immediately when the element was visible but not before the page was ready. This resulted in the click being swallowed up by the pageload. Another issue is likely due to identical link names "Skip to dashboard" in both the `intent_capture` and `launchpad`, so an additional safeguard is to add a wait for the expected URL.

Key changes:
- add waitForURL calls to ensure, at each step, that the page shown is as expected.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Pre-Release E2E

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?