### PR TITLE
Theme Showcase: Style variation badge a11y improvements

### DIFF
--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -427,3 +427,12 @@ $soft-launch-badge-font-size: 0.725rem;
 		border-radius: 2px;
 	}
 }
+
+.theme__info-style-variations {
+	.style-variation__badge-wrapper,
+	.style-variation__badge-more-wrapper {
+		&:focus-visible span {
+			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2), 0 0 0 2px var(--color-primary-light);
+		}
+	}
+}

--- a/packages/design-picker/src/components/style-variation-badges/badge.tsx
+++ b/packages/design-picker/src/components/style-variation-badges/badge.tsx
@@ -55,7 +55,7 @@ const Badge: React.FC< BadgeProps > = ( { variation, onClick, isSelected } ) => 
 					// Prevent the event from bubbling to the parent button.
 					e.stopPropagation();
 					e.preventDefault();
-					onClick?.( variation, e );
+					onClick?.( variation );
 				}
 			} }
 		>

--- a/packages/design-picker/src/components/style-variation-badges/badge.tsx
+++ b/packages/design-picker/src/components/style-variation-badges/badge.tsx
@@ -25,6 +25,11 @@ const Badge: React.FC< BadgeProps > = ( { variation, onClick, isSelected } ) => 
 		return null;
 	}
 
+	const title = variation.title
+		? // translators: %(title)s - the style variation title.
+		  sprintf( __( 'Style: %(title)s' ), { title: variation.title } )
+		: __( 'Preview with this style' );
+
 	return (
 		<div
 			className={ classnames( 'style-variation__badge-wrapper', {
@@ -32,12 +37,8 @@ const Badge: React.FC< BadgeProps > = ( { variation, onClick, isSelected } ) => 
 			} ) }
 			tabIndex={ 0 }
 			role="button"
-			aria-label={
-				variation.title
-					? // translators: %(title)s - the style variation title.
-					  sprintf( __( 'Style: %(title)s' ), { title: variation.title } )
-					: __( 'Preview with this style' )
-			}
+			title={ title }
+			aria-label={ title }
 			onClick={ ( e ) => {
 				if ( isSelected ) {
 					return;
@@ -53,7 +54,8 @@ const Badge: React.FC< BadgeProps > = ( { variation, onClick, isSelected } ) => 
 				if ( e.keyCode === SPACE_BAR_KEYCODE ) {
 					// Prevent the event from bubbling to the parent button.
 					e.stopPropagation();
-					onClick?.( variation );
+					e.preventDefault();
+					onClick?.( variation, e );
 				}
 			} }
 		>

--- a/packages/design-picker/src/components/style-variation-badges/index.tsx
+++ b/packages/design-picker/src/components/style-variation-badges/index.tsx
@@ -64,6 +64,7 @@ const Badges: React.FC< BadgesProps > = ( {
 						if ( onMoreClick && e.keyCode === SPACE_BAR_KEYCODE ) {
 							// Prevent the event from bubbling to the the parent button.
 							e.stopPropagation();
+							e.preventDefault();
 							onMoreClick();
 						}
 					} }


### PR DESCRIPTION
## Proposed Changes

As suggested in pdtkmj-1gp-p2#comment-2288, this PR updates the style variation badge with several a11y improvements:

`focus-visible` state.

![Screenshot 2023-03-20 at 10 40 57 AM](https://user-images.githubusercontent.com/797888/226234314-c560ff26-37e8-4dc8-aadc-2cd6266b2cb6.png)

Set `title` to show the style variation name as tooltip.
![Screenshot 2023-03-20 at 10 42 01 AM](https://user-images.githubusercontent.com/797888/226234454-7c82796f-71ee-49fa-8b66-c50fe0011fff.png)

And, prevent unintended page scroll on the press of the space bar click.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Using keyboard navigation, ensure that the `focus-visible` state is as described above.
* Ensure that a tooltip with the style variation name appears when hovering on the style variation badge.
* Ensure that when the style variation badge is focused, pressing the space bar does not scroll the page.  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?