### PR TITLE
E2E: use API calls in Widgets: Legacy spec to deactivate/remove widgets before the spec is run.

### DIFF
--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -996,12 +996,12 @@ export class RestAPIClient {
 	}
 
 	/**
+	 * Deletes or deactivates all widgets for a given site.
 	 *
-	 * @param siteID
+	 * @param {number} siteID ID of the target site.
 	 */
 	async deleteAllWidgets( siteID: number ): Promise< void > {
 		const widgets = await this.getAllWidgets( siteID );
-		console.log( widgets );
 
 		widgets.map( async ( widget ) => await this.deleteWidget( siteID, widget.id ) );
 	}

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -119,6 +119,14 @@ export interface Invite {
 // Export as Array to expose function calls of arrays.
 export type AllInvitesResponse = Array< Invite >;
 
+interface Widget {
+	id: string;
+	sidebar: string;
+	position: number;
+}
+
+export type AllWidgetsResponse = Array< Widget >;
+
 export interface DeleteInvitesResponse {
 	deleted: string[];
 	invalid: string[];


### PR DESCRIPTION
## Proposed Changes

This PR updates the Widgets: Legacy spec to use API calls in order to first deactivate all widgets.

Context: Gutenberg 15.3.1 release.
Thread: p1678383789296349/1678381006.233999-slack-CBTN58FTJ

Mobile viewport is not supported due to https://github.com/Automattic/wp-calypso/issues/64536.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile) (suite is skipped)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?