### PR TITLE
Jetpack Pro Dashboard: Fix Stats types

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/utils.ts
@@ -204,8 +204,9 @@ describe( 'utils', () => {
 						value: sites[ 0 ],
 					},
 					stats: {
+						status: 'active',
 						type: 'stats',
-						data: sites[ 0 ].site_stats,
+						value: sites[ 0 ].site_stats,
 					},
 					backup: {
 						status: 'success',

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -12,6 +12,7 @@ export type SiteColumns = Array< {
 } >;
 
 export type AllowedStatusTypes =
+	| 'active'
 	| 'inactive'
 	| 'progress'
 	| 'failed'
@@ -67,7 +68,8 @@ export interface SiteNode {
 
 export interface StatsNode {
 	type: AllowedTypes;
-	data: SiteStats;
+	status: AllowedStatusTypes;
+	value: SiteStats;
 }
 export interface BackupNode {
 	type: AllowedTypes;
@@ -97,6 +99,7 @@ export interface MonitorNode {
 }
 export interface SiteData {
 	site: SiteNode;
+	stats: StatsNode;
 	backup: BackupNode;
 	scan: ScanNode;
 	plugin: PluginNode;
@@ -107,7 +110,7 @@ export interface SiteData {
 
 export interface RowMetaData {
 	row: {
-		value: Site | any;
+		value: Site | SiteStats | ReactChild;
 		status: AllowedStatusTypes | string;
 		error?: boolean;
 	};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -315,8 +315,9 @@ export const getRowMetaData = (
 
 const formatStatsData = ( site: Site ) => {
 	const statsData: StatsNode = {
+		status: 'active',
 		type: 'stats',
-		data: site.site_stats,
+		value: site.site_stats,
 	};
 	return statsData;
 };


### PR DESCRIPTION
Related to 1203940061556608-as-1204183399335412

## Proposed Changes

This PR fixes the stats types used in the Jetpack Pro Dashboard.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/stats-types-pro-dashboard` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Expand any site data -> verify the expanded block for site insights show the data as expected.
4. Verify that all the test cases are passing.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?