### PR TITLE
Add term dropdown selector when purchasing Akismet product

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -1,4 +1,4 @@
-import { isJetpackPurchasableItem } from '@automattic/calypso-products';
+import { isAkismetProduct, isJetpackPurchasableItem } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { isCopySiteFlow } from '@automattic/onboarding';
 import {
@@ -192,12 +192,13 @@ function LineItemWrapper( {
 	const variants = useGetProductVariants( product, ( variant ) => {
 		// Only show term variants which are equal to or longer than the variant that
 		// was in the cart when checkout finished loading (not necessarily the
-		// current variant). For WordPress.com only, not Jetpack. See
+		// current variant). For WordPress.com only, not Jetpack or Akismet. See
 		// https://github.com/Automattic/wp-calypso/issues/69633
 		if ( ! initialVariantTerm ) {
 			return true;
 		}
-		if ( isJetpack ) {
+		const isAkismet = isAkismetProduct( { product_slug: variant.productSlug } );
+		if ( isJetpack || isAkismet ) {
 			return true;
 		}
 		return variant.termIntervalInMonths >= initialVariantTerm;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 1204136657007202-as-1204194673432332/f

## Proposed Changes
This PR adds an ability to select the term ( monthly / yearly ) when navigating through checkout for Akismet product. 
Originally, the dropdown should be disabled only in certain cases for WPCOM product (more info: https://github.com/Automattic/wp-calypso/issues/69633), so we just mimic the behavior of Jetpack purchase.

## Testing Instructions
- Apply the branch locally and spin `yarn start` OR use Live link provided below
- Navigate to `/checkout/akismet/ak_plus_yearly_1` (if using live link provide a Feature flag param `?flags=akismet/siteless-checkout`)
- Observe that there's a dropdown to select billing term

**Before**
![Screenshot 2023-03-17 at 12 59 30](https://user-images.githubusercontent.com/60262784/226020042-31e809b7-10a0-4f18-b305-c2255feba45e.jpg)

**After**
![Screenshot 2023-03-17 at 12 59 30___2](https://user-images.githubusercontent.com/60262784/226020146-dea96e30-bcca-4e8c-988a-356aff817d6e.jpg)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?