### PR TITLE
Migrate wpcom global styles to createReduxStore

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.js
@@ -5,7 +5,6 @@ import domReady from '@wordpress/dom-ready';
 import { registerPlugin } from '@wordpress/plugins';
 import GlobalStylesModal from './modal';
 import GlobalStylesNotice from './notice';
-import './store';
 
 const showGlobalStylesComponents = () => {
 	registerPlugin( 'wpcom-global-styles', {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -7,15 +7,13 @@ import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 import image from './image.svg';
+import { store as globalStylesStore } from './store';
 
 import './modal.scss';
 
 const GlobalStylesModal = () => {
-	const isVisible = useSelect(
-		( select ) => select( 'automattic/wpcom-global-styles' ).isModalVisible(),
-		[]
-	);
-	const { dismissModal } = useDispatch( 'automattic/wpcom-global-styles' );
+	const isVisible = useSelect( ( select ) => select( globalStylesStore ).isModalVisible(), [] );
+	const { dismissModal } = useDispatch( globalStylesStore );
 	const { set: setPreference } = useDispatch( 'core/preferences' );
 
 	// Hide the welcome guide modal, so it doesn't conflict with our modal.

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/store.js
@@ -1,10 +1,10 @@
-import { createRegistrySelector, registerStore } from '@wordpress/data';
+import { createRegistrySelector, register, createReduxStore } from '@wordpress/data';
 
 const DEFAULT_STATE = {
 	isModalVisible: true,
 };
 
-registerStore( 'automattic/wpcom-global-styles', {
+export const store = createReduxStore( 'automattic/wpcom-global-styles', {
 	reducer: ( state = DEFAULT_STATE, action ) => {
 		switch ( action.type ) {
 			case 'DISMISS_MODAL':
@@ -33,3 +33,5 @@ registerStore( 'automattic/wpcom-global-styles', {
 
 	persist: true,
 } );
+
+register( store );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See #74399 for more info

## Proposed Changes

Migrates wpcom global styles from `registerStore` to `createReduxStore`. (The former is deprecated and the latter provides better typescript integration).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

TBD -- suggestions on the best way to test?


