### PR TITLE
Site Assembler - Notices - Set notice timeout to 5 seconds (part of Snackbar)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
@@ -7,7 +7,7 @@ import './notices.scss';
 const NOTICE_TIMEOUT = 5000;
 
 type Notice = NoticeList.Notice & {
-	timer: ReturnType< typeof setTimeout >;
+	timer?: ReturnType< typeof setTimeout >;
 };
 
 const Notices = ( {
@@ -15,11 +15,16 @@ const Notices = ( {
 	noticeOperations,
 }: Pick< withNotices.Props, 'noticeList' | 'noticeOperations' > ) => {
 	const onRemoveNotice = ( id: string ) => {
+		const notice = noticeList.find( ( notice ) => id === notice.id ) as Notice;
+		if ( notice?.timer ) {
+			clearTimeout( notice.timer );
+			delete notice.timer;
+		}
 		noticeOperations.removeNotice( id );
 	};
 
 	useEffect( () => {
-		const lastNotice = noticeList.at( -1 ) as Notice;
+		const lastNotice = noticeList[ noticeList.length - 1 ] as Notice;
 
 		if ( lastNotice?.id && ! lastNotice?.timer ) {
 			lastNotice.timer = setTimeout(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
@@ -1,10 +1,14 @@
-import { SnackbarList, withNotices } from '@wordpress/components';
+import { SnackbarList, withNotices, NoticeList } from '@wordpress/components';
 import i18n from 'i18n-calypso';
 import { useEffect } from 'react';
 import type { Pattern } from '../types';
 import './notices.scss';
 
 const NOTICE_TIMEOUT = 5000;
+
+type Notice = NoticeList.Notice & {
+	timer: ReturnType< typeof setTimeout >;
+};
 
 const Notices = ( {
 	noticeList,
@@ -15,13 +19,14 @@ const Notices = ( {
 	};
 
 	useEffect( () => {
-		setTimeout( () => {
-			const lastNotice = noticeList.at( -1 );
+		const lastNotice = noticeList.at( -1 ) as Notice;
 
-			if ( lastNotice?.id ) {
-				noticeOperations.removeNotice( lastNotice.id );
-			}
-		}, NOTICE_TIMEOUT );
+		if ( lastNotice?.id && ! lastNotice?.timer ) {
+			lastNotice.timer = setTimeout(
+				() => noticeOperations.removeNotice( lastNotice.id ),
+				NOTICE_TIMEOUT
+			);
+		}
 	}, [ noticeList, noticeOperations ] );
 
 	return <SnackbarList notices={ noticeList } onRemove={ onRemoveNotice } />;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/notices/notices.tsx
@@ -1,7 +1,10 @@
 import { SnackbarList, withNotices } from '@wordpress/components';
 import i18n from 'i18n-calypso';
+import { useEffect } from 'react';
 import type { Pattern } from '../types';
 import './notices.scss';
+
+const NOTICE_TIMEOUT = 5000;
 
 const Notices = ( {
 	noticeList,
@@ -10,6 +13,16 @@ const Notices = ( {
 	const onRemoveNotice = ( id: string ) => {
 		noticeOperations.removeNotice( id );
 	};
+
+	useEffect( () => {
+		setTimeout( () => {
+			const lastNotice = noticeList.at( -1 );
+
+			if ( lastNotice?.id ) {
+				noticeOperations.removeNotice( lastNotice.id );
+			}
+		}, NOTICE_TIMEOUT );
+	}, [ noticeList, noticeOperations ] );
 
 	return <SnackbarList notices={ noticeList } onRemove={ onRemoveNotice } />;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74758

## Proposed Changes

* Set notice timeout to 5s (before 10s)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler
* Add patterns
* Verify that notices are dismissed after 5 seconds

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
