### PR TITLE
Subscription Management settings page: Get the current values from the API

### DIFF
--- a/client/my-sites/subscriptions/index.tsx
+++ b/client/my-sites/subscriptions/index.tsx
@@ -10,11 +10,11 @@ import { makeLayout, render } from 'calypso/controller';
 
 const SitesView = () => <span>Sites View</span>;
 const CommentsView = () => <span>Comments View</span>;
-const SettingsView = () => <SubscriptionManager.UserSettings />;
 
 const SubscriptionManagementPage = () => {
 	const translate = useTranslate();
 	const { data: counts } = Reader.useSubscriptionManagerSubscriptionsCountQuery();
+	const { data: settings } = Reader.useSubscriptionManagerUserSettingsQuery();
 	const locale = useLocale();
 
 	return (
@@ -39,7 +39,7 @@ const SubscriptionManagementPage = () => {
 						{
 							label: translate( 'Settings' ),
 							path: 'settings',
-							view: SettingsView,
+							view: () => <SubscriptionManager.UserSettings value={ settings } />,
 						},
 					] }
 				/>

--- a/client/my-sites/subscriptions/index.tsx
+++ b/client/my-sites/subscriptions/index.tsx
@@ -14,10 +14,12 @@ const CommentsView = () => <span>Comments View</span>;
 const SubscriptionManagementPage = () => {
 	const translate = useTranslate();
 	const { data: counts } = Reader.useSubscriptionManagerSubscriptionsCountQuery();
-	const { data: settings } = Reader.useSubscriptionManagerUserSettingsQuery();
 	const locale = useLocale();
 
-	const SettingsView = () => <SubscriptionManager.UserSettings value={ settings } />;
+	const SettingsView = () => {
+		const { data: settings } = Reader.useSubscriptionManagerUserSettingsQuery();
+		return <SubscriptionManager.UserSettings value={ settings } />;
+	};
 
 	return (
 		<MomentProvider currentLocale={ locale }>

--- a/client/my-sites/subscriptions/index.tsx
+++ b/client/my-sites/subscriptions/index.tsx
@@ -17,6 +17,8 @@ const SubscriptionManagementPage = () => {
 	const { data: settings } = Reader.useSubscriptionManagerUserSettingsQuery();
 	const locale = useLocale();
 
+	const SettingsView = () => <SubscriptionManager.UserSettings value={ settings } />;
+
 	return (
 		<MomentProvider currentLocale={ locale }>
 			<SubscriptionManager>
@@ -39,7 +41,7 @@ const SubscriptionManagementPage = () => {
 						{
 							label: translate( 'Settings' ),
 							path: 'settings',
-							view: () => <SubscriptionManager.UserSettings value={ settings } />,
+							view: SettingsView,
 						},
 					] }
 				/>

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -1,9 +1,12 @@
 export type EmailFormatType = 'html' | 'text';
 
+export type DeliveryWindowDayType = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+export type DeliveryWindowHourType = 0 | 2 | 4 | 6 | 8 | 10 | 12 | 14 | 16 | 18 | 20 | 22;
+
 export type SubscriptionManagerUserSettings = Partial< {
 	mail_option: EmailFormatType;
-	delivery_day: number; // 0-6, 0 is Sunday
-	delivery_hour: number; // 0-23, 0 is midnight
+	delivery_day: DeliveryWindowDayType; // 0-6, 0 is Sunday
+	delivery_hour: DeliveryWindowHourType; // 0-23, 0 is midnight
 	blocked: boolean;
 	email: string;
 } >;

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -5,8 +5,8 @@ export type DeliveryWindowHourType = 0 | 2 | 4 | 6 | 8 | 10 | 12 | 14 | 16 | 18 
 
 export type SubscriptionManagerUserSettings = Partial< {
 	mail_option: EmailFormatType;
-	delivery_day: DeliveryWindowDayType; // 0-6, 0 is Sunday
-	delivery_hour: DeliveryWindowHourType; // 0-23, 0 is midnight
+	delivery_day: DeliveryWindowDayType;
+	delivery_hour: DeliveryWindowHourType;
 	blocked: boolean;
 	email: string;
 } >;

--- a/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
+++ b/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
@@ -1,11 +1,11 @@
 import { FormEvent } from 'react';
 import { BlockEmailsSetting } from '../fields/BlockEmailsSetting';
-import {
-	DeliveryWindowInput,
+import { DeliveryWindowInput } from '../fields/DeliveryWindowInput';
+import { EmailFormatInput, EmailFormatType } from '../fields/EmailFormatInput';
+import type {
 	DeliveryWindowDayType,
 	DeliveryWindowHourType,
-} from '../fields/DeliveryWindowInput';
-import { EmailFormatInput, EmailFormatType } from '../fields/EmailFormatInput';
+} from '@automattic/data-stores/src/reader/types';
 
 type SubscriptionUserSettings = Partial< {
 	mail_option: EmailFormatType;

--- a/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
+++ b/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
@@ -43,7 +43,7 @@ const UserSettings = ( { value = {}, loading = false, onChange }: UserSettingsPr
 			}
 		/>
 		<BlockEmailsSetting
-			value={ value.blocked }
+			value={ value.blocked ?? false }
 			onChange={ ( value ) => onChange?.( { blocked: !! value.target.value } ) }
 		/>
 	</div>

--- a/packages/subscription-manager/src/components/fields/DeliveryWindowInput/DeliveryWindowInput.tsx
+++ b/packages/subscription-manager/src/components/fields/DeliveryWindowInput/DeliveryWindowInput.tsx
@@ -6,9 +6,10 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import './styles.scss';
-
-export type DeliveryWindowDayType = 0 | 1 | 2 | 3 | 4 | 5 | 6;
-export type DeliveryWindowHourType = 0 | 2 | 4 | 6 | 8 | 10 | 12 | 14 | 16 | 18 | 20 | 22;
+import type {
+	DeliveryWindowDayType,
+	DeliveryWindowHourType,
+} from '@automattic/data-stores/src/reader/types';
 
 type DeliveryWindowInputProps = {
 	dayValue: DeliveryWindowDayType;

--- a/packages/subscription-manager/src/components/fields/DeliveryWindowInput/index.ts
+++ b/packages/subscription-manager/src/components/fields/DeliveryWindowInput/index.ts
@@ -1,2 +1,1 @@
 export { default as DeliveryWindowInput } from './DeliveryWindowInput';
-export type { DeliveryWindowDayType, DeliveryWindowHourType } from './DeliveryWindowInput';


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/74764.

The goal of this PR is to make sure the Settings form fields get the current values from the API:

![Markup on 2023-03-22 at 15:24:14](https://user-images.githubusercontent.com/25105483/226934615-1f94cdc3-04aa-482c-97b4-79e7fa1deb3e.png)

## Proposed Changes

* provide current value to all Settings view form fields from the API (via `useSubscriptionManagerUserSettingsQuery()` callback)
* move `DeliveryWindowDayType` and `DeliveryWindowHourType` types definition to `packages/data-stores/src/reader/types/index.ts`
* provide default `false` value for the `BlockEmailsSetting` component (this was necessary because of "A component is changing an uncontrolled input to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen." warning)

## Testing Instructions

1. Check out the branch of this PR.
2. Navigate to https://wordpress.com/me/notifications/subscriptions and adjust the settings the way you like.
3. Open http://calypso.localhost:3000/subscriptions/settings. The changes you saved on the previous step should be reflected on the new Settings view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
