### PR TITLE
Add "count" values to the Subscription Management tabs

### DIFF
--- a/client/my-sites/subscriptions/index.tsx
+++ b/client/my-sites/subscriptions/index.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { Reader } from '@automattic/data-stores';
 import SubscriptionManager from '@automattic/subscription-manager';
 import { useTranslate } from 'i18n-calypso';
 import page, { Callback } from 'page';
@@ -11,6 +12,7 @@ const SettingsView = () => <SubscriptionManager.UserSettings />;
 
 const SubscriptionManagementPage = () => {
 	const translate = useTranslate();
+	const { data: counts } = Reader.useSubscriptionManagerSubscriptionsCountQuery();
 
 	return (
 		<SubscriptionManager>
@@ -22,13 +24,13 @@ const SubscriptionManagementPage = () => {
 						label: translate( 'Sites' ),
 						path: 'sites',
 						view: SitesView,
-						count: 2,
+						count: counts?.blogs || undefined,
 					},
 					{
 						label: translate( 'Comments' ),
 						path: 'comments',
 						view: CommentsView,
-						count: 5,
+						count: counts?.comments || undefined,
 					},
 					{
 						label: translate( 'Settings' ),


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/74562.

## Proposed Changes

* Utilize the `useSubscriptionManagerSubscriptionsCountQuery()` hook that has been introduced in https://github.com/Automattic/wp-calypso/pull/74627.

![Markup on 2023-03-20 at 15:48:54](https://user-images.githubusercontent.com/25105483/226376913-24ca0ad0-f034-4ec0-8448-278dbc64f629.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Logged-in WPCOM user**

1. Check out and build the branch of this PR.
2. Make sure the user you are testing with follows at least one site or at least one post's comments.
3. Navigate to http://calypso.localhost:3000/subscriptions/settings.
4. The correct numbers on the "Sites" and "Comments" tab should be displayed - and should match the numbers on the [Re-skinned portal](https://wordpress.com/email-subscriptions/?option=blogs).
5. If you like, you can also test the steps for a non-WPCOM user. The numbers should load as well, but for that to work currently, the following additional steps are necessary:

**Non-WPCOM user**

1. Trigger the "subscription management link" email by submitting the form on https://wordpress.com/email-subscriptions/.
3. Open the link in an Incognito browser window:
![Markup on 2023-03-20 at 16:03:35](https://user-images.githubusercontent.com/25105483/226381975-5742c80f-4d20-404e-93c7-ce270cac12af.png)
4. Copy the **decoded** cookie value:
![Markup on 2023-03-20 at 16:05:05](https://user-images.githubusercontent.com/25105483/226382665-23c3dbf1-c444-440e-bec9-0df118caa044.png)
5. Navigate to http://calypso.localhost:3000/subscriptions/settings.
6. Open console and set the cookie by `document.cookie = "subkey=PASTED_COOKIE_VALUE";`.
7. Reload http://calypso.localhost:3000/subscriptions/settings - the correct tab numbers should display.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
