### PR TITLE
Magic link: Auto submit magic link form on wpcom

### DIFF
--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -74,8 +74,20 @@ class HandleEmailedLinkForm extends Component {
 		}
 	}
 
+	componentDidMount() {
+		if (
+			this.props.clientId === config( 'wpcom_signup_id' ) &&
+			! this.props.isImmediateLoginAttempt &&
+			! wooDnaConfig( this.props.initialQuery ).isWooDnaFlow()
+		) {
+			this.handleSubmit();
+		}
+	}
+
 	handleSubmit = ( event ) => {
-		event.preventDefault();
+		if ( event ) {
+			event.preventDefault();
+		}
 
 		this.setState( {
 			hasSubmitted: true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74285

Addresses this point:

> - [x] Unsure if this screen is actually needed from a technical standpoint, but I'd perhaps remove it all together, it should log/get me in me automatically without extra click. At the most a loading or transient screen.

## Proposed Changes

* This PR auto submits the magic link landing page form on WPCOM, sending the user straight to their site and skipping an extra click.
* The landing page displays briefly existing as a transient screen and is used for errors and other login flows.

Before | After
--|--
<video src="https://user-images.githubusercontent.com/140841/226024974-fd06edd1-e3be-4432-bee1-1e8da269e4ee.mp4" /> | <video src="https://user-images.githubusercontent.com/140841/226025081-5b4c8fdb-0ec1-4ea4-bd88-148bb308ead3.mp4" />



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In your WPCOM sandbox, add the following code to your /mu-plugins/0-sandbox.php file:

```
add_filter( 'wpcom_magic_login_calypso_base_url', function() {
    l( 'overriding wpcom_magic_login_calypso_base_url per your filter', null );
    return 'http://calypso.localhost:3000';
} );
```

* Sandbox the WPCOM API and load this Calypso PR on your localhost.
* Go to `http://calypso.localhost:3000/log-in/link` and request a login link using a non a11n account.
* Go to you email and click on the login link.
* The link will land you on http://calypso.localhost:3000/log-in/link/use then it will automatically send you to your /home dashboard.

⚠️ Consider if this could affect another login flow leveraging this component.

⚠️ Consider if there are security implication around auto submitting the magic link landing page form.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
