### PR TITLE
Jetpack Pro: Add new section on license issue page for WooCommerce extensions

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -58,6 +58,10 @@ export default function IssueMultipleLicensesForm( {
 		allProducts?.filter(
 			( { family_slug }: { family_slug: string } ) => family_slug !== 'jetpack-packs'
 		) || [];
+	const woocommerceExtensions =
+		allProducts?.filter(
+			( { family_slug }: { family_slug: string } ) => family_slug === 'woocommerce-extensions'
+		) || [];
 
 	const hasPurchasedProductsWithoutBundle = useSelector( ( state ) =>
 		selectedSite ? hasPurchasedProductsOnly( state, selectedSite.ID ) : false
@@ -211,6 +215,34 @@ export default function IssueMultipleLicensesForm( {
 								/>
 							) ) }
 					</div>
+					{ woocommerceExtensions.length > 0 && (
+						<>
+							<hr className="issue-multiple-licenses-form__separator" />
+							<p className="issue-multiple-licenses-form__description">
+								{ translate(
+									'Or select any of the following premium {{strong}}WooCommerce extensions{{/strong}}:',
+									{
+										components: { strong: <strong /> },
+									}
+								) }
+							</p>
+							<div className="issue-multiple-licenses-form__bottom">
+								{ woocommerceExtensions &&
+									woocommerceExtensions.map( ( productOption, i ) => (
+										<LicenseProductCard
+											isMultiSelect
+											key={ productOption.slug }
+											product={ productOption }
+											onSelectProduct={ onSelectProduct }
+											isSelected={ selectedProductSlugs.includes( productOption.slug ) }
+											isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
+											tabIndex={ 100 + i }
+											suggestedProduct={ suggestedProduct }
+										/>
+									) ) }
+							</div>
+						</>
+					) }
 				</>
 			) }
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -56,7 +56,8 @@ export default function IssueMultipleLicensesForm( {
 		) || [];
 	const products =
 		allProducts?.filter(
-			( { family_slug }: { family_slug: string } ) => family_slug !== 'jetpack-packs'
+			( { family_slug }: { family_slug: string } ) =>
+				family_slug !== 'jetpack-packs' && family_slug !== 'woocommerce-extensions'
 		) || [];
 	const woocommerceExtensions =
 		allProducts?.filter(


### PR DESCRIPTION
## Proposed Changes

* Adds a new section below the plans section for WooCommerce extensions.

![Screen Shot 2023-03-16 at 8 41 34 AM](https://user-images.githubusercontent.com/5528445/225620310-097bdaf8-777f-4e86-a25a-506826ce727d.png)

## Testing Instructions

* You'll need a test branch for WPCOM which isn't ready yet. I'll provide instructions when that's ready.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
