### PR TITLE
Logging: `/site-logs` displays the 10 latest logs on mount

### DIFF
--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -16,6 +16,7 @@ export interface SiteLogsParams {
 	logType: 'php' | 'web';
 	start: number;
 	end: number;
+	sort_order?: 'asc' | 'desc';
 	page_size?: number;
 	scroll_id?: string;
 }

--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -1,0 +1,55 @@
+import { UseQueryOptions, useQuery } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+
+interface SiteLogsAPIResponse {
+	message: string;
+	data: {
+		total_results: number;
+		logs: object[];
+		scroll_id: string | null;
+	};
+}
+
+export type SiteLogs = SiteLogsAPIResponse[ 'data' ];
+
+export interface SiteLogsParams {
+	logType: 'php' | 'web';
+	start: number;
+	end: number;
+	page_size?: number;
+	scroll_id?: string;
+}
+
+export function useSiteLogsQuery(
+	siteId: number | null | undefined,
+	params: SiteLogsParams,
+	queryOptions: UseQueryOptions< SiteLogsAPIResponse, unknown, SiteLogs > = {}
+) {
+	return useQuery< SiteLogsAPIResponse, unknown, SiteLogs >(
+		[
+			'site-logs',
+			siteId,
+			params.logType,
+			params.start,
+			params.end,
+			params.page_size,
+			params.scroll_id,
+		],
+		() => {
+			const logTypeFragment = params.logType === 'php' ? 'error-logs' : 'logs';
+			const path = `/sites/${ siteId }/hosting/${ logTypeFragment }`;
+			return wpcom.req.post( { path, apiNamespace: 'wpcom/v2' }, params );
+		},
+		{
+			enabled: !! siteId,
+			staleTime: Infinity, // The logs within a specified time range never change.
+			select( data ) {
+				return data.data;
+			},
+			meta: {
+				persist: false,
+			},
+			...queryOptions,
+		}
+	);
+}

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -1,12 +1,44 @@
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useSiteLogsQuery } from 'calypso/data/hosting/use-site-logs-query';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export function SiteLogs() {
 	const siteId = useSelector( getSelectedSiteId );
+	const moment = useLocalizedMoment();
+
+	const [ startTime ] = useState( moment().subtract( 7, 'd' ).unix() );
+	const [ endTime ] = useState( moment().unix() );
+
+	const { data } = useSiteLogsQuery( siteId, {
+		logType: 'web',
+		start: startTime,
+		end: endTime,
+		page_size: 10,
+	} );
+
+	const formattedLogs = data?.logs
+		.map( ( log ) =>
+			Object.entries( log )
+				.sort( ( [ keyA ], [ keyB ] ) => {
+					if ( keyA === 'date' ) {
+						return -1;
+					}
+					if ( keyB === 'date' ) {
+						return 1;
+					}
+					return keyA.localeCompare( keyB );
+				} )
+				.map( ( [ key, value ] ) => `"${ key }" = ${ value }` )
+				.join( '\t' )
+		)
+		.join( '\n' );
 
 	return (
 		<>
-			<h2>Site logs for { siteId }</h2>
+			<h2>Web logs</h2>
+			<pre>{ formattedLogs }</pre>
 		</>
 	);
 }

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -15,6 +15,7 @@ export function SiteLogs() {
 		logType: 'web',
 		start: startTime,
 		end: endTime,
+		sort_order: 'desc',
 		page_size: 10,
 	} );
 

--- a/client/my-sites/site-logs/test/main.tsx
+++ b/client/my-sites/site-logs/test/main.tsx
@@ -16,7 +16,8 @@ describe( 'SiteLogs', () => {
 
 	test( 'displays the last 7 days worth of logs in descending order on mount', async () => {
 		nock( 'https://public-api.wordpress.com' )
-			.post( '/wpcom/v2/sites/113/hosting/logs', ( { start, end, sort_order } ) => {
+			// This particular test doesn't care whether we're requesting PHP or web logs
+			.post( /\/wpcom\/v2\/sites\/113\/hosting\/(error-)?logs/, ( { start, end, sort_order } ) => {
 				const sevenDays = 7 * 24 * 60 * 60;
 				const fudgeFactor = 5; // Allow for a few seconds of drift
 				const timeRange = end - start;

--- a/client/my-sites/site-logs/test/main.tsx
+++ b/client/my-sites/site-logs/test/main.tsx
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { reducer as ui } from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { useNock, nock } from 'calypso/test-helpers/use-nock';
+import { SiteLogs } from '../main';
+
+const render = ( el, options ) => renderWithProvider( el, { ...options, reducers: { ui } } );
+
+describe( 'SiteLogs', () => {
+	useNock();
+
+	test( 'displays the last 7 days worth of logs in descending order on mount', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/sites/113/hosting/logs', ( { start, end, sort_order } ) => {
+				const sevenDays = 7 * 24 * 60 * 60;
+				const fudgeFactor = 5; // Allow for a few seconds of drift
+				const timeRange = end - start;
+				return sort_order === 'desc' && Math.abs( timeRange - sevenDays ) < fudgeFactor;
+			} )
+			.reply( 200, {
+				message: 'OK',
+				data: {
+					scroll_id: null,
+					total_results: 1,
+					logs: [ { message: 'log entry' } ],
+				},
+			} );
+
+		render( <SiteLogs />, { initialState: { ui: { selectedSiteId: 113 } } } );
+
+		await waitFor( () =>
+			expect( screen.getByText( /"message" = log entry/ ) ).toBeInTheDocument()
+		);
+	} );
+} );


### PR DESCRIPTION
This PR is far from completing the feature, but it serves as a proof of concept and an initial commit that other PRs can base their work off.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/dotcom-forge#1988

## Proposed Changes

* `useSiteLogsQuery` hook for fetching logs from the server
* Naively render the 10 latest web logs
* The start and end of the time range are stored in React state so that we're not re-calculating the date range each render (which causes another request)

![CleanShot 2023-03-21 at 12 01 46@2x](https://user-images.githubusercontent.com/1500769/226484304-2de71ef2-2482-4a4b-95a3-aef5500e4987.png)

The strings aren't using `__()` yet because these aren't the strings we will use, so there's no need to send them to translators.

No memoisation for the log formatting is needed because this is all temporary code.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/site-logs/{site id}` for a WoA site
* See the latest 10 logs
* Visit frontend of your WoA site in another tab
* Refresh the site logs
* See new entries at the top of the logs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
