### PR TITLE
Remove minification bug workaround

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
+++ b/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
@@ -5,12 +5,6 @@ import { sprintf, __ } from '@wordpress/i18n';
 import config from '../config';
 import { ApiPricingPlan } from '../types.js';
 
-/**
- * This URL is broken down into parts due to 119-gh-Automattic/lighthouse-forums
- */
-const PLANS_API_URL =
-	'https' + '://' + 'public-api.wordpress.com/rest/v1.5/plans?locale=' + config.locale;
-
 export interface BlockPlan extends Plan {
 	productSlug: string;
 	pathSlug: string;
@@ -58,7 +52,9 @@ const usePricingPlans = () => {
 			setIsLoading( true );
 			setError( null );
 			try {
-				const response = await fetch( PLANS_API_URL );
+				const response = await fetch(
+					'https://public-api.wordpress.com/rest/v1.5/plans?locale=' + config.locale
+				);
 				const data = await response.json();
 				setPlans( parsePlans( data ) );
 			} catch ( e: unknown ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

In this Pull Request we're removing a workaround we did to avoid a minification problem we found and documented in 119-gh-Automattic/lighthouse-forums.

After having undone this workaround I was not able to reproduce the problem on my sandbox and the built assets seem to have the correct output so far.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync these changes with `yarn dev --sync`
* Ensure the issue reported in 119-gh-Automattic/lighthouse-forums is still not present.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
