### PR TITLE
Site Assembler: Restyle the font preview to display the entire font name

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -266,6 +266,8 @@ $font-family: "SF Pro Text", $sans;
 		margin-bottom: 32px;
 		overflow-y: auto;
 		flex-grow: 1;
+		// Reserve space for the scrollbar to prevent unwanted layout change
+		scrollbar-gutter: stable;
 	}
 
 	.screen-container__body--no-padding {

--- a/packages/global-styles/src/components/color-palette-variations/style.scss
+++ b/packages/global-styles/src/components/color-palette-variations/style.scss
@@ -15,19 +15,24 @@
 	margin: 2px;
 	cursor: pointer;
 
+	&::after {
+		content: "";
+		display: block;
+		position: absolute;
+		top: -2px;
+		bottom: -2px;
+		left: -2px;
+		right: -2px;
+		border-radius: 3px; /* stylelint-disable-line scales/radii */
+		opacity: 0;
+		pointer-events: none;
+	}
+
 	&:hover,
 	&:focus-visible,
 	&.is-active {
 		&::after {
-			border-radius: 3px; /* stylelint-disable-line scales/radii */
-			bottom: -2px;
-			content: "";
-			display: block;
-			left: -2px;
-			pointer-events: none;
-			position: absolute;
-			right: -2px;
-			top: -2px;
+			opacity: 1;
 		}
 	}
 

--- a/packages/global-styles/src/components/color-palette-variations/style.scss
+++ b/packages/global-styles/src/components/color-palette-variations/style.scss
@@ -6,7 +6,7 @@
 	box-sizing: border-box;
 
 	.global-styles-variation-container__iframe {
-		max-height: 50px;
+		max-height: 47px;
 	}
 }
 

--- a/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/preview.tsx
@@ -94,7 +94,7 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 									overflow: 'hidden',
 								} }
 							>
-								<VStack spacing={ 2 * ratio } style={ { margin: '16px' } }>
+								<VStack spacing={ 1 } style={ { margin: '16px' } }>
 									<div
 										title={ headingFontFamilyName }
 										aria-label={ headingFontFamilyName }
@@ -115,7 +115,7 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 										style={ {
 											...DEFAULT_FONT_STYLES,
 											color: '#444444',
-											fontSize: '12px',
+											fontSize: '14px',
 											fontWeight: textFontWeight,
 											fontFamily: textFontFamily,
 											fontStyle: textFontStyle,

--- a/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/preview.tsx
@@ -41,7 +41,7 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 
 	const [ containerResizeListener, { width } ] = useResizeObserver();
 	const ratio = width ? width / STYLE_PREVIEW_WIDTH : 1;
-	const normalizedHeight = Math.ceil( STYLE_PREVIEW_HEIGHT * ratio );
+	const normalizedHeight = Math.ceil( STYLE_PREVIEW_HEIGHT * ratio * 0.5 );
 	const externalFontFamilies = fontFamilies.filter( ( { slug } ) => slug !== SYSTEM_FONT_SLUG );
 	const [ isLoaded, setIsLoaded ] = useState( ! externalFontFamilies.length );
 
@@ -94,7 +94,7 @@ const FontPairingVariationPreview = ( { title }: Props ) => {
 									overflow: 'hidden',
 								} }
 							>
-								<VStack spacing={ 4 * ratio } style={ { margin: '16px' } }>
+								<VStack spacing={ 2 * ratio } style={ { margin: '16px' } }>
 									<div
 										title={ headingFontFamilyName }
 										aria-label={ headingFontFamilyName }

--- a/packages/global-styles/src/components/font-pairing-variations/style.scss
+++ b/packages/global-styles/src/components/font-pairing-variations/style.scss
@@ -1,12 +1,12 @@
 .font-pairing-variations {
 	display: grid;
 	gap: 12px;
-	grid-template-columns: repeat(2, 1fr);
+	grid-template-columns: repeat(1, 1fr);
 	width: 100%;
 	box-sizing: border-box;
 
 	.global-styles-variation-container__iframe {
-		max-height: 79px;
+		max-height: 80px;
 	}
 }
 

--- a/packages/global-styles/src/components/font-pairing-variations/style.scss
+++ b/packages/global-styles/src/components/font-pairing-variations/style.scss
@@ -15,19 +15,24 @@
 	margin: 3px;
 	cursor: pointer;
 
+	&::after {
+		content: "";
+		display: block;
+		position: absolute;
+		top: -3px;
+		bottom: -3px;
+		left: -3px;
+		right: -3px;
+		border-radius: 3px; /* stylelint-disable-line scales/radii */
+		opacity: 0;
+		pointer-events: none;
+	}
+
 	&:hover,
 	&:focus-visible,
 	&.is-active {
 		&::after {
-			border-radius: 3px; /* stylelint-disable-line scales/radii */
-			bottom: -3px;
-			content: "";
-			display: block;
-			left: -3px;
-			pointer-events: none;
-			position: absolute;
-			right: -3px;
-			top: -3px;
+			opacity: 1;
 		}
 	}
 

--- a/packages/global-styles/src/components/global-styles-variation-container/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variation-container/index.tsx
@@ -46,6 +46,7 @@ const GlobalStylesVariationContainer = ( {
 				visibility: width ? 'visible' : 'hidden',
 			} }
 			tabIndex={ -1 }
+			scrolling="no"
 			{ ...props }
 		>
 			{ containerResizeListener }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbxlJb-3EX-p2

## Proposed Changes

* People want to see the entire font name of the preview so they're able to know which font we will apply. So, this PR is proposing to restyle the font preview to display the full font name.
* There is an [issue](https://github.com/Automattic/wp-calypso/pull/74268) related to the scrollbar width inside the iframe. Sometimes it sill happens. So, this PR is also proposing to disable scrolling inside the iframe.

![image](https://user-images.githubusercontent.com/13596067/227482393-968b0b2a-d8ef-4a3d-bc70-1d612f5de1b2.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_site>&flags=pattern-assembler/color-and-fonts
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Select `Fonts` and verify you're able to see the entire font name

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?