### PR TITLE
Staging Sites: Add margin to staging label

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -192,7 +192,9 @@ class Site extends Component {
 							<span className="site__badge is-p2">P2</span>
 						) }
 						{ site.is_wpcom_staging_site && (
-							<SitesStagingBadge secondary>{ translate( 'Staging' ) }</SitesStagingBadge>
+							<SitesStagingBadge className="site__badge" secondary>
+								{ translate( 'Staging' ) }
+							</SitesStagingBadge>
 						) }
 						{ this.props.isP2Hub && (
 							<span className="site__badge is-p2-workspace">P2 Workspace</span>

--- a/client/sites-dashboard/components/sites-staging-badge.tsx
+++ b/client/sites-dashboard/components/sites-staging-badge.tsx
@@ -4,11 +4,17 @@ interface SitesStagingBadgeProps {
 	secondary?: boolean;
 }
 
+const COLOR = '#4f3500';
+const BACKGROUND_COLOR = '#f0c930';
+
 const SitesStagingBadge = styled( SitesLaunchStatusBadge )( ( props: SitesStagingBadgeProps ) => ( {
-	color: '#4f3500',
-	backgroundColor: '#f0c930',
-	marginRight: props.secondary ? 3 : 0,
+	color: COLOR,
+	backgroundColor: BACKGROUND_COLOR,
 	borderRadius: props.secondary ? 12 : 4,
+	'.layout__secondary .site-selector &.site__badge': {
+		color: COLOR,
+		backgroundColor: BACKGROUND_COLOR,
+	},
 	'.current-site .site:hover &, .notouch .layout__secondary .site-selector.is-hover-enabled .site:hover  &':
 		{
 			color: '#1C1300',

--- a/client/sites-dashboard/components/sites-staging-badge.tsx
+++ b/client/sites-dashboard/components/sites-staging-badge.tsx
@@ -11,7 +11,7 @@ const SitesStagingBadge = styled( SitesLaunchStatusBadge )( ( props: SitesStagin
 	color: COLOR,
 	backgroundColor: BACKGROUND_COLOR,
 	borderRadius: props.secondary ? 12 : 4,
-	'.layout__secondary .site-selector &.site__badge': {
+	'.layout__secondary .site-selector &.site__badge, .layout__secondary &.site__badge': {
 		color: COLOR,
 		backgroundColor: BACKGROUND_COLOR,
 	},

--- a/client/sites-dashboard/components/sites-staging-badge.tsx
+++ b/client/sites-dashboard/components/sites-staging-badge.tsx
@@ -7,6 +7,7 @@ interface SitesStagingBadgeProps {
 const SitesStagingBadge = styled( SitesLaunchStatusBadge )( ( props: SitesStagingBadgeProps ) => ( {
 	color: '#4f3500',
 	backgroundColor: '#f0c930',
+	marginRight: props.secondary ? 3 : 0,
 	borderRadius: props.secondary ? 12 : 4,
 	'.current-site .site:hover &, .notouch .layout__secondary .site-selector.is-hover-enabled .site:hover  &':
 		{


### PR DESCRIPTION
* Closes https://github.com/Automattic/dotcom-forge/issues/1971

## Proposed Changes

This PR adds a margin to the staging badge on the site switcher

## Testing Instructions

* Make sure that you have a staging site 
* Navigate to the homepage of that site by accessing `/home`
* Observe the margin added to the staging label in the top left corner:

<img width="791" alt="Screenshot 2023-03-16 at 3 06 05 PM" src="https://user-images.githubusercontent.com/25575134/225642634-a0ed2b4a-da58-453e-9741-16797068b0df.png">

* Navigate to `/sites` and select the grid view
* Check that there is **NO** extra right margin added to the label:

<img width="1186" alt="Screenshot 2023-03-16 at 3 08 37 PM" src="https://user-images.githubusercontent.com/25575134/225643245-12b6294e-386b-4510-bdd2-607d74e190b4.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
