### PR TITLE
Only show option to update contact info when appropriate

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -16,6 +16,8 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import {
 	canCurrentUserAddEmail,
 	getDomainTypeText,
+	isDomainInGracePeriod,
+	isDomainUpdateable,
 	resolveDomainStatus,
 } from 'calypso/lib/domains';
 import { type as domainTypes, domainInfoContext } from 'calypso/lib/domains/constants';
@@ -390,9 +392,13 @@ class DomainRow extends PureComponent {
 					<PopoverMenuItem icon="info-outline" onClick={ this.goToDNSManagement }>
 						{ translate( 'Manage DNS' ) }
 					</PopoverMenuItem>
-					<PopoverMenuItem icon="book" onClick={ this.goToEditContactInfo }>
-						{ translate( 'Manage Contact Info' ) }
-					</PopoverMenuItem>
+
+					{ domain.type === domainTypes.REGISTERED &&
+						( isDomainUpdateable( domain ) || isDomainInGracePeriod( domain ) ) && (
+							<PopoverMenuItem icon="book" onClick={ this.goToEditContactInfo }>
+								{ translate( 'Manage Contact Info' ) }
+							</PopoverMenuItem>
+						) }
 					{ canSetAsPrimary( domain, isManagingAllSites, shouldUpgradeToMakePrimary ) &&
 						! isRecentlyRegisteredAndDoesNotPointToWpcom( domain ) && (
 							<PopoverMenuItem onClick={ this.makePrimary }>


### PR DESCRIPTION
We should only show the "Manage contact info" option for domains that are registered with us and in a state where the contact info can be updated.

<img width="1172" alt="Cursor_and_Domains_‹_A8C_Test_Site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/225154197-fee7fe3a-b815-4867-8ca0-17bbb3168eb0.png">

<img width="1178" alt="Domains_‹_A8C_Test_Site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/225154398-bc402d0d-c614-412b-ae68-6bee2766a5a0.png">


### Test

- On a site with a mapped domain, make sure that this option does not appear in the list of actions for action  menu.
- Make sure that the option does appear for domains that are registered with us and in an updateable state.
