### PR TITLE
Data Stores: Refactor partner portal credit card store to `createReduxStore()`

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/credit-card-element-field.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/credit-card-element-field.tsx
@@ -3,8 +3,8 @@ import { CardElement } from '@stripe/react-stripe-js';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
+import { creditCardStore } from 'calypso/state/partner-portal/credit-card-form';
 import type { StripeElementChangeEvent, StripeElementStyle } from '@stripe/stripe-js';
-import type { CreditCardSelectors } from 'calypso/state/partner-portal/types';
 
 export default function CreditCardElementField( {
 	setIsStripeFullyLoaded,
@@ -19,7 +19,7 @@ export default function CreditCardElementField( {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 	const { card: cardError } = useSelect(
-		( select ) => ( select( 'credit-card' ) as CreditCardSelectors ).getCardDataErrors(),
+		( select ) => select( creditCardStore ).getCardDataErrors(),
 		[]
 	);
 

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/credit-card-submit-button.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/credit-card-submit-button.tsx
@@ -4,13 +4,13 @@ import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
 import { useMemo } from 'react';
+import { creditCardStore } from 'calypso/state/partner-portal/credit-card-form';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
 import type { ProcessPayment } from '@automattic/composite-checkout';
 import type { StoreState } from '@automattic/wpcom-checkout';
 import type { Stripe } from '@stripe/stripe-js';
 import type { I18n } from '@wordpress/i18n';
 import type { State } from 'calypso/state/partner-portal/credit-card-form/reducer';
-import type { CreditCardSelectors } from 'calypso/state/partner-portal/types';
 
 const debug = debugFactory( 'calypso:partner-portal:credit-card' );
 
@@ -31,11 +31,11 @@ export default function CreditCardSubmitButton( {
 } ) {
 	const { __ } = useI18n();
 	const fields: StoreState< string > = useSelect(
-		( select ) => ( select( 'credit-card' ) as CreditCardSelectors ).getFields(),
+		( select ) => select( creditCardStore ).getFields(),
 		[]
 	);
 	const useAsPrimaryPaymentMethod: boolean = useSelect(
-		( select ) => ( select( 'credit-card' ) as CreditCardSelectors ).useAsPrimaryPaymentMethod(),
+		( select ) => select( creditCardStore ).useAsPrimaryPaymentMethod(),
 		[]
 	);
 	const cardholderName = fields.cardholderName;

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/index.tsx
@@ -7,23 +7,23 @@ import { useState } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import { useRecentPaymentMethodsQuery } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { creditCardStore } from 'calypso/state/partner-portal/credit-card-form';
 import CreditCardElementField from './credit-card-element-field';
 import CreditCardLoading from './credit-card-loading';
 import SetAsPrimaryPaymentMethod from './set-as-primary-payment-method';
 import type { StoreState } from '@automattic/wpcom-checkout';
 import type { StripeElementChangeEvent, StripeElementStyle } from '@stripe/stripe-js';
-import type { CreditCardSelectors } from 'calypso/state/partner-portal/types';
 import './style.scss';
 
 export default function CreditCardFields() {
 	const { __ } = useI18n();
 	const [ isStripeFullyLoaded, setIsStripeFullyLoaded ] = useState( false );
 	const fields: StoreState< string > = useSelect(
-		( select ) => ( select( 'credit-card' ) as CreditCardSelectors ).getFields(),
+		( select ) => select( creditCardStore ).getFields(),
 		[]
 	);
 	const useAsPrimaryPaymentMethod: boolean = useSelect(
-		( select ) => ( select( 'credit-card' ) as CreditCardSelectors ).useAsPrimaryPaymentMethod(),
+		( select ) => select( creditCardStore ).useAsPrimaryPaymentMethod(),
 		[]
 	);
 	const getField = ( key: string | number ) => fields[ key ] || {};

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods/hooks/use-create-stored-credit-card.ts
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods/hooks/use-create-stored-credit-card.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { createStoredCreditCardMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods/stored-credit-card-method';
-import { createStoredCreditCardPaymentMethodStore } from 'calypso/state/partner-portal/credit-card-form';
+import { creditCardStore } from 'calypso/state/partner-portal/credit-card-form';
 import type { StripeConfiguration, StripeLoadingError } from '@automattic/calypso-stripe';
 import type { PaymentMethod } from '@automattic/composite-checkout';
 import type { Stripe } from '@stripe/stripe-js';
@@ -20,18 +20,16 @@ export function useCreateStoredCreditCardMethod( {
 } ): PaymentMethod | null {
 	const shouldLoadStripeMethod = ! isStripeLoading && ! stripeLoadingError;
 
-	const store = useMemo( () => createStoredCreditCardPaymentMethodStore(), [] );
-
 	return useMemo(
 		() =>
 			shouldLoadStripeMethod
 				? createStoredCreditCardMethod( {
-						store,
+						store: creditCardStore,
 						stripe,
 						stripeConfiguration,
 						activePayButtonText,
 				  } )
 				: null,
-		[ shouldLoadStripeMethod, store, stripe, stripeConfiguration, activePayButtonText ]
+		[ shouldLoadStripeMethod, stripe, stripeConfiguration, activePayButtonText ]
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -34,11 +34,11 @@ import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
+import { creditCardStore } from 'calypso/state/partner-portal/credit-card-form';
 import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
 import { fetchStoredCards } from 'calypso/state/partner-portal/stored-cards/actions';
 import getSites from 'calypso/state/selectors/get-sites';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { CreditCardSelectors } from 'calypso/state/partner-portal/types';
 
 import './style.scss';
 
@@ -63,7 +63,7 @@ function PaymentMethodAdd( { selectedSite }: { selectedSite?: SiteDetails | null
 		[ stripeMethod ]
 	);
 	const useAsPrimaryPaymentMethod: boolean = useSelect(
-		( select ) => ( select( 'credit-card' ) as CreditCardSelectors ).useAsPrimaryPaymentMethod(),
+		( select ) => select( creditCardStore ).useAsPrimaryPaymentMethod(),
 		[]
 	);
 

--- a/client/state/partner-portal/credit-card-form/index.ts
+++ b/client/state/partner-portal/credit-card-form/index.ts
@@ -1,14 +1,12 @@
-import { registerStore } from '@wordpress/data';
+import { createReduxStore, register } from '@wordpress/data';
 import * as actions from 'calypso/state/partner-portal/credit-card-form/actions';
 import reducer from 'calypso/state/partner-portal/credit-card-form/reducer';
 import * as selectors from 'calypso/state/partner-portal/credit-card-form/selectors';
 
-export function createStoredCreditCardPaymentMethodStore(): Record< string, unknown > {
-	const store = registerStore( 'credit-card', {
-		reducer,
-		actions,
-		selectors,
-	} );
+export const creditCardStore = createReduxStore( 'credit-card', {
+	reducer,
+	actions,
+	selectors,
+} );
 
-	return { ...store, actions, selectors };
-}
+register( creditCardStore );

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -5,10 +5,6 @@ import {
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
-import * as creditCardSelectors from './credit-card-form/selectors';
-import type { SelectFromMap } from '@automattic/data-stores';
-
-export type CreditCardSelectors = SelectFromMap< typeof creditCardSelectors >;
 
 /**
  * Utility.


### PR DESCRIPTION
## Proposed Changes

This PR migrates the partner portal credit card store to use `createReduxStore()` and `register()` instead of `registerStore()`.

Part of #74399. A follow-up to #73890.

## Testing Instructions

* Follow testing instructions in #61583.
* Verify all checks are green (there are a bunch of unit tests covering the changes).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
