### PR TITLE
Launchpad: Avoid showing Launchpad if tasks are complete

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -2,7 +2,6 @@ import { isNewsletterFlow, StepContainer } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -46,21 +45,6 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		[]
 	);
 
-	const areLaunchpadTasksCompleted = useCallback(
-		( flow: string | null ) => {
-			if ( isNewsletterFlow( flow ) ) {
-				return Boolean( checklist_statuses?.first_post_published );
-			}
-			return isSiteLaunched || Boolean( checklist_statuses?.site_launched );
-		},
-		[ checklist_statuses?.first_post_published, checklist_statuses?.site_launched, isSiteLaunched ]
-	);
-
-	const redirectToSiteHome = useCallback( ( siteSlug: string | null, flow: string | null ) => {
-		recordTracksEvent( 'calypso_launchpad_redirect_to_home', { flow: flow } );
-		window.location.replace( `/home/${ siteSlug }` );
-	}, [] );
-
 	if (
 		! isLoggedIn ||
 		launchpadScreenOption === 'off' ||
@@ -72,6 +56,18 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 
 	if ( ! siteSlug || fetchingSiteError?.error ) {
 		window.location.replace( '/home' );
+	}
+
+	function areLaunchpadTasksCompleted( flow: string | null ) {
+		if ( isNewsletterFlow( flow ) ) {
+			return Boolean( checklist_statuses?.first_post_published );
+		}
+		return isSiteLaunched || Boolean( checklist_statuses?.site_launched );
+	}
+
+	function redirectToSiteHome( siteSlug: string | null, flow: string | null ) {
+		recordTracksEvent( 'calypso_launchpad_redirect_to_home', { flow: flow } );
+		window.location.replace( `/home/${ siteSlug }` );
 	}
 
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -17,6 +17,7 @@ import { successNotice } from 'calypso/state/notices/actions';
 import { useQuery } from '../../../../hooks/use-query';
 import StepContent from './step-content';
 import { areLaunchpadTasksCompleted } from './task-helper';
+import { launchpadFlowTasks } from './tasks';
 import type { Step } from '../../types';
 import type { SiteSelect } from '@automattic/data-stores';
 
@@ -49,7 +50,12 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	if (
 		! isLoggedIn ||
 		launchpadScreenOption === 'off' ||
-		areLaunchpadTasksCompleted( site_intent, checklist_statuses, isSiteLaunched ) ||
+		areLaunchpadTasksCompleted(
+			site_intent,
+			launchpadFlowTasks,
+			checklist_statuses,
+			isSiteLaunched
+		) ||
 		( launchpadScreenOption === false && 'videopress' !== flow )
 	) {
 		redirectToSiteHome( siteSlug, flow );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -1,8 +1,8 @@
 import { StepContainer } from '@automattic/onboarding';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch as useWPDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useLaunchpad } from 'calypso/data/sites/use-launchpad';
@@ -40,7 +40,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 	const recordSignupComplete = useRecordSignupComplete( flow );
 	const dispatch = useDispatch();
-	const { saveSiteSettings } = useDispatch( SITE_STORE );
+	const { saveSiteSettings } = useWPDispatch( SITE_STORE );
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const fetchingSiteError = useSelect(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -14,6 +14,7 @@ import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
+import { saveSiteSettings } from 'calypso/state/site-settings/actions';
 import { useQuery } from '../../../../hooks/use-query';
 import StepContent from './step-content';
 import { areLaunchpadTasksCompleted } from './task-helper';
@@ -50,14 +51,20 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	if (
 		! isLoggedIn ||
 		launchpadScreenOption === 'off' ||
+		( launchpadScreenOption === false && 'videopress' !== flow )
+	) {
+		redirectToSiteHome( siteSlug, flow );
+	}
+
+	if (
 		areLaunchpadTasksCompleted(
 			site_intent,
 			launchpadFlowTasks,
 			checklist_statuses,
 			isSiteLaunched
-		) ||
-		( launchpadScreenOption === false && 'videopress' !== flow )
+		)
 	) {
+		saveSiteSettings( site?.ID, { launchpad_screen: 'off' } );
 		redirectToSiteHome( siteSlug, flow );
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -1,8 +1,8 @@
 import { StepContainer } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useLaunchpad } from 'calypso/data/sites/use-launchpad';
@@ -14,7 +14,6 @@ import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
-import { saveSiteSettings } from 'calypso/state/site-settings/actions';
 import { useQuery } from '../../../../hooks/use-query';
 import StepContent from './step-content';
 import { areLaunchpadTasksCompleted } from './task-helper';
@@ -41,6 +40,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 	const recordSignupComplete = useRecordSignupComplete( flow );
 	const dispatch = useDispatch();
+	const { saveSiteSettings } = useDispatch( SITE_STORE );
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const fetchingSiteError = useSelect(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -1,4 +1,4 @@
-import { isNewsletterFlow, StepContainer } from '@automattic/onboarding';
+import { StepContainer } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
@@ -16,6 +16,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
 import { useQuery } from '../../../../hooks/use-query';
 import StepContent from './step-content';
+import { areLaunchpadTasksCompleted } from './task-helper';
 import type { Step } from '../../types';
 import type { SiteSelect } from '@automattic/data-stores';
 
@@ -33,7 +34,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	const verifiedParam = useQuery().get( 'verified' );
 	const site = useSite();
 	const {
-		data: { launchpad_screen: launchpadScreenOption, checklist_statuses },
+		data: { launchpad_screen: launchpadScreenOption, checklist_statuses, site_intent },
 	} = useLaunchpad( siteSlug );
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 	const recordSignupComplete = useRecordSignupComplete( flow );
@@ -48,7 +49,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	if (
 		! isLoggedIn ||
 		launchpadScreenOption === 'off' ||
-		areLaunchpadTasksCompleted( flow ) ||
+		areLaunchpadTasksCompleted( site_intent, checklist_statuses, isSiteLaunched ) ||
 		( launchpadScreenOption === false && 'videopress' !== flow )
 	) {
 		redirectToSiteHome( siteSlug, flow );
@@ -56,13 +57,6 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 
 	if ( ! siteSlug || fetchingSiteError?.error ) {
 		window.location.replace( '/home' );
-	}
-
-	function areLaunchpadTasksCompleted( flow: string | null ) {
-		if ( isNewsletterFlow( flow ) ) {
-			return Boolean( checklist_statuses?.first_post_published );
-		}
-		return isSiteLaunched || Boolean( checklist_statuses?.site_launched );
 	}
 
 	function redirectToSiteHome( siteSlug: string | null, flow: string | null ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -15,7 +15,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isVideoPressFlow } from 'calypso/signup/utils';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { launchpadFlowTasks } from './tasks';
-import { LaunchpadStatuses, Task } from './types';
+import { LaunchpadFlowTaskList, LaunchpadStatuses, Task } from './types';
 import type { SiteDetails } from '@automattic/data-stores';
 
 export function getEnhancedTasks(
@@ -396,11 +396,14 @@ export function getArrayOfFilteredTasks(
  */
 export function areLaunchpadTasksCompleted(
 	site_intent: string,
+	launchpadFlowTasks: LaunchpadFlowTaskList,
 	checklist_statuses: LaunchpadStatuses,
 	isSiteLaunched: boolean
 ) {
-	if ( 'newsletter' === site_intent ) {
-		return Boolean( checklist_statuses?.first_post_published );
-	}
-	return isSiteLaunched || Boolean( checklist_statuses?.site_launched );
+	const lastTask =
+		launchpadFlowTasks[ site_intent ][ launchpadFlowTasks[ site_intent ].length - 1 ];
+
+	return lastTask === 'site_launched'
+		? isSiteLaunched || Boolean( checklist_statuses[ lastTask ] )
+		: Boolean( checklist_statuses[ lastTask as keyof LaunchpadStatuses ] );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -400,9 +400,21 @@ export function areLaunchpadTasksCompleted(
 	checklist_statuses: LaunchpadStatuses,
 	isSiteLaunched: boolean
 ) {
+	// If we don't have needed data, return false
+	if (
+		! site_intent ||
+		! checklist_statuses ||
+		! isSiteLaunched ||
+		! launchpadFlowTasks[ site_intent ]
+	) {
+		return false;
+	}
+
 	const lastTask =
 		launchpadFlowTasks[ site_intent ][ launchpadFlowTasks[ site_intent ].length - 1 ];
 
+	// If last task is site_launched, return true if site is launched OR site_launch task is completed
+	// Else return the status of the last task (will be false if task is not in checklist_statuses)
 	return lastTask === 'site_launched'
 		? isSiteLaunched || Boolean( checklist_statuses[ lastTask ] )
 		: Boolean( checklist_statuses[ lastTask as keyof LaunchpadStatuses ] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -384,3 +384,23 @@ export function getArrayOfFilteredTasks(
 		}, [] as Task[] )
 	);
 }
+
+/*
+ * Confirms if final task for a given site_intent is completed.
+ * This is used to as a fallback check to determine if the full
+ * screen launchpad should be shown or not.
+ *
+ * @param {string} siteIntent - The value of a site's site_intent option
+ * @param {Task[]} checklist_statuses - The value of a site's checklist_statuses option
+ * @returns {boolean} - True if the final task for the given site_intent is completed
+ */
+export function areLaunchpadTasksCompleted(
+	site_intent: string,
+	checklist_statuses: LaunchpadStatuses,
+	isSiteLaunched: boolean
+) {
+	if ( 'newsletter' === site_intent ) {
+		return Boolean( checklist_statuses?.first_post_published );
+	}
+	return isSiteLaunched || Boolean( checklist_statuses?.site_launched );
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -391,7 +391,9 @@ export function getArrayOfFilteredTasks(
  * screen launchpad should be shown or not.
  *
  * @param {string} siteIntent - The value of a site's site_intent option
- * @param {Task[]} checklist_statuses - The value of a site's checklist_statuses option
+ * @param {LaunchpadStatuses} checklist_statuses - The value of a site's checklist_statuses option
+ * @param {boolean} isSiteLaunched - The value of a site's is_launched option
+ * @param {LaunchpadFlowTaskList} launchpadFlowTasks - The list of tasks for each site_intent
  * @returns {boolean} - True if the final task for the given site_intent is completed
  */
 export function areLaunchpadTasksCompleted(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -402,13 +402,7 @@ export function areLaunchpadTasksCompleted(
 	checklist_statuses: LaunchpadStatuses,
 	isSiteLaunched: boolean
 ) {
-	// If we don't have needed data, return false
-	if (
-		! site_intent ||
-		! checklist_statuses ||
-		! isSiteLaunched ||
-		! launchpadFlowTasks[ site_intent ]
-	) {
+	if ( ! site_intent ) {
 		return false;
 	}
 

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,6 +1,7 @@
 import { isEcommerce } from '@automattic/calypso-products/src';
 import page from 'page';
 import { fetchLaunchpad } from 'calypso/data/sites/use-launchpad';
+import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
@@ -44,16 +45,12 @@ export async function maybeRedirect( context, next ) {
 	const site = getSelectedSite( state );
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 
-	function areLaunchpadTasksCompleted( site_intent, checklist_statuses, isSiteLaunched ) {
-		if ( 'newsletter' === site_intent ) {
-			return Boolean( checklist_statuses?.first_post_published );
-		}
-		return isSiteLaunched || Boolean( checklist_statuses?.site_launched );
-	}
-
 	try {
 		const { launchpad_screen, checklist_statuses, site_intent } = await fetchLaunchpad( slug );
-		if ( launchpad_screen === 'full' && ! areLaunchpadTasksCompleted( site_intent, checklist_statuses, isSiteLaunched ) ) {
+		if (
+			launchpad_screen === 'full' &&
+			! areLaunchpadTasksCompleted( site_intent, checklist_statuses, isSiteLaunched )
+		) {
 			// The new stepper launchpad onboarding flow isn't registered within the "page"
 			// client-side router, so page.redirect won't work. We need to use the
 			// traditional window.location Web API.

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -2,6 +2,7 @@ import { isEcommerce } from '@automattic/calypso-products/src';
 import page from 'page';
 import { fetchLaunchpad } from 'calypso/data/sites/use-launchpad';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
+import { launchpadFlowTasks } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
@@ -49,7 +50,12 @@ export async function maybeRedirect( context, next ) {
 		const { launchpad_screen, checklist_statuses, site_intent } = await fetchLaunchpad( slug );
 		if (
 			launchpad_screen === 'full' &&
-			! areLaunchpadTasksCompleted( site_intent, checklist_statuses, isSiteLaunched )
+			! areLaunchpadTasksCompleted(
+				site_intent,
+				launchpadFlowTasks,
+				checklist_statuses,
+				isSiteLaunched
+			)
 		) {
 			// The new stepper launchpad onboarding flow isn't registered within the "page"
 			// client-side router, so page.redirect won't work. We need to use the


### PR DESCRIPTION
### Proposed Changes

We periodically have cases where a user has gone through all launchpad steps and/or a site has already been launched, but `launchpad_screen` is still set to to 'full'. We're not exactly sure how such cases arise - theoretically, once tasks are complete, launchpad_screen should be off. 

Regardless of how the situation arises, because we only update `launchpad_screen` during actual site launch - on the `wpcom_site_launched` action - there is no way for a normal end user to turn off launchpad once their site is in this condition. That means they'll keep getting redirected from My Home to Launchpad indefinitely. 

This adds an check to Launchpad and too My Home. We use site_intent to determine the last launchpad task for each site. In most cases, that will be `site_launched`, but it may different for others (ie, for newsletter, it is `first_post_published`). We then confirm if that last task has been completed. If so, we do not redirect from My Home to Launchpad, and if the user accesses Launchpad directly, we turn launchpad_screen off and redirect to My Home. 

### Testing

**Review Time: Medium**
**Testing Time: Medium**

To start, check out this branch and run yarn and yarn start if needed. 

**Test Free Flow** (could also test write/build/link in bio)
1. Start a new free site at http://calypso.localhost:3000/setup/free/intro, and go through to Launchpad.
2. First, test that Launchpad works as expected under normal conditions. 
   - TEST: Confirm Launchpad screen loads as expected when you first arrive. 
   - TEST: Click 'Skip to Dashboard', navigate to My Home, and confirm you are redirected back to Launchpad. 
   - TEST: Click the Launch button to launch the site, go to My Home, and confirm you are not redirected to Launchpad.
3. Second, test the specific situation we're fixing. 
   - Go to [YOURSITEURL]/wp-admin/options.php and update the launchpad_screen option to full. This duplicates the bug situation: the site is fully launched with all required launchpad tasks complete, but launchpad_screen is still `full`. 
   - TEST: Go to My Home (be sure you are on localhost, not wordpress.com) and confirm you are **NOT** redirected to My Home even though launchpad_screen === full. Prior to this PR, you would be. 
   - TEST: Go to launchpad at http://calypso.localhost:3000/setup/free/launchpad?siteSlug=YOURSITESLUG, and confirm you **ARE** redirected to launchpad even though launchpad_screen === full. 
   - TEST: Finally go back to [YOURSITEURL]/wp-admin/options.php and confirm launchpad_screen is now 'off'. 
   
**Test Newsletter Flow** (this is different because sites are created in 'launched state and last task if publishing a post)
1. Start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro, and go through to Launchpad.
2. First, test that Launchpad works as expected under normal conditions. 
   - TEST: Confirm Launchpad screen loads as expected when you first arrive. 
   - TEST: Click 'Skip to Dashboard', navigate to My Home, and confirm you are redirected back to Launchpad. 
   - TEST: Click the Publish Post button, publish a post, go to My Home, and confirm you are not redirected to Launchpad.
3. Second, test the specific situation we're fixing. 
   - Go to [YOURSITEURL]/wp-admin/options.php and update the launchpad_screen option to full. This duplicates the bug situation: the site is fully launched with all required launchpad tasks complete, but launchpad_screen is still `full`. 
   - TEST: Go to My Home (be sure you are on localhost, not wordpress.com) and confirm you are **NOT** redirected to launchpad even though launchpad_screen === full. Prior to this PR, you would be. 
   - TEST: Go to launchpad at http://calypso.localhost:3000/setup/newsletter/launchpad?siteSlug=YOURSITESLUG, and confirm you **ARE** redirected to My Home even though launchpad_screen === full. 
   - TEST: Finally go back to [YOURSITEURL]/wp-admin/options.php and confirm launchpad_screen is now 'off'. 