### PR TITLE
Magic link: Update style on magic link landing page.

### DIFF
--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -74,20 +74,8 @@ class HandleEmailedLinkForm extends Component {
 		}
 	}
 
-	componentDidMount() {
-		if (
-			this.props.clientId === config( 'wpcom_signup_id' ) &&
-			! this.props.isImmediateLoginAttempt &&
-			! wooDnaConfig( this.props.initialQuery ).isWooDnaFlow()
-		) {
-			this.handleSubmit();
-		}
-	}
-
 	handleSubmit = ( event ) => {
-		if ( event ) {
-			event.preventDefault();
-		}
+		event.preventDefault();
 
 		this.setState( {
 			hasSubmitted: true,

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -74,8 +74,20 @@ class HandleEmailedLinkForm extends Component {
 		}
 	}
 
+	componentDidMount() {
+		if (
+			this.props.clientId === config( 'wpcom_signup_id' ) &&
+			! this.props.isImmediateLoginAttempt &&
+			! wooDnaConfig( this.props.initialQuery ).isWooDnaFlow()
+		) {
+			this.handleSubmit();
+		}
+	}
+
 	handleSubmit = ( event ) => {
-		event.preventDefault();
+		if ( event ) {
+			event.preventDefault();
+		}
 
 		this.setState( {
 			hasSubmitted: true,
@@ -178,9 +190,9 @@ class HandleEmailedLinkForm extends Component {
 			);
 		}
 
-		const illustration =
-			'/calypso/images/illustrations/' +
-			( isWooDna ? 'illustration-woo-magic-link.svg' : 'illustration-nosites.svg' );
+		const illustration = isWooDna
+			? '/calypso/images/illustrations/illustration-woo-magic-link.svg'
+			: '';
 
 		this.props.recordTracksEvent( 'calypso_login_email_link_handle_click_view' );
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -22,6 +22,23 @@
 	}
 }
 
+.is-white-login .magic-login__handle-link {
+	.empty-content__title {
+		font-family: $brand-serif;
+		font-size: rem(42px);
+	}
+
+	.empty-content__line {
+		font-weight: normal;
+		font-size: $font-body;
+	}
+
+	.button.is-primary:not([disabled]) {
+		background-color: #007cba;
+		border-color: #007cba;
+	}
+}
+
 .magic-login__handle-link.jetpack {
 	.jetpack-logo {
 		margin: 35px 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74285

Addresses these points:
> - [x] If we do need to keep it, align styling (fonts and colors) with the other steps.
> - [x] If we do need to keep it, remove the illustration for now, as we are moving away from those styles.

## Proposed Changes

* Remove the illustration for now.
* Update the font style, font size, and button color to match the rest of the login framework.

Before | After
--|--
![magic-link-before](https://user-images.githubusercontent.com/140841/226011609-1333264c-de00-4ebd-bc89-92e9ff67e9f0.png)  |  ![magic-link-after](https://user-images.githubusercontent.com/140841/226011670-001ce862-b097-4875-ab12-d8027b8e008e.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In your WPCOM sandbox, add the following code to your /mu-plugins/0-sandbox.php file:

```
add_filter( 'wpcom_magic_login_calypso_base_url', function() {
    l( 'overriding wpcom_magic_login_calypso_base_url per your filter', null );
    return 'http://calypso.localhost:3000';
} );
```

* Sandbox the WPCOM API and load this Calypso PR on your localhost.
* Go to `http://calypso.localhost:3000/log-in/link` and request a login link using a non a11n account.
* Go to you email and click on the login link.
* The link will land you on http://calypso.localhost:3000/log-in/link/use
* The updates should match the screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
