### PR TITLE
Changed 'block' to 'pause' in subscription settings

### DIFF
--- a/packages/subscription-manager/src/components/fields/BlockEmailsSetting/BlockEmailsSetting.tsx
+++ b/packages/subscription-manager/src/components/fields/BlockEmailsSetting/BlockEmailsSetting.tsx
@@ -20,12 +20,12 @@ const BlockEmailsSetting = ( { value, onChange }: BlockEmailsSettingProps ) => {
 	return (
 		<FormFieldset className="block-emails-setting">
 			<FormLabel htmlFor="blocked" className="title">
-				{ translate( 'Block emails' ) }
+				{ translate( 'Pause emails' ) }
 			</FormLabel>
 			<FormLabel htmlFor="blocked">
 				<FormInputCheckbox id="blocked" name="blocked" checked={ value } onChange={ onChange } />
 				<span>
-					{ translate( 'Block all email updates from sites you’re following on WordPress.com' ) }
+					{ translate( 'Pause all email updates from sites you’re following on WordPress.com' ) }
 				</span>
 			</FormLabel>
 		</FormFieldset>


### PR DESCRIPTION
## Proposed Changes

This super small PR changes one word in the Subscription settings page: `Block emails` to `Pause mails`.

## Testing Instructions
1. Apply this PR.
2. Go to http://calypso.localhost:3000/subscriptions/settings in your browser.
3. You should see the text like this:
<img width="615" alt="Screenshot 2023-03-20 at 12 53 27" src="https://user-images.githubusercontent.com/3832570/226332753-79f22027-eb75-4b25-9b88-30fa70a7a27f.png">

Fixes https://github.com/Automattic/wp-calypso/issues/74624
