### PR TITLE
Site Assembler - Snackbar notifications as in the editor

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -4,6 +4,7 @@ import { StepContainer, WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding
 import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalNavigatorScreen as NavigatorScreen,
+	withNotices,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import classnames from 'classnames';
@@ -25,6 +26,7 @@ import useGlobalStylesUpgradeModal from './hooks/use-global-styles-upgrade-modal
 import usePatternCategories from './hooks/use-pattern-categories';
 import usePatternsMapByCategory from './hooks/use-patterns-map-by-category';
 import NavigatorListener from './navigator-listener';
+import Notices, { getNoticeContent } from './notices/notices';
 import PatternAssemblerContainer from './pattern-assembler-container';
 import PatternLargePreview from './pattern-large-preview';
 import { useAllPatterns, useSectionPatterns } from './patterns-data';
@@ -37,13 +39,19 @@ import ScreenPatternList from './screen-pattern-list';
 import { encodePatternId } from './utils';
 import withGlobalStylesProvider from './with-global-styles-provider';
 import type { Pattern, Category } from './types';
-import type { Step } from '../../types';
+import type { StepProps } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { DesignRecipe, Design } from '@automattic/design-picker/src/types';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 import './style.scss';
 
-const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
+const PatternAssembler = ( {
+	navigation,
+	flow,
+	stepName,
+	noticeList,
+	noticeOperations,
+}: StepProps & withNotices.Props ) => {
 	const [ navigatorPath, setNavigatorPath ] = useState( '/' );
 	const [ header, setHeader ] = useState< Pattern | null >( null );
 	const [ footer, setFooter ] = useState< Pattern | null >( null );
@@ -187,6 +195,10 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 		} );
 	};
 
+	const showNotice = ( action: string, pattern: Pattern ) => {
+		noticeOperations.createNotice( { content: getNoticeContent( action, pattern ) } );
+	};
+
 	const getDesign = () =>
 		( {
 			...selectedDesign,
@@ -224,6 +236,7 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 				...sections.slice( sectionPosition + 1 ),
 			] );
 			updateActivePatternPosition( sectionPosition );
+			showNotice( 'replace', pattern );
 		}
 	};
 
@@ -237,6 +250,7 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 			},
 		] );
 		updateActivePatternPosition( sections.length );
+		showNotice( 'add', pattern );
 	};
 
 	const deleteSection = ( position: number ) => {
@@ -411,6 +425,9 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 			ref={ wrapperRef }
 			tabIndex={ -1 }
 		>
+			{ isEnabled( 'pattern-assembler/notices' ) && (
+				<Notices noticeList={ noticeList } noticeOperations={ noticeOperations } />
+			) }
 			<NavigatorProvider className="pattern-assembler__sidebar" initialPath="/">
 				<NavigatorScreen path="/">
 					<ScreenMain
@@ -549,4 +566,4 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 	);
 };
 
-export default withGlobalStylesProvider( PatternAssembler );
+export default withGlobalStylesProvider( withNotices( PatternAssembler ) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -218,11 +218,29 @@ const PatternAssembler = ( {
 	const updateHeader = ( pattern: Pattern | null ) => {
 		setHeader( pattern );
 		updateActivePatternPosition( -1 );
+		if ( pattern ) {
+			if ( header ) {
+				showNotice( 'replace', pattern );
+			} else {
+				showNotice( 'add', pattern );
+			}
+		} else if ( header ) {
+			showNotice( 'remove', header );
+		}
 	};
 
 	const updateFooter = ( pattern: Pattern | null ) => {
 		setFooter( pattern );
 		updateActivePatternPosition( sections.length );
+		if ( pattern ) {
+			if ( footer ) {
+				showNotice( 'replace', pattern );
+			} else {
+				showNotice( 'add', pattern );
+			}
+		} else if ( footer ) {
+			showNotice( 'remove', footer );
+		}
 	};
 
 	const replaceSection = ( pattern: Pattern ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -254,6 +254,7 @@ const PatternAssembler = ( {
 	};
 
 	const deleteSection = ( position: number ) => {
+		showNotice( 'remove', sections[ position ] );
 		setSections( [ ...sections.slice( 0, position ), ...sections.slice( position + 1 ) ] );
 		updateActivePatternPosition( position );
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.scss
@@ -1,0 +1,11 @@
+.pattern-assembler {
+	.components-snackbar-list {
+		overflow: hidden;
+		bottom: 8px;
+		padding-inline-end: 8px;
+	}
+
+	.components-snackbar {
+		margin-inline-start: auto;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.scss
@@ -1,8 +1,8 @@
 .pattern-assembler {
 	.components-snackbar-list {
 		overflow: hidden;
-		bottom: 8px;
-		padding-inline-end: 8px;
+		bottom: 16px;
+		padding-inline-end: 16px;
 	}
 
 	.components-snackbar {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
@@ -1,0 +1,38 @@
+import { SnackbarList, withNotices } from '@wordpress/components';
+import i18n from 'i18n-calypso';
+import { ReactNode } from 'react';
+import type { Pattern } from '../types';
+import './notices.scss';
+
+type NoticesProps = {
+	noticeList: withNotices.Props[ 'noticeList' ];
+	noticeOperations: withNotices.Props[ 'noticeOperations' ];
+	noticeUI?: ReactNode;
+};
+
+const Notices = ( { noticeList, noticeOperations }: NoticesProps ) => {
+	const onRemoveNotice = ( id: string ) => {
+		noticeOperations.removeNotice( id );
+	};
+
+	return <SnackbarList notices={ noticeList } onRemove={ onRemoveNotice } />;
+};
+
+export const getNoticeContent = ( action: string, pattern: Pattern ) => {
+	const actions: { [ key: string ]: any } = {
+		add: i18n.translate( 'Pattern "%(categoryName)s" added.', {
+			comment: 'A pattern is added to the list using the pattern category as name',
+			args: { categoryName: pattern.category?.label },
+		} ),
+		replace: i18n.translate( 'Pattern "%(categoryName)s" replaced.', {
+			args: { categoryName: pattern.category?.label },
+		} ),
+		remove: i18n.translate( 'Pattern "%(categoryName)s" removed.', {
+			args: { categoryName: pattern.category?.label },
+		} ),
+	};
+
+	return actions[ action ];
+};
+
+export default Notices;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
@@ -16,15 +16,14 @@ const Notices = ( {
 
 export const getNoticeContent = ( action: string, pattern: Pattern ) => {
 	const actions: { [ key: string ]: any } = {
-		add: i18n.translate( 'Pattern "%(categoryName)s" added.', {
-			comment: 'A pattern is added to the list using the pattern category as name',
-			args: { categoryName: pattern.category?.label },
+		add: i18n.translate( 'Block pattern "%(patternName)s" inserted.', {
+			args: { patternName: pattern.name },
 		} ),
-		replace: i18n.translate( 'Pattern "%(categoryName)s" replaced.', {
-			args: { categoryName: pattern.category?.label },
+		replace: i18n.translate( 'Block pattern "%(patternName)s" replaced.', {
+			args: { patternName: pattern.name },
 		} ),
-		remove: i18n.translate( 'Pattern "%(categoryName)s" removed.', {
-			args: { categoryName: pattern.category?.label },
+		remove: i18n.translate( 'Block pattern "%(patternName)s" removed.', {
+			args: { patternName: pattern.name },
 		} ),
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
@@ -1,16 +1,12 @@
 import { SnackbarList, withNotices } from '@wordpress/components';
 import i18n from 'i18n-calypso';
-import { ReactNode } from 'react';
 import type { Pattern } from '../types';
 import './notices.scss';
 
-type NoticesProps = {
-	noticeList: withNotices.Props[ 'noticeList' ];
-	noticeOperations: withNotices.Props[ 'noticeOperations' ];
-	noticeUI?: ReactNode;
-};
-
-const Notices = ( { noticeList, noticeOperations }: NoticesProps ) => {
+const Notices = ( {
+	noticeList,
+	noticeOperations,
+}: Pick< withNotices.Props, 'noticeList' | 'noticeOperations' > ) => {
 	const onRemoveNotice = ( id: string ) => {
 		noticeOperations.removeNotice( id );
 	};

--- a/config/development.json
+++ b/config/development.json
@@ -135,6 +135,7 @@
 		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/inline-styles": true,
+		"pattern-assembler/notices": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -86,6 +86,7 @@
 		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/inline-styles": true,
+		"pattern-assembler/notices": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/production.json
+++ b/config/production.json
@@ -101,6 +101,7 @@
 		"pattern-assembler/color-and-fonts": false,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/inline-styles": false,
+		"pattern-assembler/notices": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -99,6 +99,7 @@
 		"pattern-assembler/color-and-fonts": false,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/inline-styles": true,
+		"pattern-assembler/notices": false,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -109,6 +109,7 @@
 		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/inline-styles": true,
+		"pattern-assembler/notices": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74758

## Proposed Changes

* Add feature flag `pattern-assembler/notices`
* Use `withNotices` HOC to handle the notices state 
* Use `SnackbarList` component to handle the stack of notices.
* Show a notice stacked (as in the editor but on the bottom-right of the screen) when any pattern is added, replaced, or removed.
* Use the same notice copy as the editor `Block pattern "Name" inserted.`
* Auto dismisses after 10 seconds (as in the editor). The time is hardcoded in the component, maybe for accessibility reasons.    
* Dismiss a notice immediately on click (as in the editor).


https://user-images.githubusercontent.com/1881481/227452174-b606574f-a376-40d0-a071-1c5dd7e68b74.mov


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click on the `Calypso Live` link from the first comment
* Create a new site
* Continue until the design picker
* Scroll down and click `Start designing`
* Click `Homepage > Add patterns` to add patterns and verify that the notice shows the category name of the patterns added
* Replace the patterns and verify that the notice shows the category name of the new pattern and says `replaced`.
* Remove patterns to verify that the notice says `removed`
* Click on a notice to dismiss it
* Wait 10 seconds to see the notice disappear
* Click the `<` back or `Save` button and verify the notices stay
* Go back to the design picker or click `Continue` to verify the notices disappear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
