### PR TITLE
Add Theme card to Marketplace thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -105,7 +105,7 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 				</ThemeSectionName>
 				<ThemeSectionButtons>
 					<Button isPrimary onClick={ handleActivateTheme }>
-						{ translate( 'Theme details' ) }
+						{ translate( 'Activate this design' ) }
 					</Button>
 				</ThemeSectionButtons>
 			</ThemeSectionContent>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -43,6 +43,7 @@ const ThemeSectionContent = styled.div`
 	justify-content: space-between;
 	align-items: center;
 	flex-wrap: wrap;
+	gap: 16px;
 `;
 
 const ThemeSectionName = styled.div`
@@ -61,7 +62,12 @@ const ThemeSectionName = styled.div`
 const ThemeSectionButtons = styled.div`
 	display: flex;
 	gap: 16px;
-	min-width: auto;
+	flex-wrap: wrap;
+
+	& a {
+		flex-grow: 1;
+		justify-content: center;
+	}
 
 	.gridicon.gridicons-external {
 		margin-right: 4px;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -88,8 +88,8 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const isActive = useSelector( ( state ) => isThemeActive( state, theme.id, siteId ) );
-	const { data, isLoading } = useActiveThemeQuery( siteId, true );
-	const isFSEActive = data?.[ 0 ]?.theme_supports[ 'block-templates' ] ?? false;
+	const { data: activeThemeData, isLoading } = useActiveThemeQuery( siteId, true );
+	const isFSEActive = activeThemeData?.[ 0 ]?.theme_supports[ 'block-templates' ] ?? false;
 	const hasActivated = useSelector( ( state ) => hasActivatedTheme( state, siteId ) );
 	const isActivating = useSelector( ( state ) => isActivatingTheme( state, siteId ) );
 	const customizeUrl = useSelector( ( state ) =>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
+import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import { activate } from 'calypso/state/themes/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -82,6 +83,7 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 	return (
 		<ThemeSectionContainer>
 			<AutoLoadingHomepageModal source="details" />
+			<ThanksModal source="details" themeId={ theme.id } />
 			<ThemeSectionImage
 				src={ theme.screenshot }
 				alt={

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -62,6 +62,10 @@ const ThemeSectionButtons = styled.div`
 	display: flex;
 	gap: 16px;
 	min-width: auto;
+
+	.gridicon.gridicons-external {
+		margin-right: 4px;
+	}
 `;
 
 export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -3,8 +3,10 @@ import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
-import { useSelector } from 'react-redux';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { useSelector, useDispatch } from 'react-redux';
+import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
+import { activate } from 'calypso/state/themes/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const ThemeSectionContainer = styled.div`
 	display: flex;
@@ -59,8 +61,8 @@ const ThemeSectionButtons = styled.div`
 
 export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	const sendTrackEvent = useCallback(
 		( name: string ) => {
@@ -72,12 +74,14 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 		[ siteId, theme ]
 	);
 
-	const getThemeDetailsUrl = () => {
-		return `/theme/${ theme.id }/${ siteSlug }`;
+	const handleActivateTheme = () => {
+		sendTrackEvent( 'calypso_theme_thank_you_activate_theme_click' );
+		dispatch( activate( theme.id, Number( siteId ), 'marketplace-thank-you' ) );
 	};
 
 	return (
 		<ThemeSectionContainer>
+			<AutoLoadingHomepageModal source="details" />
 			<ThemeSectionImage
 				src={ theme.screenshot }
 				alt={
@@ -98,11 +102,7 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 					</small>
 				</ThemeSectionName>
 				<ThemeSectionButtons>
-					<Button
-						isPrimary
-						href={ getThemeDetailsUrl() }
-						onClick={ () => sendTrackEvent( 'calypso_theme_thank_you_activate_theme_click' ) }
-					>
+					<Button isPrimary onClick={ handleActivateTheme }>
 						{ translate( 'Theme details' ) }
 					</Button>
 				</ThemeSectionButtons>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -18,10 +18,6 @@ const ThemeSectionContainer = styled.div`
 	flex-direction: column;
 	width: 720px;
 	box-sizing: border-box;
-	border-radius: 16px;
-
-	box-shadow: 0px 15px 20px rgba( 0, 0, 0, 0.04 ), 0px 13px 10px rgba( 0, 0, 0, 0.03 ),
-		0px 6px 6px rgba( 0, 0, 0, 0.02 );
 
 	@media ( max-width: 740px ) {
 		width: 500px;
@@ -32,18 +28,24 @@ const ThemeSectionContainer = styled.div`
 	}
 `;
 
-const ThemeSectionImage = styled.img`
+const ThemeSectionImageContainer = styled.div`
 	padding: 8px 8px 0 8px;
+	border-radius: 16px;
+	box-shadow: 0px 15px 20px rgba( 0, 0, 0, 0.04 ), 0px 13px 10px rgba( 0, 0, 0, 0.03 ),
+		0px 6px 6px rgba( 0, 0, 0, 0.02 );
+`;
+
+const ThemeSectionImage = styled.img`
 	border-radius: 13px;
 `;
 
 const ThemeSectionContent = styled.div`
-	padding: 24px;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 	flex-wrap: wrap;
 	gap: 16px;
+	padding-top: 26px;
 `;
 
 const ThemeSectionName = styled.div`
@@ -72,6 +74,10 @@ const ThemeSectionButtons = styled.div`
 	.gridicon.gridicons-external {
 		margin-right: 4px;
 	}
+`;
+
+const ThemeButton = styled( Button )`
+	border-radius: 4px;
 `;
 
 export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
@@ -110,16 +116,18 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 	return (
 		<ThemeSectionContainer>
 			<AutoLoadingHomepageModal source="details" />
-			<ThemeSectionImage
-				src={ theme.screenshot }
-				alt={
-					translate( "%(theme)s's icon", {
-						args: {
-							theme: theme.name,
-						},
-					} ) as string
-				}
-			/>
+			<ThemeSectionImageContainer>
+				<ThemeSectionImage
+					src={ theme.screenshot }
+					alt={
+						translate( "%(theme)s's icon", {
+							args: {
+								theme: theme.name,
+							},
+						} ) as string
+					}
+				/>
+			</ThemeSectionImageContainer>
 			<ThemeSectionContent>
 				<ThemeSectionName>
 					<h5>{ theme.name }</h5>
@@ -130,7 +138,7 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 					</small>
 				</ThemeSectionName>
 				<ThemeSectionButtons>
-					<Button
+					<ThemeButton
 						isPrimary
 						isBusy={ ( isActivating && ! hasActivated ) || isLoading }
 						onClick={ handleActivateTheme }
@@ -139,13 +147,13 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 						{ isActive
 							? translate( 'Customize this design' )
 							: translate( 'Activate this design' ) }
-					</Button>
+					</ThemeButton>
 
 					{ isActive ? (
-						<Button isSecondary href={ siteUrl }>
+						<ThemeButton isSecondary href={ siteUrl }>
 							<Gridicon size={ 18 } icon="external" />
 							{ translate( 'View site' ) }
-						</Button>
+						</ThemeButton>
 					) : null }
 				</ThemeSectionButtons>
 			</ThemeSectionContent>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -2,14 +2,18 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Gridicon, Button } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import AutoLoadingHomepageModal from 'calypso/my-sites/themes/auto-loading-homepage-modal';
 import getCustomizeUrl from 'calypso/state/selectors/get-customize-url';
 import getSiteUrl from 'calypso/state/sites/selectors/get-site-url';
 import { activate } from 'calypso/state/themes/actions';
-import { isThemeActive, hasActivatedTheme } from 'calypso/state/themes/selectors';
+import {
+	isThemeActive,
+	isActivatingTheme,
+	hasActivatedTheme,
+} from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const ThemeSectionContainer = styled.div`
@@ -80,7 +84,6 @@ const ThemeButton = styled( Button )`
 `;
 
 export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
-	const [ isActivating, setIsActivating ] = useState( false );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -88,6 +91,7 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 	const { data, isLoading } = useActiveThemeQuery( siteId, true );
 	const isFSEActive = data?.[ 0 ]?.theme_supports[ 'block-templates' ] ?? false;
 	const hasActivated = useSelector( ( state ) => hasActivatedTheme( state, siteId ) );
+	const isActivating = useSelector( ( state ) => isActivatingTheme( state, siteId ) );
 	const customizeUrl = useSelector( ( state ) =>
 		getCustomizeUrl( state, theme.id, siteId, isFSEActive )
 	);
@@ -109,7 +113,6 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 		}
 		sendTrackEvent( 'calypso_theme_thank_you_activate_theme_click' );
 		dispatch( activate( theme.id, siteId, 'marketplace-thank-you' ) );
-		setIsActivating( true );
 	};
 
 	return (

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -1,7 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Gridicon } from '@automattic/components';
+import { Gridicon, Button } from '@automattic/components';
 import styled from '@emotion/styled';
-import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -87,8 +86,8 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const isActive = useSelector( ( state ) => isThemeActive( state, theme.id, siteId ) );
 	const { data, isLoading } = useActiveThemeQuery( siteId, true );
-	const hasActivated = useSelector( ( state ) => hasActivatedTheme( state, siteId ) );
 	const isFSEActive = data?.[ 0 ]?.theme_supports[ 'block-templates' ] ?? false;
+	const hasActivated = useSelector( ( state ) => hasActivatedTheme( state, siteId ) );
 	const customizeUrl = useSelector( ( state ) =>
 		getCustomizeUrl( state, theme.id, siteId, isFSEActive )
 	);
@@ -139,8 +138,8 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 				</ThemeSectionName>
 				<ThemeSectionButtons>
 					<ThemeButton
-						isPrimary
-						isBusy={ ( isActivating && ! hasActivated ) || isLoading }
+						primary
+						busy={ ( isActivating && ! hasActivated ) || isLoading }
 						onClick={ handleActivateTheme }
 						href={ isActive ? customizeUrl : undefined }
 					>
@@ -150,7 +149,7 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 					</ThemeButton>
 
 					{ isActive ? (
-						<ThemeButton isSecondary href={ siteUrl }>
+						<ThemeButton href={ siteUrl }>
 							<Gridicon size={ 18 } icon="external" />
 							{ translate( 'View site' ) }
 						</ThemeButton>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -1,0 +1,112 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import styled from '@emotion/styled';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+const ThemeSectionContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	width: 720px;
+	box-sizing: border-box;
+	border-radius: 16px;
+
+	box-shadow: 0px 15px 20px rgba( 0, 0, 0, 0.04 ), 0px 13px 10px rgba( 0, 0, 0, 0.03 ),
+		0px 6px 6px rgba( 0, 0, 0, 0.02 );
+
+	@media ( max-width: 740px ) {
+		width: 500px;
+	}
+
+	@media ( max-width: 520px ) {
+		width: 280px;
+	}
+`;
+
+const ThemeSectionImage = styled.img`
+	padding: 8px 8px 0 8px;
+	border-radius: 13px;
+`;
+
+const ThemeSectionContent = styled.div`
+	padding: 24px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	flex-wrap: wrap;
+`;
+
+const ThemeSectionName = styled.div`
+	font-size: 16px;
+	font-weight: 500;
+	line-height: 24px;
+	color: var( --studio-gray-100 );
+	& small {
+		font-size: 14px;
+		line-height: 22px;
+		font-weight: 400;
+		color: var( --studio-gray-60 );
+	}
+`;
+
+const ThemeSectionButtons = styled.div`
+	display: flex;
+	gap: 16px;
+	min-width: auto;
+`;
+
+export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const sendTrackEvent = useCallback(
+		( name: string ) => {
+			recordTracksEvent( name, {
+				site_id: siteId,
+				theme: theme.id,
+			} );
+		},
+		[ siteId, theme ]
+	);
+
+	const getThemeDetailsUrl = () => {
+		return `/theme/${ theme.id }/${ siteSlug }`;
+	};
+
+	return (
+		<ThemeSectionContainer>
+			<ThemeSectionImage
+				src={ theme.screenshot }
+				alt={
+					translate( "%(theme)s's icon", {
+						args: {
+							theme: theme.name,
+						},
+					} ) as string
+				}
+			/>
+			<ThemeSectionContent>
+				<ThemeSectionName>
+					<h5>{ theme.name }</h5>
+					<small>
+						{ theme.author
+							? translate( 'by %(author)s', { args: { author: theme.author } } )
+							: null }
+					</small>
+				</ThemeSectionName>
+				<ThemeSectionButtons>
+					<Button
+						isPrimary
+						href={ getThemeDetailsUrl() }
+						onClick={ () => sendTrackEvent( 'calypso_theme_thank_you_activate_theme_click' ) }
+					>
+						{ translate( 'Theme details' ) }
+					</Button>
+				</ThemeSectionButtons>
+			</ThemeSectionContent>
+		</ThemeSectionContainer>
+	);
+};

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { useQueryThemes } from 'calypso/components/data/query-theme';
 import { ThankYouSectionProps } from 'calypso/components/thank-you/types';
 import { getThemes } from 'calypso/state/themes/selectors';
+import { ThankYouThemeSection } from './marketplace-thank-you-theme-section';
 
 export function useThemesThankYouData( themeSlugs: string[] ): [ ThankYouSectionProps, boolean ] {
 	const dotComThemes = useSelector( ( state ) => getThemes( state, 'wpcom', themeSlugs ) );
@@ -20,7 +21,7 @@ export function useThemesThankYouData( themeSlugs: string[] ): [ ThankYouSection
 		sectionKey: 'theme_information',
 		nextSteps: themesList.map( ( theme ) => ( {
 			stepKey: `theme_information_${ theme?.id }`,
-			stepSection: <></>, // TODO: Add theme card
+			stepSection: <ThankYouThemeSection theme={ theme } />,
 		} ) ),
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

**Depends on:** 

- https://github.com/Automattic/wp-calypso/pull/74534

**Additional logic implemented as part of:**
- - https://github.com/Automattic/wp-calypso/issues/74760

Resolve #73995

## Proposed Changes

This task creates a new card for Themes in the Marketplace thank you page. It implements the changes as designed in 5ddl1WFTEnaIatL2WlZp4k-fi-2580%3A5886 with the following adjustments:
- The padding between the image and the card border is `8px` 
- The padding in the bottom row that contains the title and buttons is `24px` to be consistent with the plugin cards

![CleanShot 2023-03-21 at 13 46 11](https://user-images.githubusercontent.com/3519124/226610587-abc39bd6-386e-4508-a44d-27b459610c62.gif)


## Testing Instructions

Currently, the redirection for the Thank You page for themes is not completed, so this can be tested changing the URL in the browser:
- Navigate to `/marketplace/thank-you/:siteId?plugins=woocommerce-bookings&themes=loudness`, changing the plugin or theme for any valid value, in the example I have used the theme `loudness` but any other theme can be used, e.g. `lincoln` or `yuna`
- Check that the theme card corresponds to the design
- Click on the `Theme Details` button
- A confirmation modal is displayed showing options for keeping or switching the home page is displayed
- Click on `Activate this design`
- There is a loading indicator in the button, and after some seconds, the following two buttons are displayed: `Customize this design` and `View site`
- Click on `Customize this design` and make sure the browser navigates to the customization screens.
- Go back using the Back button in the browser
- The same buttons are displayed, click now on `View site`
- Make sure the browser navigates to your site and the selected theme is active




<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?