### PR TITLE
Staging Sites: display an access error when the user doesn't belong to the staging sites

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -22,6 +22,7 @@ import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/
 import { getSelectedSiteId, getSelectedSite } from 'calypso/state/ui/selectors';
 import { DeleteStagingSite } from './delete-staging-site';
 import { useDeleteStagingSite } from './use-delete-staging-site';
+import { useHasSiteAccess } from './use-has-site-access';
 
 const stagingSiteAddFailureNoticeId = 'staging-site-add-failure';
 
@@ -81,6 +82,7 @@ export const StagingSiteCard = ( {
 	const stagingSite = useMemo( () => {
 		return stagingSites && stagingSites.length ? stagingSites[ 0 ] : [];
 	}, [ stagingSites ] );
+	const hasSiteAccess = useHasSiteAccess( stagingSite.id );
 
 	const showAddStagingSite = ! isLoadingStagingSites && stagingSites?.length === 0;
 	const showManageStagingSite = ! isLoadingStagingSites && stagingSites?.length > 0;
@@ -259,9 +261,29 @@ export const StagingSiteCard = ( {
 		);
 	};
 
+	const getAccessError = () => {
+		return (
+			<Notice status="is-error" showDismiss={ false }>
+				{ translate(
+					'Unable to access the staging site {{a}}%(stagingSiteName)s{{/a}}. Please contact with the site owner.',
+					{
+						args: {
+							stagingSiteName: stagingSite.url,
+						},
+						components: {
+							a: <a href={ stagingSite.url } />,
+						},
+					}
+				) }
+			</Notice>
+		);
+	};
+
 	let stagingSiteCardContent;
 	if ( ! isLoadingStagingSites && loadingError ) {
 		stagingSiteCardContent = getLoadingErrorContent();
+	} else if ( ! wasCreating && ! hasSiteAccess ) {
+		stagingSiteCardContent = getAccessError();
 	} else if ( addingStagingSite || isTrasferInProgress || isReverting ) {
 		stagingSiteCardContent = getTransferringStagingSiteContent();
 	} else if ( showManageStagingSite && isStagingSiteTransferComplete ) {

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -282,7 +282,7 @@ export const StagingSiteCard = ( {
 	let stagingSiteCardContent;
 	if ( ! isLoadingStagingSites && loadingError ) {
 		stagingSiteCardContent = getLoadingErrorContent();
-	} else if ( ! wasCreating && ! hasSiteAccess && transferStatus === null ) {
+	} else if ( ! wasCreating && ! hasSiteAccess && transferStatus !== null ) {
 		stagingSiteCardContent = getAccessError();
 	} else if ( addingStagingSite || isTrasferInProgress || isReverting ) {
 		stagingSiteCardContent = getTransferringStagingSiteContent();

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -264,17 +264,19 @@ export const StagingSiteCard = ( {
 	const getAccessError = () => {
 		return (
 			<Notice status="is-error" showDismiss={ false }>
-				{ translate(
-					'Unable to access the staging site {{a}}%(stagingSiteName)s{{/a}}. Please contact with the site owner.',
-					{
-						args: {
-							stagingSiteName: stagingSite.url,
-						},
-						components: {
-							a: <a href={ stagingSite.url } />,
-						},
-					}
-				) }
+				<div data-testid="staging-sites-access-message">
+					{ translate(
+						'Unable to access the staging site {{a}}%(stagingSiteName)s{{/a}}. Please contact with the site owner.',
+						{
+							args: {
+								stagingSiteName: stagingSite.url,
+							},
+							components: {
+								a: <a href={ stagingSite.url } />,
+							},
+						}
+					) }
+				</div>
 			</Notice>
 		);
 	};

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -282,7 +282,7 @@ export const StagingSiteCard = ( {
 	let stagingSiteCardContent;
 	if ( ! isLoadingStagingSites && loadingError ) {
 		stagingSiteCardContent = getLoadingErrorContent();
-	} else if ( ! wasCreating && ! hasSiteAccess ) {
+	} else if ( ! wasCreating && ! hasSiteAccess && transferStatus === null ) {
 		stagingSiteCardContent = getAccessError();
 	} else if ( addingStagingSite || isTrasferInProgress || isReverting ) {
 		stagingSiteCardContent = getTransferringStagingSiteContent();

--- a/client/my-sites/hosting/staging-site-card/test/index.js
+++ b/client/my-sites/hosting/staging-site-card/test/index.js
@@ -6,6 +6,7 @@ import { useAddStagingSiteMutation } from 'calypso/my-sites/hosting/staging-site
 import { useCheckStagingSiteStatus } from 'calypso/my-sites/hosting/staging-site-card/use-check-staging-site-status';
 import { useStagingSite } from 'calypso/my-sites/hosting/staging-site-card/use-staging-site';
 import { StagingSiteCard } from '..';
+import { useHasSiteAccess } from '../use-has-site-access';
 
 const addStagingSiteBtnName = 'Add staging site';
 const manageStagingBtnName = 'Manage staging site';
@@ -174,5 +175,12 @@ describe( 'StagingSiteCard component', () => {
 		expect( useAddStagingSiteMutation().addStagingSite ).toHaveBeenCalled();
 
 		expect( mockUseDispatch ).toHaveBeenCalled();
+	} );
+
+	it( 'show access site error', () => {
+		useHasSiteAccess.mockReturnValue( false );
+		render( <StagingSiteCard { ...defaultProps } /> );
+		expect( screen.queryByTestId( 'staging-sites-access-message' ) ).toBeVisible();
+		expect( screen.queryByText( addStagingSiteBtnName ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/my-sites/hosting/staging-site-card/test/index.js
+++ b/client/my-sites/hosting/staging-site-card/test/index.js
@@ -66,6 +66,11 @@ jest.mock( 'calypso/my-sites/hosting/staging-site-card/use-staging-site', () => 
 	useStagingSite: jest.fn(),
 } ) );
 
+jest.mock( 'calypso/my-sites/hosting/staging-site-card/use-has-site-access', () => ( {
+	__esModule: true,
+	useHasSiteAccess: jest.fn( () => true ),
+} ) );
+
 const defaultProps = {
 	disabled: false,
 	spaceQuotaExceededForStaging: false,

--- a/client/my-sites/hosting/staging-site-card/use-has-site-access.ts
+++ b/client/my-sites/hosting/staging-site-card/use-has-site-access.ts
@@ -1,0 +1,7 @@
+import { useSelector } from 'react-redux';
+import { getSite } from 'calypso/state/sites/selectors';
+
+export function useHasSiteAccess( stagingId: number | null ): boolean {
+	const userSite = useSelector( ( state ) => stagingId && getSite( state, stagingId ) );
+	return ! stagingId || Boolean( stagingId && userSite );
+}


### PR DESCRIPTION
- closes https://github.com/Automattic/dotcom-forge/issues/2008

## Proposed Changes

* Add a new message error to the Staging sites Card on the Hosting configuration.

## Testing Instructions

* Create a staging site on a business site
* Invite a second user as administrator to the production site. Do not invite the user to the staging site.
* With that second other user, accept the invitation and access to Hosting configuration
* Observe the error. 
* Using the first user, invite the user to the staging site as an administrator.
* Observe the staging site card display the manage site information.
* Test creating a staging site and deleting it with any users.
* Observe the new error is not visible for normal use.

### Screenshot

![Screenshot 2023-03-24 at 17 57 48](https://user-images.githubusercontent.com/779993/227603988-1af857ef-e7b1-47af-a5d7-d7b0f581770f.png)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
