### PR TITLE
Hosting onboarding: allow skipping domain step

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -656,11 +656,9 @@ class DomainsStep extends Component {
 		if ( HOSTING_LP_FLOW === flowName ) {
 			const components = {
 				span: (
-					// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
-					<span
-						role="button"
+					<button
 						className="tailored-flow-subtitle__cta-text"
-						style={ { fontWeight: 500 } }
+						style={ { fontWeight: 500, fontSize: '1em', display: 'inline' } }
 						onClick={ () => this.handleSkip( undefined, true ) }
 					/>
 				),

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,4 +1,4 @@
-import { VIDEOPRESS_FLOW, isWithThemeFlow } from '@automattic/onboarding';
+import { VIDEOPRESS_FLOW, isWithThemeFlow, HOSTING_LP_FLOW } from '@automattic/onboarding';
 import { isTailoredSignupFlow } from '@automattic/onboarding/src';
 import { localize } from 'i18n-calypso';
 import { defer, get, isEmpty } from 'lodash';
@@ -649,6 +649,25 @@ class DomainsStep extends Component {
 
 			return translate(
 				'Set your video site apart with a custom domain. Not sure yet? {{span}}Decide later{{/span}}.',
+				{ components }
+			);
+		}
+
+		if ( HOSTING_LP_FLOW === flowName ) {
+			const components = {
+				span: (
+					// eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/interactive-supports-focus
+					<span
+						role="button"
+						className="tailored-flow-subtitle__cta-text"
+						style={ { fontWeight: 500 } }
+						onClick={ () => this.handleSkip( undefined, true ) }
+					/>
+				),
+			};
+
+			return translate(
+				'Enter some descriptive keywords to get started. Not sure yet? {{span}}Decide later{{/span}}.',
 				{ components }
 			);
 		}


### PR DESCRIPTION
Part of https://github.com/Automattic/dotcom-forge/issues/2122

## Proposed Changes

This PR allows the user to skip the domains step and use a free, generated blog URL when checking out.

The user shouldn't need to pick a domain when signing up through `/start/hosting`.

The idea for that flow is to showcase and highlight hosting features, unrelated to domain selection. I don't think we should remove the domains step because the user _might_ want to choose a domain from the get-go if they're confident about moving to WPCOM.

![image](https://user-images.githubusercontent.com/26530524/227630191-840375b8-1337-4866-b6e0-166527f7762a.png)

## Testing Instructions

- Check out this branch;
- Visit `/start/hosting`;
- Pick a plan;
- Verify that it's possible to skip the domain selection;
- Checkout works correctly and you can buy the business plan.