### PR TITLE
Revert "Migrate wpcom global styles to createReduxStore"

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.js
@@ -5,6 +5,7 @@ import domReady from '@wordpress/dom-ready';
 import { registerPlugin } from '@wordpress/plugins';
 import GlobalStylesModal from './modal';
 import GlobalStylesNotice from './notice';
+import './store';
 
 const showGlobalStylesComponents = () => {
 	registerPlugin( 'wpcom-global-styles', {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -7,13 +7,15 @@ import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 import image from './image.svg';
-import { store as globalStylesStore } from './store';
 
 import './modal.scss';
 
 const GlobalStylesModal = () => {
-	const isVisible = useSelect( ( select ) => select( globalStylesStore ).isModalVisible(), [] );
-	const { dismissModal } = useDispatch( globalStylesStore );
+	const isVisible = useSelect(
+		( select ) => select( 'automattic/wpcom-global-styles' ).isModalVisible(),
+		[]
+	);
+	const { dismissModal } = useDispatch( 'automattic/wpcom-global-styles' );
 	const { set: setPreference } = useDispatch( 'core/preferences' );
 
 	// Hide the welcome guide modal, so it doesn't conflict with our modal.

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/store.js
@@ -1,10 +1,10 @@
-import { createRegistrySelector, register, createReduxStore } from '@wordpress/data';
+import { createRegistrySelector, registerStore } from '@wordpress/data';
 
 const DEFAULT_STATE = {
 	isModalVisible: true,
 };
 
-export const store = createReduxStore( 'automattic/wpcom-global-styles', {
+registerStore( 'automattic/wpcom-global-styles', {
 	reducer: ( state = DEFAULT_STATE, action ) => {
 		switch ( action.type ) {
 			case 'DISMISS_MODAL':
@@ -33,5 +33,3 @@ export const store = createReduxStore( 'automattic/wpcom-global-styles', {
 
 	persist: true,
 } );
-
-register( store );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#74398 because I didn't realize the persistence plugin was used there.