### PR TITLE
Jetpack Pro Dashboard: implement tooltip for help icon on boost expandable block and update button links

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -2,6 +2,8 @@ import { Button } from '@automattic/components';
 import { Icon, help } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useRef, useState } from 'react';
+import Tooltip from 'calypso/components/tooltip';
 import { jetpackBoostDesktopIcon, jetpackBoostMobileIcon } from '../../icons';
 import { getBoostRating, getBoostRatingClass } from '../utils';
 import ExpandedCard from './expanded-card';
@@ -10,15 +12,20 @@ import type { BoostData } from '../types';
 interface Props {
 	boostData: BoostData;
 	hasBoost: boolean;
+	siteId: number;
 	siteUrlWithScheme: string;
 }
 
 export default function BoostSitePerformance( {
 	boostData,
 	hasBoost,
+	siteId,
 	siteUrlWithScheme,
 }: Props ) {
 	const translate = useTranslate();
+
+	const helpIconRef = useRef< HTMLElement | null >( null );
+	const [ showTooltip, setShowTooltip ] = useState( false );
 
 	const { overall: overallScore, mobile: mobileScore, desktop: desktopScore } = boostData;
 
@@ -26,7 +33,12 @@ export default function BoostSitePerformance( {
 		strong: <strong></strong>,
 	};
 
+	const tooltip = translate(
+		'Your Overall Score is a summary of your website performance across both mobile and desktop devices.'
+	);
+
 	const href = `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`;
+
 	return (
 		<ExpandedCard
 			header={ translate( 'Boost site performance' ) }
@@ -48,7 +60,23 @@ export default function BoostSitePerformance( {
 							) }
 						>
 							{ getBoostRating( overallScore ) }
-							<Icon size={ 20 } className="site-expanded-content__help-icon" icon={ help } />
+
+							<span
+								ref={ helpIconRef }
+								onMouseEnter={ () => setShowTooltip( true ) }
+								onMouseLeave={ () => setShowTooltip( false ) }
+							>
+								<Icon size={ 20 } className="site-expanded-content__help-icon" icon={ help } />
+							</span>
+							<Tooltip
+								id={ `${ siteId }-boost-help-text` }
+								context={ helpIconRef.current }
+								isVisible={ showTooltip }
+								position="bottom"
+								className="site-expanded-content__tooltip"
+							>
+								{ tooltip }
+							</Tooltip>
 						</div>
 						<div className="site-expanded-content__card-content-score-title">
 							{ translate( 'Overall' ) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -10,9 +10,14 @@ import type { BoostData } from '../types';
 interface Props {
 	boostData: BoostData;
 	hasBoost: boolean;
+	siteUrlWithScheme: string;
 }
 
-export default function BoostSitePerformance( { boostData, hasBoost }: Props ) {
+export default function BoostSitePerformance( {
+	boostData,
+	hasBoost,
+	siteUrlWithScheme,
+}: Props ) {
 	const translate = useTranslate();
 
 	const { overall: overallScore, mobile: mobileScore, desktop: desktopScore } = boostData;
@@ -21,6 +26,7 @@ export default function BoostSitePerformance( { boostData, hasBoost }: Props ) {
 		strong: <strong></strong>,
 	};
 
+	const href = `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`;
 	return (
 		<ExpandedCard
 			header={ translate( 'Boost site performance' ) }
@@ -73,7 +79,12 @@ export default function BoostSitePerformance( { boostData, hasBoost }: Props ) {
 					</div>
 				</div>
 				<div className="site-expanded-content__card-footer">
-					<Button className="site-expanded-content__card-button" compact>
+					<Button
+						href={ href }
+						target="_blank"
+						className="site-expanded-content__card-button"
+						compact
+					>
 						{ translate( 'Optimize CSS' ) }
 					</Button>
 				</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -35,6 +35,7 @@ export default function SiteExpandedContent( {
 			{ columns.includes( 'boost' ) && (
 				<BoostSitePerformance
 					boostData={ boostData }
+					siteId={ site.blog_id }
 					siteUrlWithScheme={ siteUrlWithScheme }
 					hasBoost={ site.has_boost }
 				/>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -33,7 +33,11 @@ export default function SiteExpandedContent( {
 				<InsightsStats stats={ stats } siteUrlWithScheme={ siteUrlWithScheme } />
 			) }
 			{ columns.includes( 'boost' ) && (
-				<BoostSitePerformance boostData={ boostData } hasBoost={ site.has_boost } />
+				<BoostSitePerformance
+					boostData={ boostData }
+					siteUrlWithScheme={ siteUrlWithScheme }
+					hasBoost={ site.has_boost }
+				/>
 			) }
 			{ columns.includes( 'backup' ) && stats && <BackupStorage site={ site } /> }
 		</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -21,6 +21,7 @@ export default function SiteExpandedContent( {
 }: Props ) {
 	const stats = site.site_stats;
 	const boostData = site.jetpack_boost_scores;
+	const siteUrlWithScheme = site.url_with_scheme;
 
 	return (
 		<div
@@ -28,7 +29,9 @@ export default function SiteExpandedContent( {
 				'is-small-screen': isSmallScreen,
 			} ) }
 		>
-			{ columns.includes( 'stats' ) && stats && <InsightsStats stats={ stats } /> }
+			{ columns.includes( 'stats' ) && stats && (
+				<InsightsStats stats={ stats } siteUrlWithScheme={ siteUrlWithScheme } />
+			) }
 			{ columns.includes( 'boost' ) && (
 				<BoostSitePerformance boostData={ boostData } hasBoost={ site.has_boost } />
 			) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats.tsx
@@ -7,9 +7,10 @@ import type { SiteStats } from '../types';
 
 interface Props {
 	stats: SiteStats;
+	siteUrlWithScheme: string;
 }
 
-export default function InsightsStats( { stats }: Props ) {
+export default function InsightsStats( { stats, siteUrlWithScheme }: Props ) {
 	const translate = useTranslate();
 
 	const data = {
@@ -52,6 +53,8 @@ export default function InsightsStats( { stats }: Props ) {
 		);
 	};
 
+	const href = `${ siteUrlWithScheme }/wp-admin/admin.php?page=stats`;
+
 	return (
 		<ExpandedCard header={ translate( '7 days insights stats' ) }>
 			<div className="site-expanded-content__card-content-container">
@@ -76,7 +79,12 @@ export default function InsightsStats( { stats }: Props ) {
 					</div>
 				</div>
 				<div className="site-expanded-content__card-footer">
-					<Button className="site-expanded-content__card-button" compact>
+					<Button
+						href={ href }
+						target="_blank"
+						className="site-expanded-content__card-button"
+						compact
+					>
 						{ translate( 'See all stats' ) }
 					</Button>
 				</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -203,3 +203,7 @@ $color-yellow: var(--studio-yellow-50);
 	inset-block-start: 3px;
 	inset-inline-end: 5px;
 }
+
+.site-expanded-content__tooltip .popover__inner {
+	width: 300px;
+}


### PR DESCRIPTION
Related to 1203940061556608-as-1204062388154427

## Proposed Changes

This PR 
- implements tooltip for the boost card help icon
- updates href to the buttons - `See all stats` and `Optimize CSS`

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_**  You can always append the live link URL with `?flags=jetpack/pro-dashboard-expandable-block` to test these changes using the live link.

**Instructions**

1. Run `add/implement-tooltip-for-boost-expandable-block` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Expand any site where there is Boost paid plan is enabled, hover over the help icon on the boost  card, and verify that the tooltip looks as  shown below

<img width="342" alt="Screenshot 2023-03-27 at 4 06 10 PM" src="https://user-images.githubusercontent.com/10586875/227924139-0a854b8b-e3d5-42ce-a3d1-a55438170f15.png">

4. Click on `See all stats` and `Optimize CSS` and verify that redirects to Stats and Boost `wp-admin` pages.

<img width="670" alt="Screenshot 2023-03-27 at 4 29 57 PM" src="https://user-images.githubusercontent.com/10586875/227924195-33a02a98-6531-4f9b-ad2b-75ffee10b11d.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?