### PR TITLE
Jetpack Pro Dashboard: show "Not supported on multisite" when a product is not supported on a multisite

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
@@ -4,6 +4,7 @@
 
 import { render, fireEvent } from '@testing-library/react';
 import nock from 'nock';
+import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -31,6 +32,7 @@ describe( '<SiteCard>', () => {
 			connected: true,
 		} );
 	test( 'should render correctly and expand card on click', () => {
+		const blogId = 1234;
 		const siteObj = {
 			blog_id: 1234,
 			url: 'test.jurassic.ninja',
@@ -65,6 +67,11 @@ describe( '<SiteCard>', () => {
 			partnerPortal: {
 				partner: {
 					isPartnerOAuthTokenLoaded: true,
+				},
+			},
+			sites: {
+				items: {
+					[ blogId ]: siteObj,
 				},
 			},
 		};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
@@ -23,9 +23,10 @@ describe( '<SiteContent>', () => {
 		.reply( 200, {
 			connected: true,
 		} );
+	const blogId = 1234;
 	const sites = [
 		{
-			blog_id: 1234,
+			blog_id: blogId,
 			url: 'test.jurassic.ninja',
 			monitor_settings: {
 				monitor_active: true,
@@ -42,6 +43,11 @@ describe( '<SiteContent>', () => {
 		partnerPortal: {
 			partner: {
 				isPartnerOAuthTokenLoaded: true,
+			},
+		},
+		sites: {
+			items: {
+				[ blogId ]: sites[ 0 ],
 			},
 		},
 	};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -315,7 +315,7 @@ export default function SiteStatusContent( {
 
 	let updatedContent = content;
 
-	if ( ! isMultiSite ) {
+	if ( ! showMultisiteNotSupported ) {
 		if ( link ) {
 			let target = '_self';
 			let rel;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -45,11 +45,13 @@ export default function SiteStatusContent( {
 		isExternalLink,
 		row: { value, status, error },
 		siteError,
-		tooltip,
 		tooltipId,
 		siteDown,
 		eventName,
+		...metadataRest
 	} = getRowMetaData( rows, type, isLargeScreen );
+
+	let { tooltip } = metadataRest;
 
 	const { isBulkManagementActive } = useContext( SitesOverviewContext );
 	const isExpandedBlockEnabled = isEnabled( 'jetpack/pro-dashboard-expandable-block' );
@@ -179,7 +181,6 @@ export default function SiteStatusContent( {
 	}
 
 	let content;
-	let updatedTooltip = tooltip;
 
 	// Show "Not supported on multisite" when the the site is multisite and the product is Scan or
 	// Backup and the site does not have a backup subscription https://href.li/?https://wp.me/pbuNQi-1jg
@@ -188,7 +189,7 @@ export default function SiteStatusContent( {
 
 	if ( showMultisiteNotSupported ) {
 		content = <Gridicon icon="minus-small" size={ 18 } className="sites-overview__icon-active" />;
-		updatedTooltip = translate( 'Not supported on multisite' );
+		tooltip = translate( 'Not supported on multisite' );
 	} else {
 		// We will show "Site Down" when the site is down which is handled differently.
 		if ( type === 'monitor' && ! siteDown ) {
@@ -197,7 +198,7 @@ export default function SiteStatusContent( {
 					site={ rows.site.value }
 					settings={ rows.monitor.settings }
 					status={ status }
-					tooltip={ updatedTooltip }
+					tooltip={ tooltip }
 					tooltipId={ tooltipId }
 					siteError={ siteError }
 					isLargeScreen={ isLargeScreen }
@@ -345,7 +346,7 @@ export default function SiteStatusContent( {
 
 	return (
 		<>
-			{ updatedTooltip && ! disabledStatus ? (
+			{ tooltip && ! disabledStatus ? (
 				<>
 					<span
 						ref={ statusContentRef }
@@ -365,7 +366,7 @@ export default function SiteStatusContent( {
 						position="bottom"
 						className="sites-overview__tooltip"
 					>
-						{ updatedTooltip }
+						{ tooltip }
 					</Tooltip>
 				</>
 			) : (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -182,7 +182,7 @@ export default function SiteStatusContent( {
 	let updatedTooltip = tooltip;
 
 	// Show "Not supported on multisite" when the the site is multisite and the product is Scan or
-	// Backup and the site does not have Backup subscription https://href.li/?https://wp.me/pbuNQi-1jg
+	// Backup and the site does not have a backup subscription https://href.li/?https://wp.me/pbuNQi-1jg
 	const showMultisiteNotSupported =
 		isMultiSite && ( type === 'scan' || ( type === 'backup' && ! rows.site.value.has_backup ) );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
@@ -5,6 +5,7 @@
 import { render, waitFor } from '@testing-library/react';
 import { translate } from 'i18n-calypso';
 import nock from 'nock';
+import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -91,11 +92,20 @@ describe( '<SiteTableRow>', () => {
 	const props = {
 		item,
 		columns: siteColumns,
+		setExpanded: function (): void {
+			throw new Error( 'Function not implemented.' );
+		},
+		isExpanded: false,
 	};
 	const initialState = {
 		partnerPortal: {
 			partner: {
 				isPartnerOAuthTokenLoaded: true,
+			},
+		},
+		sites: {
+			items: {
+				[ blogId ]: siteObj,
 			},
 		},
 	};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -103,6 +103,11 @@ describe( '<SiteTable>', () => {
 				isPartnerOAuthTokenLoaded: true,
 			},
 		},
+		sites: {
+			items: {
+				[ blogId ]: siteObj,
+			},
+		},
 	};
 	const mockStore = configureStore();
 	const store = mockStore( initialState );


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/73406

## Proposed Changes

This PR makes the following changes

- Show `-` with a tooltip showing `Not supported on multisite` when the product is `Scan`
- Show `-` with a tooltip showing `Not supported on multisite` when the product is `Backup` and does not have a backup subscription https://href.li/?https://wp.me/pbuNQi-1jg

## Testing Instructions

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/handle-unsupported-products-for-multisite` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Add a multisite with a plan that usually would include Backup & Scan, e.g. Complete.
4. Verify that the Backup column shows the clock or check icon and Scan shows `-` and when hovering over, it shows `Not supported on multisite`. We will show the backup as it is if it is already added - https://href.li/?https://wp.me/pbuNQi-1jg
5. Add another multisite without any plan
6. Verify that both Backup &  Scan shows `-` and when hovering over, it shows `Not supported on multisite`.

<img width="1100" alt="Screenshot 2023-03-21 at 12 16 03 PM" src="https://user-images.githubusercontent.com/10586875/226540507-99fe672b-7dd0-4dbc-b7c0-02593e2a150d.png">

<img width="435" alt="Screenshot 2023-03-21 at 12 36 06 PM" src="https://user-images.githubusercontent.com/10586875/226539368-021af099-e6ad-4218-b973-389818cb27b6.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
