### PR TITLE
WoA Logging i1: Add tabs to the site logs page 1st pass

### DIFF
--- a/client/my-sites/site-logs/components/site-logs-tab-panel.tsx
+++ b/client/my-sites/site-logs/components/site-logs-tab-panel.tsx
@@ -8,11 +8,13 @@ export const tabs = [
 	{ name: 'web', title: __( 'Webserver Logs' ) },
 ];
 
+export type SiteLogsTab = 'php' | 'web';
+
 interface SiteLogsTabPanelProps {
 	children( tab: TabPanel.Tab ): JSX.Element;
+	selectedTab?: SiteLogsTab;
 	className?: string;
-	onSelected?: ( tab: string ) => void;
-	initialTab?: TabPanel.Tab;
+	onSelected?: ( tabName: string ) => void;
 }
 
 const LogsTabPanel = styled( TabPanel )`
@@ -38,15 +40,15 @@ const LogsTabPanel = styled( TabPanel )`
 
 export const SiteLogsTabPanel = ( {
 	children: renderContents,
+	selectedTab = 'php',
 	className,
 	onSelected,
-	initialTab = tabs[ 0 ],
 }: SiteLogsTabPanelProps ) => {
 	return (
 		<LogsTabPanel
+			initialTabName={ selectedTab }
 			className={ className }
 			tabs={ tabs }
-			initialTabName={ initialTab.name }
 			onSelect={ ( tabName ) => {
 				onTabSelected( tabName );
 				onSelected?.( tabName );

--- a/client/my-sites/site-logs/components/site-logs-tab-panel.tsx
+++ b/client/my-sites/site-logs/components/site-logs-tab-panel.tsx
@@ -1,0 +1,64 @@
+import styled from '@emotion/styled';
+import { TabPanel } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import page from 'page';
+
+export const tabs = [
+	{ name: 'php', title: __( 'PHP Logs' ) },
+	{ name: 'web', title: __( 'Webserver Logs' ) },
+];
+
+interface SiteLogsTabPanelProps {
+	children( tab: TabPanel.Tab ): JSX.Element;
+	className?: string;
+	onSelected?: ( tab: string ) => void;
+	initialTab?: TabPanel.Tab;
+}
+
+const LogsTabPanel = styled( TabPanel )`
+	.components-tab-panel__tabs {
+		overflow-x: auto;
+	}
+	.components-tab-panel__tabs-item {
+		--wp-admin-theme-color: var( --studio-gray-100 );
+		color: var( --studio-gray-60 );
+		padding: 0;
+		margin-right: 24px;
+		font-size: 16px;
+		flex-shrink: 0;
+	}
+	.components-tab-panel__tabs-item:hover,
+	.components-tab-panel__tabs-item.is-active,
+	.components-tab-panel__tabs-item.is-active:focus,
+	.components-tab-panel__tabs-item:focus:not( :disabled ) {
+		box-shadow: inset 0 -2px 0 0 var( --wp-admin-theme-color );
+		color: var( --studio-gray-100 );
+	}
+`;
+
+export const SiteLogsTabPanel = ( {
+	children: renderContents,
+	className,
+	onSelected,
+	initialTab = tabs[ 0 ],
+}: SiteLogsTabPanelProps ) => {
+	return (
+		<LogsTabPanel
+			className={ className }
+			tabs={ tabs }
+			initialTabName={ initialTab.name }
+			onSelect={ ( tabName ) => {
+				onTabSelected( tabName );
+				onSelected?.( tabName );
+			} }
+		>
+			{ ( tab ) => renderContents( tab ) }
+		</LogsTabPanel>
+	);
+};
+
+function onTabSelected( tabName: string ) {
+	const url = new URL( window.location.href );
+	url.searchParams.set( 'logType', tabName );
+	page.replace( url.pathname + url.search );
+}

--- a/client/my-sites/site-logs/components/site-logs-tab-panel.tsx
+++ b/client/my-sites/site-logs/components/site-logs-tab-panel.tsx
@@ -14,7 +14,7 @@ interface SiteLogsTabPanelProps {
 	children( tab: TabPanel.Tab ): JSX.Element;
 	selectedTab?: SiteLogsTab;
 	className?: string;
-	onSelected?: ( tabName: string ) => void;
+	onSelected?: ( tabName: SiteLogsTab ) => void;
 }
 
 const LogsTabPanel = styled( TabPanel )`
@@ -51,7 +51,7 @@ export const SiteLogsTabPanel = ( {
 			tabs={ tabs }
 			onSelect={ ( tabName ) => {
 				onTabSelected( tabName );
-				onSelected?.( tabName );
+				onSelected?.( tabName as SiteLogsTab );
 			} }
 		>
 			{ ( tab ) => renderContents( tab ) }

--- a/client/my-sites/site-logs/components/site-logs-tab-panel.tsx
+++ b/client/my-sites/site-logs/components/site-logs-tab-panel.tsx
@@ -61,6 +61,6 @@ export const SiteLogsTabPanel = ( {
 
 function onTabSelected( tabName: string ) {
 	const url = new URL( window.location.href );
-	url.searchParams.set( 'logType', tabName );
+	url.searchParams.set( 'log-type', tabName );
 	page.replace( url.pathname + url.search );
 }

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -18,7 +18,7 @@ export function SiteLogs() {
 	const [ endTime ] = useState( moment().unix() );
 
 	const [ logType, setLogType ] = useState< SiteLogsTab >( () => {
-		const queryParam = new URL( window.location.href ).searchParams.get( 'logType' );
+		const queryParam = new URL( window.location.href ).searchParams.get( 'log-type' );
 		return (
 			queryParam && [ 'php', 'web' ].includes( queryParam ) ? queryParam : 'php'
 		 ) as SiteLogsTab;

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -1,5 +1,5 @@
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -24,7 +24,7 @@ export function SiteLogs() {
 		 ) as SiteLogsTab;
 	} );
 
-	const { data, refetch } = useSiteLogsQuery( siteId, {
+	const { data } = useSiteLogsQuery( siteId, {
 		logType,
 		start: startTime,
 		end: endTime,
@@ -32,13 +32,9 @@ export function SiteLogs() {
 		page_size: 10,
 	} );
 
-	const handleTabSelected = useCallback(
-		( tabName ) => {
-			setLogType( tabName );
-			refetch();
-		},
-		[ refetch ]
-	);
+	const handleTabSelected = ( tabName: SiteLogsTab ) => {
+		setLogType( tabName );
+	};
 
 	const formattedLogs = data?.logs
 		.map( ( log ) =>
@@ -69,12 +65,7 @@ export function SiteLogs() {
 				align="left"
 			/>
 
-			<SiteLogsTabPanel
-				selectedTab={ logType }
-				onSelected={ ( tabName ) => {
-					handleTabSelected( tabName );
-				} }
-			>
+			<SiteLogsTabPanel selectedTab={ logType } onSelected={ handleTabSelected }>
 				{ ( tab ) => (
 					<>
 						<h2 style={ { marginTop: '24px' } }>{ tab.title }</h2>

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -7,7 +7,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import { useSiteLogsQuery } from 'calypso/data/hosting/use-site-logs-query';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { SiteLogsTabPanel, tabs } from './components/site-logs-tab-panel';
+import { SiteLogsTab, SiteLogsTabPanel } from './components/site-logs-tab-panel';
 
 export function SiteLogs() {
 	const { __ } = useI18n();
@@ -17,7 +17,12 @@ export function SiteLogs() {
 	const [ startTime ] = useState( moment().subtract( 7, 'd' ).unix() );
 	const [ endTime ] = useState( moment().unix() );
 
-	const [ logType, setLogType ] = useState< 'php' | 'web' >( 'php' );
+	const [ logType, setLogType ] = useState< SiteLogsTab >( () => {
+		const queryParam = new URL( window.location.href ).searchParams.get( 'logType' );
+		return (
+			queryParam && [ 'php', 'web' ].includes( queryParam ) ? queryParam : 'php'
+		 ) as SiteLogsTab;
+	} );
 
 	const { data, refetch } = useSiteLogsQuery( siteId, {
 		logType,
@@ -53,8 +58,6 @@ export function SiteLogs() {
 		.join( '\n' );
 
 	const titleHeader = __( 'Site Logs' );
-	const tabName = new URL( window.location.href ).searchParams.get( 'logType' ) ?? 'php';
-	const tab = tabs.find( ( tab ) => tab.name === tabName );
 
 	return (
 		<Main wideLayout>
@@ -67,7 +70,7 @@ export function SiteLogs() {
 			/>
 
 			<SiteLogsTabPanel
-				initialTab={ tab }
+				selectedTab={ logType }
 				onSelected={ ( tabName ) => {
 					handleTabSelected( tabName );
 				} }

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -1,5 +1,5 @@
 import { useI18n } from '@wordpress/react-i18n';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -7,6 +7,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import { useSiteLogsQuery } from 'calypso/data/hosting/use-site-logs-query';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { SiteLogsTabPanel, tabs } from './components/site-logs-tab-panel';
 
 export function SiteLogs() {
 	const { __ } = useI18n();
@@ -16,13 +17,23 @@ export function SiteLogs() {
 	const [ startTime ] = useState( moment().subtract( 7, 'd' ).unix() );
 	const [ endTime ] = useState( moment().unix() );
 
-	const { data } = useSiteLogsQuery( siteId, {
-		logType: 'web',
+	const [ logType, setLogType ] = useState< 'php' | 'web' >( 'php' );
+
+	const { data, refetch } = useSiteLogsQuery( siteId, {
+		logType,
 		start: startTime,
 		end: endTime,
 		sort_order: 'desc',
 		page_size: 10,
 	} );
+
+	const handleTabSelected = useCallback(
+		( tabName ) => {
+			setLogType( tabName );
+			refetch();
+		},
+		[ refetch ]
+	);
 
 	const formattedLogs = data?.logs
 		.map( ( log ) =>
@@ -42,6 +53,8 @@ export function SiteLogs() {
 		.join( '\n' );
 
 	const titleHeader = __( 'Site Logs' );
+	const tabName = new URL( window.location.href ).searchParams.get( 'logType' ) ?? 'php';
+	const tab = tabs.find( ( tab ) => tab.name === tabName );
 
 	return (
 		<Main wideLayout>
@@ -52,8 +65,20 @@ export function SiteLogs() {
 				subHeaderText={ __( 'View server logs to troubleshoot or debug problems with your site.' ) }
 				align="left"
 			/>
-			<h2>Web logs</h2>
-			<pre>{ formattedLogs }</pre>
+
+			<SiteLogsTabPanel
+				initialTab={ tab }
+				onSelected={ ( tabName ) => {
+					handleTabSelected( tabName );
+				} }
+			>
+				{ ( tab ) => (
+					<>
+						<h2 style={ { marginTop: '24px' } }>{ tab.title }</h2>
+						<pre>{ formattedLogs }</pre>
+					</>
+				) }
+			</SiteLogsTabPanel>
 		</Main>
 	);
 }

--- a/client/my-sites/site-logs/test/main.tsx
+++ b/client/my-sites/site-logs/test/main.tsx
@@ -10,6 +10,10 @@ import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { useNock, nock } from 'calypso/test-helpers/use-nock';
 import { SiteLogs } from '../main';
 
+// PageJS breaks the tests due to failing to read the document title.
+// Mock it for now to avoid the error.
+jest.mock( 'page' );
+
 const render = ( el, options ) =>
 	renderWithProvider( el, { ...options, reducers: { ui, documentHead } } );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/1992

## Proposed Changes

* Add tab panel to choose between php and webserver logs
* Fetch data based on the selected tab

## Testing Instructions

- Go to `/site-logs/:atomicSite`
- Verify tabs are rendered with `PHP Logs` selected
- Verify refreshing the browser maintains the current tab.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
![image](https://user-images.githubusercontent.com/47489215/227047407-4479bbdd-df4c-428a-b533-d7c7fbc55ff8.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
