### PR TITLE
Woo Express: Removed feature flag from the plans page

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -304,7 +304,7 @@ class Plans extends Component {
 		if ( isEcommerceTrial ) {
 			return this.renderEcommerceTrialPage();
 		}
-		if ( isWooExpressPlan && isEnabled( 'plans/wooexpress-medium' ) ) {
+		if ( isWooExpressPlan ) {
 			return this.renderWooExpressMediumPage();
 		}
 		return this.renderPlansMain();


### PR DESCRIPTION
This PR removes the check for the `plans/wooexpress-medium` feature flag before showing the Woo Express specific "Plans" page to users that already have the Woo Express plan.

## Testing

* Go to the Plans page (`/plans/<site-slug>`) using a site with the woo express plan.
* Make sure the feature flag is _disabled_ (`?flags=-plans/wooexpress-medium`)
* You should see this page:

![image](https://user-images.githubusercontent.com/3801502/226129405-a321e3aa-e763-4300-ab76-5becae10b39f.png)
