### PR TITLE
ETK: Unignore `synced-newspack-blocks` in eslint config

### DIFF
--- a/apps/editing-toolkit/.eslintrc.js
+++ b/apps/editing-toolkit/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
 		// conform to those naming conventions instead of Calypso's.
 		'wpcalypso/jsx-classname-namespace': 'off',
 	},
-	ignorePatterns: [ '**/dist/*', '**/synced-newspack-blocks/*' ],
+	ignorePatterns: [ '**/dist/*' ],
 	overrides: [
 		{
 			files: [ './bin/**/*', './webpack.config.js' ],

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -136,6 +136,10 @@
 		"@wordpress/jest-preset-default": "^10.3.0",
 		"@wordpress/readable-js-assets-webpack-plugin": "^2.5.0",
 		"babel-jest": "^27.5.1",
+		"eslint-plugin-inclusive-language": "^2.2.0",
+		"eslint-plugin-json-es": "^1.5.7",
+		"eslint-plugin-md": "^1.0.19",
+		"eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0",
 		"jest-teamcity": "^1.9.0",
 		"wait-for-expect": "^3.0.2",
 		"webpack": "^5.68.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1897,6 +1897,10 @@ __metadata:
     calypso: "workspace:^"
     classnames: ^2.3.1
     eslint: ^8.34.0
+    eslint-plugin-inclusive-language: ^2.2.0
+    eslint-plugin-json-es: ^1.5.7
+    eslint-plugin-md: ^1.0.19
+    eslint-plugin-you-dont-need-lodash-underscore: ^6.12.0
     jest: ^27.3.1
     jest-teamcity: ^1.9.0
     lodash: ^4.17.21


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 585-gh-Automattic/i18n-issues

## Proposed Changes

* Remove `'**/synced-newspack-blocks/*'` from the ignored patterns array in eslint config, in order to get the [eslint --fix](https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/bin/sync-newspack-blocks.sh#L138) command fix the text domain as intended after syncing the newspack blocks.

**Before:**
![CleanShot 2023-03-16 at 18 01 48](https://user-images.githubusercontent.com/2722412/225681017-6053ceba-a4a7-4420-a1f1-95c3f6fef6c0.png)

**After:**
![CleanShot 2023-03-16 at 18 05 20](https://user-images.githubusercontent.com/2722412/225681046-803fa6ad-7738-4d81-aa4a-dae1d234d89f.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install the ETK plugin from this branch on your sandbox (see PCYsg-mMA-p2 for more instructions) and confirm all translations of the affected newspack blocks are now rendered as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
