### PR TITLE
Changes to maintain the tabswitch aspect on mobile

### DIFF
--- a/packages/subscription-manager/src/components/TabsSwitcher/styles.scss
+++ b/packages/subscription-manager/src/components/TabsSwitcher/styles.scss
@@ -67,3 +67,43 @@
 		margin-bottom: 22px;
 	}
 }
+
+@media screen and ( max-width: $break-medium ) {
+	.section-nav.subscription-manager-tab-switcher {
+		.section-nav__mobile-header {
+			display: none;
+		}
+
+		.section-nav-group {
+			display: flex;
+		}
+
+		.section-nav__panel {
+			display: flex;
+			align-items: center;
+		}
+
+		.section-nav-tab__text {
+			display: inline;
+			width: auto;
+			text-align: center;
+			flex-grow: 0;
+			font-weight: 400;
+		}
+
+		.section-nav-tab__link {
+			display: block;
+			font-weight: 400;
+			background-color: transparent;
+		}
+
+		.section-nav-tabs {
+			flex-grow: 1;
+			flex-shrink: 0;
+		}
+
+		.section-nav-tabs__list {
+			display: flex;
+		}
+	}
+}


### PR DESCRIPTION
## Proposed Changes

The changes proposed in this PR make the tab switcher in Subscriptions Manager maintain the same aspect in mobile as in the desktop version.

This is the desktop version:
<img width="643" alt="Screenshot 2023-03-18 at 19 37 35" src="https://user-images.githubusercontent.com/3832570/226129635-948a29db-d95c-475a-a1cc-5a6bf4464c53.png">

This is the mobile version:
<img width="386" alt="Screenshot 2023-03-18 at 19 38 22" src="https://user-images.githubusercontent.com/3832570/226129641-eda8cd74-9ea7-4843-9ccb-2bf6a6c59133.png">

## Testing Instructions

1. Apply this patch.
2. Go to http://calypso.localhost:3000/subscriptions/settings in your desktop browser.
3. You should see the desktop version as the desktop image above.
4. Shrink the browser window or use the IOS Simulator on your computer (if you use Mac).
5. You should see the mobile version as the mobile image above.

Fixes https://github.com/Automattic/wp-calypso/issues/74523
