### PR TITLE
Update "Get in touch" to "Learn more" to filter out inadequate requests.

### DIFF
--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -13,7 +13,7 @@ import styled from '@emotion/styled';
 import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import classNames from 'classnames';
-import { localize, TranslateResult, useTranslate } from 'i18n-calypso';
+import i18n, { localize, TranslateResult, useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -303,9 +303,12 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			),
 		};
 
+		const shouldShowNewCta =
+			isEnglishLocale || i18n.hasTranslation( '{{ExternalLink}}Learn more{{/ExternalLink}}' );
+
 		return (
 			<Button className={ classes }>
-				{ isEnglishLocale
+				{ shouldShowNewCta
 					? translate( '{{ExternalLink}}Learn more{{/ExternalLink}}', {
 							components: translateComponents,
 					  } )

--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -292,7 +292,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	if ( isWpcomEnterpriseGridPlan ) {
 		return (
 			<Button className={ classes }>
-				{ translate( '{{ExternalLink}}Get in touch{{/ExternalLink}}', {
+				{ translate( '{{ExternalLink}}Learn more{{/ExternalLink}}', {
 					components: {
 						ExternalLink: (
 							<ExternalLinkWithTracking

--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -8,6 +8,7 @@ import {
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
@@ -266,6 +267,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	selectedSiteSlug,
 } ) => {
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const classes = classNames( 'plan-features-2023-grid__actions-button', className, {
 		'is-current-plan': current,
@@ -290,20 +292,26 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 		'https://wpvip.com/wordpress-vip-agile-content-platform?utm_source=WordPresscom&utm_medium=automattic_referral';
 
 	if ( isWpcomEnterpriseGridPlan ) {
+		const translateComponents = {
+			ExternalLink: (
+				<ExternalLinkWithTracking
+					href={ `${ vipLandingPageUrlWithoutUtmCampaign }&utm_campaign=calypso_signup` }
+					target="_blank"
+					tracksEventName="calypso_plan_step_enterprise_click"
+					tracksEventProps={ { flow: flowName } }
+				/>
+			),
+		};
+
 		return (
 			<Button className={ classes }>
-				{ translate( '{{ExternalLink}}Learn more{{/ExternalLink}}', {
-					components: {
-						ExternalLink: (
-							<ExternalLinkWithTracking
-								href={ `${ vipLandingPageUrlWithoutUtmCampaign }&utm_campaign=calypso_signup` }
-								target="_blank"
-								tracksEventName="calypso_plan_step_enterprise_click"
-								tracksEventProps={ { flow: flowName } }
-							/>
-						),
-					},
-				} ) }
+				{ isEnglishLocale
+					? translate( '{{ExternalLink}}Learn more{{/ExternalLink}}', {
+							components: translateComponents,
+					  } )
+					: translate( '{{ExternalLink}}Get in touch{{/ExternalLink}}', {
+							components: translateComponents,
+					  } ) }
 			</Button>
 		);
 	} else if ( isLaunchPage ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1638

## Proposed Changes
The text "Get in touch" has been bringing in unqualified noises to the VIP team. To begin with, we want to test if "Learn more" would weed them out. 

<img width="970" alt="image" src="https://user-images.githubusercontent.com/1842898/227193449-bd8a4d1a-ce4b-4278-9eb3-ae77edf48761.png">

## Testing Instructions

* Accessing the new pricing grid in `/start/plans` and `/plans`, make sure that the CTA text is updated accordingly.
* For locales other than English, it should be the old one. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
