### PR TITLE
Changing discount description if the user is viewing two-year plans

### DIFF
--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -64,6 +64,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 			translate,
 			annualPricePerMonth,
 			isMonthlyPlan,
+			planType,
 		} = this.props;
 
 		if ( isMonthlyPlan && annualPricePerMonth < rawPrice ) {
@@ -75,9 +76,18 @@ export class PlanFeaturesComparisonHeader extends Component {
 			const annualPriceObj = getCurrencyObject( rawPriceAnnual, currencyCode );
 			const annualPriceText = `${ annualPriceObj.symbol }${ annualPriceObj.integer }`;
 
-			return translate( 'billed as %(price)s annually', {
-				args: { price: annualPriceText },
-			} );
+			return [
+				'personal-bundle-2y',
+				'value_bundle-2y',
+				'business-bundle-2y',
+				'ecommerce-bundle-2y',
+			].includes( planType )
+				? translate( 'billed as %(price)s biannually', {
+						args: { price: annualPriceText },
+				  } )
+				: translate( 'billed as %(price)s annually', {
+						args: { price: annualPriceText },
+				  } );
 		}
 
 		return null;
@@ -100,7 +110,7 @@ export class PlanFeaturesComparisonHeader extends Component {
 				'business-bundle-2y',
 				'ecommerce-bundle-2y',
 			].includes( planType )
-				? translate( `You're saving %(discountRate)s%% by paying bi-annually`, {
+				? translate( `You're saving %(discountRate)s%% by paying biannually`, {
 						args: { discountRate },
 				  } )
 				: translate( `You're saving %(discountRate)s%% by paying annually`, {

--- a/client/my-sites/plan-features-comparison/header.jsx
+++ b/client/my-sites/plan-features-comparison/header.jsx
@@ -84,7 +84,8 @@ export class PlanFeaturesComparisonHeader extends Component {
 	}
 
 	getAnnualDiscount() {
-		const { isMonthlyPlan, rawPriceForMonthlyPlan, annualPricePerMonth, translate } = this.props;
+		const { isMonthlyPlan, rawPriceForMonthlyPlan, annualPricePerMonth, translate, planType } =
+			this.props;
 
 		if ( ! isMonthlyPlan ) {
 			const isLoading = typeof rawPriceForMonthlyPlan !== 'number';
@@ -92,9 +93,19 @@ export class PlanFeaturesComparisonHeader extends Component {
 			const discountRate = Math.round(
 				( 100 * ( rawPriceForMonthlyPlan - annualPricePerMonth ) ) / rawPriceForMonthlyPlan
 			);
-			const annualDiscountText = translate( `You're saving %(discountRate)s%% by paying annually`, {
-				args: { discountRate },
-			} );
+
+			const annualDiscountText = [
+				'personal-bundle-2y',
+				'value_bundle-2y',
+				'business-bundle-2y',
+				'ecommerce-bundle-2y',
+			].includes( planType )
+				? translate( `You're saving %(discountRate)s%% by paying bi-annually`, {
+						args: { discountRate },
+				  } )
+				: translate( `You're saving %(discountRate)s%% by paying annually`, {
+						args: { discountRate },
+				  } );
 
 			return (
 				<div


### PR DESCRIPTION
## Proposed Changes

* @gmovr [noticed](https://github.com/Automattic/wp-calypso/pull/74639#pullrequestreview-1348637475) a bug in the two-year plans that mentioned paying annually on the plans page even if the user was viewing two-year plans.
* This PR adds a check for two year plans and updates the language.

## Testing Instructions

* Check out this PR and start Calypso locally.
* Assign yourself to the Explat experiment as described in [this PR's](https://github.com/Automattic/wp-calypso/pull/74639) test instructions.
* Confirm that the discount language now refers to bi-annual payments.