### PR TITLE
Site Assembler: Display font style and font weight to the variation preview

### DIFF
--- a/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/preview.tsx
@@ -26,10 +26,19 @@ interface Props {
 
 const FontPairingVariationPreview = ( { title }: Props ) => {
 	const [ fontFamilies ] = useSetting( 'typography.fontFamilies' ) as [ FontFamily[] ];
+
 	const [ textFontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
+	const [ textFontStyle = 'normal' ] = useStyle( 'typography.fontStyle' );
+	const [ textFontWeight = 400 ] = useStyle( 'typography.fontWeight' );
+
 	const [ headingFontFamily = textFontFamily ] = useStyle(
 		'elements.heading.typography.fontFamily'
 	);
+	const [ headingFontStyle = textFontStyle ] = useStyle( 'elements.heading.typography.fontStyle' );
+	const [ headingFontWeight = textFontWeight ] = useStyle(
+		'elements.heading.typography.fontWeight'
+	);
+
 	const [ containerResizeListener, { width } ] = useResizeObserver();
 	const ratio = width ? width / STYLE_PREVIEW_WIDTH : 1;
 	const normalizedHeight = Math.ceil( STYLE_PREVIEW_HEIGHT * ratio );
@@ -93,8 +102,9 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 											...DEFAULT_FONT_STYLES,
 											color: '#000000',
 											fontSize: '16px',
-											fontWeight: 400,
+											fontWeight: headingFontWeight,
 											fontFamily: headingFontFamily,
+											fontStyle: headingFontStyle,
 										} }
 									>
 										{ headingFontFamilyName }
@@ -106,8 +116,9 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 											...DEFAULT_FONT_STYLES,
 											color: '#444444',
 											fontSize: '12px',
-											fontWeight: 400,
+											fontWeight: textFontWeight,
 											fontFamily: textFontFamily,
+											fontStyle: textFontStyle,
 										} }
 									>
 										{ textFontFamilyName }
@@ -127,10 +138,11 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 							>
 								<div
 									style={ {
-										fontFamily: headingFontFamily,
+										fontFamily: textFontFamily,
+										fontStyle: textFontStyle,
 										color: '#000000',
 										fontSize: '16px',
-										fontWeight: 400,
+										fontWeight: textFontWeight,
 										lineHeight: '1em',
 										textAlign: 'center',
 									} }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Currently, the font variation preview might not match the result on the large preview since we didn't retrieve the font style and weight from their definition. Hence, this PR is focusing on displaying the font style and font weight on the preview to match the result
* We still use specific font sizes for the heading and text to avoid preview looking disorder

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/226560265-a2d8bd0a-f3ca-4d2c-9d68-a0858638f6f3.png) |![image](https://user-images.githubusercontent.com/13596067/226560332-e944ee84-f000-4cc6-b059-8b0ed85e7577.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/color-and-fonts`
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Select any header, footer, and homepage
  * Click on "Fonts" and select any font variation
  * Ensure the preview of font variation is the same as what it looks like on the large preview

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
