### PR TITLE
Woo Express: Removed feature flag check

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -357,7 +357,7 @@ class Plans extends Component {
 				: translate( 'Choose the perfect plan' );
 
 		// Hide for WooExpress plans
-		const showPlansNavigation = isEnabled( 'plans/wooexpress-medium' ) ? ! isWooExpressPlan : true;
+		const showPlansNavigation = ! isWooExpressPlan;
 
 		return (
 			<div>


### PR DESCRIPTION
This PR removes the check for the `plans/wooexpress-medium` feature flag before showing the "My Plan | Plans" switches.

## Testing

* Go to the Plans page (`/plans/<site-slug>`) using a site with the woo express plan.
* Make sure the feature flag is _disabled_ (`?flags=-plans/wooexpress-medium`)
* You should see this page:

Before:
![image](https://user-images.githubusercontent.com/3801502/226131316-fb295d44-02e4-46ef-9030-353fae7c4592.png)

After:
![image](https://user-images.githubusercontent.com/3801502/226131344-06e93779-8b3e-4356-92e8-a2ce17bb9524.png)
