### PR TITLE
Theme Showcase: Improve filters UI responsiveness

### DIFF
--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -469,13 +469,17 @@ body.is-section-themes {
 	margin-top: 24px;
 	padding: 0;
 
-	@include break-small {
+	@include break-large {
 		flex-direction: row;
+		flex-wrap: nowrap;
+		gap: 8px;
 	}
 
 	.themes-toolbar-group {
 		height: 28px;
 		max-width: 100%;
+		// See https://stackoverflow.com/a/66689926
+		min-width: 0;
 		flex: 1;
 	}
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -469,10 +469,9 @@ body.is-section-themes {
 	margin-top: 24px;
 	padding: 0;
 
-	@include break-large {
+	@include breakpoint-deprecated( ">660px" ) {
 		flex-direction: row;
-		flex-wrap: nowrap;
-		gap: 8px;
+		gap: 0;
 	}
 
 	.themes-toolbar-group {
@@ -489,6 +488,7 @@ body.is-section-themes {
 		box-sizing: border-box;
 		height: 28px;
 		padding: 4px;
+		z-index: 1;
 
 		.segmented-control__item {
 			&.is-selected {

--- a/client/my-sites/themes/themes-toolbar-group/index.tsx
+++ b/client/my-sites/themes/themes-toolbar-group/index.tsx
@@ -28,7 +28,6 @@ const ThemesToolbarGroup: React.FC< ThemesToolbarGroupProps > = ( {
 			className="themes-toolbar-group"
 			initialActiveIndex={ activeIndex }
 			forceSwipe={ 'undefined' === typeof window }
-			swipeBreakpoint="<960px"
 			onClick={ ( index: number ) => onSelect( items[ index ]?.key ) }
 		>
 			{ items.map( ( item ) => (

--- a/client/my-sites/themes/themes-toolbar-group/index.tsx
+++ b/client/my-sites/themes/themes-toolbar-group/index.tsx
@@ -28,6 +28,7 @@ const ThemesToolbarGroup: React.FC< ThemesToolbarGroupProps > = ( {
 			className="themes-toolbar-group"
 			initialActiveIndex={ activeIndex }
 			forceSwipe={ 'undefined' === typeof window }
+			swipeBreakpoint="<960px"
 			onClick={ ( index: number ) => onSelect( items[ index ]?.key ) }
 		>
 			{ items.map( ( item ) => (


### PR DESCRIPTION
## Proposed Changes

As discussed in p1679579121281739-slack-C048CUFRGFQ, we want to change the UI responsiveness of the filters so that the pricing filters won't drop to a second line when the content overflows. Instead, we want to keep the filters in one line, and show as much category filters as possible, and group the rest of the category filters in the "More" dropdown.

1440px:
| Before | After |
| --- | --- |
| ![Screenshot 2023-03-24 at 10 56 26 AM](https://user-images.githubusercontent.com/797888/227412762-37bfcc92-3a21-4924-86ab-ae2843013beb.png) | ![Screenshot 2023-03-24 at 10 56 42 AM](https://user-images.githubusercontent.com/797888/227412797-526262c4-2e1a-4ac6-be3d-03e3bfe6ac82.png) |

1280px:
| Before | After |
| --- | --- |
| ![Screenshot 2023-03-24 at 10 58 03 AM](https://user-images.githubusercontent.com/797888/227413013-9c7759a9-1a99-4350-8449-6b9321e9f837.png) | ![Screenshot 2023-03-24 at 10 58 30 AM](https://user-images.githubusercontent.com/797888/227413031-20c1aef5-9b46-4390-8226-798bf0be798e.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Ensure that the filter UI responsiveness behaves as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?