### PR TITLE
Theme Showcase: Add event calypso_theme_sheet_global_styles_gating_modal_show

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -208,6 +208,11 @@ class ThemeSheet extends Component {
 	};
 
 	onUnlockStyleButtonClick = () => {
+		this.props.recordTracksEvent(
+			'calypso_theme_sheet_global_styles_gating_modal_show',
+			this.getPremiumGlobalStylesEventProps()
+		);
+
 		this.setState( { showUnlockStyleUpgradeModal: true } );
 	};
 


### PR DESCRIPTION
## Proposed Changes

This PR adds the Tracks event `calypso_theme_sheet_global_styles_gating_modal_show` that triggers when the user clicks on the "Unlock this style" button that shows up after selecting a non-default style variation in the Theme Detail page.

![Screenshot 2023-03-22 at 12 54 31 PM](https://user-images.githubusercontent.com/797888/226805650-dd19330b-cc23-4d50-b445-e286e7ddb482.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Detail page of a theme that has style variations.
* Select a non-default style variation and ensure that the Tracks event is triggered.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
