### PR TITLE
Plans: update copy for commerce features

### DIFF
--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -236,10 +236,12 @@ export type FeatureObject = {
 	getSlug: () => string;
 	getTitle: ( domainName?: string ) => TranslateResult;
 	getAlternativeTitle?: () => TranslateResult;
+	getConditionalTitle?: () => TranslateResult;
 	getHeader?: () => TranslateResult;
 	getDescription?: ( domainName?: string ) => TranslateResult;
 	getStoreSlug?: () => string;
 	getCompareTitle?: () => TranslateResult;
+	getCompareSubtitle?: () => TranslateResult;
 	getIcon?: () => string | { icon: string; component: MemoExoticComponent< any > } | JSX.Element;
 	isPlan?: boolean;
 };
@@ -1047,6 +1049,8 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate(
 				'Ship physical products in a snap and show live rates from shipping carriers like UPS and other shipping options.'
 			),
+		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 
 	[ FEATURE_UNLIMITED_PRODUCTS_SERVICES ]: {
@@ -1843,6 +1847,8 @@ export const FEATURES_LIST: FeatureList = {
 		getSlug: () => FEATURE_SELL_SHIP,
 		getTitle: () => i18n.translate( 'Sell and ship products' ),
 		getDescription: () => i18n.translate( 'Sell and ship out physical goods from your site.' ),
+		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	[ FEATURE_CUSTOM_STORE ]: {
 		getSlug: () => FEATURE_CUSTOM_STORE,
@@ -1851,12 +1857,16 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate(
 				'Offer customers a personalized shopping experience that they cannot find anywhere else.'
 			),
+		getConditionalTitle: () => i18n.translate( 'Available with plugins and themes' ),
+		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	[ FEATURE_INVENTORY ]: {
 		getSlug: () => FEATURE_INVENTORY,
 		getTitle: () => i18n.translate( 'Inventory management' ),
 		getDescription: () =>
 			i18n.translate( 'Stay on top of your stock with inventory management tools.' ),
+		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	[ FEATURE_CHECKOUT ]: {
 		getSlug: () => FEATURE_CHECKOUT,
@@ -1865,12 +1875,16 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate(
 				'Reduce cart abandonment and increase sales with a fast, low-friction checkout.'
 			),
+		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	[ FEATURE_ACCEPT_PAYMENTS_V2 ]: {
 		getSlug: () => FEATURE_ACCEPT_PAYMENTS_V2,
 		getTitle: () => i18n.translate( 'Payments in 60+ countries' ),
 		getDescription: () =>
 			i18n.translate( 'Accept payments for goods and services, just about anywhere.' ),
+		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	[ FEATURE_SALES_REPORTS ]: {
 		getSlug: () => FEATURE_SALES_REPORTS,
@@ -1879,12 +1893,16 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate(
 				'Stay up to date on sales and identify trends with intuitive sales reports.'
 			),
+		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	[ FEATURE_EXTENSIONS ]: {
 		getSlug: () => FEATURE_EXTENSIONS,
 		getTitle: () => i18n.translate( 'Extensions marketplace' ),
 		getDescription: () =>
 			i18n.translate( 'Find and install powerful add-ons for your site, all in one place.' ),
+		getConditionalTitle: () => i18n.translate( 'Available with plugins' ),
+		getCompareSubtitle: () => i18n.translate( 'Seamlessly integrated with your plan' ),
 	},
 	// FOLLOWING ARE JETPACK FEATURES BUNDLED IN WPCOM
 	[ FEATURE_STATS_JP ]: {

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -113,6 +113,7 @@ const Row = styled.div< { isHiddenInMobile?: boolean; className?: string } >`
 
 	${ plansBreakSmall( css`
 		display: flex;
+		align-items: center;
 		margin: 0 20px;
 		padding: 12px 0;
 		border-bottom: 1px solid #eee;
@@ -120,6 +121,7 @@ const Row = styled.div< { isHiddenInMobile?: boolean; className?: string } >`
 `;
 
 const PlanRow = styled( Row )`
+	align-items: stretch;
 	&:last-of-type {
 		display: none;
 	}
@@ -136,6 +138,7 @@ const PlanRow = styled( Row )`
 `;
 
 const TitleRow = styled( Row )`
+	align-items: stretch;
 	cursor: pointer;
 	display: flex;
 

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -113,7 +113,6 @@ const Row = styled.div< { isHiddenInMobile?: boolean; className?: string } >`
 
 	${ plansBreakSmall( css`
 		display: flex;
-		align-items: center;
 		margin: 0 20px;
 		padding: 12px 0;
 		border-bottom: 1px solid #eee;
@@ -121,7 +120,6 @@ const Row = styled.div< { isHiddenInMobile?: boolean; className?: string } >`
 `;
 
 const PlanRow = styled( Row )`
-	align-items: stretch;
 	&:last-of-type {
 		display: none;
 	}
@@ -138,7 +136,6 @@ const PlanRow = styled( Row )`
 `;
 
 const TitleRow = styled( Row )`
-	align-items: stretch;
 	cursor: pointer;
 	display: flex;
 
@@ -203,7 +200,8 @@ const RowTitleCell = styled.div`
 	display: none;
 	font-size: 14px;
 	${ plansBreakSmall( css`
-		display: block;
+		display: flex;
+		align-items: center;
 		flex: 1;
 		min-width: 290px;
 	` ) }

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -151,7 +151,7 @@ const Cell = styled.div< { textAlign?: 'start' | 'center' | 'end' } >`
 	text-align: ${ ( props ) => props.textAlign ?? 'start' };
 	display: flex;
 	flex: 1;
-	justify-content: center;
+	justify-content: flex-start;
 	flex-direction: column;
 	align-items: center;
 	padding: 33px 20px 0;
@@ -184,6 +184,7 @@ const Cell = styled.div< { textAlign?: 'start' | 'center' | 'end' } >`
 	${ plansBreakSmall( css`
 		padding: 0 14px;
 		border-right: none;
+		justify-content: center;
 
 		&:first-of-type {
 			padding-inline-start: 0;

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -952,7 +952,15 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 			@extend %plan-comparison-grid__plan-subtitle;
 		}
 
-		&:not(.has-feature) {
+		.plan-comparison-grid__plan-conditional-title {
+			@extend %plan-comparison-grid__plan-subtitle;
+			@include plans-2023-break-small {
+				color: unset;
+				margin-bottom: 0;
+			}
+		}
+
+		&:not(.has-feature):not(.has-conditional-feature) {
 			.plan-comparison-grid__plan-title,
 			.plan-comparison-grid__plan-subtitle {
 				text-decoration: line-through;

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1203,6 +1203,17 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_PLUGIN_AUTOUPDATE_JP,
 		FEATURE_SEO_JP,
 	],
+	get2023PlanComparisonConditionalFeatures: () => [
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_SELL_SHIP,
+		FEATURE_CUSTOM_STORE,
+		FEATURE_INVENTORY,
+		FEATURE_CHECKOUT,
+		FEATURE_ACCEPT_PAYMENTS_V2,
+		FEATURE_SALES_REPORTS,
+		FEATURE_SHIPPING_CARRIERS,
+		FEATURE_EXTENSIONS,
+	],
 	get2023PricingGridSignupStorageOptions: () => [ FEATURE_200GB_STORAGE ],
 	// Features not displayed but used for checking plan abilities
 	getIncludedFeatures: () => [

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -179,6 +179,12 @@ export type Plan = BillingTerm & {
 	 */
 	get2023PlanComparisonJetpackFeatureOverride?: () => Feature[];
 
+	/**
+	 * Features that are conditionally available and are to be shown in the plans comparison table.
+	 * For example: "Available with plugins"
+	 */
+	get2023PlanComparisonConditionalFeatures?: () => Feature[];
+
 	get2023PricingGridSignupStorageOptions?: () => Feature[];
 	getProductId: () => number;
 	getPathSlug?: () => string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1624

## Proposed Changes

1. On tablet and above resolutions, under "Commerce Solutions", the Business plan features should be "Available with plugins" or "Available with plugins and themes" instead of the check/dash icon, depending on the feature.
<img width="1708" alt="image" src="https://user-images.githubusercontent.com/5436027/225853466-33a3d67f-1c86-4f6d-b7dc-653be80cd94d.png">

2. On mobile, the same text should be shown as a subtitle for the Business plan.
3. On mobile, under "Commerce Solutions", the subtitle for the Commerce plan features should be "Seamlessly integrated with your plan"
<img width="759" alt="image" src="https://user-images.githubusercontent.com/5436027/225853963-6d81746d-5d11-4d9c-97dd-ee177deb1df1.png">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` and open the comparison table. 
* Confirm that the above changes are reflected for all resolutions.
* Go to `/plans/<site slug>` and confirm the same.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? - **_TBD after the PR is approved._**
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
