### PR TITLE
Fix duplicate calypso live comments

### DIFF
--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -2,7 +2,7 @@ name: Calypso Live
 
 on:
   pull_request:
-    types: ['opened']
+    types: ['synchronize']
 
 jobs:
   calypso-live:
@@ -12,18 +12,38 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     timeout-minutes: 10
     steps:
-      - name: Build calypso.live link.
-        run: |
-          echo '::set-output name=LINK::https://calypso.live?image=registry.a8c.com/calypso/app:commit-${{ github.event.pull_request.head.sha }}'
-          echo '::set-output name=QR_CALYPSO::https://chart.googleapis.com/chart?chs=150x150&cht=qr&chl=https%3A%2F%2Fcalypso.live%3Fimage%3Dregistry.a8c.com%2Fcalypso%2Fapp%3Acommit-${{ github.event.pull_request.head.sha }}%26flags%3Doauth&choe=UTF-8'
-          echo '::set-output name=QR_JETPACK::https://chart.googleapis.com/chart?chs=150x150&cht=qr&chl=https%3A%2F%2Fcalypso.live%3Fimage%3Dregistry.a8c.com%2Fcalypso%2Fapp%3Acommit-${{ github.event.pull_request.head.sha }}%26env%3Djetpack%26flags%3Doauth&choe=UTF-8'
-        id: build_link
-      - name: Post comment on PR
-        uses: actions/github-script@v3
+      - name: Check if comment exists
+        id: has_comment
+        uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
+          result-encoding: string
           script: |
-            github.issues.createComment({
+            const comments = await github.rest.issues.listComments( {
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            } );
+            // For debugging, if needed!
+            console.log( comments );
+            const existingComment = comments.data.find( comment => comment.body.includes( "calypso-live-watermark:apr@v1" ) );
+            const hasComment = existingComment ? "true" : "false";
+            console.log( `Has existing comment: ${ hasComment }` );
+            return hasComment;
+      - name: Build calypso.live link.
+        run: |
+          echo "LINK=https://calypso.live?image=registry.a8c.com/calypso/app:commit-${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          echo "QR_CALYPSO=https://chart.googleapis.com/chart?chs=150x150&cht=qr&chl=https%3A%2F%2Fcalypso.live%3Fimage%3Dregistry.a8c.com%2Fcalypso%2Fapp%3Acommit-${{ github.event.pull_request.head.sha }}%26flags%3Doauth&choe=UTF-8" >> $GITHUB_OUTPUT
+          echo "QR_JETPACK=https://chart.googleapis.com/chart?chs=150x150&cht=qr&chl=https%3A%2F%2Fcalypso.live%3Fimage%3Dregistry.a8c.com%2Fcalypso%2Fapp%3Acommit-${{ github.event.pull_request.head.sha }}%26env%3Djetpack%26flags%3Doauth&choe=UTF-}" >> $GITHUB_OUTPUT
+        id: build_link
+      - name: Post comment on PR
+        uses: actions/github-script@v6
+        if: steps.has_comment.outputs.result == 'false'
+        with:
+          # Skip adding a comment if we already have one.
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/calypso-live.yml
+++ b/.github/workflows/calypso-live.yml
@@ -2,7 +2,7 @@ name: Calypso Live
 
 on:
   pull_request:
-    types: ['synchronize']
+    types: ['opened']
 
 jobs:
   calypso-live:


### PR DESCRIPTION
## Proposed Changes
Recently, I’ve noticed some PRs get duplicate calypso.live links. (example: #74472)

We have two different places which can add calypso.live links. Firstly, in TeamCity, after the image is generated, a script will add a comment. Secondly, in GitHub actions, a script will add a comment.

Why do we have two? Well, there is an edge case where the TeamCity job will execute before you have a PR created (because it triggers on commit push.) In this scenario, you’d never get a comment about calypso.live. Additionally, it can be helpful for GitHub actions to add the comment immediately, when the PR is opened, rather than waiting several minutes for the TeamCity job to finish.

But this only impacts PR creation. After that, the TeamCity job will maintain a single comment, keeping it updated. This job _also_ deletes any existing comment from GitHub, to avoid having duplicates.

The issue with duplicate commits happens when the commit gets pushed, and TeamCity starts. You start writing your PR. You post it. Right afterwards, TeamCity gets to the point where it posts the comment, and does so. (It doesn't find an existing comment to delete either). Immediately after, the GitHub action posts its comment, because it did this after PR creation.

Essentially, we need to check in the GitHub action if a comment exists already, and if it does, skip.

## Testing Instructions

I tested that it does not post a comment if one exists. (By changing the trigger event to something else.) I think this is good enough for this PR 👍 
