### PR TITLE
Jetpack Pro Dashboard: fix boost column & expandable block styles

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -224,7 +224,7 @@ export default function SiteStatusContent( {
 			return (
 				<div
 					className={ classNames(
-						'site-expanded-content__card-content-score',
+						'sites-overview__boost-score',
 						getBoostRatingClass( overallScore )
 					) }
 				>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -418,17 +418,19 @@
 	color: var(--studio-red-50);
 }
 
-.boost-score-good {
-	@extend .sites-overview__column-content;
-	color: var(--studio-green-50);
-}
+.sites-overview__boost-score {
+	&.boost-score-good {
+		@extend .sites-overview__column-content;
+		color: var(--studio-green-50);
+	}
 
-.boost-score-okay {
-	@extend .sites-overview__column-content;
-	color: var(--studio-yellow-50);
-}
+	&.boost-score-okay {
+		@extend .sites-overview__column-content;
+		color: var(--studio-yellow-50);
+	}
 
-.boost-score-bad {
-	@extend .sites-overview__column-content;
-	color: var(--studio-red-50);
+	&.boost-score-bad {
+		@extend .sites-overview__column-content;
+		color: var(--studio-red-50);
+	}
 }


### PR DESCRIPTION
Related to 1203940061556608-as-1204214590093975

#### Proposed Changes

This PR fixes UI issues to site boost columns and expandable blocks caused due to using the same class names.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/boost-styles-in-jetpack-pro-dashboard` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify the boost column data doesn't have a font-weight of 500.
4. Click on the expand icon on any site, and verify that the boost score doesn't look tiny in the `Boost site performance` card

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>

<img width="406" alt="Screenshot 2023-03-20 at 4 39 55 PM" src="https://user-images.githubusercontent.com/10586875/226324551-05347d41-a424-4f55-9313-9450255737c6.png">

</td>
<td>

<img width="408" alt="Screenshot 2023-03-20 at 4 44 44 PM" src="https://user-images.githubusercontent.com/10586875/226324569-069848ab-b11d-4d24-b8bf-0ef4df62d0ee.png">

</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?