### PR TITLE
User Invites: Wrap long domain on accept screen

### DIFF
--- a/client/my-sites/invites/invite-form-header/style.scss
+++ b/client/my-sites/invites/invite-form-header/style.scss
@@ -4,6 +4,7 @@
 	font-size: $font-title-small;
 	line-height: 24px;
 	margin-bottom: 16px;
+	word-break: break-word;
 }
 
 .invite-form-header__explanation {
@@ -12,4 +13,5 @@
 	font-size: $font-body-small;
 	line-height: 21px;
 	margin-bottom: 16px;
+	word-break: break-word;
 }


### PR DESCRIPTION
* Close https://github.com/Automattic/wp-calypso/issues/74359

## Proposed Changes

This PR fixes the display of the long domain on accept screen on user invites.

## Testing Instructions

* Create a site with a very long domain (35-40 characters, does not have to be a custom domain name)
* Make sure that the `Site Title` field under `/settings/general/{site}` is empty
* Invite an administrator to your site from `/people/team/{site}` by clicking `Add a team member`
* Click an email link for the administrator invitation (you can copy a part of the link that starts with `accept...` from the email and append it to Calypso Live so it would be something like this: `https://container-competent-dewdney.calypso.live/accept-invite/216949641/98f5d9ffaacac36d2e0ed9e34949704c_r7Mm1RbNXk5BjJ07F3OZY6Fp`)
* Check if the domain name is going on a new line:

<img width="755" alt="Screenshot 2023-03-21 at 2 52 51 PM" src="https://user-images.githubusercontent.com/25575134/226633175-c971f186-5734-4cf6-a3c3-ef017ab24cfc.png">

* Switch to mobile view (you can use Chrome dev tools) and check if the domain fits in the container:

<img width="655" alt="Screenshot 2023-03-21 at 3 15 16 PM" src="https://user-images.githubusercontent.com/25575134/226634075-bbc3b7d2-c633-4b7b-bd9c-ab7cd5bb21fa.png">

* You can also invite yourself as a viewer (follow the same steps as above by choose "Viewer" instead of "Administrator) and check the domain:

<img width="879" alt="Screenshot 2023-03-21 at 2 56 30 PM" src="https://user-images.githubusercontent.com/25575134/226635595-18fef771-4adb-488d-abc4-1d0638aa08af.png">

**Other Notes**

* This is a bit of an edge case because as long as the user has `Site Title` set under `/settings/general/{site}` , it will be the site title that appears instead of the domain
* Another option that we can try is to set `overflow: hidden` which will cut off the part of the domain that does not fit in the box. This is what we already do on the site switcher:

<img width="508" alt="Screenshot 2023-03-21 at 3 19 40 PM" src="https://user-images.githubusercontent.com/25575134/226635295-8ead48c6-8aca-467d-976b-6255426f802c.png">

* This is what it would look like on the user invite:

<img width="772" alt="Screenshot 2023-03-21 at 2 57 08 PM" src="https://user-images.githubusercontent.com/25575134/226635420-a8a43aff-8ae9-4047-a0e8-12859c22bb86.png">

* This would be the view from mobile:

<img width="620" alt="Screenshot 2023-03-21 at 3 22 34 PM" src="https://user-images.githubusercontent.com/25575134/226636304-13065062-638a-4157-8e98-841f61fe1c95.png">

My main reasoning behind leaving a full domain would be that the user might want to see the exact site to which they accept invitations so I considered it to be important information. However, this is open to feedback!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
