### PR TITLE
Subscription Management: Add temporary redirect of unfinished tabs ("Sites" & "Comments") to the re-skinned portal

### DIFF
--- a/client/my-sites/subscriptions/index.tsx
+++ b/client/my-sites/subscriptions/index.tsx
@@ -55,7 +55,7 @@ const checkFeatureFlag: Callback = ( context, next ) => {
 };
 
 export default function () {
-	page.redirect( '/subscriptions', '/subscriptions/sites' );
+	page.redirect( '/subscriptions', '/subscriptions/settings' );
 
 	page(
 		/\/subscriptions(\/(comments|settings|sites))?/,

--- a/packages/subscription-manager/src/components/TabsSwitcher/TabsSwitcher.tsx
+++ b/packages/subscription-manager/src/components/TabsSwitcher/TabsSwitcher.tsx
@@ -21,8 +21,8 @@ type TabsSwitcherProps = {
 };
 
 const getRoute = ( baseRoute: string, path: string ): string => {
-	// This is a temporary redirect to the re-skinned Subscription Management portal
-	// Once the new Commnets and Sites views are ready, this will be removed
+	// This is a temporary redirect to the re-skinned Subscription Management portal.
+	// Once the new "Commnets" and "Sites" views are ready, this will be removed.
 	const temporaryRedirect = [ 'comments', 'sites' ];
 	if ( temporaryRedirect.includes( path ) ) {
 		return `https://wordpress.com/email-subscriptions/?option=${ path }`;

--- a/packages/subscription-manager/src/components/TabsSwitcher/TabsSwitcher.tsx
+++ b/packages/subscription-manager/src/components/TabsSwitcher/TabsSwitcher.tsx
@@ -20,7 +20,16 @@ type TabsSwitcherProps = {
 	tabs: TabItem[];
 };
 
-const getRoute = ( baseRoute: string, path: string ): string => `/${ baseRoute }/${ path }`;
+const getRoute = ( baseRoute: string, path: string ): string => {
+	// This is a temporary redirect to the re-skinned Subscription Management portal
+	// Once the new Commnets and Sites views are ready, this will be removed
+	const temporaryRedirect = [ 'comments', 'sites' ];
+	if ( temporaryRedirect.includes( path ) ) {
+		return `https://wordpress.com/email-subscriptions/?option=${ path }`;
+	}
+
+	return `/${ baseRoute }/${ path }`;
+};
 const getPath = ( route: string ) => route.substring( route.lastIndexOf( '/' ) + 1 );
 
 const TabsSwitcher = ( { baseRoute, tabs }: TabsSwitcherProps ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/74503/

## Proposed Changes

* when "Sites" tab is clicked, the user is redirected to the re-skinned portal with the "Sites" tab view open
* when "Comments" tab is clicked, the user is redirected to the re-skinned portal with the "Comments" tab view open 
* change the default view from "Sites" to "Settings" - this is because the "Sites" tab will lead to the re-skinned portal

![Markup on 2023-03-17 at 14:05:49](https://user-images.githubusercontent.com/25105483/225912984-d46de848-1952-4a0c-89f7-60f7728f45d0.png)


### Locale consideration

We don't have a mechanic to determine / get a locale of a non-logged-in user yet. If we will be able to set the locale of a non-logged-in user in the same way the logged-in user locale is handled in Calypso currently, then the tab links introduced in this PR are sufficient and the re-skinned portal will render its content in the correct language automatically.

On the other hand, if we will be implementing a custom locale setting/getting for the non-logged-in user, we may need to adjust the redirect URLs in a similar way as can be seen below (by using the `locale` URL parameter):

```jsx
	const localeSlug = getNonLoggedInUserLocaleSlug();
	if ( temporaryRedirect.includes( path ) ) {
		return `https://wordpress.com/email-subscriptions/?option=${ path }&locale=${ localeSlug }`;
	}
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the branch of this PR and build it.
2. Navigate to http://calypso.localhost:3000/subscriptions/.
3. Your browser should be redirected to http://calypso.localhost:3000/subscriptions/settings automatically.
4. Try to click on "Sites" and "Comments" tabs. The browser should lead you to the relevant pages on the re-skinned portal.
5. Follow the steps 2. to 4. for both logged-in and non-logged-in users.
6. If the user is logged-in, the tabs should load in the locale of the user, otherwise in English.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
