### PR TITLE
Allow renewal for akismet purchases

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -495,7 +495,7 @@ export function jetpackProductItem( slug: string ): MinimalRequestCartProduct {
 }
 
 /**
- * Creates a new shopping cart item for a akismet product.
+ * Creates a new shopping cart item for an Akismet product.
  */
 export function akismetProductItem( slug: string ): MinimalRequestCartProduct {
 	return {

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -41,6 +41,7 @@ import {
 	isWpComFreePlan,
 	TITAN_MAIL_MONTHLY_SLUG,
 	TITAN_MAIL_YEARLY_SLUG,
+	isAkismetProduct,
 } from '@automattic/calypso-products';
 import { isWpComProductRenewal as isRenewal } from '@automattic/wpcom-checkout';
 import { getTld } from 'calypso/lib/domains';
@@ -494,6 +495,15 @@ export function jetpackProductItem( slug: string ): MinimalRequestCartProduct {
 }
 
 /**
+ * Creates a new shopping cart item for a akismet product.
+ */
+export function akismetProductItem( slug: string ): MinimalRequestCartProduct {
+	return {
+		product_slug: slug,
+	};
+}
+
+/**
  * Creates a new shopping cart item for a renewable product.
  */
 export function renewableProductItem( slug: string ): MinimalRequestCartProduct {
@@ -536,6 +546,10 @@ function createRenewalCartItemFromProduct(
 
 	if ( isJetpackProduct( product ) ) {
 		return jetpackProductItem( slug );
+	}
+
+	if ( isAkismetProduct( product ) ) {
+		return akismetProductItem( slug );
 	}
 
 	if ( isUnlimitedThemes( product ) ) {

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -19,6 +19,7 @@ import {
 	TYPE_PRO,
 	isDIFMProduct,
 	isJetpackSearchFree,
+	isAkismetProduct,
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import { encodeProductForUrl } from '@automattic/wpcom-checkout';
@@ -292,10 +293,11 @@ export function handleRenewNowClick(
 				throw new Error( 'Could not find product slug for renewal.' );
 			}
 			const { productSlugs, purchaseIds } = getProductSlugsAndPurchaseIds( [ renewItem ] );
+			const serviceSlug = isAkismetProduct( { product_slug: productSlugs[ 0 ] } ) ? 'akismet/' : '';
 
-			let renewalUrl = `/checkout/${ productSlugs[ 0 ] }/renew/${ purchaseIds[ 0 ] }/${
-				siteSlug || ''
-			}`;
+			let renewalUrl = `/checkout/${ serviceSlug }${ productSlugs[ 0 ] }/renew/${
+				purchaseIds[ 0 ]
+			}/${ siteSlug || '' }`;
 			if ( options.redirectTo ) {
 				renewalUrl += '?redirect_to=' + encodeURIComponent( options.redirectTo );
 			}

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -266,6 +266,26 @@ describe( 'index', () => {
 		} );
 	} );
 
+	describe( '#handleRenewNowClickSiteless', () => {
+		const purchase = {
+			id: 1,
+			currencyCode: 'USD',
+			expiryDate: '2020-05-20T00:00:00+00:00',
+			productSlug: 'ak_plus_yearly_1',
+			productName: 'Akismet Plus',
+			amount: 100,
+		};
+
+		// No site
+		const siteSlug = '';
+
+		test( 'should redirect to the purchase management page with service slug URL', () => {
+			const dispatch = jest.fn();
+			handleRenewNowClick( purchase, siteSlug )( dispatch );
+			expect( page ).toHaveBeenCalledWith( '/checkout/akismet/ak_plus_yearly_1/renew/1/' );
+		} );
+	} );
+
 	describe( '#handleRenewMultiplePurchasesClick', () => {
 		const purchases = [
 			{

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -205,8 +205,10 @@ class ManagePurchase extends Component {
 	handleRenew = () => {
 		const { purchase, siteSlug, redirectTo } = this.props;
 		const options = redirectTo ? { redirectTo } : undefined;
+		const isSitelessRenewal = isAkismetTemporarySitePurchase( purchase );
 
-		this.props.handleRenewNowClick( purchase, siteSlug, options );
+		// If this renewal is for a siteless purchase, we'll drop the site slug
+		this.props.handleRenewNowClick( purchase, ! isSitelessRenewal ? siteSlug : '', options );
 	};
 
 	handleRenewMonthly = () => {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -275,7 +275,7 @@ function useAddRenewalItems( {
 	isGiftPurchase,
 }: {
 	originalPurchaseId: string | number | null | undefined;
-	sitelessCheckoutType: string | null | undefined;
+	sitelessCheckoutType: SitelessCheckoutType;
 	productAlias: string | null | undefined;
 	dispatch: ( action: PreparedProductsAction ) => void;
 	addHandler: AddHandler;
@@ -495,7 +495,7 @@ function createRenewalItemToAddToCart( {
 }: {
 	productAlias: string;
 	purchaseId: string | number | undefined | null;
-	sitelessCheckoutType: string | null | undefined;
+	sitelessCheckoutType: SitelessCheckoutType;
 	isGiftPurchase?: boolean;
 } ): RequestCartProduct | null {
 	const { slug, meta, quantity } = getProductPartsFromAlias( productAlias );

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -66,6 +66,9 @@ export function createTransactionEndpointCartFromResponseCart( {
 	) {
 		const isUserLess = responseCart.cart_key === 'no-user';
 		const isSiteLess = responseCart.blog_id === 0;
+		const isSiteLessRenewal = responseCart.products.some( ( product ) => {
+			return product.extra?.purchaseType === 'renewal' && product.extra.isAkismetSitelessCheckout;
+		} );
 
 		// At this point, cart_key will be 'no-user' | blog_id | 'no-site', in that order.
 		const cartKey = isUserLess ? responseCart.cart_key : responseCart.blog_id || 'no-site';
@@ -77,7 +80,8 @@ export function createTransactionEndpointCartFromResponseCart( {
 		return {
 			blog_id: responseCart.blog_id.toString(),
 			cart_key: cartKey as CartKey,
-			create_new_blog: isSiteLess,
+			// We do NOT need a new blog for a site-less renewal (Right now, this just Akismet renewals)
+			create_new_blog: isSiteLess && ! isSiteLessRenewal,
 			coupon: responseCart.coupon || '',
 			temporary: false,
 			products: responseCart.products.map( ( item ) =>

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -55,7 +55,7 @@ export function checkoutAkismetSiteless( context, next ) {
 function sitelessCheckout( context, next, extraProps ) {
 	const state = context.store.getState();
 	const isLoggedOut = ! isUserLoggedIn( state );
-	const { productSlug: product } = context.params;
+	const { productSlug: product, purchaseId } = context.params;
 	const isUserComingFromLoginForm = context.query?.flow === 'coming_from_login';
 
 	setSectionMiddleware( { name: 'checkout' } )( context );
@@ -73,6 +73,7 @@ function sitelessCheckout( context, next, extraProps ) {
 			<CheckoutSitelessDocumentTitle />
 
 			<CheckoutMainWrapper
+				purchaseId={ purchaseId }
 				productAliasFromUrl={ product }
 				productSourceFromUrl={ context.query.source }
 				couponCode={ couponCode }

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -212,6 +212,10 @@ export default function getThankYouPageUrl( {
 	const receiptIdOrPlaceholder = getReceiptIdOrPlaceholder( receiptId, purchaseId );
 	debug( 'receiptIdOrPlaceholder is', receiptIdOrPlaceholder );
 
+	// Check to see if the cart is a renewal and get the first renewal item
+	const firstRenewalInCart =
+		cart && hasRenewalItem( cart ) ? getRenewalItems( cart )[ 0 ] : undefined;
+
 	// jetpack userless & siteless checkout uses a special thank you page
 	if ( sitelessCheckoutType === 'jetpack' ) {
 		// extract a product from the cart, in userless/siteless checkout there should only be one
@@ -239,6 +243,10 @@ export default function getThankYouPageUrl( {
 	if ( sitelessCheckoutType === 'akismet' ) {
 		// extract a product from the cart, in siteless checkout there should only be one
 		const productSlug = cart?.products[ 0 ]?.product_slug ?? 'no_product';
+		// This is a renewal, return to the individual product management page for this subscription
+		if ( firstRenewalInCart ) {
+			return managePurchase( 'siteless.akismet.com', firstRenewalInCart.subscription_id );
+		}
 
 		debug( 'redirecting to siteless Akismet thank you' );
 		return `/checkout/akismet/thank-you/${ productSlug }`;
@@ -265,8 +273,6 @@ export default function getThankYouPageUrl( {
 
 	// Manual renewals usually have a `redirectTo` but if they do not, return to
 	// the manage purchases page.
-	const firstRenewalInCart =
-		cart && hasRenewalItem( cart ) ? getRenewalItems( cart )[ 0 ] : undefined;
 	if ( siteSlug && firstRenewalInCart?.subscription_id ) {
 		const managePurchaseUrl = managePurchase( siteSlug, firstRenewalInCart.subscription_id );
 		debug(

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1508,6 +1508,27 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/akismet/thank-you/ak_plus_yearly_2' );
 	} );
 
+	it( 'redirects to the purchase management page when is akismet siteless and the purchaseType is a renewal', () => {
+		const cart = {
+			...getEmptyResponseCart(),
+			products: [
+				{
+					...getEmptyResponseCartProduct(),
+					product_slug: 'ak_plus_yearly_2',
+					subscription_id: '123abc',
+					extra: { purchaseType: 'renewal' },
+				},
+			],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+			sitelessCheckoutType: 'akismet',
+		} );
+		expect( url ).toBe( '/me/purchases/siteless.akismet.com/123abc' );
+	} );
+
 	it( 'redirects to the jetpack checkout thank you with `no_product` when jetpack checkout arg is set and the cart is empty', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -108,6 +108,16 @@ export default function () {
 		);
 
 		page(
+			`/checkout/akismet/:productSlug/renew/:purchaseId`,
+			setLocaleMiddleware(),
+			redirectLoggedOut,
+			noSite,
+			checkoutAkismetSiteless,
+			makeLayout,
+			clientRender
+		);
+
+		page(
 			'/checkout/akismet/thank-you/:productSlug',
 			setLocaleMiddleware(),
 			noSite,


### PR DESCRIPTION
## Proposed Changes

* This PR allows for renewal of Akismet products

## Testing Instructions

* Apply this patch to your local testing Calypso environment
* You will need a test Akismet purchase for this test. If you do not already have one, you can get one by going to http://calypso.localhost:3000/checkout/akismet/ak_plus_yearly_1 and completing the checkout. (Do this in test mode)
* You will also need to test along side with D106051-code if it has not already been deployed
* After obtaining a test Akismet purchase, select it from the purchase list at `/me/purchases`
* From the purchase management page, click on the "Renew Now" navigation item that shows below the purchase details

![Screenshot 2023-03-27 at 5 59 32 PM](https://user-images.githubusercontent.com/18016357/228077005-8d616aa0-2477-4bc8-afa2-2caad6a26654.png)

* This should take you to the checkout page with a renewal purchase in the cart (note that the purchase should be labeled "Renewal")

![Screenshot 2023-03-27 at 5 59 47 PM](https://user-images.githubusercontent.com/18016357/228077029-45ee5a44-1109-472f-8dc3-a95596b499bc.png)

* Complete the renewal purchase and confirm that there are no errors
* After completing the renewal, you should be redirected back to the purchase management page with a message that indicates your purchase was successful

![Screenshot 2023-03-27 at 6 01 04 PM](https://user-images.githubusercontent.com/18016357/228077049-db60c08a-a8af-478a-9d97-0013e307d463.png)

* Note that the expiration date of your purchase has now been extended for another term

## Pre-merge Checklist
- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?