### PR TITLE
Reader: Add label to search results when feed detected

### DIFF
--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -115,7 +115,7 @@
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
-	max-height: 16px * 3.2;
+	max-height: 16px * 6.2;
 	min-width: 100%;
 
 	@include breakpoint-deprecated( "<960px" ) {

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -81,7 +81,7 @@
 .reader-subscription-list-item__site-excerpt,
 .reader-subscription-list-item__site-url-timestamp {
 	display: block;
-	max-height: 16px * 2.5;
+	max-height: 16px * 3;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	position: relative;

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -191,8 +191,8 @@ class SearchStream extends React.Component {
 					) }
 					{ ! query && <BlankSuggestions suggestions={ suggestionList } /> }
 				</div>
-				{ ! hidePostsAndSites && query && <SpacerDiv domTarget={ this.fixedAreaRef } /> }
-				{ ! hidePostsAndSites && query && wideDisplay && (
+				<SpacerDiv domTarget={ this.fixedAreaRef } />
+				{ ! hidePostsAndSites && wideDisplay && (
 					<div className={ searchStreamResultsClasses }>
 						<div className="search-stream__post-results">
 							<PostResults { ...this.props } />
@@ -209,7 +209,7 @@ class SearchStream extends React.Component {
 						) }
 					</div>
 				) }
-				{ ! hidePostsAndSites && query && ! wideDisplay && (
+				{ ! hidePostsAndSites && ! wideDisplay && (
 					<div className={ singleColumnResultsClasses }>
 						{ ( ( searchType === SEARCH_TYPES.POSTS || ! query ) && (
 							<PostResults { ...this.props } />

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -1,7 +1,7 @@
 import { CompactCard } from '@automattic/components';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { trim, flatMap } from 'lodash';
+import { trim, flatMap, some } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import * as React from 'react';
@@ -25,6 +25,7 @@ import {
 	SORT_BY_LAST_UPDATED,
 } from 'calypso/state/reader/feed-searches/actions';
 import { getReaderAliasedFollowFeedUrl } from 'calypso/state/reader/follows/selectors';
+import { commonExtensions } from 'calypso/state/reader/follows/selectors/get-reader-aliased-follow-feed-url';
 import PostResults from './post-results';
 import SearchStreamHeader, { SEARCH_TYPES } from './search-stream-header';
 import SiteResults from './site-results';
@@ -110,14 +111,11 @@ class SearchStream extends React.Component {
 			searchPlaceholderText = getSearchPlaceholderText();
 		}
 
-		let isRssFeed = false;
+		let isPotentialFeed = false;
 		if ( showFollowByUrl ) {
 			const parsedUrl = new URL( query );
 			if ( parsedUrl ) {
-				const tld = parsedUrl.pathname?.split( '.' ).pop();
-				if ( tld === 'xml' ) {
-					isRssFeed = true;
-				}
+				isPotentialFeed = some( commonExtensions, ( ext ) => parsedUrl.toString().includes( ext ) );
 			}
 		}
 
@@ -175,12 +173,7 @@ class SearchStream extends React.Component {
 					</CompactCard>
 					{ showFollowByUrl && (
 						<div className="search-stream__url-follow">
-							{ isRssFeed && (
-								<div>
-									<label>{ translate( 'Rss Feed detected' ) }</label>
-								</div>
-							) }
-							{ ! isRssFeed && (
+							{ isPotentialFeed && (
 								<div>
 									<label>{ translate( 'Feed detected' ) }</label>
 								</div>

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -110,6 +110,17 @@ class SearchStream extends React.Component {
 			searchPlaceholderText = getSearchPlaceholderText();
 		}
 
+		let isRssFeed = false;
+		if ( showFollowByUrl ) {
+			const parsedUrl = new URL( query );
+			if ( parsedUrl ) {
+				const tld = parsedUrl.pathname?.split( '.' ).pop();
+				if ( tld === 'xml' ) {
+					isRssFeed = true;
+				}
+			}
+		}
+
 		const documentTitle = translate( '%s ‹ Reader', {
 			args: this.getTitle(),
 			comment: '%s is the section name. For example: "My Likes"',
@@ -164,6 +175,16 @@ class SearchStream extends React.Component {
 					</CompactCard>
 					{ showFollowByUrl && (
 						<div className="search-stream__url-follow">
+							{ isRssFeed && (
+								<div>
+									<label>{ translate( 'Rss Feed detected' ) }</label>
+								</div>
+							) }
+							{ ! isRssFeed && (
+								<div>
+									<label>{ translate( 'Feed detected' ) }</label>
+								</div>
+							) }
 							<FollowButton
 								followLabel={ translate( 'Follow %s', {
 									args: queryWithoutProtocol,

--- a/client/reader/search-stream/search-follow-button.jsx
+++ b/client/reader/search-stream/search-follow-button.jsx
@@ -36,12 +36,10 @@ class SearchFollowButton extends Component {
 			return null;
 		}
 
-		let isNewFeed = true;
 		let isFollowing = false;
 		let followTitle = withoutHttp( query );
 
 		if ( feed && feed.name?.length ) {
-			isNewFeed = false;
 			isFollowing = feed.is_following;
 			followTitle = feed.name;
 		}
@@ -55,11 +53,7 @@ class SearchFollowButton extends Component {
 			<div className="search-stream__url-follow">
 				<p>
 					<Gridicon icon="info" size="16" />
-					<strong>
-						{ isNewFeed
-							? translate( 'Potential new feed found, click follow to add this feed to Reader' )
-							: translate( 'Click follow to add this feed to Reader' ) }
-					</strong>
+					<strong>{ translate( 'Click below to add this site to your Reader feed:' ) }</strong>
 				</p>
 				<FollowButton
 					followLabel={ translate( 'Follow %s', {

--- a/client/reader/search-stream/search-follow-button.jsx
+++ b/client/reader/search-stream/search-follow-button.jsx
@@ -1,0 +1,88 @@
+import { Gridicon } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { some } from 'lodash';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import { resemblesUrl, withoutHttp, addSchemeIfMissing } from 'calypso/lib/url';
+import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-icon';
+import ReaderFollowingFeedIcon from 'calypso/reader/components/icons/following-feed-icon';
+import FollowButton from 'calypso/reader/follow-button';
+import { SEARCH_RESULTS_URL_INPUT } from 'calypso/reader/follow-sources';
+import { getReaderAliasedFollowFeedUrl } from 'calypso/state/reader/follows/selectors';
+import { commonExtensions } from 'calypso/state/reader/follows/selectors/get-reader-aliased-follow-feed-url';
+import './style.scss';
+
+class SearchFollowButton extends Component {
+	static propTypes = {
+		query: PropTypes.string,
+		feed: PropTypes.object,
+	};
+
+	render() {
+		const { query, translate, readerAliasedFollowFeedUrl, feed } = this.props;
+		let isPotentialFeedUrl = false;
+		if ( resemblesUrl( query ) ) {
+			const parsedUrl = new URL( query );
+			if ( parsedUrl ) {
+				isPotentialFeedUrl = some( commonExtensions, ( ext ) =>
+					parsedUrl.toString().includes( ext )
+				);
+			}
+		}
+
+		// If not a potential feed then don't show the follow button
+		if ( ! isPotentialFeedUrl ) {
+			return null;
+		}
+
+		let isNewFeed = true;
+		let isFollowing = false;
+		let followTitle = withoutHttp( query );
+
+		if ( feed && feed.name?.length ) {
+			isNewFeed = false;
+			isFollowing = feed.is_following;
+			followTitle = feed.name;
+		}
+
+		// If already following this feed then don't show the follow button
+		if ( isFollowing ) {
+			return null;
+		}
+
+		return (
+			<div className="search-stream__url-follow">
+				<p>
+					<Gridicon icon="info" size="16" />
+					<strong>
+						{ isNewFeed
+							? translate( 'Potential new feed found, click follow to add this feed to Reader' )
+							: translate( 'Click follow to add this feed to Reader' ) }
+					</strong>
+				</p>
+				<FollowButton
+					followLabel={ translate( 'Follow %s', {
+						args: followTitle,
+						comment: '%s is the name of the site being followed. For example: "Discover"',
+					} ) }
+					followingLabel={ translate( 'Following %s', {
+						args: followTitle,
+						comment: '%s is the name of the site being followed. For example: "Discover"',
+					} ) }
+					siteUrl={ addSchemeIfMissing( readerAliasedFollowFeedUrl, 'http' ) }
+					followSource={ SEARCH_RESULTS_URL_INPUT }
+					followIcon={ ReaderFollowFeedIcon( { iconSize: 20 } ) }
+					followingIcon={ ReaderFollowingFeedIcon( { iconSize: 20 } ) }
+				/>
+			</div>
+		);
+	}
+}
+
+export default connect( ( state, ownProps ) => {
+	return {
+		readerAliasedFollowFeedUrl:
+			ownProps.query && getReaderAliasedFollowFeedUrl( state, ownProps.query ),
+	};
+} )( localize( SearchFollowButton ) );

--- a/client/reader/search-stream/search-follow-button.jsx
+++ b/client/reader/search-stream/search-follow-button.jsx
@@ -23,7 +23,22 @@ class SearchFollowButton extends Component {
 		const { query, translate, readerAliasedFollowFeedUrl, feed } = this.props;
 		let isPotentialFeedUrl = false;
 		if ( resemblesUrl( query ) ) {
-			const parsedUrl = new URL( query );
+			let parsedUrl;
+			try {
+				parsedUrl = new URL( query );
+			} catch {
+				// Do nothing.
+			}
+
+			// If we got an invalid URL, add a protocol and try again.
+			if ( parsedUrl === undefined ) {
+				try {
+					parsedUrl = new URL( 'http://' + query );
+				} catch {
+					// Do nothing.
+				}
+			}
+
 			if ( parsedUrl ) {
 				isPotentialFeedUrl = some( commonExtensions, ( ext ) =>
 					parsedUrl.toString().includes( ext )

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -395,6 +395,21 @@
 	position: relative;
 	z-index: z-index("root", ".following-manage__url-follow");
 
+	p {
+		color: var(--color-neutral-60);
+		font-size: $font-body-small;
+		margin: 5px 0;
+
+		.gridicon {
+			vertical-align: text-bottom;
+		}
+
+		strong {
+			padding-left: 5px;
+			color: var(--color-neutral-70);
+		}
+	}
+
 	.follow-button {
 		.gridicon {
 			fill: var(--color-primary);

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -304,8 +304,8 @@
 }
 
 .search-stream__results.is-two-columns .reader-subscription-list-item__byline {
-	min-width: 180px;
-	max-width: 180px;
+	min-width: 177px;
+	max-width: 177px;
 }
 
 .search-stream__single-column-results .reader-subscription-list-item__options {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -416,10 +416,20 @@
 		}
 
 		.follow-button__label {
-			color: var(--color-primary);
+			color: var(--color-link);
+			text-decoration: underline;
 
 			@include breakpoint-deprecated( "<660px" ) {
 				display: inline;
+			}
+		}
+
+		&:hover {
+			svg.reader-follow-feed path {
+				fill: var(--color-link);
+			}
+			.follow-button__label {
+				color: var(--color-link);
 			}
 		}
 


### PR DESCRIPTION
The goal of this PR is to improve the UX when searching for RSS feeds on Reader.

At the moment, when you lookup a RSS feed, you get a `Follow {search URL}` link below the search text area and the search results come back with no results found. This is a confusing experience for the user.

**Search Page**
<img width="997" alt="Screenshot 2023-04-06 at 22 43 45" src="https://user-images.githubusercontent.com/5560595/230499668-3c25ae7b-6903-4074-85be-0d600f5a43e6.png">

**Manage Follow**
<img width="1151" alt="Screenshot 2023-04-06 at 22 47 43" src="https://user-images.githubusercontent.com/5560595/230500127-c7f1a18f-fe9a-4f85-9404-d94eda16c347.png">

### Updates

The PR works along with D107200-code which updates the search endpoints to look up feeds based on the search RSS URL entered.

This PR creates a new `SearchFollowButton` component to be used on both pages

Now when you look up a RSS feed URL, if that feed is already subscribed to by any user, the component will show a notice `Click follow to add feed to Reader` and the Follow title updates to the feed name.

**Search Page**
<img width="1082" alt="Screenshot 2023-04-06 at 21 45 04" src="https://user-images.githubusercontent.com/5560595/230501355-6361f9d7-2433-489d-873c-a650e16a7d53.png">

**Manage Follow**
<img width="803" alt="Screenshot 2023-04-06 at 21 43 09" src="https://user-images.githubusercontent.com/5560595/230501537-a6e1a605-2076-4aac-8c84-4e53bf67544f.png">

If the feed is not subscribed to by any user yet, then the component will show the notice `Potential new feed found, click follow to add feed to Reader`

**Search Page**
<img width="1079" alt="Screenshot 2023-04-06 at 21 44 29" src="https://user-images.githubusercontent.com/5560595/230502168-ef18a3e1-c7a8-4832-8af6-3bbcf00aaa96.png">

**Manage Follow**
<img width="810" alt="Screenshot 2023-04-06 at 21 43 26" src="https://user-images.githubusercontent.com/5560595/230502011-252493a5-ccf4-4a34-a42a-922b8032271c.png">

This PR also includes style changes.

### Testing

* Apply patch code-D107200 
* Sandbox public-api.wordpress.com
* checkout PR branch
* use feeds from https://blog.feedspot.com/world_news_rss_feeds/ to test if search functionality works as expected






