### PR TITLE
Jetpack Pro Dashboard: implement add for backup expandable content

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks.tsx
@@ -2,14 +2,19 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useContext, useEffect, RefObject } from 'react';
 import { useQueryClient } from 'react-query';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { setSiteMonitorStatus } from 'calypso/state/jetpack-agency-dashboard/actions';
+import {
+	selectLicense,
+	setSiteMonitorStatus,
+	unselectLicense,
+} from 'calypso/state/jetpack-agency-dashboard/actions';
 import useToggleActivateMonitorMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-toggle-activate-monitor-mutation';
 import useUpdateMonitorSettingsMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-update-monitor-settings-mutation';
+import { hasSelectedLicensesOfType } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import SitesOverviewContext from './sites-overview/context';
-import type { Site, UpdateMonitorSettingsParams } from './sites-overview/types';
+import type { AllowedTypes, Site, UpdateMonitorSettingsParams } from './sites-overview/types';
 
 const NOTIFICATION_DURATION = 3000;
 const DESKTOP_BREAKPOINT = '>1280px';
@@ -407,4 +412,20 @@ export const useDashboardShowLargeScreen = (
 	}, [] );
 
 	return isDesktop && ! isOverflowing;
+};
+
+export const useDashboardAddRemoveLicense = ( siteId: number, type: AllowedTypes ) => {
+	const dispatch = useDispatch();
+
+	const isLicenseSelected = useSelector( ( state ) =>
+		hasSelectedLicensesOfType( state, siteId, type )
+	);
+
+	const handleAddLicenseAction = () => {
+		isLicenseSelected
+			? dispatch( unselectLicense( siteId, type ) )
+			: dispatch( selectLicense( siteId, type ) );
+	};
+
+	return { isLicenseSelected, handleAddLicenseAction };
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -6,7 +6,8 @@ import useRewindableActivityLogQuery from 'calypso/data/activity-log/use-rewinda
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { isSuccessfulRealtimeBackup } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
-import { getExtractedBackupTitle } from '../utils';
+import { useDashboardAddRemoveLicense } from '../../hooks';
+import { DASHBOARD_LICENSE_TYPES, getExtractedBackupTitle } from '../utils';
 import ExpandedCard from './expanded-card';
 import type { Site, Backup } from '../types';
 
@@ -88,7 +89,23 @@ export default function BackupStorage( { site }: Props ) {
 		strong: <strong></strong>,
 	};
 
-	const isBackupEnabled = hasBackupError ? false : site.has_backup;
+	const isBackupEnabled = ! hasBackupError && site.has_backup;
+
+	const { isLicenseSelected, handleAddLicenseAction } = useDashboardAddRemoveLicense(
+		site.blog_id,
+		DASHBOARD_LICENSE_TYPES.BACKUP
+	);
+
+	const addBackupText = isLicenseSelected ? (
+		<span className="site-expanded-content__license-selected">
+			<Gridicon icon="checkmark" size={ 16 } />
+			{ translate( 'Backup Selected' ) }
+		</span>
+	) : (
+		translate( 'Add {{strong}}Backup{{/strong}} to see your backup', {
+			components,
+		} )
+	);
 
 	return (
 		<ExpandedCard
@@ -99,10 +116,9 @@ export default function BackupStorage( { site }: Props ) {
 					? translate( 'Fix {{strong}}Backup{{/strong}} connection to see your backup storage', {
 							components,
 					  } )
-					: translate( 'Add {{strong}}Backup{{/strong}} to see your backup', {
-							components,
-					  } )
+					: addBackupText
 			}
+			onClick={ handleAddLicenseAction }
 		>
 			{ isBackupEnabled && <BackupStorageContent siteId={ site.blog_id } siteUrl={ site.url } /> }
 		</ExpandedCard>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -6,6 +6,7 @@ import useRewindableActivityLogQuery from 'calypso/data/activity-log/use-rewinda
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { isSuccessfulRealtimeBackup } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
+import { urlToSlug } from 'calypso/lib/url';
 import { useDashboardAddRemoveLicense } from '../../hooks';
 import { DASHBOARD_LICENSE_TYPES, getExtractedBackupTitle } from '../utils';
 import ExpandedCard from './expanded-card';
@@ -89,7 +90,12 @@ export default function BackupStorage( { site }: Props ) {
 		strong: <strong></strong>,
 	};
 
-	const isBackupEnabled = ! hasBackupError && site.has_backup;
+	const hasBackup = site.has_backup;
+	const isBackupEnabled = ! hasBackupError && hasBackup;
+
+	const siteUrlWithMultiSiteSupport = urlToSlug( site.url );
+	// If the backup has an error, we want to redirect the user to the backup page
+	const link = hasBackupError ? `/backup/${ siteUrlWithMultiSiteSupport }` : '';
 
 	const { isLicenseSelected, handleAddLicenseAction } = useDashboardAddRemoveLicense(
 		site.blog_id,
@@ -107,6 +113,13 @@ export default function BackupStorage( { site }: Props ) {
 		} )
 	);
 
+	const handleOnClick = () => {
+		// If the backup is not enabled, we want to add the license
+		if ( ! hasBackup ) {
+			handleAddLicenseAction();
+		}
+	};
+
 	return (
 		<ExpandedCard
 			header={ translate( 'Latest backup' ) }
@@ -118,7 +131,9 @@ export default function BackupStorage( { site }: Props ) {
 					  } )
 					: addBackupText
 			}
-			onClick={ handleAddLicenseAction }
+			// If the backup is not enabled, we don't want to allow the user to click on the card
+			onClick={ ! isBackupEnabled ? handleOnClick : undefined }
+			href={ link }
 		>
 			{ isBackupEnabled && <BackupStorageContent siteId={ site.blog_id } siteUrl={ site.url } /> }
 		</ExpandedCard>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -131,7 +131,7 @@ export default function BackupStorage( { site }: Props ) {
 					  } )
 					: addBackupText
 			}
-			// If the backup is not enabled, we don't want to allow the user to click on the card
+			// If the backup is not enabled, we want to allow the user to click on the card
 			onClick={ ! isBackupEnabled ? handleOnClick : undefined }
 			href={ link }
 		>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/expanded-card.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/expanded-card.tsx
@@ -9,6 +9,7 @@ interface Props {
 	children: ReactNode;
 	emptyContent?: ReactNode;
 	isEnabled?: boolean;
+	onClick?: () => void;
 }
 
 export default function ExpandedCard( {
@@ -16,11 +17,13 @@ export default function ExpandedCard( {
 	children,
 	isEnabled = true,
 	emptyContent,
+	onClick,
 }: Props ) {
 	return (
 		<Card
 			className={ classNames( 'expanded-card', { 'expanded-card__not-enabled': ! isEnabled } ) }
 			compact
+			onClick={ onClick }
 		>
 			{ isEnabled ? (
 				<>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/expanded-card.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/expanded-card.tsx
@@ -10,6 +10,7 @@ interface Props {
 	emptyContent?: ReactNode;
 	isEnabled?: boolean;
 	onClick?: () => void;
+	href?: string;
 }
 
 export default function ExpandedCard( {
@@ -18,13 +19,34 @@ export default function ExpandedCard( {
 	isEnabled = true,
 	emptyContent,
 	onClick,
+	href,
 }: Props ) {
+	// Trigger click event when pressing Enter or Space
+	const handleOnKeyDown = ( event: React.KeyboardEvent< HTMLDivElement > ) => {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			onClick?.();
+		}
+	};
+
+	const props = {
+		href,
+		compact: true,
+		showLinkIcon: false,
+		className: classNames( 'expanded-card', {
+			'expanded-card__not-enabled': ! isEnabled,
+			'expanded-card__clickable': onClick,
+		} ),
+		// Add click handlers if onClick is provided
+		...( onClick && {
+			role: 'button',
+			tabIndex: 0,
+			onKeyDown: handleOnKeyDown,
+			onClick: onClick,
+		} ),
+	};
+
 	return (
-		<Card
-			className={ classNames( 'expanded-card', { 'expanded-card__not-enabled': ! isEnabled } ) }
-			compact
-			onClick={ onClick }
-		>
+		<Card { ...props }>
 			{ isEnabled ? (
 				<>
 					<div className="expanded-card__header">{ header }</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -30,6 +30,10 @@ $color-yellow: var(--studio-yellow-50);
 	}
 }
 
+.expanded-card__clickable:focus-visible {
+	outline: thin dotted;
+}
+
 .expanded-card__header {
 	font-size: 0.875rem;
 	color: var(--studio-gray-80);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -193,3 +193,9 @@ $color-yellow: var(--studio-yellow-50);
 		padding: 1.5px 0;
 	}
 }
+
+.site-expanded-content__license-selected .gridicon {
+	position: relative;
+	inset-block-start: 3px;
+	inset-inline-end: 5px;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -607,3 +607,7 @@ export const getExtractedBackupTitle = ( backup: Backup ) => {
 
 	return backupTitle;
 };
+
+export const DASHBOARD_LICENSE_TYPES: { [ key: string ]: AllowedTypes } = {
+	BACKUP: 'backup',
+};

--- a/packages/components/src/card/README.md
+++ b/packages/components/src/card/README.md
@@ -35,6 +35,7 @@ function render() {
 | `target`        | `string` | null    | If used with `href`, this specifies where the link opens. Changes the icon to `external`.                                                                                                                                                                                        |
 | `compact`       | `bool`   | false   | Decreases the size of the card.                                                                                                                                                                                                                                                  |
 | `highlight`     | `string` | null    | Displays a colored highlight. If specified (default is no highlight), can be one of `info`, `success`, `error`, or `warning`.                                                                                                                                                    |
+| `showLinkIcon`  | `bool`   | true    | Shows the link indicator(icon) when there is href specified                                                                                                                                                                                                                      |
 
 ### Additional usage information
 

--- a/packages/components/src/card/index.tsx
+++ b/packages/components/src/card/index.tsx
@@ -14,6 +14,7 @@ type OwnProps = {
 	target?: string;
 	compact?: boolean;
 	highlight?: 'error' | 'info' | 'success' | 'warning';
+	showLinkIcon?: boolean;
 };
 
 type ElementProps< P, T extends TagName > = P &
@@ -34,6 +35,7 @@ const Card = < T extends TagName = 'div' >(
 		tagName = 'div',
 		href,
 		target,
+		showLinkIcon = true,
 		...props
 	}: Props< T >,
 	forwardedRef: Ref< any > // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -52,7 +54,9 @@ const Card = < T extends TagName = 'div' >(
 
 	return href ? (
 		<a { ...props } href={ href } target={ target } className={ elementClass } ref={ forwardedRef }>
-			<Gridicon className="card__link-indicator" icon={ target ? 'external' : 'chevron-right' } />
+			{ showLinkIcon && (
+				<Gridicon className="card__link-indicator" icon={ target ? 'external' : 'chevron-right' } />
+			) }
 			{ children }
 		</a>
 	) : (


### PR DESCRIPTION
Related to 1203940061556608-as-1204268265552043

## Proposed Changes

This PR 
- adds a new prop `showLinkIcon` to the `<Card />` component
- implements add functionality to the backup expandable card 
- adds focus logic and styles to the card
- handles redirecting click events when the backup is failed

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_**  You can always append the live link URL with `?flags=jetpack/pro-dashboard-expandable-block` to test these changes using the live link.

**Instructions**

1. Run `add/implement-add-for-backup-expandable-content` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Expand any card where Backup is not enabled. Click on the card which says `Add Backup to see your backup` and verify it is getting selected. Clicking again should unselect it, and clicking on `Add` on any other product in the columns should add/remove the product from the list of selected products.

<img width="333" alt="Screenshot 2023-03-27 at 2 33 17 PM" src="https://user-images.githubusercontent.com/10586875/227901374-b95b59f0-4587-405a-aa15-9d3a3338e84f.png">

<img width="341" alt="Screenshot 2023-03-27 at 3 24 11 PM" src="https://user-images.githubusercontent.com/10586875/227908351-12a359a8-00f4-4f1d-b173-fe357572c4c1.png">

https://user-images.githubusercontent.com/10586875/227902103-59acbe86-5c3e-44de-b97b-5079611f7e77.mov

4. Use the keyboard to add/remove product by focusing on the card. Verify that click events are triggered only with the "Enter" & "Space" keys. The card should be focused/clickable only when the backup is not added or failed.


https://user-images.githubusercontent.com/10586875/227901691-9c358d34-bb6b-41b0-808a-8323e9e63c10.mov

5. Clicking on a card with a failed backup should redirect the user to the backup page of that site.

<img width="336" alt="Screenshot 2023-03-27 at 2 33 09 PM" src="https://user-images.githubusercontent.com/10586875/227901217-b5d00531-e844-45e8-a544-31f076290b59.png">

6. We will handle the multisite scenario here - 1203940061556608-as-1204256456240543

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?