### PR TITLE
Email Subscriptions: Update DeliveryWindow input to display week days on user locale order

### DIFF
--- a/client/my-sites/subscriptions/index.tsx
+++ b/client/my-sites/subscriptions/index.tsx
@@ -1,10 +1,20 @@
 import config from '@automattic/calypso-config';
 import { Reader } from '@automattic/data-stores';
+import { LocaleProvider, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
 import SubscriptionManager from '@automattic/subscription-manager';
 import { useTranslate } from 'i18n-calypso';
 import page, { Callback } from 'page';
 import { createElement } from 'react';
+import MomentProvider from 'calypso/components/localized-moment/provider';
 import { makeLayout, render } from 'calypso/controller';
+
+declare global {
+	interface Window {
+		wpcomEditorSiteLaunch?: {
+			locale?: string;
+		};
+	}
+}
 
 const SitesView = () => <span>Sites View</span>;
 const CommentsView = () => <span>Comments View</span>;
@@ -15,31 +25,35 @@ const SubscriptionManagementPage = () => {
 	const { data: counts } = Reader.useSubscriptionManagerSubscriptionsCountQuery();
 
 	return (
-		<SubscriptionManager>
-			<SubscriptionManager.TabsSwitcher
-				baseRoute="subscriptions"
-				defaultTab="sites"
-				tabs={ [
-					{
-						label: translate( 'Sites' ),
-						path: 'sites',
-						view: SitesView,
-						count: counts?.blogs || undefined,
-					},
-					{
-						label: translate( 'Comments' ),
-						path: 'comments',
-						view: CommentsView,
-						count: counts?.comments || undefined,
-					},
-					{
-						label: translate( 'Settings' ),
-						path: 'settings',
-						view: SettingsView,
-					},
-				] }
-			/>
-		</SubscriptionManager>
+		<LocaleProvider localeSlug={ window.wpcomEditorSiteLaunch?.locale ?? i18nDefaultLocaleSlug }>
+			<MomentProvider>
+				<SubscriptionManager>
+					<SubscriptionManager.TabsSwitcher
+						baseRoute="subscriptions"
+						defaultTab="sites"
+						tabs={ [
+							{
+								label: translate( 'Sites' ),
+								path: 'sites',
+								view: SitesView,
+								count: counts?.blogs || undefined,
+							},
+							{
+								label: translate( 'Comments' ),
+								path: 'comments',
+								view: CommentsView,
+								count: counts?.comments || undefined,
+							},
+							{
+								label: translate( 'Settings' ),
+								path: 'settings',
+								view: SettingsView,
+							},
+						] }
+					/>
+				</SubscriptionManager>
+			</MomentProvider>
+		</LocaleProvider>
 	);
 };
 

--- a/client/my-sites/subscriptions/index.tsx
+++ b/client/my-sites/subscriptions/index.tsx
@@ -1,20 +1,12 @@
 import config from '@automattic/calypso-config';
 import { Reader } from '@automattic/data-stores';
-import { LocaleProvider, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
+import { useLocale } from '@automattic/i18n-utils';
 import SubscriptionManager from '@automattic/subscription-manager';
 import { useTranslate } from 'i18n-calypso';
 import page, { Callback } from 'page';
 import { createElement } from 'react';
 import MomentProvider from 'calypso/components/localized-moment/provider';
 import { makeLayout, render } from 'calypso/controller';
-
-declare global {
-	interface Window {
-		wpcomEditorSiteLaunch?: {
-			locale?: string;
-		};
-	}
-}
 
 const SitesView = () => <span>Sites View</span>;
 const CommentsView = () => <span>Comments View</span>;
@@ -23,37 +15,36 @@ const SettingsView = () => <SubscriptionManager.UserSettings />;
 const SubscriptionManagementPage = () => {
 	const translate = useTranslate();
 	const { data: counts } = Reader.useSubscriptionManagerSubscriptionsCountQuery();
+	const locale = useLocale();
 
 	return (
-		<LocaleProvider localeSlug={ window.wpcomEditorSiteLaunch?.locale ?? i18nDefaultLocaleSlug }>
-			<MomentProvider>
-				<SubscriptionManager>
-					<SubscriptionManager.TabsSwitcher
-						baseRoute="subscriptions"
-						defaultTab="sites"
-						tabs={ [
-							{
-								label: translate( 'Sites' ),
-								path: 'sites',
-								view: SitesView,
-								count: counts?.blogs || undefined,
-							},
-							{
-								label: translate( 'Comments' ),
-								path: 'comments',
-								view: CommentsView,
-								count: counts?.comments || undefined,
-							},
-							{
-								label: translate( 'Settings' ),
-								path: 'settings',
-								view: SettingsView,
-							},
-						] }
-					/>
-				</SubscriptionManager>
-			</MomentProvider>
-		</LocaleProvider>
+		<MomentProvider currentLocale={ locale }>
+			<SubscriptionManager>
+				<SubscriptionManager.TabsSwitcher
+					baseRoute="subscriptions"
+					defaultTab="sites"
+					tabs={ [
+						{
+							label: translate( 'Sites' ),
+							path: 'sites',
+							view: SitesView,
+							count: counts?.blogs || undefined,
+						},
+						{
+							label: translate( 'Comments' ),
+							path: 'comments',
+							view: CommentsView,
+							count: counts?.comments || undefined,
+						},
+						{
+							label: translate( 'Settings' ),
+							path: 'settings',
+							view: SettingsView,
+						},
+					] }
+				/>
+			</SubscriptionManager>
+		</MomentProvider>
 	);
 };
 

--- a/packages/subscription-manager/src/components/fields/DeliveryWindowInput/DeliveryWindowInput.tsx
+++ b/packages/subscription-manager/src/components/fields/DeliveryWindowInput/DeliveryWindowInput.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable no-restricted-imports */
 import { useTranslate } from 'i18n-calypso';
-import moment from 'moment';
 import { FormEventHandler, useCallback } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import './styles.scss';
 
 export type DeliveryWindowDayType = 0 | 1 | 2 | 3 | 4 | 5 | 6;
@@ -24,6 +24,7 @@ const DeliveryWindowInput = ( {
 	onHourChange,
 }: DeliveryWindowInputProps ) => {
 	const translate = useTranslate();
+	const moment = useLocalizedMoment();
 
 	const getLabel = useCallback(
 		( hour ) =>
@@ -37,7 +38,14 @@ const DeliveryWindowInput = ( {
 						.format( 'LT' ),
 				},
 			} ),
-		[ translate ]
+		[ moment, translate ]
+	);
+
+	const orderedWeekDays = moment.weekdays( true );
+
+	const getDayValue = useCallback(
+		( day: string ) => moment().day( day ).locale( 'en' ).weekday(),
+		[ moment ]
 	);
 
 	return (
@@ -47,13 +55,11 @@ const DeliveryWindowInput = ( {
 			</FormLabel>
 			<div className="select-row">
 				<FormSelect name="delivery_window_day" onChange={ onDayChange } value={ dayValue }>
-					<option value="0">{ translate( 'Sunday' ) }</option>
-					<option value="1">{ translate( 'Monday' ) }</option>
-					<option value="2">{ translate( 'Tuesday' ) }</option>
-					<option value="3">{ translate( 'Wednesday' ) }</option>
-					<option value="4">{ translate( 'Thursday' ) }</option>
-					<option value="5">{ translate( 'Friday' ) }</option>
-					<option value="6">{ translate( 'Saturday' ) }</option>
+					{ orderedWeekDays.map( ( weekDay: string ) => (
+						<option key={ weekDay } value={ getDayValue( weekDay ) }>
+							{ weekDay }
+						</option>
+					) ) }
 				</FormSelect>
 				<FormSelect name="delivery_window_hour" onChange={ onHourChange } value={ hourValue }>
 					{ [ 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22 ].map( ( hour ) => (

--- a/packages/subscription-manager/src/components/index.d.ts
+++ b/packages/subscription-manager/src/components/index.d.ts
@@ -109,3 +109,7 @@ declare module 'calypso/components/forms/form-label' {
 	const FormLabel: React.FC< Props & LabelProps >;
 	export default FormLabel;
 }
+
+declare module 'calypso/components/localized-moment' {
+	export const useLocalizedMoment: () => import('moment');
+}


### PR DESCRIPTION
Related to #74679

## Proposed Changes

* Add `LocaleProvider` and `MomentProvider` on Subscriptions page
* Load weekdays from moment using locale order
* Use moment instance from useLocalizedMoment hook
* Update `getDayValue` function to make sure the values will match the existing pattern (0-6, where 0 is Sunday)
* By using a localized moment, the hours select will also display the hours based on the locale format

<img width="655" alt="image" src="https://user-images.githubusercontent.com/3113712/226489842-cdbb73d0-2fa8-4bd3-b7c1-91e621a7548b.png">

## Testing Instructions

* Run this patch on your local env
* Go to http://calypso.localhost:3000/subscriptions/settings
* Test with different locales to check if the order changes 
  * eg. EN locale should start on Sunday and FR locale should start on Monday
* Verify if the option values are the expected, Sunday should be always 0 even if it's displayed as the last day of the week
* Verify if the hours are displayed as per the locale format

<img width="387" alt="Screenshot 2023-03-20 at 20 41 15" src="https://user-images.githubusercontent.com/3113712/226490670-62301304-ea11-4f9d-94a3-115f89dedeb1.png">

<img width="387" alt="Screenshot 2023-03-20 at 20 41 33" src="https://user-images.githubusercontent.com/3113712/226490678-caea7163-c6ce-4c8f-a620-9b0e47b28512.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
