### PR TITLE
Subscription management: Add UserSettings container component

### DIFF
--- a/client/my-sites/subscriptions/index.tsx
+++ b/client/my-sites/subscriptions/index.tsx
@@ -7,7 +7,7 @@ import { makeLayout, render } from 'calypso/controller';
 
 const SitesView = () => <span>Sites View</span>;
 const CommentsView = () => <span>Comments View</span>;
-const SettingsView = () => <span>Settings View</span>;
+const SettingsView = () => <SubscriptionManager.UserSettings />;
 
 const SubscriptionManagementPage = () => {
 	const translate = useTranslate();

--- a/packages/subscription-manager/src/components/TabsSwitcher/Tabs.tsx
+++ b/packages/subscription-manager/src/components/TabsSwitcher/Tabs.tsx
@@ -11,7 +11,7 @@ type TabsProps = {
 };
 
 const Tabs = ( { children }: TabsProps ) => (
-	<SectionNav>
+	<SectionNav className="subscription-manager-tab-switcher">
 		<NavTabs>{ children }</NavTabs>
 	</SectionNav>
 );

--- a/packages/subscription-manager/src/components/TabsSwitcher/styles.scss
+++ b/packages/subscription-manager/src/components/TabsSwitcher/styles.scss
@@ -1,8 +1,9 @@
 @import "@automattic/color-studio/dist/color-variables";
+@import "@wordpress/base-styles/breakpoints";
 
 .section-nav {
 	box-shadow: none !important;
-	border-bottom: 32px;
+	margin-bottom: 32px !important;
 
 	.section-nav-tabs {
 		display: flex;
@@ -58,5 +59,11 @@
 				}
 			}
 		}
+	}
+}
+
+@media screen and ( max-width: $break-medium ) {
+	.section-nav {
+		margin-bottom: 22px !important;
 	}
 }

--- a/packages/subscription-manager/src/components/TabsSwitcher/styles.scss
+++ b/packages/subscription-manager/src/components/TabsSwitcher/styles.scss
@@ -1,9 +1,9 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@wordpress/base-styles/breakpoints";
 
-.section-nav {
-	box-shadow: none !important;
-	margin-bottom: 32px !important;
+.section-nav.subscription-manager-tab-switcher {
+	box-shadow: none;
+	margin-bottom: 32px;
 
 	.section-nav-tabs {
 		display: flex;
@@ -63,7 +63,7 @@
 }
 
 @media screen and ( max-width: $break-medium ) {
-	.section-nav {
-		margin-bottom: 22px !important;
+	.section-nav.subscription-manager-tab-switcher {
+		margin-bottom: 22px;
 	}
 }

--- a/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
+++ b/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
@@ -1,18 +1,18 @@
 type SubscriptionUserSettings = Partial< {
-	subscription_delivery_mail_option: 'html' | 'text';
-	subscription_delivery_day: number; // 0-6, 0 is Sunday
-	subscription_delivery_hour: number; // 0-23, 0 is midnight
-	subscription_delivery_email_blocked: boolean;
+	mail_option: 'html' | 'text';
+	delivery_day: number; // 0-6, 0 is Sunday
+	delivery_hour: number; // 0-23, 0 is midnight
+	blocked: boolean;
 } >;
 
 type UserSettingsProps = {
-	value?: SubscriptionUserSettings;
+	value: SubscriptionUserSettings;
 	onChange?: ( value: SubscriptionUserSettings ) => void;
-	loading?: boolean;
+	loading: boolean;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- until we start using any of these props
-const UserSettings = ( props: UserSettingsProps ) => (
+const UserSettings = ( { value = {}, loading = false }: UserSettingsProps ) => (
 	<div className="user-settings">User settings will go here</div>
 );
 

--- a/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
+++ b/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
@@ -6,9 +6,9 @@ type SubscriptionUserSettings = Partial< {
 } >;
 
 type UserSettingsProps = {
-	value: SubscriptionUserSettings;
+	value?: SubscriptionUserSettings;
 	onChange?: ( value: SubscriptionUserSettings ) => void;
-	loading: boolean;
+	loading?: boolean;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- until we start using any of these props

--- a/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
+++ b/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
@@ -1,0 +1,19 @@
+type SubscriptionUserSettings = Partial< {
+	subscription_delivery_mail_option: 'html' | 'text';
+	subscription_delivery_day: number; // 0-6, 0 is Sunday
+	subscription_delivery_hour: number; // 0-23, 0 is midnight
+	subscription_delivery_email_blocked: boolean;
+} >;
+
+type UserSettingsProps = {
+	value?: SubscriptionUserSettings;
+	onChange?: ( value: SubscriptionUserSettings ) => void;
+	loading?: boolean;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- until we start using any of these props
+const UserSettings = ( props: UserSettingsProps ) => (
+	<div className="user-settings">User settings will go here</div>
+);
+
+export default UserSettings;

--- a/packages/subscription-manager/src/components/UserSettings/index.ts
+++ b/packages/subscription-manager/src/components/UserSettings/index.ts
@@ -1,0 +1,1 @@
+export { default as UserSettings } from './UserSettings';

--- a/packages/subscription-manager/src/index.tsx
+++ b/packages/subscription-manager/src/index.tsx
@@ -1,6 +1,8 @@
 import { SubscriptionManagerContainer as SubscriptionManager } from './components/SubscriptionManagerContainer';
 import { TabsSwitcher } from './components/TabsSwitcher';
+import { UserSettings } from './components/UserSettings';
 
 export default Object.assign( SubscriptionManager, {
 	TabsSwitcher,
+	UserSettings,
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves  https://github.com/Automattic/wp-calypso/issues/74420

![Screen Shot 2023-03-16 at 11 59 29](https://user-images.githubusercontent.com/2019970/225597191-7e6f7c9d-c35b-4631-96df-5984de562f9f.png)


## Proposed Changes

* Introduce `UserSettings` container component with its roughly defined props
* Adjust bottom margin on `TabsSwitcher` as per Figma design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/subscriptions/settings

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
