### PR TITLE
Post-purchase: Update success copy for plugins

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -360,7 +360,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 						showSupportSection={ false }
 						thankYouTitle={ translate( "Congrats on your site's new superpowers!" ) }
 						thankYouSubtitle={ translate(
-							"You're scratching the surface of the WordPress community. Dig in and explore more of our favorite plugins."
+							"Now you're really getting the most out of WordPress. Dig in and explore more of our favorite plugins."
 						) }
 						headerBackgroundColor="#fff"
 						headerTextColor="#000"

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -23,7 +23,6 @@ import {
 	getAutomatedTransferStatus,
 	isFetchingAutomatedTransferStatus,
 } from 'calypso/state/automated-transfer/selectors';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { pluginInstallationStateChange } from 'calypso/state/marketplace/purchase-flow/actions';
 import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
@@ -50,7 +49,6 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
-	const currentUser = useSelector( getCurrentUser );
 	const isRequestingPlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
 
 	// retrieve WPCom plugin data
@@ -352,6 +350,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 					/>
 				</div>
 			) }
+
 			{ ! showProgressBar && (
 				<div className="marketplace-thank-you__container">
 					<ConfettiAnimation delay={ 1000 } />
@@ -359,13 +358,9 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 						containerClassName="marketplace-thank-you"
 						sections={ [ pluginsSection, footerSection ] }
 						showSupportSection={ false }
-						thankYouTitle={ translate( "You're all set %(username)s!", {
-							args: {
-								username: currentUser?.display_name || currentUser?.username,
-							},
-						} ) }
+						thankYouTitle={ translate( "Congrats on your site's new superpowers!" ) }
 						thankYouSubtitle={ translate(
-							'Congratulations on your installation. You can now extend the possibilities of your site.'
+							"You're scratching the surface of the WordPress community. Dig in and explore more of our favorite plugins."
 						) }
 						headerBackgroundColor="#fff"
 						headerTextColor="#000"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74323

## Proposed Changes

* Updated plugin purchase copy to match this Figma 5ddl1WFTEnaIatL2WlZp4k-fi-2459%3A3164
* I used the American spelling of favorite.

Before | After
--|--
<img width="1187" alt="plugin-copy-before" src="https://user-images.githubusercontent.com/140841/225106356-f4440880-2a00-4cf0-81bf-24b33ef1eca9.png">  |  <img width="1218" alt="plugin-copy-after" src="https://user-images.githubusercontent.com/140841/225673371-cbfb68e1-34b2-46fd-89d8-90c01cce7ee5.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR and purchase a plugin.
* The copy should match the above After screenshot

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?