### PR TITLE
Marketplace Thank You: Add help center trigger on the masterbar

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
@@ -1,5 +1,14 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { HelpCenter, HelpCenterSelect } from '@automattic/data-stores';
 import styled from '@emotion/styled';
+import { Button } from '@wordpress/components';
+import {
+	useDispatch as useDataStoreDispatch,
+	useSelect as useDataStoreSelect,
+} from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
+
+const HELP_CENTER_STORE = HelpCenter.register();
 
 const ContactContainer = styled.div`
 	margin-top: 24px;
@@ -12,7 +21,7 @@ const ContactContainer = styled.div`
 		color: var( --studio-gray-60 );
 	}
 
-	a {
+	button.marketplace-thank-you-help-center {
 		color: var( --studio-gray-100 );
 		text-decoration: underline;
 	}
@@ -21,12 +30,29 @@ const ContactContainer = styled.div`
 export function DefaultMasterbarContact() {
 	const translate = useTranslate();
 
+	const { setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const isShowingHelpCenter = useDataStoreSelect(
+		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
+		[]
+	);
+	const toggleHelpCenter = () => {
+		recordTracksEvent(
+			`calypso_marketplace_thank_you_inlinehelp_${ isShowingHelpCenter ? 'close' : 'show' }`,
+			{
+				force_site_id: true,
+				location: 'marketplace-thank-you-help-center',
+			}
+		);
+
+		setShowHelpCenter( ! isShowingHelpCenter );
+	};
+
 	return (
 		<ContactContainer>
 			<label>{ translate( 'Need extra help?' ) }</label>&nbsp;
-			<a href="https://wordpress.com/support/" target="_blank" rel="noreferrer">
-				{ translate( 'Ask a question' ) }
-			</a>
+			<Button className="marketplace-thank-you-help-center" isLink onClick={ toggleHelpCenter }>
+				{ translate( 'Visit Help Center.' ) }
+			</Button>
 		</ContactContainer>
 	);
 }


### PR DESCRIPTION
Fixes #74857

## Proposed Changes

Update the masterbar contact link to trigger the Help Center.



## Testing Instructions
* Go to the Marketplace Thank You Page (`/marketplace/thank-you/:site?plugins=:plugin_slug`)
* On the top right of the screen check if the help center can be opened/closed/minimized.
* Check if the event `calypso_marketplace_thank_you_inlinehelp_*` is being logged when opening/closing the help center. 

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2023-03-23 at 17 49 13@2x](https://user-images.githubusercontent.com/5039531/227357549-fe9d89ee-b24f-4dbf-b989-b5280c246360.png)|![CleanShot 2023-03-23 at 17 51 25@2x](https://user-images.githubusercontent.com/5039531/227357723-aedbf29f-eb17-4638-9851-fff0b4c76469.png)|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
