### PR TITLE
Remove launchpad wordpress text for write and build flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -665,3 +665,11 @@
 		display: none;
 	}
 }
+
+// Write and Free flow {
+.write.launchpad,
+.build.launchpad {
+	.launchpad__sidebar-header-flow-name {
+		display: none;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -666,7 +666,7 @@
 	}
 }
 
-// Write and Free flow {
+// Write and Free flow
 .write.launchpad,
 .build.launchpad {
 	.launchpad__sidebar-header-flow-name {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -666,7 +666,7 @@
 	}
 }
 
-// Write and Free flow
+// Write and Build flow
 .write.launchpad,
 .build.launchpad {
 	.launchpad__sidebar-header-flow-name {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74650

## Proposed Changes

* Remove "WordPress.com" header text on Launchpad for write and build flow

![image](https://user-images.githubusercontent.com/10482592/226636004-94723d10-765a-439b-9095-e5fcb2112d03.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Create a new launchpad-enabled site or use an existing site
* Verify the "WordPress.com" header text is not visible for the `write` flow (`/setup/write/launchpad?siteSlug={siteSlug}`)
* Verify the "WordPress.com" header text is not visible for the `build` flow (`/setup/build/launchpad?siteSlug={siteSlug}`)
* Verify the header text is still visible for the other flows such as `Newsletter` or `Link-in-bio`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
