### PR TITLE
Happy Blocks: Add disable tracking feature flag

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/components/pricing-plan-detail.tsx
+++ b/apps/happy-blocks/block-library/pricing-plans/components/pricing-plan-detail.tsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { BlockSaveProps } from '@wordpress/blocks';
 import { FunctionComponent } from 'react';
+import config from '../config';
 import { BlockPlan } from '../hooks/pricing-plans';
 import { BlockAttributes } from '../types';
 import BillingButton from './billing-button';
@@ -26,6 +27,10 @@ const PricingPlanDetail: FunctionComponent< BlockSaveProps< BlockAttributes > & 
 	setPlan,
 } ) => {
 	const onCtaClick = () => {
+		if ( ! config.features.tracking ) {
+			return;
+		}
+
 		recordTracksEvent( 'calypso_happyblocks_upgrade_plan_click', {
 			plan: currentPlan.productSlug,
 			domain: attributes.domain,

--- a/apps/happy-blocks/block-library/pricing-plans/index.php
+++ b/apps/happy-blocks/block-library/pricing-plans/index.php
@@ -59,7 +59,9 @@ function happyblocks_pricing_plans_is_author() {
 function happyblocks_pricing_plans_get_config() {
 
 	return array(
-		'features' => array(),
+		'features' => array(
+			'tracking' => apply_filters( 'happy_blocks_pricing_plans_tracking', true ),
+		),
 		'locale'   => get_user_locale(),
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 189-gh-Automattic/lighthouse-forums

## Proposed Changes

Add feature flag for CTA tracking.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply D104591-code
- Look at network monitor when clicking the upgrade button on pricing plans, it should only do the request for tracks if you are not a support forum

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?