### PR TITLE
Post-purchase: Update bottom section for plugins

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { ConfettiAnimation, Gridicon } from '@automattic/components';
+import { ConfettiAnimation } from '@automattic/components';
 import { ThemeProvider, Global, css } from '@emotion/react';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -261,25 +261,6 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 		nextStepsClassName: 'thank-you__footer',
 		nextSteps: [
 			{
-				stepIcon: <FooterIcon icon="next-page" />,
-				stepKey: 'thank_you_footer_support_guides',
-				stepTitle: translate( 'Support guides' ),
-				stepDescription: translate(
-					'Our guides will show you everything you need to know about plugins.'
-				),
-				stepCta: (
-					<Button
-						isSecondary
-						href="https://wordpress.com/support/plugins/"
-						target="_blank"
-						onClick={ () => sendTrackEvent( 'calypso_plugin_thank_you_plugin_support_click' ) }
-					>
-						{ translate( 'Plugin Support' ) }
-					</Button>
-				),
-			},
-			{
-				stepIcon: <FooterIcon icon="create" />,
 				stepKey: 'thank_you_footer_explore',
 				stepTitle: translate( 'Keep growing' ),
 				stepDescription: translate(
@@ -287,7 +268,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 				),
 				stepCta: (
 					<Button
-						isPrimary
+						isLink
 						href={ `/plugins/${ siteSlug }` }
 						target="_blank"
 						onClick={ () => sendTrackEvent( 'calypso_plugin_thank_you_explore_plugins_click' ) }
@@ -297,15 +278,29 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 				),
 			},
 			{
-				stepIcon: <FooterIcon icon="help-outline" />,
+				stepKey: 'thank_you_footer_support_guides',
+				stepTitle: translate( 'Plugin Support' ),
+				stepDescription: translate( 'Discover everything you need to know about Plugins.' ),
+				stepCta: (
+					<Button
+						isLink
+						href="https://wordpress.com/support/plugins/"
+						target="_blank"
+						onClick={ () => sendTrackEvent( 'calypso_plugin_thank_you_plugin_support_click' ) }
+					>
+						{ translate( 'Plugin Support' ) }
+					</Button>
+				),
+			},
+			{
 				stepKey: 'thank_you_footer_support',
-				stepTitle: translate( 'How can we support you?' ),
+				stepTitle: translate( '24/7 support at your fingertips' ),
 				stepDescription: translate(
-					'Our team is here if you need help, or if you have any questions.'
+					'Our happiness engineers are eager to help answer your questions.'
 				),
 				stepCta: (
 					<Button
-						isSecondary
+						isLink
 						href="https://wordpress.com/help/contact"
 						target="_blank"
 						onClick={ () => sendTrackEvent( 'calypso_plugin_thank_you_ask_question_click' ) }
@@ -402,17 +397,6 @@ function getProductType(
 	}
 
 	return undefined;
-}
-
-function FooterIcon( { icon }: { icon: string } ) {
-	return (
-		<Gridicon
-			className="marketplace-thank-you__footer-icon"
-			size={ 18 }
-			color="var(--studio-gray-30)"
-			icon={ icon }
-		/>
-	);
 }
 
 export default MarketplaceThankYou;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -279,7 +279,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 			},
 			{
 				stepKey: 'thank_you_footer_support_guides',
-				stepTitle: translate( 'Plugins Support' ),
+				stepTitle: translate( 'Learn More' ),
 				stepDescription: translate( 'Discover everything you need to know about Plugins.' ),
 				stepCta: (
 					<Button
@@ -295,9 +295,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 			{
 				stepKey: 'thank_you_footer_support',
 				stepTitle: translate( '24/7 support at your fingertips' ),
-				stepDescription: translate(
-					'Our happiness engineers are eager to help answer your questions.'
-				),
+				stepDescription: translate( 'Our happiness engineers are eager to lend a hand.' ),
 				stepCta: (
 					<Button
 						isLink

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -279,7 +279,7 @@ const MarketplaceThankYou = ( { productSlug }: { productSlug: string } ) => {
 			},
 			{
 				stepKey: 'thank_you_footer_support_guides',
-				stepTitle: translate( 'Plugin Support' ),
+				stepTitle: translate( 'Plugins Support' ),
 				stepDescription: translate( 'Discover everything you need to know about Plugins.' ),
 				stepCta: (
 					<Button

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -61,7 +61,6 @@
 		.thank-you__step {
 			display: flex;
 			flex-direction: column;
-			justify-content: space-between;
 			flex-wrap: wrap;
 			height: 134px;
 			min-width: 280px;
@@ -92,6 +91,14 @@
 
 		.thank-you__step-cta {
 			margin: 0;
+
+			a {
+				font-size: $font-body-small;
+				color: var(--studio-gray-100);
+				text-decoration: underline;
+				font-weight: 500;
+				line-height: 20px;
+			}
 		}
 
 		.thank-you__step-icon {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -51,11 +51,10 @@
 
 	.thank-you__footer {
 		max-width: 1072px;
-		padding: 40px;
-		padding-top: 5px;
+		padding: 10px 0 0 40px;
 		display: flex;
 		flex-wrap: wrap;
-		gap: 75px;
+		gap: 25px;
 		justify-content: center;
 
 		.thank-you__step {
@@ -66,8 +65,7 @@
 			min-width: 280px;
 
 			@media ( max-width: 740px ) {
-				min-width: auto;
-				max-width: 420px;
+				width: 420px;
 			}
 
 			@media ( max-width: 520px ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74325

## Proposed Changes

* Update the plugins post-purchase page bottom section copy to match Figma 5ddl1WFTEnaIatL2WlZp4k-fi-2459%3A3164
* Remove the icon
* Update spacing

Before | After
--|--
<img width="1104" alt="plugins-bottom-before" src="https://user-images.githubusercontent.com/140841/225162282-38ed9260-6103-404a-a25c-791be18f9b95.png">  |  <img width="1145" alt="plugins-bottom-after" src="https://user-images.githubusercontent.com/140841/225675428-d2eb91a6-9d2a-4c84-b0e5-53153946f49a.png">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Purchase a plugin and make sure it matches the Figma
* Proof read the copy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?