### PR TITLE
Staging Sites: Show an error message on loading error

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -49,6 +49,11 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 	const { data: stagingSites, isLoading: isLoadingStagingSites } = useStagingSite( siteId, {
 		enabled: ! disabled,
 		onError: ( error ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_hosting_configuration_staging_site_load_failure', {
+					code: error.code,
+				} )
+			);
 			setLoadingError( error );
 		},
 	} );

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -8,6 +8,7 @@ import { useQueryClient } from 'react-query';
 import { connect, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import { LoadingBar } from 'calypso/components/loading-bar';
+import Notice from 'calypso/components/notice';
 import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
 import { urlToSlug } from 'calypso/lib/url';
 import { useAddStagingSiteMutation } from 'calypso/my-sites/hosting/staging-site-card/use-add-staging-site';
@@ -43,9 +44,13 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
+	const [ loadingError, setLoadingError ] = useState( false );
 
 	const { data: stagingSites, isLoading: isLoadingStagingSites } = useStagingSite( siteId, {
 		enabled: ! disabled,
+		onError: ( error ) => {
+			setLoadingError( error );
+		},
 	} );
 
 	const stagingSite = useMemo( () => {
@@ -147,6 +152,16 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 		);
 	};
 
+	const getLoadingErrorContent = () => {
+		return (
+			<Notice status="is-error" showDismiss={ false }>
+				{ __(
+					'Unable to load staging sites. Please contact support if you believe you are seeing this message in error.'
+				) }
+			</Notice>
+		);
+	};
+
 	return (
 		<Card className="staging-site-card">
 			{
@@ -157,6 +172,7 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 			{ showAddStagingSite && ! addingStagingSite && getNewStagingSiteContent() }
 			{ showManageStagingSite && isStagingSiteTransferComplete && getManageStagingSiteContent() }
 			{ isLoadingStagingSites && getLoadingStagingSitesPlaceholder() }
+			{ ! isLoadingStagingSites && loadingError && getLoadingErrorContent() }
 			{ ( addingStagingSite || ( showManageStagingSite && ! isStagingSiteTransferComplete ) ) && (
 				<>
 					<StyledLoadingBar progress={ progress } />

--- a/client/my-sites/hosting/staging-site-card/use-staging-site.ts
+++ b/client/my-sites/hosting/staging-site-card/use-staging-site.ts
@@ -26,6 +26,7 @@ export const useStagingSite = ( siteId: number, options: UseQueryOptions ) => {
 				persist: false,
 			},
 			staleTime: 10 * 1000,
+			onError: options.onError,
 		}
 	);
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1927

## Proposed Changes

Shows an error message if there was some problem with loading staging sites:

<img width="780" alt="image" src="https://user-images.githubusercontent.com/36432/225277309-c4f276db-aa6d-4ea3-aee5-6961833fb331.png">

These errors are logged to Tracks too, so we have some visibility to them: https://github.com/Automattic/tracks-events-registration/pull/1453

## Testing Instructions

1. Create a new Business site and take it Atomic.
2. Visit Hosting Configuration.
3. Verify the Staging Site module appears as expected.
4. Invite another WordPress.com user to administer your site.
5. Signed in as the non-site owner, visit Hosting Configuration.
6. Verify the error message appears after the Staging Site module loads.
7. Verify the skeleton screen appears temporarily if you switch to another window and then switch back.