### PR TITLE
Email Subscriptions: Fix memo dependencies on useSubscriberEmailAddress hook

### DIFF
--- a/packages/data-stores/src/reader/hooks/index.ts
+++ b/packages/data-stores/src/reader/hooks/index.ts
@@ -24,9 +24,9 @@ export const useIsQueryEnabled = () => {
 
 // Get subscriber's email address based on the subkey cookie
 export const useSubscriberEmailAddress = () => {
-	return useMemo( () => {
-		const subkey = getSubkey();
+	const subkey = getSubkey();
 
+	return useMemo( () => {
 		if ( ! subkey ) {
 			return null;
 		}
@@ -40,5 +40,5 @@ export const useSubscriberEmailAddress = () => {
 
 		const emailAddress = decodedSubkeyValue.slice( firstPeriodIndex + 1 );
 		return emailAddress;
-	}, [] );
+	}, [ subkey ] );
 };


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/74822

## Proposed Changes

This PR makes the `subkey` a dependency to the useMemo on useSubscriberEmailAddress hook. It can cause edge-case  issues when multiple external users access the manager on the same browser session.

## Testing Instructions

* Run this PR on your local env
* Go to http://calypso.localhost:3000/subscriptions/sites as an external user
* On your browser console, make some change on the email part of the subkey cookie
```
document.cookie='subkey=<key>.<changed_email>'
```
* Click on Settings tab, verify if the email is updated on the subtitle even without page refresh

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
