### PR TITLE
Theme Showcase: Fix missing CSS classes in the Theme Detail's 404 page

### DIFF
--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -1,7 +1,4 @@
 import debugFactory from 'debug';
-import { Provider as ReduxProvider } from 'react-redux';
-import { RouteProvider } from 'calypso/components/route';
-import LayoutLoggedOut from 'calypso/layout/logged-out';
 import { requestTheme, setBackPath } from 'calypso/state/themes/actions';
 import { getTheme, getThemeRequestErrors } from 'calypso/state/themes/selectors';
 import ThemeSheetComponent from './main';
@@ -75,12 +72,6 @@ export function details( context, next ) {
 }
 
 export function notFoundError( err, context, next ) {
-	context.layout = (
-		<RouteProvider currentSection={ context.section } currentQuery={ context.query }>
-			<ReduxProvider store={ context.store }>
-				<LayoutLoggedOut primary={ <ThemeNotFoundError /> } />
-			</ReduxProvider>
-		</RouteProvider>
-	);
+	context.primary = <ThemeNotFoundError />;
 	next( err );
 }

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -1,5 +1,6 @@
 import debugFactory from 'debug';
 import { Provider as ReduxProvider } from 'react-redux';
+import { RouteProvider } from 'calypso/components/route';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
 import { requestTheme, setBackPath } from 'calypso/state/themes/actions';
 import { getTheme, getThemeRequestErrors } from 'calypso/state/themes/selectors';
@@ -75,9 +76,11 @@ export function details( context, next ) {
 
 export function notFoundError( err, context, next ) {
 	context.layout = (
-		<ReduxProvider store={ context.store }>
-			<LayoutLoggedOut primary={ <ThemeNotFoundError /> } />
-		</ReduxProvider>
+		<RouteProvider currentSection={ context.section } currentQuery={ context.query }>
+			<ReduxProvider store={ context.store }>
+				<LayoutLoggedOut primary={ <ThemeNotFoundError /> } />
+			</ReduxProvider>
+		</RouteProvider>
 	);
 	next( err );
 }

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -218,6 +218,12 @@ body.is-section-theme-i4 {
 	}
 }
 
+.is-section-theme {
+	.empty-content {
+		margin-bottom: 20px;
+	}
+}
+
 .main.theme__sheet {
 	max-width: none;
 }


### PR DESCRIPTION
## Proposed Changes

This PR fixes an issue where the Theme Detail's 404-page looks broken due to missing CSS classes.

| Before | After |
| --- | --- |
| ![Screenshot 2023-03-23 at 2 30 16 PM](https://user-images.githubusercontent.com/797888/227121980-a316ce7b-81c7-4dbf-aaf9-9206d24c5f9d.png) | ![Screenshot 2023-03-23 at 2 29 59 PM](https://user-images.githubusercontent.com/797888/227121997-7f6aa97d-ff69-43f9-a82f-ad340bd08b40.png) |

Note the missing CSS classes `is-group-sites` and `is-section-theme`.

| Before | After |
| --- | --- |
| ![Screenshot 2023-03-23 at 2 31 47 PM](https://user-images.githubusercontent.com/797888/227122335-6f65e11c-d738-4b12-b4c7-66e7940d44b2.png) |  ![Screenshot 2023-03-23 at 2 31 25 PM](https://user-images.githubusercontent.com/797888/227122374-6767181c-bfa0-4c9d-8553-33cde43a12c0.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Detail's 404-page by typing an invalid theme name. For instance, `/theme/notatheme`.
* Ensure that the CSS classes mentioned above are present.
* Ensure that the page masthead's CSS is not broken.
* Ensure that the Theme Detail page for existing themes works as before.
* Please test both the logged-in, and the logged-out Theme Detail page. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
