### PR TITLE
Enable plans/wooexpress-medium in test, stage, horizon, and production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -90,7 +90,7 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
-		"plans/wooexpress-medium": false,
+		"plans/wooexpress-medium": true,
 		"plans/wooexpress-small": false,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,

--- a/config/production.json
+++ b/config/production.json
@@ -105,7 +105,7 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
-		"plans/wooexpress-medium": false,
+		"plans/wooexpress-medium": true,
 		"plans/wooexpress-small": false,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -103,7 +103,7 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
-		"plans/wooexpress-medium": false,
+		"plans/wooexpress-medium": true,
 		"plans/wooexpress-small": false,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,

--- a/config/test.json
+++ b/config/test.json
@@ -76,7 +76,7 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
-		"plans/wooexpress-medium": false,
+		"plans/wooexpress-medium": true,
 		"plans/wooexpress-small": false,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR enables the `plans/wooexpress-medium` feature flag in the following environments as the final step in launching the new Woo Express Performance plan:
  - horizon
  - test
  - stage
  - production

## Testing Instructions

* Verify that the changes look OK from inspection
* We will only be able to test this once we start the process of deploying the changes to production, and the built packages are available on horizon and/or the staging environment. Once the updated package is available in your testing environment, you can test that the new UI is in place as follows:
  - For a site on the eCommerce trial plan, navigate to _Upgrades_ -> _Plans_
  - Verify that the promoted plan in the UI is _Performance_ instead of _Commerce_

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [N/A] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [N/A] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
