### PR TITLE
Add back button to domains + plan selection screens

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/domain-upsell.ts
@@ -40,6 +40,10 @@ const domainUpsell: Flow = {
 		const returnUrl = `/setup/${ flowName }/launchpad?siteSlug=${ siteSlug }`;
 		const encodedReturnUrl = encodeURIComponent( returnUrl );
 
+		const exitFlow = ( location = '/sites' ) => {
+			window.location.assign( location );
+		};
+
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			switch ( currentStep ) {
 				case 'domains':
@@ -49,6 +53,9 @@ const domainUpsell: Flow = {
 					navigate( 'plans' );
 
 				case 'plans':
+					if ( providedDependencies?.returnToDomainSelection ) {
+						return navigate( 'domains' );
+					}
 					if ( providedDependencies?.goToCheckout ) {
 						const planCartItem = getPlanCartItem();
 						const domainCartItem = getDomainCartItem();
@@ -69,7 +76,7 @@ const domainUpsell: Flow = {
 			}
 		}
 
-		return { submit };
+		return { submit, exitFlow };
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -14,6 +14,8 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import {
 	domainRegistration,
 	domainMapping,
@@ -43,6 +45,8 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 	const [ showUseYourDomain, setShowUseYourDomain ] = useState( false );
 
 	const dispatch = useReduxDispatch();
+	const flowToReturnTo = useQuery().get( 'flowToReturnTo' );
+	const siteSlug = useSiteSlug();
 
 	const { submit, exitFlow } = navigation;
 
@@ -242,18 +246,22 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 		if ( showUseYourDomain ) {
 			return setShowUseYourDomain( false );
 		}
+
+		if ( flow === DOMAIN_UPSELL_FLOW ) {
+			return exitFlow?.( `/setup/${ flowToReturnTo }/launchpad?siteSlug=${ siteSlug }` );
+		}
 		return exitFlow?.( '/sites' );
 	};
 
 	const getBackLabelText = () => {
-		if ( showUseYourDomain ) {
+		if ( flow === DOMAIN_UPSELL_FLOW ) {
 			return __( 'Back' );
 		}
 		return __( 'Back to sites' );
 	};
 
 	const shouldHideBackButton = () => {
-		if ( showUseYourDomain ) {
+		if ( flow === DOMAIN_UPSELL_FLOW ) {
 			return false;
 		}
 		return ! isCopySiteFlow( flow );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -1,11 +1,13 @@
 import { is2023PricingGridActivePage } from '@automattic/calypso-products';
 import { DOMAIN_UPSELL_FLOW, StepContainer } from '@automattic/onboarding';
+import { useI18n } from '@wordpress/react-i18n';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import PlansWrapper from './plans-wrapper';
 import type { ProvidedDependencies, Step } from '../../types';
 
 const plans: Step = function Plans( { navigation, flow } ) {
-	const { submit, goBack } = navigation;
+	const { submit } = navigation;
+	const { __ } = useI18n();
 
 	const handleSubmit = () => {
 		const providedDependencies: ProvidedDependencies = {};
@@ -17,16 +19,37 @@ const plans: Step = function Plans( { navigation, flow } ) {
 		submit?.( providedDependencies );
 	};
 	const is2023PricingGridVisible = is2023PricingGridActivePage( window );
+
+	const handleGoBack = () => {
+		if ( flow === DOMAIN_UPSELL_FLOW ) {
+			submit?.( { returnToDomainSelection: true } );
+		}
+	};
+
+	const getBackLabelText = () => {
+		if ( flow === DOMAIN_UPSELL_FLOW ) {
+			return __( 'Back' );
+		}
+	};
+
+	const shouldHideBackButton = () => {
+		if ( flow === DOMAIN_UPSELL_FLOW ) {
+			return false;
+		}
+		return true;
+	};
+
 	return (
 		<StepContainer
 			stepName="plans"
-			goBack={ goBack }
+			goBack={ handleGoBack }
 			isHorizontalLayout={ false }
 			isWideLayout={ ! is2023PricingGridVisible }
 			isFullLayout={ is2023PricingGridVisible }
 			hideFormattedHeader={ true }
 			isLargeSkipLayout={ false }
-			hideBack={ true }
+			backLabelText={ getBackLabelText() }
+			hideBack={ shouldHideBackButton() }
 			stepContent={ <PlansWrapper flowName={ flow } onSubmit={ handleSubmit } /> }
 			recordTracksEvent={ recordTracksEvent }
 		/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -188,5 +188,15 @@
 	.signup-header h1 {
 		display: none;
 	}
+
+	button.button.navigation-link.is-borderless {
+		background: none;
+		border: none;
+		color: #101517;
+		font-size: 0.875rem;
+		font-weight: 600;
+		padding: 0;
+		text-decoration: none;
+	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -192,7 +192,7 @@
 	button.button.navigation-link.is-borderless {
 		background: none;
 		border: none;
-		color: #101517;
+		color: var(--studio-gray-100);
 		font-size: 0.875rem;
 		font-weight: 600;
 		padding: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Testing / Review Estimation

Test: short
Review: short

Related to #74416

## Proposed Changes

* Add back button to domain and plan selection screen

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Create or use an existing launchpad-enabled site (write/build/free flow)
* Click the "Choose a domain task"
* Verify there is a back button on the domain selection screen and verify that it navigates to the launchpad screen.
* Verify there is a back button on the plan selection screen and verify that it navigates back to the domain selection screen.

<img width="906" alt="CleanShot 2023-03-24 at 11 05 40@2x" src="https://user-images.githubusercontent.com/10482592/227563351-984d0800-656f-41fc-8185-82e6c586f57b.png">

<img width="906" alt="CleanShot 2023-03-24 at 11 07 52@2x" src="https://user-images.githubusercontent.com/10482592/227563875-ec7aae42-7c86-450e-8538-d983e834419e.png">


 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
