### PR TITLE
Site Assembler: Replace remove icon shown on the large preview with text

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.scss
@@ -11,12 +11,15 @@
 			flex-direction: column;
 			display: flex;
 			align-items: center;
+			justify-content: center;
 		}
 
 		.pattern-action-bar__action {
-			padding: 0;
-			min-width: 30px;
-			max-width: 30px;
+			&.has-icon {
+				min-width: 30px;
+				max-width: 30px;
+				padding: 0;
+			}
 
 			svg {
 				fill: var(--studio-gray-80);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
@@ -12,6 +12,7 @@ type PatternActionBarProps = {
 	disableMoveUp?: boolean;
 	disableMoveDown?: boolean;
 	patternType: string;
+	isRemoveButtonTextOnly?: boolean;
 };
 
 const PatternActionBar = ( {
@@ -22,6 +23,7 @@ const PatternActionBar = ( {
 	disableMoveUp,
 	disableMoveDown,
 	patternType,
+	isRemoveButtonTextOnly,
 }: PatternActionBarProps ) => {
 	const translate = useTranslate();
 	return (
@@ -76,16 +78,18 @@ const PatternActionBar = ( {
 			<Button
 				className="pattern-action-bar__block pattern-action-bar__action"
 				role="menuitem"
-				label={ translate( 'Delete' ) }
+				label={ translate( 'Remove' ) }
 				onClick={ () => {
 					recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_delete_click', {
 						pattern_type: patternType,
 					} );
 					onDelete();
 				} }
-				icon={ close }
+				icon={ ! isRemoveButtonTextOnly ? close : null }
 				iconSize={ 23 }
-			/>
+			>
+				{ isRemoveButtonTextOnly ? translate( 'Remove' ) : null }
+			</Button>
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -52,6 +52,10 @@
 			height: 28px;
 			padding: 2px;
 
+			&:last-child:not(.has-icon) {
+				padding-right: 6px;
+			}
+
 			&::before {
 				content: "";
 				position: absolute;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -52,7 +52,7 @@
 			height: 28px;
 			padding: 2px;
 
-			&:last-child:not(.has-icon) {
+			&:last-child:not(:only-child):not(.has-icon) {
 				padding-right: 6px;
 			}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -81,7 +81,7 @@ const PatternLargePreview = ( {
 					// Disable default max-height
 					maxHeight="none"
 				/>
-				<PatternActionBar patternType={ type } { ...getActionBarProps() } />
+				<PatternActionBar patternType={ type } isRemoveButtonTextOnly { ...getActionBarProps() } />
 			</li>
 		);
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74816

## Proposed Changes

* Display the `Remove` text instead of the icon on the action bar of the large preview
* Rename the tooltip of the remove icon on the action bar in the list view to `Remove`

![image](https://user-images.githubusercontent.com/13596067/227439242-30f3cc72-4353-4de9-a77a-3669dabe6fd5.png)

![image](https://user-images.githubusercontent.com/13596067/227439065-046fc686-c9fb-424a-8c91-44288cac0785.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_site>&flags=pattern-assembler/color-and-fonts
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Select "Homepage" > "Add patterns" to add patterns
  * Hover on any pattern on the large preview, and the remove icon should be replaced with the `Remove`
  * Save and go back to the list view
  * Hover on any pattern first, and then hover on the remove icon. The tooltip should be `Remove` as well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
