### PR TITLE
composite-checkout: Make sure that the return type of submit button onClick is always a Promise

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-methods/wechat/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/wechat/index.tsx
@@ -21,7 +21,11 @@ import {
 } from 'calypso/my-sites/checkout/composite-checkout/components/summary-details';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import WeChatPaymentQRcodeUnstyled from './wechat-payment-qrcode';
-import type { LineItem, ProcessPayment } from '@automattic/composite-checkout';
+import type {
+	LineItem,
+	PaymentMethod,
+	PaymentMethodSubmitButtonProps,
+} from '@automattic/composite-checkout';
 import type {
 	PaymentMethodStore,
 	StoreSelectors,
@@ -79,7 +83,7 @@ export function createWeChatMethod( {
 }: {
 	store: WeChatStore;
 	siteSlug?: string;
-} ) {
+} ): PaymentMethod {
 	return {
 		id: 'wechat',
 		paymentProcessorId: 'wechat',
@@ -173,9 +177,7 @@ function WeChatPayButton( {
 	onClick,
 	store,
 	siteSlug,
-}: {
-	disabled?: boolean;
-	onClick?: ProcessPayment;
+}: PaymentMethodSubmitButtonProps & {
 	store: WeChatStore;
 	siteSlug?: string;
 } ) {

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -3,9 +3,10 @@ import { useI18n } from '@wordpress/react-i18n';
 import { cloneElement } from 'react';
 import joinClasses from '../lib/join-classes';
 import { useAllPaymentMethods, usePaymentMethodId } from '../lib/payment-methods';
+import { makeErrorResponse } from '../lib/payment-processors';
 import { useFormStatus, FormStatus, useProcessPayment } from '../public-api';
 import CheckoutErrorBoundary from './checkout-error-boundary';
-import type { PaymentMethod, PaymentProcessorSubmitData } from '../types';
+import type { PaymentMethod, PaymentProcessorSubmitData, ProcessPayment } from '../types';
 
 const CheckoutSubmitButtonWrapper = styled.div`
 	&.checkout-submit-button--inactive {
@@ -63,20 +64,29 @@ function CheckoutSubmitButtonForPaymentMethod( {
 	const { __ } = useI18n();
 	const isDisabled = disabled || formStatus !== FormStatus.READY || ! isActive;
 	const onClick = useProcessPayment( paymentMethod?.paymentProcessorId ?? '' );
-	const onClickWithValidation = ( processorData: PaymentProcessorSubmitData ) => {
+	const onClickWithValidation: ProcessPayment = async (
+		processorData: PaymentProcessorSubmitData
+	) => {
 		if ( ! isActive ) {
-			return;
+			return Promise.resolve(
+				makeErrorResponse( __( 'This payment method is not currently available.' ) )
+			);
 		}
+
 		if ( validateForm ) {
-			validateForm().then( ( validationResult: boolean ) => {
+			return validateForm().then( ( validationResult: boolean ) => {
 				if ( validationResult ) {
-					onClick( processorData );
+					return onClick( processorData );
 				}
-				// Take no action if the form is not valid. User notification must be
-				// handled elsewhere.
+				// Take no action if the form is not valid. User notification should be
+				// handled inside the validation callback itself but we will return a
+				// generic error message here in case something needs it.
+				return Promise.resolve(
+					makeErrorResponse( __( 'The information requried by this payment method is not valid.' ) )
+				);
 			} );
-			return;
 		}
+
 		// Always run if there is no validation callback.
 		return onClick( processorData );
 	};

--- a/packages/composite-checkout/src/lib/payment-processors.ts
+++ b/packages/composite-checkout/src/lib/payment-processors.ts
@@ -23,8 +23,8 @@ export function usePaymentProcessors(): Record< string, PaymentProcessorFunction
 	return paymentProcessors;
 }
 
-export function makeErrorResponse( url: string ): PaymentProcessorError {
-	return { type: PaymentProcessorResponseType.ERROR, payload: url };
+export function makeErrorResponse( errorMessage: string ): PaymentProcessorError {
+	return { type: PaymentProcessorResponseType.ERROR, payload: errorMessage };
 }
 
 export function makeSuccessResponse(

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -33,13 +33,18 @@ export interface OrderSummaryData {
 	summaryContent: React.ReactNode;
 }
 
+export interface PaymentMethodSubmitButtonProps {
+	disabled?: boolean;
+	onClick?: ProcessPayment;
+}
+
 export interface PaymentMethod {
 	id: string;
 	paymentProcessorId: string;
 	label?: React.ReactNode;
 	activeContent?: React.ReactNode;
 	inactiveContent?: React.ReactNode;
-	submitButton: ReactElement;
+	submitButton: ReactElement< PaymentMethodSubmitButtonProps >;
 	getAriaLabel: ( localize: ( value: string ) => string ) => string;
 }
 


### PR DESCRIPTION
Every payment method object passed into a `CheckoutProvider` must supply a submit button component. That component is then rendered by the `CheckoutSubmitButton` which is rendered as part of every form that uses the provider. `CheckoutSubmitButton` injects a `onClick` callback prop into each submit button component which hooks that button into the transaction flow that the `@automattic/composite-checkout` package provides (specifically, it calls the payment processor function that the provider has assigned to that payment method). The return value of that callback is the same as the return value of the hook that creates it, `useProcessPayment()`, which is `Promise<PaymentProcessorResponse>`.

However, the `onClick` prop is wrapped in another function before it is injected which allows `CheckoutSubmitButton` to run a validation callback before it calls the payment processor. That wrapper has two cases where it can return `undefined` instead of a Promise. This was overlooked because most payment methods do not use the return value of `onClick`, but `WeChatPayButton` does, and this results in a fatal error (see p1679556359011019-slack-C04U5A26MJB).

This issue was created by https://github.com/Automattic/wp-calypso/pull/65414

## Proposed Changes

In this PR we modify `CheckoutSubmitButton` so that its return value is the same as the return value of the `onClick` method it wraps.

## Testing Instructions

First, modify calypso so that the checkout submit button's validation callback will always return false:

```diff
diff --git a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
index a9c6a07dc0..9b15f82882 100644
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -244,10 +244,7 @@ export default function WPCheckout( {
 
 	const validateForm = async () => {
 		setIsSubmitted( true );
-		if ( hasMarketplaceProduct && ! is3PDAccountConsentAccepted ) {
-			return false;
-		}
-		return true;
+		return false;
 	};
 
 	if ( ! checkoutActions ) {
```

Next, add a product to your cart and visit checkout.

Complete the checkout form and press the submit button.

Verify that nothing happens when the button is clicked. (If this were a real failure a different mechanism would display the error; see https://github.com/Automattic/wp-calypso/pull/65414.)