### PR TITLE
Launchpad: Add test coverage for email verification task filtering

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -64,29 +64,59 @@ describe( 'Task Helpers', () => {
 	} );
 
 	describe( 'getArrayOfFilteredTasks', () => {
-		describe( 'when no flow is provided', () => {
-			it( 'then no tasks are found', () => {
-				expect( getArrayOfFilteredTasks( tasks, null, false ) ).toBe( null );
+		describe( 'when the user has not verified their email address', () => {
+			const isEmailVerified = false;
+
+			describe( 'and no flow is provided', () => {
+				it( 'then no tasks are found', () => {
+					expect( getArrayOfFilteredTasks( tasks, null, isEmailVerified ) ).toBe( null );
+				} );
+			} );
+
+			describe( 'and a non-existing flow is provided', () => {
+				it( 'then no tasks are found', () => {
+					expect( getArrayOfFilteredTasks( tasks, 'custom-flow', isEmailVerified ) ).toBe(
+						undefined
+					);
+				} );
+			} );
+
+			describe( 'and an existing flow is provided', () => {
+				it( 'then it returns found tasks', () => {
+					expect(
+						getArrayOfFilteredTasks( tasks, 'newsletter', isEmailVerified )?.sort( ( a, b ) =>
+							a.id < b.id ? -1 : 1
+						)
+					).toEqual(
+						tasks
+							.sort( ( a, b ) => ( a.id < b.id ? -1 : 1 ) )
+							.filter( ( task ) => launchpadFlowTasks[ 'newsletter' ].includes( task.id ) )
+					);
+				} );
 			} );
 		} );
 
-		describe( 'when a non-existing flow is provided', () => {
-			it( 'then no tasks are found', () => {
-				expect( getArrayOfFilteredTasks( tasks, 'custom-flow', false ) ).toBe( undefined );
-			} );
-		} );
+		describe( 'when the user has verified their email address', () => {
+			const isEmailVerified = true;
 
-		describe( 'when an existing flow is provided', () => {
-			it( 'then it returns found tasks', () => {
-				expect(
-					getArrayOfFilteredTasks( tasks, 'newsletter', false )?.sort( ( a, b ) =>
-						a.id < b.id ? -1 : 1
-					)
-				).toEqual(
-					tasks
-						.sort( ( a, b ) => ( a.id < b.id ? -1 : 1 ) )
-						.filter( ( task ) => launchpadFlowTasks[ 'newsletter' ].includes( task.id ) )
-				);
+			describe( 'and an existing flow is provided', () => {
+				it( 'then it returns tasks without an email verified task', () => {
+					expect(
+						getArrayOfFilteredTasks( tasks, 'newsletter', isEmailVerified )?.sort( ( a, b ) =>
+							a.id < b.id ? -1 : 1
+						)
+					).toEqual(
+						tasks
+							.sort( ( a, b ) => ( a.id < b.id ? -1 : 1 ) )
+							.filter( ( task ) => {
+								if ( task.id === 'verify_email' ) {
+									return false;
+								}
+
+								return launchpadFlowTasks[ 'newsletter' ].includes( task.id );
+							} )
+					);
+				} );
 			} );
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -61,6 +61,27 @@ describe( 'Task Helpers', () => {
 				expect( enhancedTasks[ 0 ].completed ).toEqual( true );
 			} );
 		} );
+		describe( 'when creating the email verification task', () => {
+			describe( 'and the user email has been verified', () => {
+				it( 'marks the task as complete', () => {
+					const fakeTasks = [ buildTask( { id: 'verify_email', completed: false } ) ];
+					const isEmailVerified = true;
+					const enhancedTasks = getEnhancedTasks(
+						fakeTasks,
+						'fake.wordpress.com',
+						null,
+						// eslint-disable-next-line @typescript-eslint/no-empty-function
+						() => {},
+						false,
+						// eslint-disable-next-line @typescript-eslint/no-empty-function
+						() => {},
+						'newsletter',
+						isEmailVerified
+					);
+					expect( enhancedTasks[ 0 ].completed ).toEqual( true );
+				} );
+			} );
+		} );
 	} );
 
 	describe( 'getArrayOfFilteredTasks', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/74135

## Estimated Time to Test / Review:
- Test -> Short
- Review -> Short

## Proposed Changes

* Adds tests to account for email verification task filtering added in the PR above

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* Verify that `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts` passes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
