### PR TITLE
Fix Stepper CSS leaking - Follow up to #74723

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -146,9 +146,7 @@ button {
 	.step-container {
 		--color-accent: #117ac9;
 		--color-accent-60: #0e64a5;
-		@include break-medium {
-			padding-top: 0;
-		}
+
 		.form-fieldset {
 			label {
 				text-transform: none;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -209,7 +209,7 @@ $design-button-primary-color: rgb(17, 122, 201);
 			}
 
 			@include break-small {
-				margin: 16px 0 24px;
+				margin: 11px 0 24px;
 				transform: translateY(-58px);
 				min-height: 42px;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -16,7 +16,7 @@
 		}
 
 		.step-container__header {
-			margin: 20px 24px 30px 20px;
+			margin: 25px 24px 30px 20px;
 
 			@include break-small {
 				margin: 36px 0 40px 0;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -5,7 +5,8 @@ $font-family: "SF Pro Text", $sans;
 .link-in-bio-setup,
 .link-in-bio-tld-setup {
 	.step-container {
-		padding-top: 24px;
+		padding-top: 25px;
+
 		@include break-medium {
 			padding-top: 0;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -3,7 +3,7 @@
 .newsletter-setup {
 
 	.step-container {
-		padding-top: 24px;
+		padding-top: 25px;
 		@include break-medium {
 			padding-top: 0;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/patterns/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/patterns/styles.scss
@@ -20,6 +20,7 @@
 
 		@include break-small {
 			height: auto;
+			padding-top: 2px;
 		}
 
 		@include onboarding-break-mobile-landscape {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -6,16 +6,15 @@
 		padding: 0;
 
 		.step-wrapper__header {
-			margin: 14px 20px;
+			margin: 9px 20px;
 
 			@include break-large {
 				margin: 8px 20px;
 			}
 
 			.formatted-header {
-				margin-top: 8px;
 				@include break-small {
-					margin-top: 30px;
+					margin-top: 28px;
 				}
 
 				h1.formatted-header__title {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
@@ -1,10 +1,10 @@
 @import "../style";
 .subscribers {
 	.add-subscriber__title-container {
-		// Intentional override for the title margin-top.
-		margin-top: 24px !important;
+		margin-top: 25px;
+
 		@include break-medium {
-			margin-top: 36px !important;
+			margin-top: 36px;
 		}
 	}
 	.step-container {
@@ -15,7 +15,8 @@
 
 		.add-subscriber__title-container,
 		.add-subscriber__form--container {
-			margin: auto;
+			margin-left: auto;
+			margin-right: auto;
 		}
 
 		.add-subscriber .add-subscriber__title-container {

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -2,11 +2,6 @@
 .step-container.subscribers {
 	padding: 0 1.5rem;
 
-	.add-subscriber__title-container,
-	.add-subscriber__form--container {
-		margin: auto;
-	}
-
 	.add-subscriber .add-subscriber__title-container {
 		max-width: 376px;
 		text-align: center;


### PR DESCRIPTION
## Proposed Changes

* This removes the changes to `global.scss` and restricts the changes to the steps. 

## Testing Instructions
I know this looks hard to test, but I found this way super easy.

### Newsletter

1. Go to /setup/newsletter.
2. For every step before subscribers step, do the following
    - Visit the page on desktop
    - Run he following in console `$('.formatted-header__title').getBoundingClientRect().y`, you should get 96.
    - Switch to mobile in DevTools, re-reun `$('.formatted-header__title').getBoundingClientRect().y`, you should get 85.
    - Repeat for every step.
3. Subs step doesn't have the same class, please find the heading manually and see that it has the same values. 
4. Keep the site slug noted. 

### Link in Bio

1. Go to /setup/link-in-bio.
2. For every step, do the following
    - Visit the page on desktop
    - Run he following in console `$('.formatted-header__title').getBoundingClientRect().y`, you should get 96.
    - Switch to mobile in DevTools, re-reun `$('.formatted-header__title').getBoundingClientRect().y`, you should get 85.

### Regression testing

1. Visit /setup/site-setup/processing?siteSlug=YOUR_NEWSLETTER
2. Reach the loading step at the end of the flow, should be vertically centered. 
3. Go to /people/add-subscribers/YOUR_SITE, all should look good.