### PR TITLE
Site Assembler - Restyling menu items and hover/focus/active effects in the main screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/style.scss
@@ -2,17 +2,30 @@
 
 .pattern-assembler {
 	.navigator-button {
-		height: 56px;
-		line-height: 56px;
+		height: 44px;
+		line-height: 44px;
 		padding: 0;
 		font-size: $font-body-small;
-		font-weight: 500;
+		font-weight: 400;
 		letter-spacing: -0.15px;
 		color: var(--studio-gray-100);
 
 		svg {
 			flex-shrink: 0;
 			fill: currentColor;
+		}
+
+		&:hover,
+		&:focus {
+			color: var(--studio-blue-50);
+		}
+
+		&:focus {
+			border-color: transparent;
+		}
+
+		&:active {
+			background-color: var(--studio-blue-0);
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -1,9 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
-import {
-	__experimentalItemGroup as ItemGroup,
-	__experimentalDivider as Divider,
-} from '@wordpress/components';
+import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
 import { header, footer, layout, styles, typography } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { NavigationButtonAsItem } from './navigator-buttons';
@@ -27,7 +24,7 @@ const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Pr
 				) }
 				hideBack
 			/>
-			<div className="screen-container__body">
+			<div className="screen-container__body screen-container__body--no-padding">
 				<ItemGroup>
 					<NavigationButtonAsItem
 						path="/header"
@@ -39,7 +36,6 @@ const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Pr
 							{ translate( 'Choose a header' ) }
 						</span>
 					</NavigationButtonAsItem>
-					<Divider />
 					<NavigationButtonAsItem
 						path="/footer"
 						icon={ footer }
@@ -50,7 +46,6 @@ const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Pr
 							{ translate( 'Choose a footer' ) }
 						</span>
 					</NavigationButtonAsItem>
-					<Divider />
 					<NavigationButtonAsItem
 						path="/homepage"
 						icon={ layout }
@@ -63,7 +58,6 @@ const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Pr
 					</NavigationButtonAsItem>
 					{ isEnabled( 'pattern-assembler/color-and-fonts' ) && (
 						<>
-							<Divider />
 							<NavigationButtonAsItem
 								path="/color-palettes"
 								icon={ styles }
@@ -74,7 +68,6 @@ const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Pr
 									{ translate( 'Change colors' ) }
 								</span>
 							</NavigationButtonAsItem>
-							<Divider />
 							<NavigationButtonAsItem
 								path="/font-pairings"
 								icon={ typography }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -304,6 +304,10 @@ $font-family: "SF Pro Text", $sans;
 		overflow-y: auto;
 	}
 
+	.screen-container__body--no-padding {
+		padding: 0;
+	}
+
 	.screen-container__footer {
 		padding: 0 2px;
 		margin-top: auto;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/74621
Figma 7l53h5fxAUNjVRBQ82YFwn-fi-2322%3A60205

## Proposed Changes

* Remove the separators between the menu items
* Add new hover/focus and active effects
* Update other styles to match the new design 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
**Access the Assembler**
* Click on the `Calypso Live link` in the first comment
* Create a new site, continue until the Desing picker 
* Scroll and click `Start designing` from the bottom of the design picker

**Verify the styles and effects**
* Verify that the styles of the sidebar match the Figma design
* Hover the menu items 
* Verify that the active state appears when you click on an item
* Press the tab key until the focus moves to an item

**Before**

|Initial|Hover|Focus|
|---|---|---|
|<img width="341" alt="Screenshot 2566-03-20 at 16 18 17" src="https://user-images.githubusercontent.com/1881481/226296562-a34cbef5-fc6f-4393-bba9-d54539fe0962.png">|<img width="335" alt="Screenshot 2566-03-20 at 16 16 57" src="https://user-images.githubusercontent.com/1881481/226296203-e6c0117b-66a8-4dba-869e-24fb9dae0867.png">|<img width="338" alt="Screenshot 2566-03-20 at 16 17 21" src="https://user-images.githubusercontent.com/1881481/226296318-3fa4b4bc-02fe-4364-9a32-e4c36c216cdc.png">


**After**

|Initial|Hover|Focus|Active|
|---|---|---|---|
|<img width="339" alt="Screenshot 2566-03-20 at 16 21 14" src="https://user-images.githubusercontent.com/1881481/226297723-bc8ae492-ed82-4343-9d1d-eb7cec55cd72.png">|<img width="334" alt="Screenshot 2566-03-20 at 16 21 27" src="https://user-images.githubusercontent.com/1881481/226297741-63b722a3-c5f6-4471-95a6-4873b438267c.png">|<img width="334" alt="Screenshot 2566-03-20 at 16 21 27" src="https://user-images.githubusercontent.com/1881481/226297741-63b722a3-c5f6-4471-95a6-4873b438267c.png">|<img width="338" alt="Screenshot 2566-03-20 at 16 22 34" src="https://user-images.githubusercontent.com/1881481/226297750-bffa5935-02d9-467e-9dfe-474ecf71d917.png">|


**Recording**

https://user-images.githubusercontent.com/1881481/226299657-27dfb765-d360-4ed4-8308-9452774f7424.mov






## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
