### PR TITLE
Make the newsletter badge more subtle

### DIFF
--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -126,7 +126,7 @@ class MembershipsProductsSection extends Component {
 							<div className="memberships__products-product-title">{ product.title }</div>
 							{ product?.subscribe_as_site_subscriber && (
 								<div className="memberships__products-product-badge">
-									<Badge type="info-blue">{ this.props.translate( 'Newsletter' ) }</Badge>
+									<Badge type="info">{ this.props.translate( 'Newsletter' ) }</Badge>
 								</div>
 							) }
 						</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

Make the newsletter badge more subtle by making it be grey instead of blue.

<img width="1107" alt="Screenshot 2023-03-24 at 6 13 16 PM" src="https://user-images.githubusercontent.com/7076981/227659891-71ca7c06-0f36-4e51-9762-14536b50023c.png">


## Testing Instructions
1. Sandbox `romarioraffearn.wordpress.com` or you test site
2. Go to `http://calypso.localhost:3000/earn/payments-plans/{site_url}`
3. Verify the newsletter badge is now grey by creating a new newsletter plan or viewing an existing newsletter plan

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
