### PR TITLE
Plans 2023: Update discounted price styling

### DIFF
--- a/client/my-sites/plan-features-2023-grid/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/billing-timeframe.tsx
@@ -50,7 +50,7 @@ function usePerMonthDescription( {
 	if ( ! isMonthlyPlan ) {
 		const fullTermPriceText =
 			currencyCode && null !== maybeDiscountedFullTermPrice
-				? formatCurrency( maybeDiscountedFullTermPrice, currencyCode )
+				? formatCurrency( maybeDiscountedFullTermPrice, currencyCode, { stripZeros: true } )
 				: null;
 
 		if ( fullTermPriceText ) {

--- a/client/my-sites/plan-features-2023-grid/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/header-price.tsx
@@ -1,4 +1,5 @@
 import { isWpcomEnterpriseGridPlan, PlanSlug } from '@automattic/calypso-products';
+import styled from '@emotion/styled';
 import { useSelector } from 'react-redux';
 import PlanPrice from 'calypso/my-sites/plan-price';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
@@ -10,6 +11,14 @@ interface PlanFeatures2023GridHeaderPriceProps {
 	is2023OnboardingPricingGrid: boolean;
 	isLargeCurrency: boolean;
 }
+
+const PricesGroup = styled.div< { isLargeCurrency: boolean } >`
+	justify-content: flex-end;
+	display: flex;
+	flex-direction: ${ ( props ) => ( props.isLargeCurrency ? 'column' : 'row-reverse' ) };
+	align-items: ${ ( props ) => ( props.isLargeCurrency ? 'flex-start' : 'flex-end' ) };
+	gap: 4px;
+`;
 
 const PlanFeatures2023GridHeaderPrice = ( {
 	planProperties,
@@ -33,26 +42,24 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	return (
 		<div className="plan-features-2023-grid__pricing">
 			{ shouldShowDiscountedPrice && (
-				<span className="plan-features-2023-grid__header-price-group">
-					<div className="plan-features-2023-grid__header-price-group-prices">
-						<PlanPrice
-							currencyCode={ currencyCode }
-							rawPrice={ planPrices.rawPrice }
-							displayPerMonthNotation={ false }
-							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
-							isLargeCurrency={ isLargeCurrency }
-							original
-						/>
-						<PlanPrice
-							currencyCode={ currencyCode }
-							rawPrice={ planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice }
-							displayPerMonthNotation={ false }
-							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
-							isLargeCurrency={ isLargeCurrency }
-							discounted
-						/>
-					</div>
-				</span>
+				<PricesGroup isLargeCurrency={ isLargeCurrency }>
+					<PlanPrice
+						currencyCode={ currencyCode }
+						rawPrice={ planPrices.rawPrice }
+						displayPerMonthNotation={ false }
+						is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+						isLargeCurrency={ isLargeCurrency }
+						original
+					/>
+					<PlanPrice
+						currencyCode={ currencyCode }
+						rawPrice={ planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice }
+						displayPerMonthNotation={ false }
+						is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+						isLargeCurrency={ isLargeCurrency }
+						discounted
+					/>
+				</PricesGroup>
 			) }
 			{ ! shouldShowDiscountedPrice && (
 				<PlanPrice

--- a/client/my-sites/plan-features-2023-grid/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/header-price.tsx
@@ -20,6 +20,88 @@ const PricesGroup = styled.div< { isLargeCurrency: boolean } >`
 	gap: 4px;
 `;
 
+const HeaderPriceContainer = styled.div`
+	padding: 0 20px;
+	margin: 0 0 4px 0;
+
+	.plan-comparison-grid & {
+		padding: 0;
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-end;
+	}
+
+	.plan-price {
+		color: var( --studio-gray-100 );
+		margin: 0;
+		line-height: 1;
+		display: flex;
+		font-family: Recoleta, sans-serif;
+	}
+
+	.plan-price__currency-symbol,
+	.plan-price.is-discounted .plan-price__currency-symbol {
+		font-size: 14px;
+		color: var( --studio-gray-100 );
+		margin-top: 2px;
+	}
+
+	.plan-price__integer {
+		font-size: 44px;
+	}
+
+	.plan-price__term {
+		font-size: 12px;
+		font-weight: 400;
+	}
+
+	.plan-price.is-original {
+		color: var( --studio-gray-20 );
+
+		text-decoration: line-through;
+		text-decoration-thickness: 1px;
+		font-family: 'SF Pro Text', sans-serif;
+		margin-bottom: 5px;
+		font-size: 18px;
+
+		&::before {
+			display: none;
+		}
+
+		.plan-price__currency-symbol,
+		.plan-price__tax-amount {
+			color: var( --color-text-subtle );
+		}
+
+		.plan-price__integer {
+			font-size: 18px;
+		}
+		.plan-price__currency-symbol {
+			font-size: 8px;
+		}
+	}
+
+	.plan-price.is-discounted {
+		color: var( --color-neutral-70 );
+
+		.plan-price__integer-fraction {
+			color: inherit;
+		}
+	}
+
+	.plan-price.is-large-currency {
+		.plan-price__integer {
+			font-size: 38px;
+		}
+		&.is-original {
+			.plan-price__integer {
+				font-size: 16px;
+			}
+		}
+	}
+`;
+
 const PlanFeatures2023GridHeaderPrice = ( {
 	planProperties,
 	is2023OnboardingPricingGrid,
@@ -40,7 +122,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	}
 
 	return (
-		<div className="plan-features-2023-grid__pricing">
+		<HeaderPriceContainer>
 			{ shouldShowDiscountedPrice && (
 				<PricesGroup isLargeCurrency={ isLargeCurrency }>
 					<PlanPrice
@@ -70,7 +152,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 					isLargeCurrency={ isLargeCurrency }
 				/>
 			) }
-		</div>
+		</HeaderPriceContainer>
 	);
 };
 

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -296,6 +296,7 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 		planProperties: PlanProperties;
 		allVisible: boolean;
 		isLastInRow: boolean;
+		isLargeCurrency: boolean;
 	}
 > = ( {
 	planProperties,
@@ -312,6 +313,7 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 	isLaunchPage,
 	flowName,
 	selectedSiteSlug,
+	isLargeCurrency,
 	onUpgradeClick,
 } ) => {
 	const { planName, planConstantObj, availableForPurchase, current, ...planPropertiesObj } =
@@ -331,7 +333,6 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 		'is-current-plan': current,
 	} );
 	const rawPrice = planPropertiesObj.rawPrice;
-	const isLargeCurrency = rawPrice ? rawPrice > 99000 : false;
 	const showPlanSelect = ! allVisible && ! current;
 
 	return (
@@ -424,6 +425,10 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 } ) => {
 	const allVisible = visiblePlansProperties.length === displayedPlansProperties.length;
 
+	const isLargeCurrency = displayedPlansProperties.some(
+		( properties ) => properties?.rawPrice && properties?.rawPrice > 99000
+	);
+
 	return (
 		<PlanRow>
 			<RowTitleCell
@@ -448,6 +453,7 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 					selectedSiteSlug={ selectedSiteSlug }
 					onUpgradeClick={ onUpgradeClick }
 					isLaunchPage={ isLaunchPage }
+					isLargeCurrency={ isLargeCurrency }
 				/>
 			) ) }
 		</PlanRow>

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -323,6 +323,10 @@
 			font-weight: 600;
 		}
 
+		&.is-bottom-aligned {
+			vertical-align: bottom;
+		}
+
 
 		&.is-top-buttons {
 			padding: 0 20px;
@@ -336,27 +340,25 @@
 
 	.plan-features-2023-grid__pricing {
 		padding: 0 20px;
-		margin: 0;
+		margin: 0 0 4px 0;
 
 		.plan-price {
 			color: var(--studio-gray-100);
-			margin-right: 10px;
-			line-height: $font-title-large;
+			margin: 0;
+			line-height: 1;
 			display: flex;
 			@include onboarding-font-recoleta;
-			padding: 3px 0 6px;
 		}
 
 		.plan-price__currency-symbol,
 		.plan-price.is-discounted .plan-price__currency-symbol {
-			font-size: $font-title-medium;
+			font-size: rem(14px);
 			color: var(--studio-gray-100);
-			position: relative;
-			top: -7px;
+			margin-top: 2px;
 		}
 
 		.plan-price__integer {
-			font-size: 2.75rem;
+			font-size: rem(44px);
 		}
 
 		.plan-price__term {
@@ -365,18 +367,16 @@
 		}
 
 		.plan-price.is-original {
-			color: var(--color-neutral-light);
+			color: var(--studio-gray-20);
+
+			text-decoration: line-through;
+			text-decoration-thickness: 1px;
+			font-family: "SF Pro Text", $sans;
+			margin-bottom: 5px;
+			font-size: rem(18px);
 
 			&::before {
-				left: -1%;
-				top: 43%;
-				right: 80%;
-				transform: rotate(16deg);
-				border-color: #000;
-
-				@include plans-2023-break-small {
-					right: 68%;
-				}
+				display: none;
 			}
 
 			.plan-price__currency-symbol,
@@ -385,11 +385,10 @@
 			}
 
 			.plan-price__integer {
-				font-size: $font-title-medium;
+				font-size: rem(18px);
 			}
 			.plan-price__currency-symbol {
-				font-size: $font-body-extra-small;
-				top: -4px;
+				font-size: rem(8px);
 			}
 		}
 
@@ -407,7 +406,7 @@
 			}
 			&.is-original {
 				.plan-price__integer {
-					font-size: $font-body-small;
+					font-size: rem(16px);
 				}
 			}
 		}
@@ -1027,12 +1026,6 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 
 			.plan-price__integer-fraction {
 				color: inherit;
-			}
-		}
-
-		.plan-price.is-large-currency {
-			.plan-price__integer {
-				font-size: rem(30px);
 			}
 		}
 	}

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -338,80 +338,6 @@
 		}
 	}
 
-	.plan-features-2023-grid__pricing {
-		padding: 0 20px;
-		margin: 0 0 4px 0;
-
-		.plan-price {
-			color: var(--studio-gray-100);
-			margin: 0;
-			line-height: 1;
-			display: flex;
-			@include onboarding-font-recoleta;
-		}
-
-		.plan-price__currency-symbol,
-		.plan-price.is-discounted .plan-price__currency-symbol {
-			font-size: rem(14px);
-			color: var(--studio-gray-100);
-			margin-top: 2px;
-		}
-
-		.plan-price__integer {
-			font-size: rem(44px);
-		}
-
-		.plan-price__term {
-			font-size: $font-body-extra-small;
-			font-weight: 400;
-		}
-
-		.plan-price.is-original {
-			color: var(--studio-gray-20);
-
-			text-decoration: line-through;
-			text-decoration-thickness: 1px;
-			font-family: "SF Pro Text", $sans;
-			margin-bottom: 5px;
-			font-size: rem(18px);
-
-			&::before {
-				display: none;
-			}
-
-			.plan-price__currency-symbol,
-			.plan-price__tax-amount {
-				color: var(--color-text-subtle);
-			}
-
-			.plan-price__integer {
-				font-size: rem(18px);
-			}
-			.plan-price__currency-symbol {
-				font-size: rem(8px);
-			}
-		}
-
-		.plan-price.is-discounted {
-			color: var(--color-neutral-70);
-
-			.plan-price__integer-fraction {
-				color: var(--color-success);
-			}
-		}
-
-		.plan-price.is-large-currency {
-			.plan-price__integer {
-				font-size: rem(38px);
-			}
-			&.is-original {
-				.plan-price__integer {
-					font-size: rem(16px);
-				}
-			}
-		}
-	}
-
 	.plan-features-2023-grid__header-annual-discount {
 		color: var(--studio-green-60);
 		&-is-loading {
@@ -1012,22 +938,6 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 		line-height: 1.2;
 		color: var(--studio-gray-100);
 		font-weight: 400;
-	}
-
-	.plan-features-2023-grid__pricing {
-		padding: 0;
-		flex: 1;
-		display: flex;
-		flex-direction: column;
-		justify-content: flex-end;
-
-		.plan-price.is-discounted {
-			color: var(--color-neutral-70);
-
-			.plan-price__integer-fraction {
-				color: inherit;
-			}
-		}
 	}
 
 	.plan-comparison-grid__billing-info {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1472

## Proposed Changes

* This PR updates the styling of discounts according to xkhhUlDowF13dRoXJqlRDM-fi-1872-54424 . It builds on top of #74960 so that it can utilize the refactored `PlanFeatures2023GridHeaderPrice` component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm that the discount styling matches the design in the following cases:
  * On `/start/plans` for a currency with a first-year discount.
<img width="1755" alt="image" src="https://user-images.githubusercontent.com/5436027/227961166-2509ed4d-dd59-4417-8242-8e2563459d52.png">
<img width="1769" alt="image" src="https://user-images.githubusercontent.com/5436027/227961188-aec0e2f3-f70d-48ae-a3e2-dca0a5a3ec1b.png">

  * On `/plans/<site slug>` where pro-rated discounts are applicable.
 
<img width="1454" alt="image" src="https://user-images.githubusercontent.com/5436027/227961080-269662df-1acb-4556-b142-98e1718902e6.png">

  * Both the above cases after switching to the IDR currency.
  
<img width="1704" alt="image" src="https://user-images.githubusercontent.com/5436027/227960611-6665a1e9-7350-48c8-8a30-1c9d5f81e414.png">
 
<img width="1299" alt="image" src="https://user-images.githubusercontent.com/5436027/227960531-a24752eb-7690-44a7-a62d-534afb3e1c13.png">

* Also check for mobile/tablet resolutions:
<img width="294" alt="image" src="https://user-images.githubusercontent.com/5436027/227961549-851ffbde-6f35-4fbf-a2ce-7ca999549762.png">
<img width="283" alt="image" src="https://user-images.githubusercontent.com/5436027/227961575-562e1487-e491-4958-86c8-a8cd3bc77f90.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?