### PR TITLE
Migrate block editor nux to createReduxStore

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/index.js
@@ -1,6 +1,2 @@
-import { register } from './src/store';
-
 import './src/disable-core-nux';
 import './src/block-editor-nux';
-
-register();

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -1,6 +1,5 @@
 /*** THIS MUST BE THE FIRST THING EVALUATED IN THIS SCRIPT *****/
 import './public-path';
-
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 import { LocaleProvider, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
@@ -18,7 +17,7 @@ import FirstPostPublishedModal from './first-post-published-modal';
 import PurchaseNotice from './purchase-notice';
 import SellerCelebrationModal from './seller-celebration-modal';
 import PostPublishedSharingModal from './sharing-modal';
-import { DEFAULT_VARIANT, BLANK_CANVAS_VARIANT } from './store';
+import { DEFAULT_VARIANT, BLANK_CANVAS_VARIANT, store as welcomeGuideStore } from './store';
 import VideoPressCelebrationModal from './video-celebration-modal';
 import WpcomNux from './welcome-modal/wpcom-nux';
 import LaunchWpcomWelcomeTour from './welcome-tour/tour-launch';
@@ -41,23 +40,27 @@ function WelcomeTour() {
 		isNewPageLayoutModalOpen,
 		siteEditorCanvasMode,
 	} = useSelect( ( select ) => {
-		const welcomeGuideStoreSelect = select( 'automattic/wpcom-welcome-guide' );
-		const starterPageLayoutsStoreSelect = select( 'automattic/starter-page-layouts' );
+		const {
+			isWelcomeGuideShown,
+			isWelcomeGuideStatusLoaded,
+			getWelcomeGuideVariant,
+			isWelcomeGuideManuallyOpened,
+		} = select( welcomeGuideStore );
 		const _canvasMode =
 			select( 'core/edit-site' ) && unlock( select( 'core/edit-site' ) ).getCanvasMode();
 		return {
-			show: welcomeGuideStoreSelect.isWelcomeGuideShown(),
-			isLoaded: welcomeGuideStoreSelect.isWelcomeGuideStatusLoaded(),
-			variant: welcomeGuideStoreSelect.getWelcomeGuideVariant(),
-			isManuallyOpened: welcomeGuideStoreSelect.isWelcomeGuideManuallyOpened(),
-			isNewPageLayoutModalOpen: starterPageLayoutsStoreSelect?.isOpen(), // Handle the case where SPT is not initalized.
+			show: isWelcomeGuideShown(),
+			isLoaded: isWelcomeGuideStatusLoaded(),
+			variant: getWelcomeGuideVariant(),
+			isManuallyOpened: isWelcomeGuideManuallyOpened(),
+			isNewPageLayoutModalOpen: select( 'automattic/starter-page-layouts' )?.isOpen(), // Handle the case where SPT is not initalized.
 			siteEditorCanvasMode: _canvasMode,
 		};
 	}, [] );
 
 	const setOpenState = useDispatch( 'automattic/starter-page-layouts' )?.setOpenState;
 
-	const { fetchWelcomeGuideStatus } = useDispatch( 'automattic/wpcom-welcome-guide' );
+	const { fetchWelcomeGuideStatus } = useDispatch( welcomeGuideStore );
 
 	// On mount check if the WPCOM welcome guide status exists in state (from local storage), otherwise fetch it from the API.
 	useEffect( () => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
@@ -1,4 +1,5 @@
 import { select, dispatch, subscribe } from '@wordpress/data';
+import { store as welcomeGuideStore } from './store';
 
 import '@wordpress/nux'; //ensure nux store loads
 
@@ -20,22 +21,22 @@ const unsubscribe = subscribe( () => {
 subscribe( () => {
 	if ( select( 'core/nux' ).areTipsEnabled() ) {
 		dispatch( 'core/nux' ).disableTips();
-		dispatch( 'automattic/wpcom-welcome-guide' ).setShowWelcomeGuide( true );
+		dispatch( welcomeGuideStore ).setShowWelcomeGuide( true );
 	}
 	if ( select( 'core/edit-post' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
 		// On mounting, the welcomeGuide feature is turned on by default. This opens the welcome guide despite `welcomeGuideStatus` value.
 		// This check ensures that we only listen to `welcomeGuide` changes if the welcomeGuideStatus value is loaded and respected
-		if ( select( 'automattic/wpcom-welcome-guide' ).isWelcomeGuideStatusLoaded() ) {
-			dispatch( 'automattic/wpcom-welcome-guide' ).setShowWelcomeGuide( true, {
+		if ( select( welcomeGuideStore ).isWelcomeGuideStatusLoaded() ) {
+			dispatch( welcomeGuideStore ).setShowWelcomeGuide( true, {
 				openedManually: true,
 			} );
 		}
 	}
 	if ( select( 'core/edit-site' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-site' ).toggleFeature( 'welcomeGuide' );
-		if ( select( 'automattic/wpcom-welcome-guide' ).isWelcomeGuideStatusLoaded() ) {
-			dispatch( 'automattic/wpcom-welcome-guide' ).setShowWelcomeGuide( true, {
+		if ( select( welcomeGuideStore ).isWelcomeGuideStatusLoaded() ) {
+			dispatch( welcomeGuideStore ).setShowWelcomeGuide( true, {
 				openedManually: true,
 			} );
 		}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
@@ -1,5 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
-import { combineReducers, registerStore } from '@wordpress/data';
+import { combineReducers, createReduxStore, register } from '@wordpress/data';
 import { apiFetch as apiFetchControls, controls } from '@wordpress/data-controls';
 
 import 'a8c-fse-common-data-stores';
@@ -138,12 +138,12 @@ export const selectors = {
 	getShouldShowFirstPostPublishedModal: ( state ) => state.shouldShowFirstPostPublishedModal,
 };
 
-export function register() {
-	return registerStore( 'automattic/wpcom-welcome-guide', {
-		reducer,
-		actions,
-		selectors,
-		controls,
-		persist: true,
-	} );
-}
+export const store = createReduxStore( 'automattic/wpcom-welcome-guide', {
+	reducer,
+	actions,
+	selectors,
+	controls,
+	persist: true, // TODO @noahtallen: persist plugin probably doesn't work here.
+} );
+
+register( store );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/test/store.test.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/test/store.test.js
@@ -1,17 +1,14 @@
 import { dispatch, select } from '@wordpress/data';
 import waitForExpect from 'wait-for-expect';
-import { register, DEFAULT_VARIANT } from '../store';
-
-const STORE_KEY = 'automattic/wpcom-welcome-guide';
+import { store, DEFAULT_VARIANT } from '../store';
 
 beforeAll( () => {
-	register();
 	jest.useRealTimers(); // Required for wait-for-expect to work.
 } );
 
 let originalFetch;
 beforeEach( () => {
-	dispatch( STORE_KEY ).resetStore();
+	dispatch( store ).resetStore();
 	originalFetch = window.fetch;
 	window.fetch = jest.fn();
 } );
@@ -26,24 +23,22 @@ test( 'resetting the store', async () => {
 		json: () => Promise.resolve( { show_welcome_guide: true, variant: 'modal' } ),
 	} );
 
-	dispatch( STORE_KEY ).fetchWelcomeGuideStatus();
-	await waitForExpect( () =>
-		expect( select( STORE_KEY ).isWelcomeGuideStatusLoaded() ).toBe( true )
-	);
-	dispatch( STORE_KEY ).setShowWelcomeGuide( true, { openedManually: true } );
-	dispatch( STORE_KEY ).setTourRating( 'thumbs-up' );
+	dispatch( store ).fetchWelcomeGuideStatus();
+	await waitForExpect( () => expect( select( store ).isWelcomeGuideStatusLoaded() ).toBe( true ) );
+	dispatch( store ).setShowWelcomeGuide( true, { openedManually: true } );
+	dispatch( store ).setTourRating( 'thumbs-up' );
 
-	dispatch( STORE_KEY ).resetStore();
+	dispatch( store ).resetStore();
 
-	expect( select( STORE_KEY ).isWelcomeGuideManuallyOpened() ).toBe( false );
-	expect( select( STORE_KEY ).isWelcomeGuideShown() ).toBe( false );
-	expect( select( STORE_KEY ).isWelcomeGuideStatusLoaded() ).toBe( false );
-	expect( select( STORE_KEY ).getTourRating() ).toBeUndefined();
-	expect( select( STORE_KEY ).getWelcomeGuideVariant() ).toBe( DEFAULT_VARIANT );
+	expect( select( store ).isWelcomeGuideManuallyOpened() ).toBe( false );
+	expect( select( store ).isWelcomeGuideShown() ).toBe( false );
+	expect( select( store ).isWelcomeGuideStatusLoaded() ).toBe( false );
+	expect( select( store ).getTourRating() ).toBeUndefined();
+	expect( select( store ).getWelcomeGuideVariant() ).toBe( DEFAULT_VARIANT );
 } );
 
 test( "by default the store isn't loaded", () => {
-	const isLoaded = select( STORE_KEY ).isWelcomeGuideStatusLoaded();
+	const isLoaded = select( store ).isWelcomeGuideStatusLoaded();
 	expect( isLoaded ).toBe( false );
 } );
 
@@ -53,10 +48,10 @@ test( 'after fetching the guide status the store is loaded', async () => {
 		json: () => Promise.resolve( { show_welcome_guide: true, variant: DEFAULT_VARIANT } ),
 	} );
 
-	dispatch( STORE_KEY ).fetchWelcomeGuideStatus();
+	dispatch( store ).fetchWelcomeGuideStatus();
 
 	await waitForExpect( () => {
-		const isLoaded = select( STORE_KEY ).isWelcomeGuideStatusLoaded();
+		const isLoaded = select( store ).isWelcomeGuideStatusLoaded();
 		expect( isLoaded ).toBe( true );
 	} );
 
@@ -66,9 +61,9 @@ test( 'after fetching the guide status the store is loaded', async () => {
 	);
 
 	// Check the store is loaded with the state that came from the server
-	const isWelcomeGuideShown = select( STORE_KEY ).isWelcomeGuideShown();
+	const isWelcomeGuideShown = select( store ).isWelcomeGuideShown();
 	expect( isWelcomeGuideShown ).toBe( true );
-	const welcomeGuideVariant = select( STORE_KEY ).getWelcomeGuideVariant();
+	const welcomeGuideVariant = select( store ).getWelcomeGuideVariant();
 	expect( welcomeGuideVariant ).toBe( DEFAULT_VARIANT );
 } );
 
@@ -77,15 +72,15 @@ test( 'toggle welcome guide visibility', () => {
 	// rejection errors that appear in CLI output
 	window.fetch.mockResolvedValue( { status: 200, json: () => Promise.resolve( {} ) } );
 
-	dispatch( STORE_KEY ).setShowWelcomeGuide( true );
-	expect( select( STORE_KEY ).isWelcomeGuideShown() ).toBe( true );
+	dispatch( store ).setShowWelcomeGuide( true );
+	expect( select( store ).isWelcomeGuideShown() ).toBe( true );
 
-	dispatch( STORE_KEY ).setShowWelcomeGuide( false );
-	expect( select( STORE_KEY ).isWelcomeGuideShown() ).toBe( false );
+	dispatch( store ).setShowWelcomeGuide( false );
+	expect( select( store ).isWelcomeGuideShown() ).toBe( false );
 } );
 
 test( 'guide manually opened flag is false by default', () => {
-	expect( select( STORE_KEY ).isWelcomeGuideManuallyOpened() ).toBe( false );
+	expect( select( store ).isWelcomeGuideManuallyOpened() ).toBe( false );
 } );
 
 test( '"manually opened" flag can be set when opening welcome guide', () => {
@@ -93,11 +88,11 @@ test( '"manually opened" flag can be set when opening welcome guide', () => {
 	// rejection errors that appear in CLI output
 	window.fetch.mockResolvedValue( { status: 200, json: () => Promise.resolve( {} ) } );
 
-	dispatch( STORE_KEY ).setShowWelcomeGuide( true, { openedManually: true } );
-	expect( select( STORE_KEY ).isWelcomeGuideManuallyOpened() ).toBe( true );
+	dispatch( store ).setShowWelcomeGuide( true, { openedManually: true } );
+	expect( select( store ).isWelcomeGuideManuallyOpened() ).toBe( true );
 
-	dispatch( STORE_KEY ).setShowWelcomeGuide( true, { openedManually: false } );
-	expect( select( STORE_KEY ).isWelcomeGuideManuallyOpened() ).toBe( false );
+	dispatch( store ).setShowWelcomeGuide( true, { openedManually: false } );
+	expect( select( store ).isWelcomeGuideManuallyOpened() ).toBe( false );
 } );
 
 test( 'leaving `openedManually` unspecified leaves the flag unchanged', () => {
@@ -105,23 +100,23 @@ test( 'leaving `openedManually` unspecified leaves the flag unchanged', () => {
 	// rejection errors that appear in CLI output
 	window.fetch.mockResolvedValue( { status: 200, json: () => Promise.resolve( {} ) } );
 
-	expect( select( STORE_KEY ).isWelcomeGuideManuallyOpened() ).toBe( false );
+	expect( select( store ).isWelcomeGuideManuallyOpened() ).toBe( false );
 
-	dispatch( STORE_KEY ).setShowWelcomeGuide( true, { openedManually: true } );
-	expect( select( STORE_KEY ).isWelcomeGuideManuallyOpened() ).toBe( true );
+	dispatch( store ).setShowWelcomeGuide( true, { openedManually: true } );
+	expect( select( store ).isWelcomeGuideManuallyOpened() ).toBe( true );
 
-	dispatch( STORE_KEY ).setShowWelcomeGuide( false );
-	expect( select( STORE_KEY ).isWelcomeGuideManuallyOpened() ).toBe( true );
+	dispatch( store ).setShowWelcomeGuide( false );
+	expect( select( store ).isWelcomeGuideManuallyOpened() ).toBe( true );
 } );
 
 test( 'tour rating is "undefined" by default', () => {
-	expect( select( STORE_KEY ).getTourRating() ).toBeUndefined();
+	expect( select( store ).getTourRating() ).toBeUndefined();
 } );
 
 test( 'tour rating can be set to "thumbs-up" or "thumbs-down"', () => {
-	dispatch( STORE_KEY ).setTourRating( 'thumbs-up' );
-	expect( select( STORE_KEY ).getTourRating() ).toBe( 'thumbs-up' );
+	dispatch( store ).setTourRating( 'thumbs-up' );
+	expect( select( store ).getTourRating() ).toBe( 'thumbs-up' );
 
-	dispatch( STORE_KEY ).setTourRating( 'thumbs-down' );
-	expect( select( STORE_KEY ).getTourRating() ).toBe( 'thumbs-down' );
+	dispatch( store ).setTourRating( 'thumbs-down' );
+	expect( select( store ).getTourRating() ).toBe( 'thumbs-down' );
 } );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-modal/wpcom-nux.js
@@ -5,23 +5,23 @@ import { Guide, GuidePage } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { store as welcomeGuideStore } from '../store';
 import blockPickerImage from './images/block-picker.svg';
 import editorImage from './images/editor.svg';
 import previewImage from './images/preview.svg';
 import privateImage from './images/private.svg';
-
 import './style.scss';
 
 function WpcomNux() {
 	const { show, isNewPageLayoutModalOpen, isManuallyOpened } = useSelect( ( select ) => ( {
-		show: select( 'automattic/wpcom-welcome-guide' ).isWelcomeGuideShown(),
+		show: select( welcomeGuideStore ).isWelcomeGuideShown(),
 		isNewPageLayoutModalOpen:
 			select( 'automattic/starter-page-layouts' ) && // Handle the case where SPT is not initalized.
 			select( 'automattic/starter-page-layouts' ).isOpen(),
-		isManuallyOpened: select( 'automattic/wpcom-welcome-guide' ).isWelcomeGuideManuallyOpened(),
+		isManuallyOpened: select( welcomeGuideStore ).isWelcomeGuideManuallyOpened(),
 	} ) );
 
-	const { setShowWelcomeGuide } = useDispatch( 'automattic/wpcom-welcome-guide' );
+	const { setShowWelcomeGuide } = useDispatch( welcomeGuideStore );
 
 	// Track opening of the welcome guide
 	useEffect( () => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -8,6 +8,7 @@ import { useEffect, useMemo } from '@wordpress/element';
 import useSiteIntent from '../../../dotcom-fse/lib/site-intent/use-site-intent';
 import useSitePlan from '../../../dotcom-fse/lib/site-plan/use-site-plan';
 import { selectors as starterPageTemplatesSelectors } from '../../../starter-page-templates/store';
+import { selectors as wpcomBlockEditorNavSidebarSelectors } from '../../../wpcom-block-editor-nav-sidebar/src/store';
 import { store as welcomeGuideStore } from '../store';
 import { getEditorType } from './get-editor-type';
 import getTourSteps from './tour-steps';

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -8,8 +8,7 @@ import { useEffect, useMemo } from '@wordpress/element';
 import useSiteIntent from '../../../dotcom-fse/lib/site-intent/use-site-intent';
 import useSitePlan from '../../../dotcom-fse/lib/site-plan/use-site-plan';
 import { selectors as starterPageTemplatesSelectors } from '../../../starter-page-templates/store';
-import { selectors as wpcomBlockEditorNavSidebarSelectors } from '../../../wpcom-block-editor-nav-sidebar/src/store';
-import { selectors as wpcomWelcomeGuideSelectors } from '../store';
+import { store as welcomeGuideStore } from '../store';
 import { getEditorType } from './get-editor-type';
 import getTourSteps from './tour-steps';
 import './style-tour.scss';
@@ -21,7 +20,6 @@ type StarterPageTemplatesSelectors = SelectFromMap< typeof starterPageTemplatesS
 type WpcomBlockEditorNavSidebarSelectors = SelectFromMap<
 	typeof wpcomBlockEditorNavSidebarSelectors
 >;
-type WpcomWelcomeGuideSelectors = SelectFromMap< typeof wpcomWelcomeGuideSelectors >;
 type CoreEditPostPlaceholder = {
 	isInserterOpened: ( ...args: unknown[] ) => boolean;
 };
@@ -32,16 +30,12 @@ type CoreInterfacePlaceholder = {
 function LaunchWpcomWelcomeTour() {
 	const { show, isNewPageLayoutModalOpen, isManuallyOpened } = useSelect(
 		( select ) => ( {
-			show: (
-				select( 'automattic/wpcom-welcome-guide' ) as WpcomWelcomeGuideSelectors
-			 ).isWelcomeGuideShown(),
+			show: select( welcomeGuideStore ).isWelcomeGuideShown(),
+			isManuallyOpened: select( welcomeGuideStore ).isWelcomeGuideManuallyOpened(),
 			// Handle the case where the new page pattern modal is initialized and open
 			isNewPageLayoutModalOpen:
 				select( 'automattic/starter-page-layouts' ) &&
 				( select( 'automattic/starter-page-layouts' ) as StarterPageTemplatesSelectors ).isOpen(),
-			isManuallyOpened: (
-				select( 'automattic/wpcom-welcome-guide' ) as WpcomWelcomeGuideSelectors
-			 ).isWelcomeGuideManuallyOpened(),
 		} ),
 		[]
 	);
@@ -93,7 +87,7 @@ function LaunchWpcomWelcomeTour() {
 function WelcomeTour( { siteIntent }: { siteIntent?: string } ) {
 	const sitePlan = useSitePlan( window._currentSiteId );
 	const localeSlug = useLocale();
-	const { setShowWelcomeGuide } = useDispatch( 'automattic/wpcom-welcome-guide' );
+	const { setShowWelcomeGuide } = useDispatch( welcomeGuideStore );
 	const isGutenboarding = window.calypsoifyGutenberg?.isGutenboarding;
 	const isWelcomeTourNext = () => {
 		return new URLSearchParams( document.location.search ).has( 'welcome-tour-next' );
@@ -160,16 +154,10 @@ function WelcomeTour( { siteIntent }: { siteIntent?: string } ) {
 			tourRating: {
 				enabled: true,
 				useTourRating: () => {
-					return useSelect(
-						( select ) =>
-							(
-								select( 'automattic/wpcom-welcome-guide' ) as WpcomWelcomeGuideSelectors
-							 ).getTourRating(),
-						[]
-					);
+					return useSelect( ( select ) => select( welcomeGuideStore ).getTourRating(), [] );
 				},
 				onTourRate: ( rating ) => {
-					dispatch( 'automattic/wpcom-welcome-guide' ).setTourRating( rating );
+					dispatch( welcomeGuideStore ).setTourRating( rating );
 					recordTracksEvent( 'calypso_editor_wpcom_tour_rate', {
 						thumbs_up: rating === 'thumbs-up',
 						is_gutenboarding: false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

see #74399 for more info

## Proposed Changes
Migrates the block editor nux (new user experience) ETK feature to `createReduxStore`

While there are other references to `automattic/wpcom-welcome-guide` in the codebase, they're in different webpack bundles, so I continued using the string-based store identifier approach.

## Testing Instructions

TBD... you definitely start by syncing ETK. Create a new account and sandbox the new test site. At that point it might show up?

Added a couple people who recently touched these files for tips and maybe a review ;)