### PR TITLE
Staging Sites: add science gridicon and update gridicon dependency

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -171,7 +171,7 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 		<Card className="staging-site-card">
 			{
 				// eslint-disable-next-line wpcalypso/jsx-gridicon-size
-				<Gridicon icon="share-computer" size={ 32 } />
+				<Gridicon icon="science" size={ 32 } />
 			}
 			<CardHeading id="staging-site">{ translate( 'Staging site' ) }</CardHeading>
 			{ showAddStagingSite && ! addingStagingSite && getNewStagingSiteContent() }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -37,7 +37,7 @@
 		"canvas-confetti": "^1.6.0",
 		"classnames": "^2.3.1",
 		"framer-motion": "6.2.8",
-		"gridicons": "^3.4.0",
+		"gridicons": "^3.4.2",
 		"i18n-calypso": "workspace:^",
 		"lodash": "^4.17.21",
 		"prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,7 +436,7 @@ __metadata:
     canvas-confetti: ^1.6.0
     classnames: ^2.3.1
     framer-motion: 6.2.8
-    gridicons: ^3.4.0
+    gridicons: ^3.4.2
     i18n-calypso: "workspace:^"
     lodash: ^4.17.21
     prop-types: ^15.7.2
@@ -18370,14 +18370,14 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"gridicons@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "gridicons@npm:3.4.0"
+"gridicons@npm:^3.4.2":
+  version: 3.4.2
+  resolution: "gridicons@npm:3.4.2"
   dependencies:
     prop-types: ^15.5.7
   peerDependencies:
-    react: 15 - 17
-  checksum: aa595099ffdd6a2cdbbb95271270dbdaa52877c99a5f4f034fe297c3aed60cfbd85bb6d463d0bf62268b34a3aa1feccdc2dc48dddf0c3e4b01b771114839b3ff
+    react: 15 - 18
+  checksum: b2e508243bf1fa0e0daacc5e1fb52d0d74b000ca0b8862ece672cf8fea9f561c9e1a96979ee9ea9ca9e595c55c970c82bb6b7b29a42d06c139e2c657f3ecdb49
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Closes https://github.com/Automattic/dotcom-forge/issues/1962

## Proposed Changes

This PR adds a custom icon to staging sites on the Hosting Configuration card

## Testing Instructions

* Ensure you have an Atomic site
* On the Atomic site, go to `Settings -> Hosting Configuration`
* Scroll down to the **Staging Site** section 
* Observe a new icon

<img width="1257" alt="Screenshot 2023-03-16 at 2 24 32 PM" src="https://user-images.githubusercontent.com/25575134/225630869-0f94aca2-f7bb-41e7-af00-f043de26dbea.png">

**View from mobile**:

<img width="279" alt="Screenshot 2023-03-16 at 2 25 29 PM" src="https://user-images.githubusercontent.com/25575134/225631090-f459ec90-a20b-47c8-8d32-811b59e287de.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
