### PR TITLE
Hosting configuration: fire events when clicking the support card CTA

### DIFF
--- a/client/my-sites/hosting/support-card/index.js
+++ b/client/my-sites/hosting/support-card/index.js
@@ -32,7 +32,7 @@ export default function SupportCard() {
 					'If you need help or have any questions, our Happiness Engineers are here when you need them.'
 				) }
 			</p>
-			<Button onClick={ () => dispatch( trackNavigateToContactSupport ) } href="/help/contact">
+			<Button onClick={ () => dispatch( trackNavigateToContactSupport() ) } href="/help/contact">
 				{ translate( 'Contact us' ) }
 			</Button>
 		</Card>


### PR DESCRIPTION
## Proposed Changes

This PR fixes the analytics events not being dispatched correctly when clicking the CTA inside the Support card on the Hosting Configuration page.

## Testing Instructions

Open the DevTools and enable analytics logging with `localStorage.setItem( 'debug', 'calypso:analytics' );`. Verify that the log level is set to `Verbose` and that `Preserve Log` is checked, otherwise, you won't see the events being logged.

On `trunk`:

- visit HC for any Atomic site and click "Contact Us" on the right;
- verify that the `calypso_hosting_configuration_contact_support` event IS NOT dispatched and you're redirected to `/help/contact`.

On this branch:

- visit HC for any Atomic site and click "Contact Us" on the right;
- verify that the `calypso_hosting_configuration_contact_support` event IS dispatched and you're redirected to `/help/contact`.

![image](https://user-images.githubusercontent.com/26530524/227578950-11254611-76a6-447a-b592-c65b0c51da0a.png)
