### PR TITLE
Site Assembler - Category tracking improvements

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -184,6 +184,7 @@ const PatternAssembler = ( {
 				.join( ',' ),
 			pattern_ids: patterns.map( ( { id } ) => id ).join( ',' ),
 			pattern_names: patterns.map( ( { name } ) => name ).join( ',' ),
+			pattern_categories: patterns.map( ( { category } ) => category?.name ).join( ',' ),
 			pattern_count: patterns.length,
 		} );
 		patterns.forEach( ( { id, name, category } ) => {
@@ -491,6 +492,7 @@ const PatternAssembler = ( {
 							onSelect={ onSelect }
 							wrapperRef={ wrapperRef }
 							onTogglePatternPanelList={ setIsPatternPanelListOpen }
+							recordTracksEvent={ recordTracksEvent }
 						/>
 					) : (
 						<ScreenPatternList

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -24,6 +24,7 @@ interface Props {
 	selectedPattern: Pattern | null;
 	wrapperRef: React.RefObject< HTMLDivElement > | null;
 	onTogglePatternPanelList?: ( isOpen: boolean ) => void;
+	recordTracksEvent: ( name: string, eventProperties: any ) => void;
 }
 
 const ScreenCategoryList = ( {
@@ -35,6 +36,7 @@ const ScreenCategoryList = ( {
 	selectedPattern,
 	wrapperRef,
 	onTogglePatternPanelList,
+	recordTracksEvent,
 }: Props ) => {
 	const translate = useTranslate();
 	const [ selectedCategory, setSelectedCategory ] = useState< string | null >( null );
@@ -48,6 +50,12 @@ const ScreenCategoryList = ( {
 			setSelectedCategory( null );
 			onTogglePatternPanelList?.( false );
 		}
+	};
+
+	const trackEventCategoryView = ( name: string ) => {
+		recordTracksEvent( 'calypso_signup_pattern_assembler_category_click', {
+			pattern_category: name,
+		} );
 	};
 
 	useEffect( () => {
@@ -101,6 +109,7 @@ const ScreenCategoryList = ( {
 								} else {
 									setSelectedCategory( name );
 									onTogglePatternPanelList?.( true );
+									trackEventCategoryView( name );
 								}
 							} }
 						>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -52,7 +52,7 @@ const ScreenCategoryList = ( {
 		}
 	};
 
-	const trackEventCategoryView = ( name: string ) => {
+	const trackEventCategoryClick = ( name: string ) => {
 		recordTracksEvent( 'calypso_signup_pattern_assembler_category_click', {
 			pattern_category: name,
 		} );
@@ -109,7 +109,7 @@ const ScreenCategoryList = ( {
 								} else {
 									setSelectedCategory( name );
 									onTogglePatternPanelList?.( true );
-									trackEventCategoryView( name );
+									trackEventCategoryClick( name );
 								}
 							} }
 						>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74827 #74157

## Proposed Changes

 - Created a new event to track when a category is clicked, say `calypso_signup_pattern_assembler_category_click` with the prop `pattern_category`.

![Image](https://user-images.githubusercontent.com/1881481/227826792-788e9fad-33b9-45cb-8a48-9d4fd6727454.png)

 - Add `pattern_categories` with the category slugs separated by a comma on the event `calypso_signup_pattern_assembler_continue_click`.


![Image](https://user-images.githubusercontent.com/1881481/227826780-002ea40f-800d-4f14-af51-af6e44839272.png)


## TODO after the PR is approved
- Register the new event and props in Tracks 
- Document new events/props and funnels in Metrics - Site Assembler: PekYwv-WG-p2


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Click on the Calypso live link on the first comment
- Create a new site and click "Start designing" from the bottom of the design picker
- Click `Sections`, then `Add patterns`
- Click on categories
- Using the extension `Tracks vigilante` verify that the event `calypso_signup_pattern_assembler_category_click` contains the prop `pattern_category`
- Click `Continue` 
- Using the extension `Tracks vigilante` verify that the event `calypso_signup_pattern_assembler_continue_click` contains the prop `pattern_categories`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?