### PR TITLE
Pass the plan interval to getWooExpressMediumFeatureSets

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
@@ -41,8 +41,8 @@ const ECommerceTrialExpired = (): JSX.Element => {
 	}, [ setInterval ] );
 
 	const expiredTrialWooExpressMediumPlanFeatureSets = useMemo( () => {
-		return getExpiredTrialWooExpressMediumFeatureSets( { translate } );
-	}, [ translate ] );
+		return getExpiredTrialWooExpressMediumFeatureSets( { translate, interval } );
+	}, [ translate, interval ] );
 
 	const triggerTracksEvent = useCallback( ( tracksLocation: string ) => {
 		recordTracksEvent( 'calypso_wooexpress_expired_trial_upgrade_cta_clicked', {

--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -28,8 +28,8 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 
 	// WX Medium and Commerce have the same features
 	const wooExpressMediumPlanFeatureSets = useMemo( () => {
-		return getWooExpressMediumFeatureSets( { translate } );
-	}, [ translate ] );
+		return getWooExpressMediumFeatureSets( { translate, interval } );
+	}, [ translate, interval ] );
 
 	return (
 		<>

--- a/client/my-sites/plans/ecommerce-trial/wx-medium-features.ts
+++ b/client/my-sites/plans/ecommerce-trial/wx-medium-features.ts
@@ -9,6 +9,7 @@ import type { WooExpressMediumPlanFeatureSet } from 'calypso/my-sites/plans/comp
 
 type WooExpressMediumFeatureSetProps = {
 	translate: typeof i18nTranslate;
+	interval: 'monthly' | 'yearly';
 };
 
 /*
@@ -19,6 +20,7 @@ type WooExpressMediumFeatureSetProps = {
 
 export const getWooExpressMediumFeatureSets = ( {
 	translate,
+	interval,
 }: WooExpressMediumFeatureSetProps ): WooExpressMediumPlanFeatureSet[] => {
 	return [
 		{
@@ -41,7 +43,10 @@ export const getWooExpressMediumFeatureSets = ( {
 				},
 				{
 					title: translate( 'Get support 24/7', { textOnly: true } ),
-					subtitle: translate( 'Need help? Reach out anytime via email or chat.' ),
+					subtitle:
+						interval === 'yearly'
+							? translate( 'Need help? Reach out anytime via email or chat.' )
+							: translate( 'Need help? Reach out anytime via email.' ),
 				},
 				{
 					title: translate( 'Have unlimited admin accounts', { textOnly: true } ),

--- a/client/my-sites/plans/wx-medium/index.tsx
+++ b/client/my-sites/plans/wx-medium/index.tsx
@@ -39,10 +39,11 @@ const WooExpressMediumPlansPage = ( { currentPlan, selectedSite }: WXMediumPlans
 
 	const isAnnualSubscription = currentPlan.productSlug === PLAN_WOOEXPRESS_MEDIUM;
 	const activePlan = isAnnualSubscription ? annualPlan : monthlyPlan;
+	const interval = isAnnualSubscription ? 'yearly' : 'monthly';
 
 	const wooExpressMediumPlanFeatureSets = useMemo( () => {
-		return getWooExpressMediumFeatureSets( { translate } );
-	}, [ translate ] );
+		return getWooExpressMediumFeatureSets( { translate, interval } );
+	}, [ translate, interval ] );
 
 	const goToSubscriptionPage = () => {
 		if ( selectedSite?.slug && currentPlan?.id ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #74777

## Proposed Changes

This lets us have slightly different copy for the annual vs the monthly plan. In particular, we want to make sure that monthly users don't think they get chat support

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On an eCommerce trial site, visit the `/plans/:siteSlug` page.
  * You can create a new trial site by visiting `/setup/wooexpress/`.
* Select "Pay Monthly" and check under "General features".
* "Get support 24/7" should read `Need help? Reach out anytime via email.`
![image](https://user-images.githubusercontent.com/917632/226978722-6908c19c-0d3b-4809-b09c-e80d794cb086.png)

* Select "Pay Anually" and check under "General features".
* "Get support 24/7" should read `Need help? Reach out anytime via email or chat.`
![image](https://user-images.githubusercontent.com/917632/226978846-7dbb4c09-b2ce-400c-b433-d69767cfef4a.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
