### PR TITLE
Marketplace Thank You: Update the page moving each product type logic into their own hook

### DIFF
--- a/client/components/data/query-theme/index.jsx
+++ b/client/components/data/query-theme/index.jsx
@@ -25,6 +25,18 @@ export function useQueryTheme( siteId, themeId ) {
 	}, [ dispatch, siteId, themeId ] );
 }
 
+export function useQueryThemes( siteId, themeIds ) {
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		themeIds.forEach( ( themeId ) => {
+			if ( siteId && themeId ) {
+				dispatch( request( siteId, themeId ) );
+			}
+		} );
+	}, [ dispatch, siteId, themeIds ] );
+}
+
 QueryTheme.propTypes = {
 	siteId: PropTypes.oneOfType( [ PropTypes.number, PropTypes.oneOf( [ 'wpcom', 'wporg' ] ) ] )
 		.isRequired,

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -4,7 +4,6 @@ import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useEffect, useState, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import QueryTheme from 'calypso/components/data/query-theme';
 import { ThankYou } from 'calypso/components/thank-you';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import MasterbarStyled from 'calypso/my-sites/marketplace/components/masterbar-styled';
@@ -136,13 +135,6 @@ const MarketplaceThankYou = ( {
 				backText={ translate( 'Back to plugins' ) }
 				canGoBack={ areAllProductsFetched }
 			/>
-			{ /* TODO: Remove after https://github.com/Automattic/wp-calypso/issues/74532 and move it to useThemesThankYouData */ }
-			{ themeSlugs.map( ( themeSlug, index ) => (
-				<>
-					<QueryTheme key={ 'query-wpcom-theme-' + index } siteId="wpcom" themeId={ themeSlug } />
-					<QueryTheme key={ 'query-wporg-theme-' + index } siteId="wporg" themeId={ themeSlug } />
-				</>
-			) ) }
 			{ showProgressBar && (
 				// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 				<div className="marketplace-plugin-install__root">

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -37,7 +37,7 @@ const MarketplaceThankYou = ( {
 	const currentUser = useSelector( getCurrentUser );
 	const isRequestingPlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
 
-	const allSlugs = [ ...pluginSlugs, ...themeSlugs ];
+	const allSlugs = useMemo( () => [ ...pluginSlugs, ...themeSlugs ], [ pluginSlugs, themeSlugs ] );
 	const defaultThankYouFooter = useDefaultThankYouFoooter( allSlugs );
 
 	const [ pluginsSection, allPluginsFetched ] = usePluginsThankYouData( pluginSlugs );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -37,7 +37,7 @@ const MarketplaceThankYou = ( {
 	const currentUser = useSelector( getCurrentUser );
 	const isRequestingPlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
 
-	const allSlugs = useMemo( () => [ ...pluginSlugs, ...themeSlugs ], [ pluginSlugs, themeSlugs ] );
+	const allSlugs = [ ...pluginSlugs, ...themeSlugs ];
 	const defaultThankYouFooter = useDefaultThankYouFoooter( allSlugs );
 
 	const [ pluginsSection, allPluginsFetched ] = usePluginsThankYouData( pluginSlugs );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-default-thank-you-footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-default-thank-you-footer.tsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -27,7 +26,6 @@ export function useDefaultThankYouFoooter( slugs: string[] ): ThankYouSectionPro
 		nextStepsClassName: 'thank-you__footer',
 		nextSteps: [
 			{
-				stepIcon: <FooterIcon icon="next-page" />,
 				stepKey: 'thank_you_footer_support_guides',
 				stepTitle: translate( 'Support guides' ),
 				stepDescription: translate(
@@ -35,7 +33,7 @@ export function useDefaultThankYouFoooter( slugs: string[] ): ThankYouSectionPro
 				),
 				stepCta: (
 					<Button
-						isSecondary
+						isLink
 						href="https://wordpress.com/support/plugins/"
 						target="_blank"
 						onClick={ () => sendTrackEvent( 'calypso_plugin_thank_you_plugin_support_click' ) }
@@ -45,7 +43,6 @@ export function useDefaultThankYouFoooter( slugs: string[] ): ThankYouSectionPro
 				),
 			},
 			{
-				stepIcon: <FooterIcon icon="create" />,
 				stepKey: 'thank_you_footer_explore',
 				stepTitle: translate( 'Keep growing' ),
 				stepDescription: translate(
@@ -53,7 +50,7 @@ export function useDefaultThankYouFoooter( slugs: string[] ): ThankYouSectionPro
 				),
 				stepCta: (
 					<Button
-						isPrimary
+						isLink
 						href={ `/plugins/${ siteSlug }` }
 						target="_blank"
 						onClick={ () => sendTrackEvent( 'calypso_plugin_thank_you_explore_plugins_click' ) }
@@ -63,7 +60,6 @@ export function useDefaultThankYouFoooter( slugs: string[] ): ThankYouSectionPro
 				),
 			},
 			{
-				stepIcon: <FooterIcon icon="help-outline" />,
 				stepKey: 'thank_you_footer_support',
 				stepTitle: translate( 'How can we support you?' ),
 				stepDescription: translate(
@@ -71,7 +67,7 @@ export function useDefaultThankYouFoooter( slugs: string[] ): ThankYouSectionPro
 				),
 				stepCta: (
 					<Button
-						isSecondary
+						isLink
 						href="https://wordpress.com/help/contact"
 						target="_blank"
 						onClick={ () => sendTrackEvent( 'calypso_plugin_thank_you_ask_question_click' ) }
@@ -82,15 +78,4 @@ export function useDefaultThankYouFoooter( slugs: string[] ): ThankYouSectionPro
 			},
 		],
 	};
-}
-
-function FooterIcon( { icon }: { icon: string } ) {
-	return (
-		<Gridicon
-			className="marketplace-thank-you__footer-icon"
-			size={ 18 }
-			color="var(--studio-gray-30)"
-			icon={ icon }
-		/>
-	);
 }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-default-thank-you-footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-default-thank-you-footer.tsx
@@ -1,0 +1,96 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { ThankYouSectionProps } from 'calypso/components/thank-you/types';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+export function useDefaultThankYouFoooter( slugs: string[] ): ThankYouSectionProps {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const sendTrackEvent = useCallback(
+		( name: string ) => {
+			recordTracksEvent( name, {
+				site_id: siteId,
+				plugins: slugs.join( '/' ),
+			} );
+		},
+		[ siteId, slugs ]
+	);
+
+	return {
+		sectionKey: 'thank_you_footer',
+		nextStepsClassName: 'thank-you__footer',
+		nextSteps: [
+			{
+				stepIcon: <FooterIcon icon="next-page" />,
+				stepKey: 'thank_you_footer_support_guides',
+				stepTitle: translate( 'Support guides' ),
+				stepDescription: translate(
+					'Our guides will show you everything you need to know about plugins.'
+				),
+				stepCta: (
+					<Button
+						isSecondary
+						href="https://wordpress.com/support/plugins/"
+						target="_blank"
+						onClick={ () => sendTrackEvent( 'calypso_plugin_thank_you_plugin_support_click' ) }
+					>
+						{ translate( 'Plugin Support' ) }
+					</Button>
+				),
+			},
+			{
+				stepIcon: <FooterIcon icon="create" />,
+				stepKey: 'thank_you_footer_explore',
+				stepTitle: translate( 'Keep growing' ),
+				stepDescription: translate(
+					'Take your site to the next level. We have all the solutions to help you.'
+				),
+				stepCta: (
+					<Button
+						isPrimary
+						href={ `/plugins/${ siteSlug }` }
+						target="_blank"
+						onClick={ () => sendTrackEvent( 'calypso_plugin_thank_you_explore_plugins_click' ) }
+					>
+						{ translate( 'Explore plugins' ) }
+					</Button>
+				),
+			},
+			{
+				stepIcon: <FooterIcon icon="help-outline" />,
+				stepKey: 'thank_you_footer_support',
+				stepTitle: translate( 'How can we support you?' ),
+				stepDescription: translate(
+					'Our team is here if you need help, or if you have any questions.'
+				),
+				stepCta: (
+					<Button
+						isSecondary
+						href="https://wordpress.com/help/contact"
+						target="_blank"
+						onClick={ () => sendTrackEvent( 'calypso_plugin_thank_you_ask_question_click' ) }
+					>
+						{ translate( 'Ask a question' ) }
+					</Button>
+				),
+			},
+		],
+	};
+}
+
+function FooterIcon( { icon }: { icon: string } ) {
+	return (
+		<Gridicon
+			className="marketplace-thank-you__footer-icon"
+			size={ 18 }
+			color="var(--studio-gray-30)"
+			icon={ icon }
+		/>
+	);
+}

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useMemo } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { ThankYouSectionProps } from 'calypso/components/thank-you/types';
+import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
+import { waitFor } from 'calypso/my-sites/marketplace/util';
+import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
+import {
+	getAutomatedTransferStatus,
+	isFetchingAutomatedTransferStatus,
+} from 'calypso/state/automated-transfer/selectors';
+import { pluginInstallationStateChange } from 'calypso/state/marketplace/purchase-flow/actions';
+import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
+import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
+import { getPluginsOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
+import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
+import { areFetched, areFetching, getPlugins } from 'calypso/state/plugins/wporg/selectors';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { ThankYouPluginSection } from './marketplace-thank-you-plugin-section';
+
+export function usePluginsThankYouData( pluginSlugs: string[] ): [ ThankYouSectionProps, boolean ] {
+	const dispatch = useDispatch();
+	const siteId = useSelector( getSelectedSiteId );
+
+	// retrieve WPCom plugin data
+	const wpComPluginsDataResults = useWPCOMPlugins( pluginSlugs );
+	const wpComPluginsData: Array< any > = wpComPluginsDataResults.map(
+		( wpComPluginData ) => wpComPluginData.data
+	);
+	const softwareSlugs = wpComPluginsData.map( ( wpComPluginData, i ) =>
+		wpComPluginData ? wpComPluginData.software_slug || wpComPluginData.org_slug : pluginSlugs[ i ]
+	);
+
+	const isRequestingPlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
+	const pluginsOnSite: [] = useSelector( ( state ) =>
+		getPluginsOnSite( state, siteId, softwareSlugs )
+	);
+	const wporgPlugins = useSelector(
+		( state ) => getPlugins( state, pluginSlugs ),
+		( newPluginsValue: Array< Plugin >, oldPluginsValue: Array< Plugin > ) =>
+			oldPluginsValue.length === newPluginsValue.length &&
+			oldPluginsValue.every( ( oldPluginValue, i ) => {
+				return (
+					oldPluginValue?.slug === newPluginsValue[ i ]?.slug &&
+					Boolean( oldPluginValue ) === Boolean( newPluginsValue[ i ] )
+				);
+			} )
+	);
+	const areWporgPluginsFetched: Array< boolean > = useSelector(
+		( state ) => areFetched( state, pluginSlugs ),
+		( newValues: Array< boolean >, oldValues: Array< boolean > ) =>
+			newValues.every( ( newValue, i ) => newValue === oldValues[ i ] )
+	);
+	const areWporgPluginsFetching: Array< boolean > = useSelector( ( state ) =>
+		areFetching( state, pluginSlugs )
+	);
+	const areAllWporgPluginsFetched = areWporgPluginsFetched.every( Boolean );
+	const isFetchingTransferStatus = useSelector( ( state ) =>
+		isFetchingAutomatedTransferStatus( state, siteId )
+	);
+
+	const allPluginsFetched =
+		!! pluginsOnSite.length && pluginsOnSite.every( ( pluginOnSite ) => !! pluginOnSite );
+
+	const transferStatus = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
+	const isJetpackSelfHosted = isJetpack && ! isAtomic;
+
+	// Consolidate the plugin information from the .org and .com sources in a single list
+	const pluginsInformationList = useMemo( () => {
+		return pluginsOnSite.reduce(
+			( pluginsList: Array< any >, pluginOnSite: Plugin, index: number ) => {
+				pluginsList.push( {
+					...pluginOnSite,
+					...wpComPluginsData[ index ],
+					...wporgPlugins[ index ],
+				} );
+
+				return pluginsList;
+			},
+			[]
+		);
+	}, [ pluginsOnSite, wpComPluginsData, wporgPlugins ] );
+
+	useEffect( () => {
+		dispatch(
+			pluginInstallationStateChange(
+				MARKETPLACE_ASYNC_PROCESS_STATUS.COMPLETED,
+				'deauthorize plugin installation URL'
+			)
+		);
+	}, [ dispatch ] );
+
+	// retrieve wporg plugin data if not available
+	useEffect( () => {
+		if ( ! areAllWporgPluginsFetched ) {
+			areWporgPluginsFetched.forEach( ( isPluginFetched, index ) => {
+				const isPluginFeching = areWporgPluginsFetching[ index ];
+				if ( ! isPluginFetched && ! isPluginFeching ) {
+					dispatch( wporgFetchPluginData( pluginSlugs[ index ] ) );
+				}
+			} );
+		}
+
+		// We don't want it to run at every change of areWporgPluginsFetching,
+		// we only rerun when areWporgPluginsFetched changes
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ areAllWporgPluginsFetched, areWporgPluginsFetched, pluginSlugs, dispatch, wporgPlugins ] );
+
+	// Site is transferring to Atomic.
+	// Poll the transfer status.
+	useEffect( () => {
+		if (
+			! siteId ||
+			transferStatus === transferStates.COMPLETE ||
+			isJetpackSelfHosted ||
+			pluginSlugs.length === 0
+		) {
+			return;
+		}
+		if ( ! isFetchingTransferStatus ) {
+			waitFor( 2 ).then( () => dispatch( fetchAutomatedTransferStatus( siteId ) ) );
+		}
+	}, [
+		siteId,
+		dispatch,
+		transferStatus,
+		isFetchingTransferStatus,
+		isJetpackSelfHosted,
+		pluginSlugs,
+	] );
+
+	// Site is already Atomic (or just transferred).
+	// Poll the plugin installation status.
+	useEffect( () => {
+		if (
+			! siteId ||
+			( ! isJetpackSelfHosted && transferStatus !== transferStates.COMPLETE ) ||
+			allPluginsFetched ||
+			pluginSlugs.length === 0
+		) {
+			return;
+		}
+
+		if ( ! isRequestingPlugins ) {
+			waitFor( 1 ).then( () => dispatch( fetchSitePlugins( siteId ) ) );
+		}
+	}, [
+		isRequestingPlugins,
+		dispatch,
+		siteId,
+		transferStatus,
+		isJetpackSelfHosted,
+		allPluginsFetched,
+		pluginSlugs,
+	] );
+
+	const pluginsSection: ThankYouSectionProps = {
+		sectionKey: 'plugin_information',
+		nextSteps: pluginsInformationList.map( ( plugin: any ) => ( {
+			stepKey: `plugin_information_${ plugin.slug }`,
+			stepSection: <ThankYouPluginSection plugin={ plugin } />,
+		} ) ),
+	};
+
+	return [ pluginsSection, allPluginsFetched ];
+}
+
+type Plugin = {
+	slug: string;
+	fetched: boolean;
+	wporg: boolean;
+	icon: string;
+};

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { ThankYouSectionProps } from 'calypso/components/thank-you/types';
+import { getThemes } from 'calypso/state/themes/selectors';
+
+export function useThemesThankYouData( themeSlugs: string[] ): [ ThankYouSectionProps, boolean ] {
+	const dotComThemes = useSelector( ( state ) => getThemes( state, 'wpcom', themeSlugs ) );
+	const dotOrgThemes = useSelector( ( state ) => getThemes( state, 'wporg', themeSlugs ) );
+	const themesList = useMemo(
+		() => themeSlugs.map( ( slug, index ) => dotComThemes[ index ] || dotOrgThemes[ index ] ),
+		[ dotComThemes, dotOrgThemes, themeSlugs ]
+	);
+	const allThemesFetched = themesList.every( ( theme ) => !! theme );
+
+	const themesSection: ThankYouSectionProps = {
+		sectionKey: 'theme_information',
+		nextSteps: themesList.map( ( theme ) => ( {
+			stepKey: `theme_information_${ theme?.id }`,
+			stepSection: <></>,
+		} ) ),
+	};
+
+	return [ themesSection, allThemesFetched ];
+}

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { useQueryThemes } from 'calypso/components/data/query-theme';
 import { ThankYouSectionProps } from 'calypso/components/thank-you/types';
 import { getThemes } from 'calypso/state/themes/selectors';
 
@@ -12,11 +13,14 @@ export function useThemesThankYouData( themeSlugs: string[] ): [ ThankYouSection
 	);
 	const allThemesFetched = themesList.every( ( theme ) => !! theme );
 
+	useQueryThemes( 'wpcom', themeSlugs );
+	useQueryThemes( 'wporg', themeSlugs );
+
 	const themesSection: ThankYouSectionProps = {
 		sectionKey: 'theme_information',
 		nextSteps: themesList.map( ( theme ) => ( {
 			stepKey: `theme_information_${ theme?.id }`,
-			stepSection: <></>,
+			stepSection: <></>, // TODO: Add theme card
 		} ) ),
 	};
 


### PR DESCRIPTION
Fixes [#74300](https://github.com/Automattic/wp-calypso/issues/74300)

## Proposed Changes

* Create a hook to provide data for each product type: plugins and themes.
* Move the logic from the main Marketplace Thank You component to its hooks
* Create a hook to provide the default footer sections
* Add `useQueryThemes` to allow query for a list of ids instead of a single id

PS: Currently this page is only being used for plugins, when actually adding themes the strings will be changed to be more generalized.

## Testing Instructions
* Install free and paid plugins 
* Install more than 1 paid plugin
* The Thank You page shown should be the same as the current version in production. NO VISUAL CHANGES.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
