### PR TITLE
Checkout: Send correct tax data from one-click upsell to cart

### DIFF
--- a/client/lib/checkout/payment-methods.tsx
+++ b/client/lib/checkout/payment-methods.tsx
@@ -28,6 +28,18 @@ export interface PaymentMethod {
 	remember: '1' | '0';
 	stored_details_id: string;
 	user_id: string;
+	tax_location: StoredPaymentMethodTaxLocation | null;
+}
+
+export interface StoredPaymentMethodTaxLocation {
+	country_code?: string;
+	postal_code?: string;
+	subdivision_code?: string;
+	ip_address?: string;
+	vat_id?: string;
+	organization?: string;
+	address?: string;
+	city?: string;
 }
 
 export interface PaymentMethodMeta {

--- a/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
@@ -294,7 +294,7 @@ function convertValidationResponse( rawResponse: unknown ): DomainContactValidat
 	};
 }
 
-export async function wpcomValidateTaxContactInformation(
+async function wpcomValidateTaxContactInformation(
 	contactInformation: ContactValidationRequestContactInformation
 ): Promise< DomainContactValidationResponse > {
 	return wp.req

--- a/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/composite-checkout/lib/contact-validation.tsx
@@ -294,7 +294,7 @@ function convertValidationResponse( rawResponse: unknown ): DomainContactValidat
 	};
 }
 
-async function wpcomValidateTaxContactInformation(
+export async function wpcomValidateTaxContactInformation(
 	contactInformation: ContactValidationRequestContactInformation
 ): Promise< DomainContactValidationResponse > {
 	return wp.req

--- a/client/my-sites/checkout/composite-checkout/lib/update-cart-contact-details-for-checkout.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/update-cart-contact-details-for-checkout.ts
@@ -1,6 +1,5 @@
 import { getCountryPostalCodeSupport, getCountryTaxRequirements } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
-import contactDetailsFormFields from 'calypso/components/domains/contact-details-form-fields';
 import getContactDetailsType from '../lib/get-contact-details-type';
 import type { ResponseCart, UpdateTaxLocationInCart } from '@automattic/shopping-cart';
 import type {
@@ -38,12 +37,11 @@ export async function updateCartContactDetailsForCheckout(
 		debug( 'not updating cart contact details; countries are not loaded' );
 		return;
 	}
-	if ( ! arePostalCodesSupported ) {
-		debug( 'postal codes are not supported by', countryCode );
-	} else {
-		debug( 'postal codes are supported by', countryCode );
-	}
-	debug( 'contact details type is', contactDetailsFormFields );
+	debug(
+		`postal codes ${ arePostalCodesSupported ? 'are' : 'are not' } supported by`,
+		countryCode
+	);
+	debug( 'contact details type is', contactDetailsType );
 	debug( 'tax requirements for country are', taxRequirements );
 
 	// The tax form does not include a subdivisionCode field but the server

--- a/client/my-sites/checkout/composite-checkout/lib/update-cart-contact-details-for-checkout.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/update-cart-contact-details-for-checkout.ts
@@ -1,4 +1,5 @@
 import { getCountryPostalCodeSupport, getCountryTaxRequirements } from '@automattic/wpcom-checkout';
+import debugFactory from 'debug';
 import getContactDetailsType from '../lib/get-contact-details-type';
 import type { ResponseCart, UpdateTaxLocationInCart } from '@automattic/shopping-cart';
 import type {
@@ -6,6 +7,8 @@ import type {
 	CountryListItem,
 	VatDetails,
 } from '@automattic/wpcom-checkout';
+
+const debug = debugFactory( 'calypso:update-cart-contact-details-for-checkout' );
 
 /**
  * Update the shopping cart's tax location to adjust its prices.
@@ -28,7 +31,12 @@ export async function updateCartContactDetailsForCheckout(
 		contactInfo?.countryCode?.value ?? ''
 	);
 
-	if ( ! contactInfo || ! areCountriesLoaded ) {
+	if ( ! contactInfo ) {
+		debug( 'not updating cart contact details; there is no contact info' );
+		return;
+	}
+	if ( ! areCountriesLoaded ) {
+		debug( 'not updating cart contact details; countries are not loaded' );
 		return;
 	}
 
@@ -52,7 +60,7 @@ export async function updateCartContactDetailsForCheckout(
 		( taxRequirements.address ? contactInfo.address1?.value : undefined ) ??
 		'';
 
-	return updateLocation( {
+	const cartLocationData = {
 		// Typically the contact country code and the VAT country code will be the
 		// same, but the VAT form has special country codes it sometimes uses like
 		// `XI` for Northern Ireland so we keep track of them separately and will
@@ -64,5 +72,7 @@ export async function updateCartContactDetailsForCheckout(
 		organization,
 		address,
 		city: ( taxRequirements.city ? contactInfo.city?.value : undefined ) ?? '',
-	} );
+	};
+	debug( 'updating cart with', cartLocationData );
+	return updateLocation( cartLocationData );
 }

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -10,6 +10,7 @@ import { pick } from 'lodash';
 import page from 'page';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import QueryPaymentCountries from 'calypso/components/data/query-countries/payments';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
@@ -201,6 +202,7 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 				: upsellType;
 		return (
 			<Main className={ styleClass }>
+				<QueryPaymentCountries />
 				<QuerySites siteId={ selectedSiteId } />
 				<QueryStoredCards />
 				{ ! hasProductsList && <QueryProductsList /> }

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -19,8 +19,8 @@ import { Experiment } from 'calypso/lib/explat';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import { TITAN_MAIL_MONTHLY_SLUG, TITAN_MAIL_YEARLY_SLUG } from 'calypso/lib/titan/constants';
 import {
+	getTaxValidationResult,
 	isContactValidationResponseValid,
-	wpcomValidateTaxContactInformation,
 } from 'calypso/my-sites/checkout/composite-checkout/lib/contact-validation';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/get-thank-you-page-url';
 import ProfessionalEmailUpsell from 'calypso/my-sites/checkout/upsell-nudge/professional-email-upsell';
@@ -153,9 +153,15 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 		const storedCard = this.props.cards[ 0 ];
 
 		const validateContactDetails = async () => {
-			const validationResult = await wpcomValidateTaxContactInformation(
-				storedCard.tax_location ?? {}
-			);
+			const validationResult = await getTaxValidationResult( {
+				state: wrapValueInManagedValue( storedCard.tax_location?.subdivision_code ),
+				city: wrapValueInManagedValue( storedCard.tax_location?.city ),
+				postalCode: wrapValueInManagedValue( storedCard.tax_location?.postal_code ),
+				countryCode: wrapValueInManagedValue( storedCard.tax_location?.country_code ),
+				organization: wrapValueInManagedValue( storedCard.tax_location?.organization ),
+				address1: wrapValueInManagedValue( storedCard.tax_location?.address ),
+				vatId: wrapValueInManagedValue( storedCard.tax_location?.vat_id ),
+			} );
 			return isContactValidationResponseValid( validationResult );
 		};
 

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -519,8 +519,13 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 
 	renderPurchaseModal = () => {
 		const isCartUpdating = this.props.shoppingCartManager.isPendingUpdate;
-		const onCloseModal = () => {
-			this.props.shoppingCartManager.replaceProductsInCart( [] );
+		const onCloseModal = async () => {
+			try {
+				this.props.shoppingCartManager.updateLocation( { countryCode: '' } );
+				this.props.shoppingCartManager.replaceProductsInCart( [] );
+			} catch {
+				// No need to do anything if this fails.
+			}
 			this.setState( { showPurchaseModal: false } );
 		};
 

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -412,6 +412,7 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 			};
 
 			try {
+				debug( 'updating cart with contact info', contactInfo, vatDetails );
 				await updateCartContactDetailsForCheckout(
 					this.props.countries ?? [],
 					this.props.cart,

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -19,7 +19,7 @@ import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import { TITAN_MAIL_MONTHLY_SLUG, TITAN_MAIL_YEARLY_SLUG } from 'calypso/lib/titan/constants';
 import {
 	isContactValidationResponseValid,
-	getTaxValidationResult,
+	wpcomValidateTaxContactInformation,
 } from 'calypso/my-sites/checkout/composite-checkout/lib/contact-validation';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/get-thank-you-page-url';
 import ProfessionalEmailUpsell from 'calypso/my-sites/checkout/upsell-nudge/professional-email-upsell';
@@ -148,23 +148,11 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 		debug( 'validating contact info' );
 
 		const storedCard = this.props.cards[ 0 ];
-		const countryCode = extractStoredCardMetaValue( storedCard, 'country_code' ) ?? '';
-		const postalCode = extractStoredCardMetaValue( storedCard, 'card_zip' ) ?? '';
 
 		const validateContactDetails = async () => {
-			const contactInfo = {
-				postalCode: {
-					value: postalCode,
-					isTouched: true,
-					errors: [],
-				},
-				countryCode: {
-					value: countryCode,
-					isTouched: true,
-					errors: [],
-				},
-			};
-			const validationResult = await getTaxValidationResult( contactInfo );
+			const validationResult = await wpcomValidateTaxContactInformation(
+				storedCard.tax_location ?? {}
+			);
 			return isContactValidationResponseValid( validationResult );
 		};
 

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -414,25 +414,28 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 			};
 
 			try {
-				debug( 'updating cart with contact info', contactInfo, vatDetails );
-				await updateCartContactDetailsForCheckout(
-					this.props.countries ?? [],
-					this.props.cart,
-					this.props.shoppingCartManager.updateLocation,
+				debug(
+					'updating cart with contact info and product',
 					contactInfo,
-					vatDetails
+					vatDetails,
+					productToAdd
 				);
+				await Promise.all( [
+					updateCartContactDetailsForCheckout(
+						this.props.countries ?? [],
+						this.props.cart,
+						this.props.shoppingCartManager.updateLocation,
+						contactInfo,
+						vatDetails
+					),
+					this.props.shoppingCartManager.replaceProductsInCart( [ productToAdd ] ),
+				] );
 			} catch {
 				// If updating the cart fails, we should not continue. No need
 				// to do anything else, though, because CartMessages will
 				// display the error.
 				return false;
 			}
-
-			this.props.shoppingCartManager.replaceProductsInCart( [ productToAdd ] ).catch( () => {
-				// Nothing needs to be done here. CartMessages will display the error to the user.
-			} );
-			return;
 		}
 
 		// Professional Email needs to add the locally built cartItem to the cart,

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -2,7 +2,7 @@ import { isMonthly, getPlanByPathSlug, TERM_MONTHLY } from '@automattic/calypso-
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CompactCard, Gridicon } from '@automattic/components';
 import { withShoppingCart, createRequestCartProduct } from '@automattic/shopping-cart';
-import { ManagedContactDetails, VatDetails } from '@automattic/wpcom-checkout';
+import { CountryListItem, ManagedContactDetails, VatDetails } from '@automattic/wpcom-checkout';
 import { isURL } from '@wordpress/url';
 import debugFactory from 'debug';
 import { localize, useTranslate } from 'i18n-calypso';
@@ -106,6 +106,7 @@ export interface UpsellNudgeAutomaticProps extends WithShoppingCartProps {
 	cards: PaymentMethod[];
 	currentPlanTerm: string;
 	currentPlan?: object;
+	countries: CountryListItem[] | null;
 }
 
 export type UpsellNudgeProps = UpsellNudgeManualProps & UpsellNudgeAutomaticProps;

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
@@ -101,7 +101,7 @@ function PaymentMethodStep( { card, siteSlug }: { card: StoredCard; siteSlug: st
 		page( event.target.href );
 	}, [] );
 	// translators: %s will be replaced with the last 4 digits of a credit card.
-	const maskedCard = sprintf( translate( '**** %s' ), card?.card || '' );
+	const maskedCard = sprintf( translate( '**** %s' ), card.card || '' );
 
 	return (
 		<PurchaseModalStep id="payment-method">
@@ -112,13 +112,13 @@ function PaymentMethodStep( { card, siteSlug }: { card: StoredCard; siteSlug: st
 				</a>
 			</div>
 			<div className="purchase-modal__step-content">
-				<div className="purchase-modal__card-holder">{ card?.name }</div>
+				<div className="purchase-modal__card-holder">{ card.name }</div>
 				<div>
-					<PaymentLogo brand={ card?.card_type } isSummary={ true } />
+					<PaymentLogo brand={ card.card_type } isSummary={ true } />
 					<span className="purchase-modal__card-number">{ maskedCard }</span>
 					<span className="purchase-modal__card-expiry">{ `${ translate(
 						'Expiry:'
-					) } ${ formatDate( card?.expiry ) }` }</span>
+					) } ${ formatDate( card.expiry ) }` }</span>
 				</div>
 			</div>
 		</PurchaseModalStep>
@@ -203,6 +203,8 @@ export default function PurchaseModalContent( {
 } ) {
 	const translate = useTranslate();
 	const creditsLineItem = getCreditsLineItemFromCart( cart );
+	const firstProduct = cart.products.length > 0 ? cart.products[ 0 ] : undefined;
+	const firstCard = cards.length > 0 ? cards[ 0 ] : undefined;
 
 	return (
 		<>
@@ -214,13 +216,13 @@ export default function PurchaseModalContent( {
 			>
 				<Gridicon icon="cross-small" />
 			</Button>
-			<OrderStep siteSlug={ siteSlug } product={ cart.products?.[ 0 ] } />
-			<PaymentMethodStep siteSlug={ siteSlug } card={ cards?.[ 0 ] } />
+			{ firstProduct && <OrderStep siteSlug={ siteSlug } product={ firstProduct } /> }
+			{ firstCard && <PaymentMethodStep siteSlug={ siteSlug } card={ firstCard } /> }
 			<CheckoutTerms cart={ cart } />
 			<hr />
 			<OrderReview
 				creditsLineItem={ cart.sub_total_integer > 0 ? creditsLineItem : null }
-				shouldDisplayTax={ cart.tax?.display_taxes }
+				shouldDisplayTax={ cart.tax.display_taxes }
 				total={ formatCurrency( cart.total_cost_integer, cart.currency, {
 					isSmallestUnit: true,
 					stripZeros: true,

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -12,7 +12,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { BEFORE_SUBMIT } from './constants';
 import Content from './content';
 import Placeholder from './placeholder';
-import { useSubmitTransaction, extractStoredCardMetaValue } from './util';
+import { useSubmitTransaction } from './util';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type { ManagedValue } from '@automattic/wpcom-checkout';
 import type { PaymentProcessorOptions } from 'calypso/my-sites/checkout/composite-checkout/types/payment-processors';
@@ -57,7 +57,7 @@ export function PurchaseModal( {
 	);
 }
 
-function wrapValueInManagedValue( value: string | undefined ): ManagedValue {
+export function wrapValueInManagedValue( value: string | undefined ): ManagedValue {
 	return {
 		value: value ?? '',
 		isTouched: true,
@@ -80,8 +80,6 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 	const includeDomainDetails = contactDetailsType === 'domain';
 	const includeGSuiteDetails = contactDetailsType === 'gsuite';
 	const storedCard = props.cards[ 0 ];
-	const countryCode = extractStoredCardMetaValue( storedCard, 'country_code' );
-	const postalCode = extractStoredCardMetaValue( storedCard, 'card_zip' );
 	const dataForProcessor: PaymentProcessorOptions = useMemo(
 		() => ( {
 			createUserAndSiteBeforeTransaction: false,
@@ -95,13 +93,12 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 			stripe,
 			stripeConfiguration,
 			contactDetails: {
-				countryCode: wrapValueInManagedValue( countryCode ),
-				postalCode: wrapValueInManagedValue( postalCode ),
+				countryCode: wrapValueInManagedValue( storedCard.tax_location?.country_code ),
+				postalCode: wrapValueInManagedValue( storedCard.tax_location?.postal_code ),
 			},
 		} ),
 		[
-			countryCode,
-			postalCode,
+			storedCard,
 			includeDomainDetails,
 			includeGSuiteDetails,
 			stripe,

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/util.ts
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/util.ts
@@ -6,10 +6,6 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
 import type { StoredCard } from 'calypso/my-sites/checkout/composite-checkout/types/stored-cards';
 
-export function extractStoredCardMetaValue( card: StoredCard, key: string ): string | undefined {
-	return card.meta?.find( ( meta ) => meta.meta_key === key )?.meta_value;
-}
-
 type SetStep = ( step: string ) => void;
 type OnClose = () => void;
 type SubmitTransactionFunction = () => void;


### PR DESCRIPTION
## Proposed Changes

This PR modifies the one-click upsell dialog to correctly send tax data from the saved card to the shopping cart.

<img width="500" alt="Screenshot 2023-03-20 at 2 01 09 PM" src="https://user-images.githubusercontent.com/2036909/226428098-08771c40-3c68-4c59-a478-30986e94fcda.png">

Requires D105292-code

Fixes https://github.com/Automattic/payments-shilling/issues/1471

## Testing Instructions

Make sure that D105292-code is applied.

- Use an account that has at least one saved credit card that includes tax info (any card that has a recent purchase in a taxable jurisdiction should work).
- With this PR running, visit `/checkout/example.com/offer-plan-upgrade/business/12345` but replace `example.com` with your test site.
- In your browser's JS console run `localStorage.setItem('debug', 'calypso:upsell-nudge')` and reload the page to view debug info.
- Click to agree to the upsell.
- In your browser's JS console, verify that you see `updating cart with contact info and product` and that it includes some objects that contain contact information; that contact information comes from the card data and will be used to construct the tax data for the cart.
- In your browser's network devtools, go to the most recent POST request to the `/me/shopping-cart` endpoint and verify that it includes the same info in the `tax` field.

<img width="222" alt="Screenshot 2023-03-20 at 3 21 53 PM" src="https://user-images.githubusercontent.com/2036909/226462530-df551fcd-6035-43ac-bd3a-8c8d68080efc.png">

