### PR TITLE
Plugin: Fix the multisite purchase button

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -10,6 +10,7 @@ import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-t
 import PluginInstallButton from 'calypso/my-sites/plugins/plugin-install-button';
 import UpdatePlugin from 'calypso/my-sites/plugins/plugin-management-v2/update-plugin';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
 import {
 	isPluginActionInProgress,
 	getPluginOnSite,
@@ -44,6 +45,8 @@ export default function PluginRowFormatter( {
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const billingPeriod = useSelector( getBillingInterval );
 
 	const PluginDetailsButton = (
 		props: PropsWithChildren< { className: string; onClick?: MouseEventHandler } >
@@ -255,6 +258,7 @@ export default function PluginRowFormatter( {
 						selectedSite={ selectedSite }
 						plugin={ item }
 						isInstalling={ installInProgress }
+						billingPeriod={ billingPeriod }
 					/>
 				</div>
 			);

--- a/client/my-sites/plugins/plugin-management-v2/test/plugin-common-card.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/plugin-common-card.test.tsx
@@ -36,6 +36,11 @@ const initialState = {
 			},
 		},
 	},
+	marketplace: {
+		billingInterval: {
+			interval: 'yearly',
+		},
+	},
 };
 
 const props = {

--- a/client/my-sites/plugins/plugin-management-v2/test/plugin-common-table.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/plugin-common-table.test.tsx
@@ -36,6 +36,11 @@ const initialState = {
 			},
 		},
 	},
+	marketplace: {
+		billingInterval: {
+			interval: 'yearly',
+		},
+	},
 };
 
 const props = {

--- a/client/my-sites/plugins/plugin-management-v2/test/plugin-row-formatter.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/plugin-row-formatter.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import moment from 'moment';
 import React from 'react';
 import documentHead from 'calypso/state/document-head/reducer';
+import marketplace from 'calypso/state/marketplace/reducer';
 import plugins from 'calypso/state/plugins/reducer';
 import productsList from 'calypso/state/products-list/reducer';
 import siteConnection from 'calypso/state/site-connection/reducer';
@@ -31,12 +32,17 @@ const initialReduxState = {
 	productsList: {
 		items: {},
 	},
+	marketplace: {
+		billingInterval: {
+			interval: 'yearly',
+		},
+	},
 };
 
 const render = ( el ) =>
 	renderWithProvider( el, {
 		initialState: initialReduxState,
-		reducers: { ui, plugins, documentHead, productsList, siteConnection },
+		reducers: { ui, plugins, documentHead, productsList, siteConnection, marketplace },
 		store: undefined,
 	} );
 


### PR DESCRIPTION

Related to #74448

## Proposed Changes

Pass the `billingPeriod` property as required to `PluginInstallButton` component. This allows the component to redirect properly to the cart with the given plugin.

## Testing Instructions
* Go to a multisite view page of a paid plugin. Ex: `/plugins/woocommerce-shipment-tracking`
* Click on `"Manage sites"`
* Select a site and click on `Puchase and activate` or `Upgrade and activate`
* This should redirect to the cart with the given plugin. The current version in production produces an error.

| Before  | After |
| ------------- | ------------- |
|<img width="612" alt="CleanShot 2023-03-15 at 14 18 50@2x" src="https://user-images.githubusercontent.com/5039531/225391181-1f7bd34b-4cda-4ced-8d5b-70a994826d91.png">|<img width="975" alt="CleanShot 2023-03-15 at 14 20 20@2x" src="https://user-images.githubusercontent.com/5039531/225391202-308028a1-25f4-41a6-87ce-dff8809d1389.png">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
