### PR TITLE
Checkout: add CTA to Akismet thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/akismet-checkout-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/akismet-checkout-thank-you.tsx
@@ -1,10 +1,11 @@
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import QueryProducts from 'calypso/components/data/query-products-list';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isProductsListFetching, getProductName } from 'calypso/state/products-list/selectors';
 import type { FunctionComponent } from 'react';
 
@@ -15,11 +16,20 @@ interface AkismetCheckoutThankYouProps {
 const AkismetCheckoutThankYou: FunctionComponent< AkismetCheckoutThankYouProps > = ( {
 	productSlug,
 } ) => {
+	const dispatch = useDispatch();
 	const hasProduct = productSlug !== 'no_product';
 	const productName = useSelector( ( state ) =>
 		hasProduct ? getProductName( state, productSlug ) : null
 	);
 	const isLoading = useSelector( isProductsListFetching );
+
+	const onManagePurchaseClick = () => {
+		dispatch(
+			recordTracksEvent( 'calypso_akismet_checkout_thank_you_page_manage_purchase_click', {
+				product_slug: productSlug,
+			} )
+		);
+	};
 
 	return (
 		<Main className="akismet-checkout-thank-you">
@@ -61,6 +71,15 @@ const AkismetCheckoutThankYou: FunctionComponent< AkismetCheckoutThankYouProps >
 						{ strong: <strong /> }
 					) }
 				</p>
+
+				<Button
+					primary
+					busy={ isLoading }
+					href="https://akismet.com/account/"
+					onClick={ onManagePurchaseClick }
+				>
+					{ __( 'Manage Purchase' ) }
+				</Button>
 			</Card>
 
 			<div className="akismet-checkout-thank-you__footer-img"></div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1201210512993648-as-1204210417785458

## Proposed Changes

* Add a "Manage Purchase" button to the Thank Page. This button links to akismet.com/account

<img width="1014" alt="image" src="https://user-images.githubusercontent.com/5714212/227066215-58af7228-a45d-4bf1-a287-b926a085a06f.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR locally
* `yarn start`
* Visit http://calypso.localhost:3000/checkout/akismet/thank-you/ak_plus_yearly_2
* Confirm that it has a "Manage Purchase"
* Click on the button and make sure you are redirected to akismet.com/account
* Open the Network tab, filter by `calypso_akismet`, and confirm that an event was recorded for the button click

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?