### PR TITLE
Update signout logic to redirect to Mag-16 versions of apppromo page

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -31,13 +32,15 @@ class MeSidebar extends Component {
 	onSignOut = async () => {
 		const { currentUser } = this.props;
 
-		// If user is using en locale, redirect to app promo page on sign out
-		const isEnLocale = config( 'english_locales' ).includes( currentUser?.localeSlug );
+		// If user is using a supported locale, redirect to app promo page on sign out
+		const isSupportedLocale =
+			config( 'english_locales' ).includes( currentUser?.localeSlug ) ||
+			config( 'magnificent_non_en_locales' ).includes( currentUser?.localeSlug );
 
 		let redirectTo = null;
 
-		if ( isEnLocale && ! config.isEnabled( 'desktop' ) ) {
-			redirectTo = '/?apppromo';
+		if ( isSupportedLocale && ! config.isEnabled( 'desktop' ) ) {
+			redirectTo = localizeUrl( 'https://wordpress.com/?apppromo' );
 		}
 
 		try {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Fix the onSignOut redirect to ?apppromo, so that it'd redirect to the localized URLs if the users locale is one of Magnificent-16. Currently most of visits to ?apppromo are coming from this redirect, so enabling it for Mag-16 users should increase the mobile app adoption.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In calypso.localhost or calypso.live change your user locale to any non-English language from the list of Popular languages.
* Click on `Log out` and confirm that you were redirected to the localized URL of https://wordpress.com/?apppromo
* Repeat with an English locale to test for regression issues and some non-Mag-16 language to confirm that it won't redirect to ?apppromo on logout.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
