### PR TITLE
Theme Showcase: Show correct fonts in style variation previews via inline font-faces

### DIFF
--- a/packages/design-preview/src/components/style-variation-preview.js
+++ b/packages/design-preview/src/components/style-variation-preview.js
@@ -62,7 +62,7 @@ const normalizedHeight = 152;
 
 const normalizedColorSwatchSize = 32;
 
-const StylesPreview = ( { label, isFocused, withHoverView } ) => {
+const StylesPreview = ( { label, inlineCss, isFocused, withHoverView } ) => {
 	const [ fontWeight ] = useStyle( 'typography.fontWeight' );
 	const [ fontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
 	const [ headingFontFamily = fontFamily ] = useStyle( 'elements.h1.typography.fontFamily' );
@@ -97,6 +97,12 @@ const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 				...styles,
 				{
 					// Custom WP.com code - START.
+					css: inlineCss?.match( /@font-face{([^}])+}/g )?.join( '' ),
+					isGlobalStyles: true,
+					// Custom WP.com code - END.
+				},
+				{
+					// Custom WP.com code - START.
 					css: 'html{overflow:hidden}body{min-width: 0;padding: 0;border: none;transform:scale(1);}',
 					// Custom WP.com code - END.
 					isGlobalStyles: true,
@@ -105,7 +111,7 @@ const StylesPreview = ( { label, isFocused, withHoverView } ) => {
 		}
 
 		return styles;
-	}, [ styles ] );
+	}, [ inlineCss, styles ] );
 	const isReady = !! width;
 
 	return (

--- a/packages/design-preview/src/components/style-variation.tsx
+++ b/packages/design-preview/src/components/style-variation.tsx
@@ -76,6 +76,7 @@ const StyleVariationPreview: React.FC< StyleVariationPreviewProps > = ( {
 				<GlobalStylesContext.Provider value={ context }>
 					<Preview
 						label={ variation.title }
+						inlineCss={ variation.inline_css || '' }
 						isFocused={ isFocused || showOnlyHoverView }
 						withHoverView
 					/>


### PR DESCRIPTION
## Proposed Changes

This PR ensures that the fonts are rendering correctly by injecting `@font-face{}` definitions into the preview iframe. The `@font-face{}` definitions are extracted from the `inline_css` property provided by the theme endpoint.

| Before | After |
| --- | --- |
| ![Screenshot 2023-03-24 at 6 00 11 PM](https://user-images.githubusercontent.com/797888/227490597-93381ee3-423b-443f-b06c-59843239c7ca.png) | ![Screenshot 2023-03-24 at 5 58 58 PM](https://user-images.githubusercontent.com/797888/227490291-eed826ab-2720-49f2-85f3-edab8aa1ac9d.png)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Click on any theme with style variation.
* Ensure that the fonts are rendering correctly, you can compare them with the ones in the Site Editor.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
