### PR TITLE
Launchpad: Add basic tests for step-content.tsx file

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -74,6 +74,8 @@ function renderStepContent( emailVerified = false, flow: string ) {
 }
 
 describe( 'StepContent', () => {
+	// To get things started, test basic rendering for Newsletter flow
+	// In future, we can add additional flows and test interactivity of items
 	describe( 'when flow is Newsletter', () => {
 		it( 'renders correct sidebar header content', () => {
 			renderStepContent( false, NEWSLETTER_FLOW );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+import { NEWSLETTER_FLOW } from '@automattic/onboarding';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import { createReduxStore } from 'calypso/state';
+import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
+import initialReducer from 'calypso/state/reducer';
+import { setStore } from 'calypso/state/redux-store';
+import StepContent from '../step-content';
+import { defaultSiteDetails } from './lib/fixtures';
+
+const mockSite = defaultSiteDetails;
+
+const stepContentProps = {
+	siteSlug: 'testsite.wordpress.com',
+	/* eslint-disable @typescript-eslint/no-empty-function */
+	submit: () => {},
+	goNext: () => {},
+	goToStep: () => {},
+	/* eslint-enable @typescript-eslint/no-empty-function */
+};
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site', () => ( {
+	useSite: () => ( {
+		site: mockSite,
+	} ),
+} ) );
+
+jest.mock( 'react-router-dom', () => ( {
+	...jest.requireActual( 'react-router-dom' ),
+	useLocation: jest.fn().mockImplementation( () => ( {
+		pathname: '/setup/launchpad',
+		search: `?flow=newsletter&siteSlug=testlinkinbio.wordpress.com`,
+		hash: '',
+		state: undefined,
+	} ) ),
+} ) );
+
+const user = {
+	ID: 1234,
+	username: 'testUser',
+	email: 'testemail@wordpress.com',
+	email_verified: false,
+};
+
+function renderStepContent( emailVerified = false, flow: string ) {
+	const initialState = getInitialState( initialReducer, user.ID );
+	const reduxStore = createReduxStore(
+		{
+			...initialState,
+			currentUser: {
+				user: {
+					...user,
+					email_verified: emailVerified,
+				},
+			},
+		},
+		initialReducer
+	);
+	setStore( reduxStore, getStateFromCache( user.ID ) );
+	const queryClient = new QueryClient();
+
+	render(
+		<Provider store={ reduxStore }>
+			<QueryClientProvider client={ queryClient }>
+				<StepContent { ...stepContentProps } flow={ flow } />
+			</QueryClientProvider>
+		</Provider>
+	);
+}
+
+describe( 'StepContent', () => {
+	describe( 'when flow is Newsletter', () => {
+		it( 'renders correct sidebar header content', () => {
+			renderStepContent( false, NEWSLETTER_FLOW );
+
+			expect( screen.getByText( 'Newsletter' ) ).toBeInTheDocument();
+			expect( screen.getByText( "You're all set to start publishing" ) ).toBeInTheDocument();
+			expect(
+				screen.getByText( 'Why not welcome your readers with your first post?' )
+			).toBeInTheDocument();
+		} );
+		it( 'renders correct sidebar tasks', () => {
+			renderStepContent( false, NEWSLETTER_FLOW );
+
+			expect( screen.getByText( 'Personalize Newsletter' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Choose a Plan' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Add Subscribers' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Confirm Email (Check Your Inbox)' ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: 'Write your first post' } ) ).toBeInTheDocument();
+		} );
+		it( 'renders correct status for each task', () => {
+			renderStepContent( false, NEWSLETTER_FLOW );
+
+			const personalizeListItem = screen.getByText( 'Personalize Newsletter' ).closest( 'li' );
+			const choosePlanListItem = screen.getByText( 'Choose a Plan' ).closest( 'li' );
+			const addSubscribersListItem = screen.getByText( 'Add Subscribers' ).closest( 'li' );
+			const confirmEmailListItem = screen
+				.getByText( 'Confirm Email (Check Your Inbox)' )
+				.closest( 'li' );
+			const firstPostListItem = screen
+				.getByRole( 'button', { name: 'Write your first post' } )
+				.closest( 'li' );
+
+			expect( personalizeListItem ).toHaveClass( 'completed' );
+			expect( choosePlanListItem ).toHaveClass( 'completed' );
+			expect( addSubscribersListItem ).toHaveClass( 'completed' );
+			expect( confirmEmailListItem ).toHaveClass( 'pending' );
+			expect( firstPostListItem ).toHaveClass( 'pending' );
+		} );
+		it( 'renders skip to dashboard link', () => {
+			renderStepContent( false, NEWSLETTER_FLOW );
+
+			expect( screen.getByRole( 'button', { name: 'Skip to dashboard' } ) ).toBeInTheDocument();
+		} );
+		it( 'renders web preview section', () => {
+			renderStepContent( false, NEWSLETTER_FLOW );
+
+			expect( screen.getByTitle( 'Preview' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Edit design' ) ).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -86,6 +86,7 @@ describe( 'StepContent', () => {
 				screen.getByText( 'Why not welcome your readers with your first post?' )
 			).toBeInTheDocument();
 		} );
+
 		it( 'renders correct sidebar tasks', () => {
 			renderStepContent( false, NEWSLETTER_FLOW );
 
@@ -95,6 +96,7 @@ describe( 'StepContent', () => {
 			expect( screen.getByText( 'Confirm Email (Check Your Inbox)' ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'button', { name: 'Write your first post' } ) ).toBeInTheDocument();
 		} );
+
 		it( 'renders correct status for each task', () => {
 			renderStepContent( false, NEWSLETTER_FLOW );
 
@@ -114,11 +116,13 @@ describe( 'StepContent', () => {
 			expect( confirmEmailListItem ).toHaveClass( 'pending' );
 			expect( firstPostListItem ).toHaveClass( 'pending' );
 		} );
+
 		it( 'renders skip to dashboard link', () => {
 			renderStepContent( false, NEWSLETTER_FLOW );
 
 			expect( screen.getByRole( 'button', { name: 'Skip to dashboard' } ) ).toBeInTheDocument();
 		} );
+
 		it( 'renders web preview section', () => {
 			renderStepContent( false, NEWSLETTER_FLOW );
 


### PR DESCRIPTION
### Proposed Changes

In a [recent PR](https://github.com/Automattic/wp-calypso/pull/74386), we removed tests for this file because they were focused on a single component (EmailVerificationBanner) that was removed. I noted I would follow up and add at least some basic test coverage for this file. 

This PR adds basic rendering tests for the Newsletter flow. If we think it's worth adding other flows and/or adding interactivity, I can do so. Note that tests in this file are somewhat redundant with tests we have in place for child components (sidebar, checklist, checklist item). So the goal here is just to cast a wide net and ensure the general content and behavior we expect for Launchpad as a whole is there. 

### Testing Instructions

**Review Time: Short**
**Testing Time: Short**

To test, checkout this branch locally, run the following line, and confirm all tests pass (1 test suite, 5 tests):
`yarn run test-client client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx`