### PR TITLE
format-currency: Refactor to use createFormatter factory

### DIFF
--- a/packages/format-currency/README.md
+++ b/packages/format-currency/README.md
@@ -2,14 +2,34 @@
 
 A library for formatting currency.
 
-Exports two functions, `formatCurrency` and `getCurrencyObject`.
-
-`formatCurrency` is also the default export so either of these imports will work:
+The `formatCurrency` function is the main use of this package and is also the default export so any of these imports will work:
 
 ```
 import { formatCurrency } from '@automattic/format-currency';`
+formatCurrency( /* ... */ );
+
+// Or
 import formatCurrency from '@automattic/format-currency';`
+formatCurrency( /* ... */ );
+
+// Or
+import { createFormatter } from '@automattic/format-currency';`
+const formatter = createFormatter();
+formatter.formatCurrency( /* ... */ );
 ```
+
+The formatting functions exposed by this package are actually methods on a `CurrencyFormatter` object. A default global formatter is created by the package but you can create your own formatter by using the `createFormatter` function if you want more control.
+
+## createFormatter()
+
+`createFormatter(): CurrencyFormatter`
+
+Returns a formatter object that exposes the following methods:
+
+- `formatCurrency` (see below)
+- `getCurrencyObject` (see below)
+- `setDefaultLocale` (see below)
+- `setCurrencySymbol` (see below)
 
 ## formatCurrency()
 
@@ -40,6 +60,16 @@ Since rounding errors are common in floating point math, sometimes a price is pr
 `setDefaultLocale( locale: string ): void`
 
 A function that can be used to set a default locale for use by `formatCurrency()` and `getCurrencyObject()`. Note that this is global and will override any browser locale that is set! Use it with care.
+
+## setCurrencySymbol()
+
+`setCurrencySymbol( currencyCode: string, currencySymbol: string | undefined ): void`
+
+Change the currency symbol override used by formatting.
+
+By default, `formatCurrency` and `getCurrencyObject` use a currency symbol from a list of hard-coded overrides in this package keyed by the currency code. For example, `CAD` is always rendered as `C$` even if the locale is `en-CA` which would normally render the symbol `$`.
+
+With this function, you can change the override used by any given currency.
 
 ## FormatCurrencyOptions
 

--- a/packages/format-currency/README.md
+++ b/packages/format-currency/README.md
@@ -29,7 +29,6 @@ Returns a formatter object that exposes the following methods:
 - `formatCurrency` (see below)
 - `getCurrencyObject` (see below)
 - `setDefaultLocale` (see below)
-- `setCurrencySymbol` (see below)
 
 ## formatCurrency()
 
@@ -60,16 +59,6 @@ Since rounding errors are common in floating point math, sometimes a price is pr
 `setDefaultLocale( locale: string ): void`
 
 A function that can be used to set a default locale for use by `formatCurrency()` and `getCurrencyObject()`. Note that this is global and will override any browser locale that is set! Use it with care.
-
-## setCurrencySymbol()
-
-`setCurrencySymbol( currencyCode: string, currencySymbol: string | undefined ): void`
-
-Change the currency symbol override used by formatting.
-
-By default, `formatCurrency` and `getCurrencyObject` use a currency symbol from a list of hard-coded overrides in this package keyed by the currency code. For example, `CAD` is always rendered as `C$` even if the locale is `en-CA` which would normally render the symbol `$`.
-
-With this function, you can change the override used by any given currency.
 
 ## FormatCurrencyOptions
 

--- a/packages/format-currency/src/currencies.ts
+++ b/packages/format-currency/src/currencies.ts
@@ -1,8 +1,6 @@
-interface CurrencyOverride {
-	symbol?: string;
-}
+import type { CurrencyOverride } from './types';
 
-const CURRENCIES: Record< string, CurrencyOverride > = {
+export const defaultCurrencyOverrides: Record< string, CurrencyOverride > = {
 	AED: {
 		symbol: 'د.إ.‏',
 	},
@@ -438,7 +436,9 @@ const CURRENCIES: Record< string, CurrencyOverride > = {
 	UGX: {
 		symbol: 'USh',
 	},
-	USD: {},
+	USD: {
+		// No override. Do what the locale thinks is best.
+	},
 	UYU: {
 		symbol: '$U',
 	},
@@ -485,11 +485,3 @@ const CURRENCIES: Record< string, CurrencyOverride > = {
 		symbol: '₩',
 	},
 };
-
-export function getCurrencyOverride( code: string ): CurrencyOverride | undefined {
-	return CURRENCIES[ code ];
-}
-
-export function doesCurrencyExist( code: string ): boolean {
-	return Boolean( CURRENCIES[ code ] );
-}

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -1,21 +1,233 @@
-import { doesCurrencyExist, getCurrencyOverride } from './currencies';
-import type { CurrencyObject, CurrencyObjectOptions } from './types';
+import { defaultCurrencyOverrides } from './currencies';
+import type {
+	CurrencyObject,
+	CurrencyObjectOptions,
+	CurrencyFormatter,
+	CurrencyOverride,
+} from './types';
 
 export * from './types';
 
-let defaultLocale: string | undefined = undefined;
 const formatterCache = new Map< string, Intl.NumberFormat >();
 const fallbackLocale = 'en';
 const fallbackCurrency = 'USD';
 
-/**
- * Set a default locale for use by `formatCurrency` and `getCurrencyObject`.
- *
- * Note that this is global and will override any browser locale that is set!
- * Use it with care.
- */
-export function setDefaultLocale( locale: string | undefined ): void {
-	defaultLocale = locale;
+export function createFormatter(): CurrencyFormatter {
+	const currencyOverrides: Record< string, { symbol?: string | undefined } > = {};
+	let defaultLocale: string | undefined = undefined;
+
+	function getFormatter(
+		number: number,
+		code: string,
+		options: CurrencyObjectOptions
+	): Intl.NumberFormat {
+		const locale = options.locale ?? defaultLocale ?? getLocaleFromBrowser();
+
+		return getCachedFormatter( {
+			locale,
+			currency: code,
+			noDecimals: isNoDecimals( number, options ),
+		} );
+	}
+
+	/**
+	 * Formats money with a given currency code.
+	 *
+	 * The currency will define the properties to use for this formatting, but
+	 * those properties can be overridden using the options. Be careful when doing
+	 * this.
+	 *
+	 * For currencies that include decimals, this will always return the amount
+	 * with decimals included, even if those decimals are zeros. To exclude the
+	 * zeros, use the `stripZeros` option. For example, the function will normally
+	 * format `10.00` in `USD` as `$10.00` but when this option is true, it will
+	 * return `$10` instead.
+	 *
+	 * Since rounding errors are common in floating point math, sometimes a price
+	 * is provided as an integer in the smallest unit of a currency (eg: cents in
+	 * USD or yen in JPY). Set the `isSmallestUnit` to change the function to
+	 * operate on integer numbers instead. If this option is not set or false, the
+	 * function will format the amount `1025` in `USD` as `$1,025.00`, but when the
+	 * option is true, it will return `$10.25` instead.
+	 *
+	 * If the number is NaN, it will be treated as 0.
+	 *
+	 * If the currency code is not known, this will assume a default currency
+	 * similar to USD.
+	 *
+	 * If `isSmallestUnit` is set and the number is not an integer, it will be
+	 * rounded to an integer.
+	 *
+	 * @param      {number}                   number     number to format; assumed to be a float unless isSmallestUnit is set.
+	 * @param      {string}                   code       currency code e.g. 'USD'
+	 * @param      {CurrencyObjectOptions}    options    options object
+	 * @returns    {string}                  A formatted string.
+	 */
+	function formatCurrency(
+		number: number,
+		code: string,
+		options: CurrencyObjectOptions = {}
+	): string {
+		const locale = options.locale ?? defaultLocale ?? getLocaleFromBrowser();
+		code = getValidCurrency( code );
+		const currencyOverride = getCurrencyOverride( code );
+		const currencyPrecision = getPrecisionForLocaleAndCurrency( locale, code );
+
+		const numberAsFloat = prepareNumberForFormatting( number, currencyPrecision, options );
+		const formatter = getFormatter( numberAsFloat, code, options );
+		const parts = formatter.formatToParts( numberAsFloat );
+
+		return parts.reduce( ( formatted, part ) => {
+			switch ( part.type ) {
+				case 'currency':
+					if ( currencyOverride?.symbol ) {
+						return formatted + currencyOverride.symbol;
+					}
+					return formatted + part.value;
+				default:
+					return formatted + part.value;
+			}
+		}, '' );
+	}
+
+	/**
+	 * Returns a formatted price object.
+	 *
+	 * The currency will define the properties to use for this formatting, but
+	 * those properties can be overridden using the options. Be careful when doing
+	 * this.
+	 *
+	 * For currencies that include decimals, this will always return the amount
+	 * with decimals included, even if those decimals are zeros. To exclude the
+	 * zeros, use the `stripZeros` option. For example, the function will normally
+	 * format `10.00` in `USD` as `$10.00` but when this option is true, it will
+	 * return `$10` instead.
+	 *
+	 * Since rounding errors are common in floating point math, sometimes a price
+	 * is provided as an integer in the smallest unit of a currency (eg: cents in
+	 * USD or yen in JPY). Set the `isSmallestUnit` to change the function to
+	 * operate on integer numbers instead. If this option is not set or false, the
+	 * function will format the amount `1025` in `USD` as `$1,025.00`, but when the
+	 * option is true, it will return `$10.25` instead.
+	 *
+	 * Note that the `integer` return value of this function is not a number, but a
+	 * locale-formatted string which may include symbols like spaces, commas, or
+	 * periods as group separators. Similarly, the `fraction` property is a string
+	 * that contains the decimal separator.
+	 *
+	 * If the number is NaN, it will be treated as 0.
+	 *
+	 * If the currency code is not known, this will assume a default currency
+	 * similar to USD.
+	 *
+	 * If `isSmallestUnit` is set and the number is not an integer, it will be
+	 * rounded to an integer.
+	 *
+	 * @param      {number}                   number     number to format; assumed to be a float unless isSmallestUnit is set.
+	 * @param      {string}                   code       currency code e.g. 'USD'
+	 * @param      {CurrencyObjectOptions}    options    options object
+	 * @returns    {CurrencyObject}          A formatted string e.g. { symbol:'$', integer: '$99', fraction: '.99', sign: '-' }
+	 */
+	function getCurrencyObject(
+		number: number,
+		code: string,
+		options: CurrencyObjectOptions = {}
+	): CurrencyObject {
+		const locale = options.locale ?? defaultLocale ?? getLocaleFromBrowser();
+		code = getValidCurrency( code );
+		const currencyOverride = getCurrencyOverride( code );
+		const currencyPrecision = getPrecisionForLocaleAndCurrency( locale, code );
+
+		const numberAsFloat = prepareNumberForFormatting( number, currencyPrecision, options );
+		const formatter = getFormatter( numberAsFloat, code, options );
+		const parts = formatter.formatToParts( numberAsFloat );
+
+		let sign = '' as CurrencyObject[ 'sign' ];
+		let symbol = '$';
+		let symbolPosition = 'before' as CurrencyObject[ 'symbolPosition' ];
+		let hasAmountBeenSet = false;
+		let hasDecimalBeenSet = false;
+		let integer = '';
+		let fraction = '';
+
+		parts.forEach( ( part ) => {
+			switch ( part.type ) {
+				case 'currency':
+					symbol = currencyOverride?.symbol ?? part.value;
+					if ( hasAmountBeenSet ) {
+						symbolPosition = 'after';
+					}
+					return;
+				case 'group':
+					integer += part.value;
+					hasAmountBeenSet = true;
+					return;
+				case 'decimal':
+					fraction += part.value;
+					hasAmountBeenSet = true;
+					hasDecimalBeenSet = true;
+					return;
+				case 'integer':
+					integer += part.value;
+					hasAmountBeenSet = true;
+					return;
+				case 'fraction':
+					fraction += part.value;
+					hasAmountBeenSet = true;
+					hasDecimalBeenSet = true;
+					return;
+				case 'minusSign':
+					sign = '-' as CurrencyObject[ 'sign' ];
+					return;
+			}
+		} );
+
+		const hasNonZeroFraction = ! Number.isInteger( numberAsFloat ) && hasDecimalBeenSet;
+
+		return {
+			sign,
+			symbol,
+			symbolPosition,
+			integer,
+			fraction,
+			hasNonZeroFraction,
+		};
+	}
+
+	function getValidCurrency( code: string ): string {
+		if ( ! doesCurrencyExist( code ) ) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				`getCurrencyObject was called with a non-existent currency "${ code }"; falling back to ${ fallbackCurrency }`
+			);
+			return fallbackCurrency;
+		}
+		return code;
+	}
+
+	function getCurrencyOverride( code: string ): CurrencyOverride | undefined {
+		return currencyOverrides[ code ] ?? defaultCurrencyOverrides[ code ];
+	}
+
+	function doesCurrencyExist( code: string ): boolean {
+		return Boolean( getCurrencyOverride( code ) );
+	}
+
+	/**
+	 * Set a default locale for use by `formatCurrency` and `getCurrencyObject`.
+	 *
+	 * Note that this is global and will override any browser locale that is set!
+	 * Use it with care.
+	 */
+	function setDefaultLocale( locale: string | undefined ): void {
+		defaultLocale = locale;
+	}
+
+	return {
+		formatCurrency,
+		getCurrencyObject,
+		setDefaultLocale,
+	};
 }
 
 function getLocaleFromBrowser() {
@@ -26,17 +238,6 @@ function getLocaleFromBrowser() {
 		return window.navigator.languages[ 0 ];
 	}
 	return window.navigator?.language ?? fallbackLocale;
-}
-
-function getValidCurrency( code: string ): string {
-	if ( ! doesCurrencyExist( code ) ) {
-		// eslint-disable-next-line no-console
-		console.warn(
-			`getCurrencyObject was called with a non-existent currency "${ code }"; falling back to ${ fallbackCurrency }`
-		);
-		return fallbackCurrency;
-	}
-	return code;
 }
 
 function getFormatterCacheKey( {
@@ -163,184 +364,6 @@ function prepareNumberForFormatting(
 	return Math.round( number * scale ) / scale;
 }
 
-function getFormatter(
-	number: number,
-	code: string,
-	options: CurrencyObjectOptions
-): Intl.NumberFormat {
-	const locale = options.locale ?? defaultLocale ?? getLocaleFromBrowser();
-
-	return getCachedFormatter( {
-		locale,
-		currency: code,
-		noDecimals: isNoDecimals( number, options ),
-	} );
-}
-
-/**
- * Formats money with a given currency code.
- *
- * The currency will define the properties to use for this formatting, but
- * those properties can be overridden using the options. Be careful when doing
- * this.
- *
- * For currencies that include decimals, this will always return the amount
- * with decimals included, even if those decimals are zeros. To exclude the
- * zeros, use the `stripZeros` option. For example, the function will normally
- * format `10.00` in `USD` as `$10.00` but when this option is true, it will
- * return `$10` instead.
- *
- * Since rounding errors are common in floating point math, sometimes a price
- * is provided as an integer in the smallest unit of a currency (eg: cents in
- * USD or yen in JPY). Set the `isSmallestUnit` to change the function to
- * operate on integer numbers instead. If this option is not set or false, the
- * function will format the amount `1025` in `USD` as `$1,025.00`, but when the
- * option is true, it will return `$10.25` instead.
- *
- * If the number is NaN, it will be treated as 0.
- *
- * If the currency code is not known, this will assume a default currency
- * similar to USD.
- *
- * If `isSmallestUnit` is set and the number is not an integer, it will be
- * rounded to an integer.
- *
- * @param      {number}                   number     number to format; assumed to be a float unless isSmallestUnit is set.
- * @param      {string}                   code       currency code e.g. 'USD'
- * @param      {CurrencyObjectOptions}    options    options object
- * @returns    {string}                  A formatted string.
- */
-export function formatCurrency(
-	number: number,
-	code: string,
-	options: CurrencyObjectOptions = {}
-): string {
-	const locale = options.locale ?? defaultLocale ?? getLocaleFromBrowser();
-	code = getValidCurrency( code );
-	const currencyOverride = getCurrencyOverride( code );
-	const currencyPrecision = getPrecisionForLocaleAndCurrency( locale, code );
-
-	const numberAsFloat = prepareNumberForFormatting( number, currencyPrecision, options );
-	const formatter = getFormatter( numberAsFloat, code, options );
-	const parts = formatter.formatToParts( numberAsFloat );
-
-	return parts.reduce( ( formatted, part ) => {
-		switch ( part.type ) {
-			case 'currency':
-				if ( currencyOverride?.symbol ) {
-					return formatted + currencyOverride.symbol;
-				}
-				return formatted + part.value;
-			default:
-				return formatted + part.value;
-		}
-	}, '' );
-}
-
-/**
- * Returns a formatted price object.
- *
- * The currency will define the properties to use for this formatting, but
- * those properties can be overridden using the options. Be careful when doing
- * this.
- *
- * For currencies that include decimals, this will always return the amount
- * with decimals included, even if those decimals are zeros. To exclude the
- * zeros, use the `stripZeros` option. For example, the function will normally
- * format `10.00` in `USD` as `$10.00` but when this option is true, it will
- * return `$10` instead.
- *
- * Since rounding errors are common in floating point math, sometimes a price
- * is provided as an integer in the smallest unit of a currency (eg: cents in
- * USD or yen in JPY). Set the `isSmallestUnit` to change the function to
- * operate on integer numbers instead. If this option is not set or false, the
- * function will format the amount `1025` in `USD` as `$1,025.00`, but when the
- * option is true, it will return `$10.25` instead.
- *
- * Note that the `integer` return value of this function is not a number, but a
- * locale-formatted string which may include symbols like spaces, commas, or
- * periods as group separators. Similarly, the `fraction` property is a string
- * that contains the decimal separator.
- *
- * If the number is NaN, it will be treated as 0.
- *
- * If the currency code is not known, this will assume a default currency
- * similar to USD.
- *
- * If `isSmallestUnit` is set and the number is not an integer, it will be
- * rounded to an integer.
- *
- * @param      {number}                   number     number to format; assumed to be a float unless isSmallestUnit is set.
- * @param      {string}                   code       currency code e.g. 'USD'
- * @param      {CurrencyObjectOptions}    options    options object
- * @returns    {CurrencyObject}          A formatted string e.g. { symbol:'$', integer: '$99', fraction: '.99', sign: '-' }
- */
-export function getCurrencyObject(
-	number: number,
-	code: string,
-	options: CurrencyObjectOptions = {}
-): CurrencyObject {
-	const locale = options.locale ?? defaultLocale ?? getLocaleFromBrowser();
-	code = getValidCurrency( code );
-	const currencyOverride = getCurrencyOverride( code );
-	const currencyPrecision = getPrecisionForLocaleAndCurrency( locale, code );
-
-	const numberAsFloat = prepareNumberForFormatting( number, currencyPrecision, options );
-	const formatter = getFormatter( numberAsFloat, code, options );
-	const parts = formatter.formatToParts( numberAsFloat );
-
-	let sign = '' as CurrencyObject[ 'sign' ];
-	let symbol = '$';
-	let symbolPosition = 'before' as CurrencyObject[ 'symbolPosition' ];
-	let hasAmountBeenSet = false;
-	let hasDecimalBeenSet = false;
-	let integer = '';
-	let fraction = '';
-
-	parts.forEach( ( part ) => {
-		switch ( part.type ) {
-			case 'currency':
-				symbol = currencyOverride?.symbol ?? part.value;
-				if ( hasAmountBeenSet ) {
-					symbolPosition = 'after';
-				}
-				return;
-			case 'group':
-				integer += part.value;
-				hasAmountBeenSet = true;
-				return;
-			case 'decimal':
-				fraction += part.value;
-				hasAmountBeenSet = true;
-				hasDecimalBeenSet = true;
-				return;
-			case 'integer':
-				integer += part.value;
-				hasAmountBeenSet = true;
-				return;
-			case 'fraction':
-				fraction += part.value;
-				hasAmountBeenSet = true;
-				hasDecimalBeenSet = true;
-				return;
-			case 'minusSign':
-				sign = '-' as CurrencyObject[ 'sign' ];
-				return;
-		}
-	} );
-
-	const hasNonZeroFraction = ! Number.isInteger( numberAsFloat ) && hasDecimalBeenSet;
-
-	return {
-		sign,
-		symbol,
-		symbolPosition,
-		integer,
-		fraction,
-		hasNonZeroFraction,
-	};
-}
-
 function convertPriceForSmallestUnit( price: number, precision: number ): number {
 	return price / getSmallestUnitDivisor( precision );
 }
@@ -349,4 +372,22 @@ function getSmallestUnitDivisor( precision: number ): number {
 	return 10 ** precision;
 }
 
-export default formatCurrency;
+const defaultFormatter = createFormatter();
+
+export function formatCurrency( ...args: Parameters< typeof defaultFormatter.formatCurrency > ) {
+	return defaultFormatter.formatCurrency( ...args );
+}
+
+export function getCurrencyObject(
+	...args: Parameters< typeof defaultFormatter.getCurrencyObject >
+) {
+	return defaultFormatter.getCurrencyObject( ...args );
+}
+
+export function setDefaultLocale(
+	...args: Parameters< typeof defaultFormatter.setDefaultLocale >
+) {
+	return defaultFormatter.setDefaultLocale( ...args );
+}
+
+export default defaultFormatter.formatCurrency;

--- a/packages/format-currency/src/types.ts
+++ b/packages/format-currency/src/types.ts
@@ -1,3 +1,21 @@
+export interface CurrencyFormatter {
+	setDefaultLocale: ( locale: string ) => void;
+	formatCurrency: (
+		amount: number,
+		currencyCode: string,
+		options?: CurrencyObjectOptions
+	) => string;
+	getCurrencyObject: (
+		amount: number,
+		currencyCode: string,
+		options?: CurrencyObjectOptions
+	) => CurrencyObject;
+}
+
+export interface CurrencyOverride {
+	symbol?: string;
+}
+
 export interface CurrencyObjectOptions {
 	/**
 	 * The symbol separating the thousands part of an amount from its hundreds.

--- a/packages/format-currency/test/index.ts
+++ b/packages/format-currency/test/index.ts
@@ -1,327 +1,398 @@
-import formatCurrency, { getCurrencyObject, setDefaultLocale } from '../src';
+import formatCurrency, { getCurrencyObject, createFormatter } from '../src';
+import type { CurrencyFormatter } from '../src/types';
 
-describe( 'formatCurrency', () => {
+describe( 'formatCurrency default export', () => {
 	test( 'formats a number to localized currency', () => {
 		const money = formatCurrency( 99.32, 'USD' );
 		expect( money ).toBe( '$99.32' );
 	} );
+} );
+
+describe( 'getCurrencyObject default export', () => {
+	test( 'handles negative values', () => {
+		const money = getCurrencyObject( -1234.56789, 'USD' );
+		expect( money ).toEqual( {
+			symbol: '$',
+			symbolPosition: 'before',
+			integer: '1,234',
+			fraction: '.57',
+			sign: '-',
+			hasNonZeroFraction: true,
+		} );
+	} );
+} );
+
+describe( 'formatCurrency', () => {
+	let formatter: CurrencyFormatter;
+	beforeEach( () => {
+		formatter = createFormatter();
+	} );
+
+	test( 'formats a number to localized currency', () => {
+		const money = formatter.formatCurrency( 99.32, 'USD' );
+		expect( money ).toBe( '$99.32' );
+	} );
 
 	test( 'adds a localized thousands separator', () => {
-		const money = formatCurrency( 9800900.32, 'USD' );
+		const money = formatter.formatCurrency( 9800900.32, 'USD' );
 		expect( money ).toBe( '$9,800,900.32' );
 	} );
 
 	test( 'handles zero', () => {
-		const money = formatCurrency( 0, 'USD' );
+		const money = formatter.formatCurrency( 0, 'USD' );
 		expect( money ).toBe( '$0.00' );
 
-		const money2 = formatCurrency( 0, 'USD', { stripZeros: true } );
+		const money2 = formatter.formatCurrency( 0, 'USD', { stripZeros: true } );
 		expect( money2 ).toBe( '$0' );
 
-		const money3 = formatCurrency( 0, 'EUR', { locale: 'en-US' } );
+		const money3 = formatter.formatCurrency( 0, 'EUR', { locale: 'en-US' } );
 		expect( money3 ).toBe( '€0.00' );
 
-		const money4 = formatCurrency( 0, 'EUR', { stripZeros: true } );
+		const money4 = formatter.formatCurrency( 0, 'EUR', { stripZeros: true } );
 		expect( money4 ).toBe( '€0' );
 	} );
 
 	test( 'handles negative values', () => {
-		const money = formatCurrency( -1234.56789, 'USD' );
+		const money = formatter.formatCurrency( -1234.56789, 'USD' );
 		expect( money ).toBe( '-$1,234.57' );
 	} );
 
 	test( 'unknown currency codes return default', () => {
-		const money = formatCurrency( 9800900.32, '' );
+		const money = formatter.formatCurrency( 9800900.32, '' );
 		expect( money ).toBe( '$9,800,900.32' );
 	} );
 
 	test( 'unknown locale codes return default', () => {
-		const money = formatCurrency( 9800900.32, 'USD', { locale: 'foo-bar' } );
+		const money = formatter.formatCurrency( 9800900.32, 'USD', { locale: 'foo-bar' } );
 		expect( money ).toBe( '$9,800,900.32' );
 	} );
 
 	test( 'formats a number to localized currency for smallest unit', () => {
-		const money = formatCurrency( 9932, 'USD', { isSmallestUnit: true } );
+		const money = formatter.formatCurrency( 9932, 'USD', { isSmallestUnit: true } );
 		expect( money ).toBe( '$99.32' );
 	} );
 
 	test( 'formats a number to localized currency for smallest unit for non-decimal currency', () => {
-		const money = formatCurrency( 9932, 'JPY', { isSmallestUnit: true } );
+		const money = formatter.formatCurrency( 9932, 'JPY', { isSmallestUnit: true } );
 		expect( money ).toBe( '¥9,932' );
 	} );
 
 	test( 'formats a rounded number if the number is a float and smallest unit is true', () => {
-		const money = formatCurrency( 9932.1, 'USD', { isSmallestUnit: true } );
+		const money = formatter.formatCurrency( 9932.1, 'USD', { isSmallestUnit: true } );
 		expect( money ).toBe( '$99.32' );
 	} );
 
 	test( 'returns no trailing zero cents when stripZeros set to true (USD)', () => {
-		const money = formatCurrency( 9800900, 'USD', {} );
+		const money = formatter.formatCurrency( 9800900, 'USD', {} );
 		expect( money ).toBe( '$9,800,900.00' );
 
 		// Trailing zero cents should be removed.
-		const money2 = formatCurrency( 9800900, 'USD', { stripZeros: true } );
+		const money2 = formatter.formatCurrency( 9800900, 'USD', { stripZeros: true } );
 		expect( money2 ).toBe( '$9,800,900' );
 
 		// It should not strip non-zero cents.
-		const money3 = formatCurrency( 9800900.32, 'USD', { stripZeros: true } );
+		const money3 = formatter.formatCurrency( 9800900.32, 'USD', { stripZeros: true } );
 		expect( money3 ).toBe( '$9,800,900.32' );
 	} );
 
 	test( 'returns no trailing zero cents when stripZeros set to true (EUR)', () => {
-		const money = formatCurrency( 9800900, 'EUR', { locale: 'de-DE' } );
+		const money = formatter.formatCurrency( 9800900, 'EUR', { locale: 'de-DE' } );
 		expect( money ).toBe( '9.800.900,00 €' );
 
 		// Trailing zero cents should be removed.
-		const money2 = formatCurrency( 9800900, 'EUR', { locale: 'de-DE', stripZeros: true } );
+		const money2 = formatter.formatCurrency( 9800900, 'EUR', {
+			locale: 'de-DE',
+			stripZeros: true,
+		} );
 		expect( money2 ).toBe( '9.800.900 €' );
 
 		// It should not strip non-zero cents.
-		const money3 = formatCurrency( 9800900.32, 'EUR', { locale: 'de-DE', stripZeros: true } );
+		const money3 = formatter.formatCurrency( 9800900.32, 'EUR', {
+			locale: 'de-DE',
+			stripZeros: true,
+		} );
 		expect( money3 ).toBe( '9.800.900,32 €' );
 	} );
 
 	test( 'returns a number in latin numbers even for locales which default to other character sets', () => {
-		const money = formatCurrency( 9800900, 'INR', { locale: 'mr-IN' } );
+		const money = formatter.formatCurrency( 9800900, 'INR', { locale: 'mr-IN' } );
 		expect( money ).toBe( '₹9,800,900.00' );
 	} );
 
-	describe( 'supported currencies', () => {
+	describe( 'specific currencies', () => {
 		beforeEach( () => {
-			setDefaultLocale( undefined );
+			formatter.setCurrencySymbol( 'USD', undefined );
 		} );
 
 		test( 'USD', () => {
-			const money = formatCurrency( 9800900.32, 'USD' );
+			const money = formatter.formatCurrency( 9800900.32, 'USD' );
 			expect( money ).toBe( '$9,800,900.32' );
 		} );
+		test( 'USD with the currency symbol overridden', () => {
+			formatter.setCurrencySymbol( 'USD', 'US$' );
+			const money = formatter.formatCurrency( 9800900.32, 'USD' );
+			expect( money ).toBe( 'US$9,800,900.32' );
+		} );
 		test( 'USD in Canadian English', () => {
-			const money = formatCurrency( 9800900.32, 'USD', { locale: 'en-CA' } );
+			const money = formatter.formatCurrency( 9800900.32, 'USD', { locale: 'en-CA' } );
 			expect( money ).toBe( 'US$9,800,900.32' );
 		} );
 		test( 'AUD', () => {
-			const money = formatCurrency( 9800900.32, 'AUD' );
+			const money = formatter.formatCurrency( 9800900.32, 'AUD' );
 			expect( money ).toBe( 'A$9,800,900.32' );
 		} );
 		test( 'CAD in Canadian English', () => {
-			const money = formatCurrency( 9800900.32, 'CAD', { locale: 'en-CA' } );
+			const money = formatter.formatCurrency( 9800900.32, 'CAD', { locale: 'en-CA' } );
 			expect( money ).toBe( 'C$9,800,900.32' );
 		} );
 		test( 'CAD in US English', () => {
-			const money = formatCurrency( 9800900.32, 'CAD', { locale: 'en-US' } );
+			const money = formatter.formatCurrency( 9800900.32, 'CAD', { locale: 'en-US' } );
 			expect( money ).toBe( 'C$9,800,900.32' );
 		} );
 		test( 'CAD in Canadian French', () => {
-			const money = formatCurrency( 9800900.32, 'CAD', { locale: 'fr-CA' } );
+			const money = formatter.formatCurrency( 9800900.32, 'CAD', { locale: 'fr-CA' } );
 			expect( money ).toBe( '9 800 900,32 C$' );
 		} );
 		test( 'EUR in EN locale', () => {
-			const money = formatCurrency( 9800900.32, 'EUR', { locale: 'en-US' } );
+			const money = formatter.formatCurrency( 9800900.32, 'EUR', { locale: 'en-US' } );
 			expect( money ).toBe( '€9,800,900.32' );
 		} );
 		test( 'EUR in DE locale set by setDefaultLocale', () => {
-			setDefaultLocale( 'de-DE' );
-			const money = formatCurrency( 9800900.32, 'EUR' );
+			formatter.setDefaultLocale( 'de-DE' );
+			const money = formatter.formatCurrency( 9800900.32, 'EUR' );
 			expect( money ).toBe( '9.800.900,32 €' );
 		} );
 		test( 'EUR in DE locale', () => {
-			const money = formatCurrency( 9800900.32, 'EUR', { locale: 'de-DE' } );
+			const money = formatter.formatCurrency( 9800900.32, 'EUR', { locale: 'de-DE' } );
 			expect( money ).toBe( '9.800.900,32 €' );
 		} );
 		test( 'EUR in FR locale', () => {
-			const money = formatCurrency( 9800900.32, 'EUR', { locale: 'fr-FR' } );
+			const money = formatter.formatCurrency( 9800900.32, 'EUR', { locale: 'fr-FR' } );
 			expect( money ).toBe( '9 800 900,32 €' );
 		} );
 		test( 'GBP', () => {
-			const money = formatCurrency( 9800900.32, 'GBP' );
+			const money = formatter.formatCurrency( 9800900.32, 'GBP' );
 			expect( money ).toBe( '£9,800,900.32' );
 		} );
 		test( 'JPY', () => {
-			const money = formatCurrency( 9800900.32, 'JPY' );
+			const money = formatter.formatCurrency( 9800900.32, 'JPY' );
 			expect( money ).toBe( '¥9,800,900' );
 		} );
 		test( 'BRL in EN locale', () => {
-			const money = formatCurrency( 9800900.32, 'BRL', { locale: 'en-US' } );
+			const money = formatter.formatCurrency( 9800900.32, 'BRL', { locale: 'en-US' } );
 			expect( money ).toBe( 'R$9,800,900.32' );
 		} );
 		test( 'BRL in PT locale', () => {
-			const money = formatCurrency( 9800900.32, 'BRL', { locale: 'pt-BR' } );
+			const money = formatter.formatCurrency( 9800900.32, 'BRL', { locale: 'pt-BR' } );
 			expect( money ).toBe( 'R$ 9.800.900,32' );
 		} );
 		test( 'IDR', () => {
-			const money = formatCurrency( 107280000, 'IDR', { locale: 'in-ID', isSmallestUnit: true } );
+			const money = formatter.formatCurrency( 107280000, 'IDR', {
+				locale: 'in-ID',
+				isSmallestUnit: true,
+			} );
 			expect( money ).toBe( 'Rp 1.072.800,00' );
 		} );
 	} );
+} );
 
-	describe( 'getCurrencyObject()', () => {
-		test( 'handles zero', () => {
-			const money = getCurrencyObject( 0, 'USD' );
-			expect( money ).toEqual( {
-				symbol: '$',
-				symbolPosition: 'before',
-				integer: '0',
-				fraction: '.00',
-				sign: '',
-				hasNonZeroFraction: false,
-			} );
+describe( 'getCurrencyObject()', () => {
+	let formatter: CurrencyFormatter;
+	beforeEach( () => {
+		formatter = createFormatter();
+	} );
+
+	test( 'handles zero', () => {
+		const money = formatter.getCurrencyObject( 0, 'USD' );
+		expect( money ).toEqual( {
+			symbol: '$',
+			symbolPosition: 'before',
+			integer: '0',
+			fraction: '.00',
+			sign: '',
+			hasNonZeroFraction: false,
 		} );
+	} );
 
-		test( 'handles negative values', () => {
-			const money = getCurrencyObject( -1234.56789, 'USD' );
-			expect( money ).toEqual( {
-				symbol: '$',
-				symbolPosition: 'before',
-				integer: '1,234',
-				fraction: '.57',
-				sign: '-',
-				hasNonZeroFraction: true,
-			} );
+	test( 'handles negative values', () => {
+		const money = formatter.getCurrencyObject( -1234.56789, 'USD' );
+		expect( money ).toEqual( {
+			symbol: '$',
+			symbolPosition: 'before',
+			integer: '1,234',
+			fraction: '.57',
+			sign: '-',
+			hasNonZeroFraction: true,
 		} );
+	} );
 
-		test( 'handles values that round up', () => {
-			const money = getCurrencyObject( 9.99876, 'USD' );
-			expect( money ).toEqual( {
-				symbol: '$',
-				symbolPosition: 'before',
-				integer: '10',
-				fraction: '.00',
-				sign: '',
-				hasNonZeroFraction: false,
-			} );
+	test( 'handles values that round up', () => {
+		const money = formatter.getCurrencyObject( 9.99876, 'USD' );
+		expect( money ).toEqual( {
+			symbol: '$',
+			symbolPosition: 'before',
+			integer: '10',
+			fraction: '.00',
+			sign: '',
+			hasNonZeroFraction: false,
 		} );
+	} );
 
-		test( 'handles values that round down', () => {
-			const money = getCurrencyObject( 9.99432, 'USD' );
-			expect( money ).toEqual( {
-				symbol: '$',
-				symbolPosition: 'before',
-				integer: '9',
-				fraction: '.99',
-				sign: '',
-				hasNonZeroFraction: true,
-			} );
+	test( 'handles values that round down', () => {
+		const money = formatter.getCurrencyObject( 9.99432, 'USD' );
+		expect( money ).toEqual( {
+			symbol: '$',
+			symbolPosition: 'before',
+			integer: '9',
+			fraction: '.99',
+			sign: '',
+			hasNonZeroFraction: true,
 		} );
+	} );
 
-		test( 'handles a number in the smallest unit', () => {
-			const money = getCurrencyObject( 9932, 'USD', { isSmallestUnit: true } );
+	test( 'handles a number in the smallest unit', () => {
+		const money = formatter.getCurrencyObject( 9932, 'USD', { isSmallestUnit: true } );
+		expect( money ).toEqual( {
+			symbol: '$',
+			symbolPosition: 'before',
+			integer: '99',
+			fraction: '.32',
+			sign: '',
+			hasNonZeroFraction: true,
+		} );
+	} );
+
+	test( 'handles a number in the smallest unit for non-decimal currency', () => {
+		const money = formatter.getCurrencyObject( 9932, 'JPY', { isSmallestUnit: true } );
+		expect( money ).toEqual( {
+			symbol: '¥',
+			symbolPosition: 'before',
+			integer: '9,932',
+			fraction: '',
+			sign: '',
+			hasNonZeroFraction: false,
+		} );
+	} );
+
+	test( 'handles the number as rounded if the number is a float and smallest unit is set', () => {
+		const money = formatter.getCurrencyObject( 9932.1, 'USD', { isSmallestUnit: true } );
+		expect( money ).toEqual( {
+			symbol: '$',
+			symbolPosition: 'before',
+			integer: '99',
+			fraction: '.32',
+			sign: '',
+			hasNonZeroFraction: true,
+		} );
+	} );
+
+	describe( 'specific currencies', () => {
+		test( 'USD', () => {
+			const money = formatter.getCurrencyObject( 9800900.32, 'USD' );
 			expect( money ).toEqual( {
 				symbol: '$',
 				symbolPosition: 'before',
-				integer: '99',
+				integer: '9,800,900',
 				fraction: '.32',
 				sign: '',
 				hasNonZeroFraction: true,
 			} );
 		} );
 
-		test( 'handles a number in the smallest unit for non-decimal currency', () => {
-			const money = getCurrencyObject( 9932, 'JPY', { isSmallestUnit: true } );
+		test( 'USD with the currency symbol overridden', () => {
+			formatter.setCurrencySymbol( 'USD', 'US$' );
+			const money = formatter.getCurrencyObject( 9800900.32, 'USD' );
+			expect( money ).toEqual( {
+				symbol: 'US$',
+				symbolPosition: 'before',
+				integer: '9,800,900',
+				fraction: '.32',
+				sign: '',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'USD in Canadian English', () => {
+			const money = formatter.getCurrencyObject( 9800900.32, 'USD', { locale: 'en-CA' } );
+			expect( money ).toEqual( {
+				symbol: 'US$',
+				symbolPosition: 'before',
+				integer: '9,800,900',
+				fraction: '.32',
+				sign: '',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'AUD', () => {
+			const money = formatter.getCurrencyObject( 9800900.32, 'AUD' );
+			expect( money ).toEqual( {
+				symbol: 'A$',
+				symbolPosition: 'before',
+				integer: '9,800,900',
+				fraction: '.32',
+				sign: '',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'CAD', () => {
+			const money = formatter.getCurrencyObject( 9800900.32, 'CAD', { locale: 'en-US' } );
+			expect( money ).toEqual( {
+				symbol: 'C$',
+				symbolPosition: 'before',
+				integer: '9,800,900',
+				fraction: '.32',
+				sign: '',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'EUR', () => {
+			const money = formatter.getCurrencyObject( 9800900.32, 'EUR', { locale: 'de-DE' } );
+			expect( money ).toEqual( {
+				symbol: '€',
+				symbolPosition: 'after',
+				integer: '9.800.900',
+				fraction: ',32',
+				sign: '',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'GBP', () => {
+			const money = formatter.getCurrencyObject( 9800900.32, 'GBP' );
+			expect( money ).toEqual( {
+				symbol: '£',
+				symbolPosition: 'before',
+				integer: '9,800,900',
+				fraction: '.32',
+				sign: '',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'JPY', () => {
+			const money = formatter.getCurrencyObject( 9800900.32, 'JPY' );
 			expect( money ).toEqual( {
 				symbol: '¥',
 				symbolPosition: 'before',
-				integer: '9,932',
+				integer: '9,800,900',
 				fraction: '',
 				sign: '',
 				hasNonZeroFraction: false,
 			} );
 		} );
 
-		test( 'handles the number as rounded if the number is a float and smallest unit is set', () => {
-			const money = getCurrencyObject( 9932.1, 'USD', { isSmallestUnit: true } );
+		test( 'BRL', () => {
+			const money = formatter.getCurrencyObject( 9800900.32, 'BRL', { locale: 'pt-BR' } );
 			expect( money ).toEqual( {
-				symbol: '$',
+				symbol: 'R$',
 				symbolPosition: 'before',
-				integer: '99',
-				fraction: '.32',
+				integer: '9.800.900',
+				fraction: ',32',
 				sign: '',
 				hasNonZeroFraction: true,
-			} );
-		} );
-
-		describe( 'supported currencies', () => {
-			test( 'USD', () => {
-				const money = getCurrencyObject( 9800900.32, 'USD' );
-				expect( money ).toEqual( {
-					symbol: '$',
-					symbolPosition: 'before',
-					integer: '9,800,900',
-					fraction: '.32',
-					sign: '',
-					hasNonZeroFraction: true,
-				} );
-			} );
-
-			test( 'AUD', () => {
-				const money = getCurrencyObject( 9800900.32, 'AUD' );
-				expect( money ).toEqual( {
-					symbol: 'A$',
-					symbolPosition: 'before',
-					integer: '9,800,900',
-					fraction: '.32',
-					sign: '',
-					hasNonZeroFraction: true,
-				} );
-			} );
-
-			test( 'CAD', () => {
-				const money = getCurrencyObject( 9800900.32, 'CAD', { locale: 'en-US' } );
-				expect( money ).toEqual( {
-					symbol: 'C$',
-					symbolPosition: 'before',
-					integer: '9,800,900',
-					fraction: '.32',
-					sign: '',
-					hasNonZeroFraction: true,
-				} );
-			} );
-
-			test( 'EUR', () => {
-				const money = getCurrencyObject( 9800900.32, 'EUR', { locale: 'de-DE' } );
-				expect( money ).toEqual( {
-					symbol: '€',
-					symbolPosition: 'after',
-					integer: '9.800.900',
-					fraction: ',32',
-					sign: '',
-					hasNonZeroFraction: true,
-				} );
-			} );
-
-			test( 'GBP', () => {
-				const money = getCurrencyObject( 9800900.32, 'GBP' );
-				expect( money ).toEqual( {
-					symbol: '£',
-					symbolPosition: 'before',
-					integer: '9,800,900',
-					fraction: '.32',
-					sign: '',
-					hasNonZeroFraction: true,
-				} );
-			} );
-
-			test( 'JPY', () => {
-				const money = getCurrencyObject( 9800900.32, 'JPY' );
-				expect( money ).toEqual( {
-					symbol: '¥',
-					symbolPosition: 'before',
-					integer: '9,800,900',
-					fraction: '',
-					sign: '',
-					hasNonZeroFraction: false,
-				} );
-			} );
-
-			test( 'BRL', () => {
-				const money = getCurrencyObject( 9800900.32, 'BRL', { locale: 'pt-BR' } );
-				expect( money ).toEqual( {
-					symbol: 'R$',
-					symbolPosition: 'before',
-					integer: '9.800.900',
-					fraction: ',32',
-					sign: '',
-					hasNonZeroFraction: true,
-				} );
 			} );
 		} );
 	} );

--- a/packages/format-currency/test/index.ts
+++ b/packages/format-currency/test/index.ts
@@ -120,18 +120,9 @@ describe( 'formatCurrency', () => {
 	} );
 
 	describe( 'specific currencies', () => {
-		beforeEach( () => {
-			formatter.setCurrencySymbol( 'USD', undefined );
-		} );
-
 		test( 'USD', () => {
 			const money = formatter.formatCurrency( 9800900.32, 'USD' );
 			expect( money ).toBe( '$9,800,900.32' );
-		} );
-		test( 'USD with the currency symbol overridden', () => {
-			formatter.setCurrencySymbol( 'USD', 'US$' );
-			const money = formatter.formatCurrency( 9800900.32, 'USD' );
-			expect( money ).toBe( 'US$9,800,900.32' );
 		} );
 		test( 'USD in Canadian English', () => {
 			const money = formatter.formatCurrency( 9800900.32, 'USD', { locale: 'en-CA' } );
@@ -291,19 +282,6 @@ describe( 'getCurrencyObject()', () => {
 			const money = formatter.getCurrencyObject( 9800900.32, 'USD' );
 			expect( money ).toEqual( {
 				symbol: '$',
-				symbolPosition: 'before',
-				integer: '9,800,900',
-				fraction: '.32',
-				sign: '',
-				hasNonZeroFraction: true,
-			} );
-		} );
-
-		test( 'USD with the currency symbol overridden', () => {
-			formatter.setCurrencySymbol( 'USD', 'US$' );
-			const money = formatter.getCurrencyObject( 9800900.32, 'USD' );
-			expect( money ).toEqual( {
-				symbol: 'US$',
 				symbolPosition: 'before',
 				integer: '9,800,900',
 				fraction: '.32',


### PR DESCRIPTION
## Proposed Changes

This PR refactors how the `@automattic/format-currency` library is organized. Previously it was a set of standalone functions (mainly the `formatCurrency()` default export). However, over time it has gained some persistent state, like the addition of `setDefaultLocale()`. That state has been stored globally. As the package is likely to gain more persistent state over time (eg: https://github.com/Automattic/wp-calypso/pull/74351 which allows setting currency overrides) and global state makes things like testing somewhat difficult, this PR refactors the package to move all the formatting functions into methods of a "CurrencyFormatter" object created by the `createFormatter()` factory function.

In order to preserve backwards compatibility, this PR adds a default global `CurrencyFormatter` and exports aliases of each of its methods so they will continue to work as before. However, it gives more control to any code that wants to use a fresh formatter without influencing the global state.

## Testing Instructions

Automated tests should cover everything.

View a page that has prices (eg: `/plans` or `/checkout`) and verify that the prices are still shown.