### PR TITLE
Migrate legacy global styles to register from registerStore

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/README.md
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/README.md
@@ -1,5 +1,7 @@
 # Global Styles plugin <!-- omit in toc -->
 
+Note: as of March 2023, this is still available for older themes which declare support for "jetpack-global-styles". If you activate one of those themes (like "Leven") on a site, you can access and test this feature in both the page and post editor. Look for the typography icon in the top toolbar, or "Global Styles" under the plugins section of the editor more menu.
+
 This plugin creates a new sidebar for the block editor through which the users can update the styles site-wide, if the active theme has declared support. At the moment, users can set the base and headings fonts.
 
 - [How to develop and build the plugin](#how-to-develop-and-build-the-plugin)

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/index.js
@@ -20,25 +20,25 @@ import './editor.scss';
 // Global variable.
 const { PLUGIN_NAME, STORE_NAME, REST_PATH } = JETPACK_GLOBAL_STYLES_EDITOR_CONSTANTS; // eslint-disable-line no-undef
 
-registerStore( STORE_NAME, REST_PATH );
-registerDOMUpdater( [ FONT_BASE, FONT_HEADINGS ], select( STORE_NAME ).getOption );
+const globalStylesStore = registerStore( STORE_NAME, REST_PATH );
+registerDOMUpdater( [ FONT_BASE, FONT_HEADINGS ], select( globalStylesStore ).getOption );
 
 registerPlugin( PLUGIN_NAME, {
 	render: compose(
 		withSelect( ( getSelectors ) => ( {
-			siteName: getSelectors( STORE_NAME ).getOption( SITE_NAME ),
-			fontHeadings: getSelectors( STORE_NAME ).getOption( FONT_HEADINGS ),
-			fontHeadingsDefault: getSelectors( STORE_NAME ).getOption( FONT_HEADINGS_DEFAULT ),
-			fontBase: getSelectors( STORE_NAME ).getOption( FONT_BASE ),
-			fontBaseDefault: getSelectors( STORE_NAME ).getOption( FONT_BASE_DEFAULT ),
-			fontPairings: getSelectors( STORE_NAME ).getOption( FONT_PAIRINGS ),
-			fontOptions: getSelectors( STORE_NAME ).getOption( FONT_OPTIONS ),
-			hasLocalChanges: getSelectors( STORE_NAME ).hasLocalChanges(),
+			siteName: getSelectors( globalStylesStore ).getOption( SITE_NAME ),
+			fontHeadings: getSelectors( globalStylesStore ).getOption( FONT_HEADINGS ),
+			fontHeadingsDefault: getSelectors( globalStylesStore ).getOption( FONT_HEADINGS_DEFAULT ),
+			fontBase: getSelectors( globalStylesStore ).getOption( FONT_BASE ),
+			fontBaseDefault: getSelectors( globalStylesStore ).getOption( FONT_BASE_DEFAULT ),
+			fontPairings: getSelectors( globalStylesStore ).getOption( FONT_PAIRINGS ),
+			fontOptions: getSelectors( globalStylesStore ).getOption( FONT_OPTIONS ),
+			hasLocalChanges: getSelectors( globalStylesStore ).hasLocalChanges(),
 		} ) ),
 		withDispatch( ( dispatch ) => ( {
-			updateOptions: dispatch( STORE_NAME ).updateOptions,
-			publishOptions: dispatch( STORE_NAME ).publishOptions,
-			resetLocalChanges: dispatch( STORE_NAME ).resetLocalChanges,
+			updateOptions: dispatch( globalStylesStore ).updateOptions,
+			publishOptions: dispatch( globalStylesStore ).publishOptions,
+			resetLocalChanges: dispatch( globalStylesStore ).resetLocalChanges,
 		} ) )
 	)( GlobalStylesSidebar ),
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/index.js
@@ -24,16 +24,19 @@ registerDOMUpdater( [ FONT_BASE, FONT_HEADINGS ], storeSelect( globalStylesStore
 
 registerPlugin( PLUGIN_NAME, {
 	render: compose(
-		withSelect( ( select ) => ( {
-			siteName: select( globalStylesStore ).getOption( SITE_NAME ),
-			fontHeadings: select( globalStylesStore ).getOption( FONT_HEADINGS ),
-			fontHeadingsDefault: select( globalStylesStore ).getOption( FONT_HEADINGS_DEFAULT ),
-			fontBase: select( globalStylesStore ).getOption( FONT_BASE ),
-			fontBaseDefault: select( globalStylesStore ).getOption( FONT_BASE_DEFAULT ),
-			fontPairings: select( globalStylesStore ).getOption( FONT_PAIRINGS ),
-			fontOptions: select( globalStylesStore ).getOption( FONT_OPTIONS ),
-			hasLocalChanges: select( globalStylesStore ).hasLocalChanges(),
-		} ) ),
+		withSelect( ( select ) => {
+			const { getOption, hasLocalChanges } = select( globalStylesStore );
+			return {
+				siteName: getOption( SITE_NAME ),
+				fontHeadings: getOption( FONT_HEADINGS ),
+				fontHeadingsDefault: getOption( FONT_HEADINGS_DEFAULT ),
+				fontBase: getOption( FONT_BASE ),
+				fontBaseDefault: getOption( FONT_BASE_DEFAULT ),
+				fontPairings: getOption( FONT_PAIRINGS ),
+				fontOptions: getOption( FONT_OPTIONS ),
+				hasLocalChanges: hasLocalChanges(),
+			};
+		} ),
 		withDispatch( ( dispatch ) => ( {
 			updateOptions: dispatch( globalStylesStore ).updateOptions,
 			publishOptions: dispatch( globalStylesStore ).publishOptions,

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/index.js
@@ -1,5 +1,5 @@
 import { compose } from '@wordpress/compose';
-import { withDispatch, withSelect, select } from '@wordpress/data';
+import { withDispatch, withSelect, select as storeSelect } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
 import {
 	FONT_BASE,
@@ -20,19 +20,19 @@ import './editor.scss';
 // Global data passed from PHP.
 const { PLUGIN_NAME } = JETPACK_GLOBAL_STYLES_EDITOR_CONSTANTS; // eslint-disable-line no-undef
 
-registerDOMUpdater( [ FONT_BASE, FONT_HEADINGS ], select( globalStylesStore ).getOption );
+registerDOMUpdater( [ FONT_BASE, FONT_HEADINGS ], storeSelect( globalStylesStore ).getOption );
 
 registerPlugin( PLUGIN_NAME, {
 	render: compose(
-		withSelect( ( getSelectors ) => ( {
-			siteName: getSelectors( globalStylesStore ).getOption( SITE_NAME ),
-			fontHeadings: getSelectors( globalStylesStore ).getOption( FONT_HEADINGS ),
-			fontHeadingsDefault: getSelectors( globalStylesStore ).getOption( FONT_HEADINGS_DEFAULT ),
-			fontBase: getSelectors( globalStylesStore ).getOption( FONT_BASE ),
-			fontBaseDefault: getSelectors( globalStylesStore ).getOption( FONT_BASE_DEFAULT ),
-			fontPairings: getSelectors( globalStylesStore ).getOption( FONT_PAIRINGS ),
-			fontOptions: getSelectors( globalStylesStore ).getOption( FONT_OPTIONS ),
-			hasLocalChanges: getSelectors( globalStylesStore ).hasLocalChanges(),
+		withSelect( ( select ) => ( {
+			siteName: select( globalStylesStore ).getOption( SITE_NAME ),
+			fontHeadings: select( globalStylesStore ).getOption( FONT_HEADINGS ),
+			fontHeadingsDefault: select( globalStylesStore ).getOption( FONT_HEADINGS_DEFAULT ),
+			fontBase: select( globalStylesStore ).getOption( FONT_BASE ),
+			fontBaseDefault: select( globalStylesStore ).getOption( FONT_BASE_DEFAULT ),
+			fontPairings: select( globalStylesStore ).getOption( FONT_PAIRINGS ),
+			fontOptions: select( globalStylesStore ).getOption( FONT_OPTIONS ),
+			hasLocalChanges: select( globalStylesStore ).hasLocalChanges(),
 		} ) ),
 		withDispatch( ( dispatch ) => ( {
 			updateOptions: dispatch( globalStylesStore ).updateOptions,

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/index.js
@@ -12,15 +12,14 @@ import {
 } from './src/constants';
 import registerDOMUpdater from './src/dom-updater';
 import GlobalStylesSidebar from './src/global-styles-sidebar';
-import registerStore from './src/store';
+import { store as globalStylesStore } from './src/store';
 
 // Tell Webpack to compile this into CSS
 import './editor.scss';
 
-// Global variable.
-const { PLUGIN_NAME, STORE_NAME, REST_PATH } = JETPACK_GLOBAL_STYLES_EDITOR_CONSTANTS; // eslint-disable-line no-undef
+// Global data passed from PHP.
+const { PLUGIN_NAME } = JETPACK_GLOBAL_STYLES_EDITOR_CONSTANTS; // eslint-disable-line no-undef
 
-const globalStylesStore = registerStore( STORE_NAME, REST_PATH );
 registerDOMUpdater( [ FONT_BASE, FONT_HEADINGS ], select( globalStylesStore ).getOption );
 
 registerPlugin( PLUGIN_NAME, {

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/store.js
@@ -1,5 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
-import { registerStore } from '@wordpress/data';
+import { register, createReduxStore } from '@wordpress/data';
 
 let cache = {};
 let alreadyFetchedOptions = false;
@@ -52,7 +52,7 @@ const actions = {
  * @param {string} optionsPath REST path used to interact with the options API.
  */
 export default ( storeName, optionsPath ) => {
-	registerStore( storeName, {
+	const store = createReduxStore( storeName, {
 		reducer( state, action ) {
 			switch ( action.type ) {
 				case 'UPDATE_OPTIONS':
@@ -116,4 +116,6 @@ export default ( storeName, optionsPath ) => {
 			},
 		},
 	} );
+	register( store );
+	return store;
 };

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/src/store.js
@@ -1,6 +1,9 @@
 import apiFetch from '@wordpress/api-fetch';
 import { register, createReduxStore } from '@wordpress/data';
 
+// Global data passed from PHP.
+const { STORE_NAME, REST_PATH } = JETPACK_GLOBAL_STYLES_EDITOR_CONSTANTS; // eslint-disable-line no-undef
+
 let cache = {};
 let alreadyFetchedOptions = false;
 
@@ -34,88 +37,69 @@ const actions = {
 	},
 };
 
-/**
- * Store API
- *
- * Selectors under `wp.data.select( STORE_NAME )`:
- *
- * - getOption( String optionName )
- * - hasLocalChanges()
- *
- * Actions under `wp.data.dispatch( STORE_NAME )`:
- *
- * - updateOptions( Object optionsToUpdate )
- * - publishOptions( Object optionsToUpdate )
- * - resetLocalChanges()
- *
- * @param {string} storeName Name of the store.
- * @param {string} optionsPath REST path used to interact with the options API.
- */
-export default ( storeName, optionsPath ) => {
-	const store = createReduxStore( storeName, {
-		reducer( state, action ) {
-			switch ( action.type ) {
-				case 'UPDATE_OPTIONS':
-				case 'RESET_OPTIONS':
-				case 'PUBLISH_OPTIONS':
-					return {
-						...state,
-						...action.options,
-					};
+export const store = createReduxStore( STORE_NAME, {
+	reducer( state, action ) {
+		switch ( action.type ) {
+			case 'UPDATE_OPTIONS':
+			case 'RESET_OPTIONS':
+			case 'PUBLISH_OPTIONS':
+				return {
+					...state,
+					...action.options,
+				};
+		}
+
+		return state;
+	},
+
+	actions,
+
+	selectors: {
+		getOption( state, key ) {
+			return state ? state[ key ] : undefined;
+		},
+		hasLocalChanges( state ) {
+			return !! state && Object.keys( cache ).some( ( key ) => cache[ key ] !== state[ key ] );
+		},
+	},
+
+	resolvers: {
+		// eslint-disable-next-line no-unused-vars
+		*getOption( key ) {
+			if ( alreadyFetchedOptions ) {
+				return; // do nothing
 			}
 
-			return state;
+			let options;
+			try {
+				alreadyFetchedOptions = true;
+				options = yield actions.fetchOptions();
+			} catch ( error ) {
+				options = {};
+			}
+			cache = options;
+			return {
+				type: 'UPDATE_OPTIONS',
+				options,
+			};
 		},
+	},
 
-		actions,
-
-		selectors: {
-			getOption( state, key ) {
-				return state ? state[ key ] : undefined;
-			},
-			hasLocalChanges( state ) {
-				return !! state && Object.keys( cache ).some( ( key ) => cache[ key ] !== state[ key ] );
-			},
+	controls: {
+		IO_FETCH_OPTIONS() {
+			return apiFetch( { path: REST_PATH } );
 		},
-
-		resolvers: {
-			// eslint-disable-next-line no-unused-vars
-			*getOption( key ) {
-				if ( alreadyFetchedOptions ) {
-					return; // do nothing
-				}
-
-				let options;
-				try {
-					alreadyFetchedOptions = true;
-					options = yield actions.fetchOptions();
-				} catch ( error ) {
-					options = {};
-				}
-				cache = options;
-				return {
-					type: 'UPDATE_OPTIONS',
-					options,
-				};
-			},
+		IO_PUBLISH_OPTIONS( { options } ) {
+			cache = options; // optimistically update the cache
+			return apiFetch( {
+				path: REST_PATH,
+				method: 'POST',
+				data: {
+					...options,
+				},
+			} );
 		},
+	},
+} );
 
-		controls: {
-			IO_FETCH_OPTIONS() {
-				return apiFetch( { path: optionsPath } );
-			},
-			IO_PUBLISH_OPTIONS( { options } ) {
-				cache = options; // optimistically update the cache
-				return apiFetch( {
-					path: optionsPath,
-					method: 'POST',
-					data: {
-						...options,
-					},
-				} );
-			},
-		},
-	} );
-	register( store );
-	return store;
-};
+register( store );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See #74399 for more info

## Proposed Changes
Very simple PR which migrates global styles from registerStore to createReduxStore. The store is only used in one file, as far as I can tell.

## Testing Instructions
1. Sandbox a test site and sync the ETK build to your sandbox
2. Activate a theme with "jetpack-global-styles" support, such as Leven, on that site.
3. Access the editor -- Global Styles can be found by the typography icon in the top toolbar.
4. Verify that changing the fonts changes the fonts in the editor.
5. Verify that publishing the changes changes the fonts in both the editor and on the front end of the site.

