### PR TITLE
Add tracks to plans block

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/view.tsx
+++ b/apps/happy-blocks/block-library/pricing-plans/view.tsx
@@ -1,4 +1,5 @@
 import './view.scss';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import domReady from '@wordpress/dom-ready';
 import { useState, render } from '@wordpress/element';
 import useI18nCalypsoTranslations from '../shared/use-i18n-calypso-translations';
@@ -31,6 +32,10 @@ function renderPricingPlansBlock( element: HTMLElement | Element ) {
 }
 
 domReady( () => {
+	recordTracksEvent( 'calypso_happyblocks_upgrade_plan_view', {
+		location: window?.location?.href,
+	} );
+
 	document
 		.querySelectorAll( '.a8c-happy-tools-pricing-plans-block-placeholder' )
 		.forEach( renderPricingPlansBlock );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#](323-gh-Automattic/lighthouse-forums)

## Proposed Changes

Fixes 323-gh-Automattic/lighthouse-forums by adding a track record for upgrade block page views.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
There should be a tracks request for `calypso_happyblocks_upgrade_plan_view` only for forum posts that have the upgrade block.
![Markup on 2023-03-15 at 4:32:17 PM](https://user-images.githubusercontent.com/2129455/225341868-64fb81c5-f02d-436b-8694-0771b7e68965.png)

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?