### PR TITLE
Logging: Move Site Logs styles to SCSS

### DIFF
--- a/client/my-sites/site-logs/components/site-logs-tab-panel/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-tab-panel/index.tsx
@@ -1,7 +1,8 @@
-import styled from '@emotion/styled';
 import { TabPanel } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import page from 'page';
+import './style.scss';
 
 export const tabs = [
 	{ name: 'php', title: __( 'PHP Logs' ) },
@@ -17,27 +18,6 @@ interface SiteLogsTabPanelProps {
 	onSelected?: ( tabName: SiteLogsTab ) => void;
 }
 
-const LogsTabPanel = styled( TabPanel )`
-	.components-tab-panel__tabs {
-		overflow-x: auto;
-	}
-	.components-tab-panel__tabs-item {
-		--wp-admin-theme-color: var( --studio-gray-100 );
-		color: var( --studio-gray-60 );
-		padding: 0;
-		margin-right: 24px;
-		font-size: 16px;
-		flex-shrink: 0;
-	}
-	.components-tab-panel__tabs-item:hover,
-	.components-tab-panel__tabs-item.is-active,
-	.components-tab-panel__tabs-item.is-active:focus,
-	.components-tab-panel__tabs-item:focus:not( :disabled ) {
-		box-shadow: inset 0 -2px 0 0 var( --wp-admin-theme-color );
-		color: var( --studio-gray-100 );
-	}
-`;
-
 export const SiteLogsTabPanel = ( {
 	children: renderContents,
 	selectedTab = 'php',
@@ -45,9 +25,9 @@ export const SiteLogsTabPanel = ( {
 	onSelected,
 }: SiteLogsTabPanelProps ) => {
 	return (
-		<LogsTabPanel
+		<TabPanel
 			initialTabName={ selectedTab }
-			className={ className }
+			className={ classnames( 'site-logs-tab-panel', className ) }
 			tabs={ tabs }
 			onSelect={ ( tabName ) => {
 				onTabSelected( tabName );
@@ -55,7 +35,7 @@ export const SiteLogsTabPanel = ( {
 			} }
 		>
 			{ ( tab ) => renderContents( tab ) }
-		</LogsTabPanel>
+		</TabPanel>
 	);
 };
 

--- a/client/my-sites/site-logs/components/site-logs-tab-panel/style.scss
+++ b/client/my-sites/site-logs/components/site-logs-tab-panel/style.scss
@@ -1,0 +1,22 @@
+.site-logs-tab-panel {
+	.components-tab-panel__tabs {
+		overflow-x: auto;
+	}
+
+	.components-tab-panel__tabs-item {
+		--wp-admin-theme-color: var(--studio-gray-100);
+		color: var(--studio-gray-60);
+		padding: 0;
+		margin-right: 24px;
+		font-size: $font-body-small;
+		flex-shrink: 0;
+	}
+
+	.components-tab-panel__tabs-item:hover,
+	.components-tab-panel__tabs-item.is-active,
+	.components-tab-panel__tabs-item.is-active:focus,
+	.components-tab-panel__tabs-item:focus:not(:disabled) {
+		box-shadow: inset 0 -2px 0 0 var(--wp-admin-theme-color);
+		color: var(--studio-gray-100);
+	}
+}

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -21,7 +21,7 @@ export function SiteLogs() {
 		const queryParam = new URL( window.location.href ).searchParams.get( 'log-type' );
 		return (
 			queryParam && [ 'php', 'web' ].includes( queryParam ) ? queryParam : 'php'
-		 ) as SiteLogsTab;
+		) as SiteLogsTab;
 	} );
 
 	const { data } = useSiteLogsQuery( siteId, {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

As discussed: https://github.com/Automattic/wp-calypso/pull/74805#discussion_r1145508490

This PR converts the styles for `<SiteLogsTabPanel>` from Emotion to SCSS.
