### PR TITLE
Update launchpad free/build/write flow sidebar copies

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/translations.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/translations.ts
@@ -19,8 +19,8 @@ describe( 'Translations', () => {
 
 				const freeFlowTranslations = getLaunchpadTranslations( 'free' );
 				expect( freeFlowTranslations.flowName ).toEqual( 'Free Website' );
-				expect( freeFlowTranslations.title ).toEqual( "Your new site's ready!" );
-				expect( freeFlowTranslations.launchTitle ).toEqual( "Your new site's ready!" );
+				expect( freeFlowTranslations.title ).toEqual( "Let's get ready to launch!" );
+				expect( freeFlowTranslations.launchTitle ).toEqual( "Let's get ready to launch!" );
 			} );
 		} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -4,6 +4,8 @@ import {
 	NEWSLETTER_FLOW,
 	VIDEOPRESS_FLOW,
 	FREE_FLOW,
+	WRITE_FLOW,
+	BUILD_FLOW,
 } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
 import { TranslatedLaunchpadStrings } from './types';
@@ -34,17 +36,20 @@ export function getLaunchpadTranslations( flow: string | null ): TranslatedLaunc
 			break;
 		case FREE_FLOW:
 			translatedStrings.flowName = translate( 'Free Website' );
-			translatedStrings.title = translate( "Your new site's ready!" );
-			translatedStrings.launchTitle = translate( "Your new site's ready!" );
-			translatedStrings.subtitle = translate(
-				'Launch it to the world. Or add some finishing touches. (You can come back to make changes any time.)'
-			);
+			translatedStrings.title = translate( "Let's get ready to launch!" );
+			translatedStrings.launchTitle = translate( "Let's get ready to launch!" );
+			translatedStrings.subtitle = translate( "Here's what to do next." );
 			break;
 		case VIDEOPRESS_FLOW:
 			translatedStrings.flowName = translate( 'Video' );
 			translatedStrings.title = translate( 'Your site is almost ready!' );
 			translatedStrings.launchTitle = translate( 'Your site is almost ready!' );
 			break;
+		case WRITE_FLOW:
+		case BUILD_FLOW:
+			translatedStrings.title = translate( "Let's get ready to launch!" );
+			translatedStrings.launchTitle = translate( "Let's get ready to launch!" );
+			translatedStrings.subtitle = translate( "Here's what to do next." );
 	}
 
 	return translatedStrings;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74417

## Proposed Changes

* Update Launchpad sidebar copies for Free, Write, and Build flows

![image](https://user-images.githubusercontent.com/10482592/225034002-fcb89f34-1481-4852-8c78-73e6daa6b6dd.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch (or use calypso.live link)
* Create or use an existing launchpad enabled site (free, write, or build flow)
* Verify the sidebar copies match the design. **Title** = `Let's get ready to launch!` and **Subtitle** = `Here's what to do next.`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
