### PR TITLE
Theme Showcase: Add tier marketplace to type check

### DIFF
--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -13,8 +13,8 @@ class QueryThemes extends Component {
 		query: PropTypes.shape( {
 			// The search string
 			search: PropTypes.string,
-			// The tier to look for -- 'free', 'premium', or '' (for all themes)
-			tier: PropTypes.oneOf( [ '', 'free', 'premium' ] ),
+			// The tier to look for -- 'free', 'premium', 'marketplace', or '' (for all themes)
+			tier: PropTypes.oneOf( [ '', 'free', 'premium', 'marketplace' ] ),
 			// Comma-separated list of filters; see my-sites/themes/theme-filters
 			filter: PropTypes.string,
 			// Which page of the results list to display

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -69,7 +69,7 @@ class ThemeShowcase extends Component {
 
 	static propTypes = {
 		emptyContent: PropTypes.element,
-		tier: PropTypes.oneOf( [ '', 'free', 'premium' ] ),
+		tier: PropTypes.oneOf( [ '', 'free', 'premium', 'marketplace' ] ),
 		search: PropTypes.string,
 		pathName: PropTypes.string,
 		// Connected props

--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -19,7 +19,7 @@ import 'calypso/state/themes/init';
  * @param  {number|string} siteId        Jetpack site ID or 'wpcom' for any WPCOM site
  * @param  {Object}        query         Theme query
  * @param  {string}        query.search  Search string
- * @param  {string}        query.tier    Theme tier: 'free', 'premium', or '' (either)
+ * @param  {string}        query.tier    Theme tier: 'free', 'premium', 'marketplace', or '' (either)
  * @param  {string}        query.filter  Filter
  * @param  {number}        query.number  How many themes to return per page
  * @param  {number}        query.offset  At which item to start the set of returned themes


### PR DESCRIPTION
## Proposed Changes

In #74769, the tier filter `marketplace` was added. This PR adds the `marketplace` tier to type checks to prevent error messages like the following:

![Screenshot 2023-03-23 at 5 17 47 PM](https://user-images.githubusercontent.com/797888/227160017-1f71e33a-ab87-4b8a-ae08-9525caac3441.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Select the "Paid" filter.
* Ensure that the is no type check errors related to the newly added `marketplace` tier.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
