### PR TITLE
AT E2E: fix the `Editor: Revisions` spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/revisions-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/revisions-page.ts
@@ -1,5 +1,4 @@
 import { Page } from 'playwright';
-import { ElementHelper } from '../..';
 
 /**
  * Represents the Revisions page used on Atomic sites.
@@ -39,20 +38,17 @@ export class RevisionsPage {
 		// slider width.
 		const clickPositionX = ( sliderWidth * ( index - 1 ) ) / ( revisionCount - 1 );
 
-		await Promise.all( [
-			// We need to rely on waiting for mutations here because neither
-			// checking the ".loading" status nor the auto-waiting are enough to
-			// indicate that the diff has been loaded and is ready to be
-			// interacted with. This might be related to the fact that the diff
-			// is rendered entirely from a fetched HTML string.
-			ElementHelper.waitForMutations( this.page, '.revisions-diff-frame' ),
-			slider.click( { position: { x: clickPositionX, y: 1 } } ),
-		] );
+		await this.page.waitForLoadState( 'networkidle' );
+		await slider.click( { position: { x: clickPositionX, y: 1 } } );
 	}
 
 	/**
-	 * Clicks the "Restore This Revision" button. Throws if the current revision
-	 * is already loaded.
+	 * Clicks the "Restore This Revision" button, then checks
+	 * that the editor screen is loaded again.
+	 *
+	 * Throws if the current revision is already loaded.
+	 *
+	 * @throws {Error} if the current revision is already loaded.
 	 */
 	async loadSelectedRevision() {
 		const restoreButton = this.page.locator( 'input[value="Restore This Revision"]' );
@@ -60,9 +56,10 @@ export class RevisionsPage {
 			throw new Error( 'Revision already loaded.' );
 		}
 
-		await Promise.all( [
-			this.page.waitForNavigation( { waitUntil: 'networkidle' } ),
-			restoreButton.click(),
-		] );
+		await restoreButton.click();
+
+		// If the spec is using RevisionsPage, this implies the
+		// account is using WP-Admin.
+		await this.page.waitForURL( /wp-admin\/post.php/, { timeout: 20 * 1000 } );
 	}
 }

--- a/test/e2e/specs/editor/editor__revisions.ts
+++ b/test/e2e/specs/editor/editor__revisions.ts
@@ -90,7 +90,6 @@ describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
 	it( 'Load selected revision', async function () {
 		if ( envVariables.TEST_ON_ATOMIC ) {
 			await revisionsPage.loadSelectedRevision();
-			await editorPage.waitUntilLoaded();
 		} else {
 			await revisionsComponent.loadSelectedRevision();
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR updates the Editor: Revision spec to ensure that it behaves as expected on AT sites.

Key changes:
- remove use of the `ElementHelper.waitForMutation` function due to the open handle it leaves for Jest to clean up.
- remove the `EditorPage.waitUntilLoaded` call once the revision is loaded.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E AT (desktop)
  - [x] Gutenberg E2E AT (mobile)

![image](https://user-images.githubusercontent.com/6549265/226789045-20ab29a3-ee9c-4c3a-b00d-701b889e7ad5.png)

![image](https://user-images.githubusercontent.com/6549265/226789864-38ce15f8-e449-42f9-b1d0-097111012f80.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
