### PR TITLE
Taxes: Fix tax name translation by country in `me/purchases/billing-history` and receipts

### DIFF
--- a/client/me/purchases/billing-history/test/tax.js
+++ b/client/me/purchases/billing-history/test/tax.js
@@ -3,9 +3,8 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import { translate } from 'i18n-calypso';
 import { renderTransactionAmount, transactionIncludesTax } from '../utils';
-
-const translate = ( x ) => x;
 
 describe( 'transactionIncludesTax', () => {
 	test( 'returns true for a transaction with tax', () => {
@@ -92,7 +91,7 @@ test( 'tax includes', () => {
 	};
 
 	render( renderTransactionAmount( transaction, { translate, addingTax: false } ) );
-	expect( screen.getByText( '(includes %(taxAmount)s tax)' ) ).toBeInTheDocument();
+	expect( screen.getByText( `(includes ${ transaction.tax } tax)` ) ).toBeInTheDocument();
 } );
 
 test( 'tax adding', () => {
@@ -108,7 +107,7 @@ test( 'tax adding', () => {
 	};
 
 	render( renderTransactionAmount( transaction, { translate, addingTax: true } ) );
-	expect( screen.getByText( '(+%(taxAmount)s tax)' ) ).toBeInTheDocument();
+	expect( screen.getByText( `(+${ transaction.tax } tax)` ) ).toBeInTheDocument();
 } );
 
 test( 'tax includes with localized tax name', () => {
@@ -125,7 +124,7 @@ test( 'tax includes with localized tax name', () => {
 	};
 
 	render( renderTransactionAmount( transaction, { translate, addingTax: false } ) );
-	expect( screen.getByText( '(includes %(taxAmount)s %(taxName)s)' ) ).toBeInTheDocument();
+	expect( screen.getByText( `(includes ${ transaction.tax } VAT)` ) ).toBeInTheDocument();
 } );
 
 test( 'tax adding with localized tax name', () => {
@@ -142,7 +141,7 @@ test( 'tax adding with localized tax name', () => {
 	};
 
 	render( renderTransactionAmount( transaction, { translate, addingTax: true } ) );
-	expect( screen.getByText( '(+%(taxAmount)s %(taxName)s)' ) ).toBeInTheDocument();
+	expect( screen.getByText( `(+${ transaction.tax } VAT)` ) ).toBeInTheDocument();
 } );
 
 test( 'tax hidden if not available', () => {

--- a/client/me/purchases/billing-history/test/tax.js
+++ b/client/me/purchases/billing-history/test/tax.js
@@ -111,6 +111,40 @@ test( 'tax adding', () => {
 	expect( screen.getByText( '(+%(taxAmount)s tax)' ) ).toBeInTheDocument();
 } );
 
+test( 'tax includes with localized tax name', () => {
+	const transaction = {
+		subtotal: '$36.00',
+		tax: '$2.48',
+		amount: '$38.48',
+		tax_country_code: 'GB',
+		items: [
+			{
+				raw_tax: 2.48,
+			},
+		],
+	};
+
+	render( renderTransactionAmount( transaction, { translate, addingTax: false } ) );
+	expect( screen.getByText( '(includes %(taxAmount)s %(taxName)s)' ) ).toBeInTheDocument();
+} );
+
+test( 'tax adding with localized tax name', () => {
+	const transaction = {
+		subtotal: '$36.00',
+		tax: '$2.48',
+		amount: '$38.48',
+		tax_country_code: 'GB',
+		items: [
+			{
+				raw_tax: 2.48,
+			},
+		],
+	};
+
+	render( renderTransactionAmount( transaction, { translate, addingTax: true } ) );
+	expect( screen.getByText( '(+%(taxAmount)s %(taxName)s)' ) ).toBeInTheDocument();
+} );
+
 test( 'tax hidden if not available', () => {
 	const transaction = {
 		subtotal: '$36.00',

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -10,6 +10,7 @@ import {
 	BillingTransaction,
 	BillingTransactionItem,
 } from 'calypso/state/billing-transactions/types';
+import { getVatVendorInfo } from './vat-vendor-details';
 import type { LocalizeProps } from 'calypso/../packages/i18n-calypso/types';
 
 interface GroupedDomainProduct {
@@ -83,15 +84,25 @@ export function renderTransactionAmount(
 		return transaction.amount;
 	}
 
+	const countryTaxInfo =
+		translate instanceof Function &&
+		getVatVendorInfo( transaction.tax_country_code, transaction.date, translate )
+			? getVatVendorInfo( transaction.tax_country_code, transaction.date, translate )
+			: { taxName: 'tax' };
+
 	const taxAmount = addingTax
-		? translate( '(+%(taxAmount)s tax)', {
+		? translate( '(+%(taxAmount)s ', {
 				args: { taxAmount: transaction.tax },
 				comment: 'taxAmount is a localized price, like $12.34',
-		  } )
-		: translate( '(includes %(taxAmount)s tax)', {
+		  } ) +
+		  countryTaxInfo.taxName +
+		  ')'
+		: translate( '(includes %(taxAmount)s ', {
 				args: { taxAmount: transaction.tax },
 				comment: 'taxAmount is a localized price, like $12.34',
-		  } );
+		  } ) +
+		  countryTaxInfo.taxName +
+		  ')';
 
 	return (
 		<Fragment>

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -93,18 +93,16 @@ export function renderTransactionAmount(
 		: { taxName: 'tax' };
 
 	const taxAmount = addingTax
-		? translate( '(+%(taxAmount)s ', {
-				args: { taxAmount: transaction.tax },
-				comment: 'taxAmount is a localized price, like $12.34',
-		  } ) +
-		  countryTaxInfo.taxName +
-		  ')'
-		: translate( '(includes %(taxAmount)s ', {
-				args: { taxAmount: transaction.tax },
-				comment: 'taxAmount is a localized price, like $12.34',
-		  } ) +
-		  countryTaxInfo.taxName +
-		  ')';
+		? translate( '(+%(taxAmount)s %(taxName)s)', {
+				args: { taxAmount: transaction.tax, taxName: countryTaxInfo.taxName },
+				comment:
+					'taxAmount is a localized price, like $12.34 | taxName is a localized tax, like VAT or GST',
+		  } )
+		: translate( '(includes %(taxAmount)s %(taxName)s)', {
+				args: { taxAmount: transaction.tax, taxName: countryTaxInfo.taxName },
+				comment:
+					'taxAmount is a localized price, like $12.34 | taxName is a localized tax, like VAT or GST',
+		  } );
 
 	return (
 		<Fragment>

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -84,11 +84,13 @@ export function renderTransactionAmount(
 		return transaction.amount;
 	}
 
-	const countryTaxInfo =
-		translate instanceof Function &&
-		getVatVendorInfo( transaction.tax_country_code, transaction.date, translate )
-			? getVatVendorInfo( transaction.tax_country_code, transaction.date, translate )
-			: { taxName: 'tax' };
+	const countryTaxInfo = getVatVendorInfo(
+		transaction.tax_country_code,
+		transaction.date,
+		translate
+	)
+		? getVatVendorInfo( transaction.tax_country_code, transaction.date, translate )
+		: { taxName: 'tax' };
 
 	const taxAmount = addingTax
 		? translate( '(+%(taxAmount)s ', {

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -88,21 +88,31 @@ export function renderTransactionAmount(
 		transaction.tax_country_code,
 		transaction.date,
 		translate
-	)
-		? getVatVendorInfo( transaction.tax_country_code, transaction.date, translate )
-		: { taxName: 'tax' };
+	);
 
-	const taxAmount = addingTax
+	const addingTaxString = countryTaxInfo
 		? translate( '(+%(taxAmount)s %(taxName)s)', {
 				args: { taxAmount: transaction.tax, taxName: countryTaxInfo.taxName },
 				comment:
 					'taxAmount is a localized price, like $12.34 | taxName is a localized tax, like VAT or GST',
 		  } )
-		: translate( '(includes %(taxAmount)s %(taxName)s)', {
+		: translate( '(+%(taxAmount)s tax)', {
+				args: { taxAmount: transaction.tax },
+				comment: 'taxAmount is a localized price, like $12.34',
+		  } );
+
+	const includesTaxString = countryTaxInfo
+		? translate( '(includes %(taxAmount)s %(taxName)s)', {
 				args: { taxAmount: transaction.tax, taxName: countryTaxInfo.taxName },
 				comment:
 					'taxAmount is a localized price, like $12.34 | taxName is a localized tax, like VAT or GST',
+		  } )
+		: translate( '(includes %(taxAmount)s tax)', {
+				args: { taxAmount: transaction.tax },
+				comment: 'taxAmount is a localized price, like $12.34',
 		  } );
+
+	const taxAmount = addingTax ? addingTaxString : includesTaxString;
 
 	return (
 		<Fragment>

--- a/client/me/purchases/billing-history/vat-vendor-details.tsx
+++ b/client/me/purchases/billing-history/vat-vendor-details.tsx
@@ -113,7 +113,12 @@ export function VatVendorDetails( { transaction }: { transaction: BillingTransac
 
 	return (
 		<li>
-			<strong>{ translate( 'Vendor ' ) + vendorInfo.taxName + translate( ' Details' ) }</strong>
+			<strong>
+				{ translate( 'Vendor %(taxName)s Details', {
+					args: { taxName: vendorInfo.taxName },
+					comment: 'taxName is a localized tax, like VAT or GST',
+				} ) }
+			</strong>
 			<span>
 				{ vendorInfo.address.map( ( addressLine ) => (
 					<div key={ addressLine }>{ addressLine }</div>

--- a/client/me/purchases/billing-history/vat-vendor-details.tsx
+++ b/client/me/purchases/billing-history/vat-vendor-details.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { isCountryInEu } from '../is-country-in-eu';
 import type { BillingTransaction } from 'calypso/state/billing-transactions/types';
+import type { LocalizeProps } from 'i18n-calypso';
 
 interface VatVendorInfo {
 	/**
@@ -37,7 +38,7 @@ export function getVatVendorInfo(
 	 */
 	date: string,
 
-	translate: ReturnType< typeof useTranslate >
+	translate: LocalizeProps[ 'translate' ]
 ): VatVendorInfo | undefined {
 	const automatticVatAddress = [
 		'Aut O’Mattic Ltd.',

--- a/client/me/purchases/billing-history/vat-vendor-details.tsx
+++ b/client/me/purchases/billing-history/vat-vendor-details.tsx
@@ -113,7 +113,7 @@ export function VatVendorDetails( { transaction }: { transaction: BillingTransac
 
 	return (
 		<li>
-			<strong>{ translate( 'Vendor VAT Details' ) }</strong>
+			<strong>{ translate( 'Vendor ' ) + vendorInfo.taxName + translate( ' Details' ) }</strong>
 			<span>
 				{ vendorInfo.address.map( ( addressLine ) => (
 					<div key={ addressLine }>{ addressLine }</div>

--- a/client/me/purchases/billing-history/vat-vendor-details.tsx
+++ b/client/me/purchases/billing-history/vat-vendor-details.tsx
@@ -95,7 +95,7 @@ export function getVatVendorInfo(
 	if ( country === 'JP' ) {
 		return {
 			country,
-			taxName: translate( 'VAT', { textOnly: true } ),
+			taxName: translate( 'CT', { textOnly: true } ),
 			address: automatticVatAddress,
 			vatId: '4700150101102',
 		};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/payments-shilling/issues/1474

Specifically, it addresses @sirbrillig's [comment](https://github.com/Automattic/payments-shilling/issues/1474#issuecomment-1478361055): 
>`getVatVendorInfo` which adds vendor info to receipts but **will soon also be used to translate the names of each tax in checkout and other pages.**

## Proposed Changes

This has a couple of changes
*  It exports `getVatVendorInfo`
* It replaces generic `tax` strings with instances of `VatVendorInfo.taxName`
* It updates the tax name for JP from `VAT` to `CT` per the Tax team's spreadsheet

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start local calypso
* Visit `me/purchases/billing-information`
* You will see all taxes described as `(includes $xx.xx tax)`
* Apply this patch to your local environment
* Now when you view `me/purchases/billing-information` you should see the tax for each country uses the correct tax name set in [getVatVendorInfo()](https://github.com/Automattic/wp-calypso/blob/3c68e088d6be1530634eecf390f94eb63897f8a0/client/me/purchases/billing-history/vat-vendor-details.tsx#L49-L56).

**Before**

![JPD105790-screencapture-calypso-localhost-3000-me-purchases-billing-2023-03-23-12_00_54](https://user-images.githubusercontent.com/12505355/227392223-206a4d8f-fc6f-4e27-90ae-d958b4f91924.png)

**After**

![taxnamefix-screencapture-calypso-localhost-3000-me-purchases-billing-2023-03-23-17_13_22](https://user-images.githubusercontent.com/12505355/227392249-9b8c3407-2426-4216-8b02-d16dc8d7f918.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
