### PR TITLE
Hosting onboarding: don't show free plan alternative

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -21,7 +21,7 @@ export function generateFlows( {
 	const flows = [
 		{
 			name: HOSTING_LP_FLOW,
-			steps: [ 'plans-hosting', 'user', 'domains' ],
+			steps: [ 'plans-hosting', 'user-hosting', 'domains' ],
 			destination: getHomeDestination,
 			description:
 				'Create an account and a blog and give the user the option of adding a domain and plan to the cart.',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -21,7 +21,7 @@ export function generateFlows( {
 	const flows = [
 		{
 			name: HOSTING_LP_FLOW,
-			steps: [ 'plans', 'user', 'domains' ],
+			steps: [ 'plans-hosting', 'user', 'domains' ],
 			destination: getHomeDestination,
 			description:
 				'Create an account and a blog and give the user the option of adding a domain and plan to the cart.',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -57,6 +57,7 @@ const stepNameToModuleName = {
 	'themes-site-selected': 'theme-selection',
 	'template-first-themes': 'theme-selection',
 	user: 'user',
+	'user-hosting': 'user',
 	'user-new': 'user',
 	'oauth2-user': 'user',
 	'oauth2-name': 'user',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -29,6 +29,7 @@ const stepNameToModuleName = {
 	'plans-new': 'plans',
 	'plans-business': 'plans',
 	'plans-ecommerce': 'plans',
+	'plans-hosting': 'plans',
 	'plans-pm': 'plans-pm',
 	'plans-pro': 'plans',
 	'plans-starter': 'plans',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -137,6 +137,24 @@ export function generateSteps( {
 			},
 		},
 
+		'user-hosting': {
+			stepName: 'user-hosting',
+			apiRequestFunction: createAccount,
+			providesToken: true,
+			providesDependencies: [
+				'bearer_token',
+				'username',
+				'marketing_price_group',
+				'plans_reorder_abtest_variation',
+				'redirect',
+			],
+			optionalDependencies: [ 'plans_reorder_abtest_variation', 'redirect' ],
+			props: {
+				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
+				isPasswordless: true,
+			},
+		},
+
 		'user-new': {
 			stepName: 'user-new',
 			apiRequestFunction: createAccount,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -218,6 +218,9 @@ export function generateSteps( {
 			fulfilledStepCallback: isPlanFulfilled,
 			props: {
 				hideFreePlan: true,
+				hidePremiumPlan: true,
+				hidePersonalPlan: true,
+				shouldHideNavButtons: true,
 			},
 		},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -209,6 +209,18 @@ export function generateSteps( {
 			fulfilledStepCallback: isPlanFulfilled,
 		},
 
+		'plans-hosting': {
+			stepName: 'plans',
+			apiRequestFunction: addPlanToCart,
+			dependencies: [ 'siteSlug' ],
+			optionalDependencies: [ 'emailItem', 'themeSlugWithRepo' ],
+			providesDependencies: [ 'cartItem', 'themeSlugWithRepo' ],
+			fulfilledStepCallback: isPlanFulfilled,
+			props: {
+				hideFreePlan: true,
+			},
+		},
+
 		'plans-pm': {
 			stepName: 'plans-pm',
 			apiRequestFunction: addPlanToCart,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -72,7 +72,7 @@ import {
 } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import flows from './config/flows';
-import { getStepComponent } from './config/step-components';
+import { getStepComponent, getStepModuleName } from './config/step-components';
 import steps from './config/steps';
 import { addP2SignupClassName } from './controller';
 import {
@@ -785,9 +785,12 @@ class Signup extends Component {
 			};
 		}
 
+		let stepName = getStepModuleName( this.props.stepName );
+		stepName = stepName === 'user' ? 'user' : stepName;
+
 		return (
 			<div className="signup__step" key={ stepKey }>
-				<div className={ `signup__step is-${ kebabCase( this.props.stepName ) }` }>
+				<div className={ `signup__step is-${ stepName }` }>
 					{ shouldRenderLocaleSuggestions && (
 						<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
 					) }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -226,6 +226,10 @@ export class PlansStep extends Component {
 		}
 
 		if ( useEmailOnboardingSubheader ) {
+			if ( hideFreePlan ) {
+				return translate( 'Add more features to your professional website with a plan. ' );
+			}
+
 			return translate(
 				'Add more features to your professional website with a plan. Or {{link}}start with email and a free site{{/link}}.',
 				{ components: { link: freePlanButton } }
@@ -237,10 +241,18 @@ export class PlansStep extends Component {
 		}
 
 		if ( this.state.isDesktop ) {
+			if ( hideFreePlan ) {
+				return translate( "Pick one that's right for you and unlock features that help you grow." );
+			}
+
 			return translate(
 				"Pick one that's right for you and unlock features that help you grow. Or {{link}}start with a free site{{/link}}.",
 				{ components: { link: freePlanButton } }
 			);
+		}
+
+		if ( hideFreePlan ) {
+			return translate( 'Choose a plan.' );
 		}
 
 		return translate( 'Choose a plan or {{link}}start with a free site{{/link}}.', {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -225,11 +225,7 @@ export class PlansStep extends Component {
 				: translate( 'The WordPress Pro plan comes with a 14-day full money back guarantee' );
 		}
 
-		if ( useEmailOnboardingSubheader ) {
-			if ( hideFreePlan ) {
-				return translate( 'Add more features to your professional website with a plan. ' );
-			}
-
+		if ( useEmailOnboardingSubheader && ! hideFreePlan ) {
 			return translate(
 				'Add more features to your professional website with a plan. Or {{link}}start with email and a free site{{/link}}.',
 				{ components: { link: freePlanButton } }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -1,6 +1,6 @@
 import { is2023PricingGridActivePage, getPlan, PLAN_FREE } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
-import { isHostingLPFlow, isSiteAssemblerFlow, isTailoredSignupFlow } from '@automattic/onboarding';
+import { isSiteAssemblerFlow, isTailoredSignupFlow } from '@automattic/onboarding';
 import { isDesktop, subscribeIsDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
 import i18n, { localize } from 'i18n-calypso';
@@ -155,8 +155,8 @@ export class PlansStep extends Component {
 					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 					shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
 					isReskinned={ isReskinned }
-					hidePremiumPlan={ isHostingLPFlow( this.props.flowName ) }
-					hidePersonalPlan={ isHostingLPFlow( this.props.flowName ) }
+					hidePremiumPlan={ this.props.hidePremiumPlan }
+					hidePersonalPlan={ this.props.hidePersonalPlan }
 				/>
 			</div>
 		);
@@ -312,7 +312,7 @@ export class PlansStep extends Component {
 					stepName={ stepName }
 					positionInFlow={ positionInFlow }
 					headerText={ headerText }
-					shouldHideNavButtons={ isHostingLPFlow( this.props.flowName ) }
+					shouldHideNavButtons={ this.props.shouldHideNavButtons }
 					fallbackHeaderText={ fallbackHeaderText }
 					subHeaderText={ subHeaderText }
 					fallbackSubHeaderText={ fallbackSubHeaderText }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { isHostingLPFlow, isNewsletterFlow } from '@automattic/onboarding';
+import { isNewsletterFlow } from '@automattic/onboarding';
 import { isMobile } from '@automattic/viewport';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -455,7 +455,7 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const { oauth2Client, isReskinned } = this.props;
+		const { oauth2Client, isReskinned, isPasswordless } = this.props;
 		let socialService;
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
@@ -485,7 +485,7 @@ export class UserStep extends Component {
 					submitButtonText={ this.submitButtonText() }
 					suggestedUsername={ this.props.suggestedUsername }
 					handleSocialResponse={ this.handleSocialResponse }
-					isPasswordless={ isMobile() || isHostingLPFlow( this.props.flowName ) }
+					isPasswordless={ isMobile() || isPasswordless }
 					queryArgs={ this.props.initialContext?.query || {} }
 					isSocialSignupEnabled={ isSocialSignupEnabled }
 					socialService={ socialService }

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -39,10 +39,6 @@ export const isFreeFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ FREE_FLOW, FREE_POST_SETUP_FLOW ].includes( flowName ) );
 };
 
-export const isHostingLPFlow = ( flowName: string | null ) => {
-	return Boolean( flowName && HOSTING_LP_FLOW === flowName );
-};
-
 export const isNewsletterOrLinkInBioFlow = ( flowName: string | null ) => {
 	return Boolean(
 		flowName &&


### PR DESCRIPTION
Closes Automattic/dotcom-forge#2113

## Proposed Changes

We're not displaying the Free plan on the grid, so let's remove the free plan link from the subheading too:

![image](https://user-images.githubusercontent.com/26530524/227617902-7ea3c1cf-9ad0-4de0-a3de-18fc91c7fd44.png)


## Testing Instructions

- Check out this branch and go to `/start/hosting`
- Verify that the subheading does not give the option to "start with a free site"

![image](https://user-images.githubusercontent.com/26530524/227618311-55bff903-c5e3-4811-9363-52a242943b52.png)
