### PR TITLE
Agency Dashboard: Fix site reported as down when enabling downtime monitoring

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
@@ -67,6 +67,9 @@ export function useToggleActivateMonitor(
 						if ( site.blog_id === siteId ) {
 							return {
 								...site,
+								// As we rely primarily on the monitor_site_status field to determine the status of the monitor,
+								// we need to update it when the monitor_active field is updated.
+								monitor_site_status: params.monitor_active,
 								monitor_settings: {
 									...site.monitor_settings,
 									monitor_active: params.monitor_active,

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
@@ -67,12 +67,12 @@ export function useToggleActivateMonitor(
 						if ( site.blog_id === siteId ) {
 							return {
 								...site,
-								// As we rely primarily on the monitor_site_status field to determine the status of the monitor,
-								// we need to update it when the monitor_active field is updated.
-								monitor_site_status: params.monitor_active,
 								monitor_settings: {
 									...site.monitor_settings,
 									monitor_active: params.monitor_active,
+									// As we rely primarily on the monitor_site_status field to determine the status of the monitor,
+									// we need to update it when the monitor_active field is updated.
+									monitor_site_status: params.monitor_active,
 								},
 							};
 						}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
@@ -29,6 +29,7 @@ describe( '<SiteContent>', () => {
 			url: 'test.jurassic.ninja',
 			monitor_settings: {
 				monitor_active: true,
+				monitor_site_status: true,
 			},
 		},
 	];

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/utils.ts
@@ -42,7 +42,8 @@ describe( 'utils', () => {
 			is_favorite: false,
 			monitor_last_status_change: '2020-12-01T00:00:00+00:00',
 			monitor_settings: {
-				monitor_active: true,
+				monitor_active: false,
+				monitor_site_status: false,
 				last_down_time: '',
 				monitor_deferment_time: 5,
 				monitor_user_emails: [],
@@ -200,6 +201,7 @@ describe( 'utils', () => {
 					monitor_site_status: true,
 					monitor_settings: {
 						monitor_active: true,
+						monitor_site_status: true,
 					},
 					site_stats: {
 						views: {
@@ -256,6 +258,7 @@ describe( 'utils', () => {
 						value: '',
 						settings: {
 							monitor_active: true,
+							monitor_site_status: true,
 						},
 					},
 					plugin: {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -23,6 +23,8 @@ export type AllowedStatusTypes =
 
 export interface MonitorSettings {
 	monitor_active: boolean;
+	monitor_site_status: boolean;
+	monitor_site_status_raw: number;
 	last_down_time: string;
 	monitor_deferment_time: number;
 	monitor_user_emails: Array< string >;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -24,7 +24,6 @@ export type AllowedStatusTypes =
 export interface MonitorSettings {
 	monitor_active: boolean;
 	monitor_site_status: boolean;
-	monitor_site_status_raw: number;
 	last_down_time: string;
 	monitor_deferment_time: number;
 	monitor_user_emails: Array< string >;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -408,11 +408,12 @@ const formatMonitorData = ( site: Site ) => {
 		error: false,
 		settings: site.monitor_settings,
 	};
-	const monitorStatus = site.monitor_settings.monitor_active;
-	if ( ! monitorStatus ) {
+	const { monitor_active: monitorActive, monitor_site_status: monitorStatus } =
+		site.monitor_settings;
+	if ( ! monitorActive ) {
 		monitor.status = 'disabled';
 	} else if (
-		! site.monitor_site_status &&
+		! monitorStatus &&
 		// This check is needed because monitor_site_status is false by default
 		// and we don't want to show the site down status when the site is first connected and the monitor is enabled
 		INITIAL_UNIX_EPOCH !== site.monitor_last_status_change


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #74711

## Proposed Changes

When downtime monitoring is enabled from the Dashboard, we optimistically update some of the fields that the ES index will return, but we don't assume that the site is live by default.

Slack: p1679400855937679-slack-C03Q2D22DGV

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `git checkout fix/jetpack-agency-dashboard-enable-monitor-site-down` and `yarn start-jetpack-cloud`
- Create a new JN site and connect Jetpack
- Visit http://jetpack.cloud.localhost:3000/
- Enable Jetpack monitor from the toggle for your site
- Verify that your site is not reported as "Site down" for a while

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?