### PR TITLE
Staging Sites: Customize progress message depending on the user

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -16,8 +16,9 @@ import { useCheckStagingSiteStatus } from 'calypso/my-sites/hosting/staging-site
 import { useStagingSite } from 'calypso/my-sites/hosting/staging-site-card/use-staging-site';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSite } from 'calypso/state/ui/selectors';
 
 const stagingSiteAddFailureNoticeId = 'staging-site-add-failure';
 
@@ -40,7 +41,7 @@ const StyledLoadingBar = styled( LoadingBar )( {
 	marginBottom: '1em',
 } );
 
-const StagingSiteCard = ( { disabled, siteId, translate } ) => {
+const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId, translate } ) => {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
@@ -169,13 +170,17 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 	};
 
 	const getTransferringStagingSiteContent = useCallback( () => {
+		const message =
+			siteOwnerId === currentUserId
+				? __( 'We are setting up your staging site. We’ll email you once it is ready.' )
+				: __( 'We are setting up the staging site. We’ll email the site owner once it is ready.' );
 		return (
 			<>
 				<StyledLoadingBar progress={ progress } />
-				<p>{ __( 'We are setting up your staging site. We’ll email you once it is ready.' ) }</p>
+				<p>{ message }</p>
 			</>
 		);
-	}, [ progress, __ ] );
+	}, [ progress, __, siteOwnerId, currentUserId ] );
 
 	const getLoadingStagingSitesPlaceholder = () => {
 		return (
@@ -223,9 +228,13 @@ const StagingSiteCard = ( { disabled, siteId, translate } ) => {
 };
 
 export default connect( ( state ) => {
+	const currentUserId = getCurrentUserId( state );
 	const siteId = getSelectedSiteId( state );
+	const siteOwnerId = getSelectedSite( state )?.site_owner;
 
 	return {
+		currentUserId,
 		siteId,
+		siteOwnerId,
 	};
 } )( localize( StagingSiteCard ) );


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/1857

## Proposed Changes

Uses a different progress message depending on whether or not the user is the site owner.

### Non-site owner

![CleanShot 2023-03-17 at 08 37 28@2x](https://user-images.githubusercontent.com/36432/225843181-ceb2b60f-f6ab-4dab-969d-767df69c2cbe.png)

### Site owner

![CleanShot 2023-03-17 at 08 38 58@2x](https://user-images.githubusercontent.com/36432/225843253-5c383791-dc81-4ac9-b2b1-a143b8fd9981.png)

## Testing Instructions

1. Create a new Business site and take it Atomic.
2. Apply D105036-code to your sandbox if it isn't yet committed. 
3. Navigate to Hosting Configuration.
4. Click 'Add staging site' and verify the message appears as expected to the site owner.
5. Delete the staging site.
6. Add another user as an administrator to the site.
7. Navigate to Hosting Configuration under that user.
8. Click 'Add staging site' and verify the message appears as expected to the non-site owner.