### PR TITLE
Marketplace Plugin: Add go back options for themes only and multiple product types

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-go-back-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-go-back-section.tsx
@@ -1,0 +1,60 @@
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import { useSelector } from 'react-redux';
+import MasterbarStyled from 'calypso/my-sites/marketplace/components/masterbar-styled';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+export function MarketplaceGoBackSection( {
+	pluginSlugs,
+	themeSlugs,
+	pluginsGoBackSection,
+	themesGoBackSection,
+	areAllProductsFetched,
+}: {
+	pluginSlugs: string[];
+	themeSlugs: string[];
+	pluginsGoBackSection: JSX.Element;
+	themesGoBackSection: JSX.Element;
+	areAllProductsFetched: boolean;
+} ): JSX.Element | null {
+	const multipleProductTypes = hasMultipleProductTypes( [ pluginSlugs, themeSlugs ] );
+
+	if ( multipleProductTypes ) {
+		return <DefaultGoBackSection areAllProductsFetched={ areAllProductsFetched } />;
+	}
+
+	if ( pluginSlugs.length > 0 ) {
+		return pluginsGoBackSection;
+	}
+
+	if ( themeSlugs.length > 0 ) {
+		return themesGoBackSection;
+	}
+
+	return null;
+}
+
+function DefaultGoBackSection( { areAllProductsFetched }: { areAllProductsFetched: boolean } ) {
+	const translate = useTranslate();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	return (
+		<MasterbarStyled
+			onClick={ () => page( `/home/${ siteSlug }` ) }
+			backText={ translate( 'Back to home' ) }
+			canGoBack={ areAllProductsFetched }
+		/>
+	);
+}
+
+/**
+ * Check if there are more than 1 product type slugs
+ *
+ * @param productSlugs An array of product slugs for each product type
+ * @returns boolean Whether there are more than multiple product type slugs
+ */
+function hasMultipleProductTypes( productSlugs: Array< string[] > ): boolean {
+	const nonEmptyProductSlugs = productSlugs.filter( ( slugs ) => slugs.length !== 0 );
+
+	return nonEmptyProductSlugs.length > 1;
+}

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -1,12 +1,10 @@
 import { ConfettiAnimation } from '@automattic/components';
 import { ThemeProvider, Global, css } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import { useEffect, useState, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { ThankYou } from 'calypso/components/thank-you';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import MasterbarStyled from 'calypso/my-sites/marketplace/components/masterbar-styled';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-plugin-install/use-marketplace-additional-steps';
 import theme from 'calypso/my-sites/marketplace/theme';
@@ -16,8 +14,9 @@ import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/sel
 import { isRequesting } from 'calypso/state/plugins/installed/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
+import { MarketplaceGoBackSection } from './marketplace-go-back-section';
 import { useDefaultThankYouFoooter } from './use-default-thank-you-footer';
 import { usePluginsThankYouData } from './use-plugins-thank-you-data';
 import { useThemesThankYouData } from './use-themes-thank-you-data';
@@ -32,14 +31,15 @@ const MarketplaceThankYou = ( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( getSelectedSiteSlug );
 	const isRequestingPlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
 
 	const allSlugs = useMemo( () => [ ...pluginSlugs, ...themeSlugs ], [ pluginSlugs, themeSlugs ] );
 	const defaultThankYouFooter = useDefaultThankYouFoooter( allSlugs );
 
-	const [ pluginsSection, allPluginsFetched ] = usePluginsThankYouData( pluginSlugs );
-	const [ themesSection, allThemesFetched ] = useThemesThankYouData( themeSlugs );
+	const [ pluginsSection, allPluginsFetched, pluginsGoBackSection ] =
+		usePluginsThankYouData( pluginSlugs );
+	const [ themesSection, allThemesFetched, themesGoBackSection ] =
+		useThemesThankYouData( themeSlugs );
 
 	const areAllProductsFetched = allPluginsFetched && allThemesFetched;
 
@@ -127,11 +127,12 @@ const MarketplaceThankYou = ( {
 					}
 				` }
 			/>
-			{ /* TODO: Update the masterbar according the product type */ }
-			<MasterbarStyled
-				onClick={ () => page( `/plugins/${ siteSlug }` ) }
-				backText={ translate( 'Back to plugins' ) }
-				canGoBack={ areAllProductsFetched }
+			<MarketplaceGoBackSection
+				pluginSlugs={ pluginSlugs }
+				pluginsGoBackSection={ pluginsGoBackSection }
+				themeSlugs={ themeSlugs }
+				themesGoBackSection={ themesGoBackSection }
+				areAllProductsFetched={ areAllProductsFetched }
 			/>
 			{ showProgressBar && (
 				// eslint-disable-next-line wpcalypso/jsx-classname-namespace

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -1,7 +1,10 @@
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { ThankYouSectionProps } from 'calypso/components/thank-you/types';
 import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
+import MasterbarStyled from 'calypso/my-sites/marketplace/components/masterbar-styled';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
@@ -17,12 +20,16 @@ import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/w
 import { areFetched, areFetching, getPlugins } from 'calypso/state/plugins/wporg/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { ThankYouPluginSection } from './marketplace-thank-you-plugin-section';
 
-export function usePluginsThankYouData( pluginSlugs: string[] ): [ ThankYouSectionProps, boolean ] {
+export function usePluginsThankYouData(
+	pluginSlugs: string[]
+): [ ThankYouSectionProps, boolean, JSX.Element ] {
 	const dispatch = useDispatch();
+	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	// retrieve WPCom plugin data
 	const wpComPluginsDataResults = useWPCOMPlugins( pluginSlugs );
@@ -165,7 +172,15 @@ export function usePluginsThankYouData( pluginSlugs: string[] ): [ ThankYouSecti
 		} ) ),
 	};
 
-	return [ pluginsSection, allPluginsFetched ];
+	const goBackSection = (
+		<MasterbarStyled
+			onClick={ () => page( `/plugins/${ siteSlug }` ) }
+			backText={ translate( 'Back to plugins' ) }
+			canGoBack={ allPluginsFetched }
+		/>
+	);
+
+	return [ pluginsSection, allPluginsFetched, goBackSection ];
 }
 
 type Plugin = {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -1,10 +1,19 @@
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useQueryThemes } from 'calypso/components/data/query-theme';
 import { ThankYouSectionProps } from 'calypso/components/thank-you/types';
+import MasterbarStyled from 'calypso/my-sites/marketplace/components/masterbar-styled';
 import { getThemes } from 'calypso/state/themes/selectors';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
-export function useThemesThankYouData( themeSlugs: string[] ): [ ThankYouSectionProps, boolean ] {
+export function useThemesThankYouData(
+	themeSlugs: string[]
+): [ ThankYouSectionProps, boolean, JSX.Element ] {
+	const translate = useTranslate();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
 	const dotComThemes = useSelector( ( state ) => getThemes( state, 'wpcom', themeSlugs ) );
 	const dotOrgThemes = useSelector( ( state ) => getThemes( state, 'wporg', themeSlugs ) );
 	const themesList = useMemo(
@@ -24,5 +33,13 @@ export function useThemesThankYouData( themeSlugs: string[] ): [ ThankYouSection
 		} ) ),
 	};
 
-	return [ themesSection, allThemesFetched ];
+	const goBackSection = (
+		<MasterbarStyled
+			onClick={ () => page( `/themes/${ siteSlug }` ) }
+			backText={ translate( 'Back to themes' ) }
+			canGoBack={ allThemesFetched }
+		/>
+	);
+
+	return [ themesSection, allThemesFetched, goBackSection ];
 }


### PR DESCRIPTION
Fixes #74737

## Proposed Changes

* Make each product hook return their own go back section to be used when there is only this product type on the page
* Create a component to manage the Go Back section
* This component checks if there are multiple product types and show a default option
* Otherwise show the section for the product type on the screen

## Testing Instructions
* Go to the Thank You page with only a plugin passed. Ex: `/marketplace/thank-you/:site?plugins=:plugin-slug`
* Check if you see the option `Back to plugins` pointing to `/plugins/:site`
* Go to the Thank You page with only a theme passed. Ex: `/marketplace/thank-you/:site?themes=:theme-slug`
* Check if you see the option `Back to themes` pointing to `/themes/:site`
* Go to the Thank You page with plugins and themes passed. Ex: `/marketplace/thank-you/:site?plugins=:plugin-slug&themes=:theme-slug`
* Check if you see the option `Back to home` pointing to `/home/:site`

| Plugins  | Themes | Multiple product types |
| ------------- | ------------- |------------- |
|<img width="224" alt="CleanShot 2023-03-22 at 11 07 09@2x" src="https://user-images.githubusercontent.com/5039531/226932648-23adc59b-8665-4743-9d7a-f27b311268f2.png">|<img width="235" alt="CleanShot 2023-03-22 at 11 07 21@2x" src="https://user-images.githubusercontent.com/5039531/226932684-7199c801-b92f-4e82-8a81-ee0167fa27e7.png">|<img width="252" alt="CleanShot 2023-03-22 at 11 08 16@2x" src="https://user-images.githubusercontent.com/5039531/226932716-49d46afc-6f8a-4396-b719-6ba85dfd2b0d.png">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
