### PR TITLE
Fix author mapping screen show twice

### DIFF
--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -36,8 +36,18 @@ class ImporterAuthorMapping extends PureComponent {
 	};
 
 	componentDidMount() {
+		this.setAuthor();
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( ! prevProps.users.length && this.props.users.length ) {
+			this.setAuthor();
+		}
+	}
+
+	setAuthor = () => {
 		const { hasSingleAuthor, onSelect: selectAuthor, users } = this.props;
-		if ( hasSingleAuthor ) {
+		if ( hasSingleAuthor && users.length ) {
 			/**
 			 * Using `defer` here is a leftover from using Flux store in the past.
 			 *
@@ -52,7 +62,7 @@ class ImporterAuthorMapping extends PureComponent {
 			 */
 			defer( () => selectAuthor( users[ 0 ] ) );
 		}
-	}
+	};
 
 	render() {
 		const {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/dotcom-forge#1888

## Proposed Changes

When we use import functionality sometimes we'll see the author mapping screen twice. To get a better understanding of this issue you can check out the related issue above. The reason behind this is when we use `withUserQuery` the users prop might not be fetched when the component is mounted. This only happens when we only have a single author, if this happens, users aren't mapped before we click the import button, that's the reason API returns with Bad authors error. 

This PR makes sure that when we only have a single author, we'll wait until users data are fetched and then run the selectAuthor function.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use any site with a single author only
* Navigate to `http://calypso.localhost:3000/import/${site_slug}`
* Click WordPress and import WXR
* Make sure the author mapping screen didn't show twice and can import correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
