### PR TITLE
Do not get wpcom subdomains from the suggestion engine to speed up the domain upsell card

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -123,7 +123,7 @@ export function RenderDomainUpsell( {
 	const shoppingCartManager = useShoppingCart( cartKey );
 
 	// Get first non-free suggested domain.
-	const domainSuggestion = allDomainSuggestions[ 0 ];
+	const domainSuggestion = allDomainSuggestions?.[ 0 ];
 
 	// It takes awhile to suggest a domain name. Set a default to an empty string.
 	const domainSuggestionName = domainSuggestion?.domain_name ?? '';

--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -96,6 +96,7 @@ export default function DomainUpsell( { context } ) {
 
 const domainSuggestionOptions = {
 	vendor: 'domain-upsell',
+	include_wordpressdotcom: false,
 };
 
 export function RenderDomainUpsell( {
@@ -122,9 +123,7 @@ export function RenderDomainUpsell( {
 	const shoppingCartManager = useShoppingCart( cartKey );
 
 	// Get first non-free suggested domain.
-	const domainSuggestion = allDomainSuggestions?.filter(
-		( suggestion ) => ! suggestion.is_free
-	)[ 0 ];
+	const domainSuggestion = allDomainSuggestions[ 0 ];
 
 	// It takes awhile to suggest a domain name. Set a default to an empty string.
 	const domainSuggestionName = domainSuggestion?.domain_name ?? '';


### PR DESCRIPTION
I noticed that we're always getting a wordpress.com subdomain suggestion for this card but we never use it. So instead of getting a wordpress.com subdomain and then stripping it out we should just pass the `include_wordpressdotcom` param to the suggestion engine and we can just get the first result.

## Proposed Changes

* Pass `include_wordpressdotcom` to the suggestion engine and remove the code to skip the wordpress.com subdomain suggestion

## Testing Instructions

* Just check that you still get the same domain suggestion in the domain upsell card

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
