### PR TITLE
Drive blazepress top menu via widget

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -57,7 +57,9 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 	}, [ isVisible ] );
 
 	const handleShowCancel = ( show: boolean ) => setShowCancelButton( show );
-	const handleGetStartedMessageClose = () => setHiddenHeader( false );
+	const handleShowTopBar = ( show: boolean ) => {
+		setHiddenHeader( ! show );
+	};
 
 	const onClose = ( goToCampaigns?: boolean ) => {
 		queryClient.invalidateQueries( [ 'promote-post-campaigns', siteId ] );
@@ -99,7 +101,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 					},
 					widgetContainer.current,
 					handleShowCancel,
-					handleGetStartedMessageClose,
+					handleShowTopBar,
 					localeSlug
 				);
 				setIsLoading( false );

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -26,6 +26,7 @@ declare global {
 				locale?: string;
 				showDialog?: boolean;
 				setShowCancelButton?: ( show: boolean ) => void;
+				setShowTopBar?: ( show: boolean ) => void;
 				uploadImageLabel?: string;
 				showGetStartedMessage?: boolean;
 				onGetStartedMessageClose?: ( dontShowAgain: boolean ) => void;
@@ -59,7 +60,7 @@ export async function showDSP(
 	translateFn: ( value: string, options?: any ) => string,
 	domNodeOrId?: HTMLElement | string | null,
 	setShowCancelButton?: ( show: boolean ) => void,
-	onGetStartedMessageClose?: ( dontShowAgain: boolean ) => void,
+	setShowTopBar?: ( show: boolean ) => void,
 	locale?: string
 ) {
 	await loadDSPWidgetJS();
@@ -81,9 +82,9 @@ export async function showDSP(
 				locale,
 				urn: `urn:wpcom:post:${ siteId }:${ postId || 0 }`,
 				setShowCancelButton: setShowCancelButton,
+				setShowTopBar: setShowTopBar,
 				uploadImageLabel: isWpMobileApp() ? __( 'Tap to add image' ) : undefined,
 				showGetStartedMessage: ! isWpMobileApp(), // Don't show the GetStartedMessage in the mobile app.
-				onGetStartedMessageClose: onGetStartedMessageClose,
 				source: source,
 			} );
 		} else {


### PR DESCRIPTION

Related to #

This task can only be tested by folks working with the DSP local system

## Proposed Changes
- We previously had a bug where the welcome message in the DSP was displaying even if the user marked the option to never show that window. The issue was that the data wasn't persisting as it was being loaded in the sessionstorage instead of the localstorage. This has faced a new bug: When the user opens the window it is not displaying the top bar. This is because the Welcome message component is hiding that bar on purpose (as a style decision)

* Drive the topmenu visibility via widget

## Testing Instructions

- Clear your browser cache
- Promote a post from calypso (you will need to bridge the widget to local calypso)
- You will see the Welcome dialog. Mark "I don't want to see this" button. Accept the dialog. The widget should display
- Click on the "cancel" button in top bar
- Promote again. What should happen: The top bar should display again. Previously it wasn't being displayed


*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
