### PR TITLE
Email Subscriptions: Fix input id and remove redundant import

### DIFF
--- a/packages/subscription-manager/src/components/fields/EmailFormatInput/EmailFormatInput.tsx
+++ b/packages/subscription-manager/src/components/fields/EmailFormatInput/EmailFormatInput.tsx
@@ -18,10 +18,8 @@ const EmailFormatInput = ( { value, onChange }: EmailFormatInputProps ) => {
 
 	return (
 		<FormFieldset className="email-format-input">
-			<FormLabel htmlFor="subscription_delivery_mail_option">
-				{ translate( 'Email format' ) }
-			</FormLabel>
-			<FormSelect name="email_format_setting" onChange={ onChange } value={ value }>
+			<FormLabel htmlFor="email_format">{ translate( 'Email format' ) }</FormLabel>
+			<FormSelect name="email_format" onChange={ onChange } value={ value }>
 				<option value="html">{ translate( 'HTML' ) }</option>
 				<option value="text">{ translate( 'Plain Text' ) }</option>
 			</FormSelect>

--- a/packages/subscription-manager/src/components/fields/EmailFormatInput/styles.scss
+++ b/packages/subscription-manager/src/components/fields/EmailFormatInput/styles.scss
@@ -1,5 +1,3 @@
-@import "@automattic/color-studio/dist/color-variables";
-@import "@wordpress/base-styles/breakpoints";
 @import "../components";
 
 .email-format-input {


### PR DESCRIPTION
Related to #74078

## Proposed Changes

* Fix typo on Email format field
* Remove redundant import on styles file

<img width="538" alt="image" src="https://user-images.githubusercontent.com/3113712/225957382-cf671620-0651-4477-a00d-598c99a57140.png">


## Testing Instructions

* Deploy this PR on your local env
* Go to http://calypso.localhost:3000/subscriptions/settings
* Verify if the Email Format input is rendered as expected
* Verify if no regression was made

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
