### PR TITLE
`useP2GuestsQuery`: fix `useQuery` usage & prepare for v4

### DIFF
--- a/client/data/p2/use-p2-guests-query.js
+++ b/client/data/p2/use-p2-guests-query.js
@@ -13,20 +13,18 @@ const useP2GuestsQuery = ( siteId, queryOptions = {} ) => {
 	return useQuery(
 		[ 'p2-guest-users', siteId ],
 		() =>
-			requestUnnecessary
-				? () => {}
-				: wpcom.req.get(
-						{
-							path: `/p2/users/guests/`,
-							apiNamespace: 'wpcom/v2',
-						},
-						{
-							blog_id: siteId,
-						}
-				  ),
+			wpcom.req.get(
+				{
+					path: `/p2/users/guests/`,
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					blog_id: siteId,
+				}
+			),
 		{
 			...queryOptions,
-			enabled: !! siteId,
+			enabled: !! siteId && ! requestUnnecessary,
 			retryDelay: 3000,
 		}
 	);


### PR DESCRIPTION
This PR is split from #74381 and part of the effort to upgrade `react-query` to version 4.

## Proposed Changes

* Move check whether request is necessary to `enabled` option
* Make sure `queryFn` doesn't return an empty function which isn't serializable

## Testing Instructions

* Go through these on a P2 and a regular site:
  * Go to `/people/team/<slug>` and check your Browser Developer Tools **Network** tab
  * Make sure there's a request to `/p2/users/guests` depending on whether you're on a P2 or not

Please consider p1678958587546719-slack-C010KDAPG49 when testing on P2s with a large number of users.