### PR TITLE
Launchpad: Fix upper case label in SetupForm

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx
@@ -86,6 +86,7 @@ const SetupForm = ( {
 					label={ __( 'Site name' ) }
 					name="setup-form-input-name"
 					id="setup-form-input-name"
+					className="setup-form-input-name"
 					value={ siteTitle }
 					onChange={ ( value ) => setComponentSiteTitle( value ) }
 					placeholder={ translatedText?.titlePlaceholder || __( 'My Site Name' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
@@ -8,6 +8,13 @@
 	width: 335px;
 	padding: 0 20px;
 
+	.setup-form-input-name {
+		// override uppercase style from BaseControl
+		.components-base-control__label {
+			text-transform: capitalize;
+		}
+	}
+
 	@include break-medium {
 		padding: 0 20px;
 		width: 368px;


### PR DESCRIPTION
### Time Estimate
Review: Short
Test: Short

### Proposed Changes
This PR fixes bleeding styles that were causing the **Site Name** label to be all caps

![bfbf](https://user-images.githubusercontent.com/20927667/225444061-3015a003-2988-4103-a1a6-4bc96ad31b5d.png)

### Cause
Currently, inside our Launchpad's [SetupForm](https://github.com/Automattic/wp-calypso/blob/fix/launchpad_setup_text_transform/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/index.tsx#L85-L93) we are using the [TextControl component](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/text-control/index.tsx) which utilizes the [BaseControl wrapper](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/base-control/index.tsx#L45-L99). As a result, the default styles [baseLabelTypography](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/utils/base-label.ts#L8-L13) are bleeding over to the Launchpad's SetupFrom causing the text to be all caps.

### Testing Instructions

#### Free Flow
1. Checkout this branch
2. Go to http://calypso.localhost:3000/setup/free/intro
3. Confirm the label says **Site Name** and not **SITE NAME**
4. Continue to Launchpad
5. Once you arrive at Launchpad, click the **Personalize your site** task
6. Confirm the label says **Site Name** and not **SITE NAME**

#### Link In Bio Flow
1. Checkout this branch
2. Go to http://calypso.localhost:3000/setup/link-in-bio/intro
3. Once you arrive at the **Personalize your Link in Bio** step, confirm the label says **Site Name** and not **SITE NAME**
4. Continue to Launchpad
5. Once you arrive at Launchpad, click the **Personalize Link in Bio** task
6. Confirm the label says **Site Name** and not **SITE NAME**

#### Newsletter Flow
1. Checkout this branch
2. Go to http://calypso.localhost:3000/setup/newsletter/intro
3. Once you arrive at the **Set up your Newsletter** step, confirm the label says **Site Name** and not **SITE NAME**
4. Continue to Launchpad
5. Once you arrive at Launchpad, click the **Personalize Newsletter** task
6. Confirm the label says **Site Name** and not **SITE NAME**
