### PR TITLE
Agency Dashboard: Fix the style of CTA when onboarding a new agency

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/onboarding-widget/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/onboarding-widget/index.tsx
@@ -57,15 +57,18 @@ export default function OnboardingWidget( { isLicensesPage }: { isLicensesPage?:
 			video:
 				'https://video.wordpress.com/embed/T6pTlPK8?hd=1&amp;autoPlay=0&amp;permalink=1&amp;loop=0&amp;preloadContent=metadata&amp;muted=0&amp;playsinline=0&amp;controls=1&amp;cover=1',
 			extraContent: (
-				<Button
-					target="_blank"
-					borderless
-					href="https://jetpack.com/support/jetpack-agency-licensing-portal-instructions/add-sites-agency-portal-dashboard/"
-					onClick={ onHowToAddNewSiteClick }
-				>
-					{ translate( 'How to add sites to the dashboard' ) } &nbsp;
+				<div className="onboarding-widget__how-to-add-sites-btn">
+					<Button
+						target="_blank"
+						borderless
+						href="https://jetpack.com/support/jetpack-agency-licensing-portal-instructions/add-sites-agency-portal-dashboard/"
+						onClick={ onHowToAddNewSiteClick }
+					>
+						{ translate( 'How to add sites to the dashboard' ) }
+					</Button>
+					&nbsp;
 					<Gridicon icon="external" size={ 24 } />
-				</Button>
+				</div>
 			),
 			isCompleted: hasSites,
 		},

--- a/client/jetpack-cloud/sections/partner-portal/primary/onboarding-widget/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/onboarding-widget/style.scss
@@ -105,6 +105,10 @@
 			height: 100%;
 		}
 	}
+
+	.onboarding-widget__how-to-add-sites-btn {
+		display: flex;
+	}
 }
 
 .onboarding-widget__step-completed {


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/74694

## Proposed Changes

Fix the style of the "How to add sites to the dashboard" button.

Before | After
--|--
<img width="468" alt="image" src="https://user-images.githubusercontent.com/1749918/226548502-22a1b649-8d1b-4950-94f1-c58c38a111b0.png">|<img width="466" alt="image" src="https://user-images.githubusercontent.com/1749918/226548642-ecbd305a-c2d0-4e2f-9279-b13d8ebdd137.png">

## Testing Instructions

- Apply D98977-code to your sandbox to make the testing easier.
- Visit the Jetpack Cloud Live and then visit the Dashboard (or the Licensing page).
- Verify that the external link icon is not part of the link itself

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?