### PR TITLE
Purchases: Add AU to countries supporting VAT

### DIFF
--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -166,6 +166,7 @@ function CountryCodeInput( {
 } ) {
 	const countries = [
 		'AT',
+		'AU',
 		'BE',
 		'BG',
 		'CH',

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -14,6 +14,7 @@ import './style.css';
 
 const countriesSupportingVat = [
 	'AT',
+	'AU',
 	'BE',
 	'BG',
 	'CH',


### PR DESCRIPTION
## Proposed Changes

This PR adds Australia to the list of countries for which we support collecting VAT info.

Part of https://github.com/Automattic/payments-shilling/issues/1475

## Testing Instructions

- Visit `/me/purchases/vat-details` and verify that `AU` is listed in the list of countries.
- Add a product to your cart and visit checkout. 
- Click to edit the billing details step of checkout if it is not already active.
- Select "Australia" from the list of countries.
- Verify that you see a "Add Business Tax ID details" checkbox.