### PR TITLE
Migrate domain suggestions to create redux store

### DIFF
--- a/packages/data-stores/src/domain-suggestions/index.ts
+++ b/packages/data-stores/src/domain-suggestions/index.ts
@@ -1,4 +1,4 @@
-import { registerStore } from '@wordpress/data';
+import { register, createReduxStore } from '@wordpress/data';
 import { controls } from '../wpcom-request-controls';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
@@ -12,18 +12,11 @@ export * from './queries';
 export { getFormattedPrice } from './utils';
 export type { State };
 
-let isRegistered = false;
-
-export function register(): typeof STORE_KEY {
-	if ( ! isRegistered ) {
-		isRegistered = true;
-		registerStore( STORE_KEY, {
-			actions,
-			controls,
-			reducer,
-			resolvers,
-			selectors,
-		} );
-	}
-	return STORE_KEY;
-}
+export const store = createReduxStore( STORE_KEY, {
+	actions,
+	controls,
+	reducer,
+	resolvers,
+	selectors,
+} );
+register( store );

--- a/packages/data-stores/src/domain-suggestions/test/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/test/selectors.ts
@@ -1,6 +1,6 @@
 import { select, subscribe } from '@wordpress/data';
 import wpcomRequest from 'wpcom-proxy-request';
-import { register } from '..';
+import { store } from '..';
 import { DataStatus } from '../constants';
 
 jest.mock( 'wpcom-proxy-request', () => ( {
@@ -8,8 +8,6 @@ jest.mock( 'wpcom-proxy-request', () => ( {
 	default: jest.fn(),
 	requestAllBlogsAccess: jest.fn( () => Promise.resolve() ),
 } ) );
-
-let store: ReturnType< typeof register >;
 
 const options = {
 	category_slug: undefined,
@@ -27,7 +25,10 @@ const apiResponse = [
 		match_reasons: [ 'tld-common', 'tld-exact' ],
 		product_id: 78,
 		product_slug: 'dotsite_domain',
-		cost: '$25.00',
+		cost: '$25',
+		raw_price: 25,
+		currency_code: 'USD',
+		unavailable: false,
 	},
 	{
 		domain_name: 'hot-test-site.com',
@@ -37,13 +38,12 @@ const apiResponse = [
 		match_reasons: [ 'tld-common' ],
 		product_id: 6,
 		product_slug: 'domain_reg',
-		cost: '$18.00',
+		cost: '$18',
+		raw_price: 18,
+		currency_code: 'USD',
+		unavailable: false,
 	},
 ];
-
-beforeAll( () => {
-	store = register();
-} );
 
 beforeEach( () => {
 	( wpcomRequest as jest.Mock ).mockReset();
@@ -55,7 +55,7 @@ describe( 'getDomainSuggestions', () => {
 
 		const query = 'test query one';
 		const listenForStateUpdate = () => {
-			return new Promise( ( resolve ) => {
+			return new Promise< void >( ( resolve ) => {
 				const unsubscribe = subscribe( () => {
 					unsubscribe();
 					resolve();
@@ -88,7 +88,7 @@ describe( 'getDomainSuggestions', () => {
 
 		expect(
 			select( 'core/data' ).isResolving( store, 'getDomainSuggestions', [ query, options ] )
-		).toStrictEqual( false );
+		).toEqual( false );
 	} );
 } );
 
@@ -102,7 +102,7 @@ describe( 'getDomainErrorMessage', () => {
 
 		const query = 'test query two';
 		const listenForStateUpdate = () => {
-			return new Promise( ( resolve ) => {
+			return new Promise< void >( ( resolve ) => {
 				const unsubscribe = subscribe( () => {
 					unsubscribe();
 					resolve();

--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -1,6 +1,4 @@
-import * as selectors from './selectors';
 import type { DataStatus } from './constants';
-import type { SelectFromMap } from '../mapped-types';
 
 export interface DomainSuggestionQuery {
 	/**
@@ -254,5 +252,3 @@ export interface DomainSuggestionState {
 export type DomainAvailabilities = Record< string, DomainAvailability | undefined >;
 
 export type DomainSuggestionSelectorOptions = Partial< Exclude< DomainSuggestionQuery, 'query' > >;
-
-export type DomainSuggestionsSelect = SelectFromMap< typeof selectors >;

--- a/packages/domain-picker/src/components/domain-categories/index.tsx
+++ b/packages/domain-picker/src/components/domain-categories/index.tsx
@@ -1,3 +1,4 @@
+import { DomainSuggestions } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -5,8 +6,6 @@ import { Icon, chevronDown } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import * as React from 'react';
-import { DOMAIN_SUGGESTIONS_STORE } from '../../constants';
-import type { DomainSuggestionsSelect } from '@automattic/data-stores';
 
 import './style.scss';
 
@@ -25,7 +24,7 @@ const DomainPickerCategories: React.FunctionComponent< Props > = ( { onSelect, s
 	};
 
 	const domainCategories = useSelect(
-		( select ) => ( select( DOMAIN_SUGGESTIONS_STORE ) as DomainSuggestionsSelect ).getCategories(),
+		( select ) => select( DomainSuggestions.store ).getCategories(),
 		[]
 	);
 

--- a/packages/domain-picker/src/constants.ts
+++ b/packages/domain-picker/src/constants.ts
@@ -1,5 +1,3 @@
-import { DomainSuggestions } from '@automattic/data-stores';
-
 export const DOMAIN_SUGGESTIONS_TO_SHOW = 5;
 export const DOMAIN_SUGGESTIONS_TO_SHOW_EXPANDED = 10;
 export const DOMAIN_QUERY_MINIMUM_LENGTH = 2;
@@ -12,7 +10,5 @@ export const DOMAIN_QUERY_MINIMUM_LENGTH = 2;
  * @see https://stackoverflow.com/a/44755058/1432801
  */
 export const DOMAIN_SEARCH_DEBOUNCE_INTERVAL = 300;
-
-export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register();
 
 export const domainIsAvailableStatus = [ 'available', 'available_premium' ];

--- a/packages/domain-picker/src/hooks/use-domain-availabilities.ts
+++ b/packages/domain-picker/src/hooks/use-domain-availabilities.ts
@@ -1,11 +1,8 @@
+import { DomainSuggestions } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
-import { DOMAIN_SUGGESTIONS_STORE } from '../constants';
-import type { DomainSuggestionsSelect } from '@automattic/data-stores';
 
 export function useDomainAvailabilities() {
 	return useSelect( ( select ) => {
-		return (
-			select( DOMAIN_SUGGESTIONS_STORE ) as DomainSuggestionsSelect
-		 ).getDomainAvailabilities();
+		return select( DomainSuggestions.store ).getDomainAvailabilities();
 	}, [] );
 }

--- a/packages/domain-picker/src/hooks/use-domain-suggestions.ts
+++ b/packages/domain-picker/src/hooks/use-domain-suggestions.ts
@@ -1,18 +1,11 @@
+import { DomainSuggestions } from '@automattic/data-stores';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useDebounce } from 'use-debounce';
-import {
-	DOMAIN_SUGGESTIONS_STORE,
-	DOMAIN_SEARCH_DEBOUNCE_INTERVAL,
-	DOMAIN_QUERY_MINIMUM_LENGTH,
-} from '../constants';
+import { DOMAIN_SEARCH_DEBOUNCE_INTERVAL, DOMAIN_QUERY_MINIMUM_LENGTH } from '../constants';
 import type { DataStatus } from '@automattic/data-stores/src/domain-suggestions/constants';
-import type {
-	DomainSuggestion,
-	DomainSuggestionsSelect,
-} from '@automattic/data-stores/src/domain-suggestions/types';
 
 type DomainSuggestionsResult = {
-	allDomainSuggestions: DomainSuggestion[] | undefined;
+	allDomainSuggestions: DomainSuggestions.DomainSuggestion[] | undefined;
 	errorMessage: string | null;
 	state: DataStatus;
 	retryRequest: () => void;
@@ -27,7 +20,7 @@ export function useDomainSuggestions(
 ): DomainSuggestionsResult | undefined {
 	const [ domainSearch ] = useDebounce( searchTerm, DOMAIN_SEARCH_DEBOUNCE_INTERVAL );
 	const { invalidateResolutionForStoreSelector } = useDispatch(
-		DOMAIN_SUGGESTIONS_STORE
+		DomainSuggestions.store
 	) as unknown as {
 		invalidateResolutionForStoreSelector: ( selectorName: string ) => void;
 	};
@@ -41,11 +34,9 @@ export function useDomainSuggestions(
 			if ( ! domainSearch || domainSearch.length < DOMAIN_QUERY_MINIMUM_LENGTH ) {
 				return;
 			}
-			const {
-				getDomainSuggestions,
-				getDomainState,
-				getDomainErrorMessage,
-			}: DomainSuggestionsSelect = select( DOMAIN_SUGGESTIONS_STORE );
+			const { getDomainSuggestions, getDomainState, getDomainErrorMessage } = select(
+				DomainSuggestions.store
+			);
 
 			const allDomainSuggestions = getDomainSuggestions( domainSearch, {
 				// Avoid `only_wordpressdotcom` — it seems to fail to find results sometimes

--- a/packages/domain-picker/src/hooks/use-persistent-selected-domain.ts
+++ b/packages/domain-picker/src/hooks/use-persistent-selected-domain.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import type { DomainSuggestions } from '@automattic/data-stores';
 
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
@@ -14,10 +14,13 @@ export function usePersistentSelectedDomain(
 	>();
 
 	// Make a complete list of suggestions with the subdomain
-	const domainSuggestionsWithSubdomain =
-		existingSubdomain && Array.isArray( domainSuggestions )
-			? [ existingSubdomain, ...domainSuggestions ]
-			: domainSuggestions;
+	const domainSuggestionsWithSubdomain = useMemo(
+		() =>
+			existingSubdomain && Array.isArray( domainSuggestions )
+				? [ existingSubdomain, ...domainSuggestions ]
+				: domainSuggestions,
+		[ domainSuggestions, existingSubdomain ]
+	);
 
 	useEffect( () => {
 		const currentDomainIsInSuggestions = domainSuggestionsWithSubdomain?.some(


### PR DESCRIPTION
See #74399 for more details.

## Proposed Changes
Migrates the domain suggestions store to `createReduxStore`. 

~I skipped every reference under the gutenboarding section, which will be removed in #74475~

## Testing Instructions
Test the domain picker everywhere it's used:
- Site creation
- Calypso
- ??
