### PR TITLE
Theme Showcase: Set max-width for the logged-out header tagline

### DIFF
--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -216,6 +216,7 @@ body.is-section-themes {
 
 		.page-sub-header {
 			font-size: 1rem;
+			max-width: 640px;
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

As discussed in p1679283208187059-slack-C048CUFRGFQ, let's set a max width for the logged-out header's tagline.

| Before | After |
| --- | --- |
|![Screenshot 2023-03-23 at 3 16 19 PM](https://user-images.githubusercontent.com/797888/227130663-eac19dce-f7a6-41dc-984b-59f40f007736.png) | ![Screenshot 2023-03-23 at 3 16 34 PM](https://user-images.githubusercontent.com/797888/227130685-ec10d4d8-f2bd-4906-9176-46e349b77542.png)|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-out Theme Showcase.
* Ensure that the header tagline has a max width (640px) as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?