### PR TITLE
Data Stores: Refactor `WpcomFeatures` store to `createReduxStore()`

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/index.ts
@@ -1,4 +1,3 @@
 import './domain-suggestions';
 import './plans';
 import './site';
-import './wpcom-features';

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/wpcom-features.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/wpcom-features.ts
@@ -1,3 +1,0 @@
-import { WPCOMFeatures } from '@automattic/data-stores';
-
-WPCOMFeatures.register();

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -63,4 +63,3 @@ export * from './contextual-help/constants';
 export type { HelpCenterSite, HelpCenterSelect } from './help-center/types';
 export type { OnboardSelect } from './onboard';
 export type { StepperInternalSelect } from './stepper-internal';
-export type { WpcomFeaturesSelect } from './wpcom-features/types';

--- a/packages/data-stores/src/wpcom-features/index.ts
+++ b/packages/data-stores/src/wpcom-features/index.ts
@@ -1,4 +1,4 @@
-import { registerStore } from '@wordpress/data';
+import { register, createReduxStore } from '@wordpress/data';
 import { controls } from '@wordpress/data-controls';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
@@ -10,16 +10,10 @@ export type { FeatureId, Feature } from './types';
 
 export { featuresList } from './features-data';
 
-let isRegistered = false;
+export const store = createReduxStore( STORE_KEY, {
+	controls,
+	reducer: reducer as Reducer< State, AnyAction >,
+	selectors,
+} );
 
-export function register(): typeof STORE_KEY {
-	if ( ! isRegistered ) {
-		isRegistered = true;
-		registerStore( STORE_KEY, {
-			controls,
-			reducer: reducer as Reducer< State, AnyAction >,
-			selectors,
-		} );
-	}
-	return STORE_KEY;
-}
+register( store );

--- a/packages/data-stores/src/wpcom-features/types.ts
+++ b/packages/data-stores/src/wpcom-features/types.ts
@@ -1,5 +1,3 @@
-import * as selectors from './selectors';
-import type { SelectFromMap } from '../mapped-types';
 import type { PlanSlug } from '../plans';
 
 export type FeatureId =
@@ -16,5 +14,3 @@ export interface Feature {
 	id: FeatureId;
 	minSupportedPlan: PlanSlug;
 }
-
-export type WpcomFeaturesSelect = SelectFromMap< typeof selectors >;

--- a/packages/plans-grid/src/plans-accordion/index.tsx
+++ b/packages/plans-grid/src/plans-accordion/index.tsx
@@ -1,3 +1,4 @@
+import { WPCOMFeatures } from '@automattic/data-stores';
 import { Button, SVG, Path } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { Icon } from '@wordpress/icons';
@@ -7,15 +8,9 @@ import * as React from 'react';
 import { useSupportedPlans } from '../hooks';
 import PlanItem from '../plans-accordion-item';
 import PlanItemPlaceholder from '../plans-accordion-item/plans-item-placeholder';
-import { PLANS_STORE, WPCOM_FEATURES_STORE } from '../stores';
+import { PLANS_STORE } from '../stores';
 import type { DisabledPlansMap } from '../plans-table/types';
-import type {
-	DomainSuggestions,
-	Plans,
-	PlansSelect,
-	WPCOMFeatures,
-	WpcomFeaturesSelect,
-} from '@automattic/data-stores';
+import type { DomainSuggestions, Plans, PlansSelect } from '@automattic/data-stores';
 
 import './style.scss';
 
@@ -67,10 +62,7 @@ const PlansAccordion: React.FunctionComponent< Props > = ( {
 		[ locale ]
 	);
 	const recommendedPlanSlug = useSelect(
-		( select ) =>
-			( select( WPCOM_FEATURES_STORE ) as WpcomFeaturesSelect ).getRecommendedPlanSlug(
-				selectedFeatures
-			),
+		( select ) => select( WPCOMFeatures.store ).getRecommendedPlanSlug( selectedFeatures ),
 		[ selectedFeatures ]
 	);
 

--- a/packages/plans-grid/src/stores.ts
+++ b/packages/plans-grid/src/stores.ts
@@ -1,4 +1,3 @@
-import { Plans, WPCOMFeatures } from '@automattic/data-stores';
+import { Plans } from '@automattic/data-stores';
 
 export const PLANS_STORE = Plans.register();
-export const WPCOM_FEATURES_STORE = WPCOMFeatures.register();


### PR DESCRIPTION
## Proposed Changes

This PR migrates the `WpcomFeatures` store to use `createReduxStore()` and `register()` instead of `registerStore()`.

Part of #74399. A follow-up to #73890.

## Testing Instructions

* This is used in ETK - @noahtallen - any ideas on how to test it?
* Verify all checks are green.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
