### PR TITLE
Plans 2023: Update the tooltip alignment to left-aligned.

### DIFF
--- a/client/my-sites/plan-features-2023-grid/plans-2023-tooltip.tsx
+++ b/client/my-sites/plan-features-2023-grid/plans-2023-tooltip.tsx
@@ -8,7 +8,7 @@ const HoverAreaContainer = styled.span``;
 const StyledTooltip = styled( Tooltip )`
 	&.tooltip.popover .popover__inner {
 		background: var( --color-masterbar-background );
-		text-align: center;
+		text-align: start;
 		border-radius: 4px;
 		min-height: 32px;
 		width: 210px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1585

## Proposed Changes

This sets the tooltip text alignment to be on the left.

![223052525-8430e09f-6fc2-4fd5-a36f-c00f513250fc](https://user-images.githubusercontent.com/2749938/226366119-d8d663d9-1cdf-478a-86b4-03ae89b582af.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` and `/plans/[SITE_ID]`
* Hover over the features, Plan icons and Jetpack icon
* The tooltip text should be left aligned
<img width="220" alt="Screenshot 2023-03-20 at 16 12 36" src="https://user-images.githubusercontent.com/2749938/226366706-ff3d5d9b-956e-4943-bde5-b04e956074fb.png">

* Switch to a RTL locale
* The tooltip text should be right aligned

<img width="220" alt="Screenshot 2023-03-20 at 16 13 10" src="https://user-images.githubusercontent.com/2749938/226366650-5d92ce57-3b85-41b4-8bf3-fa71b795522b.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
