### PR TITLE
Hosting Configuration: Add margin between SSH keys and 'Add' button

### DIFF
--- a/client/my-sites/hosting/sftp-card/ssh-keys.scss
+++ b/client/my-sites/hosting/sftp-card/ssh-keys.scss
@@ -2,7 +2,9 @@
 	max-width: calc(100vw - 32px);
 }
 
-.ssh-keys__form {
+.ssh-keys__form.form-fieldset {
+	margin-top: 16px;
+	margin-bottom: 0;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;

--- a/client/my-sites/hosting/sftp-card/ssh-keys.scss
+++ b/client/my-sites/hosting/sftp-card/ssh-keys.scss
@@ -11,6 +11,16 @@
 	gap: 16px;
 }
 
+.ssh-keys__cards-container {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 12px;
+	> .card {
+		margin: 0;
+	}
+}
+
 .ssh-keys__select {
 	max-width: 100%;
 	width: 350px;

--- a/client/my-sites/hosting/sftp-card/ssh-keys.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-keys.tsx
@@ -94,15 +94,19 @@ function SshKeys( { siteId, siteSlug, username, disabled }: SshKeysProps ) {
 				{ __( 'SSH keys' ) }
 			</label>
 
-			{ keys?.map( ( sshKey ) => (
-				<SshKeyCard
-					key={ sshKey.sha256 }
-					sshKey={ sshKey }
-					deleteText={ __( 'Detach' ) }
-					siteId={ siteId }
-					disabled={ isFetchingKeys }
-				/>
-			) ) }
+			{ keys && keys.length > 0 && (
+				<div className="ssh-keys__cards-container">
+					{ keys.map( ( sshKey ) => (
+						<SshKeyCard
+							key={ sshKey.sha256 }
+							sshKey={ sshKey }
+							deleteText={ __( 'Detach' ) }
+							siteId={ siteId }
+							disabled={ isFetchingKeys }
+						/>
+					) ) }
+				</div>
+			) }
 
 			{ isLoading && <Spinner /> }
 


### PR DESCRIPTION
## Proposed Changes

Adds a bit of margin between the listed SSH keys and the 'Attach SSH key to this site' button.

### No SSH keys

<img width="814" alt="image" src="https://user-images.githubusercontent.com/36432/225287774-96e3ad6c-369b-4d84-a666-0e35bc68fb97.png">

### Other user has a SSH key

<img width="825" alt="image" src="https://user-images.githubusercontent.com/36432/225287967-77aa0a7a-4754-4405-becb-55cc74a1a966.png">

### Two SSH keys

<img width="821" alt="image" src="https://user-images.githubusercontent.com/36432/225288689-89027cb8-2276-469d-a6eb-b2d2bac09917.png">

## Testing Instructions

1. Create a new Business site and take it Atomic.
2. Add another administrator to your site and sign into their account via incognito window or otherwise.
3. Play around with different variations of attached SSH keys.