### PR TITLE
Newsletter: Subscriber step change text position

### DIFF
--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -472,7 +472,6 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 					{ ! includesHandledError() && renderImportCsvSelectedFileLabel() }
 					{ showCsvUpload && ! includesHandledError() && renderImportCsvLabel() }
-					{ showCsvUpload && ! includesHandledError() && renderImportCsvDisclaimerMsg() }
 					{ ! includesHandledError() && renderFollowerNoticeLabel() }
 
 					{ renderEmptyFormValidationMsg() }
@@ -485,6 +484,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 					>
 						{ submitBtnName }
 					</NextButton>
+					{ showCsvUpload && ! includesHandledError() && renderImportCsvDisclaimerMsg() }
 				</form>
 			</div>
 		</div>

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -24,7 +24,7 @@
 	.add-subscriber__form-submit-btn {
 		display: block;
 		width: 100%;
-		margin: 2rem 0;
+		margin: 2rem 0 1rem 0;
 	}
 }
 


### PR DESCRIPTION
Change the text position to be under the CTA, on the `Subscribers` step.

<img width="653" alt="image" src="https://user-images.githubusercontent.com/52076348/226987953-36262e1b-8734-4330-8e5b-f739f307547d.png">

Fixes https://github.com/Automattic/wp-calypso/issues/74793