### PR TITLE
Theme Showcase: Prevent flash of empty content when theme is not found

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1362,6 +1362,7 @@ class ThemeSheet extends Component {
 		if ( this.props.error ) {
 			return <ThemeNotFoundError />;
 		}
+
 		return this.renderSheet();
 	}
 }
@@ -1465,7 +1466,7 @@ export default connect(
 			...theme,
 			themeId,
 			price: getPremiumThemePrice( state, themeId, siteId ),
-			error,
+			error: error || ! theme,
 			siteId,
 			siteSlug,
 			backPath,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1447,7 +1447,7 @@ export default connect(
 		const isCurrentUserPaid = isUserPaid( state );
 		const theme = getCanonicalTheme( state, siteId, themeId );
 		const siteIdOrWpcom = siteId || 'wpcom';
-		const error = theme ? false : getThemeRequestErrors( state, themeId, siteIdOrWpcom );
+		const error = theme ? false : getThemeRequestErrors( state, themeId, siteIdOrWpcom ) ?? true;
 		const englishUrl = 'https://wordpress.com' + getThemeDetailsUrl( state, themeId );
 
 		const isAtomic = isSiteAutomatedTransfer( state, siteId );
@@ -1466,7 +1466,7 @@ export default connect(
 			...theme,
 			themeId,
 			price: getPremiumThemePrice( state, themeId, siteId ),
-			error: error || ! theme,
+			error,
 			siteId,
 			siteSlug,
 			backPath,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1446,8 +1446,10 @@ export default connect(
 		const backPath = getBackPath( state );
 		const isCurrentUserPaid = isUserPaid( state );
 		const theme = getCanonicalTheme( state, siteId, themeId );
-		const siteIdOrWpcom = siteId || 'wpcom';
-		const error = theme ? false : getThemeRequestErrors( state, themeId, siteIdOrWpcom ) ?? true;
+		const error = theme
+			? false
+			: getThemeRequestErrors( state, themeId, 'wpcom' ) ||
+			  getThemeRequestErrors( state, themeId, siteId );
 		const englishUrl = 'https://wordpress.com' + getThemeDetailsUrl( state, themeId );
 
 		const isAtomic = isSiteAutomatedTransfer( state, siteId );


### PR DESCRIPTION
## Proposed Changes

As pointed out by @arthur791004 in https://github.com/Automattic/wp-calypso/pull/74817#issuecomment-1480710939, there is a flash of empty content when accessing the Theme Detail page of a non-existing theme. See screenshot for reference:

![Screenshot 2023-03-24 at 12 16 23 PM](https://user-images.githubusercontent.com/797888/227423061-77f85a72-13af-4594-ab4e-f3c8a40b7187.png)

This PR prevents the display of this empty content.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Detail page of a non-existing theme, such as `/theme/notatheme`.
* Ensure that the flash of empty content is no longer there.
* Please test in both logged-in and logged-out Theme Detail page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
