### PR TITLE
Jetpack Pro Dashboard: implement site expanded content for monitor activity on large and small screens

### DIFF
--- a/client/components/chart/README.md
+++ b/client/components/chart/README.md
@@ -50,3 +50,6 @@ function render() {
 - <strong>minTouchBarWidth</strong> — _default: 42_ The minimum bar width on touch devices
 - <strong>minBarWidth</strong> — _default: 15_ The minimum bar width on non-touch devices
 - <strong>barClick</strong> - The function to be called when a bar is clicked on the chart, it is passed the entire data object of the bar
+- <strong>minBarsToBeShown</strong> - The minimun no of bars to be shown
+- <strong>hideYAxis</strong> - _default: false_ A boolean value whether to hide the y-axis
+- <strong>hideXAxis</strong> - _default: false_ A boolean value whether to hide the x-axis

--- a/client/components/chart/bar-container.jsx
+++ b/client/components/chart/bar-container.jsx
@@ -14,10 +14,12 @@ export default class ChartBarContainer extends PureComponent {
 		isTouch: PropTypes.bool,
 		width: PropTypes.number,
 		yAxisMax: PropTypes.number,
+		hideXAxis: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		isPlaceholder: false,
+		hideXAxis: false,
 	};
 
 	render() {
@@ -39,7 +41,7 @@ export default class ChartBarContainer extends PureComponent {
 						/>
 					) ) }
 				</div>
-				{ ! this.props.isPlaceholder && (
+				{ ! this.props.isPlaceholder && ! this.props.hideXAxis && (
 					<XAxis
 						data={ this.props.data }
 						labelWidth={ X_AXIS_LABEL_WIDTH }

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -115,6 +115,7 @@ function Chart( {
 	const minWidth = isTouch ? minTouchBarWidth : minBarWidth;
 
 	const width = isTouch && sizing.clientWidth <= 0 ? 350 : sizing.clientWidth - chartXPadding; // mobile safari bug with zero width
+	// Max number of bars that can fit in the chart. If minBarsToBeShown is set, use that instead.
 	const maxBars = minBarsToBeShown ?? Math.floor( width / minWidth );
 
 	useEffect( () => {

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -57,6 +57,8 @@ function Chart( {
 	sliceFromBeginning,
 	onChangeMaxBars,
 	minBarsToBeShown,
+	hideYAxis,
+	hideXAxis,
 } ) {
 	const [ tooltip, setTooltip ] = useState( { isTooltipVisible: false } );
 	const [ sizing, setSizing ] = useState( { clientWidth: 0, hasResized: false } );
@@ -192,7 +194,7 @@ function Chart( {
 					</div>
 				) }
 			</div>
-			{ ! isPlaceholder && <ChartYAxis /> }
+			{ ! isPlaceholder && ! hideYAxis && <ChartYAxis /> }
 			<BarContainer
 				barClick={ barClick }
 				chartWidth={ width }
@@ -202,6 +204,7 @@ function Chart( {
 				isTouch={ hasTouch() }
 				setTooltip={ handleTooltipChange }
 				yAxisMax={ yMax }
+				hideXAxis={ hideXAxis }
 			/>
 			{ isTooltipVisible && (
 				<Tooltip
@@ -230,6 +233,8 @@ Chart.propTypes = {
 	chartXPadding: PropTypes.number,
 	sliceFromBeginning: PropTypes.bool,
 	minBarsToBeShown: PropTypes.number,
+	hideYAxis: PropTypes.bool,
+	hideXAxis: PropTypes.bool,
 };
 
 Chart.defaultProps = {
@@ -239,6 +244,8 @@ Chart.defaultProps = {
 	minTouchBarWidth: 42,
 	chartXPadding: 20,
 	sliceFromBeginning: true,
+	hideYAxis: false,
+	hideXAxis: false,
 };
 
 export default withRtl( localize( Chart ) );

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -56,6 +56,7 @@ function Chart( {
 	chartXPadding,
 	sliceFromBeginning,
 	onChangeMaxBars,
+	minBarsToBeShown,
 } ) {
 	const [ tooltip, setTooltip ] = useState( { isTooltipVisible: false } );
 	const [ sizing, setSizing ] = useState( { clientWidth: 0, hasResized: false } );
@@ -112,7 +113,7 @@ function Chart( {
 	const minWidth = isTouch ? minTouchBarWidth : minBarWidth;
 
 	const width = isTouch && sizing.clientWidth <= 0 ? 350 : sizing.clientWidth - chartXPadding; // mobile safari bug with zero width
-	const maxBars = Math.floor( width / minWidth );
+	const maxBars = minBarsToBeShown ?? Math.floor( width / minWidth );
 
 	useEffect( () => {
 		if ( onChangeMaxBars ) {
@@ -228,6 +229,7 @@ Chart.propTypes = {
 	translate: PropTypes.func,
 	chartXPadding: PropTypes.number,
 	sliceFromBeginning: PropTypes.bool,
+	minBarsToBeShown: PropTypes.number,
 };
 
 Chart.defaultProps = {

--- a/client/data/agency-dashboard/use-fetch-monitor-data.ts
+++ b/client/data/agency-dashboard/use-fetch-monitor-data.ts
@@ -20,8 +20,8 @@ const useFetchMonitorData = ( siteId: number ) => {
 					incidents: dates.map( ( date, index ) => ( {
 						date,
 						// eslint-disable-next-line no-nested-ternary
-						status: index < 10 ? 'down' : index < 15 ? 'up' : 'no-data',
-						total_downtime: 305,
+						status: index < 10 ? 'down' : index < 15 ? 'up' : 'monitor_inactive',
+						downtime_in_minutes: 10,
 					} ) ),
 				};
 			},

--- a/client/data/agency-dashboard/use-fetch-monitor-data.ts
+++ b/client/data/agency-dashboard/use-fetch-monitor-data.ts
@@ -1,0 +1,32 @@
+import moment from 'moment';
+import { useQuery } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+const useFetchMonitorData = ( siteId: number ) => {
+	return useQuery(
+		[ 'jetpack-monitor-incidents', siteId ],
+		() =>
+			wpcom.req.get( {
+				path: `/sites/${ siteId }/jetpack-monitor-incidents`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		{
+			select: () => {
+				const dates = new Array( 20 );
+				for ( let i = 0; i < dates.length; i++ ) {
+					dates[ i ] = moment().subtract( i, 'days' ).format( 'YYYY-MM-DDTHH:mm:ss.000[Z]' );
+				}
+				return {
+					incidents: dates.map( ( date, index ) => ( {
+						date,
+						// eslint-disable-next-line no-nested-ternary
+						status: index < 10 ? 'down' : index < 15 ? 'up' : 'no-data',
+						total_downtime: 305,
+					} ) ),
+				};
+			},
+		}
+	);
+};
+
+export default useFetchMonitorData;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/expanded-card.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/expanded-card.tsx
@@ -11,6 +11,7 @@ interface Props {
 	isEnabled?: boolean;
 	onClick?: () => void;
 	href?: string;
+	isLoading?: boolean;
 }
 
 export default function ExpandedCard( {
@@ -20,6 +21,7 @@ export default function ExpandedCard( {
 	emptyContent,
 	onClick,
 	href,
+	isLoading,
 }: Props ) {
 	// Trigger click event when pressing Enter or Space
 	const handleOnKeyDown = ( event: React.KeyboardEvent< HTMLDivElement > ) => {
@@ -28,16 +30,19 @@ export default function ExpandedCard( {
 		}
 	};
 
+	const isClickable = !! onClick && ! isLoading;
+
 	const props = {
 		href,
 		compact: true,
 		showLinkIcon: false,
 		className: classNames( 'expanded-card', {
 			'expanded-card__not-enabled': ! isEnabled,
-			'expanded-card__clickable': onClick,
+			'expanded-card__clickable': isClickable,
+			'expanded-card__loading': isLoading,
 		} ),
 		// Add click handlers if onClick is provided
-		...( onClick && {
+		...( isClickable && {
 			role: 'button',
 			tabIndex: 0,
 			onKeyDown: handleOnKeyDown,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -5,17 +5,17 @@ import BackupStorage from './backup-storage';
 import BoostSitePerformance from './boost-site-performance';
 import InsightsStats from './insights-stats';
 import MonitorActivity from './monitor-activity';
-import type { Site } from '../types';
+import type { Site, AllowedTypes } from '../types';
 
 import './style.scss';
 
 interface Props {
 	site: Site;
-	columns?: string[];
+	columns?: AllowedTypes[];
 	isSmallScreen?: boolean;
 }
 
-const defaultColumns = siteColumns.map( ( { key } ) => key );
+const defaultColumns: AllowedTypes[] = siteColumns.map( ( { key } ) => key );
 
 export default function SiteExpandedContent( {
 	site,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -4,6 +4,7 @@ import { siteColumns } from '../utils';
 import BackupStorage from './backup-storage';
 import BoostSitePerformance from './boost-site-performance';
 import InsightsStats from './insights-stats';
+import MonitorActivity from './monitor-activity';
 import type { Site } from '../types';
 
 import './style.scss';
@@ -30,6 +31,7 @@ export default function SiteExpandedContent( {
 	const trackEvent = ( eventName: string ) => {
 		recordEvent( eventName );
 	};
+	const hasMonitor = site.monitor_settings.monitor_active;
 
 	return (
 		<div
@@ -55,6 +57,9 @@ export default function SiteExpandedContent( {
 			) }
 			{ columns.includes( 'backup' ) && stats && (
 				<BackupStorage site={ site } trackEvent={ trackEvent } />
+			) }
+			{ columns.includes( 'monitor' ) && (
+				<MonitorActivity hasMonitor={ hasMonitor } siteId={ site.blog_id } />
 			) }
 		</div>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -59,7 +59,7 @@ export default function SiteExpandedContent( {
 				<BackupStorage site={ site } trackEvent={ trackEvent } />
 			) }
 			{ columns.includes( 'monitor' ) && (
-				<MonitorActivity hasMonitor={ hasMonitor } siteId={ site.blog_id } />
+				<MonitorActivity hasMonitor={ hasMonitor } site={ site } trackEvent={ trackEvent } />
 			) }
 		</div>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
@@ -1,0 +1,102 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import moment from 'moment';
+import ElementChart from 'calypso/components/chart';
+import useFetchMonitorData from 'calypso/data/agency-dashboard/use-fetch-monitor-data';
+import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+import { getMonitorDowntimeText } from '../utils';
+import ExpandedCard from './expanded-card';
+import type { ReactChild } from 'react';
+
+interface Props {
+	hasMonitor: boolean;
+	siteId: number;
+}
+
+const MonitorDataContent = ( { siteId }: { siteId: number } ) => {
+	const translate = useTranslate();
+
+	const { data, isLoading } = useFetchMonitorData( siteId );
+
+	const incidents = data?.incidents ?? [];
+
+	const monitorData = incidents.reverse().map( ( { date, status, total_downtime } ) => {
+		let className = 'site-expanded-content__chart-bar-no-data';
+		let tooltipLabel: ReactChild = 'No data';
+
+		if ( status === 'up' ) {
+			className = 'site-expanded-content__chart-bar-is-uptime';
+			tooltipLabel = translate( '100% uptime' );
+		} else if ( status === 'down' ) {
+			className = 'site-expanded-content__chart-bar-is-downtime';
+			tooltipLabel = getMonitorDowntimeText( total_downtime );
+		}
+
+		return {
+			label: moment( date ).format,
+			value: 1, // we always show full bar, so value is always 1
+			className,
+			tooltipData: [
+				{
+					label: moment( date ).format( 'MMM D, YYYY' ),
+				},
+				{
+					label: tooltipLabel,
+				},
+			],
+		};
+	} );
+
+	return (
+		<>
+			<div className="site-expanded-content__card-content">
+				<div className="site-expanded-content__card-content-column">
+					<div className="site-expanded-content__chart">
+						{ isLoading ? (
+							<TextPlaceholder />
+						) : (
+							<ElementChart
+								data={ monitorData }
+								minBarWidth={ 10 }
+								sliceFromBeginning={ false }
+								minBarsToBeShown={ 20 }
+								hideYAxis={ true }
+								hideXAxis={ true }
+							/>
+						) }
+					</div>
+					<div className="site-expanded-content__x-axis-pointers">
+						<span>{ translate( '20d ago' ) }</span>
+						<span>{ translate( 'Today' ) }</span>
+					</div>
+				</div>
+			</div>
+			<div className="site-expanded-content__card-footer">
+				<Button className="site-expanded-content__card-button" compact>
+					{ translate( 'All activity' ) }
+				</Button>
+			</div>
+		</>
+	);
+};
+
+export default function MonitorActivity( { hasMonitor, siteId }: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<ExpandedCard
+			header={ translate( 'Monitor activity' ) }
+			isEnabled={ hasMonitor }
+			emptyContent={ translate(
+				'Activate {{strong}}Monitor{{/strong}} to see your uptime records',
+				{
+					components: {
+						strong: <strong></strong>,
+					},
+				}
+			) }
+		>
+			{ hasMonitor && <MonitorDataContent siteId={ siteId } /> }
+		</ExpandedCard>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
@@ -1,8 +1,10 @@
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
+import { useSelector } from 'react-redux';
 import ElementChart from 'calypso/components/chart';
 import useFetchMonitorData from 'calypso/data/agency-dashboard/use-fetch-monitor-data';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+import { getSiteMonitorStatuses } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { useToggleActivateMonitor } from '../../hooks';
 import { getMonitorDowntimeText } from '../utils';
 import ExpandedCard from './expanded-card';
@@ -84,6 +86,8 @@ export default function MonitorActivity( { hasMonitor, site, trackEvent }: Props
 	const translate = useTranslate();
 
 	const toggleActivateMonitor = useToggleActivateMonitor( [ site ] );
+	const statuses = useSelector( getSiteMonitorStatuses );
+	const isLoading = statuses?.[ site.blog_id ] === 'loading';
 
 	const handleOnClick = () => {
 		trackEvent( 'expandable_block_active_monitor_click' );
@@ -102,7 +106,9 @@ export default function MonitorActivity( { hasMonitor, site, trackEvent }: Props
 					},
 				}
 			) }
-			onClick={ handleOnClick }
+			isLoading={ isLoading }
+			// Allow to click on the card only if the monitor is not active
+			onClick={ ! hasMonitor ? handleOnClick : undefined }
 		>
 			{ hasMonitor && <MonitorDataContent siteId={ site.blog_id } /> }
 		</ExpandedCard>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
@@ -22,7 +22,7 @@ const START_INDEX = 10;
 const MonitorDataContent = ( { siteId }: { siteId: number } ) => {
 	const translate = useTranslate();
 
-	const { data, isLoading } = useFetchMonitorData( siteId, '30 days' );
+	const { data } = useFetchMonitorData( siteId, '30 days' );
 
 	const incidents = data ?? [];
 
@@ -60,9 +60,7 @@ const MonitorDataContent = ( { siteId }: { siteId: number } ) => {
 		<div className="site-expanded-content__card-content">
 			<div className="site-expanded-content__card-content-column">
 				<div className="site-expanded-content__chart">
-					{ isLoading ? (
-						<TextPlaceholder />
-					) : (
+					{ monitorData.length > 0 ? (
 						<ElementChart
 							data={ monitorData }
 							minBarWidth={ 10 }
@@ -71,6 +69,8 @@ const MonitorDataContent = ( { siteId }: { siteId: number } ) => {
 							hideYAxis={ true }
 							hideXAxis={ true }
 						/>
+					) : (
+						<TextPlaceholder />
 					) }
 				</div>
 				<div className="site-expanded-content__x-axis-pointers">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
@@ -90,7 +90,7 @@ export default function MonitorActivity( { hasMonitor, site, trackEvent }: Props
 	const isLoading = statuses?.[ site.blog_id ] === 'loading';
 
 	const handleOnClick = () => {
-		trackEvent( 'expandable_block_active_monitor_click' );
+		trackEvent( 'expandable_block_activate_monitor_click' );
 		toggleActivateMonitor( true );
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import ElementChart from 'calypso/components/chart';
@@ -53,35 +52,28 @@ const MonitorDataContent = ( { siteId }: { siteId: number } ) => {
 	} );
 
 	return (
-		<>
-			<div className="site-expanded-content__card-content">
-				<div className="site-expanded-content__card-content-column">
-					<div className="site-expanded-content__chart">
-						{ isLoading ? (
-							<TextPlaceholder />
-						) : (
-							<ElementChart
-								data={ monitorData }
-								minBarWidth={ 10 }
-								sliceFromBeginning={ false }
-								minBarsToBeShown={ 20 }
-								hideYAxis={ true }
-								hideXAxis={ true }
-							/>
-						) }
-					</div>
-					<div className="site-expanded-content__x-axis-pointers">
-						<span>{ translate( '20d ago' ) }</span>
-						<span>{ translate( 'Today' ) }</span>
-					</div>
+		<div className="site-expanded-content__card-content">
+			<div className="site-expanded-content__card-content-column">
+				<div className="site-expanded-content__chart">
+					{ isLoading ? (
+						<TextPlaceholder />
+					) : (
+						<ElementChart
+							data={ monitorData }
+							minBarWidth={ 10 }
+							sliceFromBeginning={ false }
+							minBarsToBeShown={ 20 }
+							hideYAxis={ true }
+							hideXAxis={ true }
+						/>
+					) }
+				</div>
+				<div className="site-expanded-content__x-axis-pointers">
+					<span>{ translate( '20d ago' ) }</span>
+					<span>{ translate( 'Today' ) }</span>
 				</div>
 			</div>
-			<div className="site-expanded-content__card-footer">
-				<Button className="site-expanded-content__card-button" compact>
-					{ translate( 'All activity' ) }
-				</Button>
-			</div>
-		</>
+		</div>
 	);
 };
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
@@ -13,14 +13,19 @@ interface Props {
 	siteId: number;
 }
 
+const START_INDEX = 10;
+
 const MonitorDataContent = ( { siteId }: { siteId: number } ) => {
 	const translate = useTranslate();
 
-	const { data, isLoading } = useFetchMonitorData( siteId );
+	const { data, isLoading } = useFetchMonitorData( siteId, '30 days' );
 
-	const incidents = data?.incidents ?? [];
+	const incidents = data ?? [];
 
-	const monitorData = incidents.reverse().map( ( { date, status, downtime_in_minutes } ) => {
+	// We need to slice the data because the API returns the latest 30 incidents
+	const monitorData = incidents.slice( START_INDEX ).map( ( data ) => {
+		const { date, status, downtime_in_minutes } = data;
+
 		let className = 'site-expanded-content__chart-bar-no-data';
 		let tooltipLabel: ReactChild = 'No data';
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
@@ -20,7 +20,7 @@ const MonitorDataContent = ( { siteId }: { siteId: number } ) => {
 
 	const incidents = data?.incidents ?? [];
 
-	const monitorData = incidents.reverse().map( ( { date, status, total_downtime } ) => {
+	const monitorData = incidents.reverse().map( ( { date, status, downtime_in_minutes } ) => {
 		let className = 'site-expanded-content__chart-bar-no-data';
 		let tooltipLabel: ReactChild = 'No data';
 
@@ -29,7 +29,7 @@ const MonitorDataContent = ( { siteId }: { siteId: number } ) => {
 			tooltipLabel = translate( '100% uptime' );
 		} else if ( status === 'down' ) {
 			className = 'site-expanded-content__chart-bar-is-downtime';
-			tooltipLabel = getMonitorDowntimeText( total_downtime );
+			tooltipLabel = getMonitorDowntimeText( downtime_in_minutes );
 		}
 
 		return {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
@@ -3,13 +3,16 @@ import moment from 'moment';
 import ElementChart from 'calypso/components/chart';
 import useFetchMonitorData from 'calypso/data/agency-dashboard/use-fetch-monitor-data';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+import { useToggleActivateMonitor } from '../../hooks';
 import { getMonitorDowntimeText } from '../utils';
 import ExpandedCard from './expanded-card';
+import type { Site } from '../types';
 import type { ReactChild } from 'react';
 
 interface Props {
 	hasMonitor: boolean;
-	siteId: number;
+	site: Site;
+	trackEvent: ( eventName: string ) => void;
 }
 
 const START_INDEX = 10;
@@ -77,8 +80,15 @@ const MonitorDataContent = ( { siteId }: { siteId: number } ) => {
 	);
 };
 
-export default function MonitorActivity( { hasMonitor, siteId }: Props ) {
+export default function MonitorActivity( { hasMonitor, site, trackEvent }: Props ) {
 	const translate = useTranslate();
+
+	const toggleActivateMonitor = useToggleActivateMonitor( [ site ] );
+
+	const handleOnClick = () => {
+		trackEvent( 'expandable_block_active_monitor_click' );
+		toggleActivateMonitor( true );
+	};
 
 	return (
 		<ExpandedCard
@@ -92,8 +102,9 @@ export default function MonitorActivity( { hasMonitor, siteId }: Props ) {
 					},
 				}
 			) }
+			onClick={ handleOnClick }
 		>
-			{ hasMonitor && <MonitorDataContent siteId={ siteId } /> }
+			{ hasMonitor && <MonitorDataContent siteId={ site.blog_id } /> }
 		</ExpandedCard>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -57,12 +57,11 @@ $color-yellow: var(--studio-yellow-50);
 	margin-block: 16px;
 	display: flex;
 	flex-wrap: wrap;
-
 }
 
 .site-expanded-content__card-content-column {
 	flex: auto;
-	max-width: 100%;
+	max-width: 285px;
 }
 
 .site-expanded-content__card-content-score {
@@ -124,7 +123,7 @@ $color-yellow: var(--studio-yellow-50);
 	.expanded-card {
 		width: 100%;
 		margin: 0;
-		min-height: 180px;
+		min-height: 150px;
 	}
 
 	.site-expanded-content__card-content-column {
@@ -206,4 +205,72 @@ $color-yellow: var(--studio-yellow-50);
 
 .site-expanded-content__tooltip .popover__inner {
 	width: 300px;
+}
+
+@mixin chart-bar-styles($background-color, $hover-background-color) {
+	.chart__bar-section {
+		background-color: $background-color;
+		border-radius: 0;
+
+		&:hover {
+			background-color: $hover-background-color;
+		}
+	}
+}
+
+
+.site-expanded-content__chart {
+	.chart {
+		padding: 0;
+
+		.chart__y-axis-markers {
+			display: none;
+		}
+
+		.chart__bar {
+			height: 24px;
+
+			&:hover {
+				background: none;
+			}
+
+			&.site-expanded-content__chart-bar-is-downtime {
+				@include chart-bar-styles($color-red, var(--studio-red-60));
+				height: 8px !important;
+				position: relative !important;
+				top: 7.5px;
+			}
+
+			&.site-expanded-content__chart-bar-is-uptime {
+				@include chart-bar-styles($color-green, var(--studio-jetpack-green-50));
+			}
+
+			&.site-expanded-content__chart-bar-no-data {
+				@include chart-bar-styles(var(--studio-gray-0), var(--studio-gray-5));
+			}
+		}
+
+		.chart__bars {
+			height: auto;
+		}
+	}
+}
+
+.site-expanded-content__x-axis-pointers {
+	font-size: 0.75rem;
+	color: var(--studio-gray-40);
+	position: relative;
+
+	span {
+		&:nth-child(2) {
+			position: absolute;
+			right: 0;
+		}
+	}
+}
+
+.chart__tooltip {
+	.popover__inner {
+		width: auto !important;
+	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -274,3 +274,7 @@ $color-yellow: var(--studio-yellow-50);
 		width: auto !important;
 	}
 }
+
+.expanded-card__loading {
+	opacity: 0.5;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -247,3 +247,9 @@ export interface Backup {
 	activityTitle: string;
 	activityDescription: { children: { text: string }[] }[];
 }
+
+export type AllowedMonitorPeriods = 'day' | 'week' | '30 days' | '90 days';
+
+export interface MonitorUptimeAPIResponse {
+	[ key: string ]: { status: string; downtime_in_minutes?: number };
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -622,15 +622,21 @@ export const DASHBOARD_LICENSE_TYPES: { [ key: string ]: AllowedTypes } = {
 
 export const getMonitorDowntimeText = ( downtime: number ) => {
 	const duration = moment.duration( downtime, 'minutes' );
+
+	const days = duration.days();
 	const hours = duration.hours();
-	const minutesRemaining = duration.minutes();
+	const minutes = duration.minutes();
+
+	const formattedDays = days > 0 ? `${ days }d ` : '';
+	const formattedHours = hours > 0 ? `${ hours }h ` : '';
+	const formattedMinutes = minutes > 0 ? `${ minutes }m` : '';
+
+	const time = `${ formattedDays }${ formattedHours }${ formattedMinutes }`;
 
 	return translate( 'Downtime for %(time)s', {
 		args: {
-			time: `${ hours > 0 ? `${ hours }h` : '' }${
-				minutesRemaining > 0 ? ` ${ minutesRemaining }m` : ''
-			}`,
+			time,
 		},
-		comment: '%(time) is the downtime, e.g. "5h", "5h 30m", "55m"',
+		comment: '%(time) is the downtime, e.g. "2d 5h 30m", "5h 30m", "55m"',
 	} );
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -620,7 +620,11 @@ export const DASHBOARD_LICENSE_TYPES: { [ key: string ]: AllowedTypes } = {
 	BACKUP: 'backup',
 };
 
-export const getMonitorDowntimeText = ( downtime: number ) => {
+export const getMonitorDowntimeText = ( downtime: number | undefined ) => {
+	if ( ! downtime ) {
+		return translate( 'Downtime' );
+	}
+
 	const duration = moment.duration( downtime, 'minutes' );
 
 	const days = duration.days();

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
+import moment from 'moment';
 import { urlToSlug } from 'calypso/lib/url';
 import type {
 	AllowedTypes,
@@ -617,4 +618,19 @@ export const getExtractedBackupTitle = ( backup: Backup ) => {
 
 export const DASHBOARD_LICENSE_TYPES: { [ key: string ]: AllowedTypes } = {
 	BACKUP: 'backup',
+};
+
+export const getMonitorDowntimeText = ( downtime: number ) => {
+	const duration = moment.duration( downtime, 'minutes' );
+	const hours = duration.hours();
+	const minutesRemaining = duration.minutes();
+
+	return translate( 'Downtime for %(time)s', {
+		args: {
+			time: `${ hours > 0 ? `${ hours }h` : '' }${
+				minutesRemaining > 0 ? ` ${ minutesRemaining }m` : ''
+			}`,
+		},
+		comment: '%(time) is the downtime, e.g. "5h", "5h 30m", "55m"',
+	} );
 };


### PR DESCRIPTION
Related to 1203940061556608-as-1204184859823427

#### Proposed Changes

This PR implements the site expanded content for monitoring activity on large and small screens.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_** 

> These changes are behind a feature flag and will not be effective in production immediately after merging. Please verify these changes are not visible in the live link below. 

**Instructions**

1. Run `git checkout add/site-expanded-content-for-monitor` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on the expand icon on any site, and verify that you can see the `Monitor Activity ` card. Verify the same for different scenarios mentioned below with different screen sizes.

---

When the monitor is not activated.

Verify

- Clicking on the card activates the monitor
- Track event API call is made

Event names

L: calypso_jetpack_agency_dashboard_expandable_block_activate_monitor_click_large_screen
S: calypso_jetpack_agency_dashboard_expandable_block_activate_monitor_click_small_screen

<img width="380" alt="Screenshot 2023-04-03 at 3 02 50 PM" src="https://user-images.githubusercontent.com/10586875/229697797-30f12129-00b8-468c-9cc6-38824e3ff3e4.png">

---

When the monitor is getting activated

Verify

- The opacity is 0.5 when the monitor is getting activated

<img width="380" alt="Screenshot 2023-04-03 at 3 02 54 PM" src="https://user-images.githubusercontent.com/10586875/229697807-cc3dda31-ed1f-4183-a07c-538e972a322f.png">

---

When the monitor data is loading

Verify 

- The loading animation is shown

<img width="380" alt="Screenshot 2023-04-03 at 3 50 42 PM" src="https://user-images.githubusercontent.com/10586875/229697812-0bdf9a8d-a17f-4930-a627-2971d68f1a43.png">

---

Monitor - Uptime

Verify

- The tooltip is shown on hover
- Hovering over the uptime(green) bar changes the background color to a slightly darker one

<img width="380" alt="Screenshot 2023-04-03 at 3 01 19 PM" src="https://user-images.githubusercontent.com/10586875/229698838-bc7871ee-3056-4773-bc70-560035e5d491.png">

---

Monitor - Downtime

Verify

- The tooltip is shown on hover
- Hovering over the downtime(red) bar changes the background color to a slightly darker one


<img width="380" alt="Screenshot 2023-04-03 at 3 01 36 PM" src="https://user-images.githubusercontent.com/10586875/229698855-e7ef2c9c-2fc1-4a76-b5cd-814f1bab761a.png">

---

Monitor - No Data

Verify 

- The tooltip is shown on hover
- Hovering over the no data(grey) bar changes the background color to a slightly darker one

<img width="380" alt="Screenshot 2023-04-03 at 3 01 28 PM" src="https://user-images.githubusercontent.com/10586875/229698852-ca199d13-6a89-4ef1-9d71-be0e4bec7cd7.png">

---

Monitor - Mobile views

<img width="289" alt="Screenshot 2023-04-04 at 11 18 30 AM" src="https://user-images.githubusercontent.com/10586875/229699249-8115cdb2-67cd-4acb-a6c6-50c215a1a4e2.png">

<img width="289" alt="Screenshot 2023-04-04 at 11 18 51 AM" src="https://user-images.githubusercontent.com/10586875/229699258-005d03ed-056b-40f6-8158-8ff16277bb11.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?