### PR TITLE
Update notification setting labels with consistent case

### DIFF
--- a/client/me/notification-settings/settings-form/locales.js
+++ b/client/me/notification-settings/settings-form/locales.js
@@ -15,8 +15,8 @@ export const settingLabels = {
 	achievement: () => i18n.translate( 'Site achievements' ),
 	mentions: () => i18n.translate( 'Username mentions' ),
 	scheduled_publicize: () => i18n.translate( 'Post Publicized' ),
-	blogging_prompt: () => i18n.translate( 'Daily Writing Prompts' ),
-	draft_post_prompt: () => i18n.translate( 'Draft Post Prompts' ),
+	blogging_prompt: () => i18n.translate( 'Daily writing prompts' ),
+	draft_post_prompt: () => i18n.translate( 'Draft post reminders' ),
 	store_order: () => i18n.translate( 'New order' ),
 };
 


### PR DESCRIPTION
## Proposed Changes

Updates notification setting labels with consistent case

| **Before** | **After** |
| - | - |
| <img width="840" alt="Screenshot 2023-03-14 at 15 27 01" src="https://user-images.githubusercontent.com/1699996/225130489-8d44d0c5-2d2a-4daf-9265-9c97f3f3a706.png"> | <img width="834" alt="Screenshot 2023-03-14 at 15 34 49" src="https://user-images.githubusercontent.com/1699996/225130446-1adfca60-56a5-4042-b51e-7d66381cb519.png"> |

## Testing Instructions

- Go to `/me/notifications` and open the notification settings for a site
