### PR TITLE
Site Assembler - Restyling menu items in the category list screen for consistency with the main screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/style.scss
@@ -3,12 +3,13 @@
 .pattern-assembler {
 	.navigator-button {
 		height: 44px;
-		line-height: 44px;
-		padding: 0;
+		padding: 10px 8px;
 		font-size: $font-body-small;
 		font-weight: 400;
 		letter-spacing: -0.15px;
 		color: var(--studio-gray-100);
+		border: none;
+		background: transparent;
 
 		svg {
 			flex-shrink: 0;
@@ -16,12 +17,17 @@
 		}
 
 		&:hover,
-		&:focus {
+		&:focus-visible {
 			color: var(--studio-blue-50);
 		}
 
 		&:focus {
-			border-color: transparent;
+			box-shadow: none;
+		}
+
+		&:focus-visible {
+			border-color: var(--color-primary);
+			box-shadow: 0 0 0 2px var(--color-primary-light);
 		}
 
 		&:active {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.scss
@@ -1,35 +1,16 @@
 @import "@automattic/components/src/styles/typography";
 
-.screen-category-list__category-button {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	/* stylelint-disable-next-line scales/radii */
-	border-radius: 3px;
-	padding: 10px 8px;
-	height: 44px;
-	font-family: $font-sf-pro-text;
-	color: var(--studio-gray-80);
-	font-weight: 400;
-	line-height: 20px;
-	letter-spacing: -0.15px;
-	border: none;
-	margin-bottom: 2px;
-	background: transparent;
+.navigator-button {
+	&.screen-category-list__category-button {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 3px;
 
-	svg {
-		fill: var(--studio-gray-30);
-	}
-
-	&.screen-category-list__category-button--is-open,
-	&:hover,
-	&:focus {
-		background-color: #f6f6f6;
-		color: var(--wp-admin-theme-color);
-
-		svg {
-			fill: var(--wp-admin-theme-color);
+		&.screen-category-list__category-button--is-open {
+			background-color: var(--studio-blue-0);
+			color: var(--studio-blue-50);
 		}
 	}
-
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -79,7 +79,7 @@ const ScreenCategoryList = ( {
 					return (
 						<Button
 							key={ name }
-							className={ classNames( 'screen-category-list__category-button', {
+							className={ classNames( 'screen-category-list__category-button navigator-button', {
 								'screen-category-list__category-button--is-open': isOpen,
 							} ) }
 							title={ description }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -67,7 +67,7 @@ const ScreenCategoryList = ( {
 						  )
 				}
 			/>
-			<div className="screen-container__body screen-category-list__body">
+			<div className="screen-container__body screen-container__body--align-sides screen-category-list__body">
 				{ categoriesInOrder.map( ( { name, label, description } ) => {
 					const isOpen = selectedCategory === name;
 					const hasPatterns = sectionsMapByCategory[ name ]?.length;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -24,7 +24,7 @@ const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Pr
 				) }
 				hideBack
 			/>
-			<div className="screen-container__body screen-container__body--no-padding">
+			<div className="screen-container__body">
 				<ItemGroup>
 					<NavigationButtonAsItem
 						path="/header"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -24,7 +24,7 @@ const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Pr
 				) }
 				hideBack
 			/>
-			<div className="screen-container__body">
+			<div className="screen-container__body screen-container__body--align-sides">
 				<ItemGroup>
 					<NavigationButtonAsItem
 						path="/header"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -146,7 +146,7 @@ $font-family: "SF Pro Text", $sans;
 				justify-content: center;
 				width: 24px;
 				height: 24px;
-				padding: 6px;
+				padding: 5px 6px 6px;
 				border-radius: 2px;
 				box-sizing: border-box;
 				color: var(--studio-white);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -272,6 +272,15 @@ $font-family: "SF Pro Text", $sans;
 		padding: 0;
 	}
 
+	.screen-container__body--align-sides {
+		// Align the content of .navigator-button with the container sides
+		margin-left: -10px;
+		margin-right: -10px;
+
+		// Reduce the padding bottom of .navigator-header__description
+		margin-top: -8px;
+	}
+
 	.screen-container__footer {
 		padding: 2px;
 		margin-top: auto;
@@ -296,6 +305,7 @@ $font-family: "SF Pro Text", $sans;
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
+		overflow-x: visible;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74622 #74633 #74157

## Proposed Changes

* Restyling menu items in categories and main list for consistency
  * **Notes for reviewers:** 
    * The idea is to use the class `.navigator-button` for the shared styles and hover, focus, and active effects. 
    * The focus effect is also consistent with other areas. See #74633
* Fix menu items and container margins using negative margins
  * **Note for reviewers:** After trying different ways, I found this to be the simplest and most atomic change to avoid adding more classes and refactoring other screens
* Fix center of plus icon
  * **Note for reviewers:** This change is not related to this PR, but it's included because it is a very small CSS change

## BEFORE
### Main list

|Initial|Hover|Focus|Active|
|---|---|---|---|
|<img width="339" alt="Screenshot 2566-03-20 at 16 21 14" src="https://user-images.githubusercontent.com/1881481/226297723-bc8ae492-ed82-4343-9d1d-eb7cec55cd72.png">|<img width="334" alt="Screenshot 2566-03-20 at 16 21 27" src="https://user-images.githubusercontent.com/1881481/226297741-63b722a3-c5f6-4471-95a6-4873b438267c.png">|<img width="334" alt="Screenshot 2566-03-20 at 16 21 27" src="https://user-images.githubusercontent.com/1881481/226297741-63b722a3-c5f6-4471-95a6-4873b438267c.png">|<img width="338" alt="Screenshot 2566-03-20 at 16 22 34" src="https://user-images.githubusercontent.com/1881481/226297750-bffa5935-02d9-467e-9dfe-474ecf71d917.png">|

### Category list

|Initial|Hover|Focus|Active|
|---|---|---|---|
|<img width="353" alt="Screenshot 2566-03-22 at 13 53 18" src="https://user-images.githubusercontent.com/1881481/226825197-798f7961-896c-44c8-b17a-3e1d72efa914.png">|<img width="349" alt="Screenshot 2566-03-22 at 13 53 51" src="https://user-images.githubusercontent.com/1881481/226825190-637b65a3-dcf9-47b5-bef1-ca9cf19e41d0.png">|<img width="354" alt="Screenshot 2566-03-22 at 13 54 29" src="https://user-images.githubusercontent.com/1881481/226825176-92708a6e-3821-4b21-8c34-89d2303917b8.png">|<img width="348" alt="Screenshot 2566-03-22 at 13 55 25" src="https://user-images.githubusercontent.com/1881481/226825167-ec95706c-d17a-4ee8-8c23-0d161bb44787.png">|

## AFTER
### Main list

|Initial|Hover|Focus|Active|
|---|---|---|---|
|<img width="359" alt="Screenshot 2566-03-22 at 13 21 15" src="https://user-images.githubusercontent.com/1881481/226822897-a5e53e6a-c374-4c11-9e7b-fd98a6f527ef.png">|<img width="357" alt="Screenshot 2566-03-22 at 13 21 43" src="https://user-images.githubusercontent.com/1881481/226822891-985c51a5-f784-4870-800f-61f24a35e9c3.png">|<img width="358" alt="Screenshot 2566-03-22 at 13 22 09" src="https://user-images.githubusercontent.com/1881481/226822873-e6c9b5c0-e1d8-4bd8-9589-73345c228103.png">|<img width="350" alt="Screenshot 2566-03-22 at 12 58 27" src="https://user-images.githubusercontent.com/1881481/226822958-eb128e7b-781d-4361-8d0d-d912e409b73d.png">|

### Category list

|Initial|Hover|Focus|Active|
|---|---|---|---|
|<img width="356" alt="Screenshot 2566-03-22 at 13 22 46" src="https://user-images.githubusercontent.com/1881481/226825340-a58f875c-06bd-4252-a105-8551c27d7529.png">|<img width="356" alt="Screenshot 2566-03-22 at 13 23 37" src="https://user-images.githubusercontent.com/1881481/226825335-e6882075-0fd5-43ff-bbe7-a1b104a6dc9c.png">|<img width="354" alt="Screenshot 2566-03-22 at 13 26 13" src="https://user-images.githubusercontent.com/1881481/226825324-217d198c-3ce6-4d89-8439-cea700cbaeef.png">|<img width="350" alt="Screenshot 2566-03-22 at 13 24 44" src="https://user-images.githubusercontent.com/1881481/226825332-6f8b7867-a13b-48a0-b68f-b0c5d246d980.png">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Access the Assembler**
* Click on the `Calypso Live link` in the first comment
* Create a new site, continue until the Desing picker 
* Scroll and click `Start designing` from the bottom of the design picker

**Verify the styles and effects in the main list**
* Verify that the initial styles of the menu items in the sidebar match the Figma design
* Hover the menu items to verify the hover effect
* Click on an item to verify the active effect
* Press the tab key until the focus moves to an item to verify the focus effect

**Category list**
* Click on `Homepage > Add patterns` to see the list of categories
* Verify that the styles and effects are consistent with the main list


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
