### PR TITLE
E2E Framework: fix empty array check in RestAPIClient.

### DIFF
--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -354,15 +354,20 @@ export class RestAPIClient {
 			params
 		);
 
+		// This handles API errors such as `unauthorized`.
 		if ( response.hasOwnProperty( 'error' ) ) {
 			throw new Error(
 				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
 			);
 		}
 
-		if ( response.errors.length === 0 ) {
-			console.log( response );
-			throw new Error( `Failed to create invite: ${ response.errors }` );
+		// This handles "errors" relating to the invite itself and can be an array.
+		// For instance, if a user tries to invite itself, or invite an already added user.
+		if ( response.errors.length !== 0 ) {
+			for ( const err of response.errors ) {
+				console.error( `${ err.code }: ${ err.message }` );
+			}
+			throw new Error( `Failed to create invite due to ${ response.errors.length } errors.` );
 		}
 
 		return response;

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -1035,7 +1035,7 @@ export class RestAPIClient {
 		if ( response.hasOwnProperty( 'error' ) && response.error === 'not_found' ) {
 			console.info( `Widget ${ widgetID } not found.` );
 			return;
-		} else if ( response === [] ) {
+		} else if ( response.length === 0 ) {
 			console.info( `Deleted widget ${ widgetID }.` );
 		} else if ( response.id === widgetID ) {
 			console.info( `Deactivated widget ${ widgetID }` );

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -360,7 +360,7 @@ export class RestAPIClient {
 			);
 		}
 
-		if ( response.errors === [] ) {
+		if ( response.errors.length === 0 ) {
 			console.log( response );
 			throw new Error( `Failed to create invite: ${ response.errors }` );
 		}

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -363,7 +363,7 @@ export class RestAPIClient {
 
 		// This handles "errors" relating to the invite itself and can be an array.
 		// For instance, if a user tries to invite itself, or invite an already added user.
-		if ( response.errors.length !== 0 ) {
+		if ( response.errors.length ) {
 			for ( const err of response.errors ) {
 				console.error( `${ err.code }: ${ err.message }` );
 			}

--- a/packages/calypso-e2e/src/test/rest-api-client.invites.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.invites.test.ts
@@ -115,7 +115,7 @@ describe( 'RestAPIClient: createInvite', function () {
 		expect( response.errors.length ).toBe( 0 );
 	} );
 
-	test( 'Invite cannot be created', async function () {
+	test( 'Invite is rejected due to existing user email', async function () {
 		const testSuccessfulEmails = [ 'test1@test.com' ];
 		const testFailedEmails = [ 'test1@test.com' ];
 		const role = 'Editor' as Roles;
@@ -126,14 +126,11 @@ describe( 'RestAPIClient: createInvite', function () {
 
 		nock( requestURL.origin ).post( requestURL.pathname ).reply( 200, testResponse );
 
-		const response: NewInviteResponse = await restAPIClient.createInvite( siteID, {
-			email: testSuccessfulEmails.concat( testFailedEmails ),
-			role: role,
-		} );
-		expect( response.sent ).toBeInstanceOf( Array );
-		expect( response.sent.length ).toBe( 1 );
-		expect( response.sent ).toEqual( testSuccessfulEmails );
-		expect( response.errors.length ).toBe( 1 );
-		expect( response.errors ).toEqual( testFailedEmails );
+		await expect( () =>
+			restAPIClient.createInvite( siteID, {
+				email: testSuccessfulEmails.concat( testFailedEmails ),
+				role: role,
+			} )
+		).rejects.toThrowError();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/74479#discussion_r1143992283.

## Proposed Changes

This PR fixes the empty array check introduced in https://github.com/Automattic/wp-calypso/pull/74479.

## Testing Instructions



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
