### PR TITLE
Reuse existing selector in jetpack sidebar

### DIFF
--- a/client/components/jetpack/sidebar/index.jsx
+++ b/client/components/jetpack/sidebar/index.jsx
@@ -1,4 +1,3 @@
-import { format as formatUrl, getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -10,8 +9,7 @@ import SidebarMenu from 'calypso/layout/sidebar/menu';
 import SidebarRegion from 'calypso/layout/sidebar/region';
 import CurrentSite from 'calypso/my-sites/current-site';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import getSiteAdminPage from 'calypso/state/sites/selectors/get-site-admin-page';
-import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
+import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import JetpackCloudSidebarMenuItems from './menu-items/jetpack-cloud';
 import JetpackIcons from './menu-items/jetpack-icons';
@@ -68,18 +66,6 @@ class JetpackCloudSidebar extends Component {
 		);
 	}
 }
-
-const getJetpackAdminUrl = ( state, siteId ) => {
-	const siteAdminUrl = getSiteAdminUrl( state, siteId );
-	if ( null === siteAdminUrl ) {
-		return undefined;
-	}
-
-	const parts = getUrlParts( siteAdminUrl + 'admin.php' );
-	parts.searchParams.set( 'page', getSiteAdminPage( state, siteId ) );
-
-	return formatUrl( getUrlFromParts( parts ) );
-};
 
 export default connect(
 	( state ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 1202858161751496-as-1204050079277215/f

## Proposed Changes
Simply change inner function with existing selector.

## Testing Instructions
- Spin up this PR branch `yarn start-jetpack-cloud` or use the JETPACK Live link below
- Create a new JN site and connect Jetpack
- Navigate to (for example) `/activity-log/:site`
- On a side bar click `WP ADMIN` link and you should be redirected correctly
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204050079277215