### PR TITLE
Logging: Move Site Logs tab type definition to `client/data/hosting`

### DIFF
--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -12,8 +12,10 @@ interface SiteLogsAPIResponse {
 
 export type SiteLogs = SiteLogsAPIResponse[ 'data' ];
 
+export type SiteLogsTab = 'php' | 'web';
+
 export interface SiteLogsParams {
-	logType: 'php' | 'web';
+	logType: SiteLogsTab;
 	start: number;
 	end: number;
 	sort_order?: 'asc' | 'desc';

--- a/client/my-sites/site-logs/components/site-logs-tab-panel/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-tab-panel/index.tsx
@@ -2,14 +2,13 @@ import { TabPanel } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import page from 'page';
+import type { SiteLogsTab } from 'calypso/data/hosting/use-site-logs-query';
 import './style.scss';
 
 export const tabs = [
 	{ name: 'php', title: __( 'PHP Logs' ) },
 	{ name: 'web', title: __( 'Webserver Logs' ) },
 ];
-
-export type SiteLogsTab = 'php' | 'web';
 
 interface SiteLogsTabPanelProps {
 	children( tab: TabPanel.Tab ): JSX.Element;

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -5,9 +5,9 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
-import { useSiteLogsQuery } from 'calypso/data/hosting/use-site-logs-query';
+import { SiteLogsTab, useSiteLogsQuery } from 'calypso/data/hosting/use-site-logs-query';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { SiteLogsTab, SiteLogsTabPanel } from './components/site-logs-tab-panel';
+import { SiteLogsTabPanel } from './components/site-logs-tab-panel';
 
 export function SiteLogs() {
 	const { __ } = useI18n();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Refactors the `'php' | 'web'` data type, which is going to be used by a lot of our logging components, to the `client/data/hosting` folder. This is the lowest-common-denominator for places that use this type, so everyone should import the type from here.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pure refactor, there should be no change
