### PR TITLE
shopping-cart: Handle errors from calling reloadFromServer

### DIFF
--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
@@ -72,7 +72,13 @@ export function MasterbarCartButton( {
 		setIsActive( ( active ) => {
 			if ( ! active ) {
 				// This is to prevent an error in updating the component in the same event loop
-				setTimeout( reloadFromServer, 0 ); // Refresh the cart whenever the popup is made visible.
+				setTimeout(
+					() =>
+						reloadFromServer().catch( () => {
+							// No need to do anything here. CartMessages will report this error to the user.
+						} ),
+					0
+				); // Refresh the cart whenever the popup is made visible.
 				reduxDispatch( recordTracksEvent( 'calypso_masterbar_cart_open' ) );
 			}
 			return ! active;

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -191,7 +191,9 @@ function useRedirectOnTransactionSuccess( {
 		// the order completes and the server empties the cart, the front-end will
 		// get an updated cached cart and future pages will show the cart correctly
 		// as empty.
-		reloadCart();
+		reloadCart().catch( () => {
+			// No need to do anything here. CartMessages will report this error to the user.
+		} );
 
 		// Wait for the receipt to load before redirecting so we can display the
 		// correct notification and possibly run analytics.

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -217,7 +217,9 @@ export default function useCreatePaymentCompleteCallback( {
 				return;
 			}
 
-			reloadCart();
+			reloadCart().catch( () => {
+				// No need to do anything here. CartMessages will report this error to the user.
+			} );
 			redirectThroughPending( url, {
 				siteSlug,
 				orderId: transactionResult.order_id,

--- a/packages/shopping-cart/src/use-refetch-on-focus.ts
+++ b/packages/shopping-cart/src/use-refetch-on-focus.ts
@@ -72,7 +72,10 @@ export default function useRefetchOnFocus( cartKey: CartKey | undefined ): void 
 			}
 
 			debug( 'window was refocused; refetching' );
-			manager.actions.reloadFromServer();
+			manager.actions.reloadFromServer().catch( () => {
+				// No need to do anything here. Errors will be surfaced by the cart
+				// accessors manually.
+			} );
 		}
 
 		debug( 'adding focus listeners' );


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/58834 we began rejecting the Promise returned by code using the `@automattic/shopping-cart` package if the `/me/shopping-cart` endpoint returns its payload with messages in the errors array or if there is a connection error.

Messages returned in this way are displayed by the `CartMessages` component regardless of what action caused the endpoint to return the errors. This is in addition to the rejected Promise.

Because the Promise rejects, any code that was calling an action can assume that the operation failed. However, some calling code does not handle the rejection, because there is no action needed. This causes the error to bubble up to the console, and more importantly, to our error logging systems. Recording errors like these are not useful.

We should make sure that every action's Promise includes a `try/catch` (if using `await`) or a `.catch()`. See https://github.com/Automattic/wp-calypso/issues/67012 for more info.

## Proposed Changes

This PR adds `catch()` calls to every call to the `reloadFromServer` action. This will stop errors from being logged for these events like p1679769139086579-slack-C04U5A26MJB which was caused by the Masterbar cart having connectivity issues reaching the public-api server.

## Screenshots

Before this PR:

<img width="730" alt="Screenshot 2023-03-25 at 4 53 23 PM" src="https://user-images.githubusercontent.com/2036909/227741778-68784989-30c2-4545-9aac-a9d4f3953b68.png">


## Testing Instructions

To verify that this silences the errors, first you need to break the shopping-cart endpoint. The easiest way to do that is to sandbox the API and then throw an exception inside the endpoint code (eg D50045-code).

Next, load a page in calypso that loads the Masterbar cart. Any site-level page should do, like the customer home page or the sites page. Leave the JavaScript console open while it loads.

Verify that there are no "Uncaught Promise" errors that refer to the shopping-cart endpoint failing.
