### PR TITLE
Stats: Add new Subscribers chart

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -95,13 +95,6 @@ Object.defineProperty( CHART_COMMENTS, 'label', {
 
 const getActiveTab = ( chartTab ) => find( CHARTS, { attr: chartTab } ) || CHARTS[ 0 ];
 
-function SubscribersSectionWrapper( { isVisible = false, dataType = 'api' } ) {
-	if ( isVisible === false ) {
-		return null;
-	}
-	return <SubscribersSection dataType={ dataType } />;
-}
-
 class StatsSite extends Component {
 	static defaultProps = {
 		chartTab: 'views',
@@ -198,7 +191,7 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 				{ isOdysseyStats && <StatsNotices siteId={ siteId } /> }
-				<SubscribersSectionWrapper isVisible={ true } dataType="api" />
+				<SubscribersSection />;
 				<HighlightsSection siteId={ siteId } />
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>
@@ -340,7 +333,7 @@ class StatsSite extends Component {
 						}
 					</div>
 				</div>
-				<SubscribersSectionWrapper isVisible={ false } dataType="api" />
+				{ /* TODO: Move SubscribersSection comp here */ }
 				{ /* Only load Jetpack Upsell Section for Odyssey Stats */ }
 				{ ! isOdysseyStats ? null : (
 					<AsyncLoad require="calypso/my-sites/stats/jetpack-upsell-section" />

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -46,6 +46,7 @@ import StatsNotices from './stats-notices';
 import StatsPeriodHeader from './stats-period-header';
 import StatsPeriodNavigation from './stats-period-navigation';
 import statsStrings from './stats-strings';
+import SubscribersSection from './subscribers-section';
 import { getPathWithUpdatedQueryString } from './utils';
 
 const memoizedQuery = memoizeLast( ( period, endOf ) => ( {
@@ -190,6 +191,7 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 				{ isOdysseyStats && <StatsNotices siteId={ siteId } /> }
+				<SubscribersSection />
 				<HighlightsSection siteId={ siteId } />
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -191,7 +191,7 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 				{ isOdysseyStats && <StatsNotices siteId={ siteId } /> }
-				<SubscribersSection />;
+				{ config.isEnabled( 'stats/subscribers-section' ) && <SubscribersSection /> }
 				<HighlightsSection siteId={ siteId } />
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -191,7 +191,6 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 				{ isOdysseyStats && <StatsNotices siteId={ siteId } /> }
-				{ config.isEnabled( 'stats/subscribers-section' ) && <SubscribersSection /> }
 				<HighlightsSection siteId={ siteId } />
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>
@@ -333,7 +332,7 @@ class StatsSite extends Component {
 						}
 					</div>
 				</div>
-				{ /* TODO: Move SubscribersSection comp here */ }
+				{ config.isEnabled( 'stats/subscribers-section' ) && <SubscribersSection /> }
 				{ /* Only load Jetpack Upsell Section for Odyssey Stats */ }
 				{ ! isOdysseyStats ? null : (
 					<AsyncLoad require="calypso/my-sites/stats/jetpack-upsell-section" />

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -95,6 +95,13 @@ Object.defineProperty( CHART_COMMENTS, 'label', {
 
 const getActiveTab = ( chartTab ) => find( CHARTS, { attr: chartTab } ) || CHARTS[ 0 ];
 
+function SubscribersSectionWrapper( { isVisible = false, dataType = 'api' } ) {
+	if ( isVisible === false ) {
+		return null;
+	}
+	return <SubscribersSection dataType={ dataType } />;
+}
+
 class StatsSite extends Component {
 	static defaultProps = {
 		chartTab: 'views',
@@ -191,7 +198,7 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 				{ isOdysseyStats && <StatsNotices siteId={ siteId } /> }
-				<SubscribersSection />
+				<SubscribersSectionWrapper isVisible={ true } dataType="api" />
 				<HighlightsSection siteId={ siteId } />
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>
@@ -333,6 +340,7 @@ class StatsSite extends Component {
 						}
 					</div>
 				</div>
+				<SubscribersSectionWrapper isVisible={ false } dataType="api" />
 				{ /* Only load Jetpack Upsell Section for Odyssey Stats */ }
 				{ ! isOdysseyStats ? null : (
 					<AsyncLoad require="calypso/my-sites/stats/jetpack-upsell-section" />

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -6,8 +6,8 @@ import './style.scss';
 // We don't have any data yet so we are just plotting visitor data.
 // Currently using the LineChart component from the Calypso library.
 
-const DATA_TYPE = 'single';
-// const DATA_TYPE = 'multi';
+const DATA_TYPE = 'api';
+// DATA_TYPE can be: 'api', 'single, or 'multi'.
 
 function getDataSingleLine() {
 	const data = [
@@ -69,7 +69,61 @@ function getDataMultiLine() {
 	return data;
 }
 
+function getDataAPISample() {
+	// From https://code.a8c.com/D105106 -- Work in progress on new endpoint.
+	const data = [
+		[ '2023-03-01', 51131, 547 ],
+		[ '2023-02-01', 51881, 750 ],
+		[ '2023-01-01', 52662, 781 ],
+		[ '2022-12-01', 52782, 120 ],
+		[ '2022-11-01', 53541, 759 ],
+		[ '2022-10-01', 53527, -14 ],
+		[ '2022-09-01', 53853, 326 ],
+		[ '2022-08-01', 54243, 390 ],
+		[ '2022-07-01', 55097, 854 ],
+		[ '2022-06-01', 55088, -9 ],
+		[ '2022-05-01', 55208, 120 ],
+		[ '2022-04-01', 55764, 556 ],
+		[ '2022-03-01', 56622, 858 ],
+		[ '2022-02-01', 57363, 741 ],
+		[ '2022-01-01', 57279, -84 ],
+		[ '2021-12-01', 57468, 189 ],
+		[ '2021-11-01', 57444, -24 ],
+		[ '2021-10-01', 57530, 86 ],
+		[ '2021-09-01', 58404, 874 ],
+		[ '2021-08-01', 58468, 64 ],
+		[ '2021-07-01', 58512, 44 ],
+		[ '2021-06-01', 59469, 957 ],
+		[ '2021-05-01', 59795, 326 ],
+		[ '2021-04-01', 60511, 716 ],
+		[ '2021-03-01', 61193, 682 ],
+		[ '2021-02-01', 61448, 255 ],
+		[ '2021-01-01', 61682, 234 ],
+		[ '2020-12-01', 61934, 252 ],
+		[ '2020-11-01', 62927, 993 ],
+		[ '2020-10-01', 62957, 30 ],
+		[ '2020-09-01', 63385, 428 ],
+	];
+	// Map the data.
+	// 1. Note that the data is ordered from newest to oldest.
+	// 2. We need to reverse the array or the LineChart component emits errors.
+	// 3. Labeling of the x-axis doesn't work too well if the data series is too big.
+	const maxDataSize = 10;
+	const processedData = data.map( ( point ) => {
+		const [ period, count, diff ] = point;
+		return {
+			date: new Date( period ).getTime(),
+			value: count,
+			diff: diff,
+		};
+	} );
+	return [ processedData.slice( 0, maxDataSize ).reverse() ];
+}
+
 function getData() {
+	if ( DATA_TYPE === 'api' ) {
+		return getDataAPISample();
+	}
 	if ( DATA_TYPE === 'single' ) {
 		return getDataSingleLine();
 	}

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -134,25 +134,9 @@ function getData( type ) {
 	return [];
 }
 
-function getLegendSingleLine() {
-	return [];
-}
-function getLegendMultiLine() {
-	return [ { name: 'Line #1' }, { name: 'Line #2' }, { name: 'Line #3' } ];
-}
-function getLegend( type ) {
-	if ( type === DATA_TYPE_SINGLE ) {
-		return getLegendSingleLine();
-	}
-	if ( type === DATA_TYPE_MULTI ) {
-		return getLegendMultiLine();
-	}
-	return [];
-}
-
-export default function SubscribersSection( { dataType = DATA_TYPE_API } ) {
+export default function SubscribersSection() {
+	const dataType = DATA_TYPE_API;
 	const data = getData( dataType );
-	const legendInfo = getLegend( dataType );
 
 	const tooltipHelper =
 		dataType !== DATA_TYPE_API ? ( datum ) => datum.value : ( datum ) => `Changed: ${ datum.diff }`;
@@ -160,12 +144,7 @@ export default function SubscribersSection( { dataType = DATA_TYPE_API } ) {
 	return (
 		<div className="subscribers-section">
 			<h1 className="highlight-cards-heading">Subscribers</h1>
-			<LineChart
-				data={ data }
-				fillArea={ false }
-				legendInfo={ legendInfo }
-				renderTooltipForDatanum={ tooltipHelper }
-			>
+			<LineChart data={ data } renderTooltipForDatanum={ tooltipHelper }>
 				<StatsEmptyState />
 			</LineChart>
 		</div>

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -49,7 +49,8 @@ function transformData( data ) {
 	// 2. We need to reverse the array or the LineChart component emits errors.
 	// 3. Labeling of the x-axis doesn't work too well if the data series is too big.
 	const maxDataSize = 10;
-	const processedData = data.map( ( point ) => {
+	const trimmedData = data.length > 10 ? data.slice( 0, maxDataSize ) : data;
+	const processedData = trimmedData.map( ( point ) => {
 		const [ period, count, diff ] = point;
 		return {
 			date: new Date( period ).getTime(),
@@ -57,7 +58,7 @@ function transformData( data ) {
 			diff: diff,
 		};
 	} );
-	return [ processedData.slice( 0, maxDataSize ).reverse() ];
+	return [ processedData.reverse() ];
 }
 
 export default function SubscribersSection() {

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -3,74 +3,10 @@ import StatsEmptyState from '../stats-empty-state';
 import './style.scss';
 
 // New Subscriber Stats
-// We don't have any data yet so we are just plotting visitor data.
+// We don't have any data yet so we are just using some test data.
 // Currently using the LineChart component from the Calypso library.
 
-const DATA_TYPE_API = 'api';
-const DATA_TYPE_SINGLE = 'single';
-const DATA_TYPE_MULTI = 'multi';
-
-function getDataSingleLine() {
-	const data = [
-		[
-			{ date: 1528462681168, value: 21 },
-			{ date: 1528549081168, value: 26 },
-			{ date: 1528635481168, value: 32 },
-			{ date: 1528721881168, value: 38 },
-			{ date: 1528808281168, value: 43 },
-			{ date: 1528894681168, value: 44 },
-			{ date: 1528981081168, value: 57 },
-			{ date: 1529067481168, value: 54 },
-			{ date: 1529153881168, value: 49 },
-			{ date: 1529240281168, value: 61 },
-		],
-	];
-	return data;
-}
-
-function getDataMultiLine() {
-	const data = [
-		[
-			{ date: 1528462681168, value: 21 },
-			{ date: 1528549081168, value: 18 },
-			{ date: 1528635481168, value: 37 },
-			{ date: 1528721881168, value: 38 },
-			{ date: 1528808281168, value: 43 },
-			{ date: 1528894681168, value: 44 },
-			{ date: 1528981081168, value: 17 },
-			{ date: 1529067481168, value: 27 },
-			{ date: 1529153881168, value: 26 },
-			{ date: 1529240281168, value: 24 },
-		],
-		[
-			{ date: 1528462681168, value: 25 },
-			{ date: 1528549081168, value: 37 },
-			{ date: 1528635481168, value: 23 },
-			{ date: 1528721881168, value: 34 },
-			{ date: 1528808281168, value: 3 },
-			{ date: 1528894681168, value: 4 },
-			{ date: 1528981081168, value: 1 },
-			{ date: 1529067481168, value: 9 },
-			{ date: 1529153881168, value: 20 },
-			{ date: 1529240281168, value: 16 },
-		],
-		[
-			{ date: 1528462681168, value: 7 },
-			{ date: 1528549081168, value: 1 },
-			{ date: 1528635481168, value: 32 },
-			{ date: 1528721881168, value: 40 },
-			{ date: 1528808281168, value: 38 },
-			{ date: 1528894681168, value: 31 },
-			{ date: 1528981081168, value: 17 },
-			{ date: 1529067481168, value: 48 },
-			{ date: 1529153881168, value: 21 },
-			{ date: 1529240281168, value: 46 },
-		],
-	];
-	return data;
-}
-
-function getDataAPISample() {
+function getData() {
 	// From https://code.a8c.com/D105106 -- Work in progress on new endpoint.
 	const data = [
 		[ '2023-03-01', 51131, 547 ],
@@ -121,25 +57,11 @@ function getDataAPISample() {
 	return [ processedData.slice( 0, maxDataSize ).reverse() ];
 }
 
-function getData( type ) {
-	if ( type === DATA_TYPE_API ) {
-		return getDataAPISample();
-	}
-	if ( type === DATA_TYPE_SINGLE ) {
-		return getDataSingleLine();
-	}
-	if ( type === DATA_TYPE_MULTI ) {
-		return getDataMultiLine();
-	}
-	return [];
-}
-
 export default function SubscribersSection() {
-	const dataType = DATA_TYPE_API;
-	const data = getData( dataType );
+	const data = getData();
 
-	const tooltipHelper =
-		dataType !== DATA_TYPE_API ? ( datum ) => datum.value : ( datum ) => `Changed: ${ datum.diff }`;
+	// Determines what is shown in the tooltip on hover.
+	const tooltipHelper = ( datum ) => `Changed: ${ datum.diff }`;
 
 	return (
 		<div className="subscribers-section">

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -1,0 +1,59 @@
+import LineChart from 'calypso/components/line-chart';
+import StatsEmptyState from '../stats-empty-state';
+import './style.scss';
+
+// New Subscriber Stats
+// We don't have any data yet so we are just plotting visitor data.
+// Currently using the LineChart component from the Calypso library.
+
+export default function SubscribersSection() {
+	const data = [
+		[
+			{ date: 1528462681168, value: 21 },
+			{ date: 1528549081168, value: 18 },
+			{ date: 1528635481168, value: 37 },
+			{ date: 1528721881168, value: 38 },
+			{ date: 1528808281168, value: 43 },
+			{ date: 1528894681168, value: 44 },
+			{ date: 1528981081168, value: 17 },
+			{ date: 1529067481168, value: 27 },
+			{ date: 1529153881168, value: 26 },
+			{ date: 1529240281168, value: 24 },
+		],
+		[
+			{ date: 1528462681168, value: 25 },
+			{ date: 1528549081168, value: 37 },
+			{ date: 1528635481168, value: 23 },
+			{ date: 1528721881168, value: 34 },
+			{ date: 1528808281168, value: 3 },
+			{ date: 1528894681168, value: 4 },
+			{ date: 1528981081168, value: 1 },
+			{ date: 1529067481168, value: 9 },
+			{ date: 1529153881168, value: 20 },
+			{ date: 1529240281168, value: 16 },
+		],
+		[
+			{ date: 1528462681168, value: 7 },
+			{ date: 1528549081168, value: 1 },
+			{ date: 1528635481168, value: 32 },
+			{ date: 1528721881168, value: 40 },
+			{ date: 1528808281168, value: 38 },
+			{ date: 1528894681168, value: 31 },
+			{ date: 1528981081168, value: 17 },
+			{ date: 1529067481168, value: 48 },
+			{ date: 1529153881168, value: 21 },
+			{ date: 1529240281168, value: 46 },
+		],
+	];
+
+	const legendInfo = [ { name: 'Line #1' }, { name: 'Line #2' }, { name: 'Line #3' } ];
+
+	return (
+		<div className="subscribers-section">
+			<h1 className="highlight-cards-heading">Subscribers</h1>
+			<LineChart data={ data } fillArea={ false } legendInfo={ legendInfo }>
+				<StatsEmptyState />
+			</LineChart>
+		</div>
+	);
+}

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -6,7 +6,28 @@ import './style.scss';
 // We don't have any data yet so we are just plotting visitor data.
 // Currently using the LineChart component from the Calypso library.
 
-export default function SubscribersSection() {
+const DATA_TYPE = 'single';
+// const DATA_TYPE = 'multi';
+
+function getDataSingleLine() {
+	const data = [
+		[
+			{ date: 1528462681168, value: 21 },
+			{ date: 1528549081168, value: 26 },
+			{ date: 1528635481168, value: 32 },
+			{ date: 1528721881168, value: 38 },
+			{ date: 1528808281168, value: 43 },
+			{ date: 1528894681168, value: 44 },
+			{ date: 1528981081168, value: 57 },
+			{ date: 1529067481168, value: 54 },
+			{ date: 1529153881168, value: 49 },
+			{ date: 1529240281168, value: 61 },
+		],
+	];
+	return data;
+}
+
+function getDataMultiLine() {
 	const data = [
 		[
 			{ date: 1528462681168, value: 21 },
@@ -45,8 +66,38 @@ export default function SubscribersSection() {
 			{ date: 1529240281168, value: 46 },
 		],
 	];
+	return data;
+}
 
-	const legendInfo = [ { name: 'Line #1' }, { name: 'Line #2' }, { name: 'Line #3' } ];
+function getData() {
+	if ( DATA_TYPE === 'single' ) {
+		return getDataSingleLine();
+	}
+	if ( DATA_TYPE === 'multi' ) {
+		return getDataMultiLine();
+	}
+	return [];
+}
+
+function getLegendSingleLine() {
+	return [];
+}
+function getLegendMultiLine() {
+	return [ { name: 'Line #1' }, { name: 'Line #2' }, { name: 'Line #3' } ];
+}
+function getLegend() {
+	if ( DATA_TYPE === 'single' ) {
+		return getLegendSingleLine();
+	}
+	if ( DATA_TYPE === 'multi' ) {
+		return getLegendMultiLine();
+	}
+	return [];
+}
+
+export default function SubscribersSection() {
+	const data = getData();
+	const legendInfo = getLegend();
 
 	return (
 		<div className="subscribers-section">

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -153,10 +153,18 @@ export default function SubscribersSection() {
 	const data = getData();
 	const legendInfo = getLegend();
 
+	const tooltipHelper =
+		DATA_TYPE !== 'api' ? ( datum ) => datum.value : ( datum ) => `Changed: ${ datum.diff }`;
+
 	return (
 		<div className="subscribers-section">
 			<h1 className="highlight-cards-heading">Subscribers</h1>
-			<LineChart data={ data } fillArea={ false } legendInfo={ legendInfo }>
+			<LineChart
+				data={ data }
+				fillArea={ false }
+				legendInfo={ legendInfo }
+				renderTooltipForDatanum={ tooltipHelper }
+			>
 				<StatsEmptyState />
 			</LineChart>
 		</div>

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -6,8 +6,9 @@ import './style.scss';
 // We don't have any data yet so we are just plotting visitor data.
 // Currently using the LineChart component from the Calypso library.
 
-const DATA_TYPE = 'api';
-// DATA_TYPE can be: 'api', 'single, or 'multi'.
+const DATA_TYPE_API = 'api';
+const DATA_TYPE_SINGLE = 'single';
+const DATA_TYPE_MULTI = 'multi';
 
 function getDataSingleLine() {
 	const data = [
@@ -120,14 +121,14 @@ function getDataAPISample() {
 	return [ processedData.slice( 0, maxDataSize ).reverse() ];
 }
 
-function getData() {
-	if ( DATA_TYPE === 'api' ) {
+function getData( type ) {
+	if ( type === DATA_TYPE_API ) {
 		return getDataAPISample();
 	}
-	if ( DATA_TYPE === 'single' ) {
+	if ( type === DATA_TYPE_SINGLE ) {
 		return getDataSingleLine();
 	}
-	if ( DATA_TYPE === 'multi' ) {
+	if ( type === DATA_TYPE_MULTI ) {
 		return getDataMultiLine();
 	}
 	return [];
@@ -139,22 +140,22 @@ function getLegendSingleLine() {
 function getLegendMultiLine() {
 	return [ { name: 'Line #1' }, { name: 'Line #2' }, { name: 'Line #3' } ];
 }
-function getLegend() {
-	if ( DATA_TYPE === 'single' ) {
+function getLegend( type ) {
+	if ( type === DATA_TYPE_SINGLE ) {
 		return getLegendSingleLine();
 	}
-	if ( DATA_TYPE === 'multi' ) {
+	if ( type === DATA_TYPE_MULTI ) {
 		return getLegendMultiLine();
 	}
 	return [];
 }
 
-export default function SubscribersSection() {
-	const data = getData();
-	const legendInfo = getLegend();
+export default function SubscribersSection( { dataType = DATA_TYPE_API } ) {
+	const data = getData( dataType );
+	const legendInfo = getLegend( dataType );
 
 	const tooltipHelper =
-		DATA_TYPE !== 'api' ? ( datum ) => datum.value : ( datum ) => `Changed: ${ datum.diff }`;
+		dataType !== DATA_TYPE_API ? ( datum ) => datum.value : ( datum ) => `Changed: ${ datum.diff }`;
 
 	return (
 		<div className="subscribers-section">

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -8,7 +8,7 @@ import './style.scss';
 
 function getData() {
 	// From https://code.a8c.com/D105106 -- Work in progress on new endpoint.
-	const data = [
+	return [
 		[ '2023-03-01', 51131, 547 ],
 		[ '2023-02-01', 51881, 750 ],
 		[ '2023-01-01', 52662, 781 ],
@@ -41,7 +41,10 @@ function getData() {
 		[ '2020-10-01', 62957, 30 ],
 		[ '2020-09-01', 63385, 428 ],
 	];
-	// Map the data.
+}
+
+function transformData( data ) {
+	// Transform the data into the format required by the chart component.
 	// 1. Note that the data is ordered from newest to oldest.
 	// 2. We need to reverse the array or the LineChart component emits errors.
 	// 3. Labeling of the x-axis doesn't work too well if the data series is too big.
@@ -58,7 +61,7 @@ function getData() {
 }
 
 export default function SubscribersSection() {
-	const data = getData();
+	const data = transformData( getData() );
 
 	// Determines what is shown in the tooltip on hover.
 	const tooltipHelper = ( datum ) => `Changed: ${ datum.diff }`;

--- a/client/my-sites/stats/subscribers-section/style.scss
+++ b/client/my-sites/stats/subscribers-section/style.scss
@@ -1,0 +1,3 @@
+.subscribers-section {
+	margin-top: 32px;
+}

--- a/config/client.json
+++ b/config/client.json
@@ -29,6 +29,7 @@
 	"stats/horizontal-bars-everywhere",
 	"stats/insights-page-grid",
 	"stats/new-video-summary",
+	"stats/subscribers-section",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",
 	"wpcom_signup_key",

--- a/config/development.json
+++ b/config/development.json
@@ -176,6 +176,7 @@
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": true,
 		"stats/new-video-summary": true,
+		"stats/subscribers-section": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -121,6 +121,7 @@
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": true,
 		"stats/new-video-summary": false,
+		"stats/subscribers-section": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/production.json
+++ b/config/production.json
@@ -142,6 +142,7 @@
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": true,
 		"stats/new-video-summary": false,
+		"stats/subscribers-section": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -138,6 +138,7 @@
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": true,
 		"stats/new-video-summary": false,
+		"stats/subscribers-section": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,

--- a/config/test.json
+++ b/config/test.json
@@ -102,6 +102,7 @@
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": true,
 		"stats/new-video-summary": false,
+		"stats/subscribers-section": false,
 		"stepper-woocommerce-poc": true,
 		"themes/premium": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -148,6 +148,7 @@
 		"stats/horizontal-bars-everywhere": true,
 		"stats/insights-page-grid": true,
 		"stats/new-video-summary": false,
+		"stats/subscribers-section": false,
 		"stepper-woocommerce-poc": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74404.

## Proposed Changes

Adds a new Subscribers chart to the Traffic page.

<img width="750" alt="SCR-20230317-rfoe" src="https://user-images.githubusercontent.com/40267301/225896407-9559608b-08b6-4fb6-8d52-67f79e190d04.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Launch the live branch and enable the feature flag to see the new chart. Currently showing sample data at the top of the page. Will be moved to the bottom of the page (under the modules grid) before public release.

1. Launch the live branch.
2. Navigate to the Stats page.
3. Confirm the chart doesn't appear at the top.
4. Append the following to the URL: `?flags=stats/subscribers-section` and refresh.
5. Confirm the chart is visible at the top of the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
