### PR TITLE
Tailored Flows: Fix uppercase label style

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -146,6 +146,11 @@ button {
 	.step-container {
 		--color-accent: #117ac9;
 		--color-accent-60: #0e64a5;
+		.form-fieldset {
+			label {
+				text-transform: none;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Context

Some flows are using TextControl from `@wordpress/components`, these components have a css rule that sets the label text-transformation property to uppercase.

## Proposed Changes

Fixes uppercase site name on flows.

Before:

<img width="698" alt="image" src="https://user-images.githubusercontent.com/2653810/225317877-aff26f41-36fd-4b98-8146-c8f3dd873bfa.png">

After: 

<img width="568" alt="image" src="https://user-images.githubusercontent.com/2653810/225318860-53437e36-2fca-474f-b853-4dec4a72f413.png">


## Testing Instructions

- Pull and run this branch or use calypso live link
- Navigate to `/setup/link-in-bio/` flow.
- On Personalize step the site name should not be uppercase
- This change is applied to all flows.


