### PR TITLE
Hosting Configuration: fix SSH key section resizing on mobile devices

### DIFF
--- a/client/my-sites/hosting/sftp-card/ssh-keys.scss
+++ b/client/my-sites/hosting/sftp-card/ssh-keys.scss
@@ -12,12 +12,9 @@
 }
 
 .ssh-keys__cards-container {
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	gap: 12px;
-	> .card {
-		margin: 0;
+	display: block;
+	> .card:not(:last-child) {
+		margin-bottom: 12px;
 	}
 }
 


### PR DESCRIPTION
*  Close https://github.com/Automattic/dotcom-forge/issues/1985

## Proposed Changes

* This PR fixes the display of the generated SSH keys section on mobile devices and makes the `Detach` button visible.

## Testing Instructions

* Make sure you have SSH keys added on your WP.com account (if not, add from `/me/security`)
* Make sure you have an Atomic site
* Navigate to `/hosting-config/{site}`
* In `SFTP/SSH credentials` section, toggle **SSH access** section
* Click on `Attach SSH key to site`
* Check the container for the SSH key on desktop:

<img width="1119" alt="Screenshot 2023-03-21 at 11 27 31 AM" src="https://user-images.githubusercontent.com/25575134/226580062-0c9068e2-4d63-4f36-b858-6d4c294fa0da.png">

* Check the display of the container on mobile (with Chrome dev tools, for example) - `Detach` button is visible and the container is sized to the screen:

<img width="596" alt="Screenshot 2023-03-21 at 11 30 41 AM" src="https://user-images.githubusercontent.com/25575134/226580602-0b1a76e5-710d-428b-9c13-dca56fdf3fc9.png">

**To test with multiple SSH keys**

* Make sure you have an administrator added to your Atomic site
* Your administrator must add SSH keys to their WP.com account first and attach it to the site (follow the same steps as above for your administrator's account)
* Check the display of two SSH keys from `/hosting-config/{site}` on desktop:

<img width="899" alt="Screenshot 2023-03-21 at 11 36 39 AM" src="https://user-images.githubusercontent.com/25575134/226581896-9e12dacd-f5ec-489d-b442-20280d4b5c37.png">

* Check the display of two SSH keys on mobile (using Chrome dev tools):

<img width="682" alt="Screenshot 2023-03-21 at 11 37 41 AM" src="https://user-images.githubusercontent.com/25575134/226582152-a396cc6e-506e-4157-93b3-0fc7fa493e5a.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
