### PR TITLE
Marketplace thank you: Only allow valid themes

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -15,6 +15,7 @@ import {
 	hasActivatedTheme,
 } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import useIsValidThankYouTheme from './use-is-valid-thank-you-theme';
 
 const ThemeSectionContainer = styled.div`
 	display: flex;
@@ -97,6 +98,8 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 	);
 	const siteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) ) ?? undefined;
 
+	const isValidThankyouSectionTheme = useIsValidThankYouTheme( theme, siteId );
+
 	const sendTrackEvent = useCallback(
 		( name: string ) => {
 			recordTracksEvent( name, {
@@ -114,6 +117,10 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 		sendTrackEvent( 'calypso_theme_thank_you_activate_theme_click' );
 		dispatch( activate( theme.id, siteId, 'marketplace-thank-you' ) );
 	};
+
+	if ( ! isValidThankyouSectionTheme ) {
+		return null;
+	}
 
 	return (
 		<ThemeSectionContainer>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-is-valid-thank-you-theme.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-is-valid-thank-you-theme.tsx
@@ -2,9 +2,7 @@ import { useSelector } from 'react-redux';
 import {
 	isThemePremium,
 	isPremiumThemeAvailable,
-	doesThemeBundleSoftwareSet,
 	isExternallyManagedTheme as getIsExternallyManagedTheme,
-	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
 	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
 } from 'calypso/state/themes/selectors';
 
@@ -24,40 +22,17 @@ const useIsValidThankYouTheme = ( theme: Theme, siteId: number ): boolean => {
 	const isMarketplaceThemeSubscribed = useSelector( ( state ) =>
 		getIsMarketplaceThemeSubscribed( state, themeId, siteId )
 	);
-	const isSiteEligibleForManagedExternalThemes = useSelector( ( state ) =>
-		getIsSiteEligibleForManagedExternalThemes( state, siteId )
-	);
 
 	const isPremium = useSelector( ( state ) => isThemePremium( state, themeId ) );
 	const isThemePurchased = useSelector( ( state ) =>
 		isPremiumThemeAvailable( state, themeId, siteId )
 	);
 
-	const isBundledSoftwareSet = useSelector( ( state ) =>
-		doesThemeBundleSoftwareSet( state, themeId )
-	);
-
-	if ( isPremium && ! isThemePurchased && ! isBundledSoftwareSet && ! isExternallyManagedTheme ) {
+	if ( isPremium && ! isThemePurchased && ! isExternallyManagedTheme ) {
 		return false;
 	}
 
-	if ( isPremium && ! isThemePurchased && isBundledSoftwareSet && ! isExternallyManagedTheme ) {
-		return false;
-	}
-
-	if (
-		isExternallyManagedTheme &&
-		! isMarketplaceThemeSubscribed &&
-		! isSiteEligibleForManagedExternalThemes
-	) {
-		return false;
-	}
-
-	if (
-		isExternallyManagedTheme &&
-		! isMarketplaceThemeSubscribed &&
-		isSiteEligibleForManagedExternalThemes
-	) {
+	if ( isExternallyManagedTheme && ! isMarketplaceThemeSubscribed ) {
 		return false;
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-is-valid-thank-you-theme.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-is-valid-thank-you-theme.tsx
@@ -1,0 +1,71 @@
+import { useSelector } from 'react-redux';
+import {
+	isThemePremium,
+	isPremiumThemeAvailable,
+	doesThemeBundleSoftwareSet,
+	isExternallyManagedTheme as getIsExternallyManagedTheme,
+	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
+	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
+} from 'calypso/state/themes/selectors';
+
+type Theme = {
+	id: string;
+	retired: boolean;
+};
+
+const useIsValidThankYouTheme = ( theme: Theme, siteId: number ): boolean => {
+	const themeId = theme.id;
+	const retired = theme.retired;
+
+	const isExternallyManagedTheme = useSelector( ( state ) =>
+		getIsExternallyManagedTheme( state, themeId )
+	);
+
+	const isMarketplaceThemeSubscribed = useSelector( ( state ) =>
+		getIsMarketplaceThemeSubscribed( state, themeId, siteId )
+	);
+	const isSiteEligibleForManagedExternalThemes = useSelector( ( state ) =>
+		getIsSiteEligibleForManagedExternalThemes( state, siteId )
+	);
+
+	const isPremium = useSelector( ( state ) => isThemePremium( state, themeId ) );
+	const isThemePurchased = useSelector( ( state ) =>
+		isPremiumThemeAvailable( state, themeId, siteId )
+	);
+
+	const isBundledSoftwareSet = useSelector( ( state ) =>
+		doesThemeBundleSoftwareSet( state, themeId )
+	);
+
+	if ( isPremium && ! isThemePurchased && ! isBundledSoftwareSet && ! isExternallyManagedTheme ) {
+		return false;
+	}
+
+	if ( isPremium && ! isThemePurchased && isBundledSoftwareSet && ! isExternallyManagedTheme ) {
+		return false;
+	}
+
+	if (
+		isExternallyManagedTheme &&
+		! isMarketplaceThemeSubscribed &&
+		! isSiteEligibleForManagedExternalThemes
+	) {
+		return false;
+	}
+
+	if (
+		isExternallyManagedTheme &&
+		! isMarketplaceThemeSubscribed &&
+		isSiteEligibleForManagedExternalThemes
+	) {
+		return false;
+	}
+
+	if ( retired ) {
+		return false;
+	}
+
+	return true;
+};
+
+export default useIsValidThankYouTheme;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolve #74760

## Proposed Changes

* Add all the logic to check if a theme that will be displayed in the Thank You page is allowed to be there. Only purchased plugins for eligible sites should be displayed.
* This logic has been extracted to a custom hook named `useIsValidThankYouTheme` 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to ` /marketplace/thank-you/:siteId?plugins=woocommerce-bookings&themes=:themeId` replacing `themeId` with the following:
#### Atomic site
* Marketplace theme without subscription for that site, e.g. `Yuna`
* Premium theme that is not purchased for that site, e.g. `Munchies`

#### Non atomic site. Sites below Business
- The non-free themes should not be displayed. Currently, the Thank You page is not displayed at all if a theme is added.

In all the above scenarios, the selected theme should **not** be displayed.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
