### PR TITLE
`HelpCenter`: use distinct query key for search

### DIFF
--- a/packages/help-center/src/hooks/use-help-search-query.ts
+++ b/packages/help-center/src/hooks/use-help-search-query.ts
@@ -16,7 +16,7 @@ export const useHelpSearchQuery = (
 	const queryClient = useQueryClient();
 
 	return useQuery< SearchResult[] >(
-		[ 'help', search ],
+		[ 'help-center-search', search ],
 		() =>
 			canAccessWpcomApis()
 				? wpcomRequest( {


### PR DESCRIPTION
Fixes #74630

## Proposed Changes

* `HelpCenter`: use distinct query key for help center search results

## Testing Instructions

* Verify #74630 is not reproducable anymore and Calypso doesn't crash when following the steps
* Smoke test help center and make sure it still works as on production

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
