### PR TITLE
Handle null string in stroke colors in SVG file

### DIFF
--- a/bin/audit-svg-colors.js
+++ b/bin/audit-svg-colors.js
@@ -161,23 +161,27 @@ SVG_FILES_TO_PROCESS.forEach( ( imagePath ) => {
 		return;
 	}
 
+	// There are SVG files where stroke value is 'null'.
+	// Added the filter before map() to ensure 'null' strings are filtered out.
 	REPLACEMENT_RULES.push( {
 		file: imagePath,
 		preset: targetPreset,
-		rules: colorValuesToReplace.map( ( value ) => {
-			const replacementValue = findClosestColor( value, targetValues );
-			const replacementName = findPaletteColorName( replacementValue );
+		rules: colorValuesToReplace
+			.filter( ( val ) => val !== 'null' )
+			.map( ( value ) => {
+				const replacementValue = findClosestColor( value, targetValues );
+				const replacementName = findPaletteColorName( replacementValue );
 
-			return {
-				from: {
-					value,
-				},
-				to: {
-					value: replacementValue,
-					name: replacementName,
-				},
-			};
-		} ),
+				return {
+					from: {
+						value,
+					},
+					to: {
+						value: replacementValue,
+						name: replacementName,
+					},
+				};
+			} ),
 	} );
 } );
 


### PR DESCRIPTION
## Description
This change is for a utility that audits .svg files. [This file](https://github.com/Automattic/wp-calypso/blob/trunk/static/images/sharing/p2-slack-logo.svg) contains 'null' as a value for the stroke attribute
It leads to this error -
Error: unknown hex color: null

`/Users/yashitamittal/.nvm/versions/node/v14.20.0/bin/node ./bin/audit-svg-colors.js
Uncaught Error Error: unknown hex color: null
    at hex2rgb (/Users/yashitamittal/Documents/Sites/wp-calypso/node_modules/chroma-js/chroma.js:786:15)
    at Color (/Users/yashitamittal/Documents/Sites/wp-calypso/node_modules/chroma-js/chroma.js:177:42)
    at distance (/Users/yashitamittal/Documents/Sites/wp-calypso/node_modules/chroma-js/chroma.js:3050:13)
    at findClosestColor (/Users/yashitamittal/Documents/Sites/wp-calypso/bin/audit-svg-colors.js:231:27)
    at <anonymous> (/Users/yashitamittal/Documents/Sites/wp-calypso/bin/audit-svg-colors.js:168:29)
    at <anonymous> (/Users/yashitamittal/Documents/Sites/wp-calypso/bin/audit-svg-colors.js:167:31)
    at <anonymous> (/Users/yashitamittal/Documents/Sites/wp-calypso/bin/audit-svg-colors.js:135:22)
    at Module._compile (<node_internals>/internal/modules/cjs/loader.js:1085:14)
    at Module._extensions..js (<node_internals>/internal/modules/cjs/loader.js:1114:10)
    at Module.load (<node_internals>/internal/modules/cjs/loader.js:950:32)
    at Module._load (<node_internals>/internal/modules/cjs/loader.js:790:12)
    at executeUserEntryPoint (<node_internals>/internal/modules/run_main.js:75:12)
    at <anonymous> (<node_internals>/internal/main/run_main_module.js:17:47)`

## Proposed Changes

* I have added the code to filter out the 'null' string 

## Testing Instructions

1. Open the file bin/audit-svg-colors.js
2. Click on Run and Debug 
3. The error is visible in the Debug Console


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Ran `yarn test` and checked no errors were introduced from this change.
- [x] Have you checked for TypeScript, React or other console errors?

**Screenshot of the null value** 
<img width="661" alt="Null striing in replacement rules" src="https://user-images.githubusercontent.com/21078987/227817799-0095dd0a-8b7e-408b-817f-0dea0268cdf9.png">

Here's the video screencast to show the error code generated

https://user-images.githubusercontent.com/21078987/227818523-81a669cc-394d-48b1-92db-7ad7f8f2cd3a.mov

