### PR TITLE
Jetpack Pro Dashboard: implement PHP version in the expandable block

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -14,6 +14,7 @@ import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partn
 import SiteActions from '../site-actions';
 import SiteErrorContent from '../site-error-content';
 import SiteExpandedContent from '../site-expanded-content';
+import SitePhpVersion from '../site-expanded-content/site-php-version';
 import SiteStatusContent from '../site-status-content';
 import type { SiteData, SiteColumns, AllowedTypes } from '../types';
 
@@ -162,6 +163,11 @@ export default function SiteCard( { rows, columns }: Props ) {
 								);
 							}
 						} ) }
+					{ isExpandableBlockEnabled && (
+						<div className="site-card__expanded-content-list site-card__content-list-no-error">
+							<SitePhpVersion phpVersion={ rows.site.value.php_version_num } />
+						</div>
+					) }
 				</div>
 			) }
 		</Card>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/site-php-version.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/site-php-version.tsx
@@ -1,0 +1,20 @@
+import { useTranslate } from 'i18n-calypso';
+
+export default function SitePhpVersion( {
+	phpVersion,
+}: {
+	phpVersion: number;
+} ): JSX.Element | null {
+	const translate = useTranslate();
+
+	if ( ! phpVersion ) {
+		return null;
+	}
+
+	return (
+		<div className="site-expanded-content__php-version">
+			{ translate( 'PHP Version' ) }&nbsp;
+			{ phpVersion }
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -182,3 +182,14 @@ $color-yellow: var(--studio-yellow-50);
 .expanded-card__not-enabled {
 	background: none;
 }
+
+.site-expanded-content__php-version {
+	@extend .site-expanded-content__card-content-score-title;
+	padding: 0 16px 16px;
+}
+
+.site-content__small-screen-view {
+	.site-expanded-content__php-version {
+		padding: 1.5px 0;
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -14,6 +14,7 @@ import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partn
 import SiteActions from '../site-actions';
 import SiteErrorContent from '../site-error-content';
 import SiteExpandedContent from '../site-expanded-content';
+import SitePhpVersion from '../site-expanded-content/site-php-version';
 import SiteStatusContent from '../site-status-content';
 import type { SiteData, SiteColumns } from '../types';
 
@@ -139,6 +140,7 @@ export default function SiteTableRow( { columns, item, setExpanded, isExpanded }
 				<tr className="site-table__table-row-expanded">
 					<td colSpan={ Object.keys( item ).length + 1 }>
 						<SiteExpandedContent site={ site.value } />
+						<SitePhpVersion phpVersion={ site.value.php_version_num } />
 					</td>
 				</tr>
 			) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -67,6 +67,7 @@ export interface Site {
 	site_stats: SiteStats;
 	onSelect?: ( value: boolean ) => void;
 	jetpack_boost_scores: BoostData;
+	php_version_num: number;
 }
 export interface SiteNode {
 	value: Site;


### PR DESCRIPTION
Related to 1203940061556608-as-1204212324782440

## Proposed Changes

The PR adds the PHP version in the expandable block

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/show-php-version-in-site-expandable-block` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Expand any site, and verify that the PHP version is shown.
4. Verify the same on a small screen device(<1280px)

<img width="692" alt="Screenshot 2023-03-22 at 5 10 49 PM" src="https://user-images.githubusercontent.com/10586875/227213627-10c7e7d0-1ea9-4b71-973d-1495d528c9c6.png">

<img width="347" alt="Screenshot 2023-03-22 at 5 12 28 PM" src="https://user-images.githubusercontent.com/10586875/227213644-90d740a5-a7fb-499d-b651-3c9fdb7bc1b2.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?