### PR TITLE
format-currency: Use i18n USD currency symbol if geolocation is US but locale is not en

### DIFF
--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -16,6 +16,7 @@ const geolocationEndpointUrl = 'https://public-api.wordpress.com/geo/';
 export function createFormatter(): CurrencyFormatter {
 	const currencyOverrides: Record< string, { symbol?: string | undefined } > = {};
 	let defaultLocale: string | undefined = undefined;
+	let geoLocation = '';
 
 	// If the user is inside the US using USD, they should only see `$` and not `US$`.
 	async function geolocateCurrencySymbol(): Promise< void > {
@@ -34,11 +35,7 @@ export function createFormatter(): CurrencyFormatter {
 		if ( ! geoData.country_short ) {
 			return;
 		}
-		if ( geoData.country_short === 'US' ) {
-			setCurrencySymbol( 'USD', '$' );
-		} else {
-			setCurrencySymbol( 'USD', 'US$' );
-		}
+		geoLocation = geoData.country_short;
 	}
 
 	function getFormatter(
@@ -251,6 +248,9 @@ export function createFormatter(): CurrencyFormatter {
 	}
 
 	function getCurrencyOverride( code: string ): CurrencyOverride | undefined {
+		if ( code === 'USD' && geoLocation !== '' && geoLocation !== 'US' ) {
+			return { symbol: 'US$' };
+		}
 		return currencyOverrides[ code ] ?? defaultCurrencyOverrides[ code ];
 	}
 

--- a/packages/format-currency/test/index.ts
+++ b/packages/format-currency/test/index.ts
@@ -154,6 +154,22 @@ describe( 'formatCurrency', () => {
 		expect( money ).toBe( '9 800 900,32 $US' );
 	} );
 
+	test( 'sets USD currency symbol to US$ if geolocation is US but locale is an en variant', async () => {
+		globalThis.fetch = jest.fn(
+			( url: string ) =>
+				Promise.resolve( {
+					json: () =>
+						url.includes( '/geo' )
+							? Promise.resolve( { country_short: 'US' } )
+							: Promise.resolve( 'invalid' ),
+				} ) as any
+		);
+		formatter = createFormatter();
+		await formatter.geolocateCurrencySymbol();
+		const money = formatter.formatCurrency( 9800900.32, 'USD', { locale: 'en-CA' } );
+		expect( money ).toBe( 'US$9,800,900.32' );
+	} );
+
 	test( 'does not change USD currency symbol from $ if geolocation is unknown and locale is en', async () => {
 		globalThis.fetch = jest.fn(
 			( url: string ) =>

--- a/packages/format-currency/test/index.ts
+++ b/packages/format-currency/test/index.ts
@@ -122,7 +122,7 @@ describe( 'formatCurrency', () => {
 		expect( money ).toBe( '₹9,800,900.00' );
 	} );
 
-	test( 'sets USD currency symbol to $ if geolocation is US', async () => {
+	test( 'sets USD currency symbol to $ if geolocation is US and locale is en', async () => {
 		globalThis.fetch = jest.fn(
 			( url: string ) =>
 				Promise.resolve( {
@@ -134,7 +134,7 @@ describe( 'formatCurrency', () => {
 		);
 		formatter = createFormatter();
 		await formatter.geolocateCurrencySymbol();
-		const money = formatter.formatCurrency( 9800900.32, 'USD' );
+		const money = formatter.formatCurrency( 9800900.32, 'USD', { locale: 'en-US' } );
 		expect( money ).toBe( '$9,800,900.32' );
 	} );
 

--- a/packages/format-currency/test/index.ts
+++ b/packages/format-currency/test/index.ts
@@ -138,7 +138,23 @@ describe( 'formatCurrency', () => {
 		expect( money ).toBe( '$9,800,900.32' );
 	} );
 
-	test( 'does not change USD currency symbol from $ if geolocation is unknown', async () => {
+	test( 'sets USD currency symbol to US$ if geolocation is US but locale is not en', async () => {
+		globalThis.fetch = jest.fn(
+			( url: string ) =>
+				Promise.resolve( {
+					json: () =>
+						url.includes( '/geo' )
+							? Promise.resolve( { country_short: 'US' } )
+							: Promise.resolve( 'invalid' ),
+				} ) as any
+		);
+		formatter = createFormatter();
+		await formatter.geolocateCurrencySymbol();
+		const money = formatter.formatCurrency( 9800900.32, 'USD', { locale: 'fr' } );
+		expect( money ).toBe( '9 800 900,32 $US' );
+	} );
+
+	test( 'does not change USD currency symbol from $ if geolocation is unknown and locale is en', async () => {
 		globalThis.fetch = jest.fn(
 			( url: string ) =>
 				Promise.resolve( {
@@ -150,11 +166,11 @@ describe( 'formatCurrency', () => {
 		);
 		formatter = createFormatter();
 		await formatter.geolocateCurrencySymbol();
-		const money = formatter.formatCurrency( 9800900.32, 'USD' );
+		const money = formatter.formatCurrency( 9800900.32, 'USD', { locale: 'en' } );
 		expect( money ).toBe( '$9,800,900.32' );
 	} );
 
-	test( 'sets USD currency symbol to US$ if geolocation is not US', async () => {
+	test( 'sets USD currency symbol to US$ if geolocation is not US and locale is en', async () => {
 		globalThis.fetch = jest.fn(
 			( url: string ) =>
 				Promise.resolve( {
@@ -166,7 +182,7 @@ describe( 'formatCurrency', () => {
 		);
 		formatter = createFormatter();
 		await formatter.geolocateCurrencySymbol();
-		const money = formatter.formatCurrency( 9800900.32, 'USD' );
+		const money = formatter.formatCurrency( 9800900.32, 'USD', { locale: 'en' } );
 		expect( money ).toBe( 'US$9,800,900.32' );
 	} );
 


### PR DESCRIPTION
## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/74351 which added code to use geolocation to determine the USD currency symbol of the functions of the `@automattic/format-currency` package (eg: `formatCurrency()` and `getCurrencyObject()`). That PR missed something subtle but important: if the currency is USD and the location is `US` and the locale starts with `en`, we want the currency symbol to be `$` **but** if the locale is not `en` we still want to use the default i18n currency symbol. This PR corrects that oversight.

Props to @jjchrisdiehl who noticed this.

Before:

<img width="179" alt="Screenshot 2023-03-21 at 10 53 15 AM" src="https://user-images.githubusercontent.com/2036909/226645762-98a84d52-ec33-4a46-8e00-d2f79d0f716d.png">

After:

<img width="169" alt="Screenshot 2023-03-21 at 10 53 41 AM" src="https://user-images.githubusercontent.com/2036909/226645800-2fa28d41-98a5-427a-9ffd-666e4ee26097.png">


## Testing Instructions

Automated tests should cover it. 

To manually test this:

- Set your currency to USD.
- Geolocate yourself in the US (using a VPN if necessary).
- Set your user interface language to a non-English one with right-aligned currency symbols (eg: `fr`).
- View a page that displays prices (eg: `/plans`).
- Verify that the currency symbol for the prices is `$US`.
