### PR TITLE
BBE Landing: Update headline and CTA copy

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -416,16 +416,6 @@ export default function DIFMLanding( {
 								</li>
 								<li>
 									{ translate(
-										'Choose {{b}}New site{{/b}} to begin a new site or {{b}}Existing WordPress.com{{/b}} site if you’d like to use an existing site on your account. (Note that all existing website content will be deleted from the site so we can start fresh).',
-										{
-											components: {
-												b: <b />,
-											},
-										}
-									) }
-								</li>
-								<li>
-									{ translate(
 										'Submit your business information and optionally add your social media profiles.'
 									) }
 								</li>

--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -275,7 +275,7 @@ export default function DIFMLanding( {
 		: getPlan( PLAN_PREMIUM )?.getTitle();
 
 	const headerText = translate(
-		'Hire a professional to set up your site for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
+		'Let us build your site for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
 		{
 			components: {
 				PriceWrapper: ! hasPriceDataLoaded ? <Placeholder /> : <span />,
@@ -369,7 +369,7 @@ export default function DIFMLanding( {
 					</p>
 					<CTASectionWrapper>
 						<NextButton onClick={ onSubmit } isPrimary={ true }>
-							{ translate( 'Hire a professional' ) }
+							{ translate( 'Get started' ) }
 						</NextButton>
 					</CTASectionWrapper>
 				</ContentSection>
@@ -408,7 +408,7 @@ export default function DIFMLanding( {
 						<FoldableFAQ id="faq-2" question={ translate( 'How do I get started?' ) }>
 							<ul>
 								<li>
-									{ translate( 'Click {{a}}Hire a professional{{/a}} to begin.', {
+									{ translate( 'Click {{a}}Get started{{/a}} to begin.', {
 										components: {
 											a: <LinkButton isLink={ true } onClick={ onSubmit } />,
 										},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1643

## Proposed Changes

* Updates the headline copy to `Let us build your site for ...`.
* Updates the CTA copy to `Get started`.

<img width="1798" alt="image" src="https://user-images.githubusercontent.com/5436027/227108854-f73b473f-4733-4eb2-9f55-bf4ec7a0a217.png">

* Also removes an incorrect bullet point from the second FAQ item.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/5436027/227445226-b9ecc352-38a8-4d09-a925-0eb65c7f024b.png)|<img width="1297" alt="image" src="https://user-images.githubusercontent.com/5436027/227445284-3bb1ea29-1268-43df-b461-21a963ec274a.png">|



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/site-setup/difmStartingPoint?siteSlug=<site slug>` and confirm that it matches the changes described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
