### PR TITLE
Checkout: Pre-check Northern Ireland checkbox if saved VAT info is for XI

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -106,8 +106,8 @@ export function VatForm( {
 				...vatDetailsFromServer,
 				// Initialize the VAT country in this form data to match the country in
 				// the parent form, which may differ from the country in the saved VAT
-				// details.
-				country: countryCode,
+				// details unless Northern Ireland is saved.
+				country: vatDetailsFromServer.country === 'XI' ? vatDetailsFromServer.country : countryCode,
 			} );
 			// Pre-check the checkbox to show the form when the country is supported
 			// if there are saved VAT details.

--- a/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
@@ -187,6 +187,30 @@ describe( 'Checkout contact step VAT form', () => {
 		expect( await screen.findByLabelText( 'Address for tax ID' ) ).toHaveValue( '123 Main Street' );
 	} );
 
+	it( 'renders the Northern Ireland checkbox pre-filled if the VAT endpoint returns XI', async () => {
+		nock.cleanAll();
+		mockCachedContactDetailsEndpoint( {
+			country_code: 'GB',
+			postal_code: '',
+		} );
+		mockContactDetailsValidationEndpoint( 'tax', { success: false, messages: [ 'Invalid' ] } );
+		mockGetVatInfoEndpoint( {
+			id: '12345',
+			name: 'Test company',
+			address: '123 Main Street',
+			country: 'XI',
+		} );
+		const cartChanges = { products: [ planWithoutDomain ] };
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
+
+		// Wait for checkout to load.
+		await screen.findByLabelText( 'Continue with the entered contact details' );
+		const countryField = await screen.findByLabelText( 'Country' );
+
+		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
+		expect( await screen.findByLabelText( 'Is the tax ID for Northern Ireland?' ) ).toBeChecked();
+	} );
+
 	it( 'does not allow unchecking the VAT details checkbox if the VAT fields are pre-filled', async () => {
 		nock.cleanAll();
 		mockCachedContactDetailsEndpoint( {


### PR DESCRIPTION
## Proposed Changes

When pre-filling the billing information step's VAT section in checkout, if there is already saved VAT information and the saved country code is `XI` (Northern Ireland's fake country code for tax purposes), the "Northern Ireland" checkbox should be pre-checked. This diff makes that happen.

Fixes https://github.com/Automattic/wp-calypso/issues/73407

Before:

<img width="570" alt="Screenshot 2023-03-15 at 1 08 44 PM" src="https://user-images.githubusercontent.com/2036909/225387052-6bd14f58-800d-4bd8-82d6-3d5ecd356872.png">

After:

<img width="568" alt="Screenshot 2023-03-15 at 1 09 33 PM" src="https://user-images.githubusercontent.com/2036909/225387286-15974327-1819-4b13-bdcf-2bc2b99fb165.png">


## Testing Instructions

Automated tests are included but you can try this manually.

- Use an account without VAT info saved. Use Payments Admin to remove VAT info from the account if it is already set.
- Add a product to your cart and visit checkout.
- Click to edit the billing information step and change the country to "United Kingdom" and enter a valid postal code like `GU16 7HF`.
- Press "Continue" to save the address.
- Find a valid Northern Ireland VAT ID and save it to your account using Payments Admin or https://wordpress.com/me/purchases/vat-details. You can find a valid one by searching the database for VAT info for the country `XI`.
- Reload checkout.
- Click to edit the billing information step.
- Verify that the checkbox labeled "Is the tax ID for Northern Ireland?" is pre-checked.