### PR TITLE
Stats: Add loading placeholders to post stats cards on the Insights page

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/latest-post-card.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/latest-post-card.tsx
@@ -5,8 +5,8 @@ import { useSelector } from 'react-redux';
 import QueryPostStats from 'calypso/components/data/query-post-stats';
 import { decodeEntities, stripHTML } from 'calypso/lib/formatting';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import { getPostsForQuery } from 'calypso/state/posts/selectors';
-import { getPostStat } from 'calypso/state/stats/posts/selectors';
+import { getPostsForQuery, isRequestingPostsForQuery } from 'calypso/state/posts/selectors';
+import { getPostStat, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 
 const POST_STATS_CARD_TITLE_LIMIT = 60;
 
@@ -37,11 +37,21 @@ export default function LatestPostCard( {
 		getPostsForQuery( state, siteId, { status: 'publish', number: 1 } )
 	);
 
+	const isRequestingPosts = useSelector( ( state ) =>
+		isRequestingPostsForQuery( state, siteId, { status: 'publish', number: 1 } )
+	);
+
 	const latestPost = posts && posts.length ? posts[ 0 ] : null;
 
 	const lastesPostViewCount = useSelector( ( state ) =>
 		getPostStat( state, siteId, latestPost?.ID, 'views' )
 	);
+
+	const isRequestingLatestPostViewCount = useSelector( ( state ) =>
+		isRequestingPostStats( state, siteId, latestPost?.ID, [ 'views' ] )
+	);
+
+	const isLoadingLatestPost = isRequestingPosts || isRequestingLatestPostViewCount;
 
 	const latestPostData = {
 		date: latestPost?.date,
@@ -50,7 +60,7 @@ export default function LatestPostCard( {
 			stripHTML( textTruncator( latestPost?.title, POST_STATS_CARD_TITLE_LIMIT ) )
 		),
 		likeCount: latestPost?.like_count,
-		viewCount: lastesPostViewCount,
+		viewCount: lastesPostViewCount || 0,
 		commentCount: latestPost?.discussion?.comment_count,
 	};
 
@@ -60,16 +70,17 @@ export default function LatestPostCard( {
 				<QueryPostStats siteId={ siteId } postId={ latestPost.ID } fields={ [ 'views' ] } />
 			) }
 
-			{ latestPost && (
+			{ ( isLoadingLatestPost || latestPost ) && (
 				<PostStatsCard
 					heading={ translate( 'Latest post' ) }
 					likeCount={ latestPostData?.likeCount }
 					post={ latestPostData }
 					viewCount={ latestPostData?.viewCount }
 					commentCount={ latestPostData?.commentCount }
-					titleLink={ `/stats/post/${ latestPost.ID }/${ siteSlug }` }
-					uploadHref={ ! isOdysseyStats ? `/post/${ siteSlug }/${ latestPost.ID }` : undefined }
+					titleLink={ `/stats/post/${ latestPost?.ID }/${ siteSlug }` }
+					uploadHref={ ! isOdysseyStats ? `/post/${ siteSlug }/${ latestPost?.ID }` : undefined }
 					locale={ userLocale }
+					isLoading={ isLoadingLatestPost }
 				/>
 			) }
 		</>

--- a/packages/components/src/post-stats-card/index.tsx
+++ b/packages/components/src/post-stats-card/index.tsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { eye } from '@automattic/components/src/icons';
 import { Icon, commentContent, starEmpty } from '@wordpress/icons';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { Card, ShortenedNumber, Button } from '../';
@@ -19,6 +20,7 @@ type PostStatsCardProps = {
 	titleLink?: string | undefined;
 	uploadHref?: string | undefined;
 	locale?: string | undefined;
+	isLoading?: boolean | undefined;
 };
 
 export default function PostStatsCard( {
@@ -30,6 +32,7 @@ export default function PostStatsCard( {
 	titleLink,
 	uploadHref,
 	locale,
+	isLoading,
 }: PostStatsCardProps ) {
 	const translate = useTranslate();
 	const parsedDate = useMemo(
@@ -49,14 +52,18 @@ export default function PostStatsCard( {
 		}
 	};
 
+	const classes = classNames( 'post-stats-card', {
+		'is-loading': isLoading,
+	} );
+
 	return (
-		<Card className="post-stats-card">
+		<Card className={ classes }>
 			<div className="post-stats-card__heading">{ heading }</div>
 			<div className="post-stats-card__post-info">
 				<TitleTag className="post-stats-card__post-title" href={ titleLink }>
 					{ post?.title }
 				</TitleTag>
-				{ post?.date && (
+				{ ( isLoading || post?.date ) && (
 					<div className="post-stats-card__post-date">
 						{ translate( 'Published %(date)s', {
 							// TODO: Show relative duration instead of published date. Show actual date in a tooltip.
@@ -71,25 +78,35 @@ export default function PostStatsCard( {
 					<Icon className="gridicon" icon={ eye } />
 					<div className="post-stats-card__count-header">{ translate( 'Views' ) }</div>
 					<div className="post-stats-card__count-value">
-						<ShortenedNumber value={ viewCount } />
+						<ShortenedNumber value={ isLoading ? null : viewCount } />
 					</div>
 				</div>
 				<div className="post-stats-card__count post-stats-card__count--like">
 					<Icon className="gridicon" icon={ starEmpty } />
 					<div className="post-stats-card__count-header">{ translate( 'Likes' ) }</div>
 					<div className="post-stats-card__count-value">
-						<ShortenedNumber value={ likeCount } />
+						<ShortenedNumber value={ isLoading ? null : likeCount } />
 					</div>
 				</div>
 				<div className="post-stats-card__count post-stats-card__count--comment">
 					<Icon className="gridicon" icon={ commentContent } />
 					<div className="post-stats-card__count-header">{ translate( 'Comments' ) }</div>
 					<div className="post-stats-card__count-value">
-						<ShortenedNumber value={ commentCount } />
+						<ShortenedNumber value={ isLoading ? null : commentCount } />
 					</div>
 				</div>
 			</div>
-			{ post?.post_thumbnail && (
+			{ ( isLoading || ( ! post?.post_thumbnail && uploadHref ) ) && (
+				<div className="post-stats-card__upload">
+					<Button
+						className="post-stats-card__upload-btn is-compact"
+						onClick={ recordClickOnUploadImageButton }
+					>
+						{ translate( 'Add featured image' ) }
+					</Button>
+				</div>
+			) }
+			{ ! isLoading && post?.post_thumbnail && (
 				<img
 					className="post-stats-card__thumbnail"
 					src={ post?.post_thumbnail }
@@ -99,16 +116,6 @@ export default function PostStatsCard( {
 						textOnly: true,
 					} ) }
 				/>
-			) }
-			{ uploadHref && ! post?.post_thumbnail && (
-				<div className="post-stats-card__upload">
-					<Button
-						className="post-stats-card__upload-btn is-compact"
-						onClick={ recordClickOnUploadImageButton }
-					>
-						{ translate( 'Add featured image' ) }
-					</Button>
-				</div>
 			) }
 		</Card>
 	);

--- a/packages/components/src/post-stats-card/style.scss
+++ b/packages/components/src/post-stats-card/style.scss
@@ -7,6 +7,12 @@
 $card-padding: 24px;
 $border-radius: 5px; // stylelint-disable-line scales/radii
 
+@keyframes shine {
+	to {
+		background-position-x: -200%;
+	}
+}
+
 .post-stats-card {
 	border-color: var(--studio-gray-5);
 	border-radius: $border-radius;
@@ -14,6 +20,8 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 	font-family: $font-sf-pro-text;
 	font-size: $font-body-small;
 	grid-template-columns: minmax(10px, 1.5fr) minmax(0, auto);
+	// 26px is the height of the heading, the remaining should be auto.
+	grid-template-rows: 26px auto auto;
 	grid-template-areas:
 		"heading thumbnail"
 		"post thumbnail"
@@ -28,6 +36,27 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 	&.card::after {
 		display: none;
 	}
+
+	&.is-loading {
+		.post-stats-card__heading,
+		.post-stats-card__post-info,
+		.post-stats-card__upload {
+			position: relative;
+
+			&::after {
+				content: "";
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 100%;
+				height: 100%;
+				background: linear-gradient(94deg, #ececec 8%, #f5f5f5 18%, #ececec 33%);
+				border-radius: 4px;
+				background-size: 200% 100%;
+				animation: 1.5s shine linear infinite;
+			}
+		}
+	}
 }
 
 .post-stats-card__heading {
@@ -37,13 +66,14 @@ $border-radius: 5px; // stylelint-disable-line scales/radii
 	font-weight: 500;
 	grid-area: heading;
 	line-height: 1.3;
-
 }
 
 .post-stats-card__post-title {
 	@include stats-section-header;
 	display: block;
 	margin-bottom: 4px;
+	// For loading placeholder
+	min-height: 80px;
 
 	&:visited {
 		color: var(--studio-gray-100);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74008#issuecomment-1476639537

## Proposed Changes

* Introduce prop `isLoading` support to component `PostStatsCard`.
* Check the loading status for the latest post card and most popular post card.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the change on a local Storybook instance via `yarn workspace @automattic/components run storybook`.
* Take a look at the `Post Stats Card` stories and ensure they look reasonable.
* Spin up the change with the Live Branch.
* Navigate to the Stats `Insights` page.
* Ensure the `Most popular post` and `Latest post` cards are displayed and covered by the loading mask when the data is loading.
* Ensure the `Most popular post` is hidden after loading if there is no data, which is common on new sites.

|Only the Latest post card|Two cards|
|-|-|
|![ezgif-5-62a4289bb3](https://user-images.githubusercontent.com/6869813/227591921-6aa5317b-0fff-4c9a-a547-4e84409478c8.gif)|![ezgif-5-2a6bcdf3fe](https://user-images.githubusercontent.com/6869813/227591972-ca31e0a9-4600-4753-9548-dc2c65f98348.gif)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
