### PR TITLE
Add hook for useSubscriptionManagerSubscriptionsCountQuery

### DIFF
--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -1,3 +1,4 @@
 export { useSubscriptionManagerUserSettingsQuery } from './queries/use-subscription-manager-user-settings-query';
+export { useSubscriptionManagerSubscriptionsCountQuery } from './queries/use-subscription-manager-subscriptions-count-query';
 
 export type { SubscriptionManagerUserSettings, EmailFormatType } from './types';

--- a/packages/data-stores/src/reader/queries/use-subscription-manager-subscriptions-count-query.ts
+++ b/packages/data-stores/src/reader/queries/use-subscription-manager-subscriptions-count-query.ts
@@ -1,0 +1,29 @@
+import { useQuery } from 'react-query';
+import { fetchFromApi } from '../helpers';
+import { useIsLoggedIn, useIsQueryEnabled } from '../hooks';
+import type { SubscriptionManagerSubscriptionsCount } from '../types';
+
+const useSubscriptionManagerSubscriptionsCountQuery = () => {
+	const isLoggedIn = useIsLoggedIn();
+	const enabled = useIsQueryEnabled();
+
+	return useQuery(
+		[ 'read', 'subscriptions-count', isLoggedIn ],
+		async () => {
+			return await fetchFromApi< SubscriptionManagerSubscriptionsCount >( {
+				path: '/read/subscriptions-count',
+				isLoggedIn,
+			} );
+		},
+		{
+			enabled,
+			initialData: {
+				blogs: null,
+				comments: null,
+				pending: null,
+			},
+		}
+	);
+};
+
+export { useSubscriptionManagerSubscriptionsCountQuery };

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -7,3 +7,9 @@ export type SubscriptionManagerUserSettings = Partial< {
 	blocked: boolean;
 	email: string;
 } >;
+
+export type SubscriptionManagerSubscriptionsCount = {
+	blogs: number | null;
+	comments: number | null;
+	pending: number | null;
+};


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/74424

## Proposed Changes

This PR adds a hook to use the `useSubscriptionManagerSubscriptionsCountQuery`. 

## Testing Instructions

- Apply this PR
- For testing, open up a component inside `packages/subscription-manager` and add the hook. This is for example the hook applied in `SubscriptionManagerContainer.tsx`:

```js
/* eslint-disable no-restricted-imports */
/**
 * External dependencies
 */
import { useTranslate } from 'i18n-calypso';
import DocumentHead from 'calypso/components/data/document-head';
import FormattedHeader from 'calypso/components/formatted-header';
import Main from 'calypso/components/main';
import './styles.scss';
import { Reader  } from '@automattic/data-stores';



export type SubscriptionManagerContainerProps = {
	children?: React.ReactNode;
};

const SubscriptionManagerContainer = ( { children }: SubscriptionManagerContainerProps ) => {
	const translate = useTranslate();
	const { data } = Reader.useSubscriptionManagerSubscriptionsCountQuery();
	console.log(data);
	return (
		<Main className="subscription-manager-container">
			<DocumentHead title="Subscriptions" />
			<FormattedHeader
				brandFont
				headerText={ translate( 'Subscription management' ) }
				subHeaderText={ translate(
					'Manage your WordPress.com newsletter and blog subscriptions.'
				) }
				align="left"
			/>
			{ children }
		</Main>
	);
};

export default SubscriptionManagerContainer;
```

- Visit this page logged in
- In the console, you should see the API response (the initialData should be `{ blogs: null, comments: null, pending: null }, after that the actual data will be shown`)
- `document.cookie = 'document.cookie = "subkey=b90ae2522a3f21638c6f4dae21255d30.jefpober+testetstx@gmail.com"';`
- Visit the same page
- In the console you should see the API response (the initialData should be `{ blogs: null, comments: null, pending: null }`, after that the actual data will be shown)

Note: testing with a real subkey from an email redirect currently doesn't work. I'll create an issue for it.

## Pre-merge Checklist


- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
