### PR TITLE
Create new Explat experiment on Plans step in the paid media flow

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -30,6 +30,7 @@ import {
 	getFixedDomainSearch,
 } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
 import wpcom from 'calypso/lib/wp';
@@ -145,6 +146,13 @@ class DomainsStep extends Component {
 				}
 			);
 		}
+
+		loadExperimentAssignment( 'paid_media_signup_2023_03_legacy_free_presentation' ).then(
+			( experimentName ) => {
+				this.setState( { experiment: experimentName } );
+				this.setState( { experimentIsLoading: false } );
+			}
+		);
 	}
 
 	getLocale() {

--- a/client/signup/steps/plans-pm/index.jsx
+++ b/client/signup/steps/plans-pm/index.jsx
@@ -33,7 +33,7 @@ export class PlansStepPM extends Component {
 		);
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
 
-		loadExperimentAssignment( 'paid_media_signup_2023_03_biannual_toggle_hide_free' ).then(
+		loadExperimentAssignment( 'paid_media_signup_2023_03_legacy_free_presentation' ).then(
 			( experimentName ) => {
 				this.setState( { experiment: experimentName } );
 				this.setState( { experimentIsLoading: false } );
@@ -100,7 +100,7 @@ export class PlansStepPM extends Component {
 			<Button onClick={ () => buildUpgradeFunction( this.props, null ) } borderless />
 		);
 
-		if ( this.state.experiment?.variationName === 'treatment' ) {
+		if ( this.state.experiment?.variationName === 'treatment' && this.props.hideFreePlan ) {
 			if ( this.state.isDesktop ) {
 				return translate( "Pick one that's right for you and unlock features that help you grow." );
 			}


### PR DESCRIPTION
## Proposed Changes

* This PR implements Explat experiment `paid_media_signup_2023_03_legacy_free_presentation`
* The treatment variation changes two things:
1) Replaces the Monthly term length option with a Two year term length option
2) Restores the prior control behavior for the Free plan link (the link is not shown if the person selects a paid domain or the skip option on the domains step).

![CleanShot 2023-03-20 at 08 09 53@2x](https://user-images.githubusercontent.com/35781181/226336265-e86a1ea9-1f3a-4403-b9fc-5d99b0fff4fd.png)


## Testing Instructions

* Assign yourself to the Treatment variation of `paid_media_signup_2023_03_legacy_free_presentation` in Abacus.
* Checkout this PR and start it locally.
* Navigate to `/start/onboarding-pm`
* Proceed through the domain step with a free domain option. Confirm that the Free link is shown.
* Go back to the domain step and select a paid domain. Confirm that the Free link is not shown.
* Go back to the domain step and select the skip option on the right. Confirm that the Free link is not shown.
* Confirm that the 1 year and 2 years term-length toggles are present on all experiences.

