### PR TITLE
My Home: use a try/catch on Launchpad fetching

### DIFF
--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -37,16 +37,17 @@ export async function maybeRedirect( context, next ) {
 	}
 
 	const siteId = getSelectedSiteId( state );
-	const { launchpad_screen, site_intent } = await fetchLaunchpad( slug );
-
-	if ( launchpad_screen === 'full' ) {
-		// The new stepper launchpad onboarding flow isn't registered within the "page"
-		// client-side router, so page.redirect won't work. We need to use the
-		// traditional window.location Web API.
-		const verifiedParam = getQueryArgs()?.verified;
-		redirectToLaunchpad( slug, site_intent, verifiedParam );
-		return;
-	}
+	try {
+		const { launchpad_screen, site_intent } = await fetchLaunchpad( slug );
+		if ( launchpad_screen === 'full' ) {
+			// The new stepper launchpad onboarding flow isn't registered within the "page"
+			// client-side router, so page.redirect won't work. We need to use the
+			// traditional window.location Web API.
+			const verifiedParam = getQueryArgs()?.verified;
+			redirectToLaunchpad( slug, site_intent, verifiedParam );
+			return;
+		}
+	} catch ( error ) {}
 
 	// Ecommerce Plan's Home redirects to WooCommerce Home.
 	// Temporary redirection until we create a dedicated Home for Ecommerce.


### PR DESCRIPTION
We have some issues with customers accessing My Home after #74365

Related to p1679068865093079-slack-C02FMH4G8

## Proposed Changes

* Use try/catch to prevent the error

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try visiting My Home on an Atomic site while logged in as a less-than-admin -level user

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?