### PR TITLE
Updated Blaze check to work with multiple sites

### DIFF
--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -5,7 +5,8 @@ import { useSelector } from 'react-redux';
 import request, { requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 declare global {
 	interface Window {
@@ -138,17 +139,18 @@ export enum PromoteWidgetStatus {
  * @returns bool
  */
 export const usePromoteWidget = (): PromoteWidgetStatus => {
-	const value = useSelector( ( state ) => {
-		const userData = getCurrentUser( state );
-		if ( userData ) {
-			const originalSetting = userData[ 'has_promote_widget' ];
-			if ( originalSetting !== undefined ) {
-				return originalSetting === true
-					? PromoteWidgetStatus.ENABLED
-					: PromoteWidgetStatus.DISABLED;
-			}
-		}
-		return PromoteWidgetStatus.FETCHING;
-	} );
-	return value;
+	const selectedSite = useSelector( getSelectedSite );
+
+	const value = useSelector( ( state ) =>
+		getSiteOption( state, selectedSite?.ID, 'has_promote_widget' )
+	);
+
+	switch ( value ) {
+		case false:
+			return PromoteWidgetStatus.DISABLED;
+		case true:
+			return PromoteWidgetStatus.ENABLED;
+		default:
+			return PromoteWidgetStatus.FETCHING;
+	}
 };

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -141,9 +141,7 @@ export enum PromoteWidgetStatus {
 export const usePromoteWidget = (): PromoteWidgetStatus => {
 	const selectedSite = useSelector( getSelectedSite );
 
-	const value = useSelector( ( state ) =>
-		getSiteOption( state, selectedSite?.ID, 'has_promote_widget' )
-	);
+	const value = useSelector( ( state ) => getSiteOption( state, selectedSite?.ID, 'can_blaze' ) );
 
 	switch ( value ) {
 		case false:

--- a/client/lib/promote-post/test/index.jsx
+++ b/client/lib/promote-post/test/index.jsx
@@ -53,7 +53,7 @@ describe( 'index', () => {
 		);
 	} );
 
-	test( 'Should dissalow Blaze usage', async () => {
+	test( 'Should disallow Blaze usage', async () => {
 		function Blaze() {
 			const canUseBlaze = usePromoteWidget();
 			expect( canUseBlaze ).toBe( PromoteWidgetStatus.DISABLED );

--- a/client/lib/promote-post/test/index.jsx
+++ b/client/lib/promote-post/test/index.jsx
@@ -60,7 +60,7 @@ describe( 'index', () => {
 			return <div />;
 		}
 
-		initialState.sites.items[ 1 ].options.has_promote_widget = false;
+		initialState.sites.items[ 1 ].options.can_blaze = false;
 
 		const mockStore = configureStore();
 		const store = mockStore( initialState );
@@ -79,7 +79,7 @@ describe( 'index', () => {
 			return <div />;
 		}
 
-		initialState.sites.items[ 1 ].options.has_promote_widget = true;
+		initialState.sites.items[ 1 ].options.can_blaze = true;
 
 		const mockStore = configureStore();
 		const store = mockStore( initialState );

--- a/client/lib/promote-post/test/index.jsx
+++ b/client/lib/promote-post/test/index.jsx
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { PromoteWidgetStatus, usePromoteWidget } from '../';
+
+const sites = [];
+sites[ 1 ] = {
+	ID: 1,
+	URL: 'example.wordpress.com',
+	plan: {
+		product_slug: 'free_plan',
+	},
+	options: {},
+};
+
+const initialState = {
+	sites: {
+		items: sites,
+		domains: {
+			items: [ 'example.wordpress.com' ],
+		},
+	},
+	ui: {
+		selectedSiteId: 1,
+	},
+	currentUser: {
+		id: 12,
+		user: {
+			email_verified: true,
+		},
+	},
+};
+
+describe( 'index', () => {
+	test( 'Should be fetching when undefined', async () => {
+		function Blaze() {
+			const canUseBlaze = usePromoteWidget();
+			expect( canUseBlaze ).toBe( PromoteWidgetStatus.FETCHING );
+			return <div />;
+		}
+
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+
+		render(
+			<Provider store={ store }>
+				<Blaze />
+			</Provider>
+		);
+	} );
+
+	test( 'Should dissalow Blaze usage', async () => {
+		function Blaze() {
+			const canUseBlaze = usePromoteWidget();
+			expect( canUseBlaze ).toBe( PromoteWidgetStatus.DISABLED );
+			return <div />;
+		}
+
+		initialState.sites.items[ 1 ].options.has_promote_widget = false;
+
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+
+		render(
+			<Provider store={ store }>
+				<Blaze />
+			</Provider>
+		);
+	} );
+
+	test( 'Should allow Blaze usage', async () => {
+		function Blaze() {
+			const canUseBlaze = usePromoteWidget();
+			expect( canUseBlaze ).toBe( PromoteWidgetStatus.ENABLED );
+			return <div />;
+		}
+
+		initialState.sites.items[ 1 ].options.has_promote_widget = true;
+
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+
+		render(
+			<Provider store={ store }>
+				<Blaze />
+			</Provider>
+		);
+	} );
+} );

--- a/client/lib/user/shared-utils/filter-user-object.js
+++ b/client/lib/user/shared-utils/filter-user-object.js
@@ -21,7 +21,6 @@ const allowedKeys = [
 	'logout_URL',
 	'primary_blog',
 	'primary_blog_is_jetpack',
-	'has_promote_widget',
 	'has_jetpack_partner_access',
 	'jetpack_partner_types',
 	'primary_blog_url',

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -35,7 +35,6 @@ export type OptionalUserData = {
 	primary_blog_url: string;
 	site_count: number;
 	jetpack_site_count?: number;
-	has_promote_widget?: boolean;
 	has_jetpack_partner_access?: boolean;
 	jetpack_partner_types?: string[];
 	social_login_connections: unknown;

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -171,9 +171,9 @@ export default function PromotedPosts( { tab }: Props ) {
 
 	useEffect( () => {
 		if ( false === canBlaze ) {
-			page( '/' );
+			page( `/home/${ selectedSite?.domain }` );
 		}
-	}, [ canBlaze ] );
+	}, [ selectedSite, canBlaze ] );
 
 	const subtitle = translate(
 		'Reach new readers and customers with WordPress Blaze. Promote a post or a page on our network of millions blogs and web sites. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -2,7 +2,6 @@ import './style.scss';
 import { useTranslate } from 'i18n-calypso';
 import { debounce } from 'lodash';
 import moment from 'moment';
-import page from 'page';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -18,7 +17,6 @@ import useCampaignsStatsQuery from 'calypso/data/promote-post/use-promote-post-c
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import memoizeLast from 'calypso/lib/memoize-last';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
-import { usePromoteWidget, PromoteWidgetStatus } from 'calypso/lib/promote-post';
 import CampaignsList from 'calypso/my-sites/promote-post/components/campaigns-list';
 import PostsList from 'calypso/my-sites/promote-post/components/posts-list';
 import PostsListBanner from 'calypso/my-sites/promote-post/components/posts-list-banner';
@@ -166,14 +164,6 @@ export default function PromotedPosts( { tab }: Props ) {
 	const isLoadingByCommentsQuery = useSelector( ( state ) =>
 		isRequestingPostsForQuery( state, selectedSiteId, queryPageAndPostsByComments )
 	);
-
-	const canBlaze = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
-
-	useEffect( () => {
-		if ( false === canBlaze ) {
-			page( `/home/${ selectedSite?.domain }` );
-		}
-	}, [ selectedSite, canBlaze ] );
 
 	const subtitle = translate(
 		'Reach new readers and customers with WordPress Blaze. Promote a post or a page on our network of millions blogs and web sites. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',

--- a/client/my-sites/promote-post/main.tsx
+++ b/client/my-sites/promote-post/main.tsx
@@ -167,9 +167,13 @@ export default function PromotedPosts( { tab }: Props ) {
 		isRequestingPostsForQuery( state, selectedSiteId, queryPageAndPostsByComments )
 	);
 
-	if ( usePromoteWidget() === PromoteWidgetStatus.DISABLED ) {
-		page( '/' );
-	}
+	const canBlaze = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
+
+	useEffect( () => {
+		if ( false === canBlaze ) {
+			page( '/' );
+		}
+	}, [ canBlaze ] );
 
 	const subtitle = translate(
 		'Reach new readers and customers with WordPress Blaze. Promote a post or a page on our network of millions blogs and web sites. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',

--- a/client/my-sites/stats/stats-list/action-promote.jsx
+++ b/client/my-sites/stats/stats-list/action-promote.jsx
@@ -10,7 +10,7 @@ import {
 	PromoteWidgetStatus,
 } from 'calypso/lib/promote-post';
 import { useRouteModal } from 'calypso/lib/route-modal';
-import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const PromotePost = ( props ) => {
 	const { moduleName, postId, onToggleVisibility } = props;
@@ -22,11 +22,7 @@ const PromotePost = ( props ) => {
 	const { isModalOpen, value, openModal } = useRouteModal( 'blazepress-widget', keyValue );
 
 	const selectedSiteId = useSelector( getSelectedSiteId );
-
-	const site = useSelector( getSelectedSite );
-	const { is_private, is_coming_soon } = site;
-	const showPromotePost =
-		usePromoteWidget() === PromoteWidgetStatus.ENABLED && ! is_private && ! is_coming_soon;
+	const showPromotePost = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
 
 	const showDSPWidget = async ( event ) => {
 		event.stopPropagation();

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -80,4 +80,5 @@ export const SITE_REQUEST_OPTIONS = [
 	'launchpad_checklist_tasks_statuses',
 	'wpcom_production_blog_id',
 	'wpcom_staging_blog_ids',
+	'has_promote_widget',
 ].join();

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -81,4 +81,5 @@ export const SITE_REQUEST_OPTIONS = [
 	'wpcom_production_blog_id',
 	'wpcom_staging_blog_ids',
 	'has_promote_widget',
+	'can_blaze',
 ].join();

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -80,6 +80,5 @@ export const SITE_REQUEST_OPTIONS = [
 	'launchpad_checklist_tasks_statuses',
 	'wpcom_production_blog_id',
 	'wpcom_staging_blog_ids',
-	'has_promote_widget',
 	'can_blaze',
 ].join();

--- a/client/state/ui/selectors/is-blaze-enabled.js
+++ b/client/state/ui/selectors/is-blaze-enabled.js
@@ -1,5 +1,7 @@
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import getSelectedSite from './get-selected-site';
 import 'calypso/state/ui/init';
 
 export default function isBlazeEnabled( state ) {
-	return !! state.currentUser?.user?.has_promote_widget || false;
+	return !! getSiteOption( state, getSelectedSite( state ).ID, 'can_blaze' ) || false;
 }

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -235,7 +235,7 @@ export interface SiteDetailsOptions {
 	launchpad_checklist_tasks_statuses?: LaunchPadCheckListTasksStatuses;
 	wpcom_production_blog_id?: number;
 	wpcom_staging_blog_ids?: number[];
-	has_promote_widget?: boolean;
+	can_blaze?: boolean;
 }
 
 export type SiteOption = keyof SiteDetails[ 'options' ];

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -235,6 +235,7 @@ export interface SiteDetailsOptions {
 	launchpad_checklist_tasks_statuses?: LaunchPadCheckListTasksStatuses;
 	wpcom_production_blog_id?: number;
 	wpcom_staging_blog_ids?: number[];
+	has_promote_widget?: boolean;
 }
 
 export type SiteOption = keyof SiteDetails[ 'options' ];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1532-gh-Automattic/dotcom-forge

## Proposed Changes

* Switched to [new jetpack endpoint can_blaze](https://github.com/Automattic/jetpack/pull/29614) to check if the user has Blaze enabled.

More context here: p1679438980595779/1679438966.648259-slack-C04DZ725FEK

## Testing Instructions

This feature should allow you having a Published Site A (allowing you to use Blaze) and Comming soon Site B (restricting Blaze access).

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Test 1  - Testing user Interface Language

* Make sure [your Interface Language](https://wordpress.com/me/account) is in English
* Verify if you can see Blaze banner at /home, /advertising is available at the `Tools` menu and you can Blaze a post in the status page:

<img width="907" alt="image" src="https://user-images.githubusercontent.com/1044309/227027273-657cb36e-09bd-4193-b526-3d843895a562.png">

<img width="1411" alt="image" src="https://user-images.githubusercontent.com/1044309/227027411-16f41116-8776-411b-8520-12322e2ba726.png">

![image](https://user-images.githubusercontent.com/1044309/227241252-7de3eb37-d365-47cc-be14-af59d59771bb.png)

* Update [your Interface Language](https://wordpress.com/me/account) to Portuguese
* You shouldn't see Blaze banners and /advertising anymore
* Test on Simple and Atomic sites


## Test 2 - Testing Site visibility

* Update [your Interface Language](https://wordpress.com/me/account) to English again
* Set your Primary site as "Comming soon"
* This will hide Blaze for it:
<img width="1264" alt="image" src="https://user-images.githubusercontent.com/1044309/230603830-2013698c-53d1-4dc8-81ec-9a13d7a85ec4.png">

* Make sure other "Public" sites works normally.

## Test 3 - Testing full version with backend changes

Both Tests 1 and Test 2 assume your sandbox is running trunk, so we can safely deploy these Calypso changes before any backend change. Once they're validated, let's validate the full solution: Making our backend code works by site language, so please apply this diff to your sandbox to continue: D107323-code

With this code, we start to looking at the **Site language** instead of **Interface language**.

* Update your [Site Language](https://wordpress.com/settings/general/yourSite) to Portuguese and see Blaze's menu and banners are hidden
* Make sure your **Primary site** doesn't interfere in the other sites by having it in Portuguese for instance, and your other sites in English.
* With this backend code, the Interface Language is not relevant anymore because we look at each site language instead.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?