### PR TITLE
Themes: Always show dotorg themes when there is a match on the search

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -91,19 +91,12 @@ export const ThemesList = ( props ) => {
 			) || [],
 		[ props.wpOrgThemes, props.searchTerm ]
 	);
+	const themes = useMemo(
+		() => [ ...props.themes, ...matchingWpOrgThemes ],
+		[ props.themes, matchingWpOrgThemes ]
+	);
 
-	if ( ! props.loading && props.themes.length === 0 ) {
-		if ( matchingWpOrgThemes.length ) {
-			return (
-				<>
-					<WPOrgMatchingThemes matchingThemes={ matchingWpOrgThemes } { ...props } />
-					{ isPatternAssemblerCTAEnabled && (
-						<PatternAssemblerCta onButtonClick={ goToSiteAssemblerFlow } />
-					) }
-				</>
-			);
-		}
-
+	if ( ! props.loading && themes.length === 0 ) {
 		return (
 			<Empty
 				isFSEActive={ props.isFSEActive }
@@ -125,14 +118,14 @@ export const ThemesList = ( props ) => {
 
 	return (
 		<div className="themes-list" ref={ themesListRef }>
-			{ props.themes.map( ( theme, index ) => (
+			{ themes.map( ( theme, index ) => (
 				<ThemeBlock key={ 'theme-block' + index } theme={ theme } index={ index } { ...props } />
 			) ) }
 			{ /* Don't show second upsell nudge when less than 6 rows are present.
 				 Second plan upsell at 7th row is implemented through CSS. */ }
 			{ showSecondUpsellNudge && SecondUpsellNudge }
 			{ /* The Pattern Assembler CTA will display on the 9th row and the behavior is controlled by CSS */ }
-			{ isPatternAssemblerCTAEnabled && props.themes.length > 0 && (
+			{ isPatternAssemblerCTAEnabled && themes.length > 0 && (
 				<PatternAssemblerCta onButtonClick={ goToSiteAssemblerFlow } />
 			) }
 			{ props.loading && <LoadingPlaceholders placeholderCount={ props.placeholderCount } /> }
@@ -378,36 +371,6 @@ function Empty( props ) {
 				upsellCardDisplayed={ props.upsellCardDisplayed }
 			/>
 		</>
-	);
-}
-
-function WPOrgMatchingThemes( props ) {
-	const { matchingThemes } = props;
-
-	const onWPOrgCardClick = useCallback(
-		( theme ) => {
-			props.recordTracksEvent( 'calypso_themeshowcase_search_empty_wp_org_card_click', {
-				site_plan: props.selectedSite?.plan?.product_slug,
-				theme_id: theme?.id,
-			} );
-		},
-		[ props.recordTracksEvent, props.selectedSite ]
-	);
-
-	return (
-		<div className="themes-list">
-			{ matchingThemes.map( ( theme, index ) => (
-				<div
-					onClick={ () => onWPOrgCardClick( theme ) }
-					key={ 'theme-block' + index }
-					role="button"
-					tabIndex={ 0 }
-					onKeyUp={ () => onWPOrgCardClick( theme ) }
-				>
-					<ThemeBlock theme={ theme } index={ index } { ...props } />
-				</div>
-			) ) }
-		</div>
 	);
 }
 


### PR DESCRIPTION
## Proposed Changes

* Concatenate the dotcom search list with the dotorg search list 
* Show the dotcom results concatenated with dotorg results if there is a match on name or slug of the theme with the term searched

## Testing Instructions
* Go to themes search page (`/themes/:site`)
* Search for a term that retrieves dotorg and dotcom results (Ex: `astra`), you should see both on the list
* Search for a term that only retrieves dotorg results as `astral`, you should only the dotorg result on the list
* Search for a term that doesn't retrieves results on dotcom or dotorg as `abc`, and you should see an empty list message.
* Click on any theme and verify if the event `calypso_themeshowcase_theme_click` is logged with the proper themeId

| Dotcom + Dotorg  | Dotorg only | No Results | 
| ------------- | ------------- | ------------- |
|<img width="1220" alt="CleanShot 2023-03-24 at 14 16 50@2x" src="https://user-images.githubusercontent.com/5039531/227596644-5153a55b-0ecd-455f-8a25-d28dbbf75657.png">|<img width="1218" alt="CleanShot 2023-03-24 at 14 16 59@2x" src="https://user-images.githubusercontent.com/5039531/227596665-714c66f3-74da-4af3-8f12-2c2db4ec657d.png">|<img width="1222" alt="CleanShot 2023-03-24 at 14 17 06@2x" src="https://user-images.githubusercontent.com/5039531/227596686-999bb0dd-b852-4ca0-b2c7-e9404e5c4da5.png">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
