### PR TITLE
Subscription management: Apply updated design to mobile header

### DIFF
--- a/packages/subscription-manager/src/components/SubscriptionManagerContainer/styles.scss
+++ b/packages/subscription-manager/src/components/SubscriptionManagerContainer/styles.scss
@@ -34,13 +34,13 @@
 
 	@media screen and ( max-width: $break-medium ) {
 		.layout__content {
-			padding: 4px 24px;
+			padding: 30px 24px;
 
 			.subscription-manager-container {
 				.formatted-header {
 					&__title {
-						font-size: $font-title-medium !important;
-						line-height: $font-title-large;
+						font-size: rem(28px) !important;
+						line-height: $font-headline-small;
 						margin-bottom: 8px;
 					}
 				}

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -790,24 +790,32 @@ $x-menu-heading-line-height-wide: $x-menu-heading-font-size-wide + 7px; /* 1 */
 				}
 				.x-nav-list__right {
 					padding-right: 24px;
+
+					.x-nav-item__narrow {
+						display: none;
+					}
+
+					.x-nav-item__wide {
+						display: block;
+					}
 				}
 
 				.x-nav-item {
 					height: 66px;
 
-					@media ( min-width: $x-nav-breakpoint-medium-wide ) {
-						.x-nav-link.x-link:not(.cta-btn-nav) {
-							padding-top: 23px;
-						}
-					}
-					@media ( min-width: $x-nav-breakpoint-small ) {
-						.x-nav-link.x-link {
-							padding-top: 14px;
-						}
+					.x-nav-link.x-link:not(.cta-btn-nav) {
+						padding-top: 23px;
 					}
 
 					.x-nav-link.x-link.x-nav-link__logo {
 						padding: 14px 0 0 0;
+
+						@media (max-width: calc($x-nav-breakpoint-small + 1px)) {
+							display: block;
+							overflow: hidden;
+							padding-left: 1px;
+							width: 25px;
+						}
 					}
 
 					.cta-btn-nav {
@@ -815,7 +823,10 @@ $x-menu-heading-line-height-wide: $x-menu-heading-font-size-wide + 7px; /* 1 */
 						background: inherit !important;
 						border: 1px solid $studio-gray-100;
 						filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.05));
-						padding: 12px 24px 12px 24px !important;
+						font-size: $font-body-small;
+						font-weight: 500;
+						line-height: $font-title-small;
+						padding: 10px 16px !important;
 						margin-right: 0;
 					}
 				}

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1,3 +1,5 @@
+@import "@automattic/typography/styles/variables";
+
 $lp-font-stack-emoji: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 $lp-font-stack-default: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica", "Arial", sans-serif, $lp-font-stack-emoji;
 $x-content-font-stack: $lp-font-stack-default;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes [#74526](https://github.com/Automattic/wp-calypso/issues/74526)

## Proposed Changes

* Apply the updated design to mobile header
* Hide the floating menu
* Hide the WordPress blue text from the logo on small screen sizes (< 480px)
* Update nav CTA button padding to match the Figma design
* Update title font size to match the Figma design
* Increase space between content and header to match the Figma design

<img width="357" alt="Screenshot 2023-03-21 at 18 07 09" src="https://user-images.githubusercontent.com/3113712/226743868-a9f667d4-47ce-477b-84ad-1e3cb9ad724a.png">

## Testing Instructions

* Run this patch on your local env
* Go to http://calypso.localhost:3000/subscriptions/settings
* Verify if the header is rendered as expected on small screen sizes
* Verify if no regression was made on bigger sizes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
