### PR TITLE
Reader: Fix following feeds

### DIFF
--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -157,9 +157,9 @@ class FeedHeader extends Component {
 							</span>
 						) }
 						<div className="reader-feed-header__follow-and-settings">
-							{ feed && ! feed.is_error && (
+							{ siteUrl && (
 								<div className="reader-feed-header__follow-button">
-									<ReaderFollowButton siteUrl={ feed.feed_URL } iconSize={ 24 } />
+									<ReaderFollowButton siteUrl={ siteUrl } iconSize={ 24 } />
 								</div>
 							) }
 

--- a/client/reader/follow-helpers.tsx
+++ b/client/reader/follow-helpers.tsx
@@ -35,3 +35,9 @@ export function filterFollowsByQuery(
 		);
 	} );
 }
+
+export function filterFollowsByIsFollowed( follows: Array< Follow > ): Array< Follow > {
+	return follows.filter( ( follow ) => {
+		return follow.is_following;
+	} );
+}

--- a/client/reader/stream/reader-list-followed-sites/index.jsx
+++ b/client/reader/stream/reader-list-followed-sites/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import UrlSearch from 'calypso/lib/url-search';
-import { filterFollowsByQuery } from 'calypso/reader/follow-helpers';
+import { filterFollowsByIsFollowed, filterFollowsByQuery } from 'calypso/reader/follow-helpers';
 import FollowingManageSearchFollowed from 'calypso/reader/following-manage/search-followed';
 import { isEligibleForUnseen } from 'calypso/reader/get-helpers';
 import { hasReaderFollowOrganization } from 'calypso/state/reader/follows/selectors';
@@ -83,7 +83,8 @@ export class ReaderListFollowedSites extends Component {
 		const { sites, sitesPerPage, translate } = this.props;
 		const { sitePage, query } = this.state;
 		const searchThreshold = 15;
-		const filteredFollows = filterFollowsByQuery( query, sites );
+		let filteredFollows = filterFollowsByQuery( query, sites );
+		filteredFollows = filterFollowsByIsFollowed( filteredFollows );
 		const allSitesLoaded = sitesPerPage * sitePage >= filteredFollows.length;
 		const sitesToShow = filteredFollows.slice( 0, sitesPerPage * sitePage );
 

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -149,8 +149,11 @@ const itemsReducer = ( state = {}, action ) => {
 
 			return Object.assign( newState, {
 				[ urlKey ]: merge(
-					{ feed_URL: actualFeedUrl },
+					{},
 					state[ urlKey ],
+					{
+						feed_URL: actualFeedUrl,
+					},
 					action.payload.follow,
 					newValues
 				),
@@ -169,6 +172,9 @@ const itemsReducer = ( state = {}, action ) => {
 			if ( ! ( currentFollow && currentFollow.is_following ) ) {
 				return state;
 			}
+
+			// We need to delete alternative patterns to avoid duplication of feeds
+			delete state[ urlKey + '/feed' ];
 
 			return {
 				...state,

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -149,11 +149,10 @@ const itemsReducer = ( state = {}, action ) => {
 
 			return Object.assign( newState, {
 				[ urlKey ]: merge(
-					{},
-					state[ urlKey ],
 					{
 						feed_URL: actualFeedUrl,
 					},
+					state[ urlKey ],
 					action.payload.follow,
 					newValues
 				),
@@ -172,9 +171,6 @@ const itemsReducer = ( state = {}, action ) => {
 			if ( ! ( currentFollow && currentFollow.is_following ) ) {
 				return state;
 			}
-
-			// We need to delete alternative patterns to avoid duplication of feeds
-			delete state[ urlKey + '/feed' ];
 
 			return {
 				...state,


### PR DESCRIPTION
There is a bug when trying to follow certain types of feeds, where reader will not let you follow the feed/site.

This is a follow up to https://github.com/Automattic/wp-calypso/pull/69116.

When you go to the feed at `read/feeds/94933479` you shouldn't be able to follow that feed;

https://user-images.githubusercontent.com/5560595/226360457-4db61fe7-48a3-4f45-82e8-c636843ac193.mov

There is also a bug in the follow list of sites. When you unfollow/follow a site, the list of followed sites remains unchanged until you refresh the page;

https://user-images.githubusercontent.com/5560595/226361021-d38ab8c0-dbbf-40ae-a8e1-b5851693d2a8.mov

### Testing
Apply patch and try following/unfollowing and confirm works as expected.

### Scope
I couldn't figure out how to get the list of followed sites to consistently update state, this PR just fixes it for regular feeds.
The PR also doesn't fix the subscriber count (which doesn't change after follow/unfollows).



