### PR TITLE
Purchases: Add JP to countries supporting VAT

### DIFF
--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -183,6 +183,7 @@ function CountryCodeInput( {
 		'HU',
 		'IE',
 		'IT',
+		'JP',
 		'LT',
 		'LU',
 		'LV',

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -32,6 +32,7 @@ const countriesSupportingVat = [
 	'HU',
 	'IE',
 	'IT',
+	'JP',
 	'LT',
 	'LU',
 	'LV',


### PR DESCRIPTION
## Proposed Changes

This PR adds Japan to the list of countries for which we support collecting VAT info.

Part of https://github.com/Automattic/payments-shilling/issues/1474

Depends on D105260-code to provide a validator for Japanese VAT info.

## Testing Instructions

- Visit `/me/purchases/vat-details` and verify that `JP` is listed in the list of countries.
- Add a product to your cart and visit checkout. 
- Click to edit the billing details step of checkout if it is not already active.
- Set the country to "Japan".
- Verify that you see a "Add Business Tax ID details" checkbox.