### PR TITLE
Add/backup clone select point

### DIFF
--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -32,12 +32,14 @@ class ActivityCardList extends Component {
 		showDateSeparators: PropTypes.bool,
 		showFilter: PropTypes.bool,
 		showPagination: PropTypes.bool,
+		availableActions: PropTypes.array,
 	};
 
 	static defaultProps = {
 		showDateSeparators: true,
 		showFilter: true,
 		showPagination: true,
+		availableActions: [ 'rewind', 'download' ],
 	};
 
 	state = {
@@ -137,7 +139,8 @@ class ActivityCardList extends Component {
 	}
 
 	renderLogs( pageLogs ) {
-		const { applySiteOffset, moment, showDateSeparators, translate, userLocale } = this.props;
+		const { applySiteOffset, moment, showDateSeparators, translate, userLocale, availableActions } =
+			this.props;
 
 		const today = ( applySiteOffset ?? moment )();
 
@@ -171,6 +174,7 @@ class ActivityCardList extends Component {
 									: getSecondaryCardClassName( hasMore )
 							}
 							key={ activity.activityId }
+							availableActions={ availableActions }
 						/>
 					) ) }
 				</div>

--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -33,6 +33,7 @@ class ActivityCardList extends Component {
 		showFilter: PropTypes.bool,
 		showPagination: PropTypes.bool,
 		availableActions: PropTypes.array,
+		onClickClone: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -139,8 +140,15 @@ class ActivityCardList extends Component {
 	}
 
 	renderLogs( pageLogs ) {
-		const { applySiteOffset, moment, showDateSeparators, translate, userLocale, availableActions } =
-			this.props;
+		const {
+			applySiteOffset,
+			moment,
+			showDateSeparators,
+			translate,
+			userLocale,
+			availableActions,
+			onClickClone,
+		} = this.props;
 
 		const today = ( applySiteOffset ?? moment )();
 
@@ -175,6 +183,7 @@ class ActivityCardList extends Component {
 							}
 							key={ activity.activityId }
 							availableActions={ availableActions }
+							onClickClone={ onClickClone }
 						/>
 					) ) }
 				</div>

--- a/client/components/activity-card/index.tsx
+++ b/client/components/activity-card/index.tsx
@@ -45,9 +45,16 @@ type OwnProps = {
 	summarize?: boolean;
 	shareable?: boolean;
 	activity: Activity;
+	availableActions: Array< string >;
 };
 
-const ActivityCard: React.FC< OwnProps > = ( { className, summarize, shareable, activity } ) => {
+const ActivityCard: React.FC< OwnProps > = ( {
+	className,
+	summarize,
+	shareable,
+	activity,
+	availableActions,
+} ) => {
 	const [ showContent, toggleShowContent ] = useToggleContent();
 
 	const siteId = useSelector( getSelectedSiteId ) as number;
@@ -96,6 +103,7 @@ const ActivityCard: React.FC< OwnProps > = ( { className, summarize, shareable, 
 						activity={ activity }
 						isContentExpanded={ showContent }
 						onToggleContent={ toggleShowContent }
+						availableActions={ availableActions }
 					/>
 				) }
 
@@ -107,6 +115,7 @@ const ActivityCard: React.FC< OwnProps > = ( { className, summarize, shareable, 
 							activity={ activity }
 							isContentExpanded={ showContent }
 							onToggleContent={ toggleShowContent }
+							availableActions={ availableActions }
 						/>
 					</div>
 				) }

--- a/client/components/activity-card/index.tsx
+++ b/client/components/activity-card/index.tsx
@@ -46,6 +46,7 @@ type OwnProps = {
 	shareable?: boolean;
 	activity: Activity;
 	availableActions: Array< string >;
+	onClickClone: any;
 };
 
 const ActivityCard: React.FC< OwnProps > = ( {
@@ -54,6 +55,7 @@ const ActivityCard: React.FC< OwnProps > = ( {
 	shareable,
 	activity,
 	availableActions,
+	onClickClone,
 } ) => {
 	const [ showContent, toggleShowContent ] = useToggleContent();
 
@@ -104,6 +106,7 @@ const ActivityCard: React.FC< OwnProps > = ( {
 						isContentExpanded={ showContent }
 						onToggleContent={ toggleShowContent }
 						availableActions={ availableActions }
+						onClickClone={ onClickClone }
 					/>
 				) }
 
@@ -116,6 +119,7 @@ const ActivityCard: React.FC< OwnProps > = ( {
 							isContentExpanded={ showContent }
 							onToggleContent={ toggleShowContent }
 							availableActions={ availableActions }
+							onClickClone={ onClickClone }
 						/>
 					</div>
 				) }

--- a/client/components/activity-card/index.tsx
+++ b/client/components/activity-card/index.tsx
@@ -45,8 +45,8 @@ type OwnProps = {
 	summarize?: boolean;
 	shareable?: boolean;
 	activity: Activity;
-	availableActions: Array< string >;
-	onClickClone: ( period: string ) => void;
+	availableActions?: Array< string >;
+	onClickClone?: ( period: string ) => void;
 };
 
 const ActivityCard: React.FC< OwnProps > = ( {

--- a/client/components/activity-card/index.tsx
+++ b/client/components/activity-card/index.tsx
@@ -46,7 +46,7 @@ type OwnProps = {
 	shareable?: boolean;
 	activity: Activity;
 	availableActions: Array< string >;
-	onClickClone: any;
+	onClickClone: ( period: string ) => void;
 };
 
 const ActivityCard: React.FC< OwnProps > = ( {

--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -143,7 +143,7 @@ type CloneSiteOwnProps = {
 	onClickClone: ( period: string ) => void;
 };
 
-const CloneSiteActionsButton: React.FC< CloneSiteOwnProps > = ( { rewindId, onClickClone } ) => {
+const CloneSiteActionButton: React.FC< CloneSiteOwnProps > = ( { rewindId, onClickClone } ) => {
 	const translate = useTranslate();
 
 	return (
@@ -180,12 +180,14 @@ const ActionsButton: React.FC< OwnProps > = ( {
 		);
 	}
 
-	if ( availableActions && availableActions.includes( 'clone' ) ) {
+	// Show the clone action button only if is the only action available.
+	if ( availableActions && availableActions.length === 1 && availableActions[ 0 ] === 'clone' ) {
 		return (
-			<CloneSiteActionsButton rewindId={ actionableRewindId ?? '' } onClickClone={ onClickClone } />
+			<CloneSiteActionButton rewindId={ actionableRewindId ?? '' } onClickClone={ onClickClone } />
 		);
 	}
 
+	// Show the defaults actions for simple sites.
 	return (
 		<SingleSiteActionsButton
 			siteId={ siteId }

--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -138,12 +138,29 @@ const MultisiteActionsButton: React.FC< MultisiteOwnProps > = ( { siteSlug, rewi
 	);
 };
 
+type CloneSiteOwnProps = {
+	siteId: number;
+	siteSlug: string;
+	rewindId: string;
+};
+
+const CloneSiteActionsButton: React.FC< CloneSiteOwnProps > = () => {
+	const translate = useTranslate();
+
+	return (
+		<Button compact className="toolbar__button">
+			{ translate( 'Clone from here' ) }
+		</Button>
+	);
+};
+
 type OwnProps = {
 	siteId: number;
 	activity: Activity;
+	availableActions: Array< string >;
 };
 
-const ActionsButton: React.FC< OwnProps > = ( { siteId, activity } ) => {
+const ActionsButton: React.FC< OwnProps > = ( { siteId, activity, availableActions } ) => {
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
 	// The activity itself may not be rewindable, but at least one of the
@@ -155,6 +172,16 @@ const ActionsButton: React.FC< OwnProps > = ( { siteId, activity } ) => {
 	if ( isMultisite ) {
 		return (
 			<MultisiteActionsButton siteSlug={ siteSlug ?? '' } rewindId={ actionableRewindId ?? '' } />
+		);
+	}
+
+	if ( availableActions && availableActions.includes( 'clone' ) ) {
+		return (
+			<CloneSiteActionsButton
+				siteId={ siteId }
+				siteSlug={ siteSlug ?? '' }
+				rewindId={ actionableRewindId ?? '' }
+			/>
 		);
 	}
 

--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -140,7 +140,7 @@ const MultisiteActionsButton: React.FC< MultisiteOwnProps > = ( { siteSlug, rewi
 
 type CloneSiteOwnProps = {
 	rewindId: string;
-	onClickClone: any;
+	onClickClone: ( period: string ) => void;
 };
 
 const CloneSiteActionsButton: React.FC< CloneSiteOwnProps > = ( { rewindId, onClickClone } ) => {
@@ -157,7 +157,7 @@ type OwnProps = {
 	siteId: number;
 	activity: Activity;
 	availableActions: Array< string >;
-	onClickClone: any;
+	onClickClone: ( period: string ) => void;
 };
 
 const ActionsButton: React.FC< OwnProps > = ( {

--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -156,8 +156,8 @@ const CloneSiteActionButton: React.FC< CloneSiteOwnProps > = ( { rewindId, onCli
 type OwnProps = {
 	siteId: number;
 	activity: Activity;
-	availableActions: Array< string >;
-	onClickClone: ( period: string ) => void;
+	availableActions?: Array< string >;
+	onClickClone?: ( period: string ) => void;
 };
 
 const ActionsButton: React.FC< OwnProps > = ( {
@@ -183,7 +183,9 @@ const ActionsButton: React.FC< OwnProps > = ( {
 	// Show the clone action button only if is the only action available.
 	if ( availableActions && availableActions.length === 1 && availableActions[ 0 ] === 'clone' ) {
 		return (
-			<CloneSiteActionButton rewindId={ actionableRewindId ?? '' } onClickClone={ onClickClone } />
+			// We know onClickClone is never null if the action is clone. Non-null asserting is safe here.
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			<CloneSiteActionButton rewindId={ actionableRewindId ?? '' } onClickClone={ onClickClone! } />
 		);
 	}
 

--- a/client/components/activity-card/toolbar/actions-button.tsx
+++ b/client/components/activity-card/toolbar/actions-button.tsx
@@ -139,16 +139,15 @@ const MultisiteActionsButton: React.FC< MultisiteOwnProps > = ( { siteSlug, rewi
 };
 
 type CloneSiteOwnProps = {
-	siteId: number;
-	siteSlug: string;
 	rewindId: string;
+	onClickClone: any;
 };
 
-const CloneSiteActionsButton: React.FC< CloneSiteOwnProps > = () => {
+const CloneSiteActionsButton: React.FC< CloneSiteOwnProps > = ( { rewindId, onClickClone } ) => {
 	const translate = useTranslate();
 
 	return (
-		<Button compact className="toolbar__button">
+		<Button compact className="toolbar__button" onClick={ () => onClickClone( rewindId ) }>
 			{ translate( 'Clone from here' ) }
 		</Button>
 	);
@@ -158,9 +157,15 @@ type OwnProps = {
 	siteId: number;
 	activity: Activity;
 	availableActions: Array< string >;
+	onClickClone: any;
 };
 
-const ActionsButton: React.FC< OwnProps > = ( { siteId, activity, availableActions } ) => {
+const ActionsButton: React.FC< OwnProps > = ( {
+	siteId,
+	activity,
+	availableActions,
+	onClickClone,
+} ) => {
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
 	// The activity itself may not be rewindable, but at least one of the
@@ -177,11 +182,7 @@ const ActionsButton: React.FC< OwnProps > = ( { siteId, activity, availableActio
 
 	if ( availableActions && availableActions.includes( 'clone' ) ) {
 		return (
-			<CloneSiteActionsButton
-				siteId={ siteId }
-				siteSlug={ siteSlug ?? '' }
-				rewindId={ actionableRewindId ?? '' }
-			/>
+			<CloneSiteActionsButton rewindId={ actionableRewindId ?? '' } onClickClone={ onClickClone } />
 		);
 	}
 

--- a/client/components/activity-card/toolbar/index.tsx
+++ b/client/components/activity-card/toolbar/index.tsx
@@ -12,6 +12,7 @@ type OwnProps = {
 	isContentExpanded?: boolean;
 	onToggleContent?: () => void;
 	availableActions: Array< string >;
+	onClickClone: any;
 };
 
 const Toolbar: React.FC< OwnProps > = ( {
@@ -20,6 +21,7 @@ const Toolbar: React.FC< OwnProps > = ( {
 	isContentExpanded,
 	onToggleContent,
 	availableActions,
+	onClickClone,
 } ) => {
 	const isRewindable = isSuccessfulRealtimeBackup( activity );
 	const { streams } = activity;
@@ -39,6 +41,7 @@ const Toolbar: React.FC< OwnProps > = ( {
 					siteId={ siteId }
 					activity={ activity }
 					availableActions={ availableActions }
+					onClickClone={ onClickClone }
 				/>
 			) }
 		</div>

--- a/client/components/activity-card/toolbar/index.tsx
+++ b/client/components/activity-card/toolbar/index.tsx
@@ -11,6 +11,7 @@ type OwnProps = {
 	activity: Activity;
 	isContentExpanded?: boolean;
 	onToggleContent?: () => void;
+	availableActions: Array< string >;
 };
 
 const Toolbar: React.FC< OwnProps > = ( {
@@ -18,6 +19,7 @@ const Toolbar: React.FC< OwnProps > = ( {
 	activity,
 	isContentExpanded,
 	onToggleContent,
+	availableActions,
 } ) => {
 	const isRewindable = isSuccessfulRealtimeBackup( activity );
 	const { streams } = activity;
@@ -32,7 +34,13 @@ const Toolbar: React.FC< OwnProps > = ( {
 			className={ streams ? 'activity-card__toolbar' : 'activity-card__toolbar--reverse' }
 		>
 			{ streams && <ExpandContent isExpanded={ isContentExpanded } onToggle={ onToggleContent } /> }
-			{ isRewindable && <ActionsButton siteId={ siteId } activity={ activity } /> }
+			{ isRewindable && (
+				<ActionsButton
+					siteId={ siteId }
+					activity={ activity }
+					availableActions={ availableActions }
+				/>
+			) }
 		</div>
 	);
 };

--- a/client/components/activity-card/toolbar/index.tsx
+++ b/client/components/activity-card/toolbar/index.tsx
@@ -11,8 +11,8 @@ type OwnProps = {
 	activity: Activity;
 	isContentExpanded?: boolean;
 	onToggleContent?: () => void;
-	availableActions: Array< string >;
-	onClickClone: ( period: string ) => void;
+	availableActions?: Array< string >;
+	onClickClone?: ( period: string ) => void;
 };
 
 const Toolbar: React.FC< OwnProps > = ( {

--- a/client/components/activity-card/toolbar/index.tsx
+++ b/client/components/activity-card/toolbar/index.tsx
@@ -12,7 +12,7 @@ type OwnProps = {
 	isContentExpanded?: boolean;
 	onToggleContent?: () => void;
 	availableActions: Array< string >;
-	onClickClone: any;
+	onClickClone: ( period: string ) => void;
 };
 
 const Toolbar: React.FC< OwnProps > = ( {

--- a/client/my-sites/backup/clone-flow/index.tsx
+++ b/client/my-sites/backup/clone-flow/index.tsx
@@ -198,7 +198,12 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 				{ translate( "Which point in your site's history would you like to clone from?" ) }
 			</p>
 			<div className="activity-log-v2__content">
-				<ActivityCardList logs={ logs } pageSize={ 10 } showFilter={ false } />
+				<ActivityCardList
+					logs={ logs }
+					pageSize={ 10 }
+					showFilter={ false }
+					availableActions={ [ 'clone' ] }
+				/>
 			</div>
 			<Button
 				className="clone-flow__primary-button"

--- a/client/my-sites/backup/clone-flow/index.tsx
+++ b/client/my-sites/backup/clone-flow/index.tsx
@@ -22,7 +22,6 @@ import { requestRewindBackups } from 'calypso/state/rewind/backups/actions';
 import { getInProgressBackupForSite } from 'calypso/state/rewind/selectors';
 import getInProgressRewindStatus from 'calypso/state/selectors/get-in-progress-rewind-status';
 import getRestoreProgress from 'calypso/state/selectors/get-restore-progress';
-import getRewindBackups from 'calypso/state/selectors/get-rewind-backups';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
@@ -67,13 +66,6 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 	const [ userHasSetBackupPeriod, setUserHasSetBackupPeriod ] = useState< boolean >( false );
 	const [ backupPeriod, setBackupPeriod ] = useState< string >( '' );
 	const [ backupDisplayDate, setBackupDisplayDate ] = useState< string >( '' );
-
-	// Temporary for testing until we have a backup selection UI
-	const latestBackupPeriod = useSelector( ( state ) => {
-		const backups = getRewindBackups( state, siteId ) || [];
-		const completedBackups = backups.filter( ( backup ) => backup.status === 'finished' );
-		return completedBackups.length ? completedBackups[ 0 ].period : null;
-	} );
 
 	const steps = [
 		{
@@ -203,19 +195,6 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 					onClickClone={ onSetBackupPeriod }
 				/>
 			</div>
-			<Button
-				className="clone-flow__primary-button"
-				primary
-				onClick={ () => onSetBackupPeriod( latestBackupPeriod ) }
-			>
-				{ translate( 'Clone from this point' ) }
-			</Button>
-			<Button
-				className="clone-flow__primary-button"
-				onClick={ () => onSetBackupPeriod( latestBackupPeriod ) }
-			>
-				{ translate( 'Clone from here' ) }
-			</Button>
 		</>
 	);
 

--- a/client/my-sites/backup/clone-flow/index.tsx
+++ b/client/my-sites/backup/clone-flow/index.tsx
@@ -203,6 +203,7 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 					pageSize={ 10 }
 					showFilter={ false }
 					availableActions={ [ 'clone' ] }
+					onClickClone={ onSetBackupPeriod }
 				/>
 			</div>
 			<Button

--- a/client/my-sites/backup/clone-flow/index.tsx
+++ b/client/my-sites/backup/clone-flow/index.tsx
@@ -2,6 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import ActivityCardList from 'calypso/components/activity-card-list';
 import AdvancedCredentials from 'calypso/components/advanced-credentials';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryRewindBackups from 'calypso/components/data/query-rewind-backups';
@@ -11,6 +12,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import StepProgress from 'calypso/components/step-progress';
+import useActivityLogQuery from 'calypso/data/activity-log/use-activity-log-query';
 import { Interval, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
@@ -18,6 +20,7 @@ import { rewindClone } from 'calypso/state/activity-log/actions';
 import { setValidFrom } from 'calypso/state/jetpack-review-prompt/actions';
 import { requestRewindBackups } from 'calypso/state/rewind/backups/actions';
 import { getInProgressBackupForSite } from 'calypso/state/rewind/selectors';
+import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getInProgressRewindStatus from 'calypso/state/selectors/get-in-progress-rewind-status';
 import getRestoreProgress from 'calypso/state/selectors/get-restore-progress';
 import getRewindBackups from 'calypso/state/selectors/get-rewind-backups';
@@ -154,6 +157,10 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 
 	const disableClone = false;
 
+	const filter = useSelector( ( state ) => getActivityLogFilter( state, siteId ) );
+	filter.group = [ 'rewind' ];
+	const { data: logs } = useActivityLogQuery( siteId, filter );
+
 	// Screen that allows user to add credentials for an alternate restore / clone
 	const renderSetDestination = () => (
 		<>
@@ -190,6 +197,9 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 			<p className="clone-flow__info">
 				{ translate( "Which point in your site's history would you like to clone from?" ) }
 			</p>
+			<div className="activity-log-v2__content">
+				<ActivityCardList logs={ logs } pageSize={ 10 } showFilter={ false } />
+			</div>
 			<Button
 				className="clone-flow__primary-button"
 				primary

--- a/client/my-sites/backup/clone-flow/index.tsx
+++ b/client/my-sites/backup/clone-flow/index.tsx
@@ -12,7 +12,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import StepProgress from 'calypso/components/step-progress';
-import useActivityLogQuery from 'calypso/data/activity-log/use-activity-log-query';
+import useRewindableActivityLogQuery from 'calypso/data/activity-log/use-rewindable-activity-log-query';
 import { Interval, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
@@ -20,7 +20,6 @@ import { rewindClone } from 'calypso/state/activity-log/actions';
 import { setValidFrom } from 'calypso/state/jetpack-review-prompt/actions';
 import { requestRewindBackups } from 'calypso/state/rewind/backups/actions';
 import { getInProgressBackupForSite } from 'calypso/state/rewind/selectors';
-import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getInProgressRewindStatus from 'calypso/state/selectors/get-in-progress-rewind-status';
 import getRestoreProgress from 'calypso/state/selectors/get-restore-progress';
 import getRewindBackups from 'calypso/state/selectors/get-rewind-backups';
@@ -157,9 +156,7 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 
 	const disableClone = false;
 
-	const filter = useSelector( ( state ) => getActivityLogFilter( state, siteId ) );
-	filter.group = [ 'rewind' ];
-	const { data: logs } = useActivityLogQuery( siteId, filter );
+	const { data: logs } = useRewindableActivityLogQuery( siteId, {}, { enabled: !! siteId } );
 
 	// Screen that allows user to add credentials for an alternate restore / clone
 	const renderSetDestination = () => (


### PR DESCRIPTION
Add the feature to select a specific point to be used to clone a site.

This PR will be merged in a feature branch [add/backup-clone-flow](https://github.com/Automattic/wp-calypso/pull/74663), and it was created just as a record of the wip.

