### PR TITLE
My Home: Fix Fiverr card hide button and hide Promote post slide

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/fiverr/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/fiverr/index.jsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import fiverrIllustration from 'calypso/assets/images/customer-home/illustration--task-fiverr.svg';
 import { preventWidows } from 'calypso/lib/formatting';
-import { TASK_FIND_DOMAIN } from 'calypso/my-sites/customer-home/cards/constants';
+import { TASK_FIVERR } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 
 const Fiverr = () => {
@@ -18,7 +18,7 @@ const Fiverr = () => {
 			actionUrl="https://wp.me/logo-maker/?utm_campaign=my_home_task"
 			illustration={ fiverrIllustration }
 			timing={ 10 }
-			taskId={ TASK_FIND_DOMAIN }
+			taskId={ TASK_FIVERR }
 		/>
 	);
 };

--- a/client/my-sites/customer-home/cards/tasks/promote-post/index.js
+++ b/client/my-sites/customer-home/cards/tasks/promote-post/index.js
@@ -21,6 +21,8 @@ const PromotePost = () => {
 		dispatch( recordDSPEntryPoint( 'myhome_tasks-swipeable' ) );
 	};
 
+	PromotePost.isDisabled = ! showPromotePost;
+
 	useEffect( () => {
 		loadDSPWidgetJS();
 	}, [] );

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -128,6 +128,7 @@ const Primary = ( { cards, trackCard } ) => {
 			{ cards.map(
 				( card, index ) =>
 					cardComponents[ card ] &&
+					! cardComponents[ card ].isDisabled &&
 					createElement( cardComponents[ card ], {
 						key: card + index,
 						isIos: card === 'home-task-go-mobile-ios' ? true : null,

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -28,10 +28,10 @@ const Secondary = ( { cards, siteId } ) => {
 	return (
 		<>
 			{ cards.map(
-				( card ) =>
+				( card, index ) =>
 					cardComponents[ card ] &&
 					createElement( cardComponents[ card ], {
-						key: card,
+						key: card + index,
 						...( card === SECTION_BLOGGING_PROMPT
 							? { siteId: siteId, showMenu: true, viewContext: 'home' }
 							: {} ),


### PR DESCRIPTION
Fix the hide button for Fiverr card in My Home and hide the Promote Post slide when the Promote Post card is hidden.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73688

## Proposed Changes

* Fix the Fiverr card button
* Hide the Promote Post slide when the card is hidden

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link and go to My home on a Free Site
* Try to dismiss the `Fiverr` card - now it should work
* Notice the `Promote Post` is now hidden and there's no longer an empty slide in the slideshow (if you have a non-en locale)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
