### PR TITLE
Hide free plan for domain upsell flow

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/domain-upsell.ts
@@ -1,4 +1,4 @@
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import { OnboardSelect } from 'calypso/../packages/data-stores/src';
 import {
@@ -37,6 +37,8 @@ const domainUpsell: Flow = {
 			} ),
 			[]
 		);
+		const { setHideFreePlan } = useDispatch( ONBOARD_STORE );
+
 		const returnUrl = `/setup/${ flowName }/launchpad?siteSlug=${ siteSlug }`;
 		const encodedReturnUrl = encodeURIComponent( returnUrl );
 
@@ -46,6 +48,7 @@ const domainUpsell: Flow = {
 					if ( providedDependencies?.deferDomainSelection ) {
 						return window.location.assign( returnUrl );
 					}
+					setHideFreePlan( true );
 					navigate( 'plans' );
 
 				case 'plans':

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -94,15 +94,7 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			} );
 			dispatch( submitDomainStepSelection( suggestion, getAnalyticsSection() ) );
 
-			let hideFreePlan;
-
-			if ( flow === DOMAIN_UPSELL_FLOW ) {
-				hideFreePlan = true;
-			} else {
-				hideFreePlan = Boolean( suggestion.product_slug ) || shouldHideFreePlan;
-			}
-
-			setHideFreePlan( hideFreePlan );
+			setHideFreePlan( Boolean( suggestion.product_slug ) || shouldHideFreePlan );
 			setDomainCartItem( domainCartItem );
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74416

## Testing / Review Estimation

Test: short
Review: short

## Proposed Changes

* Hides free plan on the plan selection screen for domain upsell flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Create or use an existing launchpad-enabled site (Write/build/free flow)
* Click the "Choose a domain" task
* Select a random domain and verify the plan selection screen does not display a free plan.
* Go back to the domain selection screen. Click "Use a domain I own" and go through the steps until you reach the plans screen again. Verify the plan selection screen does not display a free plan.

<img width="884" alt="CleanShot 2023-03-24 at 11 18 38@2x" src="https://user-images.githubusercontent.com/10482592/227567083-0de11453-ccca-4293-811b-9793fe65a171.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
