### PR TITLE
Jetpack Pro Dashboard: tweak CSS to fix box shadow when a license is selected

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/style.scss
@@ -68,15 +68,19 @@
 }
 
 .site-card__card-disabled {
-	opacity: 0.5;
-	user-select: none;
+	background: unset !important;
+
+	.sites-overview__overlay {
+		background: unset !important;
+	}
 }
 
 .site-card__card-active {
 	border-width: 0 1px;
 	border-style: solid;
 	border-color: var(--studio-gray-5);
-	box-shadow: 0 0 20px rgba(0, 0, 0, 0.16);
+	box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
+	margin-inline: -1px;
 }
 
 .site-card__expanded-column {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
@@ -27,7 +27,7 @@
 		border-width: 0 1px;
 		border-style: solid;
 		border-color: var(--studio-gray-5);
-		box-shadow: 0 0 20px rgba(0, 0, 0, 0.16);
+		box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
 	}
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .site-table__table-row {
-	&:hover:not(.is-expanded):not(.site-table__table-row-site-error) {
+	&:hover:not(.is-expanded):not(.site-table__table-row-site-error):not(.site-table__table-row-active) {
 		background: var(--studio-gray-0);
 
 		.sites-overview__overlay {
@@ -20,8 +20,11 @@
 		}
 	}
 	&-disabled {
-		opacity: 0.5;
-		user-select: none;
+		background: unset !important;
+
+		.sites-overview__overlay {
+			background: unset !important;
+		}
 	}
 	&-active {
 		border-width: 0 1px;


### PR DESCRIPTION
Related to 1202619025189113-as-1203462995555473

## Proposed Changes

Fixed box shadow when a license is selected in a row and the card

## Testing Instructions


- Run `git checkout fix/jetpack-agency-line-selected-shadow` and `yarn start-jetpack-cloud`
- Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
- Select an *(+ Add)* button to select a license for a site. Make sure it looks like the screenshot below. Verify the same on small-screen devices. Please ignore the columns not populating the data.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1418" alt="Screenshot 2023-04-18 at 3 42 01 PM" src="https://user-images.githubusercontent.com/10586875/232748737-138288b0-3088-47d2-91ed-a322b45f8f53.png">
</td>
<td>
<img width="1418" alt="Screenshot 2023-04-18 at 3 23 34 PM" src="https://user-images.githubusercontent.com/10586875/232748701-833f2cb8-ba9f-438f-893c-48c24b3bc138.png">
</td>
</tr>
<tr>
<td>

![mobile (23)](https://user-images.githubusercontent.com/10586875/232750296-f10fe328-33d1-4b43-8afb-95d25d07285c.jpeg)


</td>
<td>

![mobile (22)](https://user-images.githubusercontent.com/10586875/232749984-0fec740c-4588-4a2c-8d27-07ccfe17147e.jpeg)

</td>
</tr>
</table>



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?