### PR TITLE
Fix/jetpack agency dashboard enable monitor site down

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
@@ -67,6 +67,9 @@ export function useToggleActivateMonitor(
 						if ( site.blog_id === siteId ) {
 							return {
 								...site,
+								// As we rely primarily on the monitor_site_status field to determine the status of the monitor,
+								// we need to update it when the monitor_active field is updated.
+								monitor_site_status: params.monitor_active,
 								monitor_settings: {
 									...site.monitor_settings,
 									monitor_active: params.monitor_active,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -12,6 +12,7 @@ import Tooltip from 'calypso/components/tooltip';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectLicense, unselectLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { hasSelectedLicensesOfType } from 'calypso/state/jetpack-agency-dashboard/selectors';
+import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import ToggleActivateMonitoring from '../downtime-monitoring/toggle-activate-monitoring';
 import SitesOverviewContext from './context';
 import SiteSelectCheckbox from './site-select-checkbox';
@@ -59,6 +60,8 @@ export default function SiteStatusContent( {
 	const isLicenseSelected = useSelector( ( state ) =>
 		hasSelectedLicensesOfType( state, siteId, type )
 	);
+
+	const isMultiSite = useSelector( ( state ) => isJetpackSiteMultiSite( state, siteId ) );
 
 	// Disable clicks/hover when there is a site error &
 	// when the row is not monitor and monitor status is down
@@ -175,159 +178,174 @@ export default function SiteStatusContent( {
 		);
 	}
 
-	// We will show "Site Down" when the site is down which is handled differently.
-	if ( type === 'monitor' && ! siteDown ) {
-		return (
-			<ToggleActivateMonitoring
-				site={ rows.site.value }
-				settings={ rows.monitor.settings }
-				status={ status }
-				tooltip={ tooltip }
-				tooltipId={ tooltipId }
-				siteError={ siteError }
-				isLargeScreen={ isLargeScreen }
-			/>
-		);
-	}
+	let content;
+	let updatedTooltip = tooltip;
 
-	if ( type === 'stats' ) {
-		const { total: totalViews, trend: viewsTrend } = rows.stats.value.views;
-		if ( viewsTrend === 'same' ) {
+	// Show "Not supported on multisite" when the the site is multisite and the product is Scan or
+	// Backup and the site does not have Backup subscription https://href.li/?https://wp.me/pbuNQi-1jg
+	const showMultisiteNotSupported =
+		isMultiSite && ( type === 'scan' || ( type === 'backup' && ! rows.site.value.has_backup ) );
+
+	if ( showMultisiteNotSupported ) {
+		content = <Gridicon icon="minus-small" size={ 18 } className="sites-overview__icon-active" />;
+		updatedTooltip = translate( 'Not supported on multisite' );
+	} else {
+		// We will show "Site Down" when the site is down which is handled differently.
+		if ( type === 'monitor' && ! siteDown ) {
 			return (
-				<>
-					<span className="sites-overview__stats-trend sites-overview__stats-trend__same" />
+				<ToggleActivateMonitoring
+					site={ rows.site.value }
+					settings={ rows.monitor.settings }
+					status={ status }
+					tooltip={ updatedTooltip }
+					tooltipId={ tooltipId }
+					siteError={ siteError }
+					isLargeScreen={ isLargeScreen }
+				/>
+			);
+		}
+
+		if ( type === 'stats' ) {
+			const { total: totalViews, trend: viewsTrend } = rows.stats.value.views;
+			if ( viewsTrend === 'same' ) {
+				return (
+					<>
+						<span className="sites-overview__stats-trend sites-overview__stats-trend__same" />
+						<div className="sites-overview__stats">
+							<ShortenedNumber value={ totalViews } />
+						</div>
+					</>
+				);
+			}
+			const trendIcon = getTrendIcon( viewsTrend );
+			return (
+				<span
+					className={ classNames( 'sites-overview__stats-trend', {
+						'sites-overview__stats-trend__up': viewsTrend === 'up',
+						'sites-overview__stats-trend__down': viewsTrend === 'down',
+					} ) }
+				>
+					{ trendIcon && <Icon icon={ trendIcon } size={ 16 } /> }
 					<div className="sites-overview__stats">
 						<ShortenedNumber value={ totalViews } />
 					</div>
-				</>
+				</span>
 			);
 		}
-		const trendIcon = getTrendIcon( viewsTrend );
-		return (
-			<span
-				className={ classNames( 'sites-overview__stats-trend', {
-					'sites-overview__stats-trend__up': viewsTrend === 'up',
-					'sites-overview__stats-trend__down': viewsTrend === 'down',
-				} ) }
-			>
-				{ trendIcon && <Icon icon={ trendIcon } size={ 16 } /> }
-				<div className="sites-overview__stats">
-					<ShortenedNumber value={ totalViews } />
-				</div>
-			</span>
-		);
-	}
 
-	if ( type === 'boost' ) {
-		const overallScore = rows.site.value.jetpack_boost_scores.overall;
-		if ( hasBoost ) {
-			return (
-				<div
-					className={ classNames(
-						'site-expanded-content__card-content-score',
-						getBoostRatingClass( overallScore )
-					) }
-				>
-					{ translate( '%(rating)s Score', {
-						args: { rating: getBoostRating( overallScore ) },
-						comment: '%rating will be replaced by boost rating, e.g. "A", "B", "C", "D", or "F"',
-					} ) }
-				</div>
-			);
+		if ( type === 'boost' ) {
+			const overallScore = rows.site.value.jetpack_boost_scores.overall;
+			if ( hasBoost ) {
+				return (
+					<div
+						className={ classNames(
+							'site-expanded-content__card-content-score',
+							getBoostRatingClass( overallScore )
+						) }
+					>
+						{ translate( '%(rating)s Score', {
+							args: { rating: getBoostRating( overallScore ) },
+							comment: '%rating will be replaced by boost rating, e.g. "A", "B", "C", "D", or "F"',
+						} ) }
+					</div>
+				);
+			}
+			return <div></div>;
 		}
-		return <div></div>;
-	}
 
-	let content;
-
-	switch ( status ) {
-		case 'critical': {
-			content = <div className="sites-overview__critical">{ value }</div>;
-			break;
-		}
-		case 'failed': {
-			content = isExpandedBlockEnabled ? (
-				<div className="sites-overview__failed">{ value }</div>
-			) : (
-				<Badge className="sites-overview__badge" type="error">
-					{ value }
-				</Badge>
-			);
-			break;
-		}
-		case 'warning': {
-			content = isExpandedBlockEnabled ? (
-				<div className="sites-overview__warning">{ value }</div>
-			) : (
-				<Badge className="sites-overview__badge" type="warning">
-					{ value }
-				</Badge>
-			);
-			break;
-		}
-		case 'success': {
-			content = <Gridicon icon="checkmark" size={ 18 } className="sites-overview__grey-icon" />;
-			break;
-		}
-		case 'disabled': {
-			content = <Gridicon icon="minus-small" size={ 18 } className="sites-overview__icon-active" />;
-			break;
-		}
-		case 'progress': {
-			content = <Gridicon icon="time" size={ 18 } className="sites-overview__grey-icon" />;
-			break;
-		}
-		case 'inactive': {
-			content = ! isLicenseSelected ? (
-				<button onClick={ handleSelectLicenseAction }>
-					<span className="sites-overview__status-select-license">
-						<Gridicon icon="plus-small" size={ 16 } />
-						<span>{ translate( 'Add' ) }</span>
-					</span>
-				</button>
-			) : (
-				<button onClick={ handleDeselectLicenseAction }>
-					<span className="sites-overview__status-unselect-license">
-						<Gridicon icon="checkmark" size={ 16 } />
-						<span>{ translate( 'Selected' ) }</span>
-					</span>
-				</button>
-			);
-			break;
+		switch ( status ) {
+			case 'critical': {
+				content = <div className="sites-overview__critical">{ value }</div>;
+				break;
+			}
+			case 'failed': {
+				content = isExpandedBlockEnabled ? (
+					<div className="sites-overview__failed">{ value }</div>
+				) : (
+					<Badge className="sites-overview__badge" type="error">
+						{ value }
+					</Badge>
+				);
+				break;
+			}
+			case 'warning': {
+				content = isExpandedBlockEnabled ? (
+					<div className="sites-overview__warning">{ value }</div>
+				) : (
+					<Badge className="sites-overview__badge" type="warning">
+						{ value }
+					</Badge>
+				);
+				break;
+			}
+			case 'success': {
+				content = <Gridicon icon="checkmark" size={ 18 } className="sites-overview__grey-icon" />;
+				break;
+			}
+			case 'disabled': {
+				content = (
+					<Gridicon icon="minus-small" size={ 18 } className="sites-overview__icon-active" />
+				);
+				break;
+			}
+			case 'progress': {
+				content = <Gridicon icon="time" size={ 18 } className="sites-overview__grey-icon" />;
+				break;
+			}
+			case 'inactive': {
+				content = ! isLicenseSelected ? (
+					<button onClick={ handleSelectLicenseAction }>
+						<span className="sites-overview__status-select-license">
+							<Gridicon icon="plus-small" size={ 16 } />
+							<span>{ translate( 'Add' ) }</span>
+						</span>
+					</button>
+				) : (
+					<button onClick={ handleDeselectLicenseAction }>
+						<span className="sites-overview__status-unselect-license">
+							<Gridicon icon="checkmark" size={ 16 } />
+							<span>{ translate( 'Selected' ) }</span>
+						</span>
+					</button>
+				);
+				break;
+			}
 		}
 	}
 
 	let updatedContent = content;
 
-	if ( link ) {
-		let target = '_self';
-		let rel;
-		if ( isExternalLink ) {
-			target = '_blank';
-			rel = 'noreferrer';
+	if ( ! isMultiSite ) {
+		if ( link ) {
+			let target = '_self';
+			let rel;
+			if ( isExternalLink ) {
+				target = '_blank';
+				rel = 'noreferrer';
+			}
+			updatedContent = (
+				<a
+					data-testid={ `row-${ tooltipId }` }
+					target={ target }
+					rel={ rel }
+					onClick={ handleClickRowAction }
+					href={ link }
+				>
+					{ content }
+				</a>
+			);
 		}
-		updatedContent = (
-			<a
-				data-testid={ `row-${ tooltipId }` }
-				target={ target }
-				rel={ rel }
-				onClick={ handleClickRowAction }
-				href={ link }
-			>
-				{ content }
-			</a>
-		);
-	}
 
-	if ( disabledStatus ) {
-		updatedContent = (
-			<span className="sites-overview__disabled sites-overview__row-status">{ content } </span>
-		);
+		if ( disabledStatus ) {
+			updatedContent = (
+				<span className="sites-overview__disabled sites-overview__row-status">{ content } </span>
+			);
+		}
 	}
 
 	return (
 		<>
-			{ tooltip && ! disabledStatus ? (
+			{ updatedTooltip && ! disabledStatus ? (
 				<>
 					<span
 						ref={ statusContentRef }
@@ -347,7 +365,7 @@ export default function SiteStatusContent( {
 						position="bottom"
 						className="sites-overview__tooltip"
 					>
-						{ tooltip }
+						{ updatedTooltip }
 					</Tooltip>
 				</>
 			) : (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #74711

## Proposed Changes

When downtime monitoring is enabled from the Dashboard, we optimistically update some of the fields that the ES index will return, but we don't assume that the site is live by default.

Slack: p1679400855937679-slack-C03Q2D22DGV

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `git checkout fix/jetpack-agency-dashboard-enable-monitor-site-down` and `yarn start-jetpack-cloud`
- Create a new JN site and connect Jetpack
- Visit http://jetpack.cloud.localhost:3000/
- Enable Jetpack monitor from the toggle for your site
- Verify that your site is not reported as "Site down" for a while

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?