### PR TITLE
DomainStep: improve domain form safety check

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -494,10 +494,7 @@ class DomainsStep extends Component {
 	};
 
 	domainForm = () => {
-		let initialState = {};
-		if ( this.props.step ) {
-			initialState = this.props.step.domainForm;
-		}
+		const initialState = get( this.props, 'step.domainForm', {} );
 
 		// If it's the first load, rerun the search with whatever we get from the query param or signup dependencies.
 		const initialQuery =

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -494,7 +494,7 @@ class DomainsStep extends Component {
 	};
 
 	domainForm = () => {
-		const initialState = get( this.props, 'step.domainForm', {} );
+		const initialState = this.props.step?.domainForm ?? {};
 
 		// If it's the first load, rerun the search with whatever we get from the query param or signup dependencies.
 		const initialQuery =


### PR DESCRIPTION
The domainForm is used in stepper when we reach the domain step. 
And the[ persistance/save ](https://github.com/Automattic/wp-calypso/blob/877f6ce7f023012a770962de017700ccdbd226f6/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx#L241) happens on mount, input change, blur etc.

We have a case when the initial state for the `domainForm` was set to `undefined` and caused a crash.
I rewrote the code to use the already heavily used lowdash `get` to endure that the initial state is properly set.

I was hunting to reproduce the issue reported [here](p1679349038568329-slack-C0BNMNMNG) and [here](p1679349072112889-slack-C0BNMNMNG), but without success.
When persisting the `domainForm` we are destructuring [here](https://github.com/Automattic/wp-calypso/blob/015f0a01176ffe58b54f56e55d7c642334e60db2/packages/data-stores/src/onboard/actions.ts#L444-L443) and [here](https://github.com/Automattic/wp-calypso/blob/015f0a01176ffe58b54f56e55d7c642334e60db2/packages/data-stores/src/onboard/reducer.ts#L445) so the issue seems that is not caused from the save payload and action processing.

One way to fix this is to completely remove `domainForm` from being persisted and retrieved, but it just seems that it will be too easy to case regressions.
So instead to fix this issue I improved the safety check to ensure the same crash doesn't happen.


## Testing Instructions
- Checkout this branch
- Run `yarn && yarn start`
- In your code editor force the value of `props.step.domainForm` to be `undefined` before the initial state is set [here](https://github.com/Automattic/wp-calypso/blob/c4c8a86fd156986234233042c67d85b3af1aaf3d/client/signup/steps/domains/index.jsx#L497)
- Visit http://calypso.localhost:3000/start and ensure that there is no crash.