### PR TITLE
Marketplace: Added expire date for plugins on thank you page

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -449,9 +449,10 @@ export const getSoftwareSlug = ( plugin, isMarketplaceProduct ) =>
 	isMarketplaceProduct ? plugin.software_slug || plugin.org_slug : plugin.slug;
 
 /**
+ * @typedef {import('calypso/lib/purchases/types').Purchase} Purchase
  * @param  {Object} plugin The plugin object
  * @param  {Array} purchases An array of site purchases
- * @returns {Object} The purchase object, if found.
+ * @returns {Purchase} The purchase object, if found.
  */
 export const getPluginPurchased = ( plugin, purchases ) => {
 	return (

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
@@ -117,7 +117,7 @@ export const ThankYouPluginSection = ( { plugin }: { plugin: any } ) => {
 					} ).toString()
 				);
 			} else {
-				setExpirationDate( "This plugin doesn't expire" );
+				setExpirationDate( translate( "This plugin doesn't expire" ) );
 			}
 		}
 	}, [ plugin, isLoadingPurchases, translate, productPurchase ] );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
@@ -7,6 +7,8 @@ import moment from 'moment';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useQueryUserPurchases } from 'calypso/components/data/query-user-purchases';
+import { getPluginPurchased } from 'calypso/lib/plugins/utils';
+import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
 import {
 	getUserPurchases,
 	hasLoadedUserPurchasesFromServer,
@@ -94,18 +96,8 @@ export const ThankYouPluginSection = ( { plugin }: { plugin: any } ) => {
 	const [ expirationDate, setExpirationDate ] = useState( '' );
 
 	const productPurchase = useMemo(
-		() =>
-			purchases?.find( ( item ) => {
-				if ( item.siteId === siteId ) {
-					if (
-						plugin.variations?.monthly?.product_id === item.productId ||
-						plugin.variations?.yearly?.product_id === item.productId
-					) {
-						return item;
-					}
-				}
-			} ),
-		[ purchases, siteId, plugin ]
+		() => getPluginPurchased( plugin, purchases || [] ),
+		[ plugin, purchases ]
 	);
 
 	useEffect( () => {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
@@ -6,13 +6,13 @@ import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useQueryUserPurchases } from 'calypso/components/data/query-user-purchases';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { getPluginPurchased } from 'calypso/lib/plugins/utils';
 import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
 import {
-	getUserPurchases,
-	hasLoadedUserPurchasesFromServer,
-	isFetchingUserPurchases,
+	getSitePurchases,
+	hasLoadedSitePurchasesFromServer,
+	isFetchingSitePurchases,
 } from 'calypso/state/purchases/selectors';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
@@ -88,11 +88,10 @@ export const ThankYouPluginSection = ( { plugin }: { plugin: any } ) => {
 		plugin?.setup_url && siteAdminUrl ? siteAdminUrl + plugin.setup_url : null;
 	const setupURL = plugin?.action_links?.Settings || fallbackSetupUrl || managePluginsUrl;
 	const documentationURL = plugin?.documentation_url;
-	const purchases = useSelector( ( state ) => getUserPurchases( state ) );
+	const purchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
 	const isLoadingPurchases = useSelector(
-		( state ) => isFetchingUserPurchases( state ) || ! hasLoadedUserPurchasesFromServer( state )
+		( state ) => isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state )
 	);
-	useQueryUserPurchases();
 	const [ expirationDate, setExpirationDate ] = useState( '' );
 
 	const productPurchase = useMemo(
@@ -127,6 +126,7 @@ export const ThankYouPluginSection = ( { plugin }: { plugin: any } ) => {
 
 	return (
 		<PluginSectionContainer>
+			<QuerySitePurchases siteId={ siteId } />
 			<img
 				width={ 50 }
 				height={ 50 }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
@@ -8,7 +8,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { getPluginPurchased } from 'calypso/lib/plugins/utils';
-import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
 import {
 	getSitePurchases,
 	hasLoadedSitePurchasesFromServer,

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/marketplace-thank-you-plugin-section.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/marketplace-thank-you-plugin-section.jsx
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { ThankYouPluginSection } from '../marketplace-thank-you-plugin-section';
+
+const sites = [];
+sites[ 1 ] = {
+	ID: 1,
+	URL: 'example.wordpress.com',
+};
+
+const initialState = {
+	purchases: {
+		hasLoadedUserPurchasesFromServer: true,
+	},
+	sites: {
+		items: sites,
+		domains: {
+			items: [ 'example.wordpress.com' ],
+		},
+	},
+	ui: {
+		selectedSiteId: 1,
+	},
+	currentUser: {
+		id: 12,
+		user: {
+			email_verified: true,
+		},
+	},
+};
+
+describe( 'index', () => {
+	test( "Plugin without a purchase, DOESN'T expire", async () => {
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+		const plugin = {
+			variations: [
+				{
+					yearly: {
+						product_id: 123,
+					},
+				},
+			],
+		};
+
+		render(
+			<Provider store={ store }>
+				<ThankYouPluginSection plugin={ plugin } />
+			</Provider>
+		);
+
+		expect( screen.getByText( "This plugin doesn't expire" ) ).toBeInTheDocument();
+	} );
+
+	test( 'Plugin with a purchase, MUST expire', async () => {
+		const mockStore = configureStore();
+		initialState.purchases.data = [
+			{
+				user_id: 12,
+				expiry_date: '2021-01-01T00:00:00+00:00',
+				product_id: 123,
+				blog_id: 1,
+			},
+		];
+		const store = mockStore( initialState );
+		const plugin = {
+			variations: {
+				yearly: {
+					product_id: 123,
+				},
+			},
+		};
+
+		render(
+			<Provider store={ store }>
+				<ThankYouPluginSection plugin={ plugin } />
+			</Provider>
+		);
+
+		expect( screen.getByText( 'Expires on January 1, 2021' ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/marketplace-thank-you-plugin-section.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/marketplace-thank-you-plugin-section.jsx
@@ -40,15 +40,6 @@ const initialState = {
 			email_verified: true,
 		},
 	},
-	// productsList: {
-	// 	items: {
-	// 		mock_plugin: {
-	// 			product_id: 123,
-	// 			product_slug: 'mock_plugin',
-	// 			product_type: 'marketplace_plugin',
-	// 		},
-	// 	},
-	// },
 };
 
 describe( 'index', () => {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/marketplace-thank-you-plugin-section.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/marketplace-thank-you-plugin-section.jsx
@@ -7,6 +7,14 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { ThankYouPluginSection } from '../marketplace-thank-you-plugin-section';
 
+jest.mock( 'react-redux', () => {
+	const originalModule = jest.requireActual( 'react-redux' );
+	return {
+		...originalModule,
+		useDispatch: () => jest.fn(),
+	};
+} );
+
 const sites = [];
 sites[ 1 ] = {
 	ID: 1,
@@ -15,7 +23,7 @@ sites[ 1 ] = {
 
 const initialState = {
 	purchases: {
-		hasLoadedUserPurchasesFromServer: true,
+		hasLoadedSitePurchasesFromServer: true,
 	},
 	sites: {
 		items: sites,

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/marketplace-thank-you-plugin-section.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/marketplace-thank-you-plugin-section.jsx
@@ -32,6 +32,15 @@ const initialState = {
 			email_verified: true,
 		},
 	},
+	// productsList: {
+	// 	items: {
+	// 		mock_plugin: {
+	// 			product_id: 123,
+	// 			product_slug: 'mock_plugin',
+	// 			product_type: 'marketplace_plugin',
+	// 		},
+	// 	},
+	// },
 };
 
 describe( 'index', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74324

## Proposed Changes

* Added expire date for plugins on thank you page:

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/1044309/225092356-3b57a617-ee77-42ee-9ec8-4488b7952bee.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Buy a paid plugin and check if the expire date on thank you page works as expected
* Buy a free plugin and make sure we show that plugin doesn't expire

Running unit tests: `yarn test-client client/my-sites/checkout/checkout-thank-you/marketplace/test/marketplace-thank-you-plugin-section.jsx`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
