### PR TITLE
Data Stores: Refactor `ProductsList` store to `createReduxStore()`

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -1,15 +1,16 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+import { ProductsList } from '@automattic/data-stores';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { ONBOARD_STORE, PRODUCTS_LIST_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import type { Step } from '../../types';
-import type { ProductsListSelect, OnboardSelect } from '@automattic/data-stores';
+import type { OnboardSelect } from '@automattic/data-stores';
 
 import './style.scss';
 
@@ -21,7 +22,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		( select ) => ( {
 			siteTitle: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteTitle(),
 			domain: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),
-			productsList: ( select( PRODUCTS_LIST_STORE ) as ProductsListSelect ).getProductsList(),
+			productsList: select( ProductsList.store ).getProductsList(),
 		} ),
 		[]
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/upgrade-modal.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/components';
+import { ProductsList } from '@automattic/data-stores';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import classNames from 'classnames';
@@ -7,10 +8,8 @@ import i18n, { useTranslate } from 'i18n-calypso';
 import wooCommerceImage from 'calypso/assets/images/onboarding/woo-commerce.svg';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useThemeDetails } from 'calypso/landing/stepper/hooks/use-theme-details';
-import { PRODUCTS_LIST_STORE } from 'calypso/landing/stepper/stores';
 import ThemeFeatures from './theme-features';
 import './upgrade-modal.scss';
-import type { ProductsListSelect } from '@automattic/data-stores';
 
 interface UpgradeModalProps {
 	/* Theme slug */
@@ -38,13 +37,11 @@ const UpgradeModal = ( { slug, isOpen, closeModal, checkout }: UpgradeModalProps
 	const showBundleVersion = theme_software_set;
 
 	const premiumPlanProduct = useSelect(
-		( select ) =>
-			( select( PRODUCTS_LIST_STORE ) as ProductsListSelect ).getProductBySlug( 'value_bundle' ),
+		( select ) => select( ProductsList.store ).getProductBySlug( 'value_bundle' ),
 		[]
 	);
 	const businessPlanProduct = useSelect(
-		( select ) =>
-			( select( PRODUCTS_LIST_STORE ) as ProductsListSelect ).getProductBySlug( 'business-bundle' ),
+		( select ) => select( ProductsList.store ).getProductBySlug( 'business-bundle' ),
 		[]
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/index.tsx
@@ -1,15 +1,16 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+import { ProductsList } from '@automattic/data-stores';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import ReskinSideExplainer from 'calypso/components/domains/reskin-side-explainer';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { ONBOARD_STORE, PRODUCTS_LIST_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { SenseiStepContainer } from '../components/sensei-step-container';
 import type { Step } from '../../types';
-import type { OnboardSelect, ProductsListSelect } from '@automattic/data-stores';
+import type { OnboardSelect } from '@automattic/data-stores';
 
 import './style.scss';
 
@@ -20,7 +21,7 @@ const SenseiDomain: Step = ( { navigation } ) => {
 		( select ) => ( {
 			siteTitle: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteTitle(),
 			domain: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),
-			productsList: ( select( PRODUCTS_LIST_STORE ) as ProductsListSelect ).getProductsList(),
+			productsList: select( ProductsList.store ).getProductsList(),
 		} ),
 		[]
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/sensei-plan-products.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/sensei-plan-products.ts
@@ -1,12 +1,9 @@
+import { ProductsList } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { useSelect } from '@wordpress/data';
 import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
-import { PLANS_STORE, PRODUCTS_LIST_STORE } from 'calypso/landing/stepper/stores';
-import type {
-	PlanBillingPeriod,
-	PlansSelect,
-	ProductsListSelect,
-} from 'calypso/../packages/data-stores';
+import { PLANS_STORE } from 'calypso/landing/stepper/stores';
+import type { PlanBillingPeriod, PlansSelect } from 'calypso/../packages/data-stores';
 
 const SENSEI_PRO_PRODUCT_YEARLY = 'sensei_pro_yearly';
 const SENSEI_PRO_PRODUCT_MONTHLY = 'sensei_pro_monthly';
@@ -15,7 +12,7 @@ export function useSenseiProPricing( billingPeriod: PlanBillingPeriod ) {
 	return useSelect(
 		( select ) => {
 			const isYearly = billingPeriod === 'ANNUALLY';
-			const { getProductBySlug }: ProductsListSelect = select( PRODUCTS_LIST_STORE );
+			const { getProductBySlug } = select( ProductsList.store );
 			const yearly = getProductBySlug( SENSEI_PRO_PRODUCT_YEARLY );
 			const monthly = getProductBySlug( SENSEI_PRO_PRODUCT_MONTHLY );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/sensei-plan-products.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/sensei-plan-products.ts
@@ -3,7 +3,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useSelect } from '@wordpress/data';
 import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
 import { PLANS_STORE } from 'calypso/landing/stepper/stores';
-import type { PlanBillingPeriod, PlansSelect } from 'calypso/../packages/data-stores';
+import type { PlanBillingPeriod, PlansSelect } from '@automattic/data-stores';
 
 const SENSEI_PRO_PRODUCT_YEARLY = 'sensei_pro_yearly';
 const SENSEI_PRO_PRODUCT_MONTHLY = 'sensei_pro_monthly';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/woo-confirm/index.tsx
@@ -1,3 +1,4 @@
+import { ProductsList } from '@automattic/data-stores';
 import { StepContainer } from '@automattic/onboarding';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -14,7 +15,6 @@ import {
 	AUTOMATED_ELIGIBILITY_STORE,
 	SITE_STORE,
 	ONBOARD_STORE,
-	PRODUCTS_LIST_STORE,
 } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -22,7 +22,7 @@ import { ActionSection, StyledNextButton } from 'calypso/signup/steps/woocommerc
 import { eligibilityHolds as eligibilityHoldsConstants } from 'calypso/state/automated-transfer/constants';
 import SupportCard from '../store-address/support-card';
 import type { Step } from '../../types';
-import type { ProductsListSelect, OnboardSelect, SiteSelect } from '@automattic/data-stores';
+import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
 import type { TransferEligibilityError } from '@automattic/data-stores/src/automated-transfer-eligibility/types';
 import './style.scss';
 
@@ -102,7 +102,7 @@ const WooConfirm: Step = function WooCommerceConfirm( { navigation } ) {
 		[ siteId ]
 	);
 	const productsList = useSelect(
-		( select ) => ( select( PRODUCTS_LIST_STORE ) as ProductsListSelect ).getProductsList(),
+		( select ) => select( ProductsList.store ).getProductsList(),
 		[]
 	);
 	const requiresUpgrade = useSelect(

--- a/client/landing/stepper/stores.ts
+++ b/client/landing/stepper/stores.ts
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import {
 	Onboard,
 	Site,
-	ProductsList,
 	User,
 	AutomatedTransferEligibility,
 	Plans,
@@ -16,8 +15,6 @@ export const SITE_STORE = Site.register( {
 	client_id: config( 'wpcom_signup_id' ),
 	client_secret: config( 'wpcom_signup_key' ),
 } );
-
-export const PRODUCTS_LIST_STORE = ProductsList.register();
 
 export const USER_STORE = User.register( {
 	client_id: config( 'wpcom_signup_id' ),

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -63,7 +63,6 @@ export { generateAdminSections } from './contextual-help/admin-sections';
 export type { LinksForSection } from './contextual-help/contextual-help';
 export * from './contextual-help/constants';
 export type { HelpCenterSite, HelpCenterSelect } from './help-center/types';
-export type { ProductsListSelect } from './products-list/types';
 export type { OnboardSelect } from './onboard';
 export type { StepperInternalSelect } from './stepper-internal';
 export type { WpcomFeaturesSelect } from './wpcom-features/types';

--- a/packages/data-stores/src/products-list/index.ts
+++ b/packages/data-stores/src/products-list/index.ts
@@ -1,4 +1,4 @@
-import { registerStore } from '@wordpress/data';
+import { createReduxStore, register } from '@wordpress/data';
 import { controls } from '../wpcom-request-controls';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
@@ -10,17 +10,12 @@ export * from './types';
 export type { State };
 export { STORE_KEY };
 
-let isRegistered = false;
-export function register(): typeof STORE_KEY {
-	if ( ! isRegistered ) {
-		isRegistered = true;
-		registerStore( STORE_KEY, {
-			actions,
-			controls,
-			reducer,
-			resolvers,
-			selectors,
-		} );
-	}
-	return STORE_KEY;
-}
+export const store = createReduxStore( STORE_KEY, {
+	actions,
+	controls,
+	reducer,
+	resolvers,
+	selectors,
+} );
+
+register( store );

--- a/packages/data-stores/src/products-list/test/selectors.ts
+++ b/packages/data-stores/src/products-list/test/selectors.ts
@@ -7,18 +7,12 @@
  */
 import { select, subscribe } from '@wordpress/data';
 import wpcomRequest from 'wpcom-proxy-request';
-import { register } from '..';
+import { store } from '../';
 
 jest.mock( 'wpcom-proxy-request', () => ( {
 	__esModule: true,
 	default: jest.fn(),
 } ) );
-
-let store: ReturnType< typeof register >;
-
-beforeAll( () => {
-	store = register();
-} );
 
 beforeEach( () => {
 	( wpcomRequest as jest.Mock ).mockReset();
@@ -52,7 +46,7 @@ describe( 'selectors', () => {
 		// First call returns undefined
 		expect( select( store ).getProductsList() ).toEqual( undefined );
 
-		await new Promise( ( resolve ) => {
+		await new Promise< void >( ( resolve ) => {
 			const unsubscribe = subscribe( () => {
 				if ( select( store ).getProductsList() === undefined ) {
 					return;

--- a/packages/data-stores/src/products-list/types.ts
+++ b/packages/data-stores/src/products-list/types.ts
@@ -1,8 +1,5 @@
 import * as actions from './actions';
-import * as selectors from './selectors';
-import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
-
-export type ProductsListSelect = SelectFromMap< typeof selectors >;
+import type { DispatchFromMap } from '../mapped-types';
 
 export interface Dispatch {
 	dispatch: DispatchFromMap< typeof actions >;


### PR DESCRIPTION
## Proposed Changes

This PR migrates the `ProductsList` store to use `createReduxStore()` and `register()` instead of `registerStore()`.

Part of #74399. A follow-up to #73890.

## Testing Instructions

* Domain selection - the domains and prices still appear properly.
* Design selection - the modal that appears when selecting a paid theme and the button to unlock it.
* Sensei domain selection - starting on `/setup/sensei/` you can properly pick a domain and continue with the flow.
* Sensei plan selection - plan step looks well and you can properly pick a plan.
* Woo confirm - starting with a free plan, the step after selecting that you want to sell on your site works well.
* Verify all checks are green.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
