### PR TITLE
ButtonGroup component: fix hover/focus styles

### DIFF
--- a/client/components/button-group/README.md
+++ b/client/components/button-group/README.md
@@ -21,14 +21,13 @@ function render() {
 
 ### General guidelines
 
-- Follow the same guidelines as the [Button](./buttons) component.
+- Follow the same guidelines as the [Button](./wordpress-components-gallery) component.
 - To manipulate or switch visible content, use the [SegmentedControl](./segmented-control) component instead.
 - Group together actions that have a relationship.
 - Be thoughtful about how multiple horizontally placed buttons will look and work on small screens.
 
 ## Related components
 
-- See the [Button](./buttons) component for more detail.
 - Use the [SegmentedControl](./segmented-control) component to switch content.
 - To use a button with a secondary popover menu, use the [SplitButton](./split-button) component.
 - To display a loading spinner with a button, use the [SpinnerButton](../design/spinner-button) component.

--- a/client/components/button-group/docs/example.jsx
+++ b/client/components/button-group/docs/example.jsx
@@ -16,9 +16,9 @@ class Buttons extends PureComponent {
 	render() {
 		return (
 			<div>
-				<a className="docs__design-toggle button" onClick={ this.toggleButtons }>
+				<button className="docs__design-toggle button" onClick={ this.toggleButtons }>
 					{ this.state.compact ? 'Normal Buttons' : 'Compact Buttons' }
-				</a>
+				</button>
 				<Card>
 					<div className="docs__design-button-group-row">
 						<ButtonGroup>
@@ -29,9 +29,11 @@ class Buttons extends PureComponent {
 					<div className="docs__design-button-group-row">
 						<ButtonGroup>
 							<Button compact={ this.state.compact }>Button one</Button>
-							<Button compact={ this.state.compact }>Button two</Button>
 							<Button compact={ this.state.compact } scary>
-								Button Three
+								Button two
+							</Button>
+							<Button compact={ this.state.compact } scary>
+								Button three
 							</Button>
 						</ButtonGroup>
 					</div>

--- a/client/components/button-group/style.scss
+++ b/client/components/button-group/style.scss
@@ -9,6 +9,7 @@
 			z-index: z-index("button-group-parent", ".button-group .button:focus");
 		}
 
+		&:active,
 		&:focus,
 		&:hover {
 			border-left-width: 1px;
@@ -21,10 +22,7 @@
 		border-top-left-radius: 2px;
 		border-bottom-left-radius: 2px;
 
-		&:active {
-			border-right-width: 0;
-		}
-
+		&:active,
 		&:focus,
 		&:hover {
 			margin-left: 0;
@@ -34,9 +32,6 @@
 	.button:last-child {
 		border-top-right-radius: 2px;
 		border-bottom-right-radius: 2px;
-		&:active {
-			border-left-width: 0;
-		}
 	}
 
 	.section-header & .button {

--- a/client/components/button-group/style.scss
+++ b/client/components/button-group/style.scss
@@ -8,14 +8,26 @@
 			position: relative;
 			z-index: z-index("button-group-parent", ".button-group .button:focus");
 		}
+
+		&:focus,
+		&:hover {
+			border-left-width: 1px;
+			margin-left: -1px;
+		}
 	}
 
 	.button:first-child {
 		border-left-width: 1px;
 		border-top-left-radius: 2px;
 		border-bottom-left-radius: 2px;
+
 		&:active {
 			border-right-width: 0;
+		}
+
+		&:focus,
+		&:hover {
+			margin-left: 0;
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

When using a Calypso ButtonGroup, the left border of a button does not match when hovering/focusing it:

<img width="346" alt="Screenshot 2023-03-20 at 3 31 31 PM" src="https://user-images.githubusercontent.com/17325/226236990-efaa12a4-7eba-4255-a795-dd6a683f08b7.png">

This is particularly noticeable on a 'scary' button, which has a red border.

This PR fixes the focus and hover styles for buttons within a button group so that the entire border of the current button is the same color:

<img width="355" alt="Screenshot 2023-03-20 at 3 40 15 PM" src="https://user-images.githubusercontent.com/17325/226237107-727806a1-1cf8-4f7f-baf5-3a45b7236e71.png">

## Testing Instructions

Head to http://calypso.localhost:3000/devdocs/design/button-group and try hovering over/interacting with a button. Ensure that the hovered/focused button has a continuous border in the same color.

To try this component in a real world situation, take a look at http://calypso.localhost:3000/comments/all/ and try to bulk edit comments. The spam and trash buttons here should also now show a continuous border.

<img width="126" alt="Screenshot 2023-03-20 at 3 40 37 PM" src="https://user-images.githubusercontent.com/17325/226237289-b6e2df2e-a428-4709-afff-bc339de77290.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
