### PR TITLE
Fix ftme__sell e2e spec

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -21,6 +21,8 @@ const selectors = {
 
 	// Themes
 	individualThemeContainer: ( name: string ) => `.design-button-container:has-text("${ name }")`,
+	themeContinueButton: '.design-preview__sidebar-action-buttons:has-text("Continue")',
+	themeContinueButtonSmall: '.step-container__navigation:has-text("Continue")',
 
 	// Goals
 	goalButton: ( goal: string ) => `.select-card__container:has-text("${ goal.toLowerCase() }")`,
@@ -166,5 +168,17 @@ export class StartSiteFlow {
 	 */
 	async selectTheme( themeName: string ): Promise< void > {
 		await this.page.getByRole( 'button', { name: themeName } ).click();
+	}
+
+	/**
+	 * Confirms Theme selection by clicking the correct Continue button depending on viewport size.
+	 * themeContinueButton will be visible at viewports above 1080px.
+	 * themeContinueButtonSmall will be visible at viewports below 1080px.
+	 */
+	async confirmThemeSelection(): Promise< void > {
+		await Promise.race( [
+			this.page.click( selectors.themeContinueButton ),
+			this.page.click( selectors.themeContinueButtonSmall ),
+		] );
 	}
 }

--- a/test/e2e/specs/onboarding/ftme__sell.ts
+++ b/test/e2e/specs/onboarding/ftme__sell.ts
@@ -178,7 +178,10 @@ describe( DataHelper.createSuiteTitle( 'FTME: Sell' ), function () {
 
 		it( 'Select theme', async function () {
 			await startSiteFlow.selectTheme( themeName );
-			await startSiteFlow.clickButton( `Start with ${ themeName }` );
+		} );
+
+		it( 'Confirm theme selection', async function () {
+			await startSiteFlow.confirmThemeSelection();
 		} );
 
 		it( 'Land in Home dashboard', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fix for ftme__sell spec that fails due to incorrect button text. Changes include a new step to click on a specific button locator.
  - The logic for the theme picker in the start site flow is: themes with style variations have a 'Continue' button, and themes without style variations have 'Start with {themeName}.' The theme currently used in the spec has style variations.
  - The theme preview screen can have one of two different continue buttons depending on the viewport size, so two new selectors were added. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The ftme__sell e2e spec should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
