### PR TITLE
Checkout: Use string interpolation for tax names in VAT form

### DIFF
--- a/client/me/purchases/billing-history/vat-vendor-details.tsx
+++ b/client/me/purchases/billing-history/vat-vendor-details.tsx
@@ -24,9 +24,19 @@ interface VatVendorInfo {
 	vatId: string;
 }
 
-function getVatVendorInfo(
+export function getVatVendorInfo(
+	/**
+	 * Two-letter country code.
+	 */
 	country: string,
+
+	/**
+	 * A string version of date that can be read by Date.parse.
+	 *
+	 * Can be 'now'.
+	 */
 	date: string,
+
 	translate: ReturnType< typeof useTranslate >
 ): VatVendorInfo | undefined {
 	const automatticVatAddress = [

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -1,7 +1,6 @@
 import { Field } from '@automattic/wpcom-checkout';
 import { CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { sprintf } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
@@ -193,11 +192,13 @@ export function VatForm( {
 					className="vat-form__expand-button"
 					checked={ isFormActive }
 					onChange={ toggleVatForm }
-					label={ sprintf(
+					label={
 						/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-						translate( 'Add %s details', { textOnly: true } ),
-						vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } )
-					) }
+						translate( 'Add %s details', {
+							textOnly: true,
+							args: [ vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } ) ],
+						} )
+					}
 					disabled={ isDisabled }
 				/>
 			</div>
@@ -211,11 +212,13 @@ export function VatForm( {
 					className="vat-form__expand-button"
 					checked={ isFormActive }
 					onChange={ toggleVatForm }
-					label={ sprintf(
+					label={
 						/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-						translate( 'Add %s details', { textOnly: true } ),
-						vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } )
-					) }
+						translate( 'Add %s details', {
+							textOnly: true,
+							args: [ vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } ) ],
+						} )
+					}
 					disabled={ isDisabled || Boolean( vatDetailsFromServer.id ) }
 				/>
 				{ countryCode === 'GB' && (
@@ -223,11 +226,13 @@ export function VatForm( {
 						className="vat-form__expand-button"
 						checked={ vatDetailsInForm.country === 'XI' }
 						onChange={ toggleNorthernIreland }
-						label={ sprintf(
+						label={
 							/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-							translate( 'Is %s for Northern Ireland?', { textOnly: true } ),
-							vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } )
-						) }
+							translate( 'Is %s for Northern Ireland?', {
+								textOnly: true,
+								args: [ vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } ) ],
+							} )
+						}
 						disabled={ isDisabled }
 					/>
 				) }
@@ -236,11 +241,13 @@ export function VatForm( {
 				<Field
 					id={ section + '-vat-organization' }
 					type="text"
-					label={ sprintf(
+					label={
 						/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-						translate( 'Organization for %s', { textOnly: true } ),
-						vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } )
-					) }
+						translate( 'Organization for %s', {
+							textOnly: true,
+							args: [ vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } ) ],
+						} )
+					}
 					value={ vatDetailsInForm.name ?? '' }
 					disabled={ isDisabled }
 					onChange={ ( newValue: string ) => {
@@ -253,11 +260,13 @@ export function VatForm( {
 				<Field
 					id={ section + '-vat-id' }
 					type="text"
-					label={ sprintf(
+					label={
 						/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-						translate( '%s ID', { textOnly: true } ),
-						vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } )
-					) }
+						translate( '%s ID', {
+							textOnly: true,
+							args: [ vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } ) ],
+						} )
+					}
 					value={ vatDetailsInForm.id ?? '' }
 					disabled={ isDisabled || Boolean( vatDetailsFromServer.id ) }
 					onChange={ ( newValue: string ) => {
@@ -272,11 +281,13 @@ export function VatForm( {
 				<Field
 					id={ section + '-vat-address' }
 					type="text"
-					label={ sprintf(
+					label={
 						/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-						translate( 'Address for %s', { textOnly: true } ),
-						vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } )
-					) }
+						translate( 'Address for %s', {
+							textOnly: true,
+							args: [ vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } ) ],
+						} )
+					}
 					value={ vatDetailsInForm.address ?? '' }
 					autoComplete="address"
 					disabled={ isDisabled }

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -1,11 +1,13 @@
 import { Field } from '@automattic/wpcom-checkout';
 import { CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { sprintf } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useRef } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import { getVatVendorInfo } from 'calypso/me/purchases/billing-history/vat-vendor-details';
 import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { CHECKOUT_STORE } from '../../lib/wpcom-store';
@@ -67,6 +69,7 @@ export function VatForm( {
 	const translate = useTranslate();
 	const vatDetailsInForm = useSelect( ( select ) => select( CHECKOUT_STORE ).getVatDetails(), [] );
 	const wpcomStoreActions = useDispatch( CHECKOUT_STORE );
+	const vendorInfo = getVatVendorInfo( countryCode ?? 'GB', 'now', translate );
 	const setVatDetailsInForm = wpcomStoreActions?.setVatDetails;
 	const { vatDetails: vatDetailsFromServer, isLoading: isLoadingVatDetails } = useVatDetails();
 	const [ isFormActive, setIsFormActive ] = useState< boolean >( false );
@@ -190,7 +193,11 @@ export function VatForm( {
 					className="vat-form__expand-button"
 					checked={ isFormActive }
 					onChange={ toggleVatForm }
-					label={ translate( 'Add Business Tax ID details' ) }
+					label={ sprintf(
+						/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+						translate( 'Add %s details', { textOnly: true } ),
+						vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } )
+					) }
 					disabled={ isDisabled }
 				/>
 			</div>
@@ -204,7 +211,11 @@ export function VatForm( {
 					className="vat-form__expand-button"
 					checked={ isFormActive }
 					onChange={ toggleVatForm }
-					label={ translate( 'Add Business Tax ID details' ) }
+					label={ sprintf(
+						/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+						translate( 'Add %s details', { textOnly: true } ),
+						vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } )
+					) }
 					disabled={ isDisabled || Boolean( vatDetailsFromServer.id ) }
 				/>
 				{ countryCode === 'GB' && (
@@ -212,7 +223,11 @@ export function VatForm( {
 						className="vat-form__expand-button"
 						checked={ vatDetailsInForm.country === 'XI' }
 						onChange={ toggleNorthernIreland }
-						label={ translate( 'Is the tax ID for Northern Ireland?' ) }
+						label={ sprintf(
+							/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+							translate( 'Is %s for Northern Ireland?', { textOnly: true } ),
+							vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } )
+						) }
 						disabled={ isDisabled }
 					/>
 				) }
@@ -221,7 +236,11 @@ export function VatForm( {
 				<Field
 					id={ section + '-vat-organization' }
 					type="text"
-					label={ String( translate( 'Organization for tax ID' ) ) }
+					label={ sprintf(
+						/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+						translate( 'Organization for %s', { textOnly: true } ),
+						vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } )
+					) }
 					value={ vatDetailsInForm.name ?? '' }
 					disabled={ isDisabled }
 					onChange={ ( newValue: string ) => {
@@ -234,7 +253,11 @@ export function VatForm( {
 				<Field
 					id={ section + '-vat-id' }
 					type="text"
-					label={ String( translate( 'Business Tax ID Number' ) ) }
+					label={ sprintf(
+						/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+						translate( '%s ID', { textOnly: true } ),
+						vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } )
+					) }
 					value={ vatDetailsInForm.id ?? '' }
 					disabled={ isDisabled || Boolean( vatDetailsFromServer.id ) }
 					onChange={ ( newValue: string ) => {
@@ -249,7 +272,11 @@ export function VatForm( {
 				<Field
 					id={ section + '-vat-address' }
 					type="text"
-					label={ String( translate( 'Address for tax ID' ) ) }
+					label={ sprintf(
+						/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+						translate( 'Address for %s', { textOnly: true } ),
+						vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } )
+					) }
 					value={ vatDetailsInForm.address ?? '' }
 					autoComplete="address"
 					disabled={ isDisabled }
@@ -265,8 +292,10 @@ export function VatForm( {
 				<div>
 					<FormSettingExplanation>
 						{ translate(
-							'To change your Business Tax ID number, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+							/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+							'To change your %(taxName)s ID, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
 							{
+								args: { taxName: vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } ) },
 								components: {
 									contactSupportLink: (
 										<a

--- a/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
@@ -247,10 +247,10 @@ describe( 'Checkout contact step extra tax fields', () => {
 			await user.type( await screen.findByLabelText( 'Organization' ), 'Contact Organization' );
 
 			// Check the box
-			await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+			await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 
 			// Fill in the details
-			await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+			await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 			if ( vatOrganization === 'with' ) {
 				await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
 			}
@@ -317,10 +317,10 @@ describe( 'Checkout contact step extra tax fields', () => {
 			await user.type( await screen.findByLabelText( 'Address' ), 'Contact Address' );
 
 			// Check the box
-			await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+			await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 
 			// Fill in the details
-			await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+			await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 			if ( withVatAddress === 'with' ) {
 				await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 			}

--- a/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
@@ -317,12 +317,12 @@ describe( 'Checkout contact step extra tax fields', () => {
 			await user.type( await screen.findByLabelText( 'Address' ), 'Contact Address' );
 
 			// Check the box
-			await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+			await user.click( await screen.findByLabelText( 'Add GST details' ) );
 
 			// Fill in the details
-			await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
+			await user.type( await screen.findByLabelText( 'GST ID' ), vatId );
 			if ( withVatAddress === 'with' ) {
-				await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
+				await user.type( await screen.findByLabelText( 'Address for GST' ), vatAddress );
 			}
 
 			await user.click( screen.getByText( 'Continue' ) );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
@@ -252,9 +252,9 @@ describe( 'Checkout contact step extra tax fields', () => {
 			// Fill in the details
 			await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 			if ( vatOrganization === 'with' ) {
-				await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
+				await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
 			}
-			await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+			await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 
 			await user.click( screen.getByText( 'Continue' ) );
 			expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
@@ -322,7 +322,7 @@ describe( 'Checkout contact step extra tax fields', () => {
 			// Fill in the details
 			await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 			if ( withVatAddress === 'with' ) {
-				await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+				await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 			}
 
 			await user.click( screen.getByText( 'Continue' ) );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
@@ -308,10 +308,10 @@ describe( 'Checkout contact step VAT form', () => {
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
-		await user.type( await screen.findByLabelText( 'VAT ID' ), 'CHE-' + vatId );
-		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
+		await user.click( await screen.findByLabelText( 'Add GST details' ) );
+		await user.type( await screen.findByLabelText( 'GST ID' ), 'CHE-' + vatId );
+		await user.type( await screen.findByLabelText( 'Organization for GST' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for GST' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
@@ -337,10 +337,10 @@ describe( 'Checkout contact step VAT form', () => {
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
-		await user.type( await screen.findByLabelText( 'VAT ID' ), 'CHE' + vatId );
-		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
+		await user.click( await screen.findByLabelText( 'Add GST details' ) );
+		await user.type( await screen.findByLabelText( 'GST ID' ), 'CHE' + vatId );
+		await user.type( await screen.findByLabelText( 'Organization for GST' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for GST' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
@@ -366,10 +366,10 @@ describe( 'Checkout contact step VAT form', () => {
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
-		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
-		await user.type( await screen.findByLabelText( 'VAT ID' ), 'che' + vatId );
-		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
+		await user.click( await screen.findByLabelText( 'Add GST details' ) );
+		await user.type( await screen.findByLabelText( 'GST ID' ), 'che' + vatId );
+		await user.type( await screen.findByLabelText( 'Organization for GST' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for GST' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {

--- a/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
@@ -115,9 +115,7 @@ describe( 'Checkout contact step VAT form', () => {
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
-		expect(
-			await screen.findByLabelText( 'Is the tax ID for Northern Ireland?' )
-		).toBeInTheDocument();
+		expect( await screen.findByLabelText( 'Is VAT for Northern Ireland?' ) ).toBeInTheDocument();
 	} );
 
 	it( 'hides the Northern Ireland checkbox is if the VAT checkbox is checked and the country is changed from GB to ES', async () => {
@@ -126,13 +124,9 @@ describe( 'Checkout contact step VAT form', () => {
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
-		expect(
-			await screen.findByLabelText( 'Is the tax ID for Northern Ireland?' )
-		).toBeInTheDocument();
+		expect( await screen.findByLabelText( 'Is VAT for Northern Ireland?' ) ).toBeInTheDocument();
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'ES' );
-		expect(
-			screen.queryByLabelText( 'Is the tax ID for Northern Ireland?' )
-		).not.toBeInTheDocument();
+		expect( screen.queryByLabelText( 'Is VAT for Northern Ireland?' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the VAT fields and checks the box on load if the VAT endpoint returns data', async () => {
@@ -182,10 +176,8 @@ describe( 'Checkout contact step VAT form', () => {
 
 		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
 		expect( await screen.findByLabelText( 'VAT ID' ) ).toHaveValue( '12345' );
-		expect( await screen.findByLabelText( 'Organization for tax ID' ) ).toHaveValue(
-			'Test company'
-		);
-		expect( await screen.findByLabelText( 'Address for tax ID' ) ).toHaveValue( '123 Main Street' );
+		expect( await screen.findByLabelText( 'Organization for VAT' ) ).toHaveValue( 'Test company' );
+		expect( await screen.findByLabelText( 'Address for VAT' ) ).toHaveValue( '123 Main Street' );
 	} );
 
 	it( 'renders the Northern Ireland checkbox pre-filled if the VAT endpoint returns XI', async () => {
@@ -209,7 +201,7 @@ describe( 'Checkout contact step VAT form', () => {
 		const countryField = await screen.findByLabelText( 'Country' );
 
 		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
-		expect( await screen.findByLabelText( 'Is the tax ID for Northern Ireland?' ) ).toBeChecked();
+		expect( await screen.findByLabelText( 'Is VAT for Northern Ireland?' ) ).toBeChecked();
 	} );
 
 	it( 'does not allow unchecking the VAT details checkbox if the VAT fields are pre-filled', async () => {
@@ -260,8 +252,8 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
-		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
@@ -289,8 +281,8 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 		await user.type( await screen.findByLabelText( 'VAT ID' ), countryCode + vatId );
-		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
@@ -318,8 +310,8 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 		await user.type( await screen.findByLabelText( 'VAT ID' ), 'CHE-' + vatId );
-		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
@@ -347,8 +339,8 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 		await user.type( await screen.findByLabelText( 'VAT ID' ), 'CHE' + vatId );
-		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
@@ -376,8 +368,8 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 		await user.type( await screen.findByLabelText( 'VAT ID' ), 'che' + vatId );
-		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
@@ -418,8 +410,8 @@ describe( 'Checkout contact step VAT form', () => {
 		expect( countryField.selectedOptions[ 0 ].value ).toBe( cachedContactCountry );
 		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
 		expect( await screen.findByLabelText( 'VAT ID' ) ).toHaveValue( vatId );
-		expect( await screen.findByLabelText( 'Organization for tax ID' ) ).toHaveValue( vatName );
-		expect( await screen.findByLabelText( 'Address for tax ID' ) ).toHaveValue( vatAddress );
+		expect( await screen.findByLabelText( 'Organization for VAT' ) ).toHaveValue( vatName );
+		expect( await screen.findByLabelText( 'Address for VAT' ) ).toHaveValue( vatAddress );
 
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
 		const mockVatEndpoint = mockSetVatInfoEndpoint();
@@ -448,10 +440,10 @@ describe( 'Checkout contact step VAT form', () => {
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
-		await user.click( await screen.findByLabelText( 'Is the tax ID for Northern Ireland?' ) );
+		await user.click( await screen.findByLabelText( 'Is VAT for Northern Ireland?' ) );
 		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
-		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
 		expect( mockVatEndpoint ).toHaveBeenCalledWith( {
@@ -478,8 +470,8 @@ describe( 'Checkout contact step VAT form', () => {
 
 		// Fill in the details
 		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
-		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 
 		// Uncheck the box
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
@@ -516,8 +508,8 @@ describe( 'Checkout contact step VAT form', () => {
 
 		// Fill in the details
 		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
-		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
@@ -568,8 +560,8 @@ describe( 'Checkout contact step VAT form', () => {
 
 		// Fill in the details
 		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
-		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 
 		// Uncheck the box
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
@@ -617,8 +609,8 @@ describe( 'Checkout contact step VAT form', () => {
 
 		// Fill in the details
 		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
-		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 
 		// Change the country to one that does not support VAT
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), nonVatCountryCode );
@@ -651,8 +643,8 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
-		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
-		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
+		await user.type( await screen.findByLabelText( 'Organization for VAT' ), vatName );
+		await user.type( await screen.findByLabelText( 'Address for VAT' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
 		await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
@@ -70,7 +70,7 @@ describe( 'Checkout contact step VAT form', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'US' );
-		expect( screen.queryByLabelText( 'Add Business Tax ID details' ) ).not.toBeInTheDocument();
+		expect( screen.queryByLabelText( 'Add VAT details' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the VAT field checkbox if the selected country does support VAT', async () => {
@@ -78,7 +78,7 @@ describe( 'Checkout contact step VAT form', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
-		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).toBeInTheDocument();
+		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeInTheDocument();
 	} );
 
 	it( 'does not render the VAT fields if the checkbox is not checked', async () => {
@@ -86,8 +86,8 @@ describe( 'Checkout contact step VAT form', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
-		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).not.toBeChecked();
-		expect( screen.queryByLabelText( 'Business Tax ID Number' ) ).not.toBeInTheDocument();
+		expect( await screen.findByLabelText( 'Add VAT details' ) ).not.toBeChecked();
+		expect( screen.queryByLabelText( 'VAT ID' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the VAT fields if the checkbox is checked', async () => {
@@ -95,9 +95,9 @@ describe( 'Checkout contact step VAT form', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
-		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).toBeChecked();
-		expect( await screen.findByLabelText( 'Business Tax ID Number' ) ).toBeInTheDocument();
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
+		expect( await screen.findByLabelText( 'VAT ID' ) ).toBeInTheDocument();
 	} );
 
 	it( 'does not render the Northern Ireland checkbox is if the VAT checkbox is checked and the country is EU', async () => {
@@ -105,10 +105,8 @@ describe( 'Checkout contact step VAT form', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'ES' );
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
-		expect(
-			screen.queryByLabelText( 'Is the tax ID for Northern Ireland?' )
-		).not.toBeInTheDocument();
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		expect( screen.queryByLabelText( 'Is VAT for Northern Ireland?' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the Northern Ireland checkbox is if the VAT checkbox is checked and the country is GB', async () => {
@@ -116,7 +114,7 @@ describe( 'Checkout contact step VAT form', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 		expect(
 			await screen.findByLabelText( 'Is the tax ID for Northern Ireland?' )
 		).toBeInTheDocument();
@@ -127,7 +125,7 @@ describe( 'Checkout contact step VAT form', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 		expect(
 			await screen.findByLabelText( 'Is the tax ID for Northern Ireland?' )
 		).toBeInTheDocument();
@@ -158,8 +156,8 @@ describe( 'Checkout contact step VAT form', () => {
 		const countryField = await screen.findByLabelText( 'Country' );
 
 		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
-		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).toBeChecked();
-		expect( await screen.findByLabelText( 'Business Tax ID Number' ) ).toBeInTheDocument();
+		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
+		expect( await screen.findByLabelText( 'VAT ID' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the VAT fields pre-filled if the VAT endpoint returns data', async () => {
@@ -183,7 +181,7 @@ describe( 'Checkout contact step VAT form', () => {
 		const countryField = await screen.findByLabelText( 'Country' );
 
 		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
-		expect( await screen.findByLabelText( 'Business Tax ID Number' ) ).toHaveValue( '12345' );
+		expect( await screen.findByLabelText( 'VAT ID' ) ).toHaveValue( '12345' );
 		expect( await screen.findByLabelText( 'Organization for tax ID' ) ).toHaveValue(
 			'Test company'
 		);
@@ -236,13 +234,13 @@ describe( 'Checkout contact step VAT form', () => {
 		const countryField = await screen.findByLabelText( 'Country' );
 
 		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
-		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).toBeChecked();
-		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).toBeDisabled();
+		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
+		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeDisabled();
 
 		// Try to click it anyway and make sure it does not change.
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
-		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).toBeChecked();
-		expect( await screen.findByLabelText( 'Business Tax ID Number' ) ).toBeInTheDocument();
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
+		expect( await screen.findByLabelText( 'VAT ID' ) ).toBeInTheDocument();
 	} );
 
 	it( 'sends data to the VAT endpoint when completing the step if the box is checked', async () => {
@@ -260,8 +258,8 @@ describe( 'Checkout contact step VAT form', () => {
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
-		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
@@ -289,11 +287,8 @@ describe( 'Checkout contact step VAT form', () => {
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
-		await user.type(
-			await screen.findByLabelText( 'Business Tax ID Number' ),
-			countryCode + vatId
-		);
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.type( await screen.findByLabelText( 'VAT ID' ), countryCode + vatId );
 		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
@@ -321,8 +316,8 @@ describe( 'Checkout contact step VAT form', () => {
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
-		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), 'CHE-' + vatId );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.type( await screen.findByLabelText( 'VAT ID' ), 'CHE-' + vatId );
 		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
@@ -350,8 +345,8 @@ describe( 'Checkout contact step VAT form', () => {
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
-		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), 'CHE' + vatId );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.type( await screen.findByLabelText( 'VAT ID' ), 'CHE' + vatId );
 		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
@@ -379,8 +374,8 @@ describe( 'Checkout contact step VAT form', () => {
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
-		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), 'che' + vatId );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.type( await screen.findByLabelText( 'VAT ID' ), 'che' + vatId );
 		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
@@ -421,8 +416,8 @@ describe( 'Checkout contact step VAT form', () => {
 
 		// Make sure the form has the autocompleted data.
 		expect( countryField.selectedOptions[ 0 ].value ).toBe( cachedContactCountry );
-		expect( await screen.findByLabelText( 'Add Business Tax ID details' ) ).toBeChecked();
-		expect( await screen.findByLabelText( 'Business Tax ID Number' ) ).toHaveValue( vatId );
+		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
+		expect( await screen.findByLabelText( 'VAT ID' ) ).toHaveValue( vatId );
 		expect( await screen.findByLabelText( 'Organization for tax ID' ) ).toHaveValue( vatName );
 		expect( await screen.findByLabelText( 'Address for tax ID' ) ).toHaveValue( vatAddress );
 
@@ -452,9 +447,9 @@ describe( 'Checkout contact step VAT form', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 		await user.click( await screen.findByLabelText( 'Is the tax ID for Northern Ireland?' ) );
-		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );
@@ -479,15 +474,15 @@ describe( 'Checkout contact step VAT form', () => {
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		// Check the box
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 
 		// Fill in the details
-		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 
 		// Uncheck the box
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
@@ -517,10 +512,10 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.type( await screen.findByLabelText( 'Postal code' ), postalCode );
 		// Check the box
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 
 		// Fill in the details
-		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 
@@ -569,15 +564,15 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.type( await screen.findByLabelText( 'Postal code' ), postalCode );
 		// Check the box
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 
 		// Fill in the details
-		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 
 		// Uncheck the box
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 
 		await user.click( screen.getByText( 'Continue' ) );
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();
@@ -618,10 +613,10 @@ describe( 'Checkout contact step VAT form', () => {
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.type( await screen.findByLabelText( 'Postal code' ), postalCode );
 		// Check the box
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 
 		// Fill in the details
-		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 
@@ -654,8 +649,8 @@ describe( 'Checkout contact step VAT form', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
-		await user.click( await screen.findByLabelText( 'Add Business Tax ID details' ) );
-		await user.type( await screen.findByLabelText( 'Business Tax ID Number' ), vatId );
+		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
+		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );
 		await user.type( await screen.findByLabelText( 'Organization for tax ID' ), vatName );
 		await user.type( await screen.findByLabelText( 'Address for tax ID' ), vatAddress );
 		await user.click( screen.getByText( 'Continue' ) );


### PR DESCRIPTION
## Proposed Changes

The checkout billing info/contact info form sometimes collects VAT information depending on the country chosen. Because the name of VAT changes based on country, it would be better to use a localized term. In https://github.com/Automattic/wp-calypso/pull/73686 we modified the labels for the VAT form use use the more generic term "Business Tax", but this is still a little unclear.

In this PR we switch each of these labels to replace "Business Tax" with the selected country's term for VAT (eg: "GST", "CT", etc.).

**NOTE:** this adds a good number of new strings. Make sure to translate these before merging!

**NOTE 2:** this does not alter the labels of other pages that interact with VAT, like `/me/purchases/vat-details`, because on those pages it's not as easy to tell what country we should use to determine the label. Updating those (if possible) will be the subject of a different PR.

Before:

<img width="570" alt="Screenshot 2023-03-16 at 4 05 16 PM" src="https://user-images.githubusercontent.com/2036909/225740277-00db52ee-85f1-437c-a617-69450d1af7b1.png">

After:

<img width="578" alt="Screenshot 2023-03-16 at 4 04 27 PM" src="https://user-images.githubusercontent.com/2036909/225740262-9bccf458-de14-4fcf-ae6c-60335851af84.png">

<img width="571" alt="Screenshot 2023-03-16 at 4 07 49 PM" src="https://user-images.githubusercontent.com/2036909/225740859-d640ff36-1c80-4d98-8df2-8a4e7ff6e535.png">


## Testing Instructions

- Add a product to your cart and visit checkout.
- Click to edit the billing details step if it is not already active.
- Select "United Kingdom" as the country.
- Check the VAT checkbox.
- Verify that the form mentions "VAT".
- Change the country to "Switzerland".
- Check the GST checkbox.
- Verify that the form mentions "GST".