### PR TITLE
update: pass force URL for Akismet checkout

### DIFF
--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -41,7 +41,7 @@ const CheckoutMasterbar = ( {
 	loadHelpCenterIcon,
 }: Props ) => {
 	const translate = useTranslate();
-	const jetpackCheckoutBackUrl = useValidCheckoutBackUrl( siteSlug );
+	const forceCheckoutBackUrl = useValidCheckoutBackUrl( siteSlug );
 
 	const getCheckoutType = () => {
 		if ( window.location.pathname.startsWith( '/checkout/jetpack' ) || isJetpackNotAtomic ) {
@@ -69,7 +69,7 @@ const CheckoutMasterbar = ( {
 	const closeAndLeave = () =>
 		leaveCheckout( {
 			siteSlug,
-			jetpackCheckoutBackUrl,
+			forceCheckoutBackUrl,
 			previousPath,
 			tracksEvent: 'calypso_masterbar_close_clicked',
 		} );

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -223,17 +223,11 @@ export default function WPCheckout( {
 		? String( translate( 'Updating cart…' ) )
 		: String( translate( 'Please wait…' ) );
 
-	const jetpackCheckoutBackUrl = useValidCheckoutBackUrl( siteUrl );
-	const isAkismetCheckout = window.location.pathname.startsWith( '/checkout/akismet' );
-	let forceCheckoutBackUrl: string;
-	if ( siteUrl === undefined && isAkismetCheckout ) {
-		forceCheckoutBackUrl = 'https://akismet.com/plans';
-	}
+	const forceCheckoutBackUrl = useValidCheckoutBackUrl( siteUrl );
 	const previousPath = useSelector( getPreviousRoute );
 	const goToPreviousPage = () =>
 		leaveCheckout( {
 			siteSlug: siteUrl,
-			jetpackCheckoutBackUrl,
 			forceCheckoutBackUrl,
 			previousPath: customizedPreviousPath || previousPath,
 			tracksEvent: 'calypso_checkout_composite_empty_cart_clicked',

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -224,11 +224,17 @@ export default function WPCheckout( {
 		: String( translate( 'Please wait…' ) );
 
 	const jetpackCheckoutBackUrl = useValidCheckoutBackUrl( siteUrl );
+	const isAkismetCheckout = window.location.pathname.startsWith( '/checkout/akismet' );
+	let forceCheckoutBackUrl: string;
+	if ( siteUrl === undefined && isAkismetCheckout ) {
+		forceCheckoutBackUrl = 'https://akismet.com/plans';
+	}
 	const previousPath = useSelector( getPreviousRoute );
 	const goToPreviousPage = () =>
 		leaveCheckout( {
 			siteSlug: siteUrl,
 			jetpackCheckoutBackUrl,
+			forceCheckoutBackUrl,
 			previousPath: customizedPreviousPath || previousPath,
 			tracksEvent: 'calypso_checkout_composite_empty_cart_clicked',
 		} );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-remove-from-cart-and-redirect.ts
@@ -20,17 +20,23 @@ export default function useRemoveFromCartAndRedirect(
 	const { removeProductFromCart } = useShoppingCart( cartKey );
 
 	// In some cases, the cloud.jetpack.com/pricing page sends a `checkoutBackUrl` url query param to checkout.
-	const jetpackCheckoutBackUrl = useValidCheckoutBackUrl( siteSlug );
+	const forceCheckoutBackUrl = useValidCheckoutBackUrl( siteSlug );
 
 	const redirectDueToEmptyCart = useCallback( () => {
 		leaveCheckout( {
 			siteSlug,
-			jetpackCheckoutBackUrl,
+			forceCheckoutBackUrl,
 			createUserAndSiteBeforeTransaction,
 			previousPath: customizedPreviousPath || previousPath,
 			tracksEvent: 'calypso_empty_cart_redirect',
 		} );
-	}, [ createUserAndSiteBeforeTransaction, siteSlug, jetpackCheckoutBackUrl, previousPath ] );
+	}, [
+		createUserAndSiteBeforeTransaction,
+		siteSlug,
+		forceCheckoutBackUrl,
+		previousPath,
+		customizedPreviousPath,
+	] );
 
 	const isMounted = useRef( true );
 	useEffect( () => {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
@@ -25,6 +25,12 @@ const useValidCheckoutBackUrl = ( siteSlug: string | undefined ): string | undef
 
 	return useMemo( () => {
 		if ( ! checkoutBackUrl ) {
+			// For akismet specific checkout, if navigated with direct link
+			// We shouldn't be navigated to `start\domain` but to `akismet\plans`
+			const isAkismetCheckout = window.location.pathname.startsWith( '/checkout/akismet' );
+			if ( ! siteSlug && isAkismetCheckout ) {
+				return 'https://akismet.com/plans';
+			}
 			return undefined;
 		}
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
@@ -29,7 +29,7 @@ const useValidCheckoutBackUrl = ( siteSlug: string | undefined ): string | undef
 			// We shouldn't be navigated to `start\domain` but to `akismet\plans`
 			const isAkismetCheckout = window.location.pathname.startsWith( '/checkout/akismet' );
 			if ( ! siteSlug && isAkismetCheckout ) {
-				return 'https://akismet.com/plans';
+				return 'https://akismet.com/pricing';
 			}
 			return undefined;
 		}

--- a/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
@@ -12,14 +12,12 @@ const debug = debugFactory( 'calypso:leave-checkout' );
 
 export const leaveCheckout = ( {
 	siteSlug,
-	jetpackCheckoutBackUrl,
 	forceCheckoutBackUrl,
 	previousPath,
 	tracksEvent,
 	createUserAndSiteBeforeTransaction,
 }: {
 	siteSlug?: string;
-	jetpackCheckoutBackUrl?: string;
 	forceCheckoutBackUrl?: string;
 	previousPath?: string;
 	tracksEvent: string;
@@ -28,7 +26,6 @@ export const leaveCheckout = ( {
 	recordTracksEvent( tracksEvent );
 	debug( 'leaving checkout with args', {
 		siteSlug,
-		jetpackCheckoutBackUrl,
 		forceCheckoutBackUrl,
 		previousPath,
 		createUserAndSiteBeforeTransaction,
@@ -41,11 +38,6 @@ export const leaveCheckout = ( {
 		if ( urlFromCookie ) {
 			window.location.assign( urlFromCookie );
 		}
-	}
-
-	if ( jetpackCheckoutBackUrl ) {
-		window.location.href = jetpackCheckoutBackUrl;
-		return;
 	}
 
 	if ( forceCheckoutBackUrl ) {

--- a/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
@@ -13,12 +13,14 @@ const debug = debugFactory( 'calypso:leave-checkout' );
 export const leaveCheckout = ( {
 	siteSlug,
 	jetpackCheckoutBackUrl,
+	forceCheckoutBackUrl,
 	previousPath,
 	tracksEvent,
 	createUserAndSiteBeforeTransaction,
 }: {
 	siteSlug?: string;
 	jetpackCheckoutBackUrl?: string;
+	forceCheckoutBackUrl?: string;
 	previousPath?: string;
 	tracksEvent: string;
 	createUserAndSiteBeforeTransaction?: boolean;
@@ -27,6 +29,7 @@ export const leaveCheckout = ( {
 	debug( 'leaving checkout with args', {
 		siteSlug,
 		jetpackCheckoutBackUrl,
+		forceCheckoutBackUrl,
 		previousPath,
 		createUserAndSiteBeforeTransaction,
 	} );
@@ -42,6 +45,11 @@ export const leaveCheckout = ( {
 
 	if ( jetpackCheckoutBackUrl ) {
 		window.location.href = jetpackCheckoutBackUrl;
+		return;
+	}
+
+	if ( forceCheckoutBackUrl ) {
+		window.location.href = forceCheckoutBackUrl;
 		return;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 1201210512993648-as-1204216761211996/f

## Proposed Changes
This PR updates `Go Back` link (to `akismet.com/plans`) for akismet checkouts (Navigated directly by URL) with empty cart. It also updates logic when removing the items from the cart.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply the branch locally and spin `yarn start` OR use Live link provided below
- Sandbox `public-api.wordpress.com`
- In your 0-sandbox.php file, add the following line
```php
define( 'USE_STORE_SANDBOX', true );
```

**Scenario 1**
- Navigate to `/checkout/akismet/test` (if using live link provide a Feature flag param `?flags=akismet/siteless-checkout`)
- Hit `Go Back` button. You should be redirected to `akismet.com/plans`

**Scenario 2**
- Navigate to `/checkout/akismet/ak_plus_yearly_1` (if using live link provide a Feature flag param `?flags=akismet/siteless-checkout`)
- Remove the item from the cart. You should be redirected to `akismet.com/plans`

**Scenario 3**
- Check that behaviour is correct for **non** akismet checkout
- For example: - Navigate to `/plans/:siteSlug` (if using live link provide a Feature flag param `?flags=akismet/siteless-checkout`), and go to Checkout with one of the plans.
- Remove item from the cart. You should be redirected back to `/plans/:siteSlug`
-  - Navigate to `/checkout/jetpack/test`. Hitting `Go Back` button should navigate you to `/start/domains`



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?