### PR TITLE
Jetpack Cloud: Fix mobile header submenu overflowing issue.

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -626,6 +626,7 @@
 		margin: 0 auto;
 		display: flex;
 		justify-content: space-between;
+		box-sizing: border-box;
 		gap: 3rem;
 	}
 	@media ( max-width: 1300px ) {
@@ -783,6 +784,7 @@
 		width: 85%;
 		margin-left: auto;
 		margin-right: auto;
+		box-sizing: border-box;
 
 		@media ( max-width: 1300px ) {
 			width: 90%;


### PR DESCRIPTION
This PR fixes the issue w/ the mobile header submenu overflowing on a tighter screen causing it to be scrollable horizontally.

https://user-images.githubusercontent.com/56598660/227903749-7a76a253-3477-447d-8433-873772938b82.mov



Related to #74885

## Proposed Changes

* Modify the header submenu `box-sizing` to `border-box`.

## Testing Instructions

Run this branch by following the steps below (or you can use the Jetpack Cloud live link commented on this PR)

- Run git fetch && git checkout fix/jp-cloud-header-mobile-submenu-overflow
- Run yarn start-jetpack-cloud
- Go to http://jetpack.cloud.localhost:3000/pricing or use the Jetpack Cloud live link and append /pricing.
- Set your browser to mobile view
- Click the menu > products
- Confirm that the submenu no longer overflows and cannot be scrolled horizontally.

https://user-images.githubusercontent.com/56598660/227904718-679900a0-b0b3-4369-a432-dd8f243b5ca3.mov


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
