### PR TITLE
Add user's email address to the Subscription Management portal

### DIFF
--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -1,4 +1,5 @@
 import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
+import cookie from 'cookie';
 import wpcomRequest from 'wpcom-proxy-request';
 
 type callApiParams = {
@@ -10,11 +11,7 @@ type callApiParams = {
 
 // Get cookie named subkey
 const getSubkey = () => {
-	const subkey = document.cookie
-		?.split( ';' )
-		?.map( ( c ) => c.trim() )
-		?.find( ( c ) => c.startsWith( 'subkey=' ) )
-		?.split( '=' )[ 1 ];
+	const subkey = cookie.parse( document.cookie )?.subkey;
 	return subkey;
 };
 

--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -8,6 +8,16 @@ type callApiParams = {
 	isLoggedIn?: boolean;
 };
 
+// Get cookie named subkey
+const getSubkey = () => {
+	const subkey = document.cookie
+		?.split( ';' )
+		?.map( ( c ) => c.trim() )
+		?.find( ( c ) => c.startsWith( 'subkey=' ) )
+		?.split( '=' )[ 1 ];
+	return subkey;
+};
+
 // Helper function for fetching from subkey authenticated API. Subkey authentication process is only applied in case of logged-out users.
 async function callApi< ReturnType >( {
 	path,
@@ -25,12 +35,7 @@ async function callApi< ReturnType >( {
 		return res as ReturnType;
 	}
 
-	// get cookie named subkey
-	const subkey = document.cookie
-		?.split( ';' )
-		?.map( ( c ) => c.trim() )
-		?.find( ( c ) => c.startsWith( 'subkey=' ) )
-		?.split( '=' )[ 1 ];
+	const subkey = getSubkey();
 
 	if ( ! subkey ) {
 		throw new Error( 'Subkey not found' );
@@ -50,4 +55,4 @@ async function callApi< ReturnType >( {
 	} as APIFetchOptions );
 }
 
-export { callApi };
+export { callApi, getSubkey };

--- a/packages/data-stores/src/reader/hooks/index.ts
+++ b/packages/data-stores/src/reader/hooks/index.ts
@@ -1,5 +1,7 @@
 import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 import { register as registerUserStore } from '../../user';
+import { getSubkey } from '../helpers';
 import type { UserSelect } from '../../user';
 
 const USER_STORE = registerUserStore( { client_id: '', client_secret: '' } );
@@ -18,4 +20,25 @@ export const useIsQueryEnabled = () => {
 	}
 
 	return false;
+};
+
+// Get subscriber's email address based on the subkey cookie
+export const useSubscriberEmailAddress = () => {
+	return useMemo( () => {
+		const subkey = getSubkey();
+
+		if ( ! subkey ) {
+			return null;
+		}
+
+		const decodedSubkeyValue = decodeURIComponent( subkey );
+
+		const firstPeriodIndex = decodedSubkeyValue.indexOf( '.' );
+		if ( firstPeriodIndex === -1 ) {
+			return null;
+		}
+
+		const emailAddress = decodedSubkeyValue.slice( firstPeriodIndex + 1 );
+		return emailAddress;
+	}, [] );
 };

--- a/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
+++ b/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, LocalizeProps } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
@@ -34,27 +34,27 @@ const getEmailAddress = () => {
 	return emailAddress;
 };
 
+const getSubHeaderText = ( translate: LocalizeProps[ 'translate' ] ) => {
+	const emailAddress = getEmailAddress();
+	if ( emailAddress ) {
+		return translate(
+			"Manage the WordPress.com newsletter and blogs you've subscribed to with {{span}}%(emailAddress)s{{/span}}.",
+			{
+				args: {
+					emailAddress: emailAddress,
+				},
+				components: {
+					span: <span className="email-address" />,
+				},
+			}
+		);
+	}
+
+	return translate( 'Manage your WordPress.com newsletter and blog subscriptions.' );
+};
+
 const SubscriptionManagerContainer = ( { children }: SubscriptionManagerContainerProps ) => {
 	const translate = useTranslate();
-
-	const getSubHeaderText = () => {
-		const emailAddress = getEmailAddress();
-		if ( emailAddress ) {
-			return translate(
-				"Manage the WordPress.com newsletter and blogs you've subscribed to with {{span}}%(emailAddress)s{{/span}}.",
-				{
-					args: {
-						emailAddress: emailAddress,
-					},
-					components: {
-						span: <span className="email-address" />,
-					},
-				}
-			);
-		}
-
-		return translate( 'Manage your WordPress.com newsletter and blog subscriptions.' );
-	};
 
 	return (
 		<Main className="subscription-manager-container">
@@ -62,7 +62,7 @@ const SubscriptionManagerContainer = ( { children }: SubscriptionManagerContaine
 			<FormattedHeader
 				brandFont
 				headerText={ translate( 'Subscription management' ) }
-				subHeaderText={ getSubHeaderText() }
+				subHeaderText={ getSubHeaderText( translate ) }
 				align="left"
 			/>
 			{ children }

--- a/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
+++ b/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
@@ -12,8 +12,49 @@ export type SubscriptionManagerContainerProps = {
 	children?: React.ReactNode;
 };
 
+const getEmailAddress = () => {
+	const subkey: string | undefined = document.cookie
+		?.split( ';' )
+		?.map( ( c ) => c.trim() )
+		?.find( ( c ) => c.startsWith( 'subkey=' ) )
+		?.split( '=' )[ 1 ];
+
+	if ( ! subkey ) {
+		return null;
+	}
+
+	const decodedSubkeyValue = decodeURIComponent( subkey );
+
+	const firstPeriodIndex = decodedSubkeyValue.indexOf( '.' );
+	if ( firstPeriodIndex === -1 ) {
+		return null;
+	}
+
+	const emailAddress = decodedSubkeyValue.slice( firstPeriodIndex + 1 );
+	return emailAddress;
+};
+
 const SubscriptionManagerContainer = ( { children }: SubscriptionManagerContainerProps ) => {
 	const translate = useTranslate();
+
+	const getSubHeaderText = () => {
+		const emailAddress = getEmailAddress();
+		if ( emailAddress ) {
+			return translate(
+				"Manage the WordPress.com newsletter and blogs you've subscribed to with {{span}}%(emailAddress)s{{/span}}.",
+				{
+					args: {
+						emailAddress: emailAddress,
+					},
+					components: {
+						span: <span className="email-address" />,
+					},
+				}
+			);
+		}
+
+		return translate( 'Manage your WordPress.com newsletter and blog subscriptions.' );
+	};
 
 	return (
 		<Main className="subscription-manager-container">
@@ -21,9 +62,7 @@ const SubscriptionManagerContainer = ( { children }: SubscriptionManagerContaine
 			<FormattedHeader
 				brandFont
 				headerText={ translate( 'Subscription management' ) }
-				subHeaderText={ translate(
-					'Manage your WordPress.com newsletter and blog subscriptions.'
-				) }
+				subHeaderText={ getSubHeaderText() }
 				align="left"
 			/>
 			{ children }

--- a/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
+++ b/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import { getSubkey } from '@automattic/data-stores/src/reader/helpers';
 import { useTranslate, LocalizeProps } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -13,11 +14,7 @@ export type SubscriptionManagerContainerProps = {
 };
 
 const getEmailAddress = () => {
-	const subkey = document.cookie
-		?.split( ';' )
-		?.map( ( c ) => c.trim() )
-		?.find( ( c ) => c.startsWith( 'subkey=' ) )
-		?.split( '=' )[ 1 ];
+	const subkey = getSubkey();
 
 	if ( ! subkey ) {
 		return null;

--- a/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
+++ b/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { getSubkey } from '@automattic/data-stores/src/reader/helpers';
+import { useSubscriberEmailAddress } from '@automattic/data-stores/src/reader/hooks';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -12,26 +12,6 @@ import './styles.scss';
 
 export type SubscriptionManagerContainerProps = {
 	children?: React.ReactNode;
-};
-
-const useSubscriberEmailAddress = () => {
-	return useMemo( () => {
-		const subkey = getSubkey();
-
-		if ( ! subkey ) {
-			return null;
-		}
-
-		const decodedSubkeyValue = decodeURIComponent( subkey );
-
-		const firstPeriodIndex = decodedSubkeyValue.indexOf( '.' );
-		if ( firstPeriodIndex === -1 ) {
-			return null;
-		}
-
-		const emailAddress = decodedSubkeyValue.slice( firstPeriodIndex + 1 );
-		return emailAddress;
-	}, [] );
 };
 
 const useSubHeaderText = () => {

--- a/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
+++ b/packages/subscription-manager/src/components/SubscriptionManagerContainer/SubscriptionManagerContainer.tsx
@@ -13,7 +13,7 @@ export type SubscriptionManagerContainerProps = {
 };
 
 const getEmailAddress = () => {
-	const subkey: string | undefined = document.cookie
+	const subkey = document.cookie
 		?.split( ';' )
 		?.map( ( c ) => c.trim() )
 		?.find( ( c ) => c.startsWith( 'subkey=' ) )

--- a/packages/subscription-manager/src/components/SubscriptionManagerContainer/styles.scss
+++ b/packages/subscription-manager/src/components/SubscriptionManagerContainer/styles.scss
@@ -25,6 +25,10 @@
 					line-height: $font-title-medium;
 					color: $studio-gray-60;
 					margin-bottom: 30px;
+
+					& .email-address {
+						font-weight: 500;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/74822.

The proposed changes add user's email address to the subheading of the Subscription Management portal for non-WPCOM users:

![Markup on 2023-03-23 at 12:10:42](https://user-images.githubusercontent.com/25105483/227186131-b397807d-3dda-482d-9933-7f8bdbf00d5e.png)

## Proposed Changes

* create helper `getSubkey` function
* introduce `useEmailAddress` hook that extracts user's email address from the `subkey` cookie
* introduce `useSubHeaderText` hook that outputs the subheading text based on whether the email address is available

## Testing Instructions

Checkout the branch related to this PR and build Calypso locally.

**Non-WPCOM user**

1. Trigger the "subscription management link" email by submitting the form on https://wordpress.com/email-subscriptions/.
2. Open the link in an Incognito browser window:
![Markup on 2023-03-20 at 16:03:35](https://user-images.githubusercontent.com/25105483/226381975-5742c80f-4d20-404e-93c7-ce270cac12af.png)
3. Open the browser inspector and copy the `subkey` cookie value as it is (without decoding it):
![Markup on 2023-03-23 at 17:00:11](https://user-images.githubusercontent.com/25105483/227262915-b8fb3818-6581-495b-95b0-dd1e05cc19d2.png)
4. Navigate to http://calypso.localhost:3000/subscriptions/settings.
5. Open console and set the cookie by `document.cookie = "subkey=PASTED_COOKIE_VALUE";`.
6. Reload http://calypso.localhost:3000/subscriptions/settings → the correct email address should display in the subheading.

**WPCOM logged-in user**

If you navigate to http://calypso.localhost:3000/subscriptions/settings as a logged-in WPCOM user, the `subkey` cookie is not available and hence the subheading will be as follows: "Manage your WordPress.com newsletter and blog subscriptions. (the original subheading copy)":

![Markup on 2023-03-23 at 17:09:54](https://user-images.githubusercontent.com/25105483/227265603-17b15ce5-ad02-4f9e-a5ec-d1501dd8f660.png)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
