### PR TITLE
Jetpack Pro Dashboard: reduce the width of a few columns and set the loading column width

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -66,7 +66,7 @@ const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableEle
 				{ isLoading ? (
 					<tr>
 						{ columns.map( ( column ) => (
-							<td key={ column.key }>
+							<td className="site-table__tr-loading" key={ column.key }>
 								<TextPlaceholder />
 							</td>
 						) ) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
@@ -83,3 +83,7 @@
 .site-table-site-title {
 	margin-inline-start: 32px;
 }
+
+.site-table__tr-loading {
+	width: 200px !important;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -432,3 +432,7 @@
 	@extend .sites-overview__column-content;
 	color: var(--studio-red-50);
 }
+
+.width-fit-content {
+	width: fit-content !important;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -28,11 +28,13 @@ const extraColumns: SiteColumns = isExpandedBlockEnabled
 			{
 				key: 'stats',
 				title: translate( 'Stats' ),
+				className: 'width-fit-content',
 				isExpandable: true,
 			},
 			{
 				key: 'boost',
 				title: translate( 'Boost' ),
+				className: 'width-fit-content',
 				isExpandable: true,
 			},
 	  ]
@@ -47,11 +49,13 @@ export const siteColumns: SiteColumns = [
 	{
 		key: 'backup',
 		title: translate( 'Backup' ),
+		className: 'width-fit-content',
 		isExpandable: isExpandedBlockEnabled,
 	},
 	{
 		key: 'scan',
 		title: translate( 'Scan' ),
+		className: 'width-fit-content',
 	},
 	{
 		key: 'monitor',
@@ -62,6 +66,7 @@ export const siteColumns: SiteColumns = [
 	{
 		key: 'plugin',
 		title: translate( 'Plugins' ),
+		className: 'width-fit-content',
 	},
 ];
 


### PR DESCRIPTION
Related to 1203940061556608-as-1204236986027324

## Proposed Changes

The PR makes the following changes 
- Set width as `fit-content` to a few columns so that it takes only the required content.
- Set the loading column width to `200px` so that it doesn't break when the screen width is less.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/set-width-to-smaller-columns` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify the width set to columns looks good
4. Switch to 1281px screen width, search for an item so that the loading is shown, and verify that it doesn't break

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1366" alt="Screenshot 2023-03-22 at 5 30 05 PM" src="https://user-images.githubusercontent.com/10586875/226904888-8a4a59b6-704d-4be2-9ee9-50a78b98bbcb.png">
</td>
<td>
<img width="1366" alt="Screenshot 2023-03-22 at 5 30 23 PM" src="https://user-images.githubusercontent.com/10586875/226904912-10aa294d-82e8-4fe9-87d8-9575d31c6056.png">
</td>
</tr>

<tr>
<td>
<img width="988" alt="Screenshot 2023-03-22 at 6 00 23 PM" src="https://user-images.githubusercontent.com/10586875/226905597-741c7c7e-2832-4512-8b8c-de1d168f2195.png">
</td>
<td>
<img width="988" alt="Screenshot 2023-03-22 at 5 59 58 PM" src="https://user-images.githubusercontent.com/10586875/226905585-00f6faa8-473f-4c3e-a02b-68ea95ad5692.png">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?