### PR TITLE
Jetpack Pro Dashboard: implement column sorting in the pro dashboard

### DIFF
--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -23,7 +23,7 @@ const agencyDashboardFilterToQueryObject = ( filter: AgencyDashboardFilter ) => 
 
 const agencyDashboardSortToQueryObject = ( sort: DashboardSortInterface ) => {
 	return {
-		...( sort.field && { sort_field: sort.column } ),
+		...( sort.field && { sort_field: sort.field } ),
 		...( sort.direction && { sort_direction: sort.direction } ),
 	};
 };

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -3,7 +3,10 @@ import { useQuery } from 'react-query';
 import { useDispatch } from 'react-redux';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import { errorNotice } from 'calypso/state/notices/actions';
-import type { AgencyDashboardFilter } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import type {
+	AgencyDashboardFilter,
+	DashboardSortInterface,
+} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 
 const agencyDashboardFilterToQueryObject = ( filter: AgencyDashboardFilter ) => {
 	return {
@@ -18,16 +21,24 @@ const agencyDashboardFilterToQueryObject = ( filter: AgencyDashboardFilter ) => 
 	};
 };
 
+const agencyDashboardSortToQueryObject = ( sort: DashboardSortInterface ) => {
+	return {
+		...( sort.field && { sort_field: sort.column } ),
+		...( sort.direction && { sort_direction: sort.direction } ),
+	};
+};
+
 const useFetchDashboardSites = (
 	isPartnerOAuthTokenLoaded: boolean,
 	searchQuery: string,
 	currentPage: number,
-	filter: AgencyDashboardFilter
+	filter: AgencyDashboardFilter,
+	sort: DashboardSortInterface
 ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	return useQuery(
-		[ 'jetpack-agency-dashboard-sites', searchQuery, currentPage, filter ],
+		[ 'jetpack-agency-dashboard-sites', searchQuery, currentPage, filter, sort ],
 		() =>
 			wpcomJpl.req.get(
 				{
@@ -38,6 +49,7 @@ const useFetchDashboardSites = (
 					...( searchQuery && { query: searchQuery } ),
 					...( currentPage && { page: currentPage } ),
 					...agencyDashboardFilterToQueryObject( filter ),
+					...agencyDashboardSortToQueryObject( sort ),
 				}
 			),
 		{

--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -6,10 +6,14 @@ import Header from './header';
 import DashboardSidebar from './sidebar';
 
 export function agencyDashboardContext( context: PageJS.Context, next: VoidFunction ): void {
-	const { s: search, page: contextPage, issue_types } = context.query;
+	const { s: search, page: contextPage, issue_types, sort_field, sort_direction } = context.query;
 	const filter = {
 		issueTypes: issue_types?.split( ',' ),
 		showOnlyFavorites: context.params.filter === 'favorites',
+	};
+	const sort = {
+		field: sort_field,
+		direction: sort_direction,
 	};
 	const state = context.store.getState();
 	const isAgency = isAgencyUser( state );
@@ -22,7 +26,12 @@ export function agencyDashboardContext( context: PageJS.Context, next: VoidFunct
 	context.header = <Header />;
 	context.secondary = <DashboardSidebar path={ context.path } />;
 	context.primary = (
-		<DashboardOverview search={ search } currentPage={ currentPage } filter={ filter } />
+		<DashboardOverview
+			search={ search }
+			currentPage={ currentPage }
+			filter={ filter }
+			sort={ sort }
+		/>
 	);
 	next();
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
@@ -17,6 +17,7 @@ export default function DashboardOverview( {
 	search,
 	currentPage,
 	filter,
+	sort,
 }: DashboardOverviewContextInterface ) {
 	const hasFetched = useSelector( hasFetchedPartner );
 	const isFetching = useSelector( isFetchingPartner );
@@ -40,6 +41,7 @@ export default function DashboardOverview( {
 			search,
 			currentPage,
 			filter,
+			sort,
 			isBulkManagementActive,
 			setIsBulkManagementActive: handleSetBulkManagementActive,
 			selectedSites,

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
@@ -48,8 +48,8 @@ export function useToggleActivateMonitor(
 	const translate = useTranslate();
 
 	const queryClient = useQueryClient();
-	const { filter, search, currentPage } = useContext( SitesOverviewContext );
-	const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter ];
+	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
+	const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter, sort ];
 
 	const toggleActivateMonitoring = useToggleActivateMonitorMutation( {
 		onMutate: async ( { siteId } ) => {
@@ -198,8 +198,8 @@ export function useUpdateMonitorSettings( sites: Array< { blog_id: number; url: 
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const queryClient = useQueryClient();
-	const { filter, search, currentPage } = useContext( SitesOverviewContext );
-	const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter ];
+	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
+	const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter, sort ];
 
 	const [ status, setStatus ] = useState( 'idle' );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/icons.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/icons.tsx
@@ -20,3 +20,46 @@ export const jetpackBoostMobileIcon = (
 		/>
 	</svg>
 );
+
+export const defaultSortIcon = (
+	<svg width="8" height="11" viewBox="0 0 8 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path
+			opacity="0.2"
+			d="M0.333313 3.26659L3.99998 0.333252L7.66665 3.26659L7.06665 4.06659L3.99998 1.66659L0.99998 4.06659L0.333313 3.26659Z"
+			fill="black"
+		/>
+		<path
+			opacity="0.2"
+			d="M0.333313 7.13332L3.99998 10.0667L7.66665 7.13332L7.06665 6.33332L3.99998 8.73332L0.99998 6.33332L0.333313 7.13332Z"
+			fill="black"
+		/>
+	</svg>
+);
+
+export const descendingSortIcon = (
+	<svg width="8" height="11" viewBox="0 0 8 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path
+			opacity="0.2"
+			d="M0.333313 3.26659L3.99998 0.333252L7.66665 3.26659L7.06665 4.06659L3.99998 1.66659L0.99998 4.06659L0.333313 3.26659Z"
+			fill="black"
+		/>
+		<path
+			d="M0.333313 7.13332L3.99998 10.0667L7.66665 7.13332L7.06665 6.33332L3.99998 8.73332L0.99998 6.33332L0.333313 7.13332Z"
+			fill="black"
+		/>
+	</svg>
+);
+
+export const ascendingSortIcon = (
+	<svg width="8" height="11" viewBox="0 0 8 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path
+			d="M0.333313 3.26659L3.99998 0.333252L7.66665 3.26659L7.06665 4.06659L3.99998 1.66659L0.99998 4.06659L0.333313 3.26659Z"
+			fill="black"
+		/>
+		<path
+			opacity="0.2"
+			d="M0.333313 7.13332L3.99998 10.0667L7.66665 7.13332L7.06665 6.33332L3.99998 8.73332L0.99998 6.33332L0.333313 7.13332Z"
+			fill="black"
+		/>
+	</svg>
+);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/context.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/context.ts
@@ -13,6 +13,10 @@ const SitesOverviewContext = createContext< SitesOverviewContextInterface >( {
 	setSelectedSites: () => {
 		return undefined;
 	},
+	sort: {
+		field: 'url',
+		direction: 'asc',
+	},
 } );
 
 export default SitesOverviewContext;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -55,14 +55,15 @@ export default function SitesOverview() {
 
 	const [ highlightTab, setHighlightTab ] = useState( false );
 
-	const { search, currentPage, filter, selectedSites, setSelectedSites } =
+	const { search, currentPage, filter, sort, selectedSites, setSelectedSites } =
 		useContext( SitesOverviewContext );
 
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites(
 		isPartnerOAuthTokenLoaded,
 		search,
 		currentPage,
-		filter
+		filter,
+		sort
 	);
 
 	const selectedSiteIds = selectedSites.map( ( site ) => site.blog_id );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -10,6 +10,7 @@ import { useDashboardShowLargeScreen } from '../../hooks';
 import SitesOverviewContext from '../context';
 import SiteBulkSelect from '../site-bulk-select';
 import SiteCard from '../site-card';
+import SiteSort from '../site-sort';
 import SiteTable from '../site-table';
 import { formatSites, siteColumns } from '../utils';
 
@@ -43,6 +44,8 @@ const SiteContent = ( { data, isLoading, currentPage, isFavoritesTab }: Props, r
 
 	const isLargeScreen = useDashboardShowLargeScreen( siteTableRef, ref );
 
+	const firstColumn = siteColumns[ 0 ];
+
 	return (
 		<>
 			{ isLargeScreen ? (
@@ -61,7 +64,8 @@ const SiteContent = ( { data, isLoading, currentPage, isFavoritesTab }: Props, r
 							<SiteBulkSelect sites={ sites } isLoading={ isLoading } />
 						) : (
 							<>
-								<span className="site-content__bulk-select-label">{ siteColumns[ 0 ].title }</span>
+								<span className="site-content__bulk-select-label">{ firstColumn.title }</span>
+								{ firstColumn.isSortable && <SiteSort columnKey={ firstColumn.key } /> }
 								<EditButton sites={ sites } />
 							</>
 						) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -64,8 +64,9 @@ const SiteContent = ( { data, isLoading, currentPage, isFavoritesTab }: Props, r
 							<SiteBulkSelect sites={ sites } isLoading={ isLoading } />
 						) : (
 							<>
-								<span className="site-content__bulk-select-label">{ firstColumn.title }</span>
-								{ firstColumn.isSortable && <SiteSort columnKey={ firstColumn.key } /> }
+								<SiteSort isSortable={ firstColumn.isSortable } columnKey={ firstColumn.key }>
+									<span className="site-content__bulk-select-label">{ firstColumn.title }</span>
+								</SiteSort>
 								<EditButton sites={ sites } />
 							</>
 						) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search/index.tsx
@@ -1,8 +1,7 @@
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import Search from 'calypso/components/search';
-import { addQueryArgs } from 'calypso/lib/route';
+import { updateDashboardURLQueryArgs } from 'calypso/state/jetpack-agency-dashboard/actions';
 
 export default function SiteSearch( {
 	searchQuery,
@@ -13,15 +12,8 @@ export default function SiteSearch( {
 	const translate = useTranslate();
 	const isMobile = useMobileBreakpoint();
 
-	const handleSearchSites = ( query: string ) => {
-		const params = new URLSearchParams( window.location.search );
-		const issueTypes = params.get( 'issue_types' );
-		const queryParams = {
-			...( query && { s: query } ),
-			...( issueTypes && { issue_types: issueTypes } ),
-		};
-		const currentPath = window.location.pathname;
-		page( addQueryArgs( queryParams, currentPath ) );
+	const handleSearchSites = ( search: string ) => {
+		updateDashboardURLQueryArgs( { search } );
 	};
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
@@ -25,14 +25,14 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
 
-	const { filter, search, currentPage } = useContext( SitesOverviewContext );
+	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
 	const { showOnlyFavorites } = filter;
-	const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter ];
+	const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter, sort ];
 	const siblingQueryKey = [
 		'jetpack-agency-dashboard-sites',
 		search,
 		currentPage,
-		{ ...filter, showOnlyFavorites: ! showOnlyFavorites },
+		{ ...filter, ...sort, showOnlyFavorites: ! showOnlyFavorites },
 	];
 	const successNoticeId = 'success-notice';
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/index.tsx
@@ -56,7 +56,8 @@ export default function SiteSort( {
 	return (
 		<Icon
 			className={ classNames( 'site-sort__icon', {
-				'site-sort__icon-large_screen': isLargeScreen && isDefault,
+				'site-sort__icon-large_screen': isLargeScreen,
+				'site-sort__icon-hidden': isLargeScreen && isDefault,
 			} ) }
 			size={ 14 }
 			onClick={ setSort }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/index.tsx
@@ -16,9 +16,13 @@ const SORT_DIRECTION_DESC = 'desc';
 export default function SiteSort( {
 	columnKey,
 	isLargeScreen,
+	children,
+	isSortable,
 }: {
 	columnKey: AllowedTypes;
 	isLargeScreen?: boolean;
+	children?: React.ReactNode;
+	isSortable?: boolean;
 } ) {
 	const { sort } = useContext( SitesOverviewContext );
 	const dispatch = useDispatch();
@@ -53,15 +57,30 @@ export default function SiteSort( {
 		return defaultSortIcon;
 	};
 
+	if ( ! isSortable ) {
+		return <span className="site-sort">{ children }</span>;
+	}
+
 	return (
-		<Icon
-			className={ classNames( 'site-sort__icon', {
+		<span
+			role="button"
+			tabIndex={ 0 }
+			className={ classNames( 'site-sort site-sort__clickable', {
 				'site-sort__icon-large_screen': isLargeScreen,
-				'site-sort__icon-hidden': isLargeScreen && isDefault,
 			} ) }
-			size={ 14 }
+			onKeyDown={ setSort }
 			onClick={ setSort }
-			icon={ getSortIcon() }
-		/>
+		>
+			{ children }
+			{ isSortable && (
+				<Icon
+					className={ classNames( 'site-sort__icon', {
+						'site-sort__icon-hidden': isLargeScreen && isDefault,
+					} ) }
+					size={ 14 }
+					icon={ getSortIcon() }
+				/>
+			) }
+		</span>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/index.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@wordpress/icons';
+import classNames from 'classnames';
 import { useContext } from 'react';
 import { useDispatch } from 'react-redux';
 import { updateSort } from 'calypso/state/jetpack-agency-dashboard/actions';
@@ -9,20 +10,31 @@ import { siteColumnKeyMap } from '../utils';
 
 import './style.scss';
 
-export default function SiteSort( { columnKey }: { columnKey: AllowedTypes } ) {
+const SORT_DIRECTION_ASC = 'asc';
+const SORT_DIRECTION_DESC = 'desc';
+
+export default function SiteSort( {
+	columnKey,
+	isLargeScreen,
+}: {
+	columnKey: AllowedTypes;
+	isLargeScreen?: boolean;
+} ) {
 	const { sort } = useContext( SitesOverviewContext );
 	const dispatch = useDispatch();
 
+	const { field, direction } = sort;
+
+	const isDefault = field !== siteColumnKeyMap?.[ columnKey ] || ! field || ! direction;
+
 	const setSort = () => {
 		const updatedSort = { ...sort };
-		if ( sort.field !== siteColumnKeyMap?.[ columnKey ] || ! sort.field || ! sort.direction ) {
+		if ( isDefault ) {
 			updatedSort.field = siteColumnKeyMap?.[ columnKey ];
-			updatedSort.direction = 'asc';
-		}
-		if ( sort.direction === 'asc' ) {
-			updatedSort.direction = 'desc';
-		}
-		if ( sort.direction === 'desc' ) {
+			updatedSort.direction = SORT_DIRECTION_ASC;
+		} else if ( direction === SORT_DIRECTION_ASC ) {
+			updatedSort.direction = SORT_DIRECTION_DESC;
+		} else if ( direction === SORT_DIRECTION_DESC ) {
 			updatedSort.field = '';
 			updatedSort.direction = '';
 		}
@@ -30,24 +42,25 @@ export default function SiteSort( { columnKey }: { columnKey: AllowedTypes } ) {
 		dispatch( updateSort( updatedSort ) );
 	};
 
-	if ( sort.field !== siteColumnKeyMap?.[ columnKey ] || ! sort.field || ! sort.direction ) {
-		return (
-			<Icon className="site-sort__icon" size={ 14 } onClick={ setSort } icon={ defaultSortIcon } />
-		);
-	}
-
 	const getSortIcon = () => {
-		if ( sort.direction === 'asc' ) {
+		if ( isDefault ) {
+			return defaultSortIcon;
+		} else if ( direction === SORT_DIRECTION_ASC ) {
 			return ascendingSortIcon;
-		} else if ( sort.direction === 'desc' ) {
+		} else if ( direction === SORT_DIRECTION_DESC ) {
 			return descendingSortIcon;
 		}
 		return defaultSortIcon;
 	};
 
 	return (
-		<span>
-			<Icon className="site-sort__icon" size={ 14 } onClick={ setSort } icon={ getSortIcon() } />
-		</span>
+		<Icon
+			className={ classNames( 'site-sort__icon', {
+				'site-sort__icon-large_screen': isLargeScreen && isDefault,
+			} ) }
+			size={ 14 }
+			onClick={ setSort }
+			icon={ getSortIcon() }
+		/>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/index.tsx
@@ -7,6 +7,8 @@ import SitesOverviewContext from '../context';
 import { AllowedTypes } from '../types';
 import { siteColumnKeyMap } from '../utils';
 
+import './style.scss';
+
 export default function SiteSort( { columnKey }: { columnKey: AllowedTypes } ) {
 	const { sort } = useContext( SitesOverviewContext );
 	const dispatch = useDispatch();

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/index.tsx
@@ -14,7 +14,7 @@ export default function SiteSort( { columnKey }: { columnKey: AllowedTypes } ) {
 	const dispatch = useDispatch();
 
 	const setSort = () => {
-		let updatedSort = { ...sort };
+		const updatedSort = { ...sort };
 		if ( sort.field !== siteColumnKeyMap?.[ columnKey ] || ! sort.field || ! sort.direction ) {
 			updatedSort.field = siteColumnKeyMap?.[ columnKey ];
 			updatedSort.direction = 'asc';
@@ -23,7 +23,8 @@ export default function SiteSort( { columnKey }: { columnKey: AllowedTypes } ) {
 			updatedSort.direction = 'desc';
 		}
 		if ( sort.direction === 'desc' ) {
-			updatedSort = null;
+			updatedSort.field = '';
+			updatedSort.direction = '';
 		}
 
 		dispatch( updateSort( updatedSort ) );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/index.tsx
@@ -1,0 +1,50 @@
+import { Icon } from '@wordpress/icons';
+import { useContext } from 'react';
+import { useDispatch } from 'react-redux';
+import { updateSort } from 'calypso/state/jetpack-agency-dashboard/actions';
+import { defaultSortIcon, ascendingSortIcon, descendingSortIcon } from '../../icons';
+import SitesOverviewContext from '../context';
+import { AllowedTypes } from '../types';
+import { siteColumnKeyMap } from '../utils';
+
+export default function SiteSort( { columnKey }: { columnKey: AllowedTypes } ) {
+	const { sort } = useContext( SitesOverviewContext );
+	const dispatch = useDispatch();
+
+	const setSort = () => {
+		let updatedSort = { ...sort };
+		if ( sort.field !== siteColumnKeyMap?.[ columnKey ] || ! sort.field || ! sort.direction ) {
+			updatedSort.field = siteColumnKeyMap?.[ columnKey ];
+			updatedSort.direction = 'asc';
+		}
+		if ( sort.direction === 'asc' ) {
+			updatedSort.direction = 'desc';
+		}
+		if ( sort.direction === 'desc' ) {
+			updatedSort = null;
+		}
+
+		dispatch( updateSort( updatedSort ) );
+	};
+
+	if ( sort.field !== siteColumnKeyMap?.[ columnKey ] || ! sort.field || ! sort.direction ) {
+		return (
+			<Icon className="site-sort__icon" size={ 14 } onClick={ setSort } icon={ defaultSortIcon } />
+		);
+	}
+
+	const getSortIcon = () => {
+		if ( sort.direction === 'asc' ) {
+			return ascendingSortIcon;
+		} else if ( sort.direction === 'desc' ) {
+			return descendingSortIcon;
+		}
+		return defaultSortIcon;
+	};
+
+	return (
+		<span>
+			<Icon className="site-sort__icon" size={ 14 } onClick={ setSort } icon={ getSortIcon() } />
+		</span>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/style.scss
@@ -1,0 +1,6 @@
+.site-sort__icon {
+	cursor: pointer;
+	float: right;
+	position: relative;
+	top: 5px;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/style.scss
@@ -1,16 +1,32 @@
 .site-sort__icon {
-	cursor: pointer;
 	position: relative;
-	top: 3px;
-	left: 8px;
+	inset-block-start: 3px;
+	inset-inline-start: 8px;
 }
 
 .site-sort__icon-large_screen {
-	float: right;
-	top: 5px;
-	left: unset;
+	&.site-sort {
+		position: relative;
+		width: 100%;
+		height: 100%;
+		display: inline-flex;
+		align-items: center;
+		margin-inline-start: -16px;
+		padding-inline: 16px;
+	}
+
+	.site-sort__icon {
+		position: absolute;
+		inset-inline-end: 16px;
+		inset-block-start: unset;
+		inset-inline-start: unset;
+	}
 }
 
 .site-sort__icon-hidden {
 	visibility: hidden;
+}
+
+.site-sort__clickable {
+	cursor: pointer;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/style.scss
@@ -4,3 +4,9 @@
 	position: relative;
 	top: 5px;
 }
+
+
+.site-sort__icon-large_screen {
+	visibility: hidden;
+}
+

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/style.scss
@@ -1,12 +1,16 @@
 .site-sort__icon {
 	cursor: pointer;
-	float: right;
 	position: relative;
-	top: 5px;
+	top: 3px;
+	left: 8px;
 }
-
 
 .site-sort__icon-large_screen {
-	visibility: hidden;
+	float: right;
+	top: 5px;
+	left: unset;
 }
 
+.site-sort__icon-hidden {
+	visibility: hidden;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -7,6 +7,7 @@ import './style.scss';
 import EditButton from '../../dashboard-bulk-actions/edit-button';
 import SitesOverviewContext from '../context';
 import SiteBulkSelect from '../site-bulk-select';
+import SiteSort from '../site-sort';
 import SiteTableRow from '../site-table-row';
 import type { SiteData, SiteColumns } from '../types';
 
@@ -51,6 +52,7 @@ const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableEle
 									<span className={ classNames( index === 0 && 'site-table-site-title' ) }>
 										{ column.title }
 									</span>
+									{ column.isSortable && <SiteSort columnKey={ column.key } /> }
 								</th>
 							) ) }
 							<th colSpan={ isExpandedBlockEnabled ? 2 : 1 }>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -46,13 +46,14 @@ const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableEle
 						<>
 							{ columns.map( ( column, index ) => (
 								<th key={ column.key }>
-									{ index === 0 && (
-										<Icon className="site-table__favorite-icon" size={ 24 } icon={ starFilled } />
-									) }
-									<span className={ classNames( index === 0 && 'site-table-site-title' ) }>
-										{ column.title }
-									</span>
-									{ column.isSortable && <SiteSort isLargeScreen columnKey={ column.key } /> }
+									<SiteSort isLargeScreen isSortable={ column.isSortable } columnKey={ column.key }>
+										{ index === 0 && (
+											<Icon className="site-table__favorite-icon" size={ 24 } icon={ starFilled } />
+										) }
+										<span className={ classNames( index === 0 && 'site-table-site-title' ) }>
+											{ column.title }
+										</span>
+									</SiteSort>
 								</th>
 							) ) }
 							<th colSpan={ isExpandedBlockEnabled ? 2 : 1 }>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -52,7 +52,7 @@ const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableEle
 									<span className={ classNames( index === 0 && 'site-table-site-title' ) }>
 										{ column.title }
 									</span>
-									{ column.isSortable && <SiteSort columnKey={ column.key } /> }
+									{ column.isSortable && <SiteSort isLargeScreen columnKey={ column.key } /> }
 								</th>
 							) ) }
 							<th colSpan={ isExpandedBlockEnabled ? 2 : 1 }>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
@@ -22,6 +22,12 @@
 		color: var(--studio-gray-50);
 		font-weight: 400;
 		height: 50px;
+
+		&:hover {
+			.site-sort__icon {
+				visibility: visible;
+			}
+		}
 	}
 
 	td {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
@@ -42,6 +42,7 @@ describe( '<SitesOverview>', () => {
 		search: '',
 		filter: { issueTypes: [], showOnlyFavorites: false },
 		selectedSites: [],
+		sort: { field: 'url', direction: 'asc' },
 	};
 
 	const queryClient = new QueryClient();
@@ -63,7 +64,13 @@ describe( '<SitesOverview>', () => {
 			perPage: 1,
 			totalFavorites: 1,
 		};
-		const queryKey = [ 'jetpack-agency-dashboard-sites', context.search, 1, context.filter ];
+		const queryKey = [
+			'jetpack-agency-dashboard-sites',
+			context.search,
+			1,
+			context.filter,
+			context.sort,
+		];
 		queryClient.setQueryData( queryKey, data );
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -9,6 +9,7 @@ export type SiteColumns = Array< {
 	title: ReactChild;
 	className?: string;
 	isExpandable?: boolean;
+	isSortable?: boolean;
 } >;
 
 export type AllowedStatusTypes =
@@ -160,10 +161,15 @@ export type ActionEventNames = {
 	[ key in AllowedActionTypes ]: { small_screen: string; large_screen: string };
 };
 
+export interface DashboardSortInterface {
+	field: string;
+	direction: 'asc' | 'desc' | '';
+}
 export interface DashboardOverviewContextInterface {
 	search: string;
 	currentPage: number;
 	filter: { issueTypes: Array< AgencyDashboardFilterOption >; showOnlyFavorites: boolean };
+	sort: DashboardSortInterface;
 }
 
 export interface SitesOverviewContextInterface extends DashboardOverviewContextInterface {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -24,6 +24,10 @@ const INITIAL_UNIX_EPOCH = '1970-01-01 00:00:00';
 
 const isExpandedBlockEnabled = config.isEnabled( 'jetpack/pro-dashboard-expandable-block' );
 
+export const siteColumnKeyMap: { [ key: string ]: string } = {
+	site: 'url',
+};
+
 const extraColumns: SiteColumns = isExpandedBlockEnabled
 	? [
 			{
@@ -45,6 +49,7 @@ export const siteColumns: SiteColumns = [
 	{
 		key: 'site',
 		title: translate( 'Site' ),
+		isSortable: true,
 	},
 	...extraColumns,
 	{

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -24,6 +24,7 @@ const INITIAL_UNIX_EPOCH = '1970-01-01 00:00:00';
 
 const isExpandedBlockEnabled = config.isEnabled( 'jetpack/pro-dashboard-expandable-block' );
 
+// Mapping the columns to the site data keys
 export const siteColumnKeyMap: { [ key: string ]: string } = {
 	site: 'url',
 };

--- a/client/state/jetpack-agency-dashboard/actions.ts
+++ b/client/state/jetpack-agency-dashboard/actions.ts
@@ -32,13 +32,13 @@ export const updateDashboardURLQueryArgs = ( {
 } ) => {
 	const params = new URLSearchParams( window.location.search );
 
-	const searchQuery = search ? search : params.get( 's' );
+	const searchQuery = search !== undefined ? search : params.get( 's' );
 	const filterOptions = filter
 		? filter
 		: ( params.getAll( 'issue_types' ) as AgencyDashboardFilterOption[] );
-
 	const sortField = sort ? sort.field : params.get( 'sort_field' );
 	const sortDirection = sort ? sort.direction : params.get( 'sort_direction' );
+
 	page(
 		addQueryArgs(
 			{

--- a/client/state/jetpack-agency-dashboard/actions.ts
+++ b/client/state/jetpack-agency-dashboard/actions.ts
@@ -35,6 +35,20 @@ export const updateFilter = ( filterOptions: AgencyDashboardFilterOption[] ) => 
 	navigateToFilter( filterOptions );
 };
 
+export const updateSort = ( sort: { field: string; direction: string } | null ) => () => {
+	const params = new URLSearchParams( window.location.search );
+	const search = params.get( 's' ) ? `?s=${ params.get( 's' ) }` : '';
+	page(
+		addQueryArgs(
+			{
+				...( sort && { sort_field: sort.field, sort_direction: sort.direction } ),
+				...filterStateToQuery( params.getAll( 'issue_types' ) as AgencyDashboardFilterOption[] ),
+			},
+			window.location.pathname + search
+		)
+	);
+};
+
 export function setPurchasedLicense( productsInfo?: PurchasedProductsInfo ): AnyAction {
 	return { type: JETPACK_AGENCY_DASHBOARD_PURCHASED_LICENSE_CHANGE, payload: productsInfo };
 }

--- a/client/state/jetpack-agency-dashboard/actions.ts
+++ b/client/state/jetpack-agency-dashboard/actions.ts
@@ -21,32 +21,47 @@ const filterStateToQuery = ( filterOptions: AgencyDashboardFilterOption[] ) => {
 	return { issue_types: filterOptions.join( ',' ) };
 };
 
-function navigateToFilter( filterOptions: AgencyDashboardFilterOption[] ) {
+export const updateDashboardURLQueryArgs = ( {
+	filter,
+	sort,
+	search,
+}: {
+	filter?: AgencyDashboardFilterOption[];
+	sort?: { field: string; direction: string };
+	search?: string;
+} ) => {
 	const params = new URLSearchParams( window.location.search );
-	const search = params.get( 's' ) ? `?s=${ params.get( 's' ) }` : '';
-	page( addQueryArgs( filterStateToQuery( filterOptions ), window.location.pathname + search ) );
-}
 
-export const setFilter = ( filterOptions: AgencyDashboardFilterOption[] ) => () => {
-	navigateToFilter( filterOptions );
-};
+	const searchQuery = search ? search : params.get( 's' );
+	const filterOptions = filter
+		? filter
+		: ( params.getAll( 'issue_types' ) as AgencyDashboardFilterOption[] );
 
-export const updateFilter = ( filterOptions: AgencyDashboardFilterOption[] ) => () => {
-	navigateToFilter( filterOptions );
-};
-
-export const updateSort = ( sort: { field: string; direction: string } | null ) => () => {
-	const params = new URLSearchParams( window.location.search );
-	const search = params.get( 's' ) ? `?s=${ params.get( 's' ) }` : '';
+	const sortField = sort ? sort.field : params.get( 'sort_field' );
+	const sortDirection = sort ? sort.direction : params.get( 'sort_direction' );
 	page(
 		addQueryArgs(
 			{
-				...( sort && { sort_field: sort.field, sort_direction: sort.direction } ),
-				...filterStateToQuery( params.getAll( 'issue_types' ) as AgencyDashboardFilterOption[] ),
+				...( searchQuery && { s: searchQuery } ),
+				...filterStateToQuery( filterOptions ),
+				...( sortField && { sort_field: sortField } ),
+				...( sortDirection && { sort_direction: sortDirection } ),
 			},
-			window.location.pathname + search
+			window.location.pathname
 		)
 	);
+};
+
+export const setFilter = ( filter: AgencyDashboardFilterOption[] ) => () => {
+	updateDashboardURLQueryArgs( { filter } );
+};
+
+export const updateFilter = ( filter: AgencyDashboardFilterOption[] ) => () => {
+	updateDashboardURLQueryArgs( { filter } );
+};
+
+export const updateSort = ( sort: { field: string; direction: string } ) => () => {
+	updateDashboardURLQueryArgs( { sort } );
 };
 
 export function setPurchasedLicense( productsInfo?: PurchasedProductsInfo ): AnyAction {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/74608

## Proposed Changes

- The PR implements sorting functionality in the Jetpack Pro Dashboard. The sort is currently implemented for the site name only. 
- Refactoring the search, and filter logic to use one single function to update the query args in the URL, which is also being used by the sort functionality. 
- This is implemented on both large and small screen devices.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_** Please play around with search/filter/sort in different orders and verify everything works as expected. Eg: Apply search first, filter next, and sort at the end. Verify all the different possible orders. 

**Instructions**

1. Run `git checkout add/implement-column-sorting-in-pro-dashboard` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Hover over the site column, and verify that the default sort icon is as shown below

Before hover

<img width="789" alt="Screenshot 2023-03-22 at 3 50 59 PM" src="https://user-images.githubusercontent.com/10586875/226873823-448f903b-15ef-430d-ac3b-005fdcfb682a.png">

When hovered




<img width="789" alt="Screenshot 2023-03-22 at 3 50 57 PM" src="https://user-images.githubusercontent.com/10586875/226873809-d679089f-44a8-42e5-83fc-73b974cb6c2b.png">

4. Click the sort icon, and verify the icon is changed, and it looks as shown below. Also, verify the sites are sorted in ascending order and the URL is updated.


<img width="789" alt="Screenshot 2023-03-22 at 3 51 07 PM" src="https://user-images.githubusercontent.com/10586875/226873832-6e81dea5-e4a3-4105-88f8-563abbf5412a.png">

<img width="542" alt="Screenshot 2023-03-22 at 2 18 45 PM" src="https://user-images.githubusercontent.com/10586875/226851854-09bd5fd2-8212-400b-9e8c-33a9d317d777.png">

5. Click the sort icon again, and verify the icon is changed, and it looks as shown below. Also, verify the sites are sorted in descending order, and that the URL is updated.



<img width="789" alt="Screenshot 2023-03-22 at 3 51 11 PM" src="https://user-images.githubusercontent.com/10586875/226873838-245485a7-46af-4909-92cc-a208c7999dbb.png">

<img width="542" alt="Screenshot 2023-03-22 at 2 18 49 PM" src="https://user-images.githubusercontent.com/10586875/226851938-fd18b023-8598-4b67-af10-71d3441e5fd0.png">

6. Click the sort icon again. Verify that the default sort icon is as shown below. Hovered out if the Site column should hide the icons
7. Switch to the small screen view and perform the test instructions again. The icons on mobile devices will always be shown.

Default view

![mobile (19)](https://user-images.githubusercontent.com/10586875/226852036-432ebe14-c3d5-4c51-b928-d10a29967af2.png)

Sorted Ascending

![mobile (20)](https://user-images.githubusercontent.com/10586875/226852056-61829209-a6a4-4d35-91cb-8b29c996772f.png)

Sorted Descending 

![mobile (21)](https://user-images.githubusercontent.com/10586875/226852063-38447f18-6102-4051-aff7-d25cd57d0522.png)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
