### PR TITLE
Me Get Apps: refactor other platforms available links

### DIFF
--- a/client/blocks/get-apps/desktop-download-card.jsx
+++ b/client/blocks/get-apps/desktop-download-card.jsx
@@ -63,8 +63,8 @@ class DesktopDownloadCard extends Component {
 		}
 	}
 
-	getPlatformImage( platform ) {
-		switch ( platform ) {
+	getPlatformImage( platformOrLink ) {
+		switch ( platformOrLink ) {
 			case 'MacIntel':
 			case PLATFORM_MAC_SILICON:
 			case MAC_SILICON_LINK:
@@ -81,70 +81,68 @@ class DesktopDownloadCard extends Component {
 		}
 	}
 
-	getTranslateComponents( platform ) {
-		switch ( platform ) {
-			case 'MacIntel':
-			case PLATFORM_MAC_SILICON:
-				return {
-					firstAvailableLink: this.getLinkAnchorTag( WINDOWS_LINK ),
-					secondAvailableLink: this.getLinkAnchorTag( LINUX_TAR_LINK ),
-					thirdAvailableLink: this.getLinkAnchorTag( LINUX_DEB_LINK ),
-					firstAvailableIcon: this.getPlatformImage( WINDOWS_LINK ),
-					secondAvailableIcon: this.getPlatformImage( LINUX_TAR_LINK ),
-					thirdAvailableIcon: this.getPlatformImage( LINUX_DEB_LINK ),
-				};
-			case 'Linux i686':
-			case 'Linux i686 on x86_64':
-				return {
-					firstAvailableLink: this.getLinkAnchorTag( LINUX_DEB_LINK ),
-					secondAvailableLink: this.getLinkAnchorTag( WINDOWS_LINK ),
-					thirdAvailableLink: this.getLinkAnchorTag( MAC_INTEL_LINK ),
-					fourthAvailableLink: this.getLinkAnchorTag( MAC_SILICON_LINK ),
-					firstAvailableIcon: this.getPlatformImage( LINUX_DEB_LINK ),
-					secondAvailableIcon: this.getPlatformImage( WINDOWS_LINK ),
-					thirdAvailableIcon: this.getPlatformImage( MAC_INTEL_LINK ),
-					fourthAvailableIcon: this.getPlatformImage( MAC_SILICON_LINK ),
-				};
-			default:
-				return {
-					firstAvailableLink: this.getLinkAnchorTag( MAC_INTEL_LINK ),
-					secondAvailableLink: this.getLinkAnchorTag( MAC_SILICON_LINK ),
-					thirdAvailableLink: this.getLinkAnchorTag( LINUX_TAR_LINK ),
-					fourthAvailableLink: this.getLinkAnchorTag( LINUX_DEB_LINK ),
-					firstAvailableIcon: this.getPlatformImage( MAC_INTEL_LINK ),
-					secondAvailableIcon: this.getPlatformImage( MAC_SILICON_LINK ),
-					thirdAvailableIcon: this.getPlatformImage( LINUX_TAR_LINK ),
-					fourthAvailableIcon: this.getPlatformImage( LINUX_DEB_LINK ),
-				};
-		}
+	getAlsoAvailableComponent( { link, platformName } ) {
+		const Link = ( props ) => this.getLinkAnchorTag( { ...props, platformLink: link } );
+		const Icon = () => this.getPlatformImage( link );
+		return (
+			<Link>
+				<Icon />
+				{ platformName }
+			</Link>
+		);
 	}
 
 	getAlsoAvailableTextJetpack( platform ) {
+		const macIntelLink = this.getAlsoAvailableComponent( {
+			link: MAC_INTEL_LINK,
+			platformName: 'Mac (Intel)',
+		} );
+		const macSiliconLink = this.getAlsoAvailableComponent( {
+			link: MAC_SILICON_LINK,
+			platformName: 'Mac (Silicon)',
+		} );
+		const windowsLink = this.getAlsoAvailableComponent( {
+			link: WINDOWS_LINK,
+			platformName: 'Windows',
+		} );
+		const linuxTarLink = this.getAlsoAvailableComponent( {
+			link: LINUX_TAR_LINK,
+			platformName: 'Linux (.tar.gz)',
+		} );
+		const linuxDebLink = this.getAlsoAvailableComponent( {
+			link: LINUX_DEB_LINK,
+			platformName: 'Linux (.deb)',
+		} );
+
 		switch ( platform ) {
 			case 'MacIntel':
 			case PLATFORM_MAC_SILICON:
-				return translate(
-					'{{firstAvailableLink}}{{firstAvailableIcon /}}Windows{{/firstAvailableLink}}' +
-						'{{secondAvailableLink}} {{secondAvailableIcon /}} Linux (.tar.gz){{/secondAvailableLink}}' +
-						'{{thirdAvailableLink}} {{thirdAvailableIcon /}} Linux (.deb){{/thirdAvailableLink}}',
-					{ components: this.getTranslateComponents( platform ) }
+				return (
+					<>
+						{ windowsLink }
+						{ linuxTarLink }
+						{ linuxDebLink }
+					</>
 				);
 			case 'Linux i686':
 			case 'Linux i686 on x86_64':
-				return translate(
-					'{{firstAvailableLink}}{{firstAvailableIcon /}}Linux (.deb){{/firstAvailableLink}}' +
-						'{{secondAvailableLink}}{{secondAvailableIcon /}}Windows{{/secondAvailableLink}}' +
-						'{{thirdAvailableLink}}{{thirdAvailableIcon /}}Mac (Intel){{/thirdAvailableLink}}' +
-						'{{fourthAvailableLink}}{{fourthAvailableIcon /}}Mac (Apple Silicon){{/fourthAvailableLink}}',
-					{ components: this.getTranslateComponents( platform ) }
+				return (
+					<>
+						{ linuxDebLink }
+						{ windowsLink }
+						{ macIntelLink }
+						{ macSiliconLink }
+					</>
 				);
 			default:
-				return translate(
-					'{{firstAvailableLink}}{{firstAvailableIcon /}}MacOS (Intel){{/firstAvailableLink}}' +
-						'{{secondAvailableLink}}{{secondAvailableIcon /}}MacOS (Apple Silicon){{/secondAvailableLink}}' +
-						'{{thirdAvailableLink}}{{thirdAvailableIcon /}}Linux (.tar.gz){{/thirdAvailableLink}}' +
-						'{{fourthAvailableLink}}{{fourthAvailableIcon /}}Linux (.deb){{/fourthAvailableLink}}',
-					{ components: this.getTranslateComponents( platform ) }
+				// Windows
+				return (
+					<>
+						{ macIntelLink }
+						{ macSiliconLink }
+						{ linuxTarLink }
+						{ linuxDebLink }
+					</>
 				);
 		}
 	}
@@ -213,7 +211,7 @@ class DesktopDownloadCard extends Component {
 		}
 	}
 
-	getLinkAnchorTag( platformLink ) {
+	getLinkAnchorTag( { platformLink, children } ) {
 		const {
 			trackWindowsClick,
 			trackMacIntelClick,
@@ -222,45 +220,27 @@ class DesktopDownloadCard extends Component {
 			trackLinuxDebClick,
 		} = this.props;
 
+		let onClick = trackWindowsClick;
+
 		switch ( platformLink ) {
 			case MAC_INTEL_LINK:
-				<a
-					href={ localizeUrl( platformLink ) }
-					onClick={ trackMacIntelClick }
-					className="get-apps__desktop-link"
-				/>;
-
+				onClick = trackMacIntelClick;
 			case MAC_SILICON_LINK:
-				<a
-					href={ localizeUrl( platformLink ) }
-					onClick={ trackMacSiliconClick }
-					className="get-apps__desktop-link"
-				/>;
+				onClick = trackMacSiliconClick;
 			case LINUX_TAR_LINK:
-				return (
-					<a
-						href={ localizeUrl( platformLink ) }
-						onClick={ trackLinuxTarClick }
-						className="get-apps__desktop-link"
-					/>
-				);
+				onClick = trackLinuxTarClick;
 			case LINUX_DEB_LINK:
-				return (
-					<a
-						href={ localizeUrl( platformLink ) }
-						onClick={ trackLinuxDebClick }
-						className="get-apps__desktop-link"
-					/>
-				);
-			default:
-				return (
-					<a
-						href={ localizeUrl( platformLink ) }
-						onClick={ trackWindowsClick }
-						className="get-apps__desktop-link"
-					/>
-				);
+				onClick = trackLinuxDebClick;
 		}
+		return (
+			<a
+				href={ localizeUrl( platformLink ) }
+				onClick={ onClick }
+				className="get-apps__desktop-link"
+			>
+				{ children }
+			</a>
+		);
 	}
 
 	getMobileDeviceDownloadOptions() {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/wp-calypso/pull/74412

## Proposed Changes

* Refactor and optimize the code related to the unused translation of the other available links.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/me/get-apps`
* Observe the links, images and text belo `Also available for:` are the same. No change behaviour intended.

- Check https://github.com/Automattic/wp-calypso/pull/74412 to see how to test for different platforms.

## Screenshot

<img width="507" alt="Screenshot 2023-03-14 at 10 53 44" src="https://user-images.githubusercontent.com/779993/225075070-328b4f4e-e7d3-4c66-a1be-14e8a802e561.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
