### PR TITLE
Fix nock-related notice in launchpad tests

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -78,13 +78,16 @@ function renderStepContent( emailVerified = false, flow: string ) {
 describe( 'StepContent', () => {
 	beforeEach( () => {
 		nock( 'https://public-api.wordpress.com' )
-			.persist()
 			.get( `/wpcom/v2/sites/${ siteSlug }/launchpad` )
 			.reply( 200, {
 				checklist_statuses: {},
 				launchpad_screen: 'full',
 				site_intent: '',
 			} );
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
 	} );
 
 	// To get things started, test basic rendering for Newsletter flow

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -3,6 +3,7 @@
  */
 import { NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { render, screen } from '@testing-library/react';
+import nock from 'nock';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
@@ -14,9 +15,10 @@ import StepContent from '../step-content';
 import { defaultSiteDetails } from './lib/fixtures';
 
 const mockSite = defaultSiteDetails;
+const siteSlug = 'testlinkinbio.wordpress.com';
 
 const stepContentProps = {
-	siteSlug: 'testsite.wordpress.com',
+	siteSlug,
 	/* eslint-disable @typescript-eslint/no-empty-function */
 	submit: () => {},
 	goNext: () => {},
@@ -74,6 +76,17 @@ function renderStepContent( emailVerified = false, flow: string ) {
 }
 
 describe( 'StepContent', () => {
+	beforeEach( () => {
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( `/wpcom/v2/sites/${ siteSlug }/launchpad` )
+			.reply( 200, {
+				checklist_statuses: {},
+				launchpad_screen: 'full',
+				site_intent: '',
+			} );
+	} );
+
 	// To get things started, test basic rendering for Newsletter flow
 	// In future, we can add additional flows and test interactivity of items
 	describe( 'when flow is Newsletter', () => {


### PR DESCRIPTION
### Proposed Changes

Launchpad unit tests were passing, but throwing a notice/error related to nock and api requests. This PR resolves this by nocking our requests to the launchpad endpoint in the tests for launchpad/step-content.tsx. 

![nock error](https://user-images.githubusercontent.com/21228350/228010478-2902613f-2953-43e0-900f-aaa9cd7972ee.png)

### Testing

Check out this branch and run launchpad tests with `yarn run test-client client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/`. Confirm that all launchpad tests pass and that the error/notice above does not appear. 