### PR TITLE
WooExpress: Fixes the ring on the plans page for RTL languages

### DIFF
--- a/client/my-sites/plans/doughnut-chart/style.scss
+++ b/client/my-sites/plans/doughnut-chart/style.scss
@@ -43,5 +43,9 @@
 		inset: calc(50% - var(--line-width) / 2);
 		background: rgb(var(--main-color));
 		transform: rotate(calc(var(--percentage) * 3.6deg)) translateY(calc(50% - var(--width) / 2));
+
+		.rtl & {
+			transform: rotate(calc(var(--percentage) * 3.6deg * -1)) translateY(calc(50% - var(--width) / 2));
+		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* Fixes the tip of the progress ring for RTL languages.

<img width="252" alt="219430716-d2e70f81-1eee-4b01-b2a5-80a9ca6cf25e" src="https://user-images.githubusercontent.com/1234758/226044386-84c708e6-1d1d-4385-81c8-41910c0ff5b0.png">


#### Before

<img width="1205" alt="Screen Shot 2023-03-17 at 15 50 46" src="https://user-images.githubusercontent.com/1234758/226041929-7dca2c78-b985-481b-8054-f9b039fa0d98.png">

#### After

<img width="1184" alt="Screen Shot 2023-03-17 at 15 49 54" src="https://user-images.githubusercontent.com/1234758/226041518-e90e3771-0aa9-4907-b46d-c4562d08cb46.png">


## Testing Instructions

* Navigate to `/me/account` and set your *Interface Language* as RTL language. For example, Hebrew.
* Navigate to `/plans/SITE-SLUG` on a site with the free trial plan.
* The ring should not have a flat surface anymore.

Closes #73441
