### PR TITLE
Launchpad: Do not enable launchpad for launched sites

### DIFF
--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -150,6 +150,7 @@ const siteSetupFlow: Flow = {
 		const currentTheme = useSelector( ( state ) =>
 			getCanonicalTheme( state, site?.ID || -1, currentThemeId )
 		);
+		const isLaunched = site?.launch_status === 'launched' ? true : false;
 
 		const urlQueryParams = useQuery();
 		const isPluginBundleEligible = useIsPluginBundleEligible();
@@ -219,9 +220,12 @@ const siteSetupFlow: Flow = {
 
 					// Update Launchpad option based on site intent
 					if ( typeof siteId === 'number' ) {
+						const launchpadScreen =
+							isLaunchpadIntent( siteIntent ) && ! isLaunched ? 'full' : 'off';
+
 						pendingActions.push(
 							saveSiteSettings( siteId, {
-								launchpad_screen: isLaunchpadIntent( siteIntent ) ? 'full' : 'off',
+								launchpad_screen: launchpadScreen,
 							} )
 						);
 					}


### PR DESCRIPTION
### Proposed Changes

This PR ensures that we do not re-enable Launchpad for launched site if a users somehow goes back through the site setup flow. The original impetus for this PR was that end to end tests are periodically failing because some ad hoc tests were re-doing the site setup process on existing sites. 

But this also avoids a situation for end users where they've launched a site, somehow end up back on the site set up flow or goals page, and unintentionally re-activate launchpad. 

### Testing

**Review Time: Short**
**Testing Time: Short**

1. Create a new build site at `http://calypso.localhost:3000/start`, select 'Promote' on the goals page, and go through to Launchpad. 
2. Launch your site from Launchpad. The site should now be launched, and if you go to My Home, you should no longer be redirected to Launchpad. 
3. Now go back to the site setup flow at http://calypso.localhost:3000/setup/site-setup/goals?siteSlug=YOURSITESLUG, select 'Promote' on the goals page, and continue. You should NOT end up on Launchpad. Prior to this PR, you would have.