### PR TITLE
Email Subscriptions: Create EmailFormatInput component

### DIFF
--- a/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
+++ b/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
@@ -1,5 +1,8 @@
+import { FormEvent } from 'react';
+import { EmailFormatInput, EmailFormatType } from '../fields/EmailFormatInput';
+
 type SubscriptionUserSettings = Partial< {
-	mail_option: 'html' | 'text';
+	mail_option: EmailFormatType;
 	delivery_day: number; // 0-6, 0 is Sunday
 	delivery_hour: number; // 0-23, 0 is midnight
 	blocked: boolean;
@@ -12,8 +15,15 @@ type UserSettingsProps = {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- until we start using any of these props
-const UserSettings = ( { value = {}, loading = false }: UserSettingsProps ) => (
-	<div className="user-settings">User settings will go here</div>
+const UserSettings = ( { value = {}, loading = false, onChange }: UserSettingsProps ) => (
+	<div className="user-settings">
+		<EmailFormatInput
+			value={ value.mail_option ?? 'html' }
+			onChange={ ( evt: FormEvent< HTMLSelectElement > ) =>
+				onChange?.( { mail_option: evt.currentTarget.value as EmailFormatType } )
+			}
+		/>
+	</div>
 );
 
 export default UserSettings;

--- a/packages/subscription-manager/src/components/fields/EmailFormatInput/EmailFormatInput.tsx
+++ b/packages/subscription-manager/src/components/fields/EmailFormatInput/EmailFormatInput.tsx
@@ -6,8 +6,10 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
 import './styles.scss';
 
+export type EmailFormatType = 'html' | 'text';
+
 type EmailFormatInputProps = {
-	value: string;
+	value: EmailFormatType;
 	onChange: FormEventHandler< HTMLSelectElement >;
 };
 

--- a/packages/subscription-manager/src/components/fields/EmailFormatInput/EmailFormatInput.tsx
+++ b/packages/subscription-manager/src/components/fields/EmailFormatInput/EmailFormatInput.tsx
@@ -1,0 +1,30 @@
+/* eslint-disable no-restricted-imports */
+import { useTranslate } from 'i18n-calypso';
+import { FormEventHandler } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSelect from 'calypso/components/forms/form-select';
+import './styles.scss';
+
+type EmailFormatInputProps = {
+	value: string;
+	onChange: FormEventHandler< HTMLSelectElement >;
+};
+
+const EmailFormatInput = ( { value, onChange }: EmailFormatInputProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<FormFieldset className="email-format-input">
+			<FormLabel htmlFor="subscription_delivery_mail_option">
+				{ translate( 'Email format' ) }
+			</FormLabel>
+			<FormSelect name="email_format_setting" onChange={ onChange } value={ value }>
+				<option value="html">{ translate( 'HTML' ) }</option>
+				<option value="text">{ translate( 'Plain Text' ) }</option>
+			</FormSelect>
+		</FormFieldset>
+	);
+};
+
+export default EmailFormatInput;

--- a/packages/subscription-manager/src/components/fields/EmailFormatInput/index.ts
+++ b/packages/subscription-manager/src/components/fields/EmailFormatInput/index.ts
@@ -1,0 +1,1 @@
+export { default as EmailFormatInput } from './EmailFormatInput';

--- a/packages/subscription-manager/src/components/fields/EmailFormatInput/index.ts
+++ b/packages/subscription-manager/src/components/fields/EmailFormatInput/index.ts
@@ -1,1 +1,2 @@
 export { default as EmailFormatInput } from './EmailFormatInput';
+export type { EmailFormatType } from './EmailFormatInput';

--- a/packages/subscription-manager/src/components/fields/EmailFormatInput/styles.scss
+++ b/packages/subscription-manager/src/components/fields/EmailFormatInput/styles.scss
@@ -1,0 +1,26 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@wordpress/base-styles/breakpoints";
+
+$arrow_down_base64: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTEiIGhlaWdodD0iNyIgdmlld0JveD0iMCAwIDExIDciIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0wLjkxNjYwNSAxLjMzMzVMNS40OTk5NCA1LjUwMDE2TDEwLjA4MzMgMS4zMzM1IiBzdHJva2U9IiM4QzhGOTQiIHN0cm9rZS13aWR0aD0iMS41Ii8+Cjwvc3ZnPgo=);
+
+.email-format-input {
+	.form-label {
+		color: $studio-black;
+		font-size: 1rem;
+		font-weight: 400;
+		line-height: 24px;
+	}
+
+	.form-select {
+		background: $studio-white $arrow_down_base64 no-repeat right 20px center;
+		border-radius: 4px;
+		border-color: $studio-gray-10;
+		color: $studio-gray-100;
+		margin-bottom: 32px;
+		width: 457px;
+
+		@media screen and ( max-width: $break-small ) {
+			width: 100%;
+		}
+	}
+}

--- a/packages/subscription-manager/src/components/fields/EmailFormatInput/styles.scss
+++ b/packages/subscription-manager/src/components/fields/EmailFormatInput/styles.scss
@@ -3,6 +3,10 @@
 @import "../components";
 
 .email-format-input {
+	&.form-fieldset {
+		@extend %form-fieldset;
+	}
+
 	.form-label {
 		@extend %form-label;
 	}

--- a/packages/subscription-manager/src/components/fields/EmailFormatInput/styles.scss
+++ b/packages/subscription-manager/src/components/fields/EmailFormatInput/styles.scss
@@ -1,22 +1,14 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@wordpress/base-styles/breakpoints";
-
-$arrow_down_base64: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTEiIGhlaWdodD0iNyIgdmlld0JveD0iMCAwIDExIDciIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0wLjkxNjYwNSAxLjMzMzVMNS40OTk5NCA1LjUwMDE2TDEwLjA4MzMgMS4zMzM1IiBzdHJva2U9IiM4QzhGOTQiIHN0cm9rZS13aWR0aD0iMS41Ii8+Cjwvc3ZnPgo=);
+@import "../components";
 
 .email-format-input {
 	.form-label {
-		color: $studio-black;
-		font-size: 1rem;
-		font-weight: 400;
-		line-height: 24px;
+		@extend %form-label;
 	}
 
 	.form-select {
-		background: $studio-white $arrow_down_base64 no-repeat right 20px center;
-		border-radius: 4px;
-		border-color: $studio-gray-10;
-		color: $studio-gray-100;
-		margin-bottom: 32px;
+		@extend %form-select;
 		width: 457px;
 
 		@media screen and ( max-width: $break-small ) {

--- a/packages/subscription-manager/src/components/fields/_components.scss
+++ b/packages/subscription-manager/src/components/fields/_components.scss
@@ -3,6 +3,10 @@
 
 $arrow_down_base64: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTEiIGhlaWdodD0iNyIgdmlld0JveD0iMCAwIDExIDciIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0wLjkxNjYwNSAxLjMzMzVMNS40OTk5NCA1LjUwMDE2TDEwLjA4MzMgMS4zMzM1IiBzdHJva2U9IiM4QzhGOTQiIHN0cm9rZS13aWR0aD0iMS41Ii8+Cjwvc3ZnPgo=);
 
+%form-fieldset {
+	margin-bottom: 32px;
+}
+
 %form-label {
 	color: $studio-black;
 	font-size: 1rem;
@@ -15,5 +19,4 @@ $arrow_down_base64: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTEiIGhlaWdodD
 	border-radius: 4px;
 	border-color: $studio-gray-10;
 	color: $studio-gray-100;
-	margin-bottom: 32px;
 }

--- a/packages/subscription-manager/src/components/fields/_components.scss
+++ b/packages/subscription-manager/src/components/fields/_components.scss
@@ -1,0 +1,19 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@wordpress/base-styles/breakpoints";
+
+$arrow_down_base64: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTEiIGhlaWdodD0iNyIgdmlld0JveD0iMCAwIDExIDciIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0wLjkxNjYwNSAxLjMzMzVMNS40OTk5NCA1LjUwMDE2TDEwLjA4MzMgMS4zMzM1IiBzdHJva2U9IiM4QzhGOTQiIHN0cm9rZS13aWR0aD0iMS41Ii8+Cjwvc3ZnPgo=);
+
+%form-label {
+	color: $studio-black;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 24px;
+}
+
+%form-select {
+	background: $studio-white $arrow_down_base64 no-repeat right 20px center;
+	border-radius: 4px;
+	border-color: $studio-gray-10;
+	color: $studio-gray-100;
+	margin-bottom: 32px;
+}

--- a/packages/subscription-manager/src/components/index.d.ts
+++ b/packages/subscription-manager/src/components/index.d.ts
@@ -89,3 +89,12 @@ declare module 'calypso/components/route' {
 		currentQuery: unknown;
 	};
 }
+
+declare module 'calypso/components/forms/form-fieldset' {
+	const FormFieldset: React.FC< {
+		className?: string;
+		children?: React.ReactNode;
+	} >;
+
+	export default FormFieldset;
+}

--- a/packages/subscription-manager/src/index.tsx
+++ b/packages/subscription-manager/src/index.tsx
@@ -1,10 +1,8 @@
 import { SubscriptionManagerContainer as SubscriptionManager } from './components/SubscriptionManagerContainer';
 import { TabsSwitcher } from './components/TabsSwitcher';
 import { UserSettings } from './components/UserSettings';
-import { EmailFormatInput } from './components/fields/EmailFormatInput';
 
 export default Object.assign( SubscriptionManager, {
-	EmailFormatInput,
 	TabsSwitcher,
 	UserSettings,
 } );

--- a/packages/subscription-manager/src/index.tsx
+++ b/packages/subscription-manager/src/index.tsx
@@ -1,8 +1,10 @@
 import { SubscriptionManagerContainer as SubscriptionManager } from './components/SubscriptionManagerContainer';
 import { TabsSwitcher } from './components/TabsSwitcher';
 import { UserSettings } from './components/UserSettings';
+import { EmailFormatInput } from './components/fields/EmailFormatInput';
 
 export default Object.assign( SubscriptionManager, {
+	EmailFormatInput,
 	TabsSwitcher,
 	UserSettings,
 } );


### PR DESCRIPTION
Resolves #74078

## Proposed Changes

* Create EmailFormatInput component
* Add EmailFormatInput on UserSettings tab

<img width="650" alt="image" src="https://user-images.githubusercontent.com/3113712/225753696-f69c11bd-16a0-437e-90ed-1aff75dae39e.png">

## Testing Instructions

* Deploy the PR on your local env
* Open http://calypso.localhost:3000/subscriptions/settings
* Verify if the selected is rendered as expected (state changes aren't covered)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
