### PR TITLE
Jetpack Pro Dashboard: fix column alignment on the small screen devices

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
@@ -19,10 +19,10 @@
 
 		.components-base-control__field {
 			margin-bottom: 0;
-		}
 
-		.components-form-toggle {
-			margin-right: 4px;
+			.components-flex {
+				gap: unset;
+			}
 		}
 	}
 
@@ -31,12 +31,12 @@
 			cursor: not-allowed;
 		}
 	}
-
 }
 
 .toggle-activate-monitoring__duration {
 	button {
 		@extend .inline-flex-align-centre;
+		margin-inline-start: 4px;
 	}
 
 	img {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/style.scss
@@ -57,7 +57,7 @@
 
 	.toggle-activate-monitoring__toggle-button .components-toggle-control
 	.components-base-control__field .components-form-toggle {
-		margin-right: 12px;
+		margin-right: 4px;
 	}
 
 	.site-actions__all-actions {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -438,3 +438,10 @@
 .width-fit-content {
 	width: fit-content !important;
 }
+
+.site-content__small-screen-view {
+	.sites-overview__icon-active {
+		position: relative;
+		left: 4px;
+	}
+}


### PR DESCRIPTION
Related to 1203940061556608-as-1204250440250952

## Proposed Changes

The PR fixes column alignment in the Jetpack Pro Dashboard on the small screen devices

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/show-php-version-in-site-expandable-block` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Switch to any small screen(<1280px) view using the dev tool, and verify that all the columns when the card is expanded is aligned together.


<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="286" alt="Screenshot 2023-03-24 at 11 01 23 AM" src="https://user-images.githubusercontent.com/10586875/227434727-a2471d2a-30c1-4faf-937e-c0a8e672e330.png">



</td>
<td>
<img width="286" alt="Screenshot 2023-03-24 at 10 59 32 AM" src="https://user-images.githubusercontent.com/10586875/227434712-7a1d5923-b32f-49d7-aad7-2732e9ffb94d.png">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?