### PR TITLE
Checkout: add logged out checkout for Akismet

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
@@ -17,17 +17,19 @@ export async function createWpcomAccountBeforeTransaction(
 		( product ) => product.extra.isGiftPurchase
 	);
 
-	let signupFlowName;
+	const signupFlowName = ( () => {
+		if ( isJetpackUserLessCheckout ) {
+			return 'jetpack-userless-checkout';
+		}
+		if ( isAkismetUserLessCheckout ) {
+			return 'akismet-userless-checkout';
+		}
+		if ( isGiftingCheckout ) {
+			return 'gifting-userless-checkout';
+		}
 
-	if ( isJetpackUserLessCheckout ) {
-		signupFlowName = 'jetpack-userless-checkout';
-	} else if ( isAkismetUserLessCheckout ) {
-		signupFlowName = 'akismet-userless-checkout';
-	} else if ( isGiftingCheckout ) {
-		signupFlowName = 'gifting-userless-checkout';
-	} else {
-		signupFlowName = 'onboarding-registrationless';
-	}
+		return 'onboarding-registrationless';
+	} )();
 
 	/*
 	 * We treat Gifting as jetpack-userless-checkout to create and verify the user

--- a/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
@@ -10,21 +10,31 @@ export async function createWpcomAccountBeforeTransaction(
 	const isJetpackUserLessCheckout = transactionCart.products.some(
 		( product ) => product.extra.isJetpackCheckout
 	);
+	const isAkismetUserLessCheckout = transactionCart.products.some(
+		( product ) => product.extra.isAkismetSitelessCheckout
+	);
 	const isGiftingCheckout = transactionCart.products.some(
 		( product ) => product.extra.isGiftPurchase
 	);
+
+	let signupFlowName;
+
+	if ( isJetpackUserLessCheckout ) {
+		signupFlowName = 'jetpack-userless-checkout';
+	} else if ( isAkismetUserLessCheckout ) {
+		signupFlowName = 'akismet-userless-checkout';
+	} else if ( isGiftingCheckout ) {
+		signupFlowName = 'gifting-userless-checkout';
+	} else {
+		signupFlowName = 'onboarding-registrationless';
+	}
 
 	/*
 	 * We treat Gifting as jetpack-userless-checkout to create and verify the user
 	 * on success checkout.
 	 */
 	return createAccount( {
-		// eslint-disable-next-line no-nested-ternary
-		signupFlowName: isJetpackUserLessCheckout
-			? 'jetpack-userless-checkout'
-			: isGiftingCheckout
-			? 'gifting-userless-checkout'
-			: 'onboarding-registrationless',
+		signupFlowName,
 		email: transactionOptions.contactDetails?.email?.value,
 		siteId: transactionOptions.siteId,
 		recaptchaClientId: transactionOptions.recaptchaClientId,

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -92,11 +92,12 @@ async function wpcomPayPalExpress(
 	payload: PayPalExpressEndpointRequestPayload,
 	transactionOptions: PaymentProcessorOptions
 ) {
-	const isJetpackUserLessCheckout =
-		payload.cart.products.some( ( product ) => product.extra.isJetpackCheckout ) &&
-		payload.cart.cart_key === 'no-user';
+	const isUserLessCheckout =
+		payload.cart.products.some(
+			( product ) => product.extra.isJetpackCheckout || product.extra.isAkismetSitelessCheckout
+		) && payload.cart.cart_key === 'no-user';
 
-	if ( transactionOptions.createUserAndSiteBeforeTransaction || isJetpackUserLessCheckout ) {
+	if ( transactionOptions.createUserAndSiteBeforeTransaction || isUserLessCheckout ) {
 		payload.cart = await createWpcomAccountBeforeTransaction( payload.cart, transactionOptions );
 	}
 

--- a/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/submit-wpcom-transaction.ts
@@ -25,11 +25,12 @@ export default async function submitWpcomTransaction(
 	payload: WPCOMTransactionEndpointRequestPayload,
 	transactionOptions: PaymentProcessorOptions
 ): Promise< WPCOMTransactionEndpointResponse > {
-	const isJetpackUserLessCheckout =
-		payload.cart.products.some( ( product ) => product.extra.isJetpackCheckout ) &&
-		payload.cart.cart_key === 'no-user';
+	const isUserLessCheckout =
+		payload.cart.products.some( ( product ) => {
+			return product.extra.isJetpackCheckout || product.extra.isAkismetSitelessCheckout;
+		} ) && payload.cart.cart_key === 'no-user';
 
-	if ( transactionOptions.createUserAndSiteBeforeTransaction || isJetpackUserLessCheckout ) {
+	if ( transactionOptions.createUserAndSiteBeforeTransaction || isUserLessCheckout ) {
 		payload.cart = await createWpcomAccountBeforeTransaction( payload.cart, transactionOptions );
 	}
 

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -59,7 +59,11 @@ export function createTransactionEndpointCartFromResponseCart( {
 	contactDetails: DomainContactDetails | null;
 	responseCart: ResponseCart;
 } ): RequestCart {
-	if ( responseCart.products.some( ( product ) => product.extra.isJetpackCheckout ) ) {
+	if (
+		responseCart.products.some( ( product ) => {
+			return product.extra.isJetpackCheckout || product.extra.isAkismetSitelessCheckout;
+		} )
+	) {
 		const isUserLess = responseCart.cart_key === 'no-user';
 		const isSiteLess = responseCart.blog_id === 0;
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -561,6 +561,7 @@ export interface ResponseCartProductExtra {
 
 	afterPurchaseUrl?: string;
 	isJetpackCheckout?: boolean;
+	isAkismetSitelessCheckout?: boolean;
 
 	// Marketplace properties
 	is_marketplace_product?: boolean;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1201210512993648-as-1204136663449777

## Proposed Changes

* Add specific checkout flow for Akismet users who are not logged in. It allows users to complete the checkout process without a WordPress.com account

## Testing Instructions
* Follow the instructions in D105505-code
* Checkout this branch locally
* `yarn start`
* Go to http://calypso.localhost:3000/checkout/akismet/ak_plus_yearly_1 in a browser that doesn't have an account logged in (it can be the incognito mode)
* Add your email (e.g. your.email+test@gmail.com)
* Complete the purchase using a [test card](https://stripe.com/docs/testing#cards), and make sure you get the receipt and a welcome email

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?