### PR TITLE
Create client-side data interface for updating subscription settings.

### DIFF
--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -32,6 +32,10 @@ async function callApi< ReturnType >( {
 		?.find( ( c ) => c.startsWith( 'subkey=' ) )
 		?.split( '=' )[ 1 ];
 
+	if ( ! subkey ) {
+		throw new Error( 'Subkey not found' );
+	}
+
 	return apiFetch( {
 		global: true,
 		path: `https://public-api.wordpress.com/rest/v1.1${ path }`,

--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -1,19 +1,20 @@
 import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
 import wpcomRequest from 'wpcom-proxy-request';
 
-type FetchFromApiParams = {
+type callApiParams = {
 	path: string;
 	method?: 'GET' | 'POST';
 	body?: object;
 	isLoggedIn?: boolean;
 };
+
 // Helper function for fetching from subkey authenticated API. Subkey authentication process is only applied in case of logged-out users.
-async function fetchFromApi< ReturnType >( {
+async function callApi< ReturnType >( {
 	path,
 	method = 'GET',
-	body = {},
+	body,
 	isLoggedIn = false,
-}: FetchFromApiParams ): Promise< ReturnType > {
+}: callApiParams ): Promise< ReturnType > {
 	if ( isLoggedIn ) {
 		const res = await wpcomRequest( {
 			path,
@@ -45,4 +46,4 @@ async function fetchFromApi< ReturnType >( {
 	} as APIFetchOptions );
 }
 
-export { fetchFromApi };
+export { callApi };

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -1,4 +1,5 @@
 export { useSubscriptionManagerUserSettingsQuery } from './queries/use-subscription-manager-user-settings-query';
 export { useSubscriptionManagerSubscriptionsCountQuery } from './queries/use-subscription-manager-subscriptions-count-query';
+export { useSubscriptionManagerUserSettingsMutation } from './mutations/use-subscription-manager-user-settings-mutation';
 
 export type { SubscriptionManagerUserSettings, EmailFormatType } from './types';

--- a/packages/data-stores/src/reader/mutations/use-subscription-manager-user-settings-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-subscription-manager-user-settings-mutation.ts
@@ -1,0 +1,29 @@
+import { useMutation } from 'react-query';
+import { callApi } from '../helpers';
+import type { SubscriptionManagerUserSettings } from '../types';
+
+type APIError = {
+	error: string;
+	message: string;
+};
+
+type ApiSubscriptionManagerUserSettings = {
+	settings: SubscriptionManagerUserSettings;
+};
+
+const useSubscriptionManagerUserSettingsMutation = () => {
+	return useMutation<
+		ApiSubscriptionManagerUserSettings,
+		APIError,
+		SubscriptionManagerUserSettings
+	>( ( data: SubscriptionManagerUserSettings ) => {
+		return callApi< ApiSubscriptionManagerUserSettings >( {
+			path: '/read/email-settings',
+			method: 'POST',
+			body: data,
+			isLoggedIn: true,
+		} );
+	} );
+};
+
+export { useSubscriptionManagerUserSettingsMutation };

--- a/packages/data-stores/src/reader/mutations/use-subscription-manager-user-settings-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-subscription-manager-user-settings-mutation.ts
@@ -1,29 +1,22 @@
 import { useMutation } from 'react-query';
 import { callApi } from '../helpers';
-import type { SubscriptionManagerUserSettings } from '../types';
-
-type APIError = {
-	error: string;
-	message: string;
-};
-
-type ApiSubscriptionManagerUserSettings = {
-	settings: SubscriptionManagerUserSettings;
-};
+import { useIsLoggedIn } from '../hooks';
+import type { SubscriptionManagerUserSettings, EmailSettingsAPIResponse } from '../types';
 
 const useSubscriptionManagerUserSettingsMutation = () => {
-	return useMutation<
-		ApiSubscriptionManagerUserSettings,
-		APIError,
-		SubscriptionManagerUserSettings
-	>( ( data: SubscriptionManagerUserSettings ) => {
-		return callApi< ApiSubscriptionManagerUserSettings >( {
-			path: '/read/email-settings',
-			method: 'POST',
-			body: data,
-			isLoggedIn: true,
-		} );
-	} );
+	const isLoggedIn = useIsLoggedIn();
+
+	return useMutation< SubscriptionManagerUserSettings, Error, SubscriptionManagerUserSettings >(
+		async ( data: SubscriptionManagerUserSettings ) => {
+			const { settings } = await callApi< EmailSettingsAPIResponse >( {
+				path: '/read/email-settings',
+				method: 'POST',
+				body: data,
+				isLoggedIn,
+			} );
+			return settings;
+		}
+	);
 };
 
 export { useSubscriptionManagerUserSettingsMutation };

--- a/packages/data-stores/src/reader/queries/use-subscription-manager-subscriptions-count-query.ts
+++ b/packages/data-stores/src/reader/queries/use-subscription-manager-subscriptions-count-query.ts
@@ -1,5 +1,5 @@
 import { useQuery } from 'react-query';
-import { fetchFromApi } from '../helpers';
+import { callApi } from '../helpers';
 import { useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { SubscriptionManagerSubscriptionsCount } from '../types';
 
@@ -10,7 +10,7 @@ const useSubscriptionManagerSubscriptionsCountQuery = () => {
 	return useQuery(
 		[ 'read', 'subscriptions-count', isLoggedIn ],
 		async () => {
-			return await fetchFromApi< SubscriptionManagerSubscriptionsCount >( {
+			return await callApi< SubscriptionManagerSubscriptionsCount >( {
 				path: '/read/subscriptions-count',
 				isLoggedIn,
 			} );

--- a/packages/data-stores/src/reader/queries/use-subscription-manager-subscriptions-count-query.ts
+++ b/packages/data-stores/src/reader/queries/use-subscription-manager-subscriptions-count-query.ts
@@ -7,7 +7,7 @@ const useSubscriptionManagerSubscriptionsCountQuery = () => {
 	const isLoggedIn = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
 
-	return useQuery(
+	return useQuery< SubscriptionManagerSubscriptionsCount >(
 		[ 'read', 'subscriptions-count', isLoggedIn ],
 		async () => {
 			return await callApi< SubscriptionManagerSubscriptionsCount >( {

--- a/packages/data-stores/src/reader/queries/use-subscription-manager-user-settings-query.ts
+++ b/packages/data-stores/src/reader/queries/use-subscription-manager-user-settings-query.ts
@@ -1,5 +1,5 @@
 import { useQuery } from 'react-query';
-import { fetchFromApi } from '../helpers';
+import { callApi } from '../helpers';
 import { useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { SubscriptionManagerUserSettings } from '../types';
 
@@ -13,7 +13,7 @@ const useSubscriptionManagerUserSettingsQuery = () => {
 	return useQuery(
 		[ 'read', 'email-settings', isLoggedIn ],
 		async () => {
-			const { settings } = await fetchFromApi< EmailSettingsAPIResponse >( {
+			const { settings } = await callApi< EmailSettingsAPIResponse >( {
 				path: '/read/email-settings',
 				isLoggedIn,
 			} );

--- a/packages/data-stores/src/reader/queries/use-subscription-manager-user-settings-query.ts
+++ b/packages/data-stores/src/reader/queries/use-subscription-manager-user-settings-query.ts
@@ -1,16 +1,12 @@
 import { useQuery } from 'react-query';
 import { callApi } from '../helpers';
 import { useIsLoggedIn, useIsQueryEnabled } from '../hooks';
-import type { SubscriptionManagerUserSettings } from '../types';
-
-type EmailSettingsAPIResponse = {
-	settings: SubscriptionManagerUserSettings;
-};
+import type { SubscriptionManagerUserSettings, EmailSettingsAPIResponse } from '../types';
 
 const useSubscriptionManagerUserSettingsQuery = () => {
 	const isLoggedIn = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
-	return useQuery(
+	return useQuery< SubscriptionManagerUserSettings >(
 		[ 'read', 'email-settings', isLoggedIn ],
 		async () => {
 			const { settings } = await callApi< EmailSettingsAPIResponse >( {

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -13,3 +13,7 @@ export type SubscriptionManagerSubscriptionsCount = {
 	comments: number | null;
 	pending: number | null;
 };
+
+export type EmailSettingsAPIResponse = {
+	settings: SubscriptionManagerUserSettings;
+};


### PR DESCRIPTION
Fixes #74423

## Proposed Changes

This PR adds the `useSubscriptionManagerUserSettingsMutation`, which can be used to update the email settings.
It also improves upon the typings of the React Query hooks.

## Testing Instructions

1. Apply this PR
2. Since this PR does only include the hook, you'll have to add it to a component to test. You could add an empty component, but it's quicker to just temporary add it to an existing component such as `SubscriptionManagerContainer.tsx`

- Add the needed imports:
```js
import { useEffect } from "@wordpress/element";
import { Reader } from '@automattic/data-stores';
```

- Add the test code inside the component:
```js
	const { mutate, data, error } = Reader.useSubscriptionManagerUserSettingsMutation();

	useEffect(() => {
		setTimeout(() => {
			mutate({
				mail_option: 'html',
				delivery_day: 0, // 0-6, 0 is Sunday
				delivery_hour: 17, // 0-23, 0 is midnight
				blocked: false,
			});
		}, 10000);

	}, []);

	useEffect(() => {
		console.log(data, error);
	}, [data, error]);
```
This will initiate the mutation, call it once and print data/errors.

⁉️ Why the setTimeout? We only know that we're logged in after a few seconds (because the User datastore has to fetch our user first). In a real world scenario, we wouldn't call the mutation before the data is loaded, but here we have to simulate it.

3. Test as a WP.com user:

- Visit http://calypso.localhost:3000/subscriptions
- After 10 seconds you should see the request going out in the Network panel of devtools, and you should see the data coming in.

| | |
|-|-|
| <img width="2075" alt="CleanShot 2023-03-21 at 15 10 21@2x" src="https://user-images.githubusercontent.com/528287/226632699-94273d7b-246a-4d84-803b-368bec73507c.png"> | <img width="825" alt="CleanShot 2023-03-21 at 15 10 34@2x" src="https://user-images.githubusercontent.com/528287/226632740-d9e69e2b-6288-4dc4-80c5-69a6bdc31226.png"> |

4. Test as an external user

- Open an incognito window
- Set a subkey cookie and reload (paste this in your console: `document.cookie = 'subkey=8ee6a7e013b168ad8750dfeaac078298.jefpober%2Bxt%40gmail.com'; window.location.reload();`)
- After 10 seconds you should see the request going out in the Network panel of devtools, and you should see the data coming in.
- Verify that the subkey is being set as well

| | |
|-|-|
| ![CleanShot 2023-03-21 at 15 13 04@2x](https://user-images.githubusercontent.com/528287/226633534-8a3c9cec-6988-4679-9b84-4edb8addd1e8.png) | <img width="668" alt="CleanShot 2023-03-21 at 15 13 26@2x" src="https://user-images.githubusercontent.com/528287/226633561-6fdddb94-114a-4554-aa45-7b2b906b706e.png"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
