### PR TITLE
Newsletter: Change focus on subscribers and setup

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/setup-form/style.scss
@@ -38,9 +38,9 @@
 		background-repeat: no-repeat;
 		background-position: 95%;
 		&:focus {
-			border-color: var(--wp-admin-theme-color);
-			box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
-			outline: 2px solid transparent;
+			border-color: var(--studio-gray-10);
+			box-shadow: 0 0 0 2px var(--color-primary-10);
+			outline: none;
 		}
 	}
 
@@ -73,6 +73,12 @@
 		font-size: 0.875rem;
 		padding: 0.875rem 1rem;
 		height: 44px;
+
+		&:focus {
+			border-color: var(--studio-gray-10);
+			box-shadow: 0 0 0 2px var(--color-primary-10);
+			outline: none;
+		}
 	}
 
 	.setup-form__submit {

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -117,6 +117,10 @@
 
 	.components-base-control.is-error input {
 		border-color: var(--color-error);
+
+		&:focus {
+			box-shadow: 0 0 0 2px var(--color-error-10);
+		}
 	}
 
 	.components-base-control__field {

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -13,7 +13,7 @@
 
 		.onboarding-subtitle {
 			margin-bottom: 1.5rem;
-			font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
+			font-size: 1.25rem;
 		}
 	}
 
@@ -33,7 +33,7 @@
 	.add-subscriber .add-subscriber__title-container {
 		.onboarding-title {
 			font-size: 2rem;
-			line-height: 2.25rem; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			line-height: 2.25;
 			margin-bottom: 1.5rem;
 		}
 	}
@@ -85,7 +85,7 @@
 	.components-button {
 		height: auto;
 		padding: 0;
-		font-size: 1em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 1rem;
 		color: var(--color-text);
 		text-decoration: underline;
 		border: none;
@@ -101,7 +101,7 @@
 		display: block;
 		width: 100%;
 		font-size: 0.875rem;
-		line-height: 1.25rem; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		line-height: 1.25;
 		margin: 1rem 0;
 
 		&.add-subscriber__form-label-links {
@@ -138,6 +138,12 @@
 
 		&[disabled] {
 			background: var(--studio-gray-5);
+		}
+
+		&:focus {
+			border-color: var(--studio-gray-10);
+			box-shadow: 0 0 0 2px var(--color-primary-10);
+			outline: none;
 		}
 	}
 
@@ -191,7 +197,7 @@
 
 	.add-subscriber__form--disclaimer {
 		font-size: 0.875rem;
-		line-height: 1.25rem; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		line-height: 1.25;
 		color: var(--studio-gray-50);
 		margin-bottom: 1.5rem;
 
@@ -206,4 +212,3 @@
 		}
 	}
 }
-


### PR DESCRIPTION
On the newsletter flow, Focus state is different in user signup page and subsequent pages with inputs.

This updates the focus state on setup and subscriber steps.

Fixes https://github.com/Automattic/wp-calypso/issues/74583