### PR TITLE
Plans 2023: header-price refactors and unit tests

### DIFF
--- a/client/my-sites/plan-features-2023-grid/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/header-price.tsx
@@ -32,16 +32,6 @@ const PlanFeatures2023GridHeaderPrice = ( {
 			: planPrices.rawPrice,
 	};
 
-	// const showDiscountedPricing = Boolean(
-	// 	planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice
-	// );
-
-	// // order matters here, we want to show the discounted price if it exists, otherwise the regular price
-	// const priceToDisplay =
-	// 	planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice || planPrices.rawPrice;
-
-	// const crossoutPriceToDisplay = planPrices.rawPrice;
-
 	if ( isWpcomEnterpriseGridPlan( planName ) ) {
 		return null;
 	}

--- a/client/my-sites/plan-features-2023-grid/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/header-price.tsx
@@ -25,12 +25,6 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	const shouldShowDiscountedPrice = Boolean(
 		planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice
 	);
-	const discountedPricing = {
-		crossoutPrice: shouldShowDiscountedPrice ? planPrices.rawPrice : null,
-		price: shouldShowDiscountedPrice
-			? planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice
-			: planPrices.rawPrice,
-	};
 
 	if ( isWpcomEnterpriseGridPlan( planName ) ) {
 		return null;
@@ -43,7 +37,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 					<div className="plan-features-2023-grid__header-price-group-prices">
 						<PlanPrice
 							currencyCode={ currencyCode }
-							rawPrice={ discountedPricing.crossoutPrice ?? undefined }
+							rawPrice={ planPrices.rawPrice }
 							displayPerMonthNotation={ false }
 							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 							isLargeCurrency={ isLargeCurrency }
@@ -51,7 +45,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
-							rawPrice={ discountedPricing.price }
+							rawPrice={ planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice }
 							displayPerMonthNotation={ false }
 							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 							isLargeCurrency={ isLargeCurrency }
@@ -63,7 +57,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 			{ ! shouldShowDiscountedPrice && (
 				<PlanPrice
 					currencyCode={ currencyCode }
-					rawPrice={ discountedPricing.price }
+					rawPrice={ planPrices.rawPrice }
 					displayPerMonthNotation={ false }
 					is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 					isLargeCurrency={ isLargeCurrency }

--- a/client/my-sites/plan-features-2023-grid/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/header-price.tsx
@@ -20,7 +20,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const planPrices = usePlanPrices( {
 		planSlug: planName as PlanSlug,
-		monthly: showMonthlyPrice,
+		returnMonthly: showMonthlyPrice,
 	} );
 	const shouldShowDiscountedPrice = Boolean(
 		planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -1088,7 +1088,6 @@ const ConnectedPlanFeatures2023Grid = connect(
 				cartItemForPlan: getCartItemForPlan( getPlanSlug( state, planProductId ) ?? '' ),
 				currencyCode: getCurrentUserCurrencyCode( state ),
 				current: isCurrentPlan,
-				discountPrice,
 				features: planFeaturesTransformed,
 				jpFeatures: jetpackFeaturesTransformed,
 				isLandingPage,

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -500,7 +500,7 @@ export class PlanFeatures2023Grid extends Component<
 		);
 
 		return planPropertiesObj.map( ( properties ) => {
-			const { currencyCode, discountPrice, planName, rawPrice } = properties;
+			const { planName, rawPrice } = properties;
 			const classes = classNames( 'plan-features-2023-grid__table-item', 'is-bottom-aligned', {
 				'has-border-top': ! isReskinned,
 			} );
@@ -515,10 +515,7 @@ export class PlanFeatures2023Grid extends Component<
 				>
 					{ ! hasNoPrice && (
 						<PlanFeatures2023GridHeaderPrice
-							currencyCode={ currencyCode }
-							discountPrice={ discountPrice }
-							rawPrice={ rawPrice }
-							planName={ planName }
+							planProperties={ properties }
 							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 							isLargeCurrency={ isLargeCurrency }
 						/>
@@ -1110,6 +1107,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 				tagline,
 				storageOptions,
 				billingPeriod,
+				showMonthlyPrice,
 			};
 		} );
 

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -19,13 +19,11 @@ import { useMemo } from '@wordpress/element';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback, useEffect, ChangeEvent } from 'react';
-import { useSelector } from 'react-redux';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { FeatureObject, getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import PlanTypeSelector, {
 	PlanTypeSelectorProps,
 } from 'calypso/my-sites/plans-features-main/plan-type-selector';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import PlanFeatures2023GridActions from './actions';
 import PlanFeatures2023GridBillingTimeframe from './billing-timeframe';
 import PopularBadge from './components/popular-badge';
@@ -319,7 +317,6 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 	const { planName, planConstantObj, availableForPurchase, current, ...planPropertiesObj } =
 		planProperties;
 	const highlightLabel = useHighlightLabel( planName );
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( visiblePlansProperties );
 	const headerClasses = classNames( 'plan-comparison-grid__header-cell', getPlanClass( planName ), {
 		'popular-plan-parent-class': highlightLabel,
@@ -374,10 +371,7 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 				</h4>
 			</PlanSelector>
 			<PlanFeatures2023GridHeaderPrice
-				currencyCode={ currencyCode }
-				discountPrice={ planPropertiesObj.discountPrice }
-				rawPrice={ rawPrice || 0 }
-				planName={ planName }
+				planProperties={ planProperties }
 				is2023OnboardingPricingGrid={ true }
 				isLargeCurrency={ isLargeCurrency }
 			/>

--- a/client/my-sites/plan-features-2023-grid/test/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/test/header-price.tsx
@@ -19,7 +19,7 @@ jest.mock( '../../plans/hooks/use-plan-prices', () => jest.fn() );
 
 import { render } from '@testing-library/react';
 import React from 'react';
-import usePlanPrices from '../../plans/hooks/use-plan-prices';
+import usePlanPrices, { PlanPrices } from '../../plans/hooks/use-plan-prices';
 import PlanFeatures2023GridHeaderPrice from '../header-price';
 import { PlanProperties } from '../types';
 
@@ -39,11 +39,12 @@ describe( 'PlanFeatures2023GridHeaderPrice', () => {
 	} );
 
 	test( 'should render raw and discounted prices when discount exists', () => {
-		usePlanPrices.mockImplementation( () => ( {
+		const planPrices: PlanPrices = {
 			planDiscountedRawPrice: 0,
 			discountedRawPrice: 50,
 			rawPrice: 100,
-		} ) );
+		};
+		usePlanPrices.mockImplementation( () => planPrices );
 
 		const { container } = render( <PlanFeatures2023GridHeaderPrice { ...defaultProps } /> );
 		const rawPrice = container.querySelector( '.plan-price.is-original' );
@@ -54,11 +55,12 @@ describe( 'PlanFeatures2023GridHeaderPrice', () => {
 	} );
 
 	test( 'should render raw and plan-discounted prices when discount exists', () => {
-		usePlanPrices.mockImplementation( () => ( {
+		const planPrices: PlanPrices = {
 			planDiscountedRawPrice: 50,
-			discountedRawPrice: 0,
+			discountedRawPrice: 10,
 			rawPrice: 100,
-		} ) );
+		};
+		usePlanPrices.mockImplementation( () => planPrices );
 
 		const { container } = render( <PlanFeatures2023GridHeaderPrice { ...defaultProps } /> );
 		const rawPrice = container.querySelector( '.plan-price.is-original' );
@@ -69,11 +71,12 @@ describe( 'PlanFeatures2023GridHeaderPrice', () => {
 	} );
 
 	test( 'should render just the raw price when no discount exists', () => {
-		usePlanPrices.mockImplementation( () => ( {
+		const planPrices: PlanPrices = {
 			planDiscountedRawPrice: 0,
 			discountedRawPrice: 0,
 			rawPrice: 100,
-		} ) );
+		};
+		usePlanPrices.mockImplementation( () => planPrices );
 
 		const { container } = render( <PlanFeatures2023GridHeaderPrice { ...defaultProps } /> );
 		const rawPrice = container.querySelector( '.plan-price' );

--- a/client/my-sites/plan-features-2023-grid/test/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/test/header-price.tsx
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Default mock implementations
+ */
+jest.mock( 'calypso/state/currency-code/selectors', () => ( {
+	getCurrentUserCurrencyCode: jest.fn(),
+} ) );
+jest.mock( '@wordpress/element', () => ( {
+	...jest.requireActual( '@wordpress/element' ),
+	useCallback: jest.fn(),
+} ) );
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useSelector: jest.fn(),
+} ) );
+jest.mock( '../../plans/hooks/use-plan-prices', () => jest.fn() );
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import usePlanPrices from '../../plans/hooks/use-plan-prices';
+import PlanFeatures2023GridHeaderPrice from '../header-price';
+import { PlanProperties } from '../types';
+
+describe( 'PlanFeatures2023GridHeaderPrice', () => {
+	const planProperties = {
+		planName: 'foo',
+		showMonthlyPrice: false,
+	} as PlanProperties;
+	const defaultProps = {
+		is2023OnboardingPricingGrid: true,
+		isLargeCurrency: false,
+		planProperties,
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'should render raw and discounted prices when discount exists', () => {
+		usePlanPrices.mockImplementation( () => ( {
+			planDiscountedRawPrice: 0,
+			discountedRawPrice: 50,
+			rawPrice: 100,
+		} ) );
+
+		const { container } = render( <PlanFeatures2023GridHeaderPrice { ...defaultProps } /> );
+		const rawPrice = container.querySelector( '.plan-price.is-original' );
+		const discountedPrice = container.querySelector( '.plan-price.is-discounted' );
+
+		expect( rawPrice ).toHaveTextContent( '100' );
+		expect( discountedPrice ).toHaveTextContent( '50' );
+	} );
+
+	test( 'should render raw and plan-discounted prices when discount exists', () => {
+		usePlanPrices.mockImplementation( () => ( {
+			planDiscountedRawPrice: 50,
+			discountedRawPrice: 0,
+			rawPrice: 100,
+		} ) );
+
+		const { container } = render( <PlanFeatures2023GridHeaderPrice { ...defaultProps } /> );
+		const rawPrice = container.querySelector( '.plan-price.is-original' );
+		const discountedPrice = container.querySelector( '.plan-price.is-discounted' );
+
+		expect( rawPrice ).toHaveTextContent( '100' );
+		expect( discountedPrice ).toHaveTextContent( '50' );
+	} );
+
+	test( 'should render just the raw price when no discount exists', () => {
+		usePlanPrices.mockImplementation( () => ( {
+			planDiscountedRawPrice: 0,
+			discountedRawPrice: 0,
+			rawPrice: 100,
+		} ) );
+
+		const { container } = render( <PlanFeatures2023GridHeaderPrice { ...defaultProps } /> );
+		const rawPrice = container.querySelector( '.plan-price' );
+		const discountedPrice = container.querySelector( '.plan-price.is-discounted' );
+
+		expect( rawPrice ).toHaveTextContent( '100' );
+		expect( discountedPrice ).toBeNull();
+	} );
+} );

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -33,4 +33,5 @@ export type PlanProperties = {
 	storageOptions: string[];
 	availableForPurchase: boolean;
 	current?: boolean;
+	showMonthlyPrice: boolean;
 };

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -13,7 +13,6 @@ export type PlanProperties = {
 		product_slug: string;
 	} | null;
 	currencyCode: string | null;
-	discountPrice: number | null;
 	features: TransformedFeatureObject[];
 	jpFeatures: TransformedFeatureObject[];
 	isLandingPage?: boolean;

--- a/client/my-sites/plans/hooks/use-plan-prices.ts
+++ b/client/my-sites/plans/hooks/use-plan-prices.ts
@@ -12,22 +12,23 @@ export interface PlanPrices {
 
 interface Props {
 	planSlug: PlanSlug;
-	monthly?: boolean; // defaults to true
+	returnMonthly?: boolean; // defaults to true
 }
 
-const usePlanPrices = ( { planSlug, monthly = true }: Props ): PlanPrices => {
+const usePlanPrices = ( { planSlug, returnMonthly = true }: Props ): PlanPrices => {
 	return useSelector( ( state ) => {
 		const siteId = getSelectedSiteId( state ) ?? undefined;
 		const plan = getPlan( planSlug );
 		const productId = plan?.getProductId();
 
 		return {
-			rawPrice: ( productId && getPlanRawPrice( state, productId, monthly ) ) || 0,
-			discountedRawPrice: ( productId && getDiscountedRawPrice( state, productId, monthly ) ) || 0,
+			rawPrice: ( productId && getPlanRawPrice( state, productId, returnMonthly ) ) || 0,
+			discountedRawPrice:
+				( productId && getDiscountedRawPrice( state, productId, returnMonthly ) ) || 0,
 			planDiscountedRawPrice:
 				( siteId &&
 					planSlug &&
-					getPlanDiscountedRawPrice( state, siteId, planSlug, { isMonthly: monthly } ) ) ||
+					getPlanDiscountedRawPrice( state, siteId, planSlug, { isMonthly: returnMonthly } ) ) ||
 				0,
 		};
 	} );

--- a/client/my-sites/plans/hooks/use-plan-prices.ts
+++ b/client/my-sites/plans/hooks/use-plan-prices.ts
@@ -1,0 +1,36 @@
+import { getPlan, PlanSlug } from '@automattic/calypso-products';
+import { useSelector } from 'react-redux';
+import { getPlanRawPrice, getDiscountedRawPrice } from 'calypso/state/plans/selectors';
+import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export interface PlanPrices {
+	rawPrice: number;
+	discountedRawPrice: number; // discounted on yearly-monthly conversion
+	planDiscountedRawPrice: number; // discounted on site plan upgrade
+}
+
+interface Props {
+	planSlug: PlanSlug;
+	monthly?: boolean; // defaults to true
+}
+
+const usePlanPrices = ( { planSlug, monthly = true }: Props ): PlanPrices => {
+	return useSelector( ( state ) => {
+		const siteId = getSelectedSiteId( state ) ?? undefined;
+		const plan = getPlan( planSlug );
+		const productId = plan?.getProductId();
+
+		return {
+			rawPrice: ( productId && getPlanRawPrice( state, productId, monthly ) ) || 0,
+			discountedRawPrice: ( productId && getDiscountedRawPrice( state, productId, monthly ) ) || 0,
+			planDiscountedRawPrice:
+				( siteId &&
+					planSlug &&
+					getPlanDiscountedRawPrice( state, siteId, planSlug, { isMonthly: monthly } ) ) ||
+				0,
+		};
+	} );
+};
+
+export default usePlanPrices;

--- a/client/my-sites/plans/hooks/use-plan-prices.ts
+++ b/client/my-sites/plans/hooks/use-plan-prices.ts
@@ -12,10 +12,10 @@ export interface PlanPrices {
 
 interface Props {
 	planSlug: PlanSlug;
-	returnMonthly?: boolean; // defaults to true
+	returnMonthly: boolean; // defaults to true
 }
 
-const usePlanPrices = ( { planSlug, returnMonthly = true }: Props ): PlanPrices => {
+const usePlanPrices = ( { planSlug, returnMonthly }: Props ): PlanPrices => {
 	return useSelector( ( state ) => {
 		const siteId = getSelectedSiteId( state ) ?? undefined;
 		const plan = getPlan( planSlug );

--- a/client/my-sites/plans/test/use-plan-prices.ts
+++ b/client/my-sites/plans/test/use-plan-prices.ts
@@ -27,7 +27,7 @@ import usePlanPrices from '../hooks/use-plan-prices';
 describe( 'usePlanPrices', () => {
 	const defaultProps = {
 		planSlug: PLAN_PREMIUM,
-		monthly: true,
+		returnMonthly: true,
 	} as const;
 
 	beforeEach( () => {

--- a/client/my-sites/plans/test/use-plan-prices.ts
+++ b/client/my-sites/plans/test/use-plan-prices.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Default mock implementations
+ */
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useSelector: ( selector ) => selector(),
+} ) );
+jest.mock( 'calypso/state/plans/selectors', () => ( {
+	getPlanRawPrice: jest.fn(),
+	getDiscountedRawPrice: jest.fn(),
+} ) );
+jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
+	getPlanDiscountedRawPrice: jest.fn(),
+} ) );
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSiteId: jest.fn( () => 1 ),
+} ) );
+
+import { PLAN_PREMIUM } from '@automattic/calypso-products';
+import { getPlanRawPrice, getDiscountedRawPrice } from 'calypso/state/plans/selectors';
+import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
+import usePlanPrices from '../hooks/use-plan-prices';
+
+describe( 'usePlanPrices', () => {
+	const defaultProps = {
+		planSlug: PLAN_PREMIUM,
+		monthly: true,
+	} as const;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'should return correct pricing structure', () => {
+		getPlanRawPrice.mockImplementation( () => 300 );
+		getDiscountedRawPrice.mockImplementation( () => 200 );
+		getPlanDiscountedRawPrice.mockImplementation( () => 100 );
+
+		const planPrices = usePlanPrices( defaultProps );
+
+		expect( planPrices ).toEqual( {
+			rawPrice: 300,
+			discountedRawPrice: 200,
+			planDiscountedRawPrice: 100,
+		} );
+	} );
+} );

--- a/client/state/plans/selectors/get-discounted-raw-price.js
+++ b/client/state/plans/selectors/get-discounted-raw-price.js
@@ -15,6 +15,7 @@ export function getDiscountedRawPrice( state, productId, isMonthly = false ) {
 	const plan = getPlan( state, productId );
 	const rawPrice = plan?.raw_price ?? -1;
 	const origCost = plan?.orig_cost ?? -1;
+
 	if ( rawPrice < 0 || origCost < 0 ) {
 		return null;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74261

## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/74375 (which we have put on hold) to compile the relevant refactors that we'd like to merge into `trunk`, along with some unit/UI tests for the header-price component (should also cover usage of the new hook). We are introducing a `use-plan-prices` hook under `/plans`, something that we'll be able to repurpose into other refactors and work pricing-related.

Changes here should allow us to quickly pick up developments with  https://github.com/Automattic/wp-calypso/issues/74261 once we have a clearer idea of cost-savings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review
* Unit tests
* Go to `/plans/[SITE]` with a variety of sites (e.g. on free plan, on paid plan, with pro-rated credits, etc.) and confirm prices are displayed as expected (with cross-out prices when discounts exist)
* Confirm with different currencies e.g. IRN to ensure those discounts are also visible in the prices

p.s. This is a foundation PR that will also be tested more thoroughly in a follow-up PR that will be based on this one to update the price displays.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
