### PR TITLE
VAT Info: Use actual error message in useDisplayVatNotices

### DIFF
--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -234,31 +234,9 @@ function useDisplayVatNotices( {
 	const translate = useTranslate();
 
 	useEffect( () => {
-		if ( error?.error === 'validation_failed' ) {
-			reduxDispatch( removeNotice( 'vat_info_notice' ) );
-			reduxDispatch(
-				errorNotice(
-					translate(
-						'Your Business Tax ID details are not valid. Please check each field and try again.'
-					),
-					{ id: 'vat_info_notice' }
-				)
-			);
-			return;
-		}
-
 		if ( error ) {
 			reduxDispatch( removeNotice( 'vat_info_notice' ) );
-			reduxDispatch(
-				errorNotice(
-					translate(
-						'An error occurred while updating your Business Tax ID details. Please try again or contact support.'
-					),
-					{
-						id: 'vat_info_notice',
-					}
-				)
-			);
+			reduxDispatch( errorNotice( error.message, { id: 'vat_info_notice' } ) );
 			return;
 		}
 


### PR DESCRIPTION
## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/74360.

When validating VAT info on the VAT details page, we always display a generic failure message no matter what the server returns. However, this can be confusing for users if the message isn't a validation error (see https://github.com/Automattic/payments-shilling/issues/1451 and p1678813345163599-slack-C02BEP610).

In this PR, we change the VAT form to display the raw error message returned by the server instead.

Before:

<img width="1148" alt="Screenshot 2023-03-14 at 1 26 16 PM" src="https://user-images.githubusercontent.com/2036909/225088311-d3a8ac28-f1b0-4683-957c-3b1a4fcdf833.png">

After:

<img width="1152" alt="Screenshot 2023-03-14 at 1 26 52 PM" src="https://user-images.githubusercontent.com/2036909/225088356-dd64beb4-3dd0-4212-b113-ee6eb019bc6a.png">


## Testing Instructions

- Use an account that has no saved VAT details. You can use Payments Admin to remove saved VAT details if needed.
- Visit `/me/purchases/vat-details`.
- Enter an invalid VAT ID and submit the form.
- Verify you see a sensible error message.