### PR TITLE
Add Apple Silicon link to desktop links and footer

### DIFF
--- a/client/blocks/get-apps/desktop-download-card.jsx
+++ b/client/blocks/get-apps/desktop-download-card.jsx
@@ -119,39 +119,6 @@ class DesktopDownloadCard extends Component {
 		}
 	}
 
-	getAlsoAvailableText( platform ) {
-		switch ( platform ) {
-			case 'MacIntel':
-			case PLATFORM_MAC_SILICON:
-				return translate(
-					'Also available for: ' +
-						'{{firstAvailableLink}}Windows{{/firstAvailableLink}}, ' +
-						'{{secondAvailableLink}}Linux (.tar.gz){{/secondAvailableLink}}, ' +
-						'{{thirdAvailableLink}}Linux (.deb){{/thirdAvailableLink}}.',
-					{ components: this.getTranslateComponents( platform ) }
-				);
-			case 'Linux i686':
-			case 'Linux i686 on x86_64':
-				return translate(
-					'Also available for: ' +
-						'{{firstAvailableLink}}Linux (.deb){{/firstAvailableLink}}, ' +
-						'{{secondAvailableLink}}Windows{{/secondAvailableLink}}, ' +
-						'{{thirdAvailableLink}}Mac (Intel){{/thirdAvailableLink}}.' +
-						'{{fourthAvailableLink}}Mac (Apple Silicon){{/fourthAvailableLink}}.',
-					{ components: this.getTranslateComponents( platform ) }
-				);
-			default:
-				return translate(
-					'Also available for: ' +
-						'{{firstAvailableLink}}MacOS (Intel){{/firstAvailableLink}}, ' +
-						'{{secondAvailableLink}}MacOS (Apple Silicon){{/secondAvailableLink}}, ' +
-						'{{thirdAvailableLink}}Linux (.tar.gz){{/thirdAvailableLink}}, ' +
-						'{{fourthAvailableLink}}Linux (.deb){{/fourthAvailableLink}}.',
-					{ components: this.getTranslateComponents( platform ) }
-				);
-		}
-	}
-
 	getAlsoAvailableTextJetpack( platform ) {
 		switch ( platform ) {
 			case 'MacIntel':

--- a/client/blocks/get-apps/desktop-download-card.jsx
+++ b/client/blocks/get-apps/desktop-download-card.jsx
@@ -13,7 +13,8 @@ import userAgent from 'calypso/lib/user-agent';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 const WINDOWS_LINK = 'https://apps.wordpress.com/d/windows?ref=getapps';
-const MAC_LINK = 'https://apps.wordpress.com/d/osx?ref=getapps';
+const MAC_INTEL_LINK = 'https://apps.wordpress.com/d/osx?ref=getapps';
+const MAC_SILICON_LINK = 'https://apps.wordpress.com/d/osx-silicon?ref=getapps';
 const LINUX_TAR_LINK = 'https://apps.wordpress.com/d/linux?ref=getapps';
 const LINUX_DEB_LINK = 'https://apps.wordpress.com/d/linux-deb?ref=getapps';
 const noop = () => {};
@@ -22,14 +23,16 @@ class DesktopDownloadCard extends Component {
 	static propTypes = {
 		translate: PropTypes.func,
 		trackWindowsClick: PropTypes.func,
-		trackMacClick: PropTypes.func,
+		trackMacIntelClick: PropTypes.func,
+		trackMacSiliconClick: PropTypes.func,
 		trackLinuxTarClick: PropTypes.func,
 		trackLinuxDebClick: PropTypes.func,
 	};
 
 	static defaultProps = {
 		trackWindowsClick: noop,
-		trackMacClick: noop,
+		trackMacIntelClick: noop,
+		trackMacSiliconClick: noop,
 		trackLinuxTarClick: noop,
 		trackLinuxDebClick: noop,
 	};
@@ -60,7 +63,8 @@ class DesktopDownloadCard extends Component {
 	getPlatformImage( platform ) {
 		switch ( platform ) {
 			case 'MacIntel':
-			case MAC_LINK:
+			case MAC_SILICON_LINK:
+			case MAC_INTEL_LINK:
 				return <SVGIcon aria-hidden="true" name="apple-logo" size="24" icon={ Apple } />;
 			case 'Linux i686':
 			case 'Linux i686 on x86_64':
@@ -89,19 +93,23 @@ class DesktopDownloadCard extends Component {
 				return {
 					firstAvailableLink: this.getLinkAnchorTag( LINUX_DEB_LINK ),
 					secondAvailableLink: this.getLinkAnchorTag( WINDOWS_LINK ),
-					thirdAvailableLink: this.getLinkAnchorTag( MAC_LINK ),
+					thirdAvailableLink: this.getLinkAnchorTag( MAC_INTEL_LINK ),
+					fourthAvailableLink: this.getLinkAnchorTag( MAC_SILICON_LINK ),
 					firstAvailableIcon: this.getPlatformImage( LINUX_DEB_LINK ),
 					secondAvailableIcon: this.getPlatformImage( WINDOWS_LINK ),
-					thirdAvailableIcon: this.getPlatformImage( MAC_LINK ),
+					thirdAvailableIcon: this.getPlatformImage( MAC_INTEL_LINK ),
+					fourthAvailableIcon: this.getPlatformImage( MAC_SILICON_LINK ),
 				};
 			default:
 				return {
-					firstAvailableLink: this.getLinkAnchorTag( MAC_LINK ),
-					secondAvailableLink: this.getLinkAnchorTag( LINUX_TAR_LINK ),
-					thirdAvailableLink: this.getLinkAnchorTag( LINUX_DEB_LINK ),
-					firstAvailableIcon: this.getPlatformImage( MAC_LINK ),
-					secondAvailableIcon: this.getPlatformImage( LINUX_TAR_LINK ),
-					thirdAvailableIcon: this.getPlatformImage( LINUX_DEB_LINK ),
+					firstAvailableLink: this.getLinkAnchorTag( MAC_INTEL_LINK ),
+					secondAvailableLink: this.getLinkAnchorTag( MAC_SILICON_LINK ),
+					thirdAvailableLink: this.getLinkAnchorTag( LINUX_TAR_LINK ),
+					fourthAvailableLink: this.getLinkAnchorTag( LINUX_DEB_LINK ),
+					firstAvailableIcon: this.getPlatformImage( MAC_INTEL_LINK ),
+					secondAvailableIcon: this.getPlatformImage( MAC_SILICON_LINK ),
+					thirdAvailableIcon: this.getPlatformImage( LINUX_TAR_LINK ),
+					fourthAvailableIcon: this.getPlatformImage( LINUX_DEB_LINK ),
 				};
 		}
 	}
@@ -122,15 +130,17 @@ class DesktopDownloadCard extends Component {
 					'Also available for: ' +
 						'{{firstAvailableLink}}Linux (.deb){{/firstAvailableLink}}, ' +
 						'{{secondAvailableLink}}Windows{{/secondAvailableLink}}, ' +
-						'{{thirdAvailableLink}}Mac{{/thirdAvailableLink}}.',
+						'{{thirdAvailableLink}}Mac (Intel){{/thirdAvailableLink}}.' +
+						'{{fourthAvailableLink}}Mac (Apple Silicon){{/fourthAvailableLink}}.',
 					{ components: this.getTranslateComponents( platform ) }
 				);
 			default:
 				return translate(
 					'Also available for: ' +
-						'{{firstAvailableLink}}MacOS{{/firstAvailableLink}}, ' +
-						'{{secondAvailableLink}}Linux (.tar.gz){{/secondAvailableLink}}, ' +
-						'{{thirdAvailableLink}}Linux (.deb){{/thirdAvailableLink}}.',
+						'{{firstAvailableLink}}MacOS (Intel){{/firstAvailableLink}}, ' +
+						'{{secondAvailableLink}}MacOS (Apple Silicon){{/secondAvailableLink}}, ' +
+						'{{thirdAvailableLink}}Linux (.tar.gz){{/thirdAvailableLink}}, ' +
+						'{{fourthAvailableLink}}Linux (.deb){{/fourthAvailableLink}}.',
 					{ components: this.getTranslateComponents( platform ) }
 				);
 		}
@@ -150,25 +160,33 @@ class DesktopDownloadCard extends Component {
 				return translate(
 					'{{firstAvailableLink}}{{firstAvailableIcon /}}Linux (.deb){{/firstAvailableLink}}' +
 						'{{secondAvailableLink}}{{secondAvailableIcon /}}Windows{{/secondAvailableLink}}' +
-						'{{thirdAvailableLink}}{{thirdAvailableIcon /}}Mac{{/thirdAvailableLink}}',
+						'{{thirdAvailableLink}}{{thirdAvailableIcon /}}Mac (Intel){{/thirdAvailableLink}}' +
+						'{{fourthAvailableLink}}{{fourthAvailableIcon /}}Mac (Apple Silicon){{/fourthAvailableLink}}',
 					{ components: this.getTranslateComponents( platform ) }
 				);
 			default:
 				return translate(
-					'{{firstAvailableLink}}{{firstAvailableIcon /}}MacOS{{/firstAvailableLink}}' +
-						'{{secondAvailableLink}}{{secondAvailableIcon /}}Linux (.tar.gz){{/secondAvailableLink}}' +
-						'{{thirdAvailableLink}}{{thirdAvailableIcon /}}Linux (.deb){{/thirdAvailableLink}}',
+					'{{firstAvailableLink}}{{firstAvailableIcon /}}MacOS (Intel){{/firstAvailableLink}}' +
+						'{{secondAvailableLink}}{{secondAvailableIcon /}}MacOS (Apple Silicon){{/secondAvailableLink}}' +
+						'{{thirdAvailableLink}}{{thirdAvailableIcon /}}Linux (.tar.gz){{/thirdAvailableLink}}' +
+						'{{fourthAvailableLink}}{{fourthAvailableIcon /}}Linux (.deb){{/fourthAvailableLink}}',
 					{ components: this.getTranslateComponents( platform ) }
 				);
 		}
 	}
 
 	getButtonClickHandler( platform ) {
-		const { trackWindowsClick, trackMacClick, trackLinuxTarClick, trackLinuxDebClick } = this.props;
+		const {
+			trackWindowsClick,
+			trackMacIntelClick,
+			trackMacSiliconClick,
+			trackLinuxTarClick,
+			trackLinuxDebClick,
+		} = this.props;
 
 		switch ( platform ) {
 			case 'MacIntel':
-				return trackMacClick;
+				return trackMacIntelClick && trackMacSiliconClick;
 			case 'Linux i686':
 				return trackLinuxTarClick;
 			case 'Linux i686 on x86_64':
@@ -181,7 +199,7 @@ class DesktopDownloadCard extends Component {
 	getButtonLink( platform ) {
 		switch ( platform ) {
 			case 'MacIntel':
-				return MAC_LINK;
+				return [ MAC_INTEL_LINK, MAC_SILICON_LINK ];
 			case 'Linux i686':
 			case 'Linux i686 on x86_64':
 				return LINUX_TAR_LINK;
@@ -193,7 +211,10 @@ class DesktopDownloadCard extends Component {
 	getButtonText( platform ) {
 		switch ( platform ) {
 			case 'MacIntel':
-				return translate( 'Download for Mac (Intel)' );
+				return [
+					translate( 'Download for Mac (Intel)' ),
+					translate( 'Download for Mac (Apple Silicon)' ),
+				];
 			case 'Linux i686':
 			case 'Linux i686 on x86_64':
 				return translate( 'Download for Linux' );
@@ -215,17 +236,28 @@ class DesktopDownloadCard extends Component {
 	}
 
 	getLinkAnchorTag( platformLink ) {
-		const { trackWindowsClick, trackMacClick, trackLinuxTarClick, trackLinuxDebClick } = this.props;
+		const {
+			trackWindowsClick,
+			trackMacIntelClick,
+			trackMacSiliconClick,
+			trackLinuxTarClick,
+			trackLinuxDebClick,
+		} = this.props;
 
 		switch ( platformLink ) {
-			case MAC_LINK:
-				return (
-					<a
-						href={ localizeUrl( platformLink ) }
-						onClick={ trackMacClick }
-						className="get-apps__desktop-link"
-					/>
-				);
+			case MAC_INTEL_LINK:
+				<a
+					href={ localizeUrl( platformLink ) }
+					onClick={ trackMacIntelClick }
+					className="get-apps__desktop-link"
+				/>;
+
+			case MAC_SILICON_LINK:
+				<a
+					href={ localizeUrl( platformLink ) }
+					onClick={ trackMacSiliconClick }
+					className="get-apps__desktop-link"
+				/>;
 			case LINUX_TAR_LINK:
 				return (
 					<a
@@ -267,13 +299,33 @@ class DesktopDownloadCard extends Component {
 
 		return (
 			<>
-				<Button
-					className="get-apps__desktop-button"
-					href={ localizeUrl( this.getButtonLink( platform ) ) }
-					onClick={ this.getButtonClickHandler( platform ) }
-				>
-					{ this.getButtonText( platform ) }
-				</Button>
+				{ platform === 'MacIntel' ? (
+					<>
+						<Button
+							className="get-apps__desktop-button"
+							href={ localizeUrl( this.getButtonLink( platform )[ 0 ] ) }
+							onClick={ this.getButtonClickHandler( platform ) }
+						>
+							{ this.getButtonText( platform )[ 0 ] }
+						</Button>
+						<Button
+							className="get-apps__desktop-button"
+							href={ localizeUrl( this.getButtonLink( platform )[ 1 ] ) }
+							onClick={ this.getButtonClickHandler( platform ) }
+						>
+							{ this.getButtonText( platform )[ 1 ] }
+						</Button>
+					</>
+				) : (
+					<Button
+						className="get-apps__desktop-button"
+						href={ localizeUrl( this.getButtonLink( platform ) ) }
+						onClick={ this.getButtonClickHandler( platform ) }
+					>
+						{ this.getButtonText( platform ) }
+					</Button>
+				) }
+
 				<div className="get-apps__requirements-wrapper">
 					{ this.getPlatformImage( platform ) }
 					<p className="get-apps__requirements-paragraph">
@@ -325,7 +377,8 @@ class DesktopDownloadCard extends Component {
 
 const mapDispatchToProps = {
 	trackWindowsClick: () => recordTracksEvent( 'calypso_app_download_windows_click' ),
-	trackMacClick: () => recordTracksEvent( 'calypso_app_download_mac_click' ),
+	trackMacIntelClick: () => recordTracksEvent( 'calypso_app_download_mac_click' ),
+	trackMacSiliconClick: () => recordTracksEvent( 'calypso_app_download_mac_silicon_click' ),
 	trackLinuxTarClick: () => recordTracksEvent( 'calypso_app_download_linux_tar_click' ),
 	trackLinuxDebClick: () => recordTracksEvent( 'calypso_app_download_linux_deb_click' ),
 };

--- a/client/blocks/get-apps/desktop-download-card.jsx
+++ b/client/blocks/get-apps/desktop-download-card.jsx
@@ -63,8 +63,8 @@ class DesktopDownloadCard extends Component {
 		}
 	}
 
-	getPlatformImage( platform ) {
-		switch ( platform ) {
+	getPlatformImage( platformOrLink ) {
+		switch ( platformOrLink ) {
 			case 'MacIntel':
 			case PLATFORM_MAC_SILICON:
 			case MAC_SILICON_LINK:
@@ -81,70 +81,68 @@ class DesktopDownloadCard extends Component {
 		}
 	}
 
-	getTranslateComponents( platform ) {
-		switch ( platform ) {
-			case 'MacIntel':
-			case PLATFORM_MAC_SILICON:
-				return {
-					firstAvailableLink: this.getLinkAnchorTag( WINDOWS_LINK ),
-					secondAvailableLink: this.getLinkAnchorTag( LINUX_TAR_LINK ),
-					thirdAvailableLink: this.getLinkAnchorTag( LINUX_DEB_LINK ),
-					firstAvailableIcon: this.getPlatformImage( WINDOWS_LINK ),
-					secondAvailableIcon: this.getPlatformImage( LINUX_TAR_LINK ),
-					thirdAvailableIcon: this.getPlatformImage( LINUX_DEB_LINK ),
-				};
-			case 'Linux i686':
-			case 'Linux i686 on x86_64':
-				return {
-					firstAvailableLink: this.getLinkAnchorTag( LINUX_DEB_LINK ),
-					secondAvailableLink: this.getLinkAnchorTag( WINDOWS_LINK ),
-					thirdAvailableLink: this.getLinkAnchorTag( MAC_INTEL_LINK ),
-					fourthAvailableLink: this.getLinkAnchorTag( MAC_SILICON_LINK ),
-					firstAvailableIcon: this.getPlatformImage( LINUX_DEB_LINK ),
-					secondAvailableIcon: this.getPlatformImage( WINDOWS_LINK ),
-					thirdAvailableIcon: this.getPlatformImage( MAC_INTEL_LINK ),
-					fourthAvailableIcon: this.getPlatformImage( MAC_SILICON_LINK ),
-				};
-			default:
-				return {
-					firstAvailableLink: this.getLinkAnchorTag( MAC_INTEL_LINK ),
-					secondAvailableLink: this.getLinkAnchorTag( MAC_SILICON_LINK ),
-					thirdAvailableLink: this.getLinkAnchorTag( LINUX_TAR_LINK ),
-					fourthAvailableLink: this.getLinkAnchorTag( LINUX_DEB_LINK ),
-					firstAvailableIcon: this.getPlatformImage( MAC_INTEL_LINK ),
-					secondAvailableIcon: this.getPlatformImage( MAC_SILICON_LINK ),
-					thirdAvailableIcon: this.getPlatformImage( LINUX_TAR_LINK ),
-					fourthAvailableIcon: this.getPlatformImage( LINUX_DEB_LINK ),
-				};
-		}
+	getAlsoAvailableComponent( { link, platformName } ) {
+		const Link = ( props ) => this.getLinkAnchorTag( { ...props, platformLink: link } );
+		const Icon = () => this.getPlatformImage( link );
+		return (
+			<Link>
+				<Icon />
+				{ platformName }
+			</Link>
+		);
 	}
 
 	getAlsoAvailableTextJetpack( platform ) {
+		const macIntelLink = this.getAlsoAvailableComponent( {
+			link: MAC_INTEL_LINK,
+			platformName: 'Mac (Intel)',
+		} );
+		const macSiliconLink = this.getAlsoAvailableComponent( {
+			link: MAC_SILICON_LINK,
+			platformName: 'Mac (Silicon)',
+		} );
+		const windowsLink = this.getAlsoAvailableComponent( {
+			link: WINDOWS_LINK,
+			platformName: 'Windows',
+		} );
+		const linuxTarLink = this.getAlsoAvailableComponent( {
+			link: LINUX_TAR_LINK,
+			platformName: 'Linux (.tar.gz)',
+		} );
+		const linuxDebLink = this.getAlsoAvailableComponent( {
+			link: LINUX_DEB_LINK,
+			platformName: 'Linux (.deb)',
+		} );
+
 		switch ( platform ) {
 			case 'MacIntel':
 			case PLATFORM_MAC_SILICON:
-				return translate(
-					'{{firstAvailableLink}}{{firstAvailableIcon /}}Windows{{/firstAvailableLink}}' +
-						'{{secondAvailableLink}} {{secondAvailableIcon /}} Linux (.tar.gz){{/secondAvailableLink}}' +
-						'{{thirdAvailableLink}} {{thirdAvailableIcon /}} Linux (.deb){{/thirdAvailableLink}}',
-					{ components: this.getTranslateComponents( platform ) }
+				return (
+					<>
+						{ windowsLink }
+						{ linuxTarLink }
+						{ linuxDebLink }
+					</>
 				);
 			case 'Linux i686':
 			case 'Linux i686 on x86_64':
-				return translate(
-					'{{firstAvailableLink}}{{firstAvailableIcon /}}Linux (.deb){{/firstAvailableLink}}' +
-						'{{secondAvailableLink}}{{secondAvailableIcon /}}Windows{{/secondAvailableLink}}' +
-						'{{thirdAvailableLink}}{{thirdAvailableIcon /}}Mac (Intel){{/thirdAvailableLink}}' +
-						'{{fourthAvailableLink}}{{fourthAvailableIcon /}}Mac (Apple Silicon){{/fourthAvailableLink}}',
-					{ components: this.getTranslateComponents( platform ) }
+				return (
+					<>
+						{ linuxDebLink }
+						{ windowsLink }
+						{ macIntelLink }
+						{ macSiliconLink }
+					</>
 				);
 			default:
-				return translate(
-					'{{firstAvailableLink}}{{firstAvailableIcon /}}MacOS (Intel){{/firstAvailableLink}}' +
-						'{{secondAvailableLink}}{{secondAvailableIcon /}}MacOS (Apple Silicon){{/secondAvailableLink}}' +
-						'{{thirdAvailableLink}}{{thirdAvailableIcon /}}Linux (.tar.gz){{/thirdAvailableLink}}' +
-						'{{fourthAvailableLink}}{{fourthAvailableIcon /}}Linux (.deb){{/fourthAvailableLink}}',
-					{ components: this.getTranslateComponents( platform ) }
+				// Windows
+				return (
+					<>
+						{ macIntelLink }
+						{ macSiliconLink }
+						{ linuxTarLink }
+						{ linuxDebLink }
+					</>
 				);
 		}
 	}
@@ -213,7 +211,7 @@ class DesktopDownloadCard extends Component {
 		}
 	}
 
-	getLinkAnchorTag( platformLink ) {
+	getLinkAnchorTag( { platformLink, children } ) {
 		const {
 			trackWindowsClick,
 			trackMacIntelClick,
@@ -222,45 +220,27 @@ class DesktopDownloadCard extends Component {
 			trackLinuxDebClick,
 		} = this.props;
 
+		let onClick = trackWindowsClick;
+
 		switch ( platformLink ) {
 			case MAC_INTEL_LINK:
-				<a
-					href={ localizeUrl( platformLink ) }
-					onClick={ trackMacIntelClick }
-					className="get-apps__desktop-link"
-				/>;
-
+				onClick = trackMacIntelClick;
 			case MAC_SILICON_LINK:
-				<a
-					href={ localizeUrl( platformLink ) }
-					onClick={ trackMacSiliconClick }
-					className="get-apps__desktop-link"
-				/>;
+				onClick = trackMacSiliconClick;
 			case LINUX_TAR_LINK:
-				return (
-					<a
-						href={ localizeUrl( platformLink ) }
-						onClick={ trackLinuxTarClick }
-						className="get-apps__desktop-link"
-					/>
-				);
+				onClick = trackLinuxTarClick;
 			case LINUX_DEB_LINK:
-				return (
-					<a
-						href={ localizeUrl( platformLink ) }
-						onClick={ trackLinuxDebClick }
-						className="get-apps__desktop-link"
-					/>
-				);
-			default:
-				return (
-					<a
-						href={ localizeUrl( platformLink ) }
-						onClick={ trackWindowsClick }
-						className="get-apps__desktop-link"
-					/>
-				);
+				onClick = trackLinuxDebClick;
 		}
+		return (
+			<a
+				href={ localizeUrl( platformLink ) }
+				onClick={ onClick }
+				className="get-apps__desktop-link"
+			>
+				{ children }
+			</a>
+		);
 	}
 
 	getMobileDeviceDownloadOptions() {

--- a/client/blocks/get-apps/desktop-download-card.jsx
+++ b/client/blocks/get-apps/desktop-download-card.jsx
@@ -12,6 +12,7 @@ import SVGIcon from 'calypso/components/svg-icon';
 import userAgent from 'calypso/lib/user-agent';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
+const PLATFORM_MAC_SILICON = 'MacSilicon';
 const WINDOWS_LINK = 'https://apps.wordpress.com/d/windows?ref=getapps';
 const MAC_INTEL_LINK = 'https://apps.wordpress.com/d/osx?ref=getapps';
 const MAC_SILICON_LINK = 'https://apps.wordpress.com/d/osx-silicon?ref=getapps';
@@ -40,6 +41,7 @@ class DesktopDownloadCard extends Component {
 	getDescription( platform ) {
 		switch ( platform ) {
 			case 'MacIntel':
+			case PLATFORM_MAC_SILICON:
 			case 'Linux i686':
 			case 'Linux i686 on x86_64':
 				return translate( 'A desktop app that gives WordPress a permanent home in your dock.' );
@@ -51,6 +53,7 @@ class DesktopDownloadCard extends Component {
 	getRequirementsText( platform ) {
 		switch ( platform ) {
 			case 'MacIntel':
+			case PLATFORM_MAC_SILICON:
 				return translate( 'Requires Mac OS X 10.11+. ' );
 			case 'Linux i686':
 			case 'Linux i686 on x86_64':
@@ -63,6 +66,7 @@ class DesktopDownloadCard extends Component {
 	getPlatformImage( platform ) {
 		switch ( platform ) {
 			case 'MacIntel':
+			case PLATFORM_MAC_SILICON:
 			case MAC_SILICON_LINK:
 			case MAC_INTEL_LINK:
 				return <SVGIcon aria-hidden="true" name="apple-logo" size="24" icon={ Apple } />;
@@ -80,6 +84,7 @@ class DesktopDownloadCard extends Component {
 	getTranslateComponents( platform ) {
 		switch ( platform ) {
 			case 'MacIntel':
+			case PLATFORM_MAC_SILICON:
 				return {
 					firstAvailableLink: this.getLinkAnchorTag( WINDOWS_LINK ),
 					secondAvailableLink: this.getLinkAnchorTag( LINUX_TAR_LINK ),
@@ -117,6 +122,7 @@ class DesktopDownloadCard extends Component {
 	getAlsoAvailableText( platform ) {
 		switch ( platform ) {
 			case 'MacIntel':
+			case PLATFORM_MAC_SILICON:
 				return translate(
 					'Also available for: ' +
 						'{{firstAvailableLink}}Windows{{/firstAvailableLink}}, ' +
@@ -149,6 +155,7 @@ class DesktopDownloadCard extends Component {
 	getAlsoAvailableTextJetpack( platform ) {
 		switch ( platform ) {
 			case 'MacIntel':
+			case PLATFORM_MAC_SILICON:
 				return translate(
 					'{{firstAvailableLink}}{{firstAvailableIcon /}}Windows{{/firstAvailableLink}}' +
 						'{{secondAvailableLink}} {{secondAvailableIcon /}} Linux (.tar.gz){{/secondAvailableLink}}' +
@@ -186,7 +193,9 @@ class DesktopDownloadCard extends Component {
 
 		switch ( platform ) {
 			case 'MacIntel':
-				return trackMacIntelClick && trackMacSiliconClick;
+				return trackMacIntelClick;
+			case PLATFORM_MAC_SILICON:
+				return trackMacSiliconClick;
 			case 'Linux i686':
 				return trackLinuxTarClick;
 			case 'Linux i686 on x86_64':
@@ -199,7 +208,9 @@ class DesktopDownloadCard extends Component {
 	getButtonLink( platform ) {
 		switch ( platform ) {
 			case 'MacIntel':
-				return [ MAC_INTEL_LINK, MAC_SILICON_LINK ];
+				return MAC_INTEL_LINK;
+			case PLATFORM_MAC_SILICON:
+				return MAC_SILICON_LINK;
 			case 'Linux i686':
 			case 'Linux i686 on x86_64':
 				return LINUX_TAR_LINK;
@@ -211,10 +222,9 @@ class DesktopDownloadCard extends Component {
 	getButtonText( platform ) {
 		switch ( platform ) {
 			case 'MacIntel':
-				return [
-					translate( 'Download for Mac (Intel)' ),
-					translate( 'Download for Mac (Apple Silicon)' ),
-				];
+				return translate( 'Download for Mac (Intel)' );
+			case PLATFORM_MAC_SILICON:
+				return translate( 'Download for Mac (Apple Silicon)' );
 			case 'Linux i686':
 			case 'Linux i686 on x86_64':
 				return translate( 'Download for Linux' );
@@ -226,6 +236,7 @@ class DesktopDownloadCard extends Component {
 	getCardTitle( platform ) {
 		switch ( platform ) {
 			case 'MacIntel':
+			case PLATFORM_MAC_SILICON:
 				return translate( 'Desktop App for Mac' );
 			case 'Linux i686':
 			case 'Linux i686 on x86_64':
@@ -303,17 +314,17 @@ class DesktopDownloadCard extends Component {
 					<>
 						<Button
 							className="get-apps__desktop-button"
-							href={ localizeUrl( this.getButtonLink( platform )[ 0 ] ) }
+							href={ localizeUrl( this.getButtonLink( platform ) ) }
 							onClick={ this.getButtonClickHandler( platform ) }
 						>
-							{ this.getButtonText( platform )[ 0 ] }
+							{ this.getButtonText( platform ) }
 						</Button>
 						<Button
 							className="get-apps__desktop-button"
-							href={ localizeUrl( this.getButtonLink( platform )[ 1 ] ) }
-							onClick={ this.getButtonClickHandler( platform ) }
+							href={ localizeUrl( this.getButtonLink( PLATFORM_MAC_SILICON ) ) }
+							onClick={ this.getButtonClickHandler( PLATFORM_MAC_SILICON ) }
 						>
-							{ this.getButtonText( platform )[ 1 ] }
+							{ this.getButtonText( PLATFORM_MAC_SILICON ) }
 						</Button>
 					</>
 				) : (

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -272,13 +272,13 @@ body.get-apps__body {
 }
 
 .get-apps__desktop-button.button {
-	margin: 46px 0 15px;
+	margin: 25px 10px 25px 0;
 	font-weight: 500;
 	padding: 10px 24px;
 	width: fit-content;
 	max-width: 366px;
 	min-width: 110px;
-	display: block;
+	display: inline-block;
 	font-size: rem(18px); //typography-exception;
 
 	&:visited {


### PR DESCRIPTION
- Fix: https://github.com/Automattic/wp-calypso/issues/74232

## Proposed Changes

* This PR adds Mac (Apple Silicon) link to `https://wordpress.com/me/get-apps` to make it consistent with `https://apps.wordpress.com/`
* This PR also adds Mac (Apple Silicon) link to the section `Also available for:` on `https://wordpress.com/me/get-apps` when that page is accessed from devices other than MacOS

## Testing Instructions

**To test the link to Mac (Apple Silicon) when on MacOS**:

* Ensure that you are using MacOS
* Navigate to `https://wordpress.com/me/get-apps`
* Scroll to the bottom of the page
* Check if the button "Download for Mac (Apple Silicon)" is present alongside "Download for Mac (Intel)":

<img width="792" alt="Screenshot 2023-03-14 at 10 56 41 AM" src="https://user-images.githubusercontent.com/25575134/224964420-a83e5aec-1190-45d3-a3bc-4919fb7aefef.png">

* Click on "Mac (Intel)" and check if the link goes to `https://apps.wordpress.com/d/osx/?ref=getapps` and triggers app download
* Click on "Mac (Apple Silicon)" and check if the link goes to `https://apps.wordpress.com/d/osx-silicon/?ref=getapps` and triggers app download

**To test a modification of the "Also available for" section**:

Note: The modification can't be tested on MacOS because they only show conditionally when you are **not** on MacOs. You will need to use BrowserStack to test changes.

1. Navigate to `https://www.browserstack.com/users/sign_in`
2. Access login information from Secret Store
3. Select Windows as operating system along with a browser to use (Chrome or Firefox)
4. In the browser, navigate to **Calypso Live** link generated below
5. If you are prompted to log into WordPress.com, proceed with login
6. Then navigate to `/me/get-apps`
8. Check if Mac (Intel) and Mac (Apple Silicon) links are present in the **Also available for** section:

<img width="709" alt="Screenshot 2023-03-14 at 11 13 46 AM" src="https://user-images.githubusercontent.com/25575134/224968795-f5b87a83-60b3-49dd-b3a7-9254e2731489.png">

9.  Click on "Mac (Intel)" and check if the link goes to `https://apps.wordpress.com/d/osx/?ref=getapps` and triggers app download
10.  Click on "Mac (Apple Silicon)" and check if the link goes to `https://apps.wordpress.com/d/osx-silicon/?ref=getapps` and triggers app download

https://user-images.githubusercontent.com/25575134/224971822-2f65c0b1-30a8-4c63-90aa-6a2062cf9623.mp4

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
