### PR TITLE
Newsletter flow: Update subscriber CSV text font size

### DIFF
--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -146,16 +146,6 @@ class SelectDropdown extends Component {
 		return get( find( options, { value: selected } ), 'secondaryIcon' );
 	}
 
-	getPositionSelectedSecondaryIcon() {
-		const { positionSelectedSecondaryIconOnRight } = this.props;
-
-		if ( positionSelectedSecondaryIconOnRight ) {
-			return positionSelectedSecondaryIconOnRight;
-		}
-
-		return false;
-	}
-
 	dropdownOptions() {
 		let refIndex = 0;
 
@@ -225,7 +215,7 @@ class SelectDropdown extends Component {
 		const selectedText = this.getSelectedText();
 		const selectedIcon = this.getSelectedIcon();
 		const selectedSecondaryIcon = this.getSelectedSecondaryIcon();
-		const positionSelectedSecondaryIconOnRight = this.getPositionSelectedSecondaryIcon();
+		const { positionSelectedSecondaryIconOnRight } = this.props;
 
 		return (
 			<div id={ this.props.id } style={ this.props.style } className={ dropdownClassName }>

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -85,7 +85,7 @@
 	.components-button {
 		height: auto;
 		padding: 0;
-		font-size: 1rem;
+		font-size: 0.875rem;
 		color: var(--color-text);
 		text-decoration: underline;
 		border: none;


### PR DESCRIPTION
## What
The "uploading a CSV file." link has a bigger font size (font-size: 1rem;) instead of font-size: .875rem; like the rest of the text.

This PR changes the font-size.

## Testing
1. Calypso Live link.
2. Go to subscriber page on the newsletter flow and check CSV upload text.
3. Font should be 0.875rem.


Fixes https://github.com/Automattic/wp-calypso/issues/74845