### PR TITLE
Site Assembler: Add events when previewing either color or font variation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -432,6 +432,20 @@ const PatternAssembler = ( {
 
 	const onDeleteFooter = () => onSelect( 'footer', null );
 
+	const onSelectColorVariation = ( variation: GlobalStylesObject ) => {
+		setSelectedColorPaletteVariation( variation );
+		recordTracksEvent( 'calypso_signup_pattern_assembler_color_variation_preview_click', {
+			title: variation.title,
+		} );
+	};
+
+	const onSelectFontVariation = ( variation: GlobalStylesObject ) => {
+		setSelectedFontPairingVariation( variation );
+		recordTracksEvent( 'calypso_signup_pattern_assembler_font_variation_preview_click', {
+			title: variation.title,
+		} );
+	};
+
 	const stepContent = (
 		<div
 			className={ classnames( 'pattern-assembler__wrapper', {
@@ -510,7 +524,7 @@ const PatternAssembler = ( {
 							siteId={ site?.ID }
 							stylesheet={ stylesheet }
 							selectedColorPaletteVariation={ selectedColorPaletteVariation }
-							onSelect={ setSelectedColorPaletteVariation }
+							onSelect={ onSelectColorVariation }
 						/>
 					</NavigatorScreen>
 				) }
@@ -523,7 +537,7 @@ const PatternAssembler = ( {
 							siteId={ site?.ID }
 							stylesheet={ stylesheet }
 							selectedFontPairingVariation={ selectedFontPairingVariation }
-							onSelect={ setSelectedFontPairingVariation }
+							onSelect={ onSelectFontVariation }
 						/>
 					</NavigatorScreen>
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -432,18 +432,34 @@ const PatternAssembler = ( {
 
 	const onDeleteFooter = () => onSelect( 'footer', null );
 
-	const onSelectColorVariation = ( variation: GlobalStylesObject ) => {
+	const onScreenColorsSelect = ( variation: GlobalStylesObject ) => {
 		setSelectedColorPaletteVariation( variation );
-		recordTracksEvent( 'calypso_signup_pattern_assembler_color_variation_preview_click', {
+		recordTracksEvent( 'calypso_signup_pattern_assembler_screen_colors_preview_click', {
 			title: variation.title,
 		} );
 	};
 
-	const onSelectFontVariation = ( variation: GlobalStylesObject ) => {
+	const onScreenColorsBack = () => {
+		recordTracksEvent( 'calypso_signup_pattern_assembler_screen_colors_back_click' );
+	};
+
+	const onScreenColorsDone = () => {
+		recordTracksEvent( 'calypso_signup_pattern_assembler_screen_colors_done_click' );
+	};
+
+	const onScreenFontsSelect = ( variation: GlobalStylesObject ) => {
 		setSelectedFontPairingVariation( variation );
-		recordTracksEvent( 'calypso_signup_pattern_assembler_font_variation_preview_click', {
+		recordTracksEvent( 'calypso_signup_pattern_assembler_screen_fonts_preview_click', {
 			title: variation.title,
 		} );
+	};
+
+	const onScreenFontsBack = () => {
+		recordTracksEvent( 'calypso_signup_pattern_assembler_screen_fonts_back_click' );
+	};
+
+	const onScreenFontsDone = () => {
+		recordTracksEvent( 'calypso_signup_pattern_assembler_screen_fonts_done_click' );
 	};
 
 	const stepContent = (
@@ -524,7 +540,9 @@ const PatternAssembler = ( {
 							siteId={ site?.ID }
 							stylesheet={ stylesheet }
 							selectedColorPaletteVariation={ selectedColorPaletteVariation }
-							onSelect={ onSelectColorVariation }
+							onSelect={ onScreenColorsSelect }
+							onBack={ onScreenColorsBack }
+							onDoneClick={ onScreenColorsDone }
 						/>
 					</NavigatorScreen>
 				) }
@@ -537,7 +555,9 @@ const PatternAssembler = ( {
 							siteId={ site?.ID }
 							stylesheet={ stylesheet }
 							selectedFontPairingVariation={ selectedFontPairingVariation }
-							onSelect={ onSelectFontVariation }
+							onSelect={ onScreenFontsSelect }
+							onBack={ onScreenFontsBack }
+							onDoneClick={ onScreenFontsDone }
 						/>
 					</NavigatorScreen>
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
@@ -10,6 +10,7 @@ interface Props {
 	stylesheet: string;
 	selectedColorPaletteVariation: GlobalStylesObject | null;
 	onSelect: ( colorPaletteVariation: GlobalStylesObject | null ) => void;
+	onBack: () => void;
 	onDoneClick: () => void;
 }
 
@@ -18,6 +19,7 @@ const ScreenColorPalettes = ( {
 	stylesheet,
 	selectedColorPaletteVariation,
 	onSelect,
+	onBack,
 	onDoneClick,
 }: Props ) => {
 	const translate = useTranslate();
@@ -30,6 +32,7 @@ const ScreenColorPalettes = ( {
 					'Select from our curated color palettes or tweak to your heart’s content when you upgrade to the Premium plan or higher.'
 				) }
 				isPremium
+				onBack={ onBack }
 			/>
 			<div className="screen-container__body">
 				<ColorPaletteVariations

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
@@ -10,6 +10,7 @@ interface Props {
 	stylesheet: string;
 	selectedFontPairingVariation: GlobalStylesObject | null;
 	onSelect: ( fontPairingVariation: GlobalStylesObject | null ) => void;
+	onBack: () => void;
 	onDoneClick: () => void;
 }
 
@@ -18,6 +19,7 @@ const ScreenFontPairings = ( {
 	stylesheet,
 	selectedFontPairingVariation,
 	onSelect,
+	onBack,
 	onDoneClick,
 }: Props ) => {
 	const translate = useTranslate();
@@ -30,6 +32,7 @@ const ScreenFontPairings = ( {
 					'Select from our hand-picked font pairings or expanded library when you upgrade to the Premium plan or higher.'
 				) }
 				isPremium
+				onBack={ onBack }
 			/>
 			<div className="screen-container__body">
 				<FontPairingVariations


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71981

## Proposed Changes

* Add new events when the user selects either color or font variation to preview the style

**Colors**

| Preview | Back | Save |
| - | - | - |
| ![image](https://user-images.githubusercontent.com/13596067/227918928-a0574ea9-b755-4793-8183-f0c31a976507.png) | ![image](https://user-images.githubusercontent.com/13596067/227918372-9c3f6f0c-b931-47c0-a8c2-d7b01f827c70.png) | ![image](https://user-images.githubusercontent.com/13596067/227918767-2c75f66e-6aa6-4264-bd4e-f9bea675f5bc.png) |

**Fonts**

| Preview | Back | Save |
| - | - | - |
| ![image](https://user-images.githubusercontent.com/13596067/227919334-77bbd267-01d4-40a7-862b-d4396de19676.png) | ![image](https://user-images.githubusercontent.com/13596067/227918510-886406a4-1531-4f82-940f-0bbec38e02d4.png) | ![image](https://user-images.githubusercontent.com/13596067/227918605-efcca083-448c-43fb-8805-d79b0cecc071.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>&flags=pattern-assembler/color-and-fonts`
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Select `Colors`
    * Pick any color variation, and verify the event `calypso_signup_pattern_assembler_screen_colors_preview_click` is fired.
    * Click on `<`, and verify the event `calypso_signup_pattern_assembler_screen_colors_back_click` is fired.
    * Click on `Save`, and verify the event `calypso_signup_pattern_assembler_screen_colors_done_click` is fired.
  * Select `Fonts`
    * Pick any font variation, and verify the event `calypso_signup_pattern_assembler_screen_fonts_preview_click` is fired.
    * Click on `<`, and verify the event `calypso_signup_pattern_assembler_screen_fonts_back_click` is fired.
    * Click on `Save`, and verify the event `calypso_signup_pattern_assembler_screen_fonts_done_click` is fired.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
