### PR TITLE
Update/hide GitHub on sites page for users with no access

### DIFF
--- a/client/components/data/query-reader-teams/index.jsx
+++ b/client/components/data/query-reader-teams/index.jsx
@@ -2,11 +2,14 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { requestTeams } from 'calypso/state/teams/actions';
 
-export default function QueryReaderTeams() {
+export function useQueryReaderTeams() {
 	const dispatch = useDispatch();
 	useEffect( () => {
 		dispatch( requestTeams() );
 	}, [ dispatch ] );
+}
 
+export default function QueryReaderTeams() {
+	useQueryReaderTeams();
 	return null;
 }

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -18,13 +18,16 @@ import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { ComponentType, useEffect, useMemo, useState } from 'react';
 import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
+import { useQueryReaderTeams } from 'calypso/components/data/query-reader-teams';
 import SitePreviewLink from 'calypso/components/site-preview-link';
 import { useSiteCopy } from 'calypso/landing/stepper/hooks/use-site-copy';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'calypso/state/sites/launch/actions';
+import { getReaderTeams } from 'calypso/state/teams/selectors';
 import {
 	getHostingConfigUrl,
 	getManagePluginsUrl,
@@ -247,6 +250,9 @@ function useSubmenuItems( site: SiteExcerptData ) {
 	const isStagingSite = site.is_wpcom_staging_site;
 	const isStagingSiteEnabled = isEnabled( 'yolo/staging-sites-i1' );
 
+	useQueryReaderTeams();
+	const isA12n = useSelector( ( state ) => isAutomatticTeamMember( getReaderTeams( state ) ) );
+
 	return useMemo< { label: string; href: string; sectionName: string }[] >( () => {
 		return [
 			{
@@ -266,6 +272,7 @@ function useSubmenuItems( site: SiteExcerptData ) {
 				sectionName: 'staging_site',
 			},
 			{
+				condition: isA12n,
 				label: __( 'Deploy from GitHub' ),
 				href: `/hosting-config/${ siteSlug }#connect-github`,
 				sectionName: 'connect_github',
@@ -286,7 +293,7 @@ function useSubmenuItems( site: SiteExcerptData ) {
 				sectionName: 'logs',
 			},
 		].filter( ( { condition } ) => condition ?? true );
-	}, [ __, isStagingSiteEnabled, siteSlug, isStagingSite ] );
+	}, [ __, isStagingSiteEnabled, siteSlug, isStagingSite, isA12n ] );
 }
 
 function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The new developer sub-menu has launched to all users pesfPa-3t-p2#comment-41, but the "Deploy from GitHub" feature has not, see: https://github.com/Automattic/wp-calypso/blob/9a2605e41d93ad5e5ddf2f24e0959a1bb19484f9/client/my-sites/hosting/main.js#L180

This PR

* Refactors `<QueryReaderTeams>` so we can use it's logic in hooks
* Hides the "Deploy from GitHub" menu item unless the user is an a11n

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test on a12n and non-a12n accounts. Confirm nothing has changed for non-atomic and non-business sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~