### PR TITLE
Markeplace: Thank you page URL to have product type

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -327,10 +327,10 @@ const MarketplaceThankYou = ( {
 				backText={ translate( 'Back to plugins' ) }
 				canGoBack={ areAllProductsFetched }
 			/>
-			{ themeSlugs.map( ( productSlug, index ) => (
+			{ themeSlugs.map( ( themeSlug, index ) => (
 				<>
-					<QueryTheme key={ 'query-wpcom-theme-' + index } siteId="wpcom" themeId={ productSlug } />
-					<QueryTheme key={ 'query-wporg-theme-' + index } siteId="wporg" themeId={ productSlug } />
+					<QueryTheme key={ 'query-wpcom-theme-' + index } siteId="wpcom" themeId={ themeSlug } />
+					<QueryTheme key={ 'query-wporg-theme-' + index } siteId="wporg" themeId={ themeSlug } />
 				</>
 			) ) }
 			{ showProgressBar && (

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -313,10 +313,7 @@ const MarketplaceThankYou = ( {
 
 	return (
 		<ThemeProvider theme={ theme }>
-			<PageViewTracker
-				path="/marketplace/thank-you/:productSlug/:site"
-				title="Marketplace > Thank you"
-			/>
+			<PageViewTracker path="/marketplace/thank-you/:site" title="Marketplace > Thank you" />
 			{ /* Using Global to override Global masterbar height */ }
 			<Global
 				styles={ css`

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -44,9 +44,13 @@ type Plugin = {
 	icon: string;
 };
 
-const MarketplaceThankYou = () => {
-	const [ pluginSlugs ] = useState< Array< string > >( [ 'woocommerce-bookings', 'woocommerce' ] );
-	const [ themesSlugs ] = useState< Array< string > >( [ 'yuna' ] );
+const MarketplaceThankYou = ( {
+	pluginSlugs,
+	themeSlugs,
+}: {
+	pluginSlugs: Array< string >;
+	themeSlugs: Array< string >;
+} ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
@@ -100,8 +104,8 @@ const MarketplaceThankYou = () => {
 	);
 
 	// Retrieve theme information
-	const dotComThemes = useSelector( ( state ) => getThemes( state, 'wpcom', themesSlugs ) );
-	const dotOrgThemes = useSelector( ( state ) => getThemes( state, 'wporg', themesSlugs ) );
+	const dotComThemes = useSelector( ( state ) => getThemes( state, 'wpcom', themeSlugs ) );
+	const dotOrgThemes = useSelector( ( state ) => getThemes( state, 'wporg', themeSlugs ) );
 
 	const areAllProductsFetched =
 		!! pluginsOnSite.length &&
@@ -326,7 +330,7 @@ const MarketplaceThankYou = () => {
 				backText={ translate( 'Back to plugins' ) }
 				canGoBack={ areAllProductsFetched }
 			/>
-			{ themesSlugs.map( ( productSlug, index ) => (
+			{ themeSlugs.map( ( productSlug, index ) => (
 				<>
 					<QueryTheme key={ 'query-wpcom-theme-' + index } siteId="wpcom" themeId={ productSlug } />
 					<QueryTheme key={ 'query-wporg-theme-' + index } siteId="wporg" themeId={ productSlug } />

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -366,35 +366,6 @@ const MarketplaceThankYou = () => {
 	);
 };
 
-/**
- * Returns the type of the product
- *
- * @param dotComThemes list of WordPress.com themes
- * @param dotOrgThemes list of WordPress.org themes
- * @param dotComPlugins list of WordPress.com plugins
- * @param dotOrgPlugins list of WordPress.org plugins
- * @param index current index to search on the list
- * @returns 'theme'| 'plugin' | undefined the type of the product
- */
-// eslint-disable-next-line
-function getProductType(
-	dotComThemes: [],
-	dotOrgThemes: [],
-	dotComPlugins: Array< Plugin >,
-	dotOrgPlugins: Array< Plugin >,
-	index: number
-): 'theme' | 'plugin' | undefined {
-	if ( dotComThemes[ index ] || dotOrgThemes[ index ] ) {
-		return 'theme';
-	}
-
-	if ( dotComPlugins[ index ] || dotOrgPlugins[ index ]?.fetched ) {
-		return 'plugin';
-	}
-
-	return undefined;
-}
-
 function FooterIcon( { icon }: { icon: string } ) {
 	return (
 		<Gridicon

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -338,8 +338,8 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 			/>
 			{ productSlugs.map( ( productSlug, index ) => (
 				<>
-					<QueryTheme key={ 'query-theme-' + index } siteId="wpcom" themeId={ productSlug } />
-					<QueryTheme key={ 'query-theme-' + index } siteId="wporg" themeId={ productSlug } />
+					<QueryTheme key={ 'query-wpcom-theme-' + index } siteId="wpcom" themeId={ productSlug } />
+					<QueryTheme key={ 'query-wporg-theme-' + index } siteId="wporg" themeId={ productSlug } />
 				</>
 			) ) }
 			{ showProgressBar && (

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -533,14 +533,14 @@ function getFallbackDestination( {
 		}
 	}
 
-	const marketplaceProductSlugs =
+	const pluginSlugs =
 		cart?.products
 			?.filter( ( product ) => product?.extra?.is_marketplace_product )
 			?.map( ( product ) => product?.extra?.plugin_slug ) || [];
 
-	if ( marketplaceProductSlugs.length > 0 ) {
+	if ( pluginSlugs.length > 0 ) {
 		debug( 'site with marketplace products' );
-		return `/marketplace/thank-you/${ marketplaceProductSlugs.join( ',' ) }/${ siteSlug }`;
+		return `/marketplace/thank-you/${ siteSlug }?plugins=${ pluginSlugs.join( ',' ) }`;
 	}
 
 	debug( 'simple thank-you page' );

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1799,7 +1799,7 @@ describe( 'getThankYouPageUrl', () => {
 				},
 				siteSlug: 'site.slug',
 			} );
-			expect( url ).toBe( '/marketplace/thank-you/slug1,slug2/site.slug' );
+			expect( url ).toBe( '/marketplace/thank-you/site.slug?plugins=slug1%2Cslug2' ); // %2C is a comma
 		} );
 
 		it( 'Error when gift purchase missing blog_slug', () => {

--- a/client/my-sites/marketplace/controller.js
+++ b/client/my-sites/marketplace/controller.js
@@ -18,9 +18,11 @@ export function renderPluginsInstallPage( context, next ) {
 }
 
 export function renderMarketplaceThankYou( context, next ) {
-	const { productSlug } = context.params;
+	const { plugins, themes } = context.query;
+	const pluginSlugs = plugins ? plugins.split( ',' ) : [];
+	const themeSlugs = themes ? themes.split( ',' ) : [];
 
-	context.primary = <MarketplaceThankYou productSlug={ productSlug } />;
+	context.primary = <MarketplaceThankYou pluginSlugs={ pluginSlugs } themeSlugs={ themeSlugs } />;
 	next();
 }
 

--- a/client/my-sites/marketplace/index.js
+++ b/client/my-sites/marketplace/index.js
@@ -35,7 +35,7 @@ export default function () {
 		clientRender
 	);
 	page(
-		'/marketplace/thank-you/:productSlug/:site?',
+		'/marketplace/thank-you/:site?',
 		siteSelection,
 		renderMarketplaceThankYou,
 		makeLayout,

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -249,9 +249,9 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 		) {
 			waitFor( 1 ).then( () =>
 				page.redirect(
-					`/marketplace/thank-you/${
+					`/marketplace/thank-you/${ selectedSiteSlug }?hide-progress-bar&plugins=${
 						installedPlugin?.slug || productSlug || uploadedPluginSlug
-					}/${ selectedSiteSlug }?hide-progress-bar`
+					}`
 				)
 			);
 		}
@@ -334,11 +334,7 @@ const MarketplacePluginInstall = ( { productSlug }: MarketplacePluginInstallProp
 										primary
 										onClick={ () =>
 											page(
-												`/checkout/${
-													selectedSite?.slug || ''
-												}/${ marketplaceProductSlug }?redirect_to=/marketplace/thank-you/${ marketplaceProductSlug }/${
-													selectedSite?.slug || ''
-												}#step2`
+												`/checkout/${ selectedSite?.slug || '' }/${ marketplaceProductSlug }?#step2`
 											)
 										}
 									>

--- a/client/my-sites/marketplace/pages/marketplace-test/index.jsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.jsx
@@ -91,14 +91,14 @@ export default function MarketplaceTest() {
 			name: 'Pay & Install Woocommerce Subscription',
 			path: `/checkout/${ selectedSiteSlug }/woocommerce_subscriptions_monthly${
 				shouldUpgrade ? ',business' : '' // or business-monthly if user has selected monthly pricing
-			}?redirect_to=/marketplace/thank-you/woocommerce-subscriptions/${ selectedSiteSlug }#step2`,
+			}`,
 		},
 		{
 			name: 'Pay & Install Yoast Premium',
-			path: `/checkout/${ selectedSiteSlug }/business,wordpress_seo_premium_monthly?redirect_to=/marketplace/thank-you/wordpress-seo-premium-monthly/${ selectedSiteSlug }#step2`,
+			path: `/checkout/${ selectedSiteSlug }/business,wordpress_seo_premium_monthly#step2`,
 		},
 		{ name: 'Install Page', path: `/marketplace/test/install/${ selectedSiteSlug }?` },
-		{ name: 'Thank You Page', path: '/marketplace/thank-you/woocommerce' },
+		{ name: 'Thank You Page', path: '/marketplace/thank-you?plugins=woocommerce' },
 		{ name: 'Domains Page', path: '/marketplace/domain' },
 	];
 

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -198,13 +198,11 @@ export class PluginInstallButton extends Component {
 		}
 
 		const buttonLink = canInstallPurchasedPlugins
-			? `/checkout/${ selectedSite.slug }/${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${ selectedSite.slug }`
+			? `/checkout/${ selectedSite.slug }/${ product_slug }`
 			: `/checkout/${ selectedSite.slug }/${ marketplacePlanToAdd(
 					selectedSite?.plan,
 					billingPeriod
-			  ) },${ product_slug }?redirect_to=/marketplace/thank-you/${ plugin.slug }/${
-					selectedSite.slug
-			  }#step2`;
+			  ) },${ product_slug }#step2`;
 
 		return (
 			<span className="plugin-install-button__install embed">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #74299

## Proposed Changes

* Update the Marketplace Thank You page URL to receive slugs via the query string
* Update the occurrences of the route to use the new format
* Remove the product type properties and functions as they will be defined via the URL

## Testing Instructions

Test the current flows to guarantee there are not broken:
* Install a free plugin on a Business site and on a free site (after upgrade)
* Install a paid plugin on a Business site and on a free site (after upgrade)
* Install more than 1 paid plugin

All flows should redirect to the thank you page, showing all the installed plugins and the URL being formed by query string. Ex: `/marketplace/thank-you/site?hide-progress-bar&plugins=elementor`

* Test the purchase button via multisite view as described here #74478. PS: It should fail for now, but the URL should be already fixed to not have the `redirectTo` option

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
