### PR TITLE
Added outline in focus state for FAQs

### DIFF
--- a/client/my-sites/plans/jetpack-plans/faq/style.scss
+++ b/client/my-sites/plans/jetpack-plans/faq/style.scss
@@ -37,3 +37,7 @@
 		}
 	}
 }
+
+.jetpack-faq__section button:focus-visible {
+	outline: thin dotted;
+}


### PR DESCRIPTION
Closes to #74166 

## Proposed Changes

* On the Jetpack Pricing page, the items of the FAQ section have no visible focus state. This makes navigating the section difficult, as a user doesn't know exactly where they are.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `git checkout add/jetpack-faq-focus-highlight` and `yarn start-jetpack-cloud`
* Visit https://jetpack.cloud.localhost:3000/pricing
* Scroll to the Frequently Asked Questions section at the bottom of the page
* Click on the section title so that the next element in the section will receive focus
* Click the Tab key several times
* Notice the faint outline of each FAQ

![CleanShot 2023-03-21 at 12 26 28](https://user-images.githubusercontent.com/2293077/226724547-8fbfe87e-30d3-4e78-891d-eb0e9f937fec.gif)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
