### PR TITLE
Subscriber Detail: Provide correct avatar URL

### DIFF
--- a/client/data/followers/use-follower-query.js
+++ b/client/data/followers/use-follower-query.js
@@ -2,11 +2,27 @@ import { useQuery } from 'react-query';
 import wpcom from 'calypso/lib/wp';
 
 const useFollowerQuery = ( siteId, subscriberId, type ) => {
-	return useQuery( [ 'subscriber', subscriberId, type ], () =>
-		wpcom.req.get( {
-			path: `/sites/${ siteId }/followers/${ subscriberId }?type=${ type }&http_envelope=1`,
-			apiNamespace: 'rest/v1.1',
-		} )
+	/**
+	 * Normalizes a follower object. Changes 'avatar' to 'avatar_URL' allowing a follower
+	 * object to be used with the Gravatar component.
+	 *
+	 * @see normalizeFollower in client/data/followers/use-followers-query.js
+	 */
+	function normalizeFollower( follower ) {
+		return {
+			avatar_URL: follower.avatar,
+			...follower,
+		};
+	}
+
+	return useQuery(
+		[ 'subscriber', subscriberId, type ],
+		() =>
+			wpcom.req.get( {
+				path: `/sites/${ siteId }/followers/${ subscriberId }?type=${ type }&http_envelope=1`,
+				apiNamespace: 'rest/v1.1',
+			} ),
+		{ select: normalizeFollower }
 	);
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Introduced in #72153
## Proposed Changes

* Normalize followers in `useFollowerQuery`, similar to how `useFollowersQuery` does. 


See https://github.com/Automattic/wp-calypso/blob/trunk/client/data/followers/use-followers-query.js#L10-L25


Before | After
--- | ---
<img width="1510" alt="Screenshot 2023-03-16 at 2 20 32 PM" src="https://user-images.githubusercontent.com/1398304/225761212-76aaca76-94d6-40c7-8ad0-08545ba2a866.png"> | <img width="1510" alt="Screenshot 2023-03-16 at 2 20 23 PM" src="https://user-images.githubusercontent.com/1398304/225761207-412ea498-8992-46fa-a5f4-0d4fb5ff155e.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /people/subscribers/ on a site with subscribers.
* Click on a subscriber that has a Gravatar.
* Make sure the Gravatar still displays in the detail view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
