### PR TITLE
Marketplace: if a plugin has a purchase, we don't need to check if it's a marketplace product or not.

### DIFF
--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -451,12 +451,10 @@ export const getSoftwareSlug = ( plugin, isMarketplaceProduct ) =>
 /**
  * @param  {Object} plugin The plugin object
  * @param  {Array} purchases An array of site purchases
- * @param  {boolean} isMarketplaceProduct Is this part of WP.com Marketplace or WP.org
  * @returns {Object} The purchase object, if found.
  */
-export const getPluginPurchased = ( plugin, purchases, isMarketplaceProduct ) => {
+export const getPluginPurchased = ( plugin, purchases ) => {
 	return (
-		isMarketplaceProduct &&
 		plugin?.variations &&
 		purchases.find( ( purchase ) =>
 			Object.values( plugin.variations ).some(

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -57,7 +57,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	);
 	const softwareSlug = getSoftwareSlug( plugin, isMarketplaceProduct );
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
-	const currentPurchase = getPluginPurchased( plugin, purchases, isMarketplaceProduct );
+	const currentPurchase = getPluginPurchased( plugin, purchases );
 
 	// Site type
 	const sites = useSelector( getSelectedOrAllSitesWithPlugins );

--- a/client/my-sites/plugins/plugin-details-CTA/manage-plugin-menu.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/manage-plugin-menu.jsx
@@ -1,6 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { getPluginPurchased, getSoftwareSlug } from 'calypso/lib/plugins/utils';
@@ -21,12 +20,11 @@ export const ManagePluginMenu = ( { plugin } ) => {
 	const pluginOnSite = useSelector( ( state ) => getPluginOnSite( state, site.ID, softwareSlug ) );
 
 	const purchases = useSelector( ( state ) => getSitePurchases( state, site.ID ) );
-	const currentPurchase = getPluginPurchased( plugin, purchases, isMarketplaceProduct );
+	const currentPurchase = getPluginPurchased( plugin, purchases );
 	const settingsLink = pluginOnSite?.action_links?.Settings ?? null;
 
 	return (
 		<>
-			{ plugin.isMarketplaceProduct && <QueryUserPurchases /> }
 			<EllipsisMenu position="bottom">
 				{ currentPurchase?.id && (
 					<PopoverMenuItem

--- a/client/my-sites/plugins/plugin-management-v2/plugin-manage-subscription/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-manage-subscription/index.tsx
@@ -22,11 +22,7 @@ export default function PluginManageSubcription( { site, plugin }: Props ): Reac
 	const translate = useTranslate();
 
 	const purchases = useSelector( ( state ) => getSitePurchases( state, site.ID ) );
-	const currentPurchase: Purchase = getPluginPurchased(
-		plugin,
-		purchases,
-		plugin.isMarketplaceProduct
-	);
+	const currentPurchase: Purchase = getPluginPurchased( plugin, purchases );
 
 	return currentPurchase?.id ? (
 		<>

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -269,9 +269,7 @@ function InstalledInOrPricing( {
 	const { isPreinstalledPremiumPlugin } = usePreinstalledPremiumPlugin( plugin.slug );
 	const active = isWpcomPreinstalled || isPluginActive;
 	const isPluginActiveOnsiteWithSubscription =
-		active && ! isMarketplaceProduct
-			? true
-			: getPluginPurchased( plugin, purchases, isMarketplaceProduct )?.active;
+		active && ! isMarketplaceProduct ? true : getPluginPurchased( plugin, purchases )?.active;
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	if ( isPreinstalledPremiumPlugin ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

`isMarketplaceProduct` was creating some implications due to slugs not matching. Either way, it's not needed in `getPluginPurchased` since we just need to know if the plugin is purchased and the related data.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/:plugin/:site` of paid plugin ( choose a woocommerce one )
* Buy the plugin
* Go to the same `/plugins/:plugin/:site`
* Make sure that the tooltip includes "Manage subscription"

|Before | After|
|-------|------|
|<img width="1148" alt="CleanShot 2023-03-15 at 12 02 22@2x" src="https://user-images.githubusercontent.com/12430020/225281911-ff2e2318-5c3c-41ed-ba0b-a1838284a26d.png">|<img width="1159" alt="CleanShot 2023-03-15 at 12 34 52@2x" src="https://user-images.githubusercontent.com/12430020/225283581-f4fc7e19-4026-4405-b04b-47836b2dec81.png">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
