### PR TITLE
Stats: Use user account locale for "Best views ever / Day" 

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -9,7 +9,6 @@ import {
 import { eye } from '@automattic/components/src/icons';
 import { Icon, people, postContent, starEmpty, commentContent } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import moment from 'moment';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import QueryPosts from 'calypso/components/data/query-posts';

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -15,6 +15,7 @@ import { useSelector } from 'react-redux';
 import QueryPosts from 'calypso/components/data/query-posts';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import DotPager from 'calypso/components/dot-pager';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData,
@@ -67,6 +68,8 @@ export default function AllTimeHighlightsSection( {
 		( state ) => getSiteStatsNormalizedData( state, siteId, 'statsInsights', insightsQuery ) || {}
 	) as MostPopularData;
 
+	const userLocale = useSelector( getCurrentUserLocale );
+
 	const isStatsLoading = isStatsRequesting && ! views;
 	const isInsightsLoading = isInsightsRequesting && ! percent;
 
@@ -113,19 +116,13 @@ export default function AllTimeHighlightsSection( {
 		let bestViewsEverYear = '';
 
 		if ( viewsBestDay && ! isStatsLoading ) {
-			const theMoment = moment( viewsBestDay ).local();
+			const theDay = new Date( viewsBestDay );
 
-			const year = theMoment.year();
-			const month = theMoment.month();
-			const day = theMoment.date();
-
-			const theDay = new Date( year, month, day );
-
-			bestViewsEverMonthDay = theDay.toLocaleDateString( undefined, {
+			bestViewsEverMonthDay = theDay.toLocaleDateString( userLocale, {
 				month: 'long',
 				day: 'numeric',
 			} );
-			bestViewsEverYear = theDay.toLocaleDateString( undefined, {
+			bestViewsEverYear = theDay.toLocaleDateString( userLocale, {
 				year: 'numeric',
 			} );
 		}

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -9,6 +9,7 @@ import {
 import { eye } from '@automattic/components/src/icons';
 import { Icon, people, postContent, starEmpty, commentContent } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import moment from 'moment';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import QueryPosts from 'calypso/components/data/query-posts';
@@ -112,7 +113,14 @@ export default function AllTimeHighlightsSection( {
 		let bestViewsEverYear = '';
 
 		if ( viewsBestDay && ! isStatsLoading ) {
-			const theDay = new Date( viewsBestDay );
+			const theMoment = moment( viewsBestDay ).local();
+
+			const year = theMoment.year();
+			const month = theMoment.month();
+			const day = theMoment.date();
+
+			const theDay = new Date( year, month, day );
+
 			bestViewsEverMonthDay = theDay.toLocaleDateString( undefined, {
 				month: 'long',
 				day: 'numeric',


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/72250

## Proposed Changes

* This PR changes the locale to use the user/account set locale for "Best views ever / Day" 

## Testing Instructions

*  Using the Calypso Live Branch link, update the user account language, set via `/me/account` to a language with a different character set such as Mandarin, Japanese, Arabic etc. 
* Navigate to `stats -> insights` and check the `All-time highlights` -> `Best views ever` card. 
* Ensure the `day` information is correctly displaying in the account set locale, and is not falling back to `en`

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/30754158/225158619-e9431061-6794-4612-9736-422e693c41b9.png)  | ![image](https://user-images.githubusercontent.com/30754158/225158742-c3291f05-41fa-4e8a-ae03-88de39256834.png)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
