### PR TITLE
Unauthorized users should be redirected to subscriptions landing page.

### DIFF
--- a/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
+++ b/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import { Spinner } from '@automattic/components';
 import { Reader } from '@automattic/data-stores';
+import { useSubscriberEmailAddress } from '@automattic/data-stores/src/reader/hooks';
 import { useState, useCallback, useEffect } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
 import page from 'page';
@@ -42,12 +43,15 @@ const UserSettings = ( { value = {}, loading, userId }: UserSettingsProps ) => {
 	const { mutate, isLoading, isSuccess, error } =
 		Reader.useSubscriptionManagerUserSettingsMutation();
 	const [ notice, setNotice ] = useState< NoticeProps | null >( null );
+	const subscriberEmailAddress = useSubscriberEmailAddress();
 
 	useEffect( () => {
-		if ( ! userId ) {
+		if ( userId ) {
+			page.redirect( '/read' );
+		} else if ( ! subscriberEmailAddress ) {
 			page.redirect( '/email-subscriptions' );
 		}
-	}, [ userId ] );
+	}, [ userId, subscriberEmailAddress ] );
 
 	useEffect( () => {
 		// check if formState is empty object

--- a/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
+++ b/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
@@ -1,8 +1,12 @@
+/* eslint-disable no-restricted-imports */
 import { Spinner } from '@automattic/components';
 import { Reader } from '@automattic/data-stores';
 import { useState, useCallback, useEffect } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
+import page from 'page';
 import { FormEvent } from 'react';
+import { connect } from 'react-redux';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { Button } from '../Button';
 import { Notice } from '../Notice';
 import { BlockEmailsSetting } from '../fields/BlockEmailsSetting';
@@ -24,6 +28,7 @@ type SubscriptionUserSettings = Partial< {
 type UserSettingsProps = {
 	value?: SubscriptionUserSettings;
 	loading: boolean;
+	userId: number;
 };
 
 type NoticeProps = {
@@ -32,11 +37,17 @@ type NoticeProps = {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- until we start using any of these props
-const UserSettings = ( { value = {}, loading }: UserSettingsProps ) => {
+const UserSettings = ( { value = {}, loading, userId }: UserSettingsProps ) => {
 	const [ formState, setFormState ] = useState< SubscriptionUserSettings >( value );
 	const { mutate, isLoading, isSuccess, error } =
 		Reader.useSubscriptionManagerUserSettingsMutation();
 	const [ notice, setNotice ] = useState< NoticeProps | null >( null );
+
+	useEffect( () => {
+		if ( ! userId ) {
+			page.redirect( '/email-subscriptions' );
+		}
+	}, [ userId ] );
 
 	useEffect( () => {
 		// check if formState is empty object
@@ -109,4 +120,10 @@ const UserSettings = ( { value = {}, loading }: UserSettingsProps ) => {
 	);
 };
 
-export default UserSettings;
+const mapStateToProps = ( state ) => {
+	return {
+		userId: getCurrentUserId( state ),
+	};
+};
+
+export default connect( mapStateToProps )( UserSettings );

--- a/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
+++ b/packages/subscription-manager/src/components/UserSettings/UserSettings.tsx
@@ -17,6 +17,7 @@ import type {
 	DeliveryWindowDayType,
 	DeliveryWindowHourType,
 } from '@automattic/data-stores/src/reader/types';
+import type { AppState } from 'calypso/types';
 
 type SubscriptionUserSettings = Partial< {
 	mail_option: EmailFormatType;
@@ -124,7 +125,7 @@ const UserSettings = ( { value = {}, loading, userId }: UserSettingsProps ) => {
 	);
 };
 
-const mapStateToProps = ( state ) => {
+const mapStateToProps = ( state: AppState ) => {
 	return {
 		userId: getCurrentUserId( state ),
 	};

--- a/packages/subscription-manager/src/components/index.d.ts
+++ b/packages/subscription-manager/src/components/index.d.ts
@@ -111,3 +111,5 @@ declare module '*.svg' {
 	const url: string;
 	export default url;
 }
+
+declare module 'calypso/state/current-user/selectors';


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/74849

## Proposed Changes

If an unauthorized user goes to `http://calypso.localhost:3000/subscriptions/settings` for any reason (bookmark, for example), they will see an infinite spinner like this:

<img width="793" alt="Screenshot 2023-03-23 at 17 07 56" src="https://user-images.githubusercontent.com/3832570/227378491-b13f560b-4673-4da3-bc02-d62393873623.png">

That's because that settings page lives in Calypso, and the unauthorized user doesn't have a cookie set for Calypso to work.

The correct behavior is the user being redirected to the initial screen in the Subscription Management flow:

<img width="866" alt="Screenshot 2023-03-23 at 17 16 11" src="https://user-images.githubusercontent.com/3832570/227378923-eb119c47-2d58-4c99-be98-d82128e2c567.png">

## Testing Instructions

### Non-WPCOM user, without verifying
1. Apply this branch.
2. In an incognito window in your browser, go to `http://calypso.localhost:3000/subscriptions/settings`.
3. You should be redirected to `http://calypso.localhost:3000/email-subscriptions`. That page will show the following:
<img width="511" alt="Screenshot 2023-03-23 at 23 31 24" src="https://user-images.githubusercontent.com/3832570/227379214-d9775abb-af16-4c30-8a7f-7c3bde968dc1.png">
This is because `/email-subscriptions` doesn't leave in Calypso. In order to check that the redirection shows the correct screen, replace `http://calypso.localhost:3000` with `https://wordpress.com`

### Non-WPCOM user, verified
1. Trigger the "subscription management link" email by submitting the form at https://wordpress.com/email-subscriptions/ using an incognito window.
2. Open the link in an Incognito browser window:
![image](https://user-images.githubusercontent.com/3832570/227601989-1b546daa-3bdc-4308-9b77-e9cc7b0113c2.png)
3. Open the browser inspector and copy the subkey cookie value as it is (without decoding it):
![image](https://user-images.githubusercontent.com/3832570/227602101-ffc91c8c-a357-41e3-82e8-c2c5de9193cd.png)
4. Navigate to http://calypso.localhost:3000/subscriptions/settings.
5. Open the console and set the cookie by document.cookie = "subkey=PASTED_COOKIE_VALUE";.
6. Reload http://calypso.localhost:3000/subscriptions/settings → the correct email address should display in the subheading.

### WPCOM logged-in user

If you navigate to `http://calypso.localhost:3000/subscriptions/settings` as a logged-in WPCOM user, you will be redirected to `http://calypso.localhost:3000/read`, which is the user interface used for that kind of user.

