### PR TITLE
Logging: Add "Site logs" section to Calypso

### DIFF
--- a/client/my-sites/sidebar/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/fallback-menu.js
@@ -39,6 +39,7 @@ export default function buildFallbackResponse( {
 	shouldShowAdControl = false,
 	shouldShowAMP = false,
 	shouldShowAddOns = false,
+	showSiteLogs = false,
 } = {} ) {
 	let inbox = [];
 	if ( shouldShowInbox ) {
@@ -510,6 +511,17 @@ export default function buildFallbackResponse( {
 					type: 'submenu-item',
 					url: `/export/${ siteDomain }`,
 				},
+				...( config.isEnabled( 'woa-logging' ) && showSiteLogs
+					? [
+							{
+								parent: 'tools.php',
+								slug: 'tools-site-logs',
+								title: translate( 'Site Logs' ),
+								type: 'submenu-item',
+								url: `/site-logs/${ siteDomain }`,
+							},
+					  ]
+					: [] ),
 			],
 		},
 		{

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -91,6 +91,7 @@ const useSiteMenuItems = () => {
 		shouldShowThemes,
 		shouldShowInbox,
 		shouldShowAddOns: shouldShowAddOnsInFallbackMenu,
+		showSiteLogs: isAtomic,
 	};
 
 	return menuItems ?? buildFallbackResponse( fallbackDataOverrides );

--- a/client/my-sites/site-logs/controller.tsx
+++ b/client/my-sites/site-logs/controller.tsx
@@ -1,0 +1,12 @@
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { SiteLogs } from './main';
+
+export const siteLogs: PageJS.Callback = ( context, next ) => {
+	context.primary = (
+		<>
+			<PageViewTracker path="/site-logs/:site" title="Site logs" delay={ 500 } />
+			<SiteLogs />
+		</>
+	);
+	next();
+};

--- a/client/my-sites/site-logs/index.ts
+++ b/client/my-sites/site-logs/index.ts
@@ -1,0 +1,19 @@
+import { isEnabled } from '@automattic/calypso-config';
+import page from 'page';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
+import { siteLogs } from './controller';
+
+export default function () {
+	if ( ! isEnabled( 'woa-logging' ) ) {
+		// Redirect to Customer Home if flag isn't enabled.
+		page( '/site-logs/:siteId', ( { params: { siteId } } ) => {
+			page.replace( `/home/${ siteId }` );
+		} );
+		return;
+	}
+
+	page( '/site-logs', siteSelection, sites, makeLayout, clientRender );
+
+	page( '/site-logs/:siteId', siteSelection, navigation, siteLogs, makeLayout, clientRender );
+}

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -1,0 +1,12 @@
+import { useSelector } from 'react-redux';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export function SiteLogs() {
+	const siteId = useSelector( getSelectedSiteId );
+
+	return (
+		<>
+			<h2>Site logs for { siteId }</h2>
+		</>
+	);
+}

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -139,6 +139,9 @@ class Sites extends Component {
 			case 'jetpack-search':
 				path = 'Jetpack Search';
 				break;
+			case 'site-logs':
+				path = translate( 'Site Logs' );
+				break;
 		}
 
 		return translate( 'Select a site to open {{strong}}%(path)s{{/strong}}', {

--- a/client/sections.js
+++ b/client/sections.js
@@ -570,6 +570,12 @@ const sections = [
 		group: 'sites',
 		enableLoggedOut: true,
 	},
+	{
+		name: 'site-logs',
+		paths: [ '/site-logs' ],
+		module: 'calypso/my-sites/site-logs',
+		group: 'sites',
+	},
 ];
 
 module.exports = sections;

--- a/config/development.json
+++ b/config/development.json
@@ -199,6 +199,7 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
 		"yolo/staging-sites-i1": true,
-		"newsletter/stats": true
+		"newsletter/stats": true,
+		"woa-logging": true
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of Automattic/dotcom-forge#1987

## Proposed Changes

* Adds `/site-logs/:siteId` section to Calypso with a placeholder component
* Records the standard page view tracks event on navigation
* Shows the site selector when accidentally navigating to `/site-logs` without a site slug
* Shows the "Select a site to open Site Logs" message in the site selector
* Shows site logs in the fallback menu, which is what shows while the authoritative menu items are being loaded from `/admin-menu`

The placeholder view looks like this
![CleanShot 2023-03-20 at 20 44 11@2x](https://user-images.githubusercontent.com/1500769/226278210-abb07c70-e4c1-4e5f-aef0-ead7a67ad546.png)


For info about how "nav unification" works check out PCYsg-vFk-p2. In short the source of truth for menu items is the server so that we can show the same menu items in both Calypso and `wp-admin`. That means in order to add our new menu item for the logs we to change some code in Jetpack.

FWIW the fallback menu item is testable if you jump through some hoops and looks like this
![CleanShot 2023-03-20 at 20 28 33@2x](https://user-images.githubusercontent.com/1500769/226278316-36bfd6e9-f7fc-4251-b869-7271d2f1c3a2.png)
![CleanShot 2023-03-20 at 20 28 47@2x](https://user-images.githubusercontent.com/1500769/226278330-ad7b537d-ace4-474f-9e8f-a3076dd96dbe.png)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/site-logs` and see site selector is shown
* Navigate to `/site-logs/:someAtomicSite` and see placeholder view
* Navigate to `/site-logs/:someSimpleSite` or `/site-logs/:someJetpackSite` and get redirected away

To test the fallback menu first we need to prevent the data from `/admin-menu` loading. These instructions work in Chromium.
- Filter network requests by `admin-menu`
- Right-click the request and select **Block request URL**
- Now ensure we aren't using menu items cached in Redux by clearing IndexDB
- Refresh the page
- See the network request has been blocked so when you're testing the menu you're seeing the fallback menu.
- Test
   - Site logs menu is missing when `woa-logging` isn't defined
   - Menu entry is missing for Jetpack and Simple sites
   - Menu entry is available for Atomic sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~