### PR TITLE
Marketplace Thank You: Move the contact link to the topbar

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-go-back-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-go-back-section.tsx
@@ -43,6 +43,7 @@ function DefaultGoBackSection( { areAllProductsFetched }: { areAllProductsFetche
 			onClick={ () => page( `/home/${ siteSlug }` ) }
 			backText={ translate( 'Back to home' ) }
 			canGoBack={ areAllProductsFetched }
+			showContact={ areAllProductsFetched }
 		/>
 	);
 }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-go-back-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-go-back-section.tsx
@@ -1,8 +1,8 @@
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useSelector } from 'react-redux';
-import MasterbarStyled from 'calypso/my-sites/marketplace/components/masterbar-styled';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import MasterbarStyled from './masterbar-styled';
 
 export function MarketplaceGoBackSection( {
 	pluginSlugs,

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+
+const ContactContainer = styled.div`
+	margin-top: 24px;
+	margin-right: 24px;
+	font-size: 14px;
+	line-height: 20px;
+	font-weight: 500;
+
+	label {
+		color: var( --studio-gray-60 );
+	}
+
+	a {
+		color: var( --studio-gray-100 );
+		text-decoration: underline;
+	}
+`;
+
+export function DefaultMasterbarContact() {
+	const translate = useTranslate();
+
+	return (
+		<ContactContainer>
+			<label>{ translate( 'Need extra help?' ) }</label>&nbsp;
+			<a href="https://wordpress.com/support/" target="_blank" rel="noreferrer">
+				{ translate( 'Ask a question' ) }
+			</a>
+		</ContactContainer>
+	);
+}

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/index.tsx
@@ -3,6 +3,7 @@ import { ReactChild } from 'react';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
+import { DefaultMasterbarContact } from './default-contact';
 
 const MasterbarStyledBlock = styled( Masterbar )`
 	--color-masterbar-background: var( --studio-white );
@@ -48,12 +49,14 @@ const MasterbarStyled = ( {
 	onClick,
 	backText,
 	canGoBack = true,
-	contact = null, // adicionaria um component padrao aqui, ao inves de null
+	contact = <DefaultMasterbarContact />,
+	showContact = true,
 }: {
 	onClick: () => void;
 	backText: ReactChild;
 	canGoBack: boolean;
 	contact?: JSX.Element | null;
+	showContact?: boolean;
 } ) => (
 	<MasterbarStyledBlock>
 		<WordPressLogoStyled />
@@ -62,7 +65,7 @@ const MasterbarStyled = ( {
 				{ backText }
 			</ItemStyled>
 		) }
-		{ contact }
+		{ showContact && contact }
 	</MasterbarStyledBlock>
 );
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/index.tsx
@@ -48,10 +48,12 @@ const MasterbarStyled = ( {
 	onClick,
 	backText,
 	canGoBack = true,
+	contact = null, // adicionaria um component padrao aqui, ao inves de null
 }: {
 	onClick: () => void;
 	backText: ReactChild;
 	canGoBack: boolean;
+	contact?: JSX.Element | null;
 } ) => (
 	<MasterbarStyledBlock>
 		<WordPressLogoStyled />
@@ -60,6 +62,7 @@ const MasterbarStyled = ( {
 				{ backText }
 			</ItemStyled>
 		) }
+		{ contact }
 	</MasterbarStyledBlock>
 );
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-default-thank-you-footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-default-thank-you-footer.tsx
@@ -58,14 +58,6 @@ export function useThankYouFoooter(
 					},
 			  ]
 			: [] ),
-		{
-			key: 'thank_you_footer_support',
-			title: translate( '24/7 support at your fingertips' ),
-			description: translate( 'Our happiness engineers are eager to lend a hand.' ),
-			link: 'https://wordpress.com/help/contact',
-			linkText: translate( 'Ask a question' ),
-			eventKey: 'calypso_plugin_thank_you_ask_question_click',
-		},
 	];
 	const steps = useNextSteps( footerSteps, pluginSlugs, themeSlugs );
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { ThankYouSectionProps } from 'calypso/components/thank-you/types';
 import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
-import MasterbarStyled from 'calypso/my-sites/marketplace/components/masterbar-styled';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
@@ -22,6 +21,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { ThankYouPluginSection } from './marketplace-thank-you-plugin-section';
+import MasterbarStyled from './masterbar-styled';
 
 export function usePluginsThankYouData(
 	pluginSlugs: string[]

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -177,6 +177,7 @@ export function usePluginsThankYouData(
 			onClick={ () => page( `/plugins/${ siteSlug }` ) }
 			backText={ translate( 'Back to plugins' ) }
 			canGoBack={ allPluginsFetched }
+			showContact={ allPluginsFetched }
 		/>
 	);
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -39,6 +39,7 @@ export function useThemesThankYouData(
 			onClick={ () => page( `/themes/${ siteSlug }` ) }
 			backText={ translate( 'Back to themes' ) }
 			canGoBack={ allThemesFetched }
+			showContact={ allThemesFetched }
 		/>
 	);
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -4,10 +4,10 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useQueryThemes } from 'calypso/components/data/query-theme';
 import { ThankYouSectionProps } from 'calypso/components/thank-you/types';
-import MasterbarStyled from 'calypso/my-sites/marketplace/components/masterbar-styled';
 import { getThemes } from 'calypso/state/themes/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { ThankYouThemeSection } from './marketplace-thank-you-theme-section';
+import MasterbarStyled from './masterbar-styled';
 
 export function useThemesThankYouData(
 	themeSlugs: string[]


### PR DESCRIPTION
Fixes #74736

## Proposed Changes

* Move the `MasterbarStyled` to a Marketplace Checkout-specific folder
* Add the contact section as default on this component
* Add the link to support on the contact section
* Remove the contact section from the footer

![CleanShot 2023-03-22 at 15 57 31@2x](https://user-images.githubusercontent.com/5039531/227009205-95db512f-ef2c-43cc-9053-70144c9bfde8.png)

## Testing Instructions
* Go to the thank you page with a plugin selected. Ex: `marketplace/thank-you/:site?plugins=:plugin-slug`
* Check if the footer section for contact (24/7....) is removed
* Check if a contact section is shown on the topbar
* Click on the link and check if it opens a new tab the link `https://wordpress.com/support/`
* Open the thank you page with a theme selected and check if the same applies. Ex: `marketplace/thank-you/:site?themes=:theme-slug`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
