### PR TITLE
Site Assembler: Rename Homepage to Sections and move it between Header and Footer

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -2,3 +2,4 @@ export const PATTERN_SOURCE_SITE_ID = 174455321; // dotcompatterns
 export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
 export const SITE_TAGLINE = 'Site Tagline';
 export const PLACEHOLDER_SITE_ID = 211865921; // blankcanvas3demo.wordpress.com
+export const PATTERN_TYPES = [ 'header', 'footer', 'section' ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -19,7 +19,7 @@ import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import { recordSelectedDesign } from '../../analytics/record-design';
-import { SITE_TAGLINE, PLACEHOLDER_SITE_ID } from './constants';
+import { SITE_TAGLINE, PLACEHOLDER_SITE_ID, PATTERN_TYPES } from './constants';
 import useGlobalStylesUpgradeModal from './hooks/use-global-styles-upgrade-modal';
 import usePatternCategories from './hooks/use-pattern-categories';
 import usePatternsMapByCategory from './hooks/use-patterns-map-by-category';
@@ -30,9 +30,9 @@ import { useAllPatterns, useSectionPatterns } from './patterns-data';
 import ScreenCategoryList from './screen-category-list';
 import ScreenFooter from './screen-footer';
 import ScreenHeader from './screen-header';
-import ScreenHomepage from './screen-homepage';
 import ScreenMain from './screen-main';
 import ScreenPatternList from './screen-pattern-list';
+import ScreenSection from './screen-section';
 import { encodePatternId } from './utils';
 import withGlobalStylesProvider from './with-global-styles-provider';
 import type { Pattern, Category } from './types';
@@ -364,12 +364,8 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 	};
 
 	const onMainItemSelect = ( name: string ) => {
-		if ( name === 'header' ) {
-			trackEventPatternAdd( 'header' );
-		} else if ( name === 'footer' ) {
-			trackEventPatternAdd( 'footer' );
-		} else if ( name === 'homepage' ) {
-			trackEventPatternAdd( 'section' );
+		if ( PATTERN_TYPES.includes( name ) ) {
+			trackEventPatternAdd( name );
 		}
 
 		recordTracksEvent( 'calypso_signup_pattern_assembler_main_item_select', { name } );
@@ -430,8 +426,8 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 					/>
 				</NavigatorScreen>
 
-				<NavigatorScreen path="/homepage">
-					<ScreenHomepage
+				<NavigatorScreen path="/section">
+					<ScreenSection
 						patterns={ sections }
 						onAddSection={ onAddSection }
 						onReplaceSection={ onReplaceSection }
@@ -440,7 +436,7 @@ const PatternAssembler: Step = ( { navigation, flow, stepName } ) => {
 						onMoveDownSection={ onMoveDownSection }
 					/>
 				</NavigatorScreen>
-				<NavigatorScreen path="/homepage/patterns">
+				<NavigatorScreen path="/section/patterns">
 					{ isEnabled( 'pattern-assembler/categories' ) ? (
 						<ScreenCategoryList
 							categories={ categories }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -35,20 +35,20 @@ const ScreenMain = ( { shouldUnlockGlobalStyles, onSelect, onContinueClick }: Pr
 						<span className="pattern-layout__list-item-text">{ translate( 'Header' ) }</span>
 					</NavigationButtonAsItem>
 					<NavigationButtonAsItem
+						path="/section"
+						icon={ layout }
+						aria-label={ translate( 'Sections' ) }
+						onClick={ () => onSelect( 'section' ) }
+					>
+						<span className="pattern-layout__list-item-text">{ translate( 'Sections' ) }</span>
+					</NavigationButtonAsItem>
+					<NavigationButtonAsItem
 						path="/footer"
 						icon={ footer }
 						aria-label={ translate( 'Footer' ) }
 						onClick={ () => onSelect( 'footer' ) }
 					>
 						<span className="pattern-layout__list-item-text">{ translate( 'Footer' ) }</span>
-					</NavigationButtonAsItem>
-					<NavigationButtonAsItem
-						path="/homepage"
-						icon={ layout }
-						aria-label={ translate( 'Homepage' ) }
-						onClick={ () => onSelect( 'homepage' ) }
-					>
-						<span className="pattern-layout__list-item-text">{ translate( 'Homepage' ) }</span>
 					</NavigationButtonAsItem>
 					{ isEnabled( 'pattern-assembler/color-and-fonts' ) && (
 						<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-section.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-section.tsx
@@ -17,7 +17,7 @@ interface Props {
 	onMoveDownSection: ( position: number ) => void;
 }
 
-const ScreenHomepage = ( {
+const ScreenSection = ( {
 	patterns,
 	onAddSection,
 	onReplaceSection,
@@ -27,12 +27,12 @@ const ScreenHomepage = ( {
 }: Props ) => {
 	const translate = useTranslate();
 	const navigator = useNavigator();
-	const goToPatternList = () => navigator.goTo( '/homepage/patterns' );
+	const goToPatternList = () => navigator.goTo( '/section/patterns' );
 
 	return (
 		<>
 			<NavigatorHeader
-				title={ translate( 'Homepage' ) }
+				title={ translate( 'Sections' ) }
 				description={ translate( 'Create your homepage by adding and rearranging patterns.' ) }
 			/>
 			<div className="screen-container__body">
@@ -60,4 +60,4 @@ const ScreenHomepage = ( {
 	);
 };
 
-export default ScreenHomepage;
+export default ScreenSection;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74816

## Proposed Changes

* Rename `Homepage` to `Sections`. `Sections` might be the best option right now. See [comment](https://github.com/Automattic/wp-calypso/issues/74816#issuecomment-1482262278)
* Move it between Header and Footer

<img width="308" alt="image" src="https://user-images.githubusercontent.com/13596067/227219441-02b3fbf3-14e0-409f-bc57-f1dab453ede9.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/color-and-fonts`
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Verify the `Homepage` is renamed to `Sections`
  * Verify the new position is between the Header and the Footer
  * Click on the `Sections` and it will open the Sections screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
