### PR TITLE
Stats: Testing charts.css line chart

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -21,6 +21,7 @@ import StatTabs from '../stats-tabs';
 import { buildChartData, getQueryDate } from './utility';
 
 import './style.scss';
+import 'charts.css';
 
 const ChartTabShape = PropTypes.shape( {
 	attr: PropTypes.string,
@@ -100,6 +101,8 @@ class StatModuleChartTabs extends Component {
 			},
 		];
 
+		let previousPoint;
+
 		/* pass bars count as `key` to disable transitions between tabs with different column count */
 		return (
 			<div className={ classNames( ...classes ) }>
@@ -115,6 +118,26 @@ class StatModuleChartTabs extends Component {
 				<Chart barClick={ this.props.barClick } data={ this.props.chartData } minBarWidth={ 35 }>
 					<StatsEmptyState />
 				</Chart>
+				<div style={ { width: '100%', height: '300px' } }>
+					<table className="charts-css line" id="my-chart">
+						<tbody>
+							{ this.props.chartData.map( ( point ) => {
+								const start = previousPoint?.value / 30000 || 0;
+								const end = point.value / 30000;
+								previousPoint = point;
+
+								return (
+									<tr>
+										<td style={ { '--start': start, '--size': end } }>
+											{ ' ' }
+											<span className="data"> { point.label } </span>{ ' ' }
+										</td>
+									</tr>
+								);
+							} ) }
+						</tbody>
+					</table>
+				</div>
 				<StatTabs
 					data={ this.props.counts }
 					tabs={ this.props.charts }

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
 		"browserslist": "^4.16.0",
 		"calypso": "workspace:^",
 		"calypso-codemods": "workspace:^",
+		"charts.css": "^0.9.0",
 		"config": "^3.3.6",
 		"debug": "^4.3.3",
 		"enhanced-resolve": "5.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12218,6 +12218,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"charts.css@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "charts.css@npm:0.9.0"
+  checksum: 738ef65e8f5bc5f465715179ca3081cc5be1f2e651700d96472754b72f17d43a4c81228a7bab4e7decf842eb88e3eeecc466e717564c1b2707c3f4662f800aeb
+  languageName: node
+  linkType: hard
+
 "check-node-version@npm:^4.0.2, check-node-version@npm:^4.1.0":
   version: 4.1.0
   resolution: "check-node-version@npm:4.1.0"
@@ -33779,6 +33786,7 @@ fsevents@^1.2.7:
     calypso-codemods: "workspace:^"
     capture-website: ^1.0.0
     chalk: ^4.1.2
+    charts.css: ^0.9.0
     check-node-version: ^4.0.2
     chroma-js: ^2.1.2
     config: ^3.3.6


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74316

## Proposed Changes

* Do not merge - PR created for bundle size analysis

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
