### PR TITLE
Jetpack Pro Dashboard: trigger sorting only when Enter or Space is pressed

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-sort/index.tsx
@@ -61,6 +61,12 @@ export default function SiteSort( {
 		return <span className="site-sort">{ children }</span>;
 	}
 
+	const handleOnKeyDown = ( event: React.KeyboardEvent< HTMLDivElement > ) => {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			setSort();
+		}
+	};
+
 	return (
 		<span
 			role="button"
@@ -68,7 +74,7 @@ export default function SiteSort( {
 			className={ classNames( 'site-sort site-sort__clickable', {
 				'site-sort__icon-large_screen': isLargeScreen,
 			} ) }
-			onKeyDown={ setSort }
+			onKeyDown={ handleOnKeyDown }
 			onClick={ setSort }
 		>
 			{ children }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
@@ -23,7 +23,8 @@
 		font-weight: 400;
 		height: 50px;
 
-		&:hover {
+		&:hover,
+		&:focus-within {
 			.site-sort__icon {
 				visibility: visible;
 			}


### PR DESCRIPTION
Related to 1202619025189113-as-1204268265552051

## Proposed Changes

This PR 
- Fixes the issue with sorting sites in the Jetpack Pro Dashboard, which triggers sorting when clicking on any key when focused. 
- Shows sort icons when focused

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/trigger-click-with-keyboard-enter-and-space-press` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Hover over the site column, and verify that the default sort icon is as shown below.
4. Focus on the site column using the tab and verify the sort icons are visible
5. Now, when focused -> Verify that click events are triggered only with the "Enter" & "Space" keys


https://user-images.githubusercontent.com/10586875/227889601-ae7f053c-9e67-489e-981a-ea1389a26bf9.mov



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?