### PR TITLE
Jetpack Pro Dashboard: fix monitor column content alignment

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
@@ -14,8 +14,12 @@
 	@extend .inline-flex-align-centre;
 	width: max-content;
 
-	.components-toggle-control .components-base-control__field {
+	.components-toggle-control {
 		margin-bottom: 0;
+
+		.components-base-control__field {
+			margin-bottom: 0;
+		}
 
 		.components-form-toggle {
 			margin-right: 4px;


### PR DESCRIPTION
Related to 1202619025189113-as-1204200803174790

#### Proposed Changes

This PR fixes the issue in monitor column content alignment.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/monitor-data-ui-fixes` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that the monitor column content is vertically center aligned

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="260" alt="Screenshot 2023-03-17 at 1 53 29 PM" src="https://user-images.githubusercontent.com/10586875/225852287-530e0aa1-29ae-4c04-add5-d8e520bc9a19.png">
</td>
<td>
<img width="228" alt="Screenshot 2023-03-17 at 1 53 52 PM" src="https://user-images.githubusercontent.com/10586875/225852299-59cf3328-09c4-4140-babb-7aab1df35b80.png">
</td>
</tr>
</table>


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?