### PR TITLE
Post-purchase: Update success copy for plugins (top & bottom sections)

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -13,7 +13,6 @@ import theme from 'calypso/my-sites/marketplace/theme';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { isRequesting } from 'calypso/state/plugins/installed/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -34,7 +33,6 @@ const MarketplaceThankYou = ( {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
-	const currentUser = useSelector( getCurrentUser );
 	const isRequestingPlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
 
 	const allSlugs = useMemo( () => [ ...pluginSlugs, ...themeSlugs ], [ pluginSlugs, themeSlugs ] );
@@ -152,13 +150,9 @@ const MarketplaceThankYou = ( {
 						containerClassName="marketplace-thank-you"
 						sections={ [ themesSection, pluginsSection, defaultThankYouFooter ] }
 						showSupportSection={ false }
-						thankYouTitle={ translate( "You're all set %(username)s!", {
-							args: {
-								username: currentUser?.display_name || currentUser?.username,
-							},
-						} ) }
+						thankYouTitle={ translate( "Congrats on your site's new superpowers!" ) }
 						thankYouSubtitle={ translate(
-							'Congratulations on your installation. You can now extend the possibilities of your site.'
+							"Now you're really getting the most out of WordPress. Dig in and explore more of our favorite plugins."
 						) }
 						headerBackgroundColor="#fff"
 						headerTextColor="#000"

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-default-thank-you-footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-default-thank-you-footer.tsx
@@ -35,7 +35,6 @@ export function useDefaultThankYouFoooter( slugs: string[] ): ThankYouSectionPro
 					<Button
 						isLink
 						href={ `/plugins/${ siteSlug }` }
-						target="_blank"
 						onClick={ () => sendTrackEvent( 'calypso_plugin_thank_you_explore_plugins_click' ) }
 					>
 						{ translate( 'Explore plugins' ) }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-default-thank-you-footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-default-thank-you-footer.tsx
@@ -26,23 +26,6 @@ export function useDefaultThankYouFoooter( slugs: string[] ): ThankYouSectionPro
 		nextStepsClassName: 'thank-you__footer',
 		nextSteps: [
 			{
-				stepKey: 'thank_you_footer_support_guides',
-				stepTitle: translate( 'Support guides' ),
-				stepDescription: translate(
-					'Our guides will show you everything you need to know about plugins.'
-				),
-				stepCta: (
-					<Button
-						isLink
-						href="https://wordpress.com/support/plugins/"
-						target="_blank"
-						onClick={ () => sendTrackEvent( 'calypso_plugin_thank_you_plugin_support_click' ) }
-					>
-						{ translate( 'Plugin Support' ) }
-					</Button>
-				),
-			},
-			{
 				stepKey: 'thank_you_footer_explore',
 				stepTitle: translate( 'Keep growing' ),
 				stepDescription: translate(
@@ -60,11 +43,24 @@ export function useDefaultThankYouFoooter( slugs: string[] ): ThankYouSectionPro
 				),
 			},
 			{
-				stepKey: 'thank_you_footer_support',
-				stepTitle: translate( 'How can we support you?' ),
-				stepDescription: translate(
-					'Our team is here if you need help, or if you have any questions.'
+				stepKey: 'thank_you_footer_support_guides',
+				stepTitle: translate( 'Learn More' ),
+				stepDescription: translate( 'Discover everything you need to know about Plugins.' ),
+				stepCta: (
+					<Button
+						isLink
+						href="https://wordpress.com/support/plugins/"
+						target="_blank"
+						onClick={ () => sendTrackEvent( 'calypso_plugin_thank_you_plugin_support_click' ) }
+					>
+						{ translate( 'Plugin Support' ) }
+					</Button>
 				),
+			},
+			{
+				stepKey: 'thank_you_footer_support',
+				stepTitle: translate( '24/7 support at your fingertips' ),
+				stepDescription: translate( 'Our happiness engineers are eager to lend a hand.' ),
 				stepCta: (
 					<Button
 						isLink


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74325 & https://github.com/Automattic/wp-calypso/issues/74323

## Proposed Changes

* Update copy

These copy changes come from https://github.com/Automattic/wp-calypso/pull/74449 & https://github.com/Automattic/wp-calypso/pull/74441. Those PRs have been closed and combined into this single PR to simplify merging after a large refactor.

Before | After
--|--
![plugins-post-purchase-before](https://user-images.githubusercontent.com/140841/226685477-eed8143d-8c93-4fc8-af76-15ecd108519b.png)  |  ![plugins-post-purchase-after](https://user-images.githubusercontent.com/140841/226685489-8d9b3406-1b8f-414b-b142-4ec1097beb7e.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR and purchase a plugin
* Ensure the copy changes match the changes in https://github.com/Automattic/wp-calypso/pull/74449 & https://github.com/Automattic/wp-calypso/pull/74441
* Ensure no regressions were added.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
