### PR TITLE
Tailored Flows: Improve step titles along flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -146,7 +146,9 @@ button {
 	.step-container {
 		--color-accent: #117ac9;
 		--color-accent-60: #0e64a5;
-		padding-top: 0;
+		@include break-medium {
+			padding-top: 0;
+		}
 		.form-fieldset {
 			label {
 				text-transform: none;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -163,7 +163,7 @@ button {
 /**
  * Tailored flow stylings
  */
-.newsletter,
+.newsletter:not(.domains),
 .link-in-bio:not(.domains),
 .link-in-bio-tld:not(.domains) {
 	&:not(.launchpad):not(.subscribers) {

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -146,6 +146,7 @@ button {
 	.step-container {
 		--color-accent: #117ac9;
 		--color-accent-60: #0e64a5;
+		padding-top: 0;
 		.form-fieldset {
 			label {
 				text-transform: none;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -226,7 +226,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			hideBack={ ! isCopySiteFlow( flow ) }
 			backLabelText={ __( 'Back to sites' ) }
 			hideSkip={ true }
-			flowName={ isCopySiteFlow( flow ) ? ( flow as string ) : ( flow as string ) }
+			flowName={ flow as string }
 			stepContent={ <div className="domains__content">{ renderContent() }</div> }
 			recordTracksEvent={ recordTracksEvent }
 			goBack={ () => exitFlow?.( '/sites' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -226,7 +226,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			hideBack={ ! isCopySiteFlow( flow ) }
 			backLabelText={ __( 'Back to sites' ) }
 			hideSkip={ true }
-			flowName={ isCopySiteFlow( flow ) ? ( flow as string ) : 'linkInBio' }
+			flowName={ isCopySiteFlow( flow ) ? ( flow as string ) : flow }
 			stepContent={ <div className="domains__content">{ renderContent() }</div> }
 			recordTracksEvent={ recordTracksEvent }
 			goBack={ () => exitFlow?.( '/sites' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -226,7 +226,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			hideBack={ ! isCopySiteFlow( flow ) }
 			backLabelText={ __( 'Back to sites' ) }
 			hideSkip={ true }
-			flowName={ isCopySiteFlow( flow ) ? ( flow as string ) : flow }
+			flowName={ isCopySiteFlow( flow ) ? ( flow as string ) : ( flow as string ) }
 			stepContent={ <div className="domains__content">{ renderContent() }</div> }
 			recordTracksEvent={ recordTracksEvent }
 			goBack={ () => exitFlow?.( '/sites' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -20,7 +20,7 @@
 			margin: 20px 24px 30px 20px;
 
 			@include break-small {
-				margin: 36px 0px 40px 0px;/* stylelint-disable-line length-zero-no-unit */
+				margin: 36px 0 40px 0;
 			}
 
 			.formatted-header__title {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -1,240 +1,243 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/onboarding/styles/mixins";
 
-.step-container.domains {
-	max-width: 1280px;
-	padding: 0 20px;
-	margin: 0;
+.domains {
+	.step-container {
 
-	@include break-small {
-		margin: 0 0 0 20px;
-	}
-
-	@include break-wide {
-		margin: 0 auto;
-	}
-
-	.step-container__header {
-		margin: 20px 24px 30px 20px;
+		max-width: 1280px;
+		padding: 0 20px;
+		margin: 0;
 
 		@include break-small {
-			margin: 34px 0px 40px 0px;/* stylelint-disable-line length-zero-no-unit */
-		}
-
-		.formatted-header__title {
-			font-size: 2.25rem;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-			line-height: 2.5rem;
-			@include break-mobile {
-				font-size: 2.75rem;
-				line-height: 48px;
-			}
-		}
-	}
-
-	.domains__domain-side-content-container {
-		flex-direction: column;
-		margin-top: 40px;
-		margin-bottom: 40px;
-		display: none;
-
-		@include break-large {
-			width: 30vw;
-			margin-top: 0;
-			flex-direction: column;
-			display: flex;
+			margin: 0 0 0 20px;
 		}
 
 		@include break-wide {
-			width: 350px;
+			margin: 0 auto;
 		}
 
-		.domains__domain-side-content {
-			border-bottom: 1px solid var(--studio-gray-5);
-			margin: 0;
-			padding: 20px 0 20px 0;
-			&:not(.domains__free-domain) {
-				border-bottom: none;
+		.step-container__header {
+			margin: 20px 24px 30px 20px;
+
+			@include break-small {
+				margin: 36px 0px 40px 0px;/* stylelint-disable-line length-zero-no-unit */
+			}
+
+			.formatted-header__title {
+				font-size: 2.25rem;
+				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+				line-height: 2.5rem;
+				@include break-mobile {
+					font-size: 2.75rem;
+					line-height: 48px;
+				}
 			}
 		}
-	}
 
-	.register-domain-step .domains__domain-side-content-container {
-		display: flex;
+		.domains__domain-side-content-container {
+			flex-direction: column;
+			margin-top: 40px;
+			margin-bottom: 40px;
+			display: none;
 
-		@include break-small {
-			flex-direction: row;
+			@include break-large {
+				width: 30vw;
+				margin-top: 0;
+				flex-direction: column;
+				display: flex;
+			}
+
+			@include break-wide {
+				width: 350px;
+			}
 
 			.domains__domain-side-content {
-				padding-top: 0;
-				border-bottom: none;
+				border-bottom: 1px solid var(--studio-gray-5);
+				margin: 0;
+				padding: 20px 0 20px 0;
+				&:not(.domains__free-domain) {
+					border-bottom: none;
+				}
 			}
 		}
 
-		@include break-large {
-			display: none;
-		}
-	}
+		.register-domain-step .domains__domain-side-content-container {
+			display: flex;
 
-	.domains__step-section-wrapper {
-		.use-my-domain__page-heading {
-			padding-left: 24px;
-			padding-right: 24px;
-			text-align: center;
-		}
+			@include break-small {
+				flex-direction: row;
 
-		.use-my-domain,
-		.connect-domain-step,
-		.domain-transfer-or-connect__content {
-			background: transparent;
-			box-shadow: none;
-
-			.form-text-input {
-				height: 100%;
+				.domains__domain-side-content {
+					padding-top: 0;
+					border-bottom: none;
+				}
 			}
 
-			@include break-mobile {
-				padding-left: 0;
-				padding-right: 0;
+			@include break-large {
+				display: none;
 			}
 		}
-	}
 
-	.register-domain-step__search {
-		padding-top: 0;
-		padding-bottom: 16px;
-	}
-	.search-component.has-focus {
-		border-color: unset;
-		box-shadow: unset;
-	}
+		.domains__step-section-wrapper {
+			.use-my-domain__page-heading {
+				padding-left: 24px;
+				padding-right: 24px;
+				text-align: center;
+			}
 
-	.domain-suggestion__action {
-		border-radius: 4px;
-		margin: 0;
-	}
+			.use-my-domain,
+			.connect-domain-step,
+			.domain-transfer-or-connect__content {
+				background: transparent;
+				box-shadow: none;
 
-	.register-domain-step__search-card {
-		background: var(--color-surface);
-		border: 1px solid var(--studio-gray-20);
-		border-radius: 4px;
-		box-shadow: none;
-		display: flex;
-		padding: 0;
-	}
+				.form-text-input {
+					height: 100%;
+				}
 
-	.search-component__icon-search {
-		fill: var(--studio-gray-20);
-		margin: 8px 6px 8px 8px;
-	}
-
-	.domain-search-results__domain-suggestions {
-		margin: 0;
-		@include break-mobile {
-			margin: 0 20px;
+				@include break-mobile {
+					padding-left: 0;
+					padding-right: 0;
+				}
+			}
 		}
-		@include break-small {
+
+		.register-domain-step__search {
+			padding-top: 0;
+			padding-bottom: 16px;
+		}
+		.search-component.has-focus {
+			border-color: unset;
+			box-shadow: unset;
+		}
+
+		.domain-suggestion__action {
+			border-radius: 4px;
 			margin: 0;
 		}
-	}
 
-	.featured-domain-suggestions {
-		border-top: 1px solid var(--studio-gray-5);
-		@include break-mobile {
-			border-top: none;
-		}
-
-		.featured-domain-suggestion {
-			border-bottom: 1px solid var(--studio-gray-5);
-			box-shadow: none;
-			@include break-mobile {
-				border-bottom: none;
-				box-shadow: 0 0 0 1px var(--color-border-subtle);
-			}
+		.register-domain-step__search-card {
 			background: var(--color-surface);
+			border: 1px solid var(--studio-gray-20);
 			border-radius: 4px;
-			box-sizing: border-box;
-			margin-bottom: 12px;
-			padding: 16px 24px;
-			&:hover {
-				border: var(--studio-gray-50);
-			}
-		}
-
-		.domain-registration-suggestion__title-wrapper {
-			flex-wrap: nowrap;
-			flex-direction: column-reverse;
-			margin-bottom: initial;
-			.domain-registration-suggestion__badges {
-				margin-left: 0;
-				margin-top: 0;
-				margin-bottom: 10px;
-			}
-		}
-
-		.domain-product-price {
-			align-items: flex-start;
-			margin-top: 12px;
-		}
-	}
-
-	.domain-suggestion:not(.featured-domain-suggestion) {
-		box-shadow: unset;
-		background: none;
-		border-bottom: 1px solid var(--studio-gray-5);
-		border-top: 1px solid #fff;
-		padding: 16px 20px;
-
-		@include break-mobile {
-			padding: 16px 5px;
-		}
-
-		.domain-suggestion__content {
-			margin-right: 40px;
-		}
-
-		&:hover {
-			border-bottom: 1px solid var(--studio-gray-50);
-			border-top: 1px solid var(--studio-gray-50);
-		}
-	}
-
-	.domain-product-price__free-price {
-		font-weight: 500;
-		color: var(--studio-green-60);
-		font-size: 0.875rem;
-		letter-spacing: 0.2px;
-		line-height: 20px;
-	}
-
-	.is-borderless {
-		border: 0;
-	}
-
-	.domain-search-results__domain-not-available {
-		.domain-search-results__domain-available-notice {
 			box-shadow: none;
-			border: 0;
-			margin-bottom: 24px;
+			display: flex;
 			padding: 0;
 		}
-	}
-	.register-domain-step__next-page {
-		background: none;
-		box-shadow: none;
 
-		.register-domain-step__next-page-button {
-			padding: 0.57em 1.17em;
-			border-radius: 4px;
+		.search-component__icon-search {
+			fill: var(--studio-gray-20);
+			margin: 8px 6px 8px 8px;
+		}
+
+		.domain-search-results__domain-suggestions {
+			margin: 0;
 			@include break-mobile {
-				padding: 0.65em 2.8em;
+				margin: 0 20px;
+			}
+			@include break-small {
+				margin: 0;
 			}
 		}
-	}
-	.reskin-side-explainer__subtitle-2 {
-		display: none;
-		@include break-small {
-			display: block;
+
+		.featured-domain-suggestions {
+			border-top: 1px solid var(--studio-gray-5);
+			@include break-mobile {
+				border-top: none;
+			}
+
+			.featured-domain-suggestion {
+				border-bottom: 1px solid var(--studio-gray-5);
+				box-shadow: none;
+				@include break-mobile {
+					border-bottom: none;
+					box-shadow: 0 0 0 1px var(--color-border-subtle);
+				}
+				background: var(--color-surface);
+				border-radius: 4px;
+				box-sizing: border-box;
+				margin-bottom: 12px;
+				padding: 16px 24px;
+				&:hover {
+					border: var(--studio-gray-50);
+				}
+			}
+
+			.domain-registration-suggestion__title-wrapper {
+				flex-wrap: nowrap;
+				flex-direction: column-reverse;
+				margin-bottom: initial;
+				.domain-registration-suggestion__badges {
+					margin-left: 0;
+					margin-top: 0;
+					margin-bottom: 10px;
+				}
+			}
+
+			.domain-product-price {
+				align-items: flex-start;
+				margin-top: 12px;
+			}
+		}
+
+		.domain-suggestion:not(.featured-domain-suggestion) {
+			box-shadow: unset;
+			background: none;
+			border-bottom: 1px solid var(--studio-gray-5);
+			border-top: 1px solid #fff;
+			padding: 16px 20px;
+
+			@include break-mobile {
+				padding: 16px 5px;
+			}
+
+			.domain-suggestion__content {
+				margin-right: 40px;
+			}
+
+			&:hover {
+				border-bottom: 1px solid var(--studio-gray-50);
+				border-top: 1px solid var(--studio-gray-50);
+			}
+		}
+
+		.domain-product-price__free-price {
+			font-weight: 500;
+			color: var(--studio-green-60);
+			font-size: 0.875rem;
+			letter-spacing: 0.2px;
+			line-height: 20px;
+		}
+
+		.is-borderless {
+			border: 0;
+		}
+
+		.domain-search-results__domain-not-available {
+			.domain-search-results__domain-available-notice {
+				box-shadow: none;
+				border: 0;
+				margin-bottom: 24px;
+				padding: 0;
+			}
+		}
+		.register-domain-step__next-page {
+			background: none;
+			box-shadow: none;
+
+			.register-domain-step__next-page-button {
+				padding: 0.57em 1.17em;
+				border-radius: 4px;
+				@include break-mobile {
+					padding: 0.65em 2.8em;
+				}
+			}
+		}
+		.reskin-side-explainer__subtitle-2 {
+			display: none;
+			@include break-small {
+				display: block;
+			}
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -11,7 +11,8 @@ $font-family: "SF Pro Text", $sans;
 		min-height: unset;
 	}
 
-	.link-in-bio-setup .step-container__header {
+	.step-container__header {
 		margin-bottom: 32px;
+		margin-top: 36px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -4,6 +4,12 @@ $font-family: "SF Pro Text", $sans;
 
 .link-in-bio-setup,
 .link-in-bio-tld-setup {
+	.step-container {
+		padding-top: 24px;
+		@include break-medium {
+			padding-top: 0;
+		}
+	}
 	.step-container__content {
 		display: flex;
 		justify-content: center;
@@ -13,6 +19,9 @@ $font-family: "SF Pro Text", $sans;
 
 	.step-container__header {
 		margin-bottom: 32px;
-		margin-top: 36px;
+
+		@include break-medium {
+			margin-top: 36px;
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -1,16 +1,14 @@
 @import "../style";
 
 .newsletter-setup {
-	.step-container {
-		padding-top: 44px;
-	}
 
 	.step-container__content {
 		display: flex;
 		justify-content: center;
 	}
 
-	.newsletter-setup .step-container__header {
+	.step-container__header {
 		margin-bottom: 32px;
+		margin-top: 36px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -2,6 +2,9 @@
 
 .newsletter-setup {
 
+	.step-container {
+		padding-top: 0;
+	}
 	.step-container__content {
 		display: flex;
 		justify-content: center;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -3,7 +3,10 @@
 .newsletter-setup {
 
 	.step-container {
-		padding-top: 0;
+		padding-top: 24px;
+		@include break-medium {
+			padding-top: 0;
+		}
 	}
 	.step-container__content {
 		display: flex;
@@ -12,6 +15,9 @@
 
 	.step-container__header {
 		margin-bottom: 32px;
-		margin-top: 36px;
+
+		@include break-medium {
+			margin-top: 36px;
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/patterns/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/patterns/styles.scss
@@ -33,6 +33,7 @@
 
 		.step-container__header {
 			margin-bottom: 20px;
+			margin-top: 54px;
 
 			@include break-medium {
 				margin-bottom: 32px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/patterns/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/patterns/styles.scss
@@ -33,10 +33,9 @@
 
 		.step-container__header {
 			margin-bottom: 20px;
-			margin-top: 54px;
-
 			@include break-medium {
 				margin-bottom: 32px;
+				margin-top: 54px;
 			}
 
 			@include onboarding-break-mobile-landscape {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -1,175 +1,180 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/onboarding/styles/mixins";
 
-.step-container.plans {
-	padding: 0;
+.plans {
+	.step-container {
+		padding: 0;
 
-	.step-wrapper__header {
-		margin: 14px 20px;
+		.step-wrapper__header {
+			margin: 14px 20px;
 
-		@include break-large {
-			margin: 33px 20px;
-		}
+			@include break-large {
+				margin: 8px 20px;
+			}
 
-		.formatted-header {
-			h1.formatted-header__title {
-				font-size: 2.25rem;
-				font-weight: 500;
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-				line-height: 2.5rem;
-				padding: 0 20px;
-				text-align: center;
-				letter-spacing: 0.2px;
+			.formatted-header {
+				margin-top: 30px;
 
-				@include break-mobile {
-					font-size: 2.75rem;
+				h1.formatted-header__title {
+					font-size: 2.25rem;
+					font-weight: 500;
 					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-					line-height: 3rem;
+					line-height: 2.5rem;
+					padding: 0 20px;
+					text-align: center;
+					letter-spacing: 0.2px;
+
+					@include break-mobile {
+						font-size: 2.75rem;
+						/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+						line-height: 3rem;
+					}
+				}
+
+				.formatted-header__subtitle {
+					text-align: center;
+					font-size: 1rem;
 				}
 			}
-
-			.formatted-header__subtitle {
-				text-align: center;
-				font-size: 1rem;
-			}
 		}
-	}
 
-	.plans__loading-container {
-		margin-top: 18em;
-	}
+		.plans__loading-container {
+			margin-top: 18em;
+		}
 
-	&.is-wide-layout {
-		margin: auto;
-		max-width: 1200px;
-	}
-
-	// 2023 has extra wide layout
-	&.is-extra-wide-layout {
-		max-width: 1480px;
-	}
-
-	.formatted-header.is-without-subhead {
-		margin-bottom: 15px;
-	}
-
-	.step-wrapper {
 		&.is-wide-layout {
+			margin: auto;
 			max-width: 1200px;
 		}
-	}
 
-	.plan-features-comparison__table {
-		.plan-features-comparison__actions {
-			button.plan-features__actions-button {
-				border-radius: 4px;
+		// 2023 has extra wide layout
+		&.is-extra-wide-layout {
+			max-width: 1480px;
+		}
+
+		.formatted-header.is-without-subhead {
+			margin-bottom: 15px;
+		}
+
+		.step-wrapper {
+			&.is-wide-layout {
+				max-width: 1200px;
 			}
 		}
 
-		.plan-features-comparison__row:last-child {
+		.plan-features-comparison__table {
+			.plan-features-comparison__actions {
+				button.plan-features__actions-button {
+					border-radius: 4px;
+				}
+			}
+
+			.plan-features-comparison__row:last-child {
+				.plan-features-comparison__table-item {
+					border-bottom: none;
+				}
+			}
 			.plan-features-comparison__table-item {
-				border-bottom: none;
-			}
-		}
-		.plan-features-comparison__table-item {
-			border-left: none;
-			background-color: transparent;
+				border-left: none;
+				background-color: transparent;
 
-			&:last-of-type {
-				border-right: none;
-			}
+				&:last-of-type {
+					border-right: none;
+				}
 
-			.plan-pill.is-in-signup {
-				font-size: 0.75rem;
-				font-weight: 500;
-				letter-spacing: 0.2px;
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-				line-height: 1.25rem;
-				padding: 0 8px;
-				right: 50%;
-				transform: translate(50%);
-				border-radius: 4px;
-				background-color: var(--studio-green-5);
-				color: var(--studio-gray-80);
-			}
+				.plan-pill.is-in-signup {
+					font-size: 0.75rem;
+					font-weight: 500;
+					letter-spacing: 0.2px;
+					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+					line-height: 1.25rem;
+					padding: 0 8px;
+					right: 50%;
+					transform: translate(50%);
+					border-radius: 4px;
+					background-color: var(--studio-green-5);
+					color: var(--studio-gray-80);
+				}
 
-			.plan-features-comparison__item-annual-plan {
-				color: var(--studio-orange-40) !important;
-			}
+				.plan-features-comparison__item-annual-plan {
+					color: var(--studio-orange-40) !important;
+				}
 
-			.plan-features-comparison__header {
-				padding: 12px 15px;
-				background-color: unset;
+				.plan-features-comparison__header {
+					padding: 12px 15px;
+					background-color: unset;
 
-				.plan-features-comparison__header-title {
-					margin: 0 0 6px 0;
+					.plan-features-comparison__header-title {
+						margin: 0 0 6px 0;
+					}
+				}
+
+				.plan-features-comparison__pricing .plan-price {
+					margin-right: 0;
 				}
 			}
-
-			.plan-features-comparison__pricing .plan-price {
-				margin-right: 0;
-			}
 		}
-	}
 
-	button.is-borderless {
-		color: var(--studio-gray-90);
-		font-weight: 500;
-		border: 0;
-		box-shadow: none;
-		font-size: inherit;
-		line-height: inherit;
-		padding: 0;
-		text-decoration: underline;
-	}
+		button.is-borderless {
+			color: var(--studio-gray-90);
+			font-weight: 500;
+			border: 0;
+			box-shadow: none;
+			font-size: inherit;
+			line-height: inherit;
+			padding: 0;
+			text-decoration: underline;
+		}
 
-	.plans-features-main {
-		ul.segmented-control {
-			background-color: #f2f2f2;
-			border-radius: 6px;  /* stylelint-disable-line scales/radii */
-			border-color: var(--studio-gray-5);
+		.plans-features-main {
+			ul.segmented-control {
+				background-color: #f2f2f2;
+				border-radius: 6px;  /* stylelint-disable-line scales/radii */
+				border-color: var(--studio-gray-5);
 
-			li.segmented-control__item {
-				border: 6px;
-				padding: 2px;
-				&:first-child {
-					margin-right: 5px;
-				}
-				&.is-selected {
+				li.segmented-control__item {
+					border: 6px;
+					padding: 2px;
+					&:first-child {
+						margin-right: 5px;
+					}
+					&.is-selected {
+						a.segmented-control__link {
+							padding-top: 6px;
+							padding-bottom: 6px;
+							border: 0.5px solid #0000000a;
+							background-color: var(--studio-white);
+							color: var(--color-text);
+							border-radius: 5px;  /* stylelint-disable-line scales/radii */
+							box-shadow: 0 3px 8px #0000001f, 0 3px 1px #0000000a;
+						}
+					}
 					a.segmented-control__link {
-						padding-top: 6px;
-						padding-bottom: 6px;
-						border: 0.5px solid #0000000a;
-						background-color: var(--studio-white);
-						color: var(--color-text);
+						border: solid 1px #f2f2f2;
 						border-radius: 5px;  /* stylelint-disable-line scales/radii */
-						box-shadow: 0 3px 8px #0000001f, 0 3px 1px #0000000a;
 					}
 				}
-				a.segmented-control__link {
-					border: solid 1px #f2f2f2;
-					border-radius: 5px;  /* stylelint-disable-line scales/radii */
-				}
-			}
-			li.segmented-control__item:not(.is-selected) {
-				a.segmented-control__link {
-					border: solid 1px #f2f2f2;
-					border-radius: 5px;  /* stylelint-disable-line scales/radii */
-					&:hover {
-						background-color: unset !important;
-						border: 1px solid var(--studio-gray-10);
+				li.segmented-control__item:not(.is-selected) {
+					a.segmented-control__link {
+						border: solid 1px #f2f2f2;
 						border-radius: 5px;  /* stylelint-disable-line scales/radii */
+						&:hover {
+							background-color: unset !important;
+							border: 1px solid var(--studio-gray-10);
+							border-radius: 5px;  /* stylelint-disable-line scales/radii */
+						}
 					}
 				}
 			}
 		}
-	}
 
-	.plans__loading {
-		width: 100%;
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		position: relative;
+		.plans__loading {
+			width: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			position: relative;
+		}
 	}
 }
+

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -13,7 +13,10 @@
 			}
 
 			.formatted-header {
-				margin-top: 30px;
+				margin-top: 8px;
+				@include break-small {
+					margin-top: 30px;
+				}
 
 				h1.formatted-header__title {
 					font-size: 2.25rem;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -6,9 +6,10 @@ import { useIsEligibleSubscriberImporter } from 'calypso/landing/stepper/hooks/u
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
+import './style.scss';
 
 const Subscribers: Step = function ( { navigation } ) {
-	const __ = useTranslate();
+	const translate = useTranslate();
 	const { submit } = navigation;
 	const site = useSite();
 	const isUserEligibleForSubscriberImporter = useIsEligibleSubscriberImporter();
@@ -32,7 +33,7 @@ const Subscribers: Step = function ( { navigation } ) {
 							siteId={ site.ID }
 							isSiteOnFreePlan={ !! site?.plan?.is_free }
 							flowName="onboarding_subscribers"
-							submitBtnName={ __( 'Continue' ) }
+							submitBtnName={ translate( 'Continue' ) }
 							onImportFinished={ handleSubmit }
 							allowEmptyFormSubmit={ true }
 							manualListEmailInviting={ ! isUserEligibleForSubscriberImporter }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
@@ -2,6 +2,37 @@
 .subscribers {
 	.add-subscriber__title-container {
 		// Intentional override for the title margin-top.
-		margin-top: 26px !important;
+		margin-top: 36px !important;
+	}
+	.step-container {
+		.subscribers {
+			padding-top: 0;
+		}
+		padding: 0 1.5rem;
+
+		.add-subscriber__title-container,
+		.add-subscriber__form--container {
+			margin: auto;
+		}
+
+		.add-subscriber .add-subscriber__title-container {
+			max-width: 376px;
+			text-align: center;
+
+			.onboarding-subtitle {
+				margin-bottom: 1.5rem;
+				font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
+			}
+		}
+
+		.add-subscriber .add-subscriber__form--container {
+			max-width: 368px;
+		}
+
+		.add-subscriber__form-submit-btn {
+			display: block;
+			width: 100%;
+			margin: 2rem 0;
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
@@ -1,0 +1,7 @@
+
+.subscribers {
+	.add-subscriber__title-container {
+		// Intentional override for the title margin-top.
+		margin-top: 26px !important;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
@@ -1,8 +1,11 @@
-
+@import "../style";
 .subscribers {
 	.add-subscriber__title-container {
 		// Intentional override for the title margin-top.
-		margin-top: 36px !important;
+		margin-top: 24px !important;
+		@include break-medium {
+			margin-top: 36px !important;
+		}
 	}
 	.step-container {
 		.subscribers {

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -160,7 +160,7 @@ const StepContainer: React.FC< Props > = ( {
 		);
 	}
 
-	const classes = classNames( 'step-container', className, flowName, stepName, {
+	const classes = classNames( 'step-container', className, flowName, {
 		'is-horizontal-layout': isHorizontalLayout,
 		'is-wide-layout': isWideLayout,
 		'is-full-layout': isFullLayout,

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -160,7 +160,7 @@ const StepContainer: React.FC< Props > = ( {
 		);
 	}
 
-	const classes = classNames( 'step-container', className, flowName, {
+	const classes = classNames( 'step-container', className, flowName, stepName, {
 		'is-horizontal-layout': isHorizontalLayout,
 		'is-wide-layout': isWideLayout,
 		'is-full-layout': isFullLayout,


### PR DESCRIPTION
## Proposed Changes

Newsletter and LiB steps title are mismatching on the spacing to the top of the page, this PR fixes it.


## Testing Instructions
To make it easier, I have installed a chrome extension to help me visualize the spacing on the browser, I would recommend you to install as well, it is quite good. [Page Ruler](https://chrome.google.com/webstore/detail/page-ruler/jcbmcnpepaddcedmjdcmhbekjhbfnlff?hl=en)


- Pull and run this branch or use calypso live links
- Navigate to /setup/newsletter or /setup/link-in-bio
- Enable the extension
- All the titles should be 100px from the top. ( like image attached )
- This pattern should be consistent along the whole flow
- Would be amazing to check other flows just in case :)

<img width="1172" alt="image" src="https://user-images.githubusercontent.com/2653810/226646858-961e3b37-e4cf-4ba6-8ca1-2a5a20c17353.png">

Related to #74662 
[more context ](puPv3-e72-p2)