### PR TITLE
Support: Update live chat closure times for Easter 2023

### DIFF
--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -13,22 +13,10 @@ class PrimaryHeader extends Component {
 		return (
 			<Fragment>
 				<ClosureNotice
-					displayAt="2022-04-10 00:00Z"
-					closesAt="2022-04-17 00:00Z"
-					reopensAt="2022-04-18 07:00Z"
+					displayAt="2023-04-03 00:01Z"
+					closesAt="2023-04-09 00:01Z"
+					reopensAt="2023-04-10 07:00Z"
 					holidayName="Easter"
-				/>
-				<ClosureNotice
-					displayAt="2022-12-17 00:00Z"
-					closesAt="2022-12-24 00:00Z"
-					reopensAt="2022-12-26 07:00Z"
-					holidayName="Christmas"
-				/>
-				<ClosureNotice
-					displayAt="2022-12-26 07:00Z"
-					closesAt="2022-12-31 00:00Z"
-					reopensAt="2023-01-02 07:00Z"
-					holidayName="New Year's Day"
 				/>
 				<Card>
 					<img

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -13,8 +13,8 @@ class PrimaryHeader extends Component {
 		return (
 			<Fragment>
 				<ClosureNotice
-					displayAt="2023-04-03 00:01Z"
-					closesAt="2023-04-09 00:01Z"
+					displayAt="2023-04-03 00:00Z"
+					closesAt="2023-04-09 00:00Z"
 					reopensAt="2023-04-10 07:00Z"
 					holidayName="Easter"
 				/>

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -577,8 +577,8 @@ class HelpContact extends Component {
 								context: 'Holiday name',
 							} ) }
 							compact={ compact }
-							displayAt="2023-04-03 00:01Z"
-							closesAt="2023-04-09 00:01Z"
+							displayAt="2023-04-03 00:00Z"
+							closesAt="2023-04-09 00:00Z"
 							reopensAt="2023-04-10 07:00Z"
 						/>
 					</>

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { getPlanTermLabel } from '@automattic/calypso-products';
-import { Card, GMClosureNotice } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
 import {
 	shouldShowHelpCenterToUser,
@@ -47,7 +47,6 @@ import {
 } from 'calypso/state/happychat/connection/actions';
 import getHappychatEnv from 'calypso/state/happychat/selectors/get-happychat-env';
 import getHappychatUserInfo from 'calypso/state/happychat/selectors/get-happychat-userinfo';
-import getSupportLevel from 'calypso/state/happychat/selectors/get-support-level';
 import hasHappychatLocalizedSupport from 'calypso/state/happychat/selectors/has-happychat-localized-support';
 import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
 import { openChat as openHappychat } from 'calypso/state/happychat/ui/actions';
@@ -565,10 +564,6 @@ class HelpContact extends Component {
 		const isUserAffectedByLiveChatClosure =
 			[ SUPPORT_FORUM, SUPPORT_UPWORK_TICKET ].indexOf( supportVariation ) === -1;
 
-		const hasAccessToLivechat = ! [ 'free', 'personal', 'starter' ].includes(
-			this.props.supportLevel
-		);
-
 		return (
 			<div>
 				{ activeSupportTicketCount > 0 && (
@@ -582,33 +577,9 @@ class HelpContact extends Component {
 								context: 'Holiday name',
 							} ) }
 							compact={ compact }
-							displayAt="2022-04-10 00:00Z"
-							closesAt="2022-04-17 00:00Z"
-							reopensAt="2022-04-18 07:00Z"
-						/>
-						<GMClosureNotice
-							displayAt="2022-10-29 00:00Z"
-							closesAt="2022-11-05 00:00Z"
-							reopensAt="2022-11-14 07:00Z"
-							enabled={ hasAccessToLivechat }
-						/>
-						<ChatHolidayClosureNotice
-							holidayName={ translate( 'Christmas', {
-								context: 'Holiday name',
-							} ) }
-							compact={ compact }
-							displayAt="2022-12-17 00:00Z"
-							closesAt="2022-12-24 00:00Z"
-							reopensAt="2022-12-26 07:00Z"
-						/>
-						<ChatHolidayClosureNotice
-							holidayName={ translate( "New Year's Day", {
-								context: 'Holiday name',
-							} ) }
-							compact={ compact }
-							displayAt="2022-12-26 07:00Z"
-							closesAt="2022-12-31 00:00Z"
-							reopensAt="2023-01-02 07:00Z"
+							displayAt="2023-04-03 00:01Z"
+							closesAt="2023-04-09 00:01Z"
+							reopensAt="2023-04-10 07:00Z"
 						/>
 					</>
 				) }
@@ -673,7 +644,6 @@ export default withDispatch( ( dispatch ) => {
 				hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
 				shouldStartHappychatConnection: ! isRequestingSites( state ) && isChatEligible,
 				isRequestingSites: isRequestingSites( state ),
-				supportLevel: getSupportLevel( state ),
 				supportVariation: getInlineHelpSupportVariation( state ),
 				shouldShowHelpCenterToUser: shouldShowHelpCenterToUser( getCurrentUserId( state ) ),
 				happychatEnv: getHappychatEnv( state ),

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -125,8 +125,8 @@ export const HelpCenterContactPage: FC = () => {
 				<HelpCenterActiveTicketNotice tickets={ tickets } />
 				{ /* Easter */ }
 				<GMClosureNotice
-					displayAt="2023-04-03 00:01Z"
-					closesAt="2023-04-09 00:01Z"
+					displayAt="2023-04-03 00:00Z"
+					closesAt="2023-04-09 00:00Z"
 					reopensAt="2023-04-10 07:00Z"
 					enabled={ hasAccessToLivechat }
 				/>

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -123,11 +123,11 @@ export const HelpCenterContactPage: FC = () => {
 			<div className="help-center-contact-page__content">
 				<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
 				<HelpCenterActiveTicketNotice tickets={ tickets } />
-				{ /* Christmas */ }
+				{ /* Easter */ }
 				<GMClosureNotice
-					displayAt="2022-12-17 00:00Z"
-					closesAt="2022-12-24 00:00Z"
-					reopensAt="2022-12-26 07:00Z"
+					displayAt="2023-04-03 00:01Z"
+					closesAt="2023-04-09 00:01Z"
+					reopensAt="2023-04-10 07:00Z"
 					enabled={ hasAccessToLivechat }
 				/>
 				<div className={ classnames( 'help-center-contact-page__boxes' ) }>


### PR DESCRIPTION
As requested on peCdcN-18-p2.

### Testing
Change the dates in the code to simulate different cases - before, during and after the holiday.

Make sure you test both the old contact form (`/help/contact`) as well as the new Help Center (`?` in the main menu bar on top).
Check also the Quickstart page: `/me/quickstart/`.

<img width="438" alt="Screenshot 2023-04-03 at 12 41 02" src="https://user-images.githubusercontent.com/3392497/229512777-928ba74f-732f-4365-aea9-a420812b6cc6.png">
<img width="749" alt="Screenshot 2023-04-03 at 12 41 32" src="https://user-images.githubusercontent.com/3392497/229512787-f840d94a-9678-4dcb-a34d-8ce8e4bd079e.png">
<img width="743" alt="Screenshot 2023-04-03 at 12 45 05" src="https://user-images.githubusercontent.com/3392497/229513341-61ada32e-ec33-495b-9608-60135e9824ee.png">
