### PR TITLE
Themes: adds marketplace (paid) filter.

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -924,11 +924,7 @@ class ThemeSheet extends Component {
 			<Button
 				className="theme__sheet-primary-button"
 				href={
-					getUrl &&
-					( key === 'customize' ||
-						! isExternallyManagedTheme ||
-						! isLoggedIn ||
-						! config.isEnabled( 'themes/third-party-premium' ) )
+					getUrl && ( key === 'customize' || ! isExternallyManagedTheme || ! isLoggedIn )
 						? this.appendSelectedStyleVariationToUrl( getUrl( this.props.themeId ) )
 						: null
 				}

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -20,10 +20,10 @@ export default function ( router ) {
 	const langParam = getLanguageRouteParam();
 
 	const showcaseRoutes = [
-		`/${ langParam }/themes/:tier(free|premium)?`,
-		`/${ langParam }/themes/:tier(free|premium)?/filter/:filter`,
-		`/${ langParam }/themes/:vertical?/:tier(free|premium)?`,
-		`/${ langParam }/themes/:vertical?/:tier(free|premium)?/filter/:filter`,
+		`/${ langParam }/themes/:tier(free|premium|marketplace)?`,
+		`/${ langParam }/themes/:tier(free|premium|marketplace)?/filter/:filter`,
+		`/${ langParam }/themes/:vertical?/:tier(free|premium|marketplace)?`,
+		`/${ langParam }/themes/:vertical?/:tier(free|premium|marketplace)?/filter/:filter`,
 	];
 	router(
 		showcaseRoutes,
@@ -42,13 +42,16 @@ export default function ( router ) {
 	router(
 		[
 			'/themes/:site?/search/:search',
-			'/themes/:site?/type/:tier(free|premium)',
-			'/themes/:site?/search/:search/type/:tier(free|premium)',
+			'/themes/:site?/type/:tier(free|premium|marketplace)',
+			'/themes/:site?/search/:search/type/:tier(free|premium|marketplace)',
 		],
 		redirectSearchAndType
 	);
 	router(
-		[ '/themes/:site?/filter/:filter', '/themes/:site?/filter/:filter/type/:tier(free|premium)' ],
+		[
+			'/themes/:site?/filter/:filter',
+			'/themes/:site?/filter/:filter/type/:tier(free|premium|marketplace)',
+		],
 		redirectFilterAndType
 	);
 	router(

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -24,16 +24,16 @@ export default function ( router ) {
 
 	const langParam = getLanguageRouteParam();
 	const routesWithoutSites = [
-		`/${ langParam }/themes/:tier(free|premium)?`,
-		`/${ langParam }/themes/:tier(free|premium)?/filter/:filter`,
-		`/${ langParam }/themes/:vertical?/:tier(free|premium)?`,
-		`/${ langParam }/themes/:vertical?/:tier(free|premium)?/filter/:filter`,
+		`/${ langParam }/themes/:tier(free|premium|marketplace)?`,
+		`/${ langParam }/themes/:tier(free|premium|marketplace)?/filter/:filter`,
+		`/${ langParam }/themes/:vertical?/:tier(free|premium|marketplace)?`,
+		`/${ langParam }/themes/:vertical?/:tier(free|premium|marketplace)?/filter/:filter`,
 	];
 	const routesWithSites = [
-		`/${ langParam }/themes/:tier(free|premium)?/:site_id(${ siteId })`,
-		`/${ langParam }/themes/:tier(free|premium)?/filter/:filter/:site_id(${ siteId })`,
-		`/${ langParam }/themes/:vertical?/:tier(free|premium)?/:site_id(${ siteId })`,
-		`/${ langParam }/themes/:vertical?/:tier(free|premium)?/filter/:filter/:site_id(${ siteId })`,
+		`/${ langParam }/themes/:tier(free|premium|marketplace)?/:site_id(${ siteId })`,
+		`/${ langParam }/themes/:tier(free|premium|marketplace)?/filter/:filter/:site_id(${ siteId })`,
+		`/${ langParam }/themes/:vertical?/:tier(free|premium|marketplace)?/:site_id(${ siteId })`,
+		`/${ langParam }/themes/:vertical?/:tier(free|premium|marketplace)?/filter/:filter/:site_id(${ siteId })`,
 	];
 
 	// Upload routes are valid only when logged in. In logged-out sessions they redirect to login page.

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -177,6 +177,7 @@ class ThemeShowcase extends Component {
 			{ value: 'all', label: this.props.translate( 'All' ) },
 			{ value: 'free', label: this.props.translate( 'Free' ) },
 			{ value: 'premium', label: this.props.translate( 'Premium' ) },
+			{ value: 'marketplace', label: this.props.translate( 'Paid' ) },
 		];
 	};
 

--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { map, property } from 'lodash';
 import wpcom from 'calypso/lib/wp';
 import { fetchThemesList as fetchWporgThemesList } from 'calypso/lib/wporg';

--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -54,9 +54,6 @@ export function requestThemes( siteId, query = {}, locale ) {
 							// https://github.com/Automattic/wp-calypso/issues/71911#issuecomment-1381284172
 							// User can be redirected to PatternAssembler flow using the PatternAssemblerCTA on theme-list
 							include_blankcanvas_theme: null,
-							include_marketplace_themes: config.isEnabled( 'themes/third-party-premium' )
-								? 'true'
-								: null,
 						},
 						locale ? { locale } : null
 					)

--- a/client/state/themes/selectors/is-externally-managed-theme.tsx
+++ b/client/state/themes/selectors/is-externally-managed-theme.tsx
@@ -34,5 +34,5 @@ export function isExternallyManagedTheme( state = {}, themeId: string ): boolean
 	}
 
 	const themeType: ThemeTypes = theme.theme_type;
-	return isEnabled( 'themes/third-party-premium' ) && themeType === 'managed-external';
+	return themeType === 'managed-external';
 }

--- a/client/state/themes/selectors/is-externally-managed-theme.tsx
+++ b/client/state/themes/selectors/is-externally-managed-theme.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
 
 import 'calypso/state/themes/init';

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -65,7 +65,7 @@ import { themesUpdated } from '../actions/theme-update';
 jest.mock( '@automattic/calypso-config', () => {
 	const mock = () => 'development';
 	mock.isEnabled = jest.fn( ( flag ) => {
-		const allowedFlags = [ 'themes/third-party-premium' ];
+		const allowedFlags = [];
 		if ( allowedFlags.includes( flag ) ) {
 			return true;
 		}
@@ -198,10 +198,7 @@ describe( 'actions', () => {
 					'/rest/v1.2/themes' +
 					( config.isEnabled( 'pattern-assembler/logged-out-showcase' )
 						? '?include_blankcanvas_theme=true'
-						: '?include_blankcanvas_theme=' ) +
-					( config.isEnabled( 'themes/third-party-premium' )
-						? '&include_marketplace_themes=true'
-						: '&include_marketplace_themes=' );
+						: '?include_blankcanvas_theme=' );
 				nockScope = nock( 'https://public-api.wordpress.com:443' )
 					.get( url )
 					.reply( 200, {

--- a/config/development.json
+++ b/config/development.json
@@ -187,7 +187,6 @@
 		"themes/showcase-i4/details-and-preview": true,
 		"themes/subscription-purchases": true,
 		"themes/theme-switch-persist-template": false,
-		"themes/third-party-premium": true,
 		"titan/iframe-control-panel": false,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -133,7 +133,6 @@
 		"themes/showcase-i4/details-and-preview": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
-		"themes/third-party-premium": true,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -154,7 +154,6 @@
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
-		"themes/third-party-premium": true,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -150,7 +150,6 @@
 		"themes/showcase-i4/details-and-preview": false,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
-		"themes/third-party-premium": true,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -160,7 +160,6 @@
 		"themes/showcase-i4/details-and-preview": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
-		"themes/third-party-premium": true,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1679438478958509-slack-C048CUFRGFQ

## Proposed Changes

* Adds a `Paid` Themes filter
* Make sure you apply this patch first D105562-code

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

|Before | After|
|-------|------|
|![CleanShot 2023-03-22 at 14 52 32@2x](https://user-images.githubusercontent.com/12430020/226910245-2b7f85ee-33d0-4208-b2a7-f1622647177b.png)|![CleanShot 2023-03-22 at 14 52 56@2x](https://user-images.githubusercontent.com/12430020/226910309-1717f23b-0b18-4bda-9a84-92c84446d1f7.png)|

## Scenarios
- Logged out
- Logged in

1. Visit https://wordpress.com/themes
2. Make sure that filters work as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?