### PR TITLE
Clarify the domain registration & transfer policy in the domain management screen.

### DIFF
--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -33,7 +33,7 @@ function EmptyDomainsListCard( {
 
 	let title = translate( 'Get your domain' );
 	let line = translate(
-		'Get a free one-year domain registration or transfer with any annual plan.'
+		'Get a free one-year domain registration or transfer with any annual paid plan.'
 	);
 	let action = translate( 'Upgrade to a plan' );
 	let actionURL = `/plans/${ selectedSite.slug }`;

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -32,7 +32,9 @@ function EmptyDomainsListCard( {
 		selectedSite?.plan?.product_slug && ! isFreePlan( selectedSite.plan.product_slug );
 
 	let title = translate( 'Get your domain' );
-	let line = translate( 'Get a free one-year domain registration or transfer with any paid plan.' );
+	let line = translate(
+		'Get a free one-year domain registration or transfer with any annual plan.'
+	);
 	let action = translate( 'Upgrade to a plan' );
 	let actionURL = `/plans/${ selectedSite.slug }`;
 	let secondaryAction = translate( 'Just search for a domain' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #74521 

## Proposed Changes

This PR updates the explanation text of "Get your domain" dialog in `/domains/manage/`, clarifying that it's annual plan only since a monthly plan is a paid plan yet doesn't have that.

<img width="1231" alt="image" src="https://user-images.githubusercontent.com/1842898/227468373-b8ed50d5-b96b-4cca-8d9c-eecf8356c706.png">

Note: instead of "any annual paid plan", I've put in "any annual plan" since I feel "paid" is a bit redundant. an annual plan should imply "paid" without ambiguity.  

## Testing Instructions

Logging-in as a user without any annual plan, go `/domains/manage` and confirm that the copy is updated accordingly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
