### PR TITLE
Add support links for core/group and core/navigation

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
@@ -30,7 +30,7 @@ const blockLinks: { [ key: string ]: string } = {
 
 	'core/rss': 'https://wordpress.com/support/wordpress-editor/blocks/rss-block/',
 
-	'core/group': 'https://wordpress.com/support/wordpress-editor/blocks/row-block/',
+	'core/navigation': 'https://wordpress.com/support/site-editing/theme-blocks/navigation-block/',
 
 	'core/tag-cloud': 'https://wordpress.com/support/wordpress-editor/blocks/tag-cloud-block/',
 
@@ -183,6 +183,16 @@ const blockLinks: { [ key: string ]: string } = {
 	'jetpack/layout-grid': 'https://wordpress.com/support/wordpress-editor/blocks/layout-grid-block/',
 
 	'jetpack/mailchimp': 'https://wordpress.com/support/wordpress-editor/blocks/mailchimp-block/',
+};
+
+export const blockLinksWithVariations: {
+	[ key: string ]: { [ key: string ]: string };
+} = {
+	'core/group': {
+		group: 'https://wordpress.com/support/wordpress-editor/blocks/group-block/',
+		'group-row': 'https://wordpress.com/support/wordpress-editor/blocks/row-block/',
+		'group-stack': 'https://wordpress.com/support/wordpress-editor/blocks/row-block/',
+	},
 };
 
 export default blockLinks;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.tsx
@@ -1,8 +1,8 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
-import { ReactElement, JSXElementConstructor } from 'react';
-import blockLinks from './block-links-map';
+import { JSXElementConstructor, ReactElement } from 'react';
+import blockLinks, { blockLinksWithVariations } from './block-links-map';
 import DescriptionSupportLink from './inline-support-link';
 
 declare global {
@@ -11,8 +11,32 @@ declare global {
 	}
 }
 
+const createLocalizedDescriptionWithLearnMore = (
+	title: string,
+	description: string | ReactElement< string | JSXElementConstructor< any > >,
+	url: string
+) => {
+	const localizedUrl = localizeUrl( url, window.wpcomBlockDescriptionLinksLocale );
+
+	return createInterpolateElement( '<InlineSupportLink />', {
+		InlineSupportLink: (
+			<DescriptionSupportLink title={ String( title ) } url={ localizedUrl }>
+				{ description }
+			</DescriptionSupportLink>
+		),
+	} );
+};
+
+const processedBlocks: { [ key: string ]: true } = {};
+
 const addBlockSupportLinks = (
 	settings: {
+		variations: Array< {
+			description: string | ReactElement< string | JSXElementConstructor< any > >;
+			name: string;
+			title: string;
+		} >;
+	} & {
 		[ key: string ]: string | ReactElement< string | JSXElementConstructor< any > >;
 	},
 	name: string
@@ -21,20 +45,51 @@ const addBlockSupportLinks = (
 	const isChild = settings[ 'parent' ];
 	const blockName = isChild ? settings[ 'parent' ].toString() : name;
 
-	if ( blockLinks[ blockName ] ) {
-		const localizedUrl = localizeUrl(
-			blockLinks[ blockName ],
-			window.wpcomBlockDescriptionLinksLocale
-		);
-		const descriptionWithLink = createInterpolateElement( '<InlineSupportLink />', {
-			InlineSupportLink: (
-				<DescriptionSupportLink title={ String( settings.title ) } url={ localizedUrl }>
-					{ settings.description }
-				</DescriptionSupportLink>
-			),
-		} );
+	/**
+	 * This is needed because the `blocks.registerBlockType` filter is also triggered for deprecations.
+	 *
+	 * When the block has deprecations, this filter is triggered multiple times, resulting the Learn more link being appended multiple times.
+	 */
+	if ( processedBlocks[ name ] ) {
+		return settings;
+	}
 
-		settings.description = descriptionWithLink;
+	processedBlocks[ name ] = true;
+
+	if ( blockLinks[ blockName ] ) {
+		settings.description = createLocalizedDescriptionWithLearnMore(
+			String( settings.title ),
+			settings.description,
+			blockLinks[ blockName ]
+		);
+	}
+
+	if (
+		blockLinksWithVariations[ name ] &&
+		settings.variations &&
+		Array.isArray( settings.variations )
+	) {
+		settings.variations = settings.variations.map(
+			( variation: {
+				title: string;
+				name: string;
+				description: string | ReactElement< string | JSXElementConstructor< any > >;
+			} ) => {
+				const link = blockLinksWithVariations[ name ][ variation.name ];
+
+				if ( ! link ) {
+					return variation;
+				}
+
+				variation.description = createLocalizedDescriptionWithLearnMore(
+					variation.title,
+					variation.description,
+					link
+				);
+
+				return variation;
+			}
+		);
 	}
 
 	return settings;


### PR DESCRIPTION
This PR adds a learn more link for the core/group block (and its variations - row and stack) and for the core/navigation block.

For core/group, we have a special handling because the block description is generated based on the variations property, since the row and stack blocks are variations of the group.

To achieve this, a new map was introduced that takes into account the variation property.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71384

## Proposed Changes

* Add an implementation that handles variations
* Add the necessary mapping for `core/navigation`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install the ETK from this branch on your sandbox
* Go /wp-admin/post-new.php
* Make sure that the `Learn more` links are displaying in the sidebar for `core/navigation`, `core/group` and Row and Stack blocks.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
