### PR TITLE
Subscription management: Redirect users based on their login status

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -290,8 +290,9 @@ function setUpLoggedOutRoute( req, res, next ) {
 		setupRequests.push( setUpLocalLanguageRevisions( req ) );
 	}
 
-	if ( req.cookies?.subkey && ! req.context.user ) {
+	if ( req.cookies?.subkey ) {
 		req.context.user = {
+			...( req.context.user ?? {} ),
 			subscriptionManagementSubkey: req.cookies.subkey,
 		};
 	}
@@ -826,6 +827,18 @@ function wpcomPages( app ) {
 
 				res.send( renderJsx( 'support-user' ) );
 			} );
+	} );
+
+	app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res, next ) {
+		if ( ! req.context.isLoggedIn ) {
+			if ( req.context.user?.subscriptionManagementSubkey ) {
+				return next();
+			}
+
+			return res.redirect( 'https://wordpress.com/email-subscriptions' );
+		}
+
+		return res.redirect( 'https://wordpress.com/email-subscriptions?option=settings' );
 	} );
 }
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -830,15 +830,18 @@ function wpcomPages( app ) {
 	} );
 
 	app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res, next ) {
-		if ( ! req.context.isLoggedIn ) {
-			if ( req.context.user?.subscriptionManagementSubkey ) {
-				return next();
-			}
-
-			return res.redirect( 'https://wordpress.com/email-subscriptions' );
+		if ( req.context.isLoggedIn ) {
+			// We want to show the old subscriptions management portal to the logged-in users, until new one in reader is developped for them
+			return res.redirect( 'https://wordpress.com/email-subscriptions?option=settings' );
 		}
 
-		return res.redirect( 'https://wordpress.com/email-subscriptions?option=settings' );
+		if ( req.cookies.subkey ) {
+			// If the user is logged out, and has a subkey cookie, they are authorized to view the page
+			return next();
+		}
+
+		// Otherwise, show them email subscriptions external landing page
+		res.redirect( 'https://wordpress.com/email-subscriptions' );
 	} );
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/74886

## Proposed Changes

* When navigating to `/subscriptions`, or any sub-path, perform the following redirections:
  * for logged-in user, redirect to `https://wordpress.com/email-subscriptions`
  * for non-logged in user who has no subkey in his cookie, redirect to `https://wordpress.com/email-subscriptions?option=settings`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Testing for WPCOM logged-in users
First, you will need to set up your local test environment. It is a bit more hassle than the usual calypso's `yarn & yarn start`.
You will need to create a `/config/secrets.json` and populate it with at least the 2 following properties:
```json
{
    "wordpress_logged_in_cookie": "YOUR-VALUE-HERE",
    "wpcom_calypso_rest_api_key": "YOUR-VALUE-HERE"
}
```
Then in your `/config/development.json` you will need to set the following flag to true:
```json
"wpcom-user-bootstrap": true
```
For how to obtain the values in `/config/secrets.json`, you need to follow the: PCYsg-5YE-p2.
Once done with all above, you can now do: `yarn && yarn start` 


1. Go to http://calypso.localhost:3000/subscriptions/settings as a logged-in WPCOM user
2. You should be redirected to https://wordpress.com/email-subscriptions?option=settings 

### Testing for unauthorized external users
Before you start your local calypso env: 
* Ensure your `wpcom-user-bootstrap` flag is set to `false` in `config/development.json`.
* Ensure you have no `subkey` cookie set for `calypso.localhost`.

1. Go to http://calypso.localhost:3000/subscriptions/settings as a non-logged in user but without a cookie
2. You should be redirected to https://wordpress.com/email-subscriptions

### Testing for authorized external users
Before you start your local calypso env: 
* Ensure your `wpcom-user-bootstrap` flag is set to `false` in `config/development.json`.
* Ensure you have `subkey` cookie with a valid value set for `calypso.localhost`.
  <img width="1215" alt="Screen Shot 2023-03-27 at 20 48 01" src="https://user-images.githubusercontent.com/2019970/228039511-3420affa-b895-429d-aa5c-f6bdf46a4b3a.png">

1. Go to http://calypso.localhost:3000/subscriptions/settings as a non-logged in user but with a cookie
2. The new subscription management settings page should open for you

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?