### PR TITLE
Show tooltip for interval toggle, next to the plans comparison grid of the onboarding flow

### DIFF
--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -755,7 +755,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 				hidePersonalPlan={ planTypeSelectorProps.hidePersonalPlan }
 				basePlansPath={ planTypeSelectorProps.basePlansPath }
 				siteSlug={ planTypeSelectorProps.siteSlug }
-				hideDiscountLabel={ true }
+				hideDiscountLabel={ false }
 				showBiannualToggle={ config.isEnabled( 'plans/biannual-toggle' ) }
 			/>
 			<Grid isInSignup={ isInSignup }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1532

## Proposed Changes

This enables the discount tooltip for the interval toggle next to the Plans Compare Grid.

<img width="320" alt="219439122-d2f17f8c-b6aa-450a-b43c-afdbb85e150c" src="https://user-images.githubusercontent.com/2749938/226353139-c2895aa8-adba-4aa9-8257-44040e924f8b.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans`
* Scroll down and open the `Compare` grid 
* Select the `Pay monthly` interval
* You should see the discount tooltip next to interval toggle

<img width="240" alt="Screenshot 2023-03-20 at 15 23 15" src="https://user-images.githubusercontent.com/2749938/226352852-14471e1f-22b0-4cf4-944b-d0235ef062a7.png">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
