### PR TITLE
Add link to settings in Blaze for coming soon site

### DIFF
--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -146,34 +146,15 @@ export default function PromotedPosts( { tab }: Props ) {
 		}
 	}, [ campaignsFull, alreadyScrolled ] );
 
-	if ( selectedSite?.is_coming_soon ) {
+	if ( selectedSite?.is_coming_soon || selectedSite?.is_private ) {
 		return (
 			<EmptyContent
 				className="campaigns-empty"
-				title={ translate( 'Site is not published' ) }
-				line={ translate(
-					'To start using Blaze, you must make your site public. You can do that from {{sitePrivacySettingsLink}}here{{/sitePrivacySettingsLink}}.',
-					{
-						components: {
-							sitePrivacySettingsLink: (
-								<a
-									href={ `https://wordpress.com/settings/general/${ selectedSite.domain }#site-privacy-settings` }
-									rel="noreferrer"
-								/>
-							),
-						},
-					}
-				) }
-				illustration={ null }
-			/>
-		);
-	}
-
-	if ( selectedSite?.is_private ) {
-		return (
-			<EmptyContent
-				className="campaigns-empty"
-				title={ translate( 'Site is private' ) }
+				title={
+					selectedSite?.is_coming_soon
+						? translate( 'Site is not published' )
+						: translate( 'Site is private' )
+				}
 				line={ translate(
 					'To start using Blaze, you must make your site public. You can do that from {{sitePrivacySettingsLink}}here{{/sitePrivacySettingsLink}}.',
 					{

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -151,7 +151,19 @@ export default function PromotedPosts( { tab }: Props ) {
 			<EmptyContent
 				className="campaigns-empty"
 				title={ translate( 'Site is not published' ) }
-				line={ translate( 'To start using Blaze, you must first publish your site.' ) }
+				line={ translate(
+					'To start using Blaze, you must make your site public. You can do that from {{sitePrivacySettingsLink}}here{{/sitePrivacySettingsLink}}.',
+					{
+						components: {
+							sitePrivacySettingsLink: (
+								<a
+									href={ `https://wordpress.com/settings/general/${ selectedSite.domain }#site-privacy-settings` }
+									rel="noreferrer"
+								/>
+							),
+						},
+					}
+				) }
 				illustration={ null }
 			/>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/1474

## Proposed Changes

Before
<img width="595" alt="before@2x" src="https://user-images.githubusercontent.com/6586048/226616417-a46c3b3f-ed93-4599-8bf7-0d0bf49afa8c.png">

After

https://user-images.githubusercontent.com/6586048/226616682-85623838-5112-4e97-a4be-5099ae37d94f.mp4


* Add settings link in the Blaze page for coming soon sites
* I used the same translation for private sites, so we don't need to wait for translations

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/advertising/:site`
* See if the copy has been updated with the link
* Click on the link and make sure it goes to the settings page

Only need to test for simple and atomic sites, as [jetpack sites don't have the Coming Soon feature](https://github.com/Automattic/jetpack/issues/7857#issuecomment-908058440).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
