### PR TITLE
Checkout: Clear tax location when adding products

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -1,10 +1,12 @@
-import debugFactory from 'debug';
-import { useEffect, useRef, useState } from 'react';
-import type {
+import {
 	RequestCartProduct,
 	ApplyCouponToCart,
 	AddProductsToCart,
+	useShoppingCart,
 } from '@automattic/shopping-cart';
+import debugFactory from 'debug';
+import { useEffect, useRef, useState } from 'react';
+import useCartKey from '../../use-cart-key';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-add-products-from-url' );
 
@@ -36,6 +38,8 @@ export default function useAddProductsFromUrl( {
 	applyCoupon: ApplyCouponToCart;
 	addProductsToCart: AddProductsToCart;
 } ): isPendingAddingProductsFromUrl {
+	const cartKey = useCartKey();
+	const { updateLocation } = useShoppingCart( cartKey );
 	const isMounted = useRef( true );
 	useEffect( () => {
 		isMounted.current = true;
@@ -85,6 +89,16 @@ export default function useAddProductsFromUrl( {
 		debug( 'adding initial products to cart', productsForCart );
 		const cartPromises = [];
 		if ( productsForCart.length > 0 ) {
+			// When this hook adds products to the cart, we have just loaded checkout
+			// and we haven't yet confirmed the user's tax details. The cart may
+			// already have those details but there's at least a moderate chance that
+			// they could change when we get to the next step of the checkout
+			// process. Since calculating taxes is a very slow process for the cart,
+			// and that calculation requires tax details, here we clear the tax
+			// details in the cart to prevent calculating taxes until the user or
+			// autocomplete confirms those details.
+			cartPromises.push( updateLocation( {} ) );
+
 			cartPromises.push( addProductsToCart( productsForCart ) );
 		}
 		debug( 'adding initial coupon to cart', couponCodeFromUrl );
@@ -102,6 +116,7 @@ export default function useAddProductsFromUrl( {
 			} );
 		hasRequestedInitialProducts.current = true;
 	}, [
+		updateLocation,
 		isLoading,
 		areCartProductsPreparing,
 		isLoadingCart,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -97,7 +97,7 @@ export default function useAddProductsFromUrl( {
 			// and that calculation requires tax details, here we clear the tax
 			// details in the cart to prevent calculating taxes until the user or
 			// autocomplete confirms those details.
-			cartPromises.push( updateLocation( {} ) );
+			cartPromises.push( updateLocation( { countryCode: '' } ) );
 
 			cartPromises.push( addProductsToCart( productsForCart ) );
 		}


### PR DESCRIPTION
## Proposed Changes

As checkout loads with a product in the URL or in localstorage, it calls `useAddProductsFromUrl()` to send it to the shopping-cart endpoint. When this hook adds products to the cart, we have just loaded checkout and we haven't yet confirmed the user's tax details. The cart may already have those details but there's at least a moderate chance that they could change when we get to the next step of the checkout process. Calculating taxes is a very slow process for the cart and this could result in an unnecessary tax calculation during checkout's loading process.

Because the tax calculation requires tax details, in this PR we explicitly clear the tax details in the cart when adding products with `useAddProductsFromUrl()`. This will prevent calculating taxes on checkout load until the user (or `useCachedContactDetailsForCheckoutForm()` which tries to autocomplete the billing step) confirms those details.

**NOTE:** if the user has cached tax details and they do not change during checkout, then this PR will actually cause an extra POST request to the shopping-cart endpoint! (It must save the tax location even though it's actually unchanged.) However, the trade-off might be worthwhile because checkout's initial load (which might be more noticeable to the user) will be faster at the expense of the autocompletion of the billing info step which will be slower.

**NOTE 2:** when loading the checkout page, unless we're coming from another part of calypso there will be an initial fetch request to the cart endpoint before we try to add anything at all. That GET request will still calculate taxes if tax information is already in the cart before the POST request removes it, although in theory that call should use the tax cache.

## Testing Instructions

- Open your browser's devtools to show network traffic to the `/me/shopping-cart` endpoint.
- (Optional: this may be easier to see if you clear any existing items in your cart first which you can do in checkout or using the masterbar.)
- Visit checkout with a product in the URL, like `/checkout/personal`.
- You will see an initial `GET` request to the cart (this may have tax information), followed by a `POST` when it adds the new product.
- Verify that the first `POST` request includes your new product as well as `tax: null`.
- If you have valid cached contact details, you'll see the billing step of checkout autocomplete. If it does not, manually complete the billing info step. This will trigger another `POST` request.
- Verify that this second `POST` request includes the new product as well as correct `tax` information.

First POST:

<img width="389" alt="first-POST" src="https://user-images.githubusercontent.com/2036909/225456156-bb1b61f4-2b82-45ed-b425-6311a3b9a82a.png">

Second POST:

<img width="400" alt="second-POST" src="https://user-images.githubusercontent.com/2036909/225456169-a8ccfce8-112e-4473-9c0a-6236f0fab53d.png">
