### PR TITLE
Theme Showcase: Add context for the translation of "Paid" themes

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -447,7 +447,7 @@ export class Theme extends Component {
 					{ ...commonProps }
 					className={ classNames( commonProps.className, 'theme__marketplace-theme' ) }
 					labelText={ translate( 'Paid', {
-						comment: 'Refers to paid service, such as paid theme',
+						context: 'Refers to paid service, such as paid theme',
 						textOnly: true,
 					} ) }
 				/>


### PR DESCRIPTION
## Proposed Changes

As suggested in pdtkmj-1gp-p2#comment-2426, let's add a new context for the word "Paid" when used in the premium badges. This added context will help disambiguate the use of the word "Paid" for premium badges. 

![Screenshot 2023-03-23 at 9 25 11 AM](https://user-images.githubusercontent.com/797888/227074992-8a4df5cf-6766-4bf8-aa45-5fdc046d96c6.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?