### PR TITLE
Shopping Cart: Remove source param in shopping-cart fetch URL

### DIFF
--- a/client/my-sites/checkout/cart-manager-client.ts
+++ b/client/my-sites/checkout/cart-manager-client.ts
@@ -2,15 +2,7 @@ import { createShoppingCartManagerClient } from '@automattic/shopping-cart';
 import wp from 'calypso/lib/wp';
 import type { RequestCart, CartKey } from '@automattic/shopping-cart';
 
-const wpcomGetCart = ( cartKey: CartKey ) => {
-	let source;
-	try {
-		source = window?.location?.pathname;
-	} catch {
-		// Ignore failures here if window is not present.
-	}
-	return wp.req.get( `/me/shopping-cart/${ cartKey }?source=${ source ?? 'unknown' }` );
-};
+const wpcomGetCart = ( cartKey: CartKey ) => wp.req.get( `/me/shopping-cart/${ cartKey }` );
 const wpcomSetCart = ( cartKey: CartKey, cartData: RequestCart ) =>
 	wp.req.post( `/me/shopping-cart/${ cartKey }`, cartData );
 


### PR DESCRIPTION
## Proposed Changes

As part of trying to debug some strange authentication errors, we added a `source` param to GET requests to the `/me/shopping-cart` endpoint. However, the results of that search were not helpful. This PR removes that param.

## Testing Instructions

Add a product to your cart and visit checkout. Verify that it loads without errors and that the product is in the cart.