### PR TITLE
Migrate wpcom block editor sidebar to create redux store

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -15,19 +15,15 @@ import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
 import { get, isEmpty, partition } from 'lodash';
 import * as React from 'react';
-import { selectors as wpcomBlockEditorNavSidebarSelectors } from '../../../../wpcom-block-editor-nav-sidebar/src/store';
-import { STORE_KEY, POST_IDS_TO_EXCLUDE } from '../../constants';
+import { POST_IDS_TO_EXCLUDE } from '../../constants';
+import { store } from '../../store';
 import { Post } from '../../types';
 import CreatePage from '../create-page';
 import NavItem from '../nav-item';
 import SiteIcon from '../site-icon';
-import type { SelectFromMap } from '@automattic/data-stores';
 
 import './style.scss';
 
-type WpcomBlockEditorNavSidebarSelectors = SelectFromMap<
-	typeof wpcomBlockEditorNavSidebarSelectors
->;
 type CoreEditorPlaceholder = {
 	isEditedPostNew: ( ...args: unknown[] ) => boolean;
 	getCurrentPostId: ( ...args: unknown[] ) => number;
@@ -56,18 +52,18 @@ const Button = forwardRef(
 );
 
 function WpcomBlockEditorNavSidebar() {
-	const { toggleSidebar, setSidebarClosing } = useDispatch( STORE_KEY );
+	const { toggleSidebar, setSidebarClosing } = useDispatch( store );
 	const { isOpen, isClosing, postType, selectedItemId, siteTitle } = useSelect( ( select ) => {
 		const { getPostType, getSite } = select( 'core' ) as unknown as {
 			getPostType: ( postType: string ) => null | { slug: string };
 			getSite: () => null | { title: string };
 		};
 
-		const blockEditorNavSidebarSelect: WpcomBlockEditorNavSidebarSelectors = select( STORE_KEY );
+		const { isSidebarOpened, isSidebarClosing } = select( store );
 
 		return {
-			isOpen: blockEditorNavSidebarSelect.isSidebarOpened(),
-			isClosing: blockEditorNavSidebarSelect.isSidebarClosing(),
+			isOpen: isSidebarOpened(),
+			isClosing: isSidebarClosing(),
 			postType: getPostType(
 				( select( 'core/editor' ) as CoreEditorPlaceholder ).getCurrentPostType()
 			),

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -3,15 +3,9 @@ import { Button as OriginalButton } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-import { selectors as wpcomBlockEditorNavSidebarSelectors } from '../../../../wpcom-block-editor-nav-sidebar/src/store';
-import { STORE_KEY } from '../../constants';
+import { store } from '../../store';
 import SiteIcon from '../site-icon';
-import type { SelectFromMap } from '@automattic/data-stores';
 import './style.scss';
-
-type WpcomBlockEditorNavSidebarSelectors = SelectFromMap<
-	typeof wpcomBlockEditorNavSidebarSelectors
->;
 
 const Button = ( {
 	children,
@@ -21,11 +15,8 @@ const Button = ( {
 );
 
 export default function ToggleSidebarButton() {
-	const { toggleSidebar } = useDispatch( STORE_KEY );
-	const isSidebarOpen = useSelect(
-		( select ) => ( select( STORE_KEY ) as WpcomBlockEditorNavSidebarSelectors ).isSidebarOpened(),
-		[]
-	);
+	const { toggleSidebar } = useDispatch( store );
+	const isSidebarOpen = useSelect( ( select ) => select( store ).isSidebarOpened(), [] );
 
 	const handleClick = () => {
 		recordTracksEvent( `calypso_editor_sidebar_open` );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
@@ -1,3 +1,5 @@
+export const STORE_KEY = 'automattic/block-editor-nav-sidebar';
+
 declare global {
 	interface Window {
 		wpcomBlockEditorNavSidebar?: {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
@@ -1,5 +1,3 @@
-export const STORE_KEY = 'automattic/block-editor-nav-sidebar';
-
 declare global {
 	interface Window {
 		wpcomBlockEditorNavSidebar?: {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/store.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/store.ts
@@ -1,6 +1,5 @@
-import { combineReducers, registerStore } from '@wordpress/data';
+import { combineReducers, register, createReduxStore } from '@wordpress/data';
 import { actions, Action } from './actions';
-import { STORE_KEY } from './constants';
 import type { Reducer } from 'redux';
 
 const opened: Reducer< boolean, Action > = ( state = false, action ) => {
@@ -32,8 +31,10 @@ export const selectors = {
 	isSidebarClosing: ( state: State ) => state.closing,
 };
 
-registerStore( STORE_KEY, {
+export const store = createReduxStore( 'automattic/block-editor-nav-sidebar', {
 	actions,
 	reducer,
 	selectors,
 } );
+
+register( store );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/store.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/store.ts
@@ -1,5 +1,6 @@
 import { combineReducers, register, createReduxStore } from '@wordpress/data';
 import { actions, Action } from './actions';
+import { STORE_KEY } from './constants';
 import type { Reducer } from 'redux';
 
 const opened: Reducer< boolean, Action > = ( state = false, action ) => {
@@ -31,7 +32,7 @@ export const selectors = {
 	isSidebarClosing: ( state: State ) => state.closing,
 };
 
-export const store = createReduxStore( 'automattic/block-editor-nav-sidebar', {
+export const store = createReduxStore( STORE_KEY, {
 	actions,
 	reducer,
 	selectors,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See #74399 for more info

## Proposed Changes

Migrate wpcom block editor sidebar to `createReduxStore` instead of `registerStore`. (The latter is deprecated)

Note that I didn't change one place this store is used outside of the feature (in a nux package).

## Testing Instructions

- sandbox a test site and sync ETK to your sandbox
- verify that W sidebar on the post/page screen works correctly

