### PR TITLE
Staging Sites: Clear site excerpt query cache when new site is created

### DIFF
--- a/client/data/sites/use-site-excerpts-query.ts
+++ b/client/data/sites/use-site-excerpts-query.ts
@@ -11,6 +11,8 @@ import {
 } from './site-excerpt-constants';
 import { SiteExcerptData, SiteExcerptNetworkData } from './site-excerpt-types';
 
+export const USE_SITE_EXCERPTS_QUERY_KEY = 'sites-dashboard-sites-data';
+
 const fetchSites = (): Promise< { sites: SiteExcerptNetworkData[] } > => {
 	const siteFilter = config< string[] >( 'site_filter' );
 	return wpcom.me().sites( {
@@ -27,7 +29,7 @@ const fetchSites = (): Promise< { sites: SiteExcerptNetworkData[] } > => {
 export const useSiteExcerptsQuery = () => {
 	const store = useStore();
 
-	return useQuery( [ 'sites-dashboard-sites-data' ], fetchSites, {
+	return useQuery( [ USE_SITE_EXCERPTS_QUERY_KEY ], fetchSites, {
 		select: ( data ) => data?.sites.map( computeFields( data?.sites ) ),
 		initialData: () => {
 			// Not using `useSelector` (i.e. calling `getSites` directly) because we


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1966

## Proposed Changes

Clears the site excerpt query cache when a new staging site is created. Otherwise, the site selector search can be stale.

Redux cache doesn't need to be updated because the transfer process already fetches the new site object. https://github.com/Automattic/jetpack/pull/29453 was sufficient to resolve that part of the problem.

## Testing Instructions

1. Create a new Business site and take it Atomic.
2. Navigate to Hosting Configuration.
3. Click 'Add staging site'.
4. After the staging site is created, verify you can find it in the site switcher.