### PR TITLE
Revert the new "Offer Jetpack Complete" Jetpack post-connection page.

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -91,7 +91,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
-		"jetpack/offer-complete-after-activation": true,
+		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -58,7 +58,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
-		"jetpack/offer-complete-after-activation": true,
+		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/production.json
+++ b/config/production.json
@@ -64,7 +64,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack-social/advanced-plan": false,
-		"jetpack/offer-complete-after-activation": true,
+		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -61,7 +61,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack-social/advanced-plan": true,
-		"jetpack/offer-complete-after-activation": true,
+		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -69,7 +69,7 @@
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack-social/advanced-plan": false,
-		"jetpack/offer-complete-after-activation": true,
+		"jetpack/offer-complete-after-activation": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,


### PR DESCRIPTION
**TLDR;**
This PR reverts the **PT: Offer Jetpack Complete immediately after the main plugin activation** ( p1HpG7-jYo-p2 ) Jetpack plugin post-connection page/project and sets it back to the Jetpack Cloud Pricing page (the `wordpress.com/jetpack/connect/plans` version).
<hr/>
Upon a thorough analysis done by @simonktnga8c via P2 post: "**The new Jetpack Complete card during signup &mdash; how is it performing?**" ( pbNhbs-5JE-p2 ), it was found that this change/project resulted in poor/limited performance and therefore it was decided to revert back ( pbNhbs-5JE-p2#comment-14031 ) to the previous post-connection page (The Jetpack Cloud Pricing page).


.
### Implementation details:

Fortunately, the new "Offer Jetpack Complete" post-connection page was implemented behind the `jetpack/offer-complete-after-activation` feature-flag in Calypso, allowing us to easily enable and/or disable it.
This PR disables (sets the value to `false`) the `jetpack/offer-complete-after-activation` feature-flag in all Calypso blue (wordpress.com) environments.
These environments are defined in 6 files:
- config/production.json
- config/stage.json
- config/horizon.json
- config/wpcalypso.json
- config/test.json (This one is already set to "false")
- config/development.json

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Asana Task: 1198218726984184-as-1204195289136223/f

## Testing Instructions

**Prerequisites:**
Make sure you are logged into your A18N wordpress.com account.

**Test this PR**
- Git checkout this PR/branch and spin up Calypso blue: `git fetch && git checkout revert/offer-jetpack-complete-post-connection-page  && yarn start`
- Create Jurassic Ninja site.
- Connect Jetpack: Click the "Set up Jetpack" button.
- You should be taken to the authorization page. On this page, in the URL, replace `https://wordpress.com` with `http://calypso.localhost:3000` & reload the page.
- Click the "Approve" button.
- Verify you are redirected to the Jetpack connect pricing page: http://calypso.localhost:3000/jetpack/connect/plans/:site?various-query-args&somekey=someval&etc

**To view previous connection behavior before this PR:**
- On the pricing page, click "Start for free", so then you should be redirected back to the Jetpack plugin.
- Now go to the wp-admin Jetpack Dashboard. (Jetpack --> Dashboard). Scroll down to the "Site connection" section and click "Manage site connection" --> "Disconnect" --> "No thank you".
- Click the "Set up Jetpack" button again.
- This time on the authorization page, just click "Approve" _without_ changing the URL to calypso.localhost:3000 (staying in production).
- Verify you are redirected to the new "Offer Jetpack Complete" post-connection page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?