### PR TITLE
e2e test for changes on post purchase page

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -318,10 +318,6 @@ export class PluginsPage {
 		// Check for the correct footer cards
 		await this.page.locator( selectors.installedfooterCards ).getByText( 'Keep growing' ).waitFor();
 		await this.page.locator( selectors.installedfooterCards ).getByText( 'Learn More' ).waitFor();
-		await this.page
-			.locator( selectors.installedfooterCards )
-			.getByText( '24/7 support at your fingertips' )
-			.waitFor();
 
 		// Check for plugin name
 		if ( expectedPluginName ) {

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -48,6 +48,7 @@ const selectors = {
 
 	// Post install
 	installedPluginCard: '.thank-you__step',
+	installedfooterCards: '.thank-you__footer',
 	manageInstalledPluginButton: 'a:has-text("Manage plugin")',
 };
 
@@ -307,8 +308,22 @@ export class PluginsPage {
 	 * @param {string} expectedPluginName Name of the plugin to validate.
 	 */
 	async validateConfirmationPagePostInstall( expectedPluginName?: string ): Promise< void > {
-		await this.page.getByRole( 'heading', { name: "You're all set", exact: false } ).waitFor();
+		await this.page
+			.getByRole( 'heading', { name: "Congrats on your site's new superpowers!" } )
+			.click();
 
+		// Check for expiration text
+		await this.page.locator( selectors.installedPluginCard ).getByText( 'expire' ).waitFor();
+
+		// Check for the correct footer cards
+		await this.page.locator( selectors.installedfooterCards ).getByText( 'Keep growing' ).waitFor();
+		await this.page.locator( selectors.installedfooterCards ).getByText( 'Learn More' ).waitFor();
+		await this.page
+			.locator( selectors.installedfooterCards )
+			.getByText( '24/7 support at your fingertips' )
+			.waitFor();
+
+		// Check for plugin name
 		if ( expectedPluginName ) {
 			await this.page
 				.locator( selectors.installedPluginCard )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/74326

## Proposed Changes

The main idea is to add e2e test for purchasing 1 plugin, but as we currently don't have the correct Atomic test user ([mentioned here](https://github.com/Automattic/wp-calypso/pull/74746#issuecomment-1479967942)), I added some validations on our changes on the post-purchase page.

- [x] Validate the new copy
- [x] Check for the expiration text
- [x] Validate the ~~three~~ two cards on the bottom section (removed 24/7 card because of [this PR](https://github.com/Automattic/wp-calypso/pull/74796))

## Testing Instructions

* On `/packages/calypso-e2e`, run 'yarn build`
* On Calypso root, run `yarn workspace wp-e2e-tests test -- plugins/plugins__install`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
