### PR TITLE
Editor: Fix e2e tests related to iframe removal [ IN PROGRESS ]

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -678,7 +678,8 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 	};
 
 	render() {
-		const { iframeUrl, shouldLoadIframe, isNew7DUser, currentUserCountryCode } = this.props;
+		const { iframeUrl, shouldLoadIframe, isNew7DUser, currentUserCountryCode, shouldBypassIframe } =
+			this.props;
 		const {
 			classicBlockEditorId,
 			isMediaModalVisible,
@@ -700,6 +701,10 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 			if ( window && window.hj ) {
 				window.hj( 'trigger', 'in_survey_1' );
 			}
+		}
+
+		if ( shouldBypassIframe ) {
+			window.location.assign( iframeUrl );
 		}
 
 		return (
@@ -859,6 +864,8 @@ const mapStateToProps = (
 	// Prevents the iframe from loading using a cached frame nonce.
 	const shouldLoadIframe = ! isRequestingSite( state, siteId ?? 0 );
 
+	const shouldBypassIframe = config.isEnabled( 'block-editor/non-iframed' );
+
 	const { url: closeUrl, label: closeLabel } = getEditorCloseConfig( state, siteId, postType );
 
 	// 'shouldDisplayAppBanner' does not check if we're in Blogger Flow, because it is a selector reading from the Redux state, and
@@ -890,6 +897,7 @@ const mapStateToProps = (
 		shouldDisplayAppBanner: displayAppBanner,
 		appBannerDismissed: isAppBannerDismissed( state ),
 		isNew7DUser: isUserRegistrationDaysWithinRange( state, null, 0, 7 ),
+		shouldBypassIframe,
 	};
 };
 

--- a/config/development.json
+++ b/config/development.json
@@ -28,6 +28,7 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
+		"block-editor/non-iframed": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -13,6 +13,7 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": false,
+		"block-editor/non-iframed": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -74,20 +74,7 @@ export class EditorPage {
 		page: Page,
 		{ target = 'simple', blockTheme = false }: { target?: SiteType; blockTheme?: boolean } = {}
 	) {
-		// The first step is to determine whether the test site is running a
-		// Gutenframe, otherwise known as a Calypsofy iframe.
-		// Typically, a Gutenframe is found on Simple sites and encapsulates the
-		// entire editor window.
-		// Atomic sites typically do not feature a Gutenframe and thus the editor
-		// window is exposed in the DOM.
-		// For both Simple and Atomic, the relevant `body` root element is used when resolving
-		// the Locator. This is to present a unified behavior when other methods reference the
-		// `editorWindow`.
-		if ( target === 'atomic' ) {
-			this.editorWindow = page.locator( selectors.editor );
-		} else {
-			this.editorWindow = page.frameLocator( selectors.editorFrame ).locator( selectors.editor );
-		}
+		this.editorWindow = page.locator( selectors.editor );
 
 		// The second step is to locate the iframe that exists within the
 		// editor canvas as of Gutenberg 14.9.1 when using newer block-based themes.

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -5,7 +5,6 @@ import {
 	EditorSidebarBlockInserterComponent,
 	EditorToolbarComponent,
 	EditorWelcomeTourComponent,
-	SiteType,
 	EditorPopoverMenuComponent,
 	EditorSiteStylesComponent,
 	ColorSettings,
@@ -72,21 +71,11 @@ export class FullSiteEditorPage {
 	 * Constructs an instance of the page POM class.
 	 *
 	 * @param {Page} page The underlying page.
-	 * @param {Object} param0 Keyed object parameter.
-	 * @param {SiteType} param0.target Target editor type. Defaults to 'simple'.
 	 */
-	constructor( page: Page, { target = 'simple' }: { target?: SiteType } = {} ) {
+	constructor( page: Page ) {
 		this.page = page;
 
-		if ( target === 'atomic' ) {
-			// For Atomic editors, there is no iFrame - the editor is
-			// part of the page DOM and is thus accessible directly.
-			this.editor = page.locator( selectors.editorRoot );
-		} else {
-			// For Simple editors, the editor is located within an iFrame
-			// and thus it must first be extracted.
-			this.editor = page.frameLocator( selectors.editorIframe ).locator( selectors.editorRoot );
-		}
+		this.editor = page.locator( selectors.editorRoot );
 
 		this.editorCanvas = this.editor
 			.frameLocator( selectors.editorCanvasIframe )

--- a/test/e2e/specs/fse/fse__limited-global-styles.ts
+++ b/test/e2e/specs/fse/fse__limited-global-styles.ts
@@ -31,7 +31,6 @@ describe( DataHelper.createSuiteTitle( 'Site Editor: Limited Global Styles' ), f
 		await fullSiteEditorPage.visit( siteSlug );
 		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Edit' );
 		await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
-		await fullSiteEditorPage.closeNavSidebar();
 	} );
 
 	it( 'Open site styles', async function () {

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -49,7 +49,7 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	} );
 
 	it( 'Open the Page template', async function () {
-		fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+		fullSiteEditorPage = new FullSiteEditorPage( page );
 
 		await fullSiteEditorPage.prepareForInteraction();
 
@@ -61,7 +61,7 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	} );
 
 	it( 'Editor canvas loads', async function () {
-		fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+		fullSiteEditorPage = new FullSiteEditorPage( page );
 
 		await fullSiteEditorPage.waitUntilLoaded();
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/74384

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
