### PR TITLE
Jetpack Pro Portal: Highlight legacy/user licenses in the licenses list

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/index.ts
+++ b/client/jetpack-cloud/sections/partner-portal/index.ts
@@ -29,7 +29,7 @@ export default function () {
 
 	// List licenses.
 	page(
-		`/partner-portal/licenses/:filter(unassigned|assigned|revoked)?`,
+		`/partner-portal/licenses/:filter(unassigned|assigned|revoked|legacy)?`,
 		controller.requireAccessContext,
 		controller.requireTermsOfServiceConsentContext,
 		controller.requireSelectedPartnerKeyContext,

--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -3,7 +3,10 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
-import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import {
+	LicenseOwnerType,
+	LicenseState,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import UnassignLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/unassign-license-dialog';
 import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -11,6 +14,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 interface Props {
 	licenseKey: string;
+	ownerType: LicenseOwnerType;
 	product: string;
 	siteUrl: string | null;
 	attachedAt: string | null;
@@ -19,6 +23,7 @@ interface Props {
 
 export default function LicenseDetailsActions( {
 	licenseKey,
+	ownerType,
 	product,
 	siteUrl,
 	attachedAt,
@@ -26,7 +31,7 @@ export default function LicenseDetailsActions( {
 }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const licenseState = getLicenseState( attachedAt, revokedAt );
+	const licenseState = getLicenseState( ownerType, attachedAt, revokedAt );
 	const [ revokeDialog, setRevokeDialog ] = useState( false );
 	const [ unassignDialog, setUnassignDialog ] = useState( false );
 

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -3,12 +3,16 @@ import { useTranslate } from 'i18n-calypso';
 import FormattedDate from 'calypso/components/formatted-date';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import LicenseDetailsActions from 'calypso/jetpack-cloud/sections/partner-portal/license-details/actions';
-import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import {
+	LicenseOwnerType,
+	LicenseState,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { getLicenseState, noop } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import './style.scss';
 
 interface Props {
 	licenseKey: string;
+	ownerType: LicenseOwnerType;
 	product: string;
 	siteUrl: string | null;
 	username: string | null;
@@ -16,7 +20,6 @@ interface Props {
 	issuedAt: string;
 	attachedAt: string | null;
 	revokedAt: string | null;
-	isLegacy: boolean | null;
 	onCopyLicense?: () => void;
 }
 
@@ -24,6 +27,7 @@ const DETAILS_DATE_FORMAT = 'YYYY-MM-DD h:mm:ss A';
 
 export default function LicenseDetails( {
 	licenseKey,
+	ownerType,
 	product,
 	siteUrl,
 	username,
@@ -31,21 +35,22 @@ export default function LicenseDetails( {
 	issuedAt,
 	attachedAt,
 	revokedAt,
-	isLegacy,
 	onCopyLicense = noop,
 }: Props ) {
 	const translate = useTranslate();
-	const licenseState = getLicenseState( attachedAt, revokedAt );
+	const licenseState = getLicenseState( ownerType, attachedAt, revokedAt );
 	const debugUrl = siteUrl ? `https://jptools.wordpress.com/debug/?url=${ siteUrl }` : null;
 
 	return (
 		<Card className="license-details">
 			<ul className="license-details__list">
 				<li className="license-details__list-item license-details__list-item--wide">
-					{ isLegacy && (
+					{ licenseState === LicenseState.Legacy && (
 						<div className="license-details__legacy-notice-text">
 							<Gridicon icon="info" />
-							{ translate( 'This is a legacy Jetpack license, but can be converted to an agency license by clicking the convert button above.' ) }
+							{ translate(
+								'This is a legacy Jetpack license, but can be converted to an agency license by clicking the convert button above.'
+							) }
 						</div>
 					) }
 
@@ -125,9 +130,10 @@ export default function LicenseDetails( {
 				</li>
 			</ul>
 
-			{ ! isLegacy && (
+			{ licenseState !== LicenseState.Legacy && (
 				<LicenseDetailsActions
 					licenseKey={ licenseKey }
+					ownerType={ ownerType }
 					product={ product }
 					siteUrl={ siteUrl }
 					attachedAt={ attachedAt }

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -16,6 +16,7 @@ interface Props {
 	issuedAt: string;
 	attachedAt: string | null;
 	revokedAt: string | null;
+	isLegacy: boolean | null;
 	onCopyLicense?: () => void;
 }
 
@@ -30,6 +31,7 @@ export default function LicenseDetails( {
 	issuedAt,
 	attachedAt,
 	revokedAt,
+	isLegacy,
 	onCopyLicense = noop,
 }: Props ) {
 	const translate = useTranslate();
@@ -40,6 +42,13 @@ export default function LicenseDetails( {
 		<Card className="license-details">
 			<ul className="license-details__list">
 				<li className="license-details__list-item license-details__list-item--wide">
+					{ isLegacy && (
+						<div className="license-details__legacy-notice-text">
+							<Gridicon icon="info" />
+							{ translate( 'This is a legacy Jetpack license, but can be converted to an agency license by clicking the convert button above.' ) }
+						</div>
+					) }
+
 					<h4 className="license-details__label">{ translate( 'License code' ) }</h4>
 
 					<div className="license-details__license-key-row">
@@ -116,13 +125,15 @@ export default function LicenseDetails( {
 				</li>
 			</ul>
 
-			<LicenseDetailsActions
-				licenseKey={ licenseKey }
-				product={ product }
-				siteUrl={ siteUrl }
-				attachedAt={ attachedAt }
-				revokedAt={ revokedAt }
-			/>
+			{ ! isLegacy && (
+				<LicenseDetailsActions
+					licenseKey={ licenseKey }
+					product={ product }
+					siteUrl={ siteUrl }
+					attachedAt={ attachedAt }
+					revokedAt={ revokedAt }
+				/>
+			) }
 		</Card>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
@@ -75,4 +75,16 @@
 			display: none;
 		}
 	}
+
+	&__legacy-notice-text {
+		margin-bottom: 2rem;
+		color: var(--studio-gray-50);
+		font-style: italic;
+	}
+
+	&__legacy-notice-text .gridicon {
+		position: relative;
+		top: 6px;
+		margin-right: 10px;
+	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -83,6 +83,7 @@ export default function LicenseList() {
 						<LicenseTransition key={ license.licenseKey }>
 							<LicensePreview
 								licenseKey={ license.licenseKey }
+								ownerType={ license.ownerType }
 								product={ license.product }
 								username={ license.username }
 								blogId={ license.blogId }

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -49,6 +49,8 @@ export default function LicenseList() {
 	const showPagination = showLicenses && licenses.totalPages > 1;
 	const showNoResults = hasFetched && ! isFetching && licenses && licenses.items.length === 0;
 
+	console.log( licenses );
+
 	const onPageClick = useCallback(
 		( pageNumber: number ) => {
 			setPage( pageNumber );

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -49,8 +49,6 @@ export default function LicenseList() {
 	const showPagination = showLicenses && licenses.totalPages > 1;
 	const showNoResults = hasFetched && ! isFetching && licenses && licenses.items.length === 0;
 
-	console.log( licenses );
-
 	const onPageClick = useCallback(
 		( pageNumber: number ) => {
 			setPage( pageNumber );

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -10,7 +10,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import FormattedDate from 'calypso/components/formatted-date';
 import LicenseDetails from 'calypso/jetpack-cloud/sections/partner-portal/license-details';
 import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
-import { LicenseState, LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import {
+	LicenseState,
+	LicenseFilter,
+	LicenseOwnerType,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -20,6 +24,7 @@ import './style.scss';
 
 interface Props {
 	licenseKey: string;
+	ownerType: LicenseOwnerType;
 	product: string;
 	username: string | null;
 	blogId: number | null;
@@ -32,6 +37,7 @@ interface Props {
 
 export default function LicensePreview( {
 	licenseKey,
+	ownerType,
 	product,
 	username,
 	blogId,
@@ -48,11 +54,7 @@ export default function LicensePreview( {
 	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
 	const domain = siteUrl ? getUrlParts( siteUrl ).hostname || siteUrl : '';
 
-	// For testing only, we'd need to change this back once the API knows what legacy means
-	const licenseState =
-		'lovely-opossum.jurassic.ninja' === domain
-			? LicenseState.Legacy
-			: getLicenseState( attachedAt, revokedAt );
+	const licenseState = getLicenseState( ownerType, attachedAt, revokedAt );
 
 	const showDomain =
 		domain &&
@@ -210,7 +212,8 @@ export default function LicensePreview( {
 						</Button>
 					) }
 					{ licenseState === LicenseState.Legacy && (
-						<Button compact onClick={ () => {} }>
+						// @todo implement
+						<Button compact onClick={ () => alert( 'TBD' ) }>
 							{ translate( 'Convert' ) }
 						</Button>
 					) }
@@ -226,6 +229,7 @@ export default function LicensePreview( {
 			{ isOpen && (
 				<LicenseDetails
 					licenseKey={ licenseKey }
+					ownerType={ ownerType }
 					product={ product }
 					siteUrl={ siteUrl }
 					username={ username }
@@ -234,7 +238,6 @@ export default function LicensePreview( {
 					attachedAt={ attachedAt }
 					revokedAt={ revokedAt }
 					onCopyLicense={ onCopyLicense }
-					isLegacy={ LicenseState.Legacy === licenseState }
 				/>
 			) }
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -47,13 +47,17 @@ export default function LicensePreview( {
 	const [ isOpen, setOpen ] = useState( isHighlighted );
 	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
 	const domain = siteUrl ? getUrlParts( siteUrl ).hostname || siteUrl : '';
-	
-	const licenseState = 'winflagfootball.com' === domain 
-		? LicenseState.Legacy
-		: getLicenseState( attachedAt, revokedAt );
-	
+
+	// For testing only, we'd need to change this back once the API knows what legacy means
+	const licenseState =
+		'lovely-opossum.jurassic.ninja' === domain
+			? LicenseState.Legacy
+			: getLicenseState( attachedAt, revokedAt );
+
 	const showDomain =
-		domain && [ LicenseState.Attached, LicenseState.Revoked, LicenseState.Legacy ].indexOf( licenseState ) !== -1;
+		domain &&
+		[ LicenseState.Attached, LicenseState.Revoked, LicenseState.Legacy ].indexOf( licenseState ) !==
+			-1;
 
 	const oneMinuteAgo = moment.utc().subtract( 1, 'minute' );
 
@@ -206,7 +210,7 @@ export default function LicensePreview( {
 						</Button>
 					) }
 					{ licenseState === LicenseState.Legacy && (
-						<Button compact onClick={ () => console.log( 'convert' ) }>
+						<Button compact onClick={ () => {} }>
 							{ translate( 'Convert' ) }
 						</Button>
 					) }

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -46,10 +46,14 @@ export default function LicensePreview( {
 	const isHighlighted = getQueryArg( window.location.href, 'highlight' ) === licenseKey;
 	const [ isOpen, setOpen ] = useState( isHighlighted );
 	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
-	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl ? getUrlParts( siteUrl ).hostname || siteUrl : '';
+	
+	const licenseState = 'winflagfootball.com' === domain 
+		? LicenseState.Legacy
+		: getLicenseState( attachedAt, revokedAt );
+	
 	const showDomain =
-		domain && [ LicenseState.Attached, LicenseState.Revoked ].indexOf( licenseState ) !== -1;
+		domain && [ LicenseState.Attached, LicenseState.Revoked, LicenseState.Legacy ].indexOf( licenseState ) !== -1;
 
 	const oneMinuteAgo = moment.utc().subtract( 1, 'minute' );
 
@@ -114,10 +118,18 @@ export default function LicensePreview( {
 					'license-preview__card': true,
 					'license-preview__card--is-detached': licenseState === LicenseState.Detached,
 					'license-preview__card--is-revoked': licenseState === LicenseState.Revoked,
+					'license-preview__card--is-legacy': licenseState === LicenseState.Legacy,
 				} ) }
 			>
 				<div>
 					<h3 className="license-preview__domain">
+						{ LicenseState.Legacy === licenseState && (
+							<span className="license-preview__tag license-preview__tag--is-legacy">
+								<Gridicon icon="info-outline" size={ 18 } />
+								{ translate( 'Legacy license' ) }
+							</span>
+						) }
+
 						{ showDomain && <span>{ domain }</span> }
 
 						{ licenseState === LicenseState.Detached && (
@@ -193,6 +205,11 @@ export default function LicensePreview( {
 							{ translate( 'Assign License' ) }
 						</Button>
 					) }
+					{ licenseState === LicenseState.Legacy && (
+						<Button compact onClick={ () => console.log( 'convert' ) }>
+							{ translate( 'Convert' ) }
+						</Button>
+					) }
 				</div>
 
 				<div>
@@ -213,6 +230,7 @@ export default function LicensePreview( {
 					attachedAt={ attachedAt }
 					revokedAt={ revokedAt }
 					onCopyLicense={ onCopyLicense }
+					isLegacy={ LicenseState.Legacy === licenseState }
 				/>
 			) }
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -22,6 +22,7 @@
 
 	&__card {
 		// Increased specificity to override card styles.
+		&--is-legacy.card.is-compact,
 		&--is-detached.card.is-compact,
 		&--is-revoked.card.is-compact {
 			// Reduce padding to fit the extra border width on the left so columns are still aligned perfectly.
@@ -34,6 +35,10 @@
 
 		&--is-detached.card.is-compact {
 			border-left: 3px solid var(--studio-orange-40);
+		}
+
+		&--is-legacy.card.is-compact {
+			border-left: 3px solid var(--studio-purple-50);
 		}
 
 		&--is-revoked.card.is-compact {
@@ -87,6 +92,10 @@
 
 		&--is-detached {
 			color: var(--studio-orange-40);
+		}
+
+		&--is-legacy {
+			color: var(--studio-purple-50);
 		}
 
 		&--is-revoked {

--- a/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
@@ -23,9 +23,7 @@ function LicenseStateFilter( { doSearch }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { filter, search } = useContext( LicenseListContext );
-
-	// This is for testing only, we'd need to change this back once the API understands what Legacy means
-	const counts = Object.assign( useSelector( getLicenseCounts ), { legacy: 2 } );
+	const counts = useSelector( getLicenseCounts );
 
 	const basePath = '/partner-portal/licenses/';
 

--- a/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
@@ -23,12 +23,10 @@ function LicenseStateFilter( { doSearch }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { filter, search } = useContext( LicenseListContext );
-	
-	const counts = Object.assign(
-		useSelector( getLicenseCounts ),
-		{ legacy: 2 }
-	);
-	
+
+	// This is for testing only, we'd need to change this back once the API understands what Legacy means
+	const counts = Object.assign( useSelector( getLicenseCounts ), { legacy: 2 } );
+
 	const basePath = '/partner-portal/licenses/';
 
 	const navItems = [
@@ -51,7 +49,7 @@ function LicenseStateFilter( { doSearch }: Props ) {
 		{
 			key: LicenseFilter.Legacy,
 			label: translate( 'Legacy' ),
-		}
+		},
 	].map( ( navItem ) => ( {
 		...navItem,
 		count: counts[ navItem.key ] || 0,

--- a/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
@@ -23,7 +23,12 @@ function LicenseStateFilter( { doSearch }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { filter, search } = useContext( LicenseListContext );
-	const counts = useSelector( getLicenseCounts );
+	
+	const counts = Object.assign(
+		useSelector( getLicenseCounts ),
+		{ legacy: 2 }
+	);
+	
 	const basePath = '/partner-portal/licenses/';
 
 	const navItems = [
@@ -43,6 +48,10 @@ function LicenseStateFilter( { doSearch }: Props ) {
 			key: LicenseFilter.Revoked,
 			label: translate( 'Revoked' ),
 		},
+		{
+			key: LicenseFilter.Legacy,
+			label: translate( 'Legacy' ),
+		}
 	].map( ( navItem ) => ( {
 		...navItem,
 		count: counts[ navItem.key ] || 0,

--- a/client/jetpack-cloud/sections/partner-portal/types.ts
+++ b/client/jetpack-cloud/sections/partner-portal/types.ts
@@ -30,3 +30,5 @@ export interface AssignLicenceProps {
 	selectedSite?: SiteDetails | null;
 	suggestedProduct?: string;
 }
+
+export type LicenseOwnerType = 'jetpack_partner_key' | 'user';

--- a/client/jetpack-cloud/sections/partner-portal/types.ts
+++ b/client/jetpack-cloud/sections/partner-portal/types.ts
@@ -4,6 +4,7 @@ export enum LicenseState {
 	Detached = 'detached',
 	Attached = 'attached',
 	Revoked = 'revoked',
+	Legacy = 'legacy',
 }
 
 export enum LicenseFilter {
@@ -11,6 +12,7 @@ export enum LicenseFilter {
 	Detached = 'detached',
 	Attached = 'attached',
 	Revoked = 'revoked',
+	Legacy = 'legacy',
 }
 
 export enum LicenseSortField {

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -1,6 +1,7 @@
 import sortBy from 'lodash/sortBy';
 import {
 	LicenseFilter,
+	LicenseOwnerType,
 	LicenseSortField,
 	LicenseState,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
@@ -24,14 +25,20 @@ export function noop() {}
  * For example, if a license is neither attached to a site and revoked then it is both detached and revoked but
  * the dominant state would be considered to be revoked as it is of higher importance.
  *
+ * @param {LicenseOwnerType} ownerType Date the license was attached on, if any.
  * @param {string | null} attachedAt Date the license was attached on, if any.
  * @param {string | null} revokedAt Date the license was revoked on, if any.
  * @returns {LicenseState} State matching one of the `LicenseState` values.
  */
 export function getLicenseState(
+	ownerType: LicenseOwnerType,
 	attachedAt: string | null,
 	revokedAt: string | null
 ): LicenseState {
+	if ( ownerType === 'user' ) {
+		return LicenseState.Legacy;
+	}
+
 	if ( revokedAt ) {
 		return LicenseState.Revoked;
 	}

--- a/client/state/partner-portal/licenses/handlers.ts
+++ b/client/state/partner-portal/licenses/handlers.ts
@@ -26,8 +26,10 @@ import 'calypso/state/partner-portal/init';
 interface APILicense {
 	license_id: number;
 	license_key: string;
-	product_id: number;
+	owner_type: 'jetpack_partner_key' | 'user';
+	owner_id: number;
 	product: string;
+	product_id: number;
 	user_id: number | null;
 	username: string | null;
 	blog_id: number | null;
@@ -98,6 +100,8 @@ function formatLicenses( items: APILicense[] ): License[] {
 	return items.map( ( item ) => ( {
 		licenseId: item.license_id,
 		licenseKey: item.license_key,
+		ownerType: item.owner_type,
+		ownerId: item.owner_id,
 		product: item.product,
 		productId: item.product_id,
 		userId: item.user_id,

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -2,6 +2,7 @@ import { Action, AnyAction } from 'redux';
 import { ThunkAction } from 'redux-thunk';
 import {
 	LicenseFilter,
+	LicenseOwnerType,
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
@@ -209,6 +210,8 @@ export interface PartnerStore {
 export interface License {
 	licenseId: number;
 	licenseKey: string;
+	ownerType: LicenseOwnerType;
+	ownerId: number;
 	productId: number;
 	product: string;
 	userId: number | null;


### PR DESCRIPTION
Requires D105642-code

## Proposed Changes

Adds a new design context for the LicensePreview component to support Legacy (aka User) licenses intermingled with partner licenses in the licenses list.

## Testing Instructions

* TBD if we decide to iterate on this.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
