### PR TITLE
Fix longreads avatar issues

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -53,6 +53,7 @@ class AuthorCompactProfile extends Component {
 			'has-author-icon': siteIcon || feedIcon || author.has_avatar,
 		} );
 		const streamUrl = getStreamUrl( feedId, siteId );
+		const isLongreads = siteId === 211646052;
 
 		// If we have a feed URL, use that for the follow button in preference to the site URL
 		const followUrl = feedUrl || siteUrl;
@@ -60,10 +61,20 @@ class AuthorCompactProfile extends Component {
 		return (
 			<div className={ classes }>
 				<a href={ streamUrl } className="author-compact-profile__avatar-link">
-					<ReaderAvatar siteIcon={ siteIcon } feedIcon={ feedIcon } author={ author } />
+					<ReaderAvatar
+						isLongreads={ isLongreads }
+						siteIcon={ siteIcon }
+						feedIcon={ feedIcon }
+						author={ author }
+					/>
 				</a>
 				{ hasAuthorName && ! hasMatchingAuthorAndSiteNames && (
-					<ReaderAuthorLink author={ author } siteUrl={ streamUrl } post={ post }>
+					<ReaderAuthorLink
+						isLongreads={ isLongreads }
+						author={ author }
+						siteUrl={ streamUrl }
+						post={ post }
+					>
 						{ author.name }
 					</ReaderAuthorLink>
 				) }

--- a/client/blocks/reader-author-link/index.jsx
+++ b/client/blocks/reader-author-link/index.jsx
@@ -8,7 +8,15 @@ import './style.scss';
 
 const noop = () => {};
 
-const ReaderAuthorLink = ( { author, post, siteUrl, children, className, onClick } ) => {
+const ReaderAuthorLink = ( {
+	author,
+	post,
+	isLongreads,
+	siteUrl,
+	children,
+	className,
+	onClick,
+} ) => {
 	const recordAuthorClick = () => {
 		stats.recordAction( 'click_author' );
 		stats.recordGaEvent( 'Clicked Author Link' );
@@ -25,7 +33,7 @@ const ReaderAuthorLink = ( { author, post, siteUrl, children, className, onClick
 	const authorName = get( author, 'name', null );
 
 	// If the author name is blocked, don't return anything
-	if ( ! authorName || isAuthorNameBlocked( authorName ) ) {
+	if ( ! authorName || isAuthorNameBlocked( authorName ) || isLongreads ) {
 		return null;
 	}
 
@@ -45,6 +53,7 @@ const ReaderAuthorLink = ( { author, post, siteUrl, children, className, onClick
 
 ReaderAuthorLink.propTypes = {
 	author: PropTypes.object.isRequired,
+	isLongreads: PropTypes.bool,
 	post: PropTypes.object, // for stats only,
 	siteUrl: PropTypes.string, // used instead of author.URL if present
 };

--- a/client/blocks/reader-avatar/index.jsx
+++ b/client/blocks/reader-avatar/index.jsx
@@ -13,6 +13,7 @@ const noop = () => {};
 
 const ReaderAvatar = ( {
 	author,
+	isLongreads,
 	siteIcon,
 	feedIcon,
 	siteUrl,
@@ -58,7 +59,7 @@ const ReaderAvatar = ( {
 	}
 
 	// If we have an avatar and we prefer it, don't even consider the site icon
-	if ( hasAvatar && preferGravatar ) {
+	if ( hasAvatar && preferGravatar && ! isLongreads ) {
 		hasSiteIcon = false;
 	} else if ( preferBlavatar ) {
 		hasAvatar = false;
@@ -90,7 +91,7 @@ const ReaderAvatar = ( {
 	const siteIconElement = hasSiteIcon && (
 		<SiteIcon key="site-icon" size={ siteIconSize } site={ fakeSite } />
 	);
-	const avatarElement = ( hasAvatar || showPlaceholder ) && (
+	const avatarElement = ! isLongreads && ( hasAvatar || showPlaceholder ) && (
 		<Gravatar key="author-avatar" user={ author } size={ gravatarSize } />
 	);
 	const iconElements = [ defaultIconElement, siteIconElement, avatarElement ];
@@ -104,6 +105,7 @@ const ReaderAvatar = ( {
 
 ReaderAvatar.propTypes = {
 	author: PropTypes.object,
+	isLongreads: PropTypes.bool,
 	siteIcon: PropTypes.string,
 	feedIcon: PropTypes.string,
 	siteUrl: PropTypes.string,

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -65,8 +65,10 @@ class PostByline extends Component {
 		const hasAuthorName = !! get( post, 'author.name', null );
 		const hasMatchingAuthorAndSiteNames =
 			hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, post.author.name );
+		const isLongreads = siteId === 211646052;
 		const shouldDisplayAuthor =
 			! isDiscoverPost &&
+			! isLongreads &&
 			hasAuthorName &&
 			! isAuthorNameBlocked( post.author.name ) &&
 			( ! hasMatchingAuthorAndSiteNames || ! showSiteName );
@@ -84,6 +86,7 @@ class PostByline extends Component {
 						preferGravatar={ true }
 						siteUrl={ streamUrl }
 						isCompact={ true }
+						isLongreads={ isLongreads }
 					/>
 				) }
 				<div className="reader-post-card__byline-details">


### PR DESCRIPTION
## Description

Within the reader, whenever Peter publishes a Longreads post his personal avatar is showing up. It would be preferable if the longreads site logo always showed.

### Before

<img width="671" alt="before" src="https://user-images.githubusercontent.com/5634774/227279928-92470b3e-65fa-4b62-a906-130bcea89e54.png">

<img width="988" alt="before-post" src="https://user-images.githubusercontent.com/5634774/227279955-63f21775-cefb-45bc-9412-7290027dd494.png">

### After

<img width="640" alt="after" src="https://user-images.githubusercontent.com/5634774/227280007-5c402851-08fe-40c5-9f30-418855f44f20.png">

<img width="975" alt="after-post" src="https://user-images.githubusercontent.com/5634774/227280034-bfa38956-bb8b-46d5-bd22-c635de32b37e.png">

## Testing Instructions

- Use the Calypso preview link (or apply this PR)
- Visit http://calypso.localhost:3000/read/feeds/138734090
- Visit http://calypso.localhost:3000/read/feeds/138734090/posts/4617747083