### PR TITLE
Fixed vertical align in input in block emails setting

### DIFF
--- a/packages/subscription-manager/src/components/fields/BlockEmailsSetting/BlockEmailsSetting.tsx
+++ b/packages/subscription-manager/src/components/fields/BlockEmailsSetting/BlockEmailsSetting.tsx
@@ -23,7 +23,9 @@ const BlockEmailsSetting = ( { value, onChange }: BlockEmailsSettingProps ) => {
 				{ translate( 'Block emails' ) }
 			</FormLabel>
 			<FormLabel htmlFor="blocked">
-				<FormInputCheckbox id="blocked" name="blocked" checked={ value } onChange={ onChange } />
+				<div className="input-container">
+					<FormInputCheckbox id="blocked" name="blocked" checked={ value } onChange={ onChange } />
+				</div>
 				<span>
 					{ translate( 'Block all email updates from sites you’re following on WordPress.com' ) }
 				</span>

--- a/packages/subscription-manager/src/components/fields/BlockEmailsSetting/style.scss
+++ b/packages/subscription-manager/src/components/fields/BlockEmailsSetting/style.scss
@@ -7,13 +7,26 @@
 	&.form-fieldset {
 		@extend %form-fieldset;
 		margin-left: 2px;
-	}
 
-	.title {
-		@extend %form-label;
-	}
+		.title {
+			@extend %form-label;
+		}
 
-	.form-checkbox {
-		@extend %form-checkbox;
+		.form-label {
+			display: flex;
+			align-items: center;
+
+			.input-container {
+				display: flex;
+			}
+
+			.form-checkbox {
+				@extend %form-checkbox;
+			}
+
+			span {
+				font-weight: 400;
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

This PR fixes the alignment problems described in [this issue](https://github.com/Automattic/wp-calypso/issues/74600).

## Testing Instructions

1. Apply this PR.
2. Go to `http://calypso.localhost:3000/subscriptions/settings` in your desktop browser.
3. Check that the desktop version matches [the design](inDLaEQV8jJ21O4WXawIsJ-fi-712-29014).
4. Resize the browser window until the view shows the mobile design and check that the design (especially the position of the checkbox regarding its text) matches the mobile [design](inDLaEQV8jJ21O4WXawIsJ-fi-712-29337).

Fixes https://github.com/Automattic/wp-calypso/issues/74600