### PR TITLE
Agency Dashboard: Do not show error notices if API requests to /test-connection are failing

### DIFF
--- a/client/data/agency-dashboard/use-fetch-test-connection.ts
+++ b/client/data/agency-dashboard/use-fetch-test-connection.ts
@@ -1,17 +1,11 @@
-import { useTranslate } from 'i18n-calypso';
 import { useQuery } from 'react-query';
-import { useDispatch } from 'react-redux';
 import wpcom from 'calypso/lib/wp';
-import { errorNotice } from 'calypso/state/notices/actions';
 
 const useFetchTestConnection = (
 	isPartnerOAuthTokenLoaded: boolean,
 	isConnectionHealthy: boolean,
 	siteId: number
 ) => {
-	const translate = useTranslate();
-	const dispatch = useDispatch();
-
 	return useQuery(
 		[ 'jetpack-agency-test-connection', siteId ],
 		() =>
@@ -26,12 +20,6 @@ const useFetchTestConnection = (
 				}
 			),
 		{
-			onError: () =>
-				dispatch(
-					errorNotice(
-						translate( 'Failed to check your sites connection. Please try again later.' )
-					)
-				),
 			enabled: isPartnerOAuthTokenLoaded,
 			refetchOnWindowFocus: false,
 			// We don't want to trigger another API request to the /test-connection endpoint for a given site


### PR DESCRIPTION
Related to 1202619025189113-as-1204244982863287

## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/68837 we shipped an improvement to verify that the connection health stored in ES matches the live one. However, if the API request to the `/test-connection` endpoint fails, we shouldn't display the error notices to the user as they are irrelevant to the dashboard UI.


## Testing Instructions
- Run `git checkout fix/agency-dashboard-test-connection-error-messages` and `yarn start-jetpack-cloud`
- Open the Dev Tools panel.
- Open http://jetpack.cloud.localhost:3000/
- Locate the `/test-connection` API requests
- Right-click on some of the requests, then select "Block request URL" to simulate a failing request
- Wait for about 5 minutes (as we have `staleTime` set to 5 minutes) and reload the page
- Verify that the requests are failing and no error notices are being shown to the user
- Unblock the API requests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?