### PR TITLE
Theme Showcase: Fix Theme Detail page content overflow issue in mobile view

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -140,17 +140,15 @@ body.is-section-theme-i4 {
 		min-height: auto;
 		padding: 0;
 
-		@include breakpoint-deprecated( "<960px" ) {
-			max-width: 100%;
+		h2 {
+			font-size: 1.25rem;
+		}
 
-			video {
+		video {
+			@include breakpoint-deprecated( "<960px" ) {
 				height: auto;
 				max-width: 100%;
 			}
-		}
-
-		h2 {
-			font-size: 1.25rem;
 		}
 
 		.notes {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -140,6 +140,15 @@ body.is-section-theme-i4 {
 		min-height: auto;
 		padding: 0;
 
+		@include breakpoint-deprecated( "<960px" ) {
+			max-width: 100%;
+
+			video {
+				height: auto;
+				max-width: 100%;
+			}
+		}
+
 		h2 {
 			font-size: 1.25rem;
 		}


### PR DESCRIPTION
## Proposed Changes

This PR fixes the context overflow issue described in pdtkmj-1gp-p2#comment-2340. The issue is caused by an aspect-ratio locked video.

| Before | After |
| --- | --- |
| ![Screenshot 2023-03-20 at 6 09 58 PM](https://user-images.githubusercontent.com/797888/226309285-c3dbe8fb-2db3-4461-a979-f9c0b8417152.png) | ![Screenshot 2023-03-20 at 6 08 29 PM](https://user-images.githubusercontent.com/797888/226309312-f37881c1-a192-41c4-ab54-58ab4ffa712a.png) |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase, and select any theme that has an embedded video on its detail page. Such as Yuna.
* Expect the context overflow issue to be resolved.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?