### PR TITLE
Receipts: Add key to VatVendorDetails address lines

### DIFF
--- a/client/me/purchases/billing-history/vat-vendor-details.tsx
+++ b/client/me/purchases/billing-history/vat-vendor-details.tsx
@@ -106,10 +106,7 @@ export function VatVendorDetails( { transaction }: { transaction: BillingTransac
 			<strong>{ translate( 'Vendor VAT Details' ) }</strong>
 			<span>
 				{ vendorInfo.address.map( ( addressLine ) => (
-					<>
-						{ addressLine }
-						<br />
-					</>
+					<div key={ addressLine }>{ addressLine }</div>
 				) ) }
 			</span>
 			<span className="receipt__vat-vendor-details-number">


### PR DESCRIPTION
## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/73697 which added VAT vendor info to applicable receipts. That PR rendered a list of address strings to the receipt page using `Array.prototype.map`, but React requires that mapped nodes have a `key` property.

This PR adds a `key` property to each address line.

<img width="321" alt="Screenshot 2023-03-14 at 2 12 49 PM" src="https://user-images.githubusercontent.com/2036909/225100584-4810831f-b55e-42b2-9716-5be1e4f06eac.png">


## Testing Instructions

To test this, you'll need to use an account that has had purchases in the EU.

- Visit `/me/purchases` and click on a purchase to view its receipt.
- Verify that you see the VAT Vendor information displayed and looks similar to the same information displayed without this PR.