### PR TITLE
Newsletter: Setup color dropdown lock on right

### DIFF
--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -22,6 +22,7 @@ class SelectDropdown extends Component {
 		selectedIcon: PropTypes.element,
 		selectedCount: PropTypes.number,
 		selectedSecondaryIcon: PropTypes.element,
+		positionSelectedSecondaryIconOnRight: PropTypes.bool,
 		initialSelected: PropTypes.string,
 		className: PropTypes.string,
 		style: PropTypes.object,
@@ -145,6 +146,16 @@ class SelectDropdown extends Component {
 		return get( find( options, { value: selected } ), 'secondaryIcon' );
 	}
 
+	getPositionSelectedSecondaryIcon() {
+		const { positionSelectedSecondaryIconOnRight } = this.props;
+
+		if ( positionSelectedSecondaryIconOnRight ) {
+			return positionSelectedSecondaryIconOnRight;
+		}
+
+		return false;
+	}
+
 	dropdownOptions() {
 		let refIndex = 0;
 
@@ -214,6 +225,7 @@ class SelectDropdown extends Component {
 		const selectedText = this.getSelectedText();
 		const selectedIcon = this.getSelectedIcon();
 		const selectedSecondaryIcon = this.getSelectedSecondaryIcon();
+		const positionSelectedSecondaryIconOnRight = this.getPositionSelectedSecondaryIcon();
 
 		return (
 			<div id={ this.props.id } style={ this.props.style } className={ dropdownClassName }>
@@ -233,13 +245,14 @@ class SelectDropdown extends Component {
 				>
 					<div id={ 'select-dropdown-' + this.instanceId } className="select-dropdown__header">
 						<span className="select-dropdown__header-text" aria-label={ this.props.ariaLabel }>
-							{ selectedSecondaryIcon }
+							{ ! positionSelectedSecondaryIconOnRight && selectedSecondaryIcon }
 							{ selectedIcon }
 							{ selectedText }
 						</span>
 						{ 'number' === typeof this.props.selectedCount && (
 							<Count count={ this.props.selectedCount } />
 						) }
+						{ positionSelectedSecondaryIconOnRight && selectedSecondaryIcon }
 						<Gridicon icon="chevron-down" size={ 18 } />
 					</div>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-import { Gridicon, Popover } from '@automattic/components';
+import { Popover } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { hasMinContrast, hexToRgb, RGB } from '@automattic/onboarding';
 import { ColorPicker } from '@wordpress/components';
-import { Icon, color } from '@wordpress/icons';
+import { Icon, color, lock } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import {
@@ -162,8 +162,8 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 
 		if ( matchingOption?.isPremium || ( customColor && ! matchingOption ) ) {
 			return (
-				<Gridicon
-					icon="lock"
+				<Icon
+					icon={ lock }
 					size={ 18 }
 					className={ classNames( 'extra-gridicon', 'right-positioned' ) }
 				/>
@@ -183,7 +183,7 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 				selected={ option.value === accentColor.hex }
 				secondaryIcon={
 					shouldLimitGlobalStyles && option.isPremium ? (
-						<Gridicon icon="lock" size={ 18 } className="extra-gridicon" />
+						<Icon icon={ lock } size={ 18 } className="extra-gridicon" />
 					) : null
 				}
 			>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -161,7 +161,13 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 		const matchingOption = getMatchingOption();
 
 		if ( matchingOption?.isPremium || ( customColor && ! matchingOption ) ) {
-			return <Gridicon icon="lock" size={ 18 } className="extra-gridicon" />;
+			return (
+				<Gridicon
+					icon="lock"
+					size={ 18 }
+					className={ classNames( 'extra-gridicon', 'right-positioned' ) }
+				/>
+			);
 		}
 		return null;
 	};
@@ -257,6 +263,7 @@ const AccentColorControl = ( { accentColor, setAccentColor }: AccentColorControl
 					selectedText={ getSelectedText() }
 					selectedIcon={ getSelectedIcon() }
 					selectedSecondaryIcon={ getSelectedSecondaryIcon() }
+					positionSelectedSecondaryIconOnRight={ true }
 				>
 					{ getDropdownOptions() }
 				</SelectDropdown>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
@@ -78,6 +78,11 @@ $side-margin: 16;
 			margin-bottom: 3px;
 		}
 
+		.select-dropdown__header svg.right-positioned {
+			margin-left: auto;
+			margin-right: 8px;
+		}
+
 		.select-dropdown__item.is-selected {
 			background-color: unset;
 			color: var(--color-neutral-70);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/style.scss
@@ -78,9 +78,13 @@ $side-margin: 16;
 			margin-bottom: 3px;
 		}
 
-		.select-dropdown__header svg.right-positioned {
-			margin-left: auto;
-			margin-right: 8px;
+		.select-dropdown__header svg {
+			fill: var(--color-neutral);
+
+			&.right-positioned {
+				margin-left: auto;
+				margin-right: 8px;
+			}
 		}
 
 		.select-dropdown__item.is-selected {


### PR DESCRIPTION
[Context](puPv3-e72-p2)

The icon works better on the right side since it is easy to read colors and labels.
It has also been changed to use @wordress/icons 

![image](https://user-images.githubusercontent.com/52076348/227180447-914b89c2-b08f-4cc2-8edb-63a9bc0fafe7.png)

## Testing
1. Calypso Live link
2. Go to setup page and check the color dropdown
3. There should not be any regression in other usage of the dropdown
