### PR TITLE
Data Stores: migrate Subscriber store to `createReduxStore`

### DIFF
--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -30,7 +30,6 @@ export * from './templates';
 export * from './onboard/types';
 export * from './domain-suggestions/types';
 export * from './plans/types';
-export * from './subscriber/types';
 export * from './launch/types';
 export * from './user/types';
 

--- a/packages/data-stores/src/subscriber/index.ts
+++ b/packages/data-stores/src/subscriber/index.ts
@@ -1,4 +1,4 @@
-import { registerStore } from '@wordpress/data';
+import { register, createReduxStore } from '@wordpress/data';
 import { controls } from '../wpcom-request-controls';
 import { createActions } from './actions';
 import { STORE_KEY } from './constants';
@@ -7,16 +7,11 @@ import * as selectors from './selectors';
 export * from './types';
 export type { State };
 
-let isRegistered = false;
-export function register(): typeof STORE_KEY {
-	if ( ! isRegistered ) {
-		isRegistered = true;
-		registerStore( STORE_KEY, {
-			actions: createActions(),
-			controls,
-			reducer,
-			selectors,
-		} );
-	}
-	return STORE_KEY;
-}
+export const store = createReduxStore( STORE_KEY, {
+	actions: createActions(),
+	controls,
+	reducer,
+	selectors,
+} );
+
+register( store );

--- a/packages/data-stores/src/subscriber/types.ts
+++ b/packages/data-stores/src/subscriber/types.ts
@@ -1,6 +1,3 @@
-import * as actions from './actions';
-import type { DispatchFromMap } from '../mapped-types';
-
 export interface SubscriberState {
 	add?: {
 		inProgress: boolean;
@@ -47,7 +44,3 @@ export type ImportSubscribersResponse = {
 
 export type GetSubscribersImportResponse = ImportJob;
 export type GetSubscribersImportsResponse = ImportJob[];
-
-export interface SubscriberDispatch {
-	dispatch: DispatchFromMap< typeof actions >;
-}

--- a/packages/data-stores/src/subscriber/types.ts
+++ b/packages/data-stores/src/subscriber/types.ts
@@ -1,6 +1,5 @@
 import * as actions from './actions';
-import * as selectors from './selectors';
-import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
+import type { DispatchFromMap } from '../mapped-types';
 
 export interface SubscriberState {
 	add?: {
@@ -52,5 +51,3 @@ export type GetSubscribersImportsResponse = ImportJob[];
 export interface SubscriberDispatch {
 	dispatch: DispatchFromMap< typeof actions >;
 }
-
-export type SubscriberSelect = SelectFromMap< typeof selectors >;

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { FormInputValidation } from '@automattic/components';
+import { Subscriber } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Title, SubTitle, NextButton } from '@automattic/onboarding';
 import { TextControl, FormFileUpload, Button } from '@wordpress/components';
@@ -20,7 +21,6 @@ import React, {
 import { useActiveJobRecognition } from '../../hooks/use-active-job-recognition';
 import { useInProgressState } from '../../hooks/use-in-progress-state';
 import { RecordTrackEvents, useRecordAddFormEvents } from '../../hooks/use-record-add-form-events';
-import { SUBSCRIBER_STORE } from '../../store';
 import { tip } from './icon';
 import './style.scss';
 
@@ -68,7 +68,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		importCsvSubscribers,
 		importCsvSubscribersUpdate,
 		getSubscribersImports,
-	} = useDispatch( SUBSCRIBER_STORE );
+	} = useDispatch( Subscriber.store );
 
 	/**
 	 * ↓ Fields
@@ -91,7 +91,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	const [ submitAttemptCount, setSubmitAttemptCount ] = useState( 0 );
 	const [ submitBtnReady, setIsSubmitBtnReady ] = useState( isSubmitButtonReady() );
 	const importSelector = useSelect(
-		( select ) => select( SUBSCRIBER_STORE ).getImportSubscribersSelector(),
+		( select ) => select( Subscriber.store ).getImportSubscribersSelector(),
 		[]
 	);
 	const [ formFileUploadElement ] = useState(

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -22,7 +22,6 @@ import { useInProgressState } from '../../hooks/use-in-progress-state';
 import { RecordTrackEvents, useRecordAddFormEvents } from '../../hooks/use-record-add-form-events';
 import { SUBSCRIBER_STORE } from '../../store';
 import { tip } from './icon';
-import type { SubscriberSelect } from '@automattic/data-stores';
 import './style.scss';
 
 interface Props {
@@ -92,7 +91,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	const [ submitAttemptCount, setSubmitAttemptCount ] = useState( 0 );
 	const [ submitBtnReady, setIsSubmitBtnReady ] = useState( isSubmitButtonReady() );
 	const importSelector = useSelect(
-		( s ) => ( s( SUBSCRIBER_STORE ) as SubscriberSelect ).getImportSubscribersSelector(),
+		( select ) => select( SUBSCRIBER_STORE ).getImportSubscribersSelector(),
 		[]
 	);
 	const [ formFileUploadElement ] = useState(

--- a/packages/subscriber/src/hooks/use-active-job-recognition.ts
+++ b/packages/subscriber/src/hooks/use-active-job-recognition.ts
@@ -2,7 +2,6 @@ import { Subscriber } from '@automattic/data-stores';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { SUBSCRIBER_STORE } from '../store';
-import type { SubscriberSelect } from '@automattic/data-stores';
 
 type ImportJob = Subscriber.ImportJob;
 type ImportJobStatus = Subscriber.ImportJobStatus;
@@ -14,10 +13,7 @@ export function useActiveJobRecognition( siteId: number ) {
 	const { getSubscribersImports, importCsvSubscribersUpdate } = useDispatch( SUBSCRIBER_STORE );
 
 	const imports =
-		useSelect(
-			( s ) => ( s( SUBSCRIBER_STORE ) as SubscriberSelect ).getImportJobsSelector(),
-			[]
-		) || [];
+		useSelect( ( select ) => select( SUBSCRIBER_STORE ).getImportJobsSelector(), [] ) || [];
 	const jobs = imports.filter( ( x: ImportJob ) => ACTIVE_STATE.includes( x.status ) );
 	const activeJob = jobs.length ? jobs[ 0 ] : undefined;
 

--- a/packages/subscriber/src/hooks/use-active-job-recognition.ts
+++ b/packages/subscriber/src/hooks/use-active-job-recognition.ts
@@ -1,7 +1,6 @@
 import { Subscriber } from '@automattic/data-stores';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
-import { SUBSCRIBER_STORE } from '../store';
 
 type ImportJob = Subscriber.ImportJob;
 type ImportJobStatus = Subscriber.ImportJobStatus;
@@ -10,10 +9,10 @@ export function useActiveJobRecognition( siteId: number ) {
 	const INTERVAL_ACTIVE = 1000;
 	const INTERVAL_INACTIVE = 5000;
 	const ACTIVE_STATE: ImportJobStatus[] = [ 'pending', 'importing' ];
-	const { getSubscribersImports, importCsvSubscribersUpdate } = useDispatch( SUBSCRIBER_STORE );
+	const { getSubscribersImports, importCsvSubscribersUpdate } = useDispatch( Subscriber.store );
 
 	const imports =
-		useSelect( ( select ) => select( SUBSCRIBER_STORE ).getImportJobsSelector(), [] ) || [];
+		useSelect( ( select ) => select( Subscriber.store ).getImportJobsSelector(), [] ) || [];
 	const jobs = imports.filter( ( x: ImportJob ) => ACTIVE_STATE.includes( x.status ) );
 	const activeJob = jobs.length ? jobs[ 0 ] : undefined;
 

--- a/packages/subscriber/src/hooks/use-in-progress-state.ts
+++ b/packages/subscriber/src/hooks/use-in-progress-state.ts
@@ -1,10 +1,9 @@
+import { Subscriber } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
-import { SUBSCRIBER_STORE } from '../store';
-import type { SubscriberSelect } from '@automattic/data-stores';
 
 export function useInProgressState() {
 	const { addSelector, importSelector } = useSelect( ( select ) => {
-		const subscriber: SubscriberSelect = select( SUBSCRIBER_STORE );
+		const subscriber = select( Subscriber.store );
 		return {
 			addSelector: subscriber.getAddSubscribersSelector(),
 			importSelector: subscriber.getImportSubscribersSelector(),

--- a/packages/subscriber/src/hooks/use-record-add-form-events.ts
+++ b/packages/subscriber/src/hooks/use-record-add-form-events.ts
@@ -2,7 +2,6 @@ import { useSelect } from '@wordpress/data';
 import { useEffect, useRef } from 'react';
 import { SUBSCRIBER_STORE } from '../store';
 import { useInProgressState } from './use-in-progress-state';
-import type { SubscriberSelect } from '@automattic/data-stores';
 
 export type RecordTrackEvents = (
 	eventName: string,
@@ -14,11 +13,11 @@ export function useRecordAddFormEvents( recordTracksEvent?: RecordTrackEvents, f
 	const inProgress = useInProgressState();
 	const prevInProgress = useRef( inProgress );
 	const addSelector = useSelect(
-		( s ) => ( s( SUBSCRIBER_STORE ) as SubscriberSelect ).getAddSubscribersSelector(),
+		( select ) => select( SUBSCRIBER_STORE ).getAddSubscribersSelector(),
 		[]
 	);
 	const importSelector = useSelect(
-		( s ) => ( s( SUBSCRIBER_STORE ) as SubscriberSelect ).getImportSubscribersSelector(),
+		( select ) => select( SUBSCRIBER_STORE ).getImportSubscribersSelector(),
 		[]
 	);
 

--- a/packages/subscriber/src/hooks/use-record-add-form-events.ts
+++ b/packages/subscriber/src/hooks/use-record-add-form-events.ts
@@ -1,6 +1,6 @@
+import { Subscriber } from '@automattic/data-stores/src';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useRef } from 'react';
-import { SUBSCRIBER_STORE } from '../store';
 import { useInProgressState } from './use-in-progress-state';
 
 export type RecordTrackEvents = (
@@ -13,11 +13,11 @@ export function useRecordAddFormEvents( recordTracksEvent?: RecordTrackEvents, f
 	const inProgress = useInProgressState();
 	const prevInProgress = useRef( inProgress );
 	const addSelector = useSelect(
-		( select ) => select( SUBSCRIBER_STORE ).getAddSubscribersSelector(),
+		( select ) => select( Subscriber.store ).getAddSubscribersSelector(),
 		[]
 	);
 	const importSelector = useSelect(
-		( select ) => select( SUBSCRIBER_STORE ).getImportSubscribersSelector(),
+		( select ) => select( Subscriber.store ).getImportSubscribersSelector(),
 		[]
 	);
 

--- a/packages/subscriber/src/index.ts
+++ b/packages/subscriber/src/index.ts
@@ -1,2 +1,1 @@
-export * from './store';
 export { AddSubscriberForm } from './components/add-form';

--- a/packages/subscriber/src/store.ts
+++ b/packages/subscriber/src/store.ts
@@ -1,3 +1,3 @@
 import { Subscriber } from '@automattic/data-stores';
 
-export const SUBSCRIBER_STORE = Subscriber.register();
+export const SUBSCRIBER_STORE = Subscriber.store;

--- a/packages/subscriber/src/store.ts
+++ b/packages/subscriber/src/store.ts
@@ -1,3 +1,0 @@
-import { Subscriber } from '@automattic/data-stores';
-
-export const SUBSCRIBER_STORE = Subscriber.store;


### PR DESCRIPTION
## Proposed Changes

This PR migrates the Subscriber store to use `createReduxStore()` and `register()` instead of `registerStore()`.

Part of #74399 which is a follow-up to #73890.

## Testing Instructions

* Go to `/people/subscribers/:siteSlug` and hit _Add subscriber_
* Add subscribers to your site by using the form as well as the CSV import
* Make sure everything works exactly as on prod

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
