### PR TITLE
Data Stores: Migrate I18n to `createReduxStore()`

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/language/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/language/index.tsx
@@ -11,7 +11,7 @@ import { Step, usePath } from '../../path';
 import { I18N_STORE } from '../../stores/i18n';
 import { USER_STORE } from '../../stores/user';
 import type { StepNameType } from '../../path';
-import type { I18nSelect, UserSelect } from '@automattic/data-stores';
+import type { UserSelect } from '@automattic/data-stores';
 
 import './style.scss';
 
@@ -31,7 +31,7 @@ const LanguageStep: React.FunctionComponent< Props > = ( { previousStep } ) => {
 
 	const localizedLanguageNames = useSelect(
 		( select ) =>
-			( select( I18N_STORE ) as I18nSelect ).getLocalizedLanguageNames(
+			select( I18N_STORE ).getLocalizedLanguageNames(
 				currentUser?.language ?? LOCALIZED_LANGUAGE_NAMES_FALLBACK_LOCALE
 			),
 		[ currentUser?.language ]

--- a/client/landing/gutenboarding/onboarding-block/language/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/language/index.tsx
@@ -1,3 +1,4 @@
+import { I18n } from '@automattic/data-stores';
 import LanguagePicker, { createLanguageGroups } from '@automattic/language-picker';
 import languages from '@automattic/languages';
 import { ActionButtons, BackButton } from '@automattic/onboarding';
@@ -8,7 +9,6 @@ import { useHistory } from 'react-router-dom';
 import { ChangeLocaleContextConsumer } from '../../components/locale-context';
 import useLastLocation from '../../hooks/use-last-location';
 import { Step, usePath } from '../../path';
-import { I18N_STORE } from '../../stores/i18n';
 import { USER_STORE } from '../../stores/user';
 import type { StepNameType } from '../../path';
 import type { UserSelect } from '@automattic/data-stores';
@@ -31,7 +31,7 @@ const LanguageStep: React.FunctionComponent< Props > = ( { previousStep } ) => {
 
 	const localizedLanguageNames = useSelect(
 		( select ) =>
-			select( I18N_STORE ).getLocalizedLanguageNames(
+			select( I18n.store ).getLocalizedLanguageNames(
 				currentUser?.language ?? LOCALIZED_LANGUAGE_NAMES_FALLBACK_LOCALE
 			),
 		[ currentUser?.language ]

--- a/client/landing/gutenboarding/stores/i18n/index.ts
+++ b/client/landing/gutenboarding/stores/i18n/index.ts
@@ -1,3 +1,0 @@
-import { I18n } from '@automattic/data-stores';
-
-export const I18N_STORE = I18n.store;

--- a/client/landing/gutenboarding/stores/i18n/index.ts
+++ b/client/landing/gutenboarding/stores/i18n/index.ts
@@ -1,3 +1,3 @@
 import { I18n } from '@automattic/data-stores';
 
-export const I18N_STORE = I18n.register();
+export const I18N_STORE = I18n.store;

--- a/packages/data-stores/src/i18n/index.ts
+++ b/packages/data-stores/src/i18n/index.ts
@@ -1,4 +1,4 @@
-import { registerStore } from '@wordpress/data';
+import { createReduxStore, register } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
@@ -9,18 +9,12 @@ import * as selectors from './selectors';
 export type { State };
 export type { LocalizedLanguageNames } from './types';
 
-let isRegistered = false;
+export const store = createReduxStore( STORE_KEY, {
+	resolvers,
+	actions,
+	controls,
+	reducer,
+	selectors,
+} );
 
-export function register(): typeof STORE_KEY {
-	if ( ! isRegistered ) {
-		isRegistered = true;
-		registerStore( STORE_KEY, {
-			resolvers,
-			actions,
-			controls,
-			reducer,
-			selectors,
-		} );
-	}
-	return STORE_KEY;
-}
+register( store );

--- a/packages/data-stores/src/i18n/types.ts
+++ b/packages/data-stores/src/i18n/types.ts
@@ -1,7 +1,3 @@
-import * as selectors from './selectors';
-import type { SelectFromMap } from '../mapped-types';
-export type I18nSelect = SelectFromMap< typeof selectors >;
-
 export type LocalizedLanguageNames = {
 	[ languageSlug: string ]: { name: string; en: string; localized: string };
 };

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -61,7 +61,6 @@ export { getContextResults } from './contextual-help/contextual-help';
 export { generateAdminSections } from './contextual-help/admin-sections';
 export type { LinksForSection } from './contextual-help/contextual-help';
 export * from './contextual-help/constants';
-export type { I18nSelect } from './i18n/types';
 export type { HelpCenterSite, HelpCenterSelect } from './help-center/types';
 export type { ProductsListSelect } from './products-list/types';
 export type { OnboardSelect } from './onboard';


### PR DESCRIPTION
## Proposed Changes

This PR migrates the I18n store to use `createReduxStore()` and `register()` instead of `registerStore()`.

Part of #74399. A follow-up to #73890.

## Testing Instructions

Testing shouldn't be necessary. This is only testable with gutenboarding, but it already redirects to signup:

https://github.com/Automattic/wp-calypso/blob/a14b6727ffc1ed68b951c95f8a43ca6e1cb15ccc/client/server/pages/index.js#L882

So verify that all checks are green.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
