### PR TITLE
Checkout: Add unit tests for akismet checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -299,6 +299,26 @@ describe( 'CheckoutMain', () => {
 		} );
 	} );
 
+	it( 'adds second product when the url has two akismet products', async () => {
+		const cartChanges = { products: [] };
+		const additionalProps = {
+			productAliasFromUrl: 'ak_plus_yearly_1,ak_plus_yearly_2',
+			sitelessCheckoutType: 'akismet',
+			isNoSiteCart: true,
+		};
+
+		render(
+			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
+			container
+		);
+
+		await waitFor( async () => {
+			screen
+				.getAllByLabelText( 'Akismet Plus (20K requests/month)' )
+				.map( ( element ) => expect( element ).toHaveTextContent( '$200' ) );
+		} );
+	} );
+
 	it( 'does not redirect if the cart is empty when it loads but the url has a concierge session', async () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'concierge-session' };

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -84,7 +84,6 @@ describe( 'CheckoutMain', () => {
 			additionalCartProps: Partial< Parameters< typeof ShoppingCartProvider > >;
 			useUndefinedCartKey?: boolean;
 		} ) => {
-			console.log( `additionalProps: ${ JSON.stringify( additionalProps ) }` );
 			const managerClient = createShoppingCartManagerClient( {
 				getCart: mockGetCartEndpointWith( { ...initialCart, ...( cartChanges ?? {} ) } ),
 				setCart: mockSetCartEndpoint,

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -279,6 +279,26 @@ describe( 'CheckoutMain', () => {
 		} );
 	} );
 
+	it( 'adds the product to the siteless cart when the url has an akismet product', async () => {
+		const cartChanges = { products: [] };
+		const additionalProps = {
+			productAliasFromUrl: 'ak_plus_yearly_1',
+			sitelessCheckoutType: 'akismet',
+			isNoSiteCart: true,
+		};
+
+		render(
+			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
+			container
+		);
+
+		await waitFor( async () => {
+			screen
+				.getAllByLabelText( 'Akismet Plus (10K requests/month)' )
+				.map( ( element ) => expect( element ).toHaveTextContent( '$100' ) );
+		} );
+	} );
+
 	it( 'does not redirect if the cart is empty when it loads but the url has a concierge session', async () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'concierge-session' };

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -7,6 +7,7 @@ import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automatt
 import { render, fireEvent, screen, within, waitFor, act } from '@testing-library/react';
 import { dispatch } from '@wordpress/data';
 import nock from 'nock';
+import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import { navigate } from 'calypso/lib/navigate';
@@ -51,13 +52,13 @@ describe( 'CheckoutMain', () => {
 	beforeEach( () => {
 		dispatch( CHECKOUT_STORE ).reset();
 		jest.clearAllMocks();
-		getPlansBySiteId.mockImplementation( () => ( {
+		( getPlansBySiteId as jest.Mock ).mockImplementation( () => ( {
 			data: getActivePersonalPlanDataForType( 'yearly' ),
 		} ) );
-		hasLoadedSiteDomains.mockImplementation( () => true );
-		getDomainsBySiteId.mockImplementation( () => [] );
-		isMarketplaceProduct.mockImplementation( () => false );
-		isJetpackSite.mockImplementation( () => false );
+		( hasLoadedSiteDomains as jest.Mock ).mockImplementation( () => true );
+		( getDomainsBySiteId as jest.Mock ).mockImplementation( () => [] );
+		( isMarketplaceProduct as jest.Mock ).mockImplementation( () => false );
+		( isJetpackSite as jest.Mock ).mockImplementation( () => false );
 
 		container = document.createElement( 'div' );
 		document.body.appendChild( container );
@@ -83,12 +84,15 @@ describe( 'CheckoutMain', () => {
 			additionalCartProps: Partial< Parameters< typeof ShoppingCartProvider > >;
 			useUndefinedCartKey?: boolean;
 		} ) => {
+			console.log( `additionalProps: ${ JSON.stringify( additionalProps ) }` );
 			const managerClient = createShoppingCartManagerClient( {
 				getCart: mockGetCartEndpointWith( { ...initialCart, ...( cartChanges ?? {} ) } ),
 				setCart: mockSetCartEndpoint,
 			} );
 			const mainCartKey = 123456;
-			useCartKey.mockImplementation( () => ( useUndefinedCartKey ? undefined : mainCartKey ) );
+			( useCartKey as jest.Mock ).mockImplementation( () =>
+				useUndefinedCartKey ? undefined : mainCartKey
+			);
 			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
 			nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {} );
 			mockMatchMediaOnWindow();
@@ -239,8 +243,8 @@ describe( 'CheckoutMain', () => {
 	} );
 
 	it( 'adds the product to the cart when the url has a jetpack product', async () => {
-		isJetpackSite.mockImplementation( () => true );
-		isAtomicSite.mockImplementation( () => false );
+		( isJetpackSite as jest.Mock ).mockImplementation( () => true );
+		( isAtomicSite as jest.Mock ).mockImplementation( () => false );
 
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'jetpack_scan' };
@@ -256,8 +260,8 @@ describe( 'CheckoutMain', () => {
 	} );
 
 	it( 'adds two products to the cart when the url has two jetpack products', async () => {
-		isJetpackSite.mockImplementation( () => true );
-		isAtomicSite.mockImplementation( () => false );
+		( isJetpackSite as jest.Mock ).mockImplementation( () => true );
+		( isAtomicSite as jest.Mock ).mockImplementation( () => false );
 
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'jetpack_scan,jetpack_backup_daily' };

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -27,7 +27,7 @@ export const stripeConfiguration = {
 	processor_id: 'IE',
 	js_url: 'https://stripe-js-url',
 	public_key: 'stripe-public-key',
-	setup_intent_id: null,
+	setup_intent_id: undefined,
 };
 
 export const processorOptions = {
@@ -319,7 +319,7 @@ export const planLevel2Biannual: ResponseCartProduct = {
 export const fetchStripeConfiguration = async () => stripeConfiguration;
 
 export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
-	return async ( _: number, requestCart: RequestCart ): Promise< ResponseCart > => {
+	return async ( _: CartKey, requestCart: RequestCart ): Promise< ResponseCart > => {
 		const { products: requestProducts, coupon: requestCoupon } = requestCart;
 		const products = requestProducts.map( convertRequestProductToResponseProduct( currency ) );
 
@@ -696,6 +696,7 @@ function convertRequestProductToResponseProduct(
 								lastname: 'Person',
 								recoveryEmail: 'foo@example.com',
 								hash: '1234567',
+								password: '1234567',
 							},
 						],
 					},
@@ -759,6 +760,23 @@ function convertRequestProductToResponseProduct(
 					item_subtotal_integer: 4200,
 					bill_period: '365',
 					months_per_bill_period: 12,
+					item_tax: 0,
+					meta: product.meta,
+					volume: 1,
+					extra: {},
+				};
+
+			case 'ak_plus_yearly_1':
+				return {
+					...getEmptyResponseCartProduct(),
+					product_id: 2311,
+					product_name: 'Akismet Plus (10K requests/month)',
+					product_slug: 'ak_plus_yearly_1',
+					bill_period: '365',
+					currency: currency,
+					is_domain_registration: false,
+					item_original_cost_integer: 10000,
+					item_subtotal_integer: 10000,
 					item_tax: 0,
 					meta: product.meta,
 					volume: 1,
@@ -1179,8 +1197,9 @@ export function mockTransactionsEndpoint( transactionsEndpointResponse ) {
 }
 
 export function setMockLocation( href: string ) {
-	const url = new URL( href );
-	jest.spyOn( window, 'location', 'get' ).mockReturnValue( url );
+	const location = new Location();
+	location.href = href;
+	jest.spyOn( window, 'location', 'get' ).mockReturnValue( location );
 }
 
 export const mockCreateAccountSiteNotCreatedResponse = () => [ 200, { success: true } ];
@@ -1348,7 +1367,7 @@ expect.extend( {
 	 */
 	async toNeverAppear( elementPromise: Promise< HTMLElement > ) {
 		let pass = false;
-		let element = null;
+		let element: HTMLElement | null = null;
 		try {
 			element = await elementPromise;
 		} catch {
@@ -1420,7 +1439,7 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 		case planLevel2Monthly.product_slug:
 			return {
 				product_id: planLevel2Monthly.product_id,
-				bill_period_in_months: planLevel2Monthly.months_per_bill_period,
+				bill_period_in_months: planLevel2Monthly.months_per_bill_period as number,
 				product_slug: data.product_slug,
 				currency: planLevel2Monthly.currency,
 				price_integer: getVariantPrice( planLevel2Monthly ),
@@ -1430,7 +1449,7 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 		case planLevel2.product_slug:
 			return {
 				product_id: planLevel2.product_id,
-				bill_period_in_months: planLevel2.months_per_bill_period,
+				bill_period_in_months: planLevel2.months_per_bill_period as number,
 				product_slug: data.product_slug,
 				currency: planLevel2.currency,
 				price_integer: getVariantPrice( planLevel2 ),
@@ -1440,7 +1459,7 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 		case planLevel2Biannual.product_slug:
 			return {
 				product_id: planLevel2Biannual.product_id,
-				bill_period_in_months: planLevel2Biannual.months_per_bill_period,
+				bill_period_in_months: planLevel2Biannual.months_per_bill_period as number,
 				product_slug: data.product_slug,
 				currency: planLevel2Biannual.currency,
 				price_integer: getVariantPrice( planLevel2Biannual ),
@@ -1450,7 +1469,7 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 		case planWithoutDomainMonthly.product_slug:
 			return {
 				product_id: planWithoutDomainMonthly.product_id,
-				bill_period_in_months: planWithoutDomainMonthly.months_per_bill_period,
+				bill_period_in_months: planWithoutDomainMonthly.months_per_bill_period as number,
 				product_slug: data.product_slug,
 				currency: planWithoutDomainMonthly.currency,
 				price_integer: getVariantPrice( planWithoutDomainMonthly ),
@@ -1460,7 +1479,7 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 		case planWithoutDomain.product_slug:
 			return {
 				product_id: planWithoutDomain.product_id,
-				bill_period_in_months: planWithoutDomain.months_per_bill_period,
+				bill_period_in_months: planWithoutDomain.months_per_bill_period as number,
 				product_slug: data.product_slug,
 				currency: planWithoutDomain.currency,
 				price_integer: getVariantPrice( planWithoutDomain ),
@@ -1470,7 +1489,7 @@ function buildVariant( data: ResponseCartProduct ): ResponseCartProductVariant {
 		case planWithoutDomainBiannual.product_slug:
 			return {
 				product_id: planWithoutDomainBiannual.product_id,
-				bill_period_in_months: planWithoutDomainBiannual.months_per_bill_period,
+				bill_period_in_months: planWithoutDomainBiannual.months_per_bill_period as number,
 				product_slug: data.product_slug,
 				currency: planWithoutDomainBiannual.currency,
 				price_integer: getVariantPrice( planWithoutDomainBiannual ),

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -780,7 +780,9 @@ function convertRequestProductToResponseProduct(
 					item_tax: 0,
 					meta: product.meta,
 					volume: 1,
-					extra: {},
+					extra: {
+						isAkismetSitelessCheckout: true,
+					},
 				};
 			case planLevel2.product_slug:
 				return {

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -581,6 +581,15 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				bill_period: 'yearly',
 				currency: 'USD',
 			};
+		case 'ak_plus_yearly_1':
+			return {
+				...getEmptyResponseCartProduct(),
+				product_id: 2311,
+				product_name: 'Akismet Plus (10K requests/month)',
+				product_slug: productSlug,
+				bill_period: 'yearly',
+				currency: 'USD',
+			};
 		default:
 			return getEmptyResponseCartProduct();
 	}
@@ -1199,9 +1208,12 @@ export function mockTransactionsEndpoint( transactionsEndpointResponse ) {
 }
 
 export function setMockLocation( href: string ) {
-	const location = new Location();
-	location.href = href;
-	jest.spyOn( window, 'location', 'get' ).mockReturnValue( location );
+	Object.defineProperty( window, 'location', {
+		get() {
+			return { href: href };
+		},
+	} );
+	jest.spyOn( window, 'location', 'get' ).mockReturnValue( window.location );
 }
 
 export const mockCreateAccountSiteNotCreatedResponse = () => [ 200, { success: true } ];

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -581,15 +581,6 @@ export function convertProductSlugToResponseProduct( productSlug: string ): Resp
 				bill_period: 'yearly',
 				currency: 'USD',
 			};
-		case 'ak_plus_yearly_1':
-			return {
-				...getEmptyResponseCartProduct(),
-				product_id: 2311,
-				product_name: 'Akismet Plus (10K requests/month)',
-				product_slug: productSlug,
-				bill_period: 'yearly',
-				currency: 'USD',
-			};
 		default:
 			return getEmptyResponseCartProduct();
 	}
@@ -786,6 +777,24 @@ function convertRequestProductToResponseProduct(
 					is_domain_registration: false,
 					item_original_cost_integer: 10000,
 					item_subtotal_integer: 10000,
+					item_tax: 0,
+					meta: product.meta,
+					volume: 1,
+					extra: {
+						isAkismetSitelessCheckout: true,
+					},
+				};
+			case 'ak_plus_yearly_2':
+				return {
+					...getEmptyResponseCartProduct(),
+					product_id: 2313,
+					product_name: 'Akismet Plus (20K requests/month)',
+					product_slug: 'ak_plus_yearly_2',
+					bill_period: '365',
+					currency: currency,
+					is_domain_registration: false,
+					item_original_cost_integer: 20000,
+					item_subtotal_integer: 20000,
 					item_tax: 0,
 					meta: product.meta,
 					volume: 1,
@@ -1208,12 +1217,8 @@ export function mockTransactionsEndpoint( transactionsEndpointResponse ) {
 }
 
 export function setMockLocation( href: string ) {
-	Object.defineProperty( window, 'location', {
-		get() {
-			return { href: href };
-		},
-	} );
-	jest.spyOn( window, 'location', 'get' ).mockReturnValue( window.location );
+	const url = new URL( href );
+	jest.spyOn( window, 'location', 'get' ).mockReturnValue( url );
 }
 
 export const mockCreateAccountSiteNotCreatedResponse = () => [ 200, { success: true } ];


### PR DESCRIPTION
## Proposed Changes

This PR adds useful tests for the Akismet siteless checkout flow that haven't already been added

It also fixes a number of TypeScript errors in the files that were touched

## Testing Instructions

1. Make sure all tests are passing
2. Make sure the tests added make sense and that there aren't any more that would make sense to be added here

If you want to run the new tests manually

3. Checkout this branch
4. From the root Calypso directory, run `yarn test-client client/my-sites/checkout/composite-checkout/test/checkout-main.tsx`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
