### PR TITLE
E2E: update step in `Authentication: Magic Link` spec to accommodate changes in #74594.

### DIFF
--- a/test/e2e/specs/authentication/authentication__magic-link.ts
+++ b/test/e2e/specs/authentication/authentication__magic-link.ts
@@ -48,13 +48,8 @@ describe( DataHelper.createSuiteTitle( 'Authentication: Magic Link' ), function 
 		await page.goto( new URL( magicLinkURL ).toString() );
 	} );
 
-	it( 'Click the "Continue to WordPress.com" button', async () => {
-		// Page object for this screen is not implemented, and because it's a
-		// single-purpose screen, there really is no need to.
-		await Promise.all( [
-			page.waitForNavigation( { url: /\/home\// } ),
-			page.click( 'text=Continue to WordPress.com' ),
-		] );
+	it( 'Redirected to Home dashboard', async function () {
+		await page.waitForURL( /home/ );
 	} );
 
 	afterAll( async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74594.
Fixes https://github.com/Automattic/wp-calypso/issues/74807.

## Proposed Changes

This PR updates the test step of the aforementioned spec due to changes in #74594 which introduced an auto-redirect to the `/home` endpoint when logging in using a magic link.

## Testing Instructions

```bash
 PASS  specs/authentication/authentication__magic-link.ts (9.466 s)
  Authentication: Magic Link
    ✓ Navigate to Magic Link screen from /login (892 ms)
    ✓ Request magic link (3476 ms)
    ✓ Go to the Magic Link URL (434 ms)
    ✓ Redirected to Home dashboard (2612 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        9.648 s
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
