### PR TITLE
Fix: Jetpack App loading animation

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -91,7 +91,7 @@ class Document extends Component {
 
 		const theme = config( 'theme' );
 
-		const LoadingLogo = chooseLoadingLogo( this.props );
+		const LoadingLogo = chooseLoadingLogo( this.props, app?.isWpMobileApp );
 
 		const isRTL = isLocaleRtl( lang );
 
@@ -259,11 +259,11 @@ class Document extends Component {
 	}
 }
 
-function chooseLoadingLogo( { useLoadingEllipsis } ) {
+function chooseLoadingLogo( { useLoadingEllipsis }, isMobileApp ) {
 	if ( useLoadingEllipsis ) {
 		return LoadingEllipsis;
 	}
-	if ( config.isEnabled( 'jetpack-cloud' ) ) {
+	if ( config.isEnabled( 'jetpack-cloud' ) || isMobileApp ) {
 		return JetpackLogo;
 	}
 


### PR DESCRIPTION
This PR fixes the (W) logo that shows up in the Jetpack App webviews when calypso is loading. 

## Proposed Changes

* This change was something that was discussed and noticed in p5T066-3Ue-p2#comment-14482
* As we are implementing the Blaze webview.

The fix here is to always display the Jetpack logo. (Similarly how it currently appears in the Jetpack cloud. 
But only do this when we are in requeste a webview in the app. 

After:

https://user-images.githubusercontent.com/115071/225093898-1e4d8679-209f-4864-a196-88ce07953e05.mov


## Testing Instructions

* Open the calypso as a Mobile App. 
* Change your User agent to : `Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 wp-iphone`
* You can do this in the developer tools to change the user agent. 
* Notice the Jetpack logo when the view loads instead of the regular W

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?