### PR TITLE
Launchpad: Add domain upsell to launchpad celebration modal

### DIFF
--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -38,41 +38,33 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 
 		if ( ! isPaidPlan && ! hasCustomDomain ) {
 			contentElement = (
-				<>
-					<span>
-						{ translate( 'Supercharge your website with a' ) }{ ' ' }
-						<span className="launched__modal-upsell-content-highlight">
-							{ translate( 'custom address' ) }
-						</span>{ ' ' }
-						{ translate( 'that matches your blog, brand, or business.' ) }
-					</span>
-				</>
+				<p>
+					{ translate(
+						'Supercharge your website with a {{strong}}custom address{{/strong}} that matches your blog, brand, or business.',
+						{ components: { strong: <strong /> } }
+					) }
+				</p>
 			);
 			buttonText = translate( 'Claim your domain' );
 			buttonHref = `/domains/add/${ site.slug }`;
 		} else if ( isPaidPlan && isBilledYearly && ! hasCustomDomain ) {
 			contentElement = (
-				<>
-					<span>
-						{ translate( 'Your paid plan includes a domain name' ) }{ ' ' }
-						<span className="launched__modal-upsell-content-highlight">
-							{ translate( 'free for one year' ) }
-						</span>{ ' ' }
-						{ translate( 'Choose one that’s easy to remember and even easier to share.' ) }
-					</span>
-				</>
+				<p>
+					{ translate(
+						'Your paid plan includes a domain name {{strong}}free for one year{{/strong}}. Choose one that’s easy to remember and even easier to share.',
+						{ components: { strong: <strong /> } }
+					) }
+				</p>
 			);
 			buttonText = translate( 'Claim your free domain' );
 			buttonHref = `/domains/add/${ site.slug }`;
 		} else if ( isPaidPlan && ! hasCustomDomain ) {
 			contentElement = (
-				<>
-					<span>
-						{ translate(
-							'Interested in a custom domain? It’s free for the first year when you switch to annual billing.'
-						) }
-					</span>
-				</>
+				<p>
+					{ translate(
+						'Interested in a custom domain? It’s free for the first year when you switch to annual billing.'
+					) }
+				</p>
 			);
 			buttonText = translate( 'Claim your domain' );
 			buttonHref = `/domains/add/${ site.slug }`;

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -12,7 +12,7 @@ import './celebrate-launch-modal.scss';
 function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 	const translate = useTranslate();
 	const isPaidPlan = ! site?.plan?.is_free;
-	const isBilledYearly = site?.plan?.billing_period === 'Yearly';
+	const isBilledMonthly = site?.plan?.product_slug?.includes( 'monthly' );
 
 	const transformedDomains = allDomains.map( createSiteDomainObject );
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
@@ -47,7 +47,17 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 			);
 			buttonText = translate( 'Claim your domain' );
 			buttonHref = `/domains/add/${ site.slug }`;
-		} else if ( isPaidPlan && isBilledYearly && ! hasCustomDomain ) {
+		} else if ( isPaidPlan && isBilledMonthly && ! hasCustomDomain ) {
+			contentElement = (
+				<p>
+					{ translate(
+						'Interested in a custom domain? It’s free for the first year when you switch to annual billing.'
+					) }
+				</p>
+			);
+			buttonText = translate( 'Claim your domain' );
+			buttonHref = `/domains/add/${ site.slug }`;
+		} else if ( isPaidPlan && ! hasCustomDomain ) {
 			contentElement = (
 				<p>
 					{ translate(
@@ -57,16 +67,6 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 				</p>
 			);
 			buttonText = translate( 'Claim your free domain' );
-			buttonHref = `/domains/add/${ site.slug }`;
-		} else if ( isPaidPlan && ! hasCustomDomain ) {
-			contentElement = (
-				<p>
-					{ translate(
-						'Interested in a custom domain? It’s free for the first year when you switch to annual billing.'
-					) }
-				</p>
-			);
-			buttonText = translate( 'Claim your domain' );
 			buttonHref = `/domains/add/${ site.slug }`;
 		} else if ( isPaidPlan && hasCustomDomain ) {
 			return null;

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -75,7 +75,6 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 		return (
 			<div className="launched__modal-upsell">
 				<p className="launched__modal-upsell-content">{ contentElement }</p>
-				{ /* <Button disabled={ isFetching } isLarge isPrimary href={ buttonHref }> */ }
 				<Button isLarge isPrimary href={ buttonHref }>
 					<span>{ buttonText }</span>
 				</Button>

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -1,4 +1,4 @@
-import { ConfettiAnimation, Gridicon } from '@automattic/components';
+import { ConfettiAnimation } from '@automattic/components';
 import { Button, Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -28,24 +28,34 @@ function CelebrateLaunchModal( { setModalIsOpen, site } ) {
 						{ translate( 'Congrats, your site is live!' ) }
 					</h1>
 					<p className="launched__modal-body">
-						{ translate(
-							'Your site is live. Now you can head over to your site and share it with the world or keep working on it.'
-						) }
+						{ translate( 'Now you can head over to your site and share it with the world.' ) }
 					</p>
 				</div>
 				<div className="launched__modal-actions">
 					<div className="launched__modal-site">
 						<p className="launched__modal-domain">{ site.slug }</p>
 
-						<Button isPrimary href={ site.URL } target="_blank">
-							{ translate( 'Visit site' ) }
+						<Button href={ site.URL } target="_blank">
+							{ translate( 'View site' ) }
 						</Button>
 					</div>
-					<Button className="launched__modal-customize" href={ `/domains/add/${ site.slug }` }>
-						<Gridicon icon="domains" size={ 16 } />
-						<span>{ translate( 'Customize your domain' ) }</span>
-					</Button>
 				</div>
+			</div>
+			<div
+				className="launched__modal-upsell"
+				style={ { display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between' } }
+			>
+				<div className="launched__modal-upsell-content">
+					<h2 className="launched__modal-upsell-heading">
+						{ translate( 'Claim your free domain' ) }
+					</h2>
+					<p className="launched__modal-upsell-body">
+						{ translate( 'Your plan includes a free domain for the first year' ) }
+					</p>
+				</div>
+				<Button isPrimary href={ `/domains/add/${ site.slug }` }>
+					<span>{ translate( 'Choose a domain' ) }</span>
+				</Button>
 			</div>
 		</Modal>
 	);

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -4,24 +4,22 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useRef } from 'react';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import Tooltip from 'calypso/components/tooltip';
-import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import { omitUrlParams } from 'calypso/lib/url';
 import { createSiteDomainObject } from 'calypso/state/sites/domains/assembler';
 
 import './celebrate-launch-modal.scss';
 
-function CelebrateLaunchModal( { setModalIsOpen, site } ) {
+function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 	const translate = useTranslate();
 	const isPaidPlan = ! site?.plan?.is_free;
 	const isBilledYearly = site?.plan?.billing_period === 'Yearly';
-	const { data: allDomains = [], isFetching } = useGetDomainsQuery( site?.ID ?? null, {
-		retry: false,
-	} );
 
-	const domains = allDomains.map( createSiteDomainObject );
+	const transformedDomains = allDomains.map( createSiteDomainObject );
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const clipboardButtonEl = useRef( null );
-	const hasCustomDomain = Boolean( domains.find( ( domain ) => ! domain.isWPCOMDomain ) );
+	const hasCustomDomain = Boolean(
+		transformedDomains.find( ( domain ) => ! domain.isWPCOMDomain )
+	);
 
 	useEffect( () => {
 		// remove the celebrateLaunch URL param without reloading the page as soon as the modal loads
@@ -85,7 +83,8 @@ function CelebrateLaunchModal( { setModalIsOpen, site } ) {
 		return (
 			<div className="launched__modal-upsell">
 				<p className="launched__modal-upsell-content">{ contentElement }</p>
-				<Button disabled={ isFetching } isLarge isPrimary href={ buttonHref }>
+				{ /* <Button disabled={ isFetching } isLarge isPrimary href={ buttonHref }> */ }
+				<Button isLarge isPrimary href={ buttonHref }>
 					<span>{ buttonText }</span>
 				</Button>
 			</div>

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -1,13 +1,22 @@
-import { ConfettiAnimation } from '@automattic/components';
+import { ConfettiAnimation, Spinner } from '@automattic/components';
 import { Button, Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
+import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import { omitUrlParams } from 'calypso/lib/url';
+import { createSiteDomainObject } from 'calypso/state/sites/domains/assembler';
 
 import './celebrate-launch-modal.scss';
 
 function CelebrateLaunchModal( { setModalIsOpen, site } ) {
 	const translate = useTranslate();
+	const isPaidPlan = ! site?.plan?.is_free;
+	const { data: allDomains = [], isFetching } = useGetDomainsQuery( site?.ID ?? null, {
+		retry: false,
+	} );
+
+	const domains = allDomains.map( createSiteDomainObject );
+	const hasCustomDomain = Boolean( domains.find( ( domain ) => ! domain.isWPCOMDomain ) );
 
 	useEffect( () => {
 		// remove the celebrateLaunch URL param without reloading the page as soon as the modal loads
@@ -18,6 +27,17 @@ function CelebrateLaunchModal( { setModalIsOpen, site } ) {
 			omitUrlParams( window.location.href, 'celebrateLaunch' )
 		);
 	}, [] );
+
+	let upsellHeading = translate( 'Free One-Year Domain' );
+	let upsellBody = translate( 'Get a custom domain by upgrading your plan.' );
+
+	if ( isPaidPlan && hasCustomDomain ) {
+		upsellHeading = 'Upsell something else';
+		upsellBody = 'Placeholder to upsell something else';
+	} else if ( isPaidPlan && ! hasCustomDomain ) {
+		upsellHeading = 'Claim your free domain';
+		upsellBody = 'Your plan includes a free domain for the first year';
+	}
 
 	return (
 		<Modal onRequestClose={ () => setModalIsOpen( false ) } className="launched__modal">
@@ -42,17 +62,21 @@ function CelebrateLaunchModal( { setModalIsOpen, site } ) {
 				</div>
 			</div>
 			<div className="launched__modal-upsell">
-				<div className="launched__modal-upsell-content">
-					<h2 className="launched__modal-upsell-heading">
-						{ translate( 'Claim your free domain' ) }
-					</h2>
-					<p className="launched__modal-upsell-body">
-						{ translate( 'Your plan includes a free domain for the first year' ) }
-					</p>
-				</div>
-				<Button isPrimary href={ `/domains/add/${ site.slug }` }>
-					<span>{ translate( 'Choose a domain' ) }</span>
-				</Button>
+				{ isFetching ? (
+					<Spinner />
+				) : (
+					<>
+						<div className="launched__modal-upsell-content">
+							{ upsellHeading && (
+								<h2 className="launched__modal-upsell-heading">{ upsellHeading }</h2>
+							) }
+							<p className="launched__modal-upsell-body">{ upsellBody }</p>
+						</div>
+						<Button isPrimary href={ `/domains/add/${ site.slug }` }>
+							<span>{ translate( 'Choose a domain' ) }</span>
+						</Button>
+					</>
+				) }
 			</div>
 		</Modal>
 	);

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -74,7 +74,7 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 
 		return (
 			<div className="launched__modal-upsell">
-				<p className="launched__modal-upsell-content">{ contentElement }</p>
+				<div className="launched__modal-upsell-content">{ contentElement }</div>
 				<Button isLarge isPrimary href={ buttonHref }>
 					<span>{ buttonText }</span>
 				</Button>

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -41,10 +41,7 @@ function CelebrateLaunchModal( { setModalIsOpen, site } ) {
 					</div>
 				</div>
 			</div>
-			<div
-				className="launched__modal-upsell"
-				style={ { display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between' } }
-			>
+			<div className="launched__modal-upsell">
 				<div className="launched__modal-upsell-content">
 					<h2 className="launched__modal-upsell-heading">
 						{ translate( 'Claim your free domain' ) }

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -79,17 +79,7 @@ function CelebrateLaunchModal( { setModalIsOpen, site } ) {
 			buttonText = translate( 'Claim your domain' );
 			buttonHref = `/domains/add/${ site.slug }`;
 		} else if ( isPaidPlan && hasCustomDomain ) {
-			contentElement = (
-				<>
-					<span>
-						{ translate(
-							'Ready to expand your reach? Promote your posts with Blaze, and send relevant traffic to your site.'
-						) }
-					</span>
-				</>
-			);
-			buttonText = translate( 'Try Blaze Today' );
-			buttonHref = `/domains/add/${ site.slug }`;
+			return null;
 		}
 
 		return (

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.scss
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.scss
@@ -94,6 +94,10 @@
 		}
 	}
 
+	&-upsell-content p {
+		margin-bottom: 0;
+	}
+
 	&-upsell-content-highlight {
 		font-weight: bold;
 	}

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.scss
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.scss
@@ -4,12 +4,14 @@
 	.components-modal__content {
 		margin: 0;
 		padding: 48px;
+		width: 550px;
 	}
 
 	&-content {
 		display: flex;
 		flex-direction: column;
 		gap: 32px;
+		margin-bottom: 40px;
 	}
 
 	&-heading {
@@ -66,5 +68,32 @@
 		padding: 0;
 		margin: 0;
 		margin-top: 16px;
+	}
+
+	&-upsell {
+		align-items: flex-end;
+		background: var(--studio-gray-0);
+		border-top: 1px solid var(--studio-gray-5);
+		display: flex;
+		justify-content: space-between;
+		margin: 0 -48px -48px -48px;
+		padding: 32px 48px 32px 48px;
+	}
+
+	&-upsell-content {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+	}
+
+	&-upsell-heading {
+		margin: 0 0 4px 0;
+		font-size: 1rem;
+		font-weight: 600;
+	}
+
+	&-upsell-body {
+		margin: 0;
+		font-size: 0.875rem;
 	}
 }

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.scss
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.scss
@@ -87,7 +87,7 @@
 	}
 
 	&-upsell-heading {
-		margin: 0 0 4px 0;
+		margin: 0 0 2px 0;
 		font-size: 1rem;
 		font-weight: 600;
 	}

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.scss
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.scss
@@ -1,17 +1,21 @@
 .launched__modal {
 	max-width: 640px;
 
+	.components-modal__header {
+		padding: 48px;
+	}
+
 	.components-modal__content {
 		margin: 0;
-		padding: 48px;
-		width: 550px;
+		padding: 0;
 	}
 
 	&-content {
+		padding: 48px;
+		padding-bottom: 40px;
 		display: flex;
 		flex-direction: column;
 		gap: 32px;
-		margin-bottom: 40px;
 	}
 
 	&-heading {
@@ -25,15 +29,21 @@
 		padding-bottom: 8px;
 	}
 
-	&-body,
 	&-domain {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+
+	&-body,
+	&-domain-text {
 		margin: 0;
 		color: var(--studio-gray-80);
 		font-size: 1rem;
 		line-height: 24px;
 	}
 
-	&-domain {
+	&-domain-text {
 		padding: 0 8px;
 
 		// prevent text overflow
@@ -71,29 +81,36 @@
 	}
 
 	&-upsell {
-		align-items: flex-end;
+		border-top: 1px solid var(--studio-gray-50);
 		background: var(--studio-gray-0);
-		border-top: 1px solid var(--studio-gray-5);
 		display: flex;
-		justify-content: space-between;
-		margin: 0 -48px -48px -48px;
-		padding: 32px 48px 32px 48px;
-	}
-
-	&-upsell-content {
-		display: flex;
-		flex-direction: column;
 		justify-content: center;
+		align-items: center;
+		padding: 32px 48px;
+		gap: 32px;
+
+		.components-button {
+			height: 42px;
+		}
 	}
 
-	&-upsell-heading {
-		margin: 0 0 2px 0;
-		font-size: 1rem;
-		font-weight: 600;
+	&-upsell-content-highlight {
+		font-weight: bold;
 	}
 
-	&-upsell-body {
-		margin: 0;
-		font-size: 0.875rem;
+	&-view-site {
+		display: flex;
+		gap: 4px;
+
+		font-weight: 500;
+		/* stylelint-disable-next-line */
+		font-size: 14px;
+		line-height: 20px;
+		letter-spacing: -0.154px;
+		color: #101517;
+	}
+
+	&-view-site:hover {
+		text-decoration: underline;
 	}
 }

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.scss
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.scss
@@ -81,7 +81,7 @@
 	}
 
 	&-upsell {
-		border-top: 1px solid var(--studio-gray-50);
+		border-top: 1px solid var(--studio-gray-5);
 		background: var(--studio-gray-0);
 		display: flex;
 		justify-content: center;
@@ -107,6 +107,10 @@
 		font-size: 14px;
 		line-height: 20px;
 		letter-spacing: -0.154px;
+		color: #101517;
+	}
+
+	&-view-site:visited {
 		color: #101517;
 	}
 

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -11,6 +11,7 @@ import QuerySiteChecklist from 'calypso/components/data/query-site-checklist';
 import EmptyContent from 'calypso/components/empty-content';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -50,13 +51,15 @@ const Home = ( {
 	sitePlan,
 	isNew7DUser,
 } ) => {
-	const [ celebrateLaunchModalIsOpen, setCelebrateLaunchModalIsOpen ] = useState(
-		getQueryArgs().celebrateLaunch === 'true'
-	);
+	const [ celebrateLaunchModalIsOpen, setCelebrateLaunchModalIsOpen ] = useState( false );
 
 	const translate = useTranslate();
 
 	const { data: layout, isLoading } = useHomeLayoutQuery( siteId );
+
+	const { data: allDomains = [], isSuccess } = useGetDomainsQuery( site?.ID ?? null, {
+		retry: false,
+	} );
 
 	const detectedCountryCode = useSelector( getCurrentUserCountryCode );
 	useEffect( () => {
@@ -78,6 +81,12 @@ const Home = ( {
 			window.hj( 'trigger', 'pnp_survey_1' );
 		}
 	}, [ detectedCountryCode, sitePlan, isNew7DUser ] );
+
+	useEffect( () => {
+		if ( getQueryArgs().celebrateLaunch === 'true' && isSuccess ) {
+			setCelebrateLaunchModalIsOpen( true );
+		}
+	}, [ isSuccess ] );
 
 	if ( ! canUserUseCustomerHome ) {
 		const title = translate( 'This page is not available on this site.' );
@@ -150,7 +159,11 @@ const Home = ( {
 				</>
 			) }
 			{ celebrateLaunchModalIsOpen && (
-				<CelebrateLaunchModal setModalIsOpen={ setCelebrateLaunchModalIsOpen } site={ site } />
+				<CelebrateLaunchModal
+					setModalIsOpen={ setCelebrateLaunchModalIsOpen }
+					site={ site }
+					allDomains={ allDomains }
+				/>
 			) }
 		</Main>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74712

## Proposed Changes

* Update the launchpad celebration modal with an upsell below the modal content
* Change upsell messaging depending on three different scenarios

**1. Free user without a domain.**

COPY: Supercharge your website with a custom address that matches your blog, brand, or business.
CTA: Claim your domain

**2. Paid yearly user without a domain**

COPY: Your paid plan includes a domain name free for one year. Choose one that’s easy to remember and even easier to share.
CTA: Claim your free domain

**3. Paid monthly user without a domain**

COPY: Interested in a custom domain? It’s free for the first year when you switch to annual billing.
CTA: Claim your domain

**4. Paid users with a domain (yearly and monthly) → Remove the Upsell for now**

![noblaze](https://user-images.githubusercontent.com/20927667/228316258-0ec0f05d-82ee-43d6-9646-66e28cf8ad65.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* `yarn start`
* Create a launchpad site through any flow that requires the site to be launched ( [write](wordpress.com/start), [build](wordpress.com/start), `link-in-bio`, etc. )
* Launch the site from the Launchpad
* Confirm that the domain upsell is rendered
* Verify that the upsell text is correct and that the upsell button behaves as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
