### PR TITLE
Marketplace Thank You: Update the plugin fetch check for when there is no plugin

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -61,8 +61,7 @@ export function usePluginsThankYouData( pluginSlugs: string[] ): [ ThankYouSecti
 		isFetchingAutomatedTransferStatus( state, siteId )
 	);
 
-	const allPluginsFetched =
-		!! pluginsOnSite.length && pluginsOnSite.every( ( pluginOnSite ) => !! pluginOnSite );
+	const allPluginsFetched = pluginsOnSite.every( ( pluginOnSite ) => !! pluginOnSite );
 
 	const transferStatus = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );


### PR DESCRIPTION
## Proposed Changes

Allow a thank you page with no plugins to be displayed by removing the check for empty plugin slugs.

## Testing Instructions

* Go to the Thank you page with only a theme selected. Ex: `/marketplace/thank-you/:site?themes=yuna `
* You should see the thank you page to be displayed after the load
* On the prod version this will be stuck on the loading phase

| Before  | After |
| ------------- | ------------- |
|<img width="1247" alt="CleanShot 2023-03-20 at 15 50 55@2x" src="https://user-images.githubusercontent.com/5039531/226439066-5231c821-1adb-4329-a07c-a7479f6ed477.png">|<img width="1232" alt="CleanShot 2023-03-20 at 15 51 49@2x" src="https://user-images.githubusercontent.com/5039531/226439088-bf123fdd-765c-4bda-b510-c73829cd512c.png">|

PS: This flow is not being displayed now, but this support needs to be present for the future when we display theme cards


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
