### PR TITLE
Logging: Add standard section heading to /site-logs

### DIFF
--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -1,10 +1,15 @@
+import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import Main from 'calypso/components/main';
 import { useSiteLogsQuery } from 'calypso/data/hosting/use-site-logs-query';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export function SiteLogs() {
+	const { __ } = useI18n();
 	const siteId = useSelector( getSelectedSiteId );
 	const moment = useLocalizedMoment();
 
@@ -36,10 +41,19 @@ export function SiteLogs() {
 		)
 		.join( '\n' );
 
+	const titleHeader = __( 'Site Logs' );
+
 	return (
-		<>
+		<Main wideLayout>
+			<DocumentHead title={ titleHeader } />
+			<FormattedHeader
+				brandFont
+				headerText={ titleHeader }
+				subHeaderText={ __( 'View server logs to troubleshoot or debug problems with your site.' ) }
+				align="left"
+			/>
 			<h2>Web logs</h2>
 			<pre>{ formattedLogs }</pre>
-		</>
+		</Main>
 	);
 }

--- a/client/my-sites/site-logs/test/main.tsx
+++ b/client/my-sites/site-logs/test/main.tsx
@@ -4,12 +4,14 @@
 
 import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
+import documentHead from 'calypso/state/document-head/reducer';
 import { reducer as ui } from 'calypso/state/ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { useNock, nock } from 'calypso/test-helpers/use-nock';
 import { SiteLogs } from '../main';
 
-const render = ( el, options ) => renderWithProvider( el, { ...options, reducers: { ui } } );
+const render = ( el, options ) =>
+	renderWithProvider( el, { ...options, reducers: { ui, documentHead } } );
 
 describe( 'SiteLogs', () => {
 	useNock();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/dotcom-forge#1993

## Proposed Changes

* Adds the standard Calypso heading to the Site Logs section

![CleanShot 2023-03-21 at 22 30 46@2x](https://user-images.githubusercontent.com/1500769/226566088-3b311b3b-4b17-47da-8abc-182f3ee5aa7b.png)

There is not 100% consistency in how Calypso sections are styled. Sections which have been recently revamped like `/stats/day` and `/plans` have a heading with a white background and tabs that are embedded in the border between the header and the border. This is reminiscent of the SMP.

<img width="826" alt="CleanShot 2023-03-21 at 22 34 29@2x" src="https://user-images.githubusercontent.com/1500769/226566835-40cc5b3c-5cc4-4482-8541-2e8fecbb113b.png">

Unfortunately there's no common components for this yet. There's some styles that are copy-pasted between various sections. There are some places where one section has placed their rules into another sections SCSS files.

I think it's best to get the section heading merged and then figure out styling once we have more of the components in place.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/site-logs` in a local dev environment and confirm the section heading is there
* Confirm the `<title>` for the section makes sense.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~ We have time before this deploys to users
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
