### PR TITLE
Data Stores: Migrate Analyzer store to `createReduxStore()`

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-light/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-light/index.tsx
@@ -15,7 +15,6 @@ import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-pa
 import { ANALYZER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { ProgressState } from './types';
-import type { AnalyzerSelect } from '@automattic/data-stores';
 import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import './style.scss';
 
@@ -29,11 +28,11 @@ const ImportLight: Step = function ImportStep( props ) {
 	const [ percentage, setPercentage ] = useState( 2 );
 	const { analyzeColors } = useDispatch( ANALYZER_STORE );
 	const colorsData = useSelect(
-		( select ) => ( select( ANALYZER_STORE ) as AnalyzerSelect ).getSiteColors( url ),
+		( select ) => select( ANALYZER_STORE ).getSiteColors( url ),
 		[ url ]
 	);
 	const fetchingColorsInProgress = useSelect(
-		( select ) => ( select( ANALYZER_STORE ) as AnalyzerSelect ).isSiteColorsInAnalysis(),
+		( select ) => select( ANALYZER_STORE ).isSiteColorsInAnalysis(),
 		[]
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-light/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-light/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+import { Analyzer } from '@automattic/data-stores';
 import { StepContainer, SubTitle, Title } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createElement, createInterpolateElement } from '@wordpress/element';
@@ -12,7 +13,6 @@ import Colors from 'calypso/blocks/import-light/colors';
 import Summary from 'calypso/blocks/import-light/summary';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
-import { ANALYZER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { ProgressState } from './types';
 import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -26,13 +26,13 @@ const ImportLight: Step = function ImportStep( props ) {
 	const [ url, setUrl ] = useState( '' );
 	const [ progressState, setProgressState ] = useState< ProgressState >( 'capture' );
 	const [ percentage, setPercentage ] = useState( 2 );
-	const { analyzeColors } = useDispatch( ANALYZER_STORE );
+	const { analyzeColors } = useDispatch( Analyzer.store );
 	const colorsData = useSelect(
-		( select ) => select( ANALYZER_STORE ).getSiteColors( url ),
+		( select ) => select( Analyzer.store ).getSiteColors( url ),
 		[ url ]
 	);
 	const fetchingColorsInProgress = useSelect(
-		( select ) => select( ANALYZER_STORE ).isSiteColorsInAnalysis(),
+		( select ) => select( Analyzer.store ).isSiteColorsInAnalysis(),
 		[]
 	);
 

--- a/client/landing/stepper/stores.ts
+++ b/client/landing/stepper/stores.ts
@@ -26,4 +26,4 @@ export const USER_STORE = User.register( {
 
 export const AUTOMATED_ELIGIBILITY_STORE = AutomatedTransferEligibility.register();
 
-export const ANALYZER_STORE = Analyzer.register();
+export const ANALYZER_STORE = Analyzer.store;

--- a/client/landing/stepper/stores.ts
+++ b/client/landing/stepper/stores.ts
@@ -6,7 +6,6 @@ import {
 	User,
 	AutomatedTransferEligibility,
 	StepperInternal,
-	Analyzer,
 } from '@automattic/data-stores';
 
 export const ONBOARD_STORE = Onboard.register();
@@ -25,5 +24,3 @@ export const USER_STORE = User.register( {
 } );
 
 export const AUTOMATED_ELIGIBILITY_STORE = AutomatedTransferEligibility.register();
-
-export const ANALYZER_STORE = Analyzer.store;

--- a/packages/data-stores/src/analyzer/index.ts
+++ b/packages/data-stores/src/analyzer/index.ts
@@ -1,4 +1,4 @@
-import { registerStore } from '@wordpress/data';
+import { register, createReduxStore } from '@wordpress/data';
 import { controls } from '../wpcom-request-controls';
 import { createActions } from './actions';
 import { STORE_KEY } from './constants';
@@ -7,16 +7,11 @@ import * as selectors from './selectors';
 export * from './types';
 export type { State };
 
-let isRegistered = false;
-export function register(): typeof STORE_KEY {
-	if ( ! isRegistered ) {
-		isRegistered = true;
-		registerStore( STORE_KEY, {
-			actions: createActions(),
-			controls: controls,
-			reducer: reducer,
-			selectors,
-		} );
-	}
-	return STORE_KEY;
-}
+export const store = createReduxStore( STORE_KEY, {
+	actions: createActions(),
+	controls: controls,
+	reducer: reducer,
+	selectors,
+} );
+
+register( store );

--- a/packages/data-stores/src/analyzer/types.ts
+++ b/packages/data-stores/src/analyzer/types.ts
@@ -1,6 +1,5 @@
 import * as actions from './actions';
-import * as selectors from './selectors';
-import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
+import type { DispatchFromMap } from '../mapped-types';
 
 interface Color {
 	name: string;
@@ -36,5 +35,3 @@ export type ColorsState = {
 export interface Dispatch {
 	dispatch: DispatchFromMap< typeof actions >;
 }
-
-export type AnalyzerSelect = SelectFromMap< typeof selectors >;

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -65,7 +65,6 @@ export { getContextResults } from './contextual-help/contextual-help';
 export { generateAdminSections } from './contextual-help/admin-sections';
 export type { LinksForSection } from './contextual-help/contextual-help';
 export * from './contextual-help/constants';
-export type { AnalyzerSelect } from './analyzer/types';
 export type { I18nSelect } from './i18n/types';
 export type { HelpCenterSite, HelpCenterSelect } from './help-center/types';
 export type { ProductsListSelect } from './products-list/types';


### PR DESCRIPTION
## Proposed Changes

This PR migrates the Analyzer store to use `createReduxStore()` and `register()` instead of `registerStore()`.

Part of #74399. A follow-up to #73890.

## Testing Instructions

* The only step that uses this store is not currently enabled, so we have to manually enable it with a feature flag.
* Navigate to `/setup/site-setup/importLight?siteSlug=YOURSITE&flags=onboarding/import-light` where `YOURSITE` is the slug of one of your sites.
* If you land on the goals step, check the checkbox that you want to import your content into your site and push the button to continue forward. Retry the step above.
* Verify import process still works well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
