### PR TITLE
Newsletter: Hover effect on color dropdown

### DIFF
--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -188,6 +188,10 @@ $compact-header-height: 35;
 	&:last-child .select-dropdown__item {
 		border-radius: 0 0 2px 2px;
 	}
+
+	&:hover {
+		background-color: var(--color-neutral-5);
+	}
 }
 
 .select-dropdown__item {


### PR DESCRIPTION
## What
![image](https://user-images.githubusercontent.com/52076348/226565598-a1aa50d8-02b5-4245-9cdb-8081ab588ea0.png)
 Color dropdown was missing an hover effect, now it has it.

## Testing
1. Calypso Live link
2. Check `setup/newsletter/newsletterSetup` page
3. Verify that the hover effect is there

Fixes https://github.com/Automattic/wp-calypso/issues/74661