### PR TITLE
Site Assembler: Move the action bar on the large preview to the right side dynamically

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -6,6 +6,7 @@ import {
 	__experimentalNavigatorScreen as NavigatorScreen,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import classnames from 'classnames';
 import { useState, useRef, useMemo } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
@@ -51,6 +52,7 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
 	const incrementIndexRef = useRef( 0 );
 	const [ activePosition, setActivePosition ] = useState( -1 );
+	const [ isPatternPanelListOpen, setIsPatternPanelListOpen ] = useState( false );
 	const { goBack, goNext, submit } = navigation;
 	const { applyThemeWithPatterns } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
@@ -402,7 +404,13 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 	const onDeleteFooter = () => onSelect( 'footer', null );
 
 	const stepContent = (
-		<div className="pattern-assembler__wrapper" ref={ wrapperRef } tabIndex={ -1 }>
+		<div
+			className={ classnames( 'pattern-assembler__wrapper', {
+				'pattern-assembler__pattern-panel-list--is-open': isPatternPanelListOpen,
+			} ) }
+			ref={ wrapperRef }
+			tabIndex={ -1 }
+		>
 			<NavigatorProvider className="pattern-assembler__sidebar" initialPath="/">
 				<NavigatorScreen path="/">
 					<ScreenMain
@@ -450,6 +458,7 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 							selectedPattern={ sectionPosition !== null ? sections[ sectionPosition ] : null }
 							onSelect={ onSelect }
 							wrapperRef={ wrapperRef }
+							onTogglePatternPanelList={ setIsPatternPanelListOpen }
 						/>
 					) : (
 						<ScreenPatternList

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -36,7 +36,8 @@
 	.pattern-action-bar {
 		position: absolute;
 		top: 16px;
-		right: 16px;
+		left: 16px;
+		right: unset;
 		padding: 6px;
 		border: 1px solid #1e1e1e;
 		border-radius: 2px;
@@ -59,6 +60,11 @@
 				top: -6px;
 				bottom: -6px;
 			}
+		}
+
+		.pattern-assembler__pattern-panel-list--is-open & {
+			left: unset;
+			right: 16px;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -36,8 +36,7 @@
 	.pattern-action-bar {
 		position: absolute;
 		top: 16px;
-		left: 16px;
-		right: unset;
+		right: 16px;
 		padding: 6px;
 		border: 1px solid #1e1e1e;
 		border-radius: 2px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -23,6 +23,7 @@ interface Props {
 	replacePatternMode: boolean;
 	selectedPattern: Pattern | null;
 	wrapperRef: React.RefObject< HTMLDivElement > | null;
+	onTogglePatternPanelList?: ( isOpen: boolean ) => void;
 }
 
 const ScreenCategoryList = ( {
@@ -33,6 +34,7 @@ const ScreenCategoryList = ( {
 	onSelect,
 	selectedPattern,
 	wrapperRef,
+	onTogglePatternPanelList,
 }: Props ) => {
 	const translate = useTranslate();
 	const [ selectedCategory, setSelectedCategory ] = useState< string | null >( null );
@@ -44,6 +46,7 @@ const ScreenCategoryList = ( {
 		const target = event.target as HTMLElement;
 		if ( ! target.closest( '.pattern-action-bar' ) && target.closest( '.pattern-large-preview' ) ) {
 			setSelectedCategory( null );
+			onTogglePatternPanelList?.( false );
 		}
 	};
 
@@ -87,8 +90,10 @@ const ScreenCategoryList = ( {
 							onClick={ () => {
 								if ( isOpen ) {
 									setSelectedCategory( null );
+									onTogglePatternPanelList?.( false );
 								} else {
 									setSelectedCategory( name );
+									onTogglePatternPanelList?.( true );
 								}
 							} }
 						>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -57,6 +57,13 @@ const ScreenCategoryList = ( {
 		};
 	}, [] );
 
+	useEffect( () => {
+		// Notify the pattern panel list is going to close when umount
+		return () => {
+			onTogglePatternPanelList?.( false );
+		};
+	}, [] );
+
 	return (
 		<div className="screen-container">
 			<NavigatorHeader

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -40,8 +40,9 @@ const ScreenCategoryList = ( {
 	const categoriesInOrder = useCategoriesOrder( categories );
 
 	const handleFocusOutside = ( event: Event ) => {
-		// Click on large preview to close Pattern List
-		if ( ( event.target as HTMLElement ).closest( '.pattern-large-preview' ) ) {
+		// Click on large preview but not action bar to close Pattern List
+		const target = event.target as HTMLElement;
+		if ( ! target.closest( '.pattern-action-bar' ) && target.closest( '.pattern-large-preview' ) ) {
 			setSelectedCategory( null );
 		}
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1679458833830069-slack-CRWCHQGUB

## Proposed Changes

* Adjust the position of the action bar on the large preview to the right-hand side

https://user-images.githubusercontent.com/13596067/226812652-4eb2037a-9d81-4b68-90e0-b1608f4314ae.mov

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/color-and-fonts`
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Select any header, footer, homepage
  * Verify the action bar on the large preview is at right-hand side

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?