### PR TITLE
Billing History: Hide display of taxamo receipt in the billing history

### DIFF
--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -170,13 +170,16 @@ export function ReceiptBody( {
 					</Button>
 				</div>
 			</Card>
-			{ transaction.tax_external_id && transaction.tax_external_id.length > 0 && (
+			{ /* Temporarily disable taxamo receipt link until we can get a go ahead
+
+            { transaction.tax_external_id && transaction.tax_external_id.length > 0 && (
 				<ReceiptExternalLink transaction={ transaction } />
-			) }
+			) } */ }
 		</div>
 	);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function ReceiptExternalLink( { transaction }: { transaction: BillingTransaction } ) {
 	const translate = useTranslate();
 	const externalTaxlink =


### PR DESCRIPTION
Related to [#](https://github.com/Automattic/payments-shilling/issues/1502)

## Proposed Changes

* Hide the display of the taxamo receipt in the billing history of calypso interface until we get a go ahead

## Testing Instructions

* Before patching we should be able to see a card component with the link to an external taxamo receipt for **eligible receipts** like this at https://calypso.localhost:3000/purchases/billing-history/{siteName}/{receiptId}: ![h4AfyN.png](https://user-images.githubusercontent.com/552016/227618618-71e837d6-8f52-451d-9dfc-10d62a51bf23.png)
* Apply the patch
* Now check the same receipt under the billing history and we should **not** see the above-highlighted card component like this: ![c9iIRM.png](https://user-images.githubusercontent.com/552016/227619588-7836def6-b1c4-4135-97cf-fdf4a3c9641b.png)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?