### PR TITLE
Add Image Guide feature to Boost's lightbox description

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -970,47 +970,47 @@ export const getJetpackProductsRecommendedFor = (): Record< string, TranslateRes
 };
 
 export const useJetpack10GbStorageAmountText = (): TranslateResult => {
-	const _translate = useTranslate();
+	const translate = useTranslate();
 
 	return useMemo(
 		() =>
-			_translate( '%(numberOfGigabytes)dGB', '%(numberOfGigabytes)dGB', {
+			translate( '%(numberOfGigabytes)dGB', '%(numberOfGigabytes)dGB', {
 				comment:
 					'Displays an amount of gigabytes. Plural string used in case GB needs to be pluralized.',
 				count: 10,
 				args: { numberOfGigabytes: 10 },
 			} ),
-		[ _translate ]
+		[ translate ]
 	);
 };
 
 export const useJetpack100GbStorageAmountText = (): TranslateResult => {
-	const _translate = useTranslate();
+	const translate = useTranslate();
 
 	return useMemo(
 		() =>
-			_translate( '%(numberOfGigabytes)dGB', '%(numberOfGigabytes)dGB', {
+			translate( '%(numberOfGigabytes)dGB', '%(numberOfGigabytes)dGB', {
 				comment:
 					'Displays an amount of gigabytes. Plural string used in case GB needs to be pluralized.',
 				count: 100,
 				args: { numberOfGigabytes: 100 },
 			} ),
-		[ _translate ]
+		[ translate ]
 	);
 };
 
 export const useJetpack1TbStorageAmountText = (): TranslateResult => {
-	const _translate = useTranslate();
+	const translate = useTranslate();
 
 	return useMemo(
 		() =>
-			_translate( '%(numberOfTerabytes)dTB', '%(numberOfTerabytes)dTB', {
+			translate( '%(numberOfTerabytes)dTB', '%(numberOfTerabytes)dTB', {
 				comment:
 					'Displays an amount of terabytes. Plural string used in case TB needs to be pluralized.',
 				count: 1,
 				args: { numberOfTerabytes: 1 },
 			} ),
-		[ _translate ]
+		[ translate ]
 	);
 };
 

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -806,6 +806,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Defer non-essential JavaScript' ),
 		translate( 'Optimize CSS loading' ),
 		translate( 'Lazy image loading' ),
+		translate( 'Image Guide to discover and fix large images on your site' ),
 	];
 	const socialBasicIncludesInfo = [
 		translate( 'Automatically share your posts and products on social media' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbNhbs-5nx-p2 

## Proposed Changes

Add "_Image Guide to discover and fix large images on your site"_ sentence to [Boost's lightbox description](https://cloud.jetpack.com/pricing#jetpack_boost_yearly)

## Testing Instructions
Patch the changes and check if you see the updated copy.

Before:
<img width="1440" alt="Screen Shot 2023-03-15 at 14 42 47" src="https://user-images.githubusercontent.com/82706809/225299524-1d4c8bc5-db11-4b12-938a-2bd6af300542.png">


After:
<img width="1440" alt="Screen Shot 2023-03-15 at 14 42 36" src="https://user-images.githubusercontent.com/82706809/225299538-24465049-f4ff-4c22-967b-6681e031992c.png">




<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?