### PR TITLE
Newsletter/LiB: Signup form, change button background

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -962,11 +962,17 @@ class SignupForm extends Component {
 			);
 		}
 
+		const params = new URLSearchParams( window.location.search );
+		const variationName = params.get( 'variationName' );
+
 		return (
 			<LoggedOutFormFooter isBlended={ this.props.isSocialSignupEnabled }>
 				{ this.termsOfServiceLink() }
 				<FormButton
-					className="signup-form__submit"
+					className={ classNames(
+						'signup-form__submit',
+						variationName && `${ variationName }-signup-form`
+					) }
 					disabled={
 						this.state.submitting ||
 						this.props.disabled ||

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -576,6 +576,11 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 			font-weight: 500;
 			letter-spacing: 0.32px;
 			line-height: 17px;
+
+			&.newsletter-signup-form,
+			&.link-in-bio-signup-form {
+				background-color: var(--color-primary);
+			}
 		}
 
 		.signup-form__social-buttons {


### PR DESCRIPTION
The CTA blue hues are slightly different between the setup and the launchpad (#117AC9 vs #0675C4)

This PR changes the CTA blu in the signup form for `newsletter`and `link-in-bio` flows.

## Testing
1. Check live link
2. Navigate in incognito to reach the signup form
3. Check that the cta blue is `--color-primary` = `--studio-blue-50`

Fixes https://github.com/Automattic/wp-calypso/issues/74659