### PR TITLE
Shopping Cart: Remove unused has_bundle_credit/hasDomainCredit

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -124,10 +124,6 @@ export function hasStarterPlan( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isStarter );
 }
 
-export function hasDomainCredit( cart: ResponseCart ): boolean {
-	return cart.has_bundle_credit || hasPlan( cart );
-}
-
 export function hasMonthlyCartItem( cart: ObjectWithProducts ): boolean {
 	return getAllCartItems( cart ).some( isMonthlyProduct );
 }

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -252,7 +252,6 @@ export interface Cart {
 	coupon_discounts: unknown[];
 	coupon_discounts_integer: unknown[];
 	is_coupon_applied: boolean;
-	has_bundle_credit: boolean;
 	next_domain_is_free: boolean;
 	next_domain_condition: string;
 	products: unknown[];

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -305,7 +305,6 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	next_domain_is_free: boolean;
 	next_domain_condition: '' | 'blog';
 	bundled_domain?: string;
-	has_bundle_credit?: boolean;
 	terms_of_service?: TermsOfServiceRecord[];
 	has_pending_payment?: boolean;
 }


### PR DESCRIPTION
The `has_bundle_credit` property returned by the shopping cart is a little misleading. Its name implies that it will be true if there is an available bundle credit or possibly if there's a bundle credit applied in the cart currently. Actually it's true if the cart contains a domain product (bundled or not) or if the user has an unused domain bundle credit (but not if the cart would provide one).

Fortunately, this property is only used in one place, the function `hasDomainCredit()` which is not used anywhere.

## Proposed Changes

This PR removes the unused property `has_bundle_credit` and the unused function `hasDomainCredit`.

## Testing Instructions

Verify that neither the property nor the function are used anywhere.

Note that there is a selector function `hasDomainCredit()` that applies to plan objects, but the function we're removing here is the one for the cart. You can tell the difference by the imports or by argument passed in. The removed function accepts a cart argument only and can be called by itself. The selector function must be called inside a Redux `useSelector` or `connect` call and has two arguments.