### PR TITLE
Revert "AT E2E: fix the `Editor: Revisions` spec."

### DIFF
--- a/test/e2e/specs/editor/editor__revisions.ts
+++ b/test/e2e/specs/editor/editor__revisions.ts
@@ -90,6 +90,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Revisions` ), function () {
 	it( 'Load selected revision', async function () {
 		if ( envVariables.TEST_ON_ATOMIC ) {
 			await revisionsPage.loadSelectedRevision();
+			await editorPage.waitUntilLoaded();
 		} else {
 			await revisionsComponent.loadSelectedRevision();
 		}


### PR DESCRIPTION
Reverts Automattic/wp-calypso#74731