### PR TITLE
Woo Express: Enable `plans/wooexpress-medium` flag in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -111,7 +111,7 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
-		"plans/wooexpress-medium": false,
+		"plans/wooexpress-medium": true,
 		"plans/wooexpress-small": false,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,


### PR DESCRIPTION
This PR enables `plans/wooexpress-medium` feature flag in the `wpcalypso` environment.

## Testing

* Code inspection
* Open the plans page (`/plans/<site-slug>`) for a trial site
* With the flag enabled, you should see the Woo Express plan details
![image](https://user-images.githubusercontent.com/3801502/226133712-0f35907a-98a9-476d-a89f-b48478c97ec0.png)

* With the flag disabled, you should see the Commerce plan details
![image](https://user-images.githubusercontent.com/3801502/226133738-55921b36-c80a-4620-ac8f-e0505075c18f.png)
