### PR TITLE
Newsletter Flow: Fieldset label font-weight to 500

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -252,7 +252,7 @@ button {
 		label {
 			font-size: $font-body;
 			color: var(--studio-gray-60);
-			font-weight: 400;
+			font-weight: 500;
 		}
 	}
 


### PR DESCRIPTION
This PR increases the font-weight of the form label in newsletter, link-in-bio, link-in-bio-tld, store-profiler__form, setup-form__form 

## Testing
1. Check Live link
2. reach `setup/newsletter/newsletterSetup` step
3. Inspect the form labels, verify font-weight is 500

Fixes https://github.com/Automattic/wp-calypso/issues/74582