### PR TITLE
Magic link: Remove illustration and update CSS on expired link page

### DIFF
--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -43,8 +43,7 @@ class EmailedLoginLinkExpired extends Component {
 					actionCallback={ this.onClickTryAgainLink }
 					actionURL={ login( { twoFactorAuthType: 'link' } ) }
 					className="magic-login__link-expired"
-					illustration="/calypso/images/illustrations/illustration-404.svg"
-					illustrationWidth={ 500 }
+					illustration=""
 					line={ translate( 'Maybe try resetting your password instead' ) }
 					secondaryAction={ translate( 'Reset my password' ) }
 					secondaryActionURL={ lostPassword() }

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -22,10 +22,13 @@
 	}
 }
 
-.is-white-login .magic-login__handle-link {
+.is-white-login .magic-login__handle-link,
+.is-white-login .magic-login__link-expired {
 	.empty-content__title {
 		font-family: $brand-serif;
 		font-size: rem(42px);
+		line-height: 1.2;
+		margin-bottom: 15px;
 	}
 
 	.empty-content__line {
@@ -36,6 +39,10 @@
 	.button.is-primary:not([disabled]) {
 		background-color: #007cba;
 		border-color: #007cba;
+	}
+
+	.empty-content__action {
+		margin: 0 10px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74285

## Proposed Changes

Update the expired magic link style to match the other login flow styles by:

- Remove the illustration
- Align styling (fonts and colors) with the other login steps.
- Add some margin between the buttons.

Before | After
--|--
![expired-link-before](https://user-images.githubusercontent.com/140841/226754750-710cd537-9d8a-4dda-b4bb-7fa95869ccbd.png)  |  ![expired-link-after](https://user-images.githubusercontent.com/140841/226754768-f443c03c-927f-4ab6-9f74-aea28b95f80c.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In your WPCOM sandbox, add the following code to your /mu-plugins/0-sandbox.php file:

```
add_filter( 'wpcom_magic_login_calypso_base_url', function() {
    l( 'overriding wpcom_magic_login_calypso_base_url per your filter', null );
    return 'http://calypso.localhost:3000';
} );
```

* Sandbox the WPCOM API and load this Calypso PR on your localhost.
* Go to `http://calypso.localhost:3000/log-in/link` and request a login link using a non a11n account.
* Go to you email and click on the login link.
* The link will land you on http://calypso.localhost:3000/log-in/link/use
* Make sure the styles we introduced in https://github.com/Automattic/wp-calypso/pull/74588 still look good (since we modified the CSS a bit in this PR)
* Now try going to an expired login link, or if you're logged out, go to http://calypso.localhost:3000/log-in/link/use
* The expired magic link screen should look good and address the bullet points in the description.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
