### PR TITLE
Upgrade wp-prettier to version 2.8.5

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1135,6 +1135,8 @@ class SignupForm extends Component {
 
 		if ( this.props.isPasswordless && 'wpcc' !== this.props.flowName ) {
 			const logInUrl = this.getLoginLink();
+			const showSeparator =
+				! config.isEnabled( 'desktop' ) && this.isHorizontal() && ! this.userCreationComplete();
 
 			return (
 				<div
@@ -1155,13 +1157,11 @@ class SignupForm extends Component {
 						queryArgs={ this.props.queryArgs }
 					/>
 
-					{ ! config.isEnabled( 'desktop' ) &&
-						this.isHorizontal() &&
-						! this.userCreationComplete() && (
-							<div className="signup-form__separator">
-								<div className="signup-form__separator-text">{ this.props.translate( 'or' ) }</div>
-							</div>
-						) }
+					{ showSeparator && (
+						<div className="signup-form__separator">
+							<div className="signup-form__separator-text">{ this.props.translate( 'or' ) }</div>
+						</div>
+					) }
 
 					{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
 						<SocialSignupForm

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1193,11 +1193,13 @@ class SignupForm extends Component {
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>
 
-				{ ! config.isEnabled( 'desktop' ) && this.isHorizontal() && ! this.userCreationComplete() && (
-					<div className="signup-form__separator">
-						<div className="signup-form__separator-text">{ this.props.translate( 'or' ) }</div>
-					</div>
-				) }
+				{ ! config.isEnabled( 'desktop' ) &&
+					this.isHorizontal() &&
+					! this.userCreationComplete() && (
+						<div className="signup-form__separator">
+							<div className="signup-form__separator-text">{ this.props.translate( 'or' ) }</div>
+						</div>
+					) }
 
 				{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
 					<Fragment>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1133,10 +1133,11 @@ class SignupForm extends Component {
 			);
 		}
 
+		const showSeparator =
+			! config.isEnabled( 'desktop' ) && this.isHorizontal() && ! this.userCreationComplete();
+
 		if ( this.props.isPasswordless && 'wpcc' !== this.props.flowName ) {
 			const logInUrl = this.getLoginLink();
-			const showSeparator =
-				! config.isEnabled( 'desktop' ) && this.isHorizontal() && ! this.userCreationComplete();
 
 			return (
 				<div
@@ -1193,13 +1194,11 @@ class SignupForm extends Component {
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>
 
-				{ ! config.isEnabled( 'desktop' ) &&
-					this.isHorizontal() &&
-					! this.userCreationComplete() && (
-						<div className="signup-form__separator">
-							<div className="signup-form__separator-text">{ this.props.translate( 'or' ) }</div>
-						</div>
-					) }
+				{ showSeparator && (
+					<div className="signup-form__separator">
+						<div className="signup-form__separator-text">{ this.props.translate( 'or' ) }</div>
+					</div>
+				) }
 
 				{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
 					<Fragment>

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -46,7 +46,7 @@ interface BlockingHoldNoticeProps {
 }
 
 // This gets the values of the object transferStates.
-export type TransferStatus = typeof transferStates[ keyof typeof transferStates ];
+export type TransferStatus = ( typeof transferStates )[ keyof typeof transferStates ];
 
 interface TransferFailureNoticeProps {
 	transferStatus: TransferStatus | null;

--- a/client/data/site-checklist/use-request-site-checklist-task-update.ts
+++ b/client/data/site-checklist/use-request-site-checklist-task-update.ts
@@ -12,7 +12,7 @@ import useSiteChecklistTask from './use-site-checklist-task';
  */
 const useRequestSiteChecklistTaskUpdate = (
 	siteId: string,
-	taskId: typeof CHECKLIST_KNOWN_TASKS[ keyof typeof CHECKLIST_KNOWN_TASKS ]
+	taskId: ( typeof CHECKLIST_KNOWN_TASKS )[ keyof typeof CHECKLIST_KNOWN_TASKS ]
 ): void => {
 	const dispatch = useDispatch();
 	const task = useSiteChecklistTask( siteId, taskId );

--- a/client/data/site-checklist/use-site-checklist-task.ts
+++ b/client/data/site-checklist/use-site-checklist-task.ts
@@ -11,7 +11,7 @@ import useSiteChecklist from './use-site-checklist';
  */
 const useSiteChecklistTask = (
 	siteId: string,
-	taskId: typeof CHECKLIST_KNOWN_TASKS[ keyof typeof CHECKLIST_KNOWN_TASKS ]
+	taskId: ( typeof CHECKLIST_KNOWN_TASKS )[ keyof typeof CHECKLIST_KNOWN_TASKS ]
 ): Task | undefined => {
 	const siteChecklist = useSiteChecklist( siteId );
 	const task = useMemo(

--- a/client/data/sites/site-excerpt-types.ts
+++ b/client/data/sites/site-excerpt-types.ts
@@ -7,15 +7,16 @@ import type { SiteDetails, SiteDetailsOptions } from '@automattic/data-stores';
 
 export type SiteExcerptNetworkData = Pick<
 	SiteDetails,
-	typeof SITE_EXCERPT_REQUEST_FIELDS[ number ]
+	( typeof SITE_EXCERPT_REQUEST_FIELDS )[ number ]
 > & {
-	options?: Pick< SiteDetailsOptions, typeof SITE_EXCERPT_REQUEST_OPTIONS[ number ] >;
+	options?: Pick< SiteDetailsOptions, ( typeof SITE_EXCERPT_REQUEST_OPTIONS )[ number ] >;
 };
 
 export type SiteExcerptData = Pick<
 	SiteDetails,
-	typeof SITE_EXCERPT_REQUEST_FIELDS[ number ] | typeof SITE_EXCERPT_COMPUTED_FIELDS[ number ]
+	| ( typeof SITE_EXCERPT_REQUEST_FIELDS )[ number ]
+	| ( typeof SITE_EXCERPT_COMPUTED_FIELDS )[ number ]
 > & {
 	title: string;
-	options?: Pick< SiteDetailsOptions, typeof SITE_EXCERPT_REQUEST_OPTIONS[ number ] >;
+	options?: Pick< SiteDetailsOptions, ( typeof SITE_EXCERPT_REQUEST_OPTIONS )[ number ] >;
 };

--- a/client/jetpack-cloud/sections/comparison/table/index.tsx
+++ b/client/jetpack-cloud/sections/comparison/table/index.tsx
@@ -43,7 +43,7 @@ export const Table: React.FC = () => {
 
 				const item = (
 					isFree ? { productSlug: PLAN_JETPACK_FREE } : slugToSelectorProduct( productSlug )
-				 ) as SelectorProduct;
+				) as SelectorProduct;
 
 				return (
 					<th key={ id } scope="col" className={ `product product-jetpack-${ id.toLowerCase() }` }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/preview-toolbar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/preview-toolbar.tsx
@@ -9,7 +9,7 @@ import './preview-toolbar.scss';
 
 const possibleDevices = [ 'computer', 'tablet', 'phone' ] as const;
 
-type Device = typeof possibleDevices[ number ];
+type Device = ( typeof possibleDevices )[ number ];
 
 type PreviewToolbarProps = {
 	// The device to display, used for setting preview dimensions

--- a/client/lib/a11y/types.ts
+++ b/client/lib/a11y/types.ts
@@ -1,11 +1,11 @@
 import type { ARIA_STATES, ARIA_PROPERTIES } from './constants';
 
-export type RawAriaState = typeof ARIA_STATES[ number ];
+export type RawAriaState = ( typeof ARIA_STATES )[ number ];
 export type RawAriaStates = Record< RawAriaState, boolean >;
 export type AriaState = `aria-${ RawAriaState }`;
 export type AriaStates = Record< AriaState, boolean >;
 
-export type RawAriaProperty = typeof ARIA_PROPERTIES[ number ];
+export type RawAriaProperty = ( typeof ARIA_PROPERTIES )[ number ];
 export type RawAriaProperties = Record< RawAriaProperty, string >;
 export type AriaProperty = `aria-${ RawAriaProperty }`;
 export type AriaProperties = Record< AriaProperty, string >;

--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -33,7 +33,7 @@ const allAdTrackers = [
 	'adroll',
 ] as const;
 
-type AdTracker = typeof allAdTrackers[ number ];
+type AdTracker = ( typeof allAdTrackers )[ number ];
 
 export enum Bucket {
 	ESSENTIAL = 'essential',

--- a/client/lib/sentry/index.ts
+++ b/client/lib/sentry/index.ts
@@ -27,7 +27,7 @@ type SupportedMethods =
 	| 'withScope';
 interface QueueDataMethod< Method extends SupportedMethods > {
 	f: Method;
-	a: Parameters< typeof SentryApi[ Method ] >;
+	a: Parameters< ( typeof SentryApi )[ Method ] >;
 }
 
 let callQueue: Array< Readonly< QueueDataMethod< SupportedMethods > > > = [];
@@ -54,7 +54,7 @@ let state: SentryState = { state: 'initial' };
 
 function dispatchSentryMethodCall< Method extends SupportedMethods >(
 	method: Method,
-	args: Parameters< typeof SentryApi[ Method ] >
+	args: Parameters< ( typeof SentryApi )[ Method ] >
 ) {
 	const { state: status } = state;
 	if ( status === 'loaded' ) {

--- a/client/me/security-ssh-key/use-ssh-key-query.ts
+++ b/client/me/security-ssh-key/use-ssh-key-query.ts
@@ -17,7 +17,7 @@ export const SSH_KEY_FORMATS = [
 export interface SSHKeyData {
 	name: string;
 	key: string;
-	type: typeof SSH_KEY_FORMATS[ number ];
+	type: ( typeof SSH_KEY_FORMATS )[ number ];
 	sha256: string;
 	created_at: string;
 }

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -675,7 +675,9 @@ export default function CheckoutMain( {
 	const cartHasSearchProduct = useMemo(
 		() =>
 			responseCart.products.some( ( { product_slug } ) =>
-				JETPACK_SEARCH_PRODUCTS.includes( product_slug as typeof JETPACK_SEARCH_PRODUCTS[ number ] )
+				JETPACK_SEARCH_PRODUCTS.includes(
+					product_slug as ( typeof JETPACK_SEARCH_PRODUCTS )[ number ]
+				)
 			),
 		[ responseCart.products ]
 	);

--- a/client/my-sites/customer-home/cards/tasks/revive-auto-reverted-atomic/index.tsx
+++ b/client/my-sites/customer-home/cards/tasks/revive-auto-reverted-atomic/index.tsx
@@ -96,7 +96,7 @@ const ATOMIC_REVIVAL_TASKS = [
 	TASK_REACTIVATE_RESTORE_BACKUP,
 ] as const;
 
-type AtomicRevivalTask = typeof ATOMIC_REVIVAL_TASKS[ number ];
+type AtomicRevivalTask = ( typeof ATOMIC_REVIVAL_TASKS )[ number ];
 
 function isRevivalTask( card: string ): card is AtomicRevivalTask {
 	return ATOMIC_REVIVAL_TASKS.includes( card as AtomicRevivalTask );

--- a/client/my-sites/email/email-providers-comparison/in-depth/types.ts
+++ b/client/my-sites/email/email-providers-comparison/in-depth/types.ts
@@ -23,7 +23,7 @@ const EMAIL_PROVIDER_FEATURES_TYPE = [
 	'tools',
 ] as const;
 
-type EmailProviderFeature = typeof EMAIL_PROVIDER_FEATURES_TYPE[ number ];
+type EmailProviderFeature = ( typeof EMAIL_PROVIDER_FEATURES_TYPE )[ number ];
 
 export type EmailProviderFeatures = {
 	badge?: ReactNode;

--- a/client/my-sites/email/form/mailboxes/types.ts
+++ b/client/my-sites/email/form/mailboxes/types.ts
@@ -140,7 +140,7 @@ type MutableFormFieldNames = Exclude< FormFieldNames, typeof FIELD_DOMAIN | type
 type ValidatorFieldNames = FormFieldNames | null;
 
 type ProviderKeys = keyof typeof MailboxFormFieldsMap;
-type ProviderTypes = typeof MailboxFormFieldsMap[ ProviderKeys ];
+type ProviderTypes = ( typeof MailboxFormFieldsMap )[ ProviderKeys ];
 type ExtractInstanceType< T > = T extends new ( domain: string ) => infer R ? R : never;
 
 class MailboxFormFieldsFactory {

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -525,6 +525,8 @@ export class SharingService extends Component {
 			'is-open': this.state.isOpen,
 		} );
 		const accounts = this.state.isSelectingAccount ? this.props.availableExternalAccounts : [];
+		const showLinkedInNotice =
+			'linkedin' === this.props.service.ID && some( connections, { status: 'must_reauth' } );
 
 		const header = (
 			<div>
@@ -540,15 +542,14 @@ export class SharingService extends Component {
 						numberOfConnections={ this.getConnections().length }
 					/>
 				</div>
-				{ 'linkedin' === this.props.service.ID &&
-					some( connections, { status: 'must_reauth' } ) && (
-						<Notice isCompact status="is-error" className="sharing-service__notice">
-							{ this.props.translate(
-								'Time to reauthenticate! Some changes to LinkedIn mean that you need to re-enable Jetpack Social ' +
-									'by disconnecting and reconnecting your account.'
-							) }
-						</Notice>
-					) }
+				{ showLinkedInNotice && (
+					<Notice isCompact status="is-error" className="sharing-service__notice">
+						{ this.props.translate(
+							'Time to reauthenticate! Some changes to LinkedIn mean that you need to re-enable Jetpack Social ' +
+								'by disconnecting and reconnecting your account.'
+						) }
+					</Notice>
+				) }
 			</div>
 		);
 

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -540,14 +540,15 @@ export class SharingService extends Component {
 						numberOfConnections={ this.getConnections().length }
 					/>
 				</div>
-				{ 'linkedin' === this.props.service.ID && some( connections, { status: 'must_reauth' } ) && (
-					<Notice isCompact status="is-error" className="sharing-service__notice">
-						{ this.props.translate(
-							'Time to reauthenticate! Some changes to LinkedIn mean that you need to re-enable Jetpack Social ' +
-								'by disconnecting and reconnecting your account.'
-						) }
-					</Notice>
-				) }
+				{ 'linkedin' === this.props.service.ID &&
+					some( connections, { status: 'must_reauth' } ) && (
+						<Notice isCompact status="is-error" className="sharing-service__notice">
+							{ this.props.translate(
+								'Time to reauthenticate! Some changes to LinkedIn mean that you need to re-enable Jetpack Social ' +
+									'by disconnecting and reconnecting your account.'
+							) }
+						</Notice>
+					) }
 			</div>
 		);
 

--- a/client/my-sites/plans/jetpack-plans/get-purchased-storage-subscriptions.ts
+++ b/client/my-sites/plans/jetpack-plans/get-purchased-storage-subscriptions.ts
@@ -7,7 +7,9 @@ import type { AppState } from 'calypso/types';
 const hasUpgradeableStorage = ( slug: string ) =>
 	TIER_1_SLUGS.includes( slug ) ||
 	TIER_2_SLUGS.includes( slug ) ||
-	JETPACK_BACKUP_ADDON_PRODUCTS.includes( slug as typeof JETPACK_BACKUP_ADDON_PRODUCTS[ number ] );
+	JETPACK_BACKUP_ADDON_PRODUCTS.includes(
+		slug as ( typeof JETPACK_BACKUP_ADDON_PRODUCTS )[ number ]
+	);
 
 const getPurchasedStorageSubscriptions = ( state: AppState, siteId: number | null ): Purchase[] =>
 	( getSitePurchases( state, siteId ) ?? [] )

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-get-original-price.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-get-original-price.tsx
@@ -15,7 +15,7 @@ export const useGetOriginalPrice = ( siteId: number | null ) => {
 			// Jetpack CRM price won't come from the API, so we need to hard-code it for now.
 			if (
 				JETPACK_CRM_PRODUCTS.includes(
-					product.productSlug as typeof JETPACK_CRM_PRODUCTS[ number ]
+					product.productSlug as ( typeof JETPACK_CRM_PRODUCTS )[ number ]
 				)
 			) {
 				return product.displayPrice || -1;

--- a/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-get-product-card-data.ts
+++ b/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-get-product-card-data.ts
@@ -139,7 +139,7 @@ export const useGetMonthlyBackupsCardData = (): StorageUpgradeGetter => {
 			return {
 				...product,
 				displayName: JETPACK_BACKUP_ADDON_PRODUCTS.includes(
-					slug as typeof JETPACK_BACKUP_ADDON_PRODUCTS[ number ]
+					slug as ( typeof JETPACK_BACKUP_ADDON_PRODUCTS )[ number ]
 				)
 					? storageAmount
 					: product?.displayName,
@@ -194,7 +194,7 @@ export const useGetYearlyBackupsCardData = (): StorageUpgradeGetter => {
 			return {
 				...product,
 				displayName: JETPACK_BACKUP_ADDON_PRODUCTS.includes(
-					slug as typeof JETPACK_BACKUP_ADDON_PRODUCTS[ number ]
+					slug as ( typeof JETPACK_BACKUP_ADDON_PRODUCTS )[ number ]
 				)
 					? storageAmount
 					: product?.displayName,

--- a/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-storage-upgrades-to-display.ts
+++ b/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/hooks/use-storage-upgrades-to-display.ts
@@ -14,7 +14,7 @@ const useStorageUpgradesToDisplay = ( siteId: number ): SelectorProduct[] => {
 	return useMemo( () => {
 		const purchasedAddOns = purchases.filter( ( { productSlug } ) =>
 			JETPACK_BACKUP_ADDON_MONTHLY.includes(
-				productSlug as typeof JETPACK_BACKUP_ADDON_MONTHLY[ number ]
+				productSlug as ( typeof JETPACK_BACKUP_ADDON_MONTHLY )[ number ]
 			)
 		);
 
@@ -24,13 +24,13 @@ const useStorageUpgradesToDisplay = ( siteId: number ): SelectorProduct[] => {
 		if ( purchasedAddOns.length > 0 ) {
 			const addOnsIndices = purchasedAddOns.map( ( { productSlug } ) =>
 				JETPACK_BACKUP_ADDON_MONTHLY.indexOf(
-					productSlug as typeof JETPACK_BACKUP_ADDON_MONTHLY[ number ]
+					productSlug as ( typeof JETPACK_BACKUP_ADDON_MONTHLY )[ number ]
 				)
 			);
 
 			upgrades = upgrades.filter( ( { productSlug } ) => {
 				const index = JETPACK_BACKUP_ADDON_MONTHLY.indexOf(
-					productSlug as typeof JETPACK_BACKUP_ADDON_MONTHLY[ number ]
+					productSlug as ( typeof JETPACK_BACKUP_ADDON_MONTHLY )[ number ]
 				);
 
 				return index === -1 || index > Math.max( ...addOnsIndices );

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -171,8 +171,8 @@ const useItemPrice = (
 			if (
 				[ ...JETPACK_SOCIAL_PRODUCTS, ...JETPACK_BACKUP_T1_PRODUCTS ].includes(
 					item?.productSlug as
-						| typeof JETPACK_SOCIAL_PRODUCTS[ number ]
-						| typeof JETPACK_BACKUP_T1_PRODUCTS[ number ]
+						| ( typeof JETPACK_SOCIAL_PRODUCTS )[ number ]
+						| ( typeof JETPACK_BACKUP_T1_PRODUCTS )[ number ]
 				)
 			) {
 				discountedPrice = introductoryOfferPrices.introOfferCost || undefined;
@@ -191,7 +191,7 @@ const useItemPrice = (
 	// Jetpack CRM price won't come from the API, so we need to hard-code it for now.
 	if (
 		item &&
-		JETPACK_CRM_PRODUCTS.includes( item.productSlug as typeof JETPACK_CRM_PRODUCTS[ number ] )
+		JETPACK_CRM_PRODUCTS.includes( item.productSlug as ( typeof JETPACK_CRM_PRODUCTS )[ number ] )
 	) {
 		discountedPrice = item.displayPrice || -1;
 		originalPrice = item.displayPrice || -1;

--- a/client/signup/difm/components/BrowserView.tsx
+++ b/client/signup/difm/components/BrowserView.tsx
@@ -62,7 +62,7 @@ const Container = styled.div< { isSelected?: boolean; isClickDisabled?: boolean 
 	height: 170px;
 	position: relative;
 	cursor: ${ ( { isClickDisabled } ) => ( isClickDisabled ? 'default' : 'pointer' ) };
-	pointer-events: ${ ( { isClickDisabled } ) => ( isClickDisabled ? 'none' : 'default' ) }; ;
+	pointer-events: ${ ( { isClickDisabled } ) => ( isClickDisabled ? 'none' : 'default' ) };
 `;
 
 const HeaderContainer = styled.div< { isSelected?: boolean; isClickDisabled?: boolean } >`

--- a/client/sites-dashboard/components/sites-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-sorting-dropdown.tsx
@@ -96,7 +96,7 @@ export const SitesSortingDropdown = ( {
 				<NavigableMenu cycle={ false }>
 					<MenuItemsChoice
 						value={ currentSortingValue }
-						onSelect={ ( value: typeof choices[ 0 ][ 'value' ] ) => {
+						onSelect={ ( value: ( typeof choices )[ 0 ][ 'value' ] ) => {
 							onSitesSortingChange( parseSitesSorting( value ) );
 							onClose();
 						} }

--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
 		"postcss": "^8.4.5",
 		"postcss-cli": "^9.0.1",
 		"postcss-custom-properties": "^11.0.0",
-		"prettier": "npm:wp-prettier@2.6.2",
+		"prettier": "npm:wp-prettier@2.8.5",
 		"readline-sync": "^1.4.10",
 		"recursive-copy": "^2.0.14",
 		"replace": "^1.1.5",

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/star-rating.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/star-rating.ts
@@ -1,10 +1,10 @@
 import { BlockFlow, EditorContext, PublishedPostContext } from '.';
 
 const wholeRatings = [ 1, 2, 3, 4, 5 ] as const;
-type WholeRating = typeof wholeRatings[ number ];
+type WholeRating = ( typeof wholeRatings )[ number ];
 
 const halfRatings = [ 0.5, 1.5, 2.5, 3.5, 4.5 ] as const;
-type HalfRating = typeof halfRatings[ number ];
+type HalfRating = ( typeof halfRatings )[ number ];
 
 type StarRating = WholeRating | HalfRating;
 

--- a/packages/calypso-e2e/src/lib/blocks/cover-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/cover-block.ts
@@ -1,7 +1,7 @@
 import { ImageBlock } from './image-block';
 
 const coverStylesArray = [ 'Default', 'Bottom Wave', 'Top Wave' ] as const;
-export type coverStyles = typeof coverStylesArray[ number ];
+export type coverStyles = ( typeof coverStylesArray )[ number ];
 
 /**
  * Represents the Cover block.

--- a/packages/calypso-e2e/src/lib/pages/site-import-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/site-import-page.ts
@@ -1,6 +1,6 @@
 import { Page } from 'playwright';
 
-export type SourceService = typeof SiteImportPage.services[ number ];
+export type SourceService = ( typeof SiteImportPage.services )[ number ];
 
 const selectors = {
 	// Listing

--- a/packages/calypso-e2e/src/secrets/types.ts
+++ b/packages/calypso-e2e/src/secrets/types.ts
@@ -1,7 +1,7 @@
 import { TEST_ACCOUNT_NAMES } from '.';
 
 type OtherTestSiteName = 'notifications';
-export type TestAccountName = typeof TEST_ACCOUNT_NAMES[ number ];
+export type TestAccountName = ( typeof TEST_ACCOUNT_NAMES )[ number ];
 
 interface TestAccountSites {
 	id: number;

--- a/packages/calypso-products/src/get-plan-term-variant.ts
+++ b/packages/calypso-products/src/get-plan-term-variant.ts
@@ -11,7 +11,7 @@ import type { PlanSlug } from './types';
  */
 export function getPlanSlugForTermVariant(
 	slug: PlanSlug,
-	planTerm: typeof TERMS_LIST[ number ]
+	planTerm: ( typeof TERMS_LIST )[ number ]
 ): PlanSlug | undefined {
 	const plan = PLANS_LIST[ slug ];
 

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -26,8 +26,8 @@ import type { ReactElement } from 'react';
 export type Feature = string;
 
 // WPCom
-export type WPComProductSlug = typeof WPCOM_PRODUCTS[ number ];
-export type WPComPlanSlug = typeof WPCOM_PLANS[ number ];
+export type WPComProductSlug = ( typeof WPCOM_PRODUCTS )[ number ];
+export type WPComPlanSlug = ( typeof WPCOM_PLANS )[ number ];
 export type WPComPurchasableItemSlug = WPComProductSlug | WPComPlanSlug;
 
 export interface WPComPlan extends Plan {
@@ -60,9 +60,9 @@ export type IncompleteWPcomPlan = Partial< WPComPlan > &
 	Pick< WPComPlan, 'group' | 'type' | 'getTitle' | 'getDescription' >;
 
 // Jetpack
-export type JetpackProductSlug = typeof JETPACK_PRODUCTS_LIST[ number ];
-export type JetpackLegacyPlanSlug = typeof JETPACK_LEGACY_PLANS[ number ];
-export type JetpackResetPlanSlug = typeof JETPACK_RESET_PLANS[ number ];
+export type JetpackProductSlug = ( typeof JETPACK_PRODUCTS_LIST )[ number ];
+export type JetpackLegacyPlanSlug = ( typeof JETPACK_LEGACY_PLANS )[ number ];
+export type JetpackResetPlanSlug = ( typeof JETPACK_RESET_PLANS )[ number ];
 export type JetpackPlanSlug =
 	| typeof PLAN_JETPACK_FREE
 	| JetpackLegacyPlanSlug
@@ -103,7 +103,7 @@ export interface JetpackPlan extends Plan {
 export type IncompleteJetpackPlan = Partial< JetpackPlan > &
 	Pick< JetpackPlan, 'group' | 'type' | 'getTitle' | 'getDescription' >;
 
-export type JetpackProductCategory = typeof JETPACK_PRODUCT_CATEGORIES[ number ];
+export type JetpackProductCategory = ( typeof JETPACK_PRODUCT_CATEGORIES )[ number ];
 
 // All
 export type ProductSlug = WPComProductSlug | JetpackProductSlug;
@@ -114,8 +114,8 @@ export interface Product {
 	product_name: TranslateResult;
 	product_slug: ProductSlug;
 	type: ProductSlug;
-	term: typeof TERMS_LIST[ number ];
-	bill_period: typeof PERIOD_LIST[ number ];
+	term: ( typeof TERMS_LIST )[ number ];
+	bill_period: ( typeof PERIOD_LIST )[ number ];
 	price_tier_list?: Array< PriceTierEntry >;
 	categories: JetpackProductCategory[];
 	getFeatures?: () => Feature[];
@@ -124,7 +124,7 @@ export interface Product {
 }
 
 export interface BillingTerm {
-	term: typeof TERMS_LIST[ number ];
+	term: ( typeof TERMS_LIST )[ number ];
 	getBillingTimeFrame: () => TranslateResult;
 }
 

--- a/packages/data-stores/src/onboard/utils.ts
+++ b/packages/data-stores/src/onboard/utils.ts
@@ -1,7 +1,7 @@
 import { SiteGoal, SiteIntent } from './constants';
 
 const INTENT_DECIDING_GOALS = [ SiteGoal.Write, SiteGoal.Sell, SiteGoal.Promote ] as const;
-type IntentDecidingGoal = typeof INTENT_DECIDING_GOALS[ number ];
+type IntentDecidingGoal = ( typeof INTENT_DECIDING_GOALS )[ number ];
 
 const GOAL_TO_INTENT_MAP: { [ key in IntentDecidingGoal ]: SiteIntent } = {
 	[ SiteGoal.Write ]: SiteIntent.Write,

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -3,8 +3,8 @@ import * as selectors from './selectors';
 import type { plansProductSlugs, plansSlugs } from './constants';
 import type { SelectFromMap } from '../mapped-types';
 
-export type StorePlanSlug = typeof plansProductSlugs[ number ];
-export type PlanSlug = typeof plansSlugs[ number ];
+export type StorePlanSlug = ( typeof plansProductSlugs )[ number ];
+export type PlanSlug = ( typeof plansSlugs )[ number ];
 
 // at the moment possible plan paths are identical with plan slugs
 export type PlanPath = PlanSlug;
@@ -60,7 +60,7 @@ export interface PricedAPIPlan {
 	path_slug?: PlanPath;
 	product_slug: StorePlanSlug;
 	product_name_short: string;
-	bill_period: -1 | typeof PERIOD_LIST[ number ];
+	bill_period: -1 | ( typeof PERIOD_LIST )[ number ];
 	raw_price: number;
 	orig_cost?: number | null;
 	currency_code: string;

--- a/packages/help-center/src/components/help-center-sibyl-articles.tsx
+++ b/packages/help-center/src/components/help-center-sibyl-articles.tsx
@@ -110,7 +110,7 @@ export function SibylArticles( {
 			sibylArticles?.length
 				? sibylArticles
 				: getFilteredContextResults( sectionName, intent?.site_intent ?? '' )
-		 ).map( ( article ) => {
+		).map( ( article ) => {
 			const hasPostId = 'post_id' in article && article.post_id;
 			return {
 				...article,

--- a/packages/site-picker/src/hooks.tsx
+++ b/packages/site-picker/src/hooks.tsx
@@ -11,7 +11,7 @@ export const useArrowNavigation = (
 		( event ) => {
 			const focusableElements = (
 				element ? focus.focusable.find( element ) : []
-			 ) as HTMLButtonElement[];
+			) as HTMLButtonElement[];
 
 			let focusedIndex = focusableElements.findIndex( ( el ) => document.activeElement === el );
 			focusedIndex = focusedIndex === -1 ? 0 : focusedIndex;

--- a/packages/sites/src/site-status.tsx
+++ b/packages/sites/src/site-status.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 
 export const siteLaunchStatuses = [ 'public', 'private', 'coming-soon', 'redirect' ] as const;
 
-export type SiteLaunchStatus = typeof siteLaunchStatuses[ number ];
+export type SiteLaunchStatus = ( typeof siteLaunchStatuses )[ number ];
 
 export interface SiteObjectWithStatus {
 	is_coming_soon?: boolean;

--- a/packages/sites/src/use-sites-list-grouping.tsx
+++ b/packages/sites/src/use-sites-list-grouping.tsx
@@ -15,7 +15,7 @@ export const siteLaunchStatusGroupValues = [
 	...siteLaunchStatuses,
 ] as const;
 
-export type GroupableSiteLaunchStatuses = typeof siteLaunchStatusGroupValues[ number ];
+export type GroupableSiteLaunchStatuses = ( typeof siteLaunchStatusGroupValues )[ number ];
 
 export interface Status {
 	title: React.ReactChild;

--- a/packages/sites/src/use-sites-list-sorting.tsx
+++ b/packages/sites/src/use-sites-list-sorting.tsx
@@ -17,8 +17,8 @@ export type SiteDetailsForSorting =
 const validSortKeys = [ 'lastInteractedWith', 'updatedAt', 'alphabetically' ] as const;
 const validSortOrders = [ 'asc', 'desc' ] as const;
 
-export type SitesSortKey = typeof validSortKeys[ number ];
-export type SitesSortOrder = typeof validSortOrders[ number ];
+export type SitesSortKey = ( typeof validSortKeys )[ number ];
+export type SitesSortOrder = ( typeof validSortOrders )[ number ];
 
 export const isValidSorting = ( input: {
 	sortKey: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -26089,6 +26089,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"prettier@npm:wp-prettier@2.8.5":
+  version: 2.8.5
+  resolution: "wp-prettier@npm:2.8.5"
+  bin:
+    prettier: bin-prettier.js
+  checksum: 2b00bb73cb56daabc45fc165c8b02471052d3b01eebbdbb6954a891a3e9498c76f5c6776c083c3c34cc9304f015c2fde68b5e979aeb4cdebc25037308b113cf7
+  languageName: node
+  linkType: hard
+
 "pretty-error@npm:^2.1.1":
   version: 2.1.1
   resolution: "pretty-error@npm:2.1.1"
@@ -33717,7 +33726,7 @@ fsevents@^1.2.7:
     postcss: ^8.4.5
     postcss-cli: ^9.0.1
     postcss-custom-properties: ^11.0.0
-    prettier: "npm:wp-prettier@2.6.2"
+    prettier: "npm:wp-prettier@2.8.5"
     react: ^17.0.2
     react-dom: ^17.0.2
     react-intersection-observer: ^9.4.3


### PR DESCRIPTION
Updates the `wp-prettier` package to version 2.8.5 and reformats the codebase.

Notable changes:
- fixes extra space in ternary expressions (https://github.com/Automattic/wp-prettier/issues/34)
- type expressions like `typeof props[ 'value' ]` now get parens for clarity: `( typeof props )[ 'value' ]`
- support for latest TypeScript 5.0 syntax: `satisfies`, `in` and `out` variance specifiers, ...

I also manually fixed formatting of some JSX conditionals, as they looked rather unwieldy after breaking into lines.
