### PR TITLE
VAT: Use countries list from server to determine VAT eligibility

### DIFF
--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -194,7 +194,7 @@ function CountryCodeInput( {
 				const name = country.code === 'XI' ? translate( 'Northern Ireland' ) : country.name;
 				return country.tax_country_codes.map( ( countryCode ) => (
 					<option key={ countryCode } value={ countryCode }>
-						{ name }
+						{ countryCode } - { name }
 					</option>
 				) );
 			} ) }

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -16,7 +16,11 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
 import useVatDetails from './use-vat-details';
 import type { UpdateError, FetchError } from './use-vat-details';
-import type { VatDetails } from '@automattic/wpcom-checkout';
+import type {
+	CountryListItem,
+	CountryListItemWithVat,
+	VatDetails,
+} from '@automattic/wpcom-checkout';
 
 import './style.scss';
 
@@ -174,6 +178,9 @@ function CountryCodeInput( {
 		value = 'GB';
 	}
 
+	const isVatSupported = ( country: CountryListItem ): country is CountryListItemWithVat =>
+		country.vat_supported;
+	const vatCountries = countries.filter( isVatSupported );
 	return (
 		<FormSelect
 			name={ name }
@@ -183,16 +190,14 @@ function CountryCodeInput( {
 			className="vat-info__country-select"
 		>
 			<option value="">--</option>
-			{ countries
-				.filter( ( country ) => country.vat_supported )
-				.map( ( country ) => {
-					const name = country.code === 'XI' ? translate( 'Northern Ireland' ) : country.name;
-					return country.tax_country_codes.map( ( countryCode ) => (
-						<option key={ countryCode } value={ countryCode }>
-							{ name }
-						</option>
-					) );
-				} ) }
+			{ vatCountries.map( ( country ) => {
+				const name = country.code === 'XI' ? translate( 'Northern Ireland' ) : country.name;
+				return country.tax_country_codes.map( ( countryCode ) => (
+					<option key={ countryCode } value={ countryCode }>
+						{ name }
+					</option>
+				) );
+			} ) }
 		</FormSelect>
 	);
 }

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -11,16 +11,14 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
-import useCountryList from 'calypso/my-sites/checkout/composite-checkout/hooks/use-country-list';
+import useCountryList, {
+	isVatSupported,
+} from 'calypso/my-sites/checkout/composite-checkout/hooks/use-country-list';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
 import useVatDetails from './use-vat-details';
 import type { UpdateError, FetchError } from './use-vat-details';
-import type {
-	CountryListItem,
-	CountryListItemWithVat,
-	VatDetails,
-} from '@automattic/wpcom-checkout';
+import type { CountryListItem, VatDetails } from '@automattic/wpcom-checkout';
 
 import './style.scss';
 
@@ -157,9 +155,6 @@ function VatForm() {
 		</>
 	);
 }
-
-const isVatSupported = ( country: CountryListItem ): country is CountryListItemWithVat =>
-	country.vat_supported;
 
 function getUniqueCountries< C extends CountryListItem >( countries: C[] ): C[] {
 	const unique: C[] = [];

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -11,6 +11,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import useCountryList from 'calypso/my-sites/checkout/composite-checkout/hooks/use-country-list';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
 import useVatDetails from './use-vat-details';
@@ -164,40 +165,7 @@ function CountryCodeInput( {
 	value: string;
 	onChange: ( event: React.ChangeEvent< HTMLSelectElement > ) => void;
 } ) {
-	const countries = [
-		'AT',
-		'AU',
-		'BE',
-		'BG',
-		'CH',
-		'CY',
-		'CZ',
-		'DE',
-		'DK',
-		'EE',
-		'EL',
-		'ES',
-		'FI',
-		'FR',
-		'GB',
-		'HR',
-		'HU',
-		'IE',
-		'IT',
-		'JP',
-		'LT',
-		'LU',
-		'LV',
-		'MT',
-		'NL',
-		'PL',
-		'PT',
-		'RO',
-		'SE',
-		'SI',
-		'SK',
-		'XI',
-	];
+	const countries = useCountryList();
 
 	// Some historical country codes were set to 'UK', but that is not a valid
 	// country code. It should read 'GB'.
@@ -214,13 +182,15 @@ function CountryCodeInput( {
 			className="vat-info__country-select"
 		>
 			<option value="">--</option>
-			{ countries.map( ( countryCode ) => {
-				return (
-					<option key={ countryCode } value={ countryCode }>
-						{ countryCode }
-					</option>
-				);
-			} ) }
+			{ countries
+				.filter( ( country ) => country.vat_supported )
+				.map( ( country ) => {
+					return country.tax_country_codes.map( ( countryCode ) => (
+						<option key={ countryCode } value={ countryCode }>
+							{ countryCode }
+						</option>
+					) );
+				} ) }
 		</FormSelect>
 	);
 }

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -166,6 +166,7 @@ function CountryCodeInput( {
 	onChange: ( event: React.ChangeEvent< HTMLSelectElement > ) => void;
 } ) {
 	const countries = useCountryList();
+	const translate = useTranslate();
 
 	// Some historical country codes were set to 'UK', but that is not a valid
 	// country code. It should read 'GB'.
@@ -185,9 +186,10 @@ function CountryCodeInput( {
 			{ countries
 				.filter( ( country ) => country.vat_supported )
 				.map( ( country ) => {
+					const name = country.code === 'XI' ? translate( 'Northern Ireland' ) : country.name;
 					return country.tax_country_codes.map( ( countryCode ) => (
 						<option key={ countryCode } value={ countryCode }>
-							{ countryCode }
+							{ name }
 						</option>
 					) );
 				} ) }

--- a/client/my-sites/checkout/composite-checkout/components/country-select-menu.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/country-select-menu.tsx
@@ -38,8 +38,13 @@ export default function CountrySelectMenu( {
 			<FormCountrySelect
 				id={ countrySelectorId }
 				countriesList={ [
-					{ code: '', name: translate( 'Select Country' ), has_postal_codes: false },
-					{ code: '', name: '', has_postal_codes: false },
+					{
+						code: '',
+						name: translate( 'Select Country' ),
+						has_postal_codes: false,
+						vat_supported: false,
+					},
+					{ code: '', name: '', has_postal_codes: false, vat_supported: false },
 					...countriesList,
 				] }
 				onChange={ onChange }

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -1,4 +1,4 @@
-import { CountryListItem, CountryListItemWithVat, Field } from '@automattic/wpcom-checkout';
+import { Field } from '@automattic/wpcom-checkout';
 import { CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -8,13 +8,10 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import useCountryList from '../../hooks/use-country-list';
+import useCountryList, { isVatSupported } from '../../hooks/use-country-list';
 import { CHECKOUT_STORE } from '../../lib/wpcom-store';
 
 import './style.css';
-
-const isVatSupported = ( country: CountryListItem ): country is CountryListItemWithVat =>
-	country.vat_supported;
 
 export function VatForm( {
 	section,

--- a/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/vat-form/index.tsx
@@ -1,4 +1,4 @@
-import { Field } from '@automattic/wpcom-checkout';
+import { CountryListItem, CountryListItemWithVat, Field } from '@automattic/wpcom-checkout';
 import { CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -12,6 +12,9 @@ import useCountryList from '../../hooks/use-country-list';
 import { CHECKOUT_STORE } from '../../lib/wpcom-store';
 
 import './style.css';
+
+const isVatSupported = ( country: CountryListItem ): country is CountryListItemWithVat =>
+	country.vat_supported;
 
 export function VatForm( {
 	section,
@@ -37,7 +40,9 @@ export function VatForm( {
 
 	const isVatSupportedFor = useCallback(
 		( code: string ) =>
-			countries.find( ( country ) => country.code === code && country.vat_supported ),
+			countries
+				.filter( isVatSupported )
+				.some( ( country ) => country.code === code || country.tax_country_codes.includes( code ) ),
 		[ countries ]
 	);
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-country-list.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-country-list.ts
@@ -3,12 +3,15 @@ import { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { fetchPaymentCountries } from 'calypso/state/countries/actions';
 import getCountries from 'calypso/state/selectors/get-countries';
-import type { CountryListItem } from '@automattic/wpcom-checkout';
+import type { CountryListItem, CountryListItemWithVat } from '@automattic/wpcom-checkout';
 import type { IAppState } from 'calypso/state/types';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-country-list' );
 
 const emptyList: CountryListItem[] = [];
+
+export const isVatSupported = ( country: CountryListItem ): country is CountryListItemWithVat =>
+	country.vat_supported;
 
 export default function useCountryList(
 	overrideCountryList?: CountryListItem[]

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-autocomplete.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-autocomplete.tsx
@@ -21,6 +21,7 @@ import {
 	getBasicCart,
 	mockMatchMediaOnWindow,
 	mockGetVatInfoEndpoint,
+	countryList,
 } from './util';
 import { MockCheckout } from './util/mock-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
@@ -63,6 +64,9 @@ describe( 'Checkout contact step', () => {
 		dispatch( CHECKOUT_STORE ).reset();
 		nock.cleanAll();
 		nock( 'https://public-api.wordpress.com' ).persist().post( '/rest/v1.1/logstash' ).reply( 200 );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/transactions/supported-countries' )
+			.reply( 200, countryList );
 		mockGetVatInfoEndpoint( {} );
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.tsx
@@ -20,6 +20,7 @@ import {
 	getBasicCart,
 	mockMatchMediaOnWindow,
 	mockGetVatInfoEndpoint,
+	countryList,
 } from './util';
 import { MockCheckout } from './util/mock-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
@@ -55,6 +56,9 @@ describe( 'Checkout contact step', () => {
 		dispatch( CHECKOUT_STORE ).reset();
 		nock.cleanAll();
 		nock( 'https://public-api.wordpress.com' ).persist().post( '/rest/v1.1/logstash' ).reply( 200 );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/transactions/supported-countries' )
+			.reply( 200, countryList );
 		mockGetVatInfoEndpoint( {} );
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
@@ -23,6 +23,7 @@ import {
 	mockMatchMediaOnWindow,
 	mockGetVatInfoEndpoint,
 	mockSetVatInfoEndpoint,
+	countryList,
 } from './util';
 import { MockCheckout } from './util/mock-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
@@ -70,6 +71,9 @@ describe( 'Checkout contact step extra tax fields', () => {
 		dispatch( CHECKOUT_STORE ).reset();
 		nock.cleanAll();
 		nock( 'https://public-api.wordpress.com' ).persist().post( '/rest/v1.1/logstash' ).reply( 200 );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/transactions/supported-countries' )
+			.reply( 200, countryList );
 		mockGetVatInfoEndpoint( {} );
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -91,6 +91,9 @@ describe( 'CheckoutMain', () => {
 			useCartKey.mockImplementation( () => ( useUndefinedCartKey ? undefined : mainCartKey ) );
 			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 			nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {} );
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/rest/v1.1/me/transactions/supported-countries' )
+				.reply( 200, countryList );
 			mockMatchMediaOnWindow();
 			return (
 				<ReduxProvider store={ store }>

--- a/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
@@ -36,6 +36,13 @@ jest.mock( 'calypso/lib/analytics/utils/refresh-country-code-cookie-gdpr' );
 jest.mock( 'calypso/state/products-list/selectors/is-marketplace-product' );
 jest.mock( 'calypso/lib/navigate' );
 
+// These tests seem to be particularly slow (it might be because of using
+// it.each; it's not clear but the timeout might apply to the whole loop
+// rather that each iteration?), so we need to increase the timeout for their
+// operation. The standard timeout (at the time of writing) is 5 seconds so
+// we are increasing this to 12 seconds.
+jest.setTimeout( 12000 );
+
 describe( 'Checkout contact step VAT form', () => {
 	const mainCartKey: CartKey = 'foo.com' as CartKey;
 	const initialCart = getBasicCart();

--- a/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
@@ -22,6 +22,7 @@ import {
 	mockMatchMediaOnWindow,
 	mockGetVatInfoEndpoint,
 	mockSetVatInfoEndpoint,
+	countryList,
 } from './util';
 import { MockCheckout } from './util/mock-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
@@ -62,6 +63,9 @@ describe( 'Checkout contact step VAT form', () => {
 		dispatch( CHECKOUT_STORE ).reset();
 		nock.cleanAll();
 		nock( 'https://public-api.wordpress.com' ).persist().post( '/rest/v1.1/logstash' ).reply( 200 );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/transactions/supported-countries' )
+			.reply( 200, countryList );
 		mockGetVatInfoEndpoint( {} );
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/country-specific-payment-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/country-specific-payment-fields.tsx
@@ -16,6 +16,7 @@ const defaultProps: CountrySpecificPaymentFieldsProps = {
 			code: 'BR',
 			name: 'Brazil',
 			has_postal_codes: true,
+			vat_supported: false,
 		},
 	],
 	getErrorMessages: jest.fn().mockReturnValue( [] ),

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -64,21 +64,26 @@ export const countryList: CountryListItem[] = [
 		code: 'US',
 		name: 'United States',
 		has_postal_codes: true,
+		vat_supported: false,
 	},
 	{
 		code: 'CW',
 		name: 'Curacao',
 		has_postal_codes: false,
+		vat_supported: false,
 	},
 	{
 		code: 'AU',
 		name: 'Australia',
 		has_postal_codes: true,
+		vat_supported: false,
 	},
 	{
 		code: 'ES',
 		name: 'Spain',
 		has_postal_codes: true,
+		vat_supported: true,
+		tax_country_codes: [ 'ES' ],
 	},
 	{
 		code: 'CA',
@@ -86,30 +91,38 @@ export const countryList: CountryListItem[] = [
 		has_postal_codes: true,
 		tax_needs_city: true,
 		tax_needs_subdivision: true,
+		vat_supported: true,
+		tax_country_codes: [ 'CA' ],
 	},
 	{
 		code: 'CH',
 		name: 'Switzerland',
 		has_postal_codes: true,
 		tax_needs_address: true,
+		vat_supported: true,
+		tax_country_codes: [ 'CH' ],
 	},
 	{
 		code: 'GB',
 		name: 'United Kingdom',
 		has_postal_codes: true,
 		tax_needs_organization: true, // added for testing, not present in API data
+		vat_supported: true,
+		tax_country_codes: [ 'GB', 'XI' ],
 	},
 	{
 		code: 'IN',
 		name: 'India',
 		has_postal_codes: true,
 		tax_needs_subdivision: true,
+		vat_supported: false,
 	},
 	{
 		code: 'JP',
 		name: 'Japan',
 		has_postal_codes: true,
 		tax_needs_organization: true,
+		vat_supported: false,
 	},
 	{
 		code: 'NO',
@@ -117,6 +130,7 @@ export const countryList: CountryListItem[] = [
 		has_postal_codes: true,
 		tax_needs_city: true,
 		tax_needs_organization: true,
+		vat_supported: false,
 	},
 ];
 

--- a/packages/wpcom-checkout/src/get-country-postal-code-support.ts
+++ b/packages/wpcom-checkout/src/get-country-postal-code-support.ts
@@ -22,7 +22,9 @@ export function getCountryPostalCodeSupport(
 		return false;
 	}
 	const countryListItem = countries.find(
-		( country ) => country.code === countryCode.toUpperCase()
+		( country ) =>
+			country.code === countryCode.toUpperCase() ||
+			( country.vat_supported && country.tax_country_codes.includes( countryCode.toUpperCase() ) )
 	);
 	if ( ! countryListItem ) {
 		// eslint-disable-next-line no-console

--- a/packages/wpcom-checkout/src/get-country-tax-requirements.ts
+++ b/packages/wpcom-checkout/src/get-country-tax-requirements.ts
@@ -29,7 +29,9 @@ export function getCountryTaxRequirements(
 		return {};
 	}
 	const countryListItem = countries.find(
-		( country ) => country.code === countryCode.toUpperCase()
+		( country ) =>
+			country.code === countryCode.toUpperCase() ||
+			( country.vat_supported && country.tax_country_codes.includes( countryCode.toUpperCase() ) )
 	);
 	if ( ! countryListItem ) {
 		// eslint-disable-next-line no-console

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -496,7 +496,7 @@ export type RawDomainContactValidationResponse =
 			messages_simple: string[];
 	  };
 
-export interface CountryListItem {
+export interface CountryListItemBase {
 	code: string;
 	name: string;
 	has_postal_codes?: boolean;
@@ -504,8 +504,14 @@ export interface CountryListItem {
 	tax_needs_subdivision?: boolean;
 	tax_needs_organization?: boolean;
 	tax_needs_address?: boolean;
-	vat_supported: boolean;
+}
+export interface CountryListItemWithoutVat extends CountryListItemBase {
+	vat_supported: false;
+}
+export interface CountryListItemWithVat extends CountryListItemBase {
+	vat_supported: true;
 	tax_country_codes: string[];
 }
+export type CountryListItem = CountryListItemWithVat | CountryListItemWithoutVat;
 
 export type SitelessCheckoutType = 'jetpack' | 'akismet' | undefined;

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -504,6 +504,8 @@ export interface CountryListItem {
 	tax_needs_subdivision?: boolean;
 	tax_needs_organization?: boolean;
 	tax_needs_address?: boolean;
+	vat_supported: boolean;
+	tax_country_codes: string[];
 }
 
 export type SitelessCheckoutType = 'jetpack' | 'akismet' | undefined;


### PR DESCRIPTION
## Proposed Changes

This PR replaces the hard-coded lists of countries supporting VAT with a list from the `/me/transactions/supported-countries` endpoint.

Requires D106018-code

## Testing Instructions

This affects two forms which must be tested:

#### VatInfo

<img width="687" alt="Screenshot 2023-03-24 at 5 51 22 PM" src="https://user-images.githubusercontent.com/2036909/227647955-c29b9182-2967-49f2-87c1-d5c051473ae0.png">

- Visit `/me/purchases/vat-details`.
- Verify that the country dropdown menu contains a list of countries; make sure that it contains "Northern Ireland" (XI) and "Greece" (EL).

#### VatForm

<img width="577" alt="Screenshot 2023-03-25 at 12 16 04 AM" src="https://user-images.githubusercontent.com/2036909/227695533-0562cc6c-2160-40e4-963e-b231821d45d1.png">

- Add a product to your cart and visit checkout.
- In the billing info (aka: "contact details") step, select a country for which we support VAT collection (eg: United Kingdom).
- Verify that the "Add VAT details" (aka: "Add Business Tax ID details") checkbox appears.