### PR TITLE
AT E2E: refactor the `Editor: Advanced Post Flow` spec to bypass iframe issues.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -657,13 +657,11 @@ export class EditorPage {
 
 		// AT and Simple sites have slightly differing response from the API.
 		let publishedURL: string;
-		try {
+		if ( json.link ) {
 			publishedURL = json.link;
-		} catch {
+		} else if ( json.body.link ) {
 			publishedURL = json.body.link;
-		}
-
-		if ( ! publishedURL ) {
+		} else {
 			throw new Error( 'No published article URL found in response.' );
 		}
 

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -69,6 +69,11 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 			postURL = await editorPage.publish();
 		} );
 
+		/**
+		 * Validates post in the same tab to work around an issue with AT caching.
+		 *
+		 * @see https://github.com/Automattic/wp-calypso/pull/67964
+		 */
 		it( 'Validate post', async function () {
 			await page.goto( postURL.href );
 
@@ -84,11 +89,8 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 
 	describe( 'Edit published post', function () {
 		beforeAll( async () => {
-			await postsPage.visit();
-		} );
-
-		it( 'Click on published post', async function () {
-			await postsPage.clickPost( postTitle );
+			// See: https://github.com/Automattic/wp-calypso/issues/74925
+			await page.goBack();
 		} );
 
 		it( 'Editor is shown', async function () {
@@ -109,6 +111,11 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 			postURL = await editorPage.publish();
 		} );
 
+		/**
+		 * Validates post in the same tab to work around an issue with AT caching.
+		 *
+		 * @see https://github.com/Automattic/wp-calypso/pull/67964
+		 */
 		it( 'Ensure published post contains additional content', async function () {
 			await page.goto( postURL.href );
 			await ParagraphBlock.validatePublishedContent( page, [ originalContent, additionalContent ] );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74925.

## Proposed Changes

This PR is a minor refactor to the `EditorPage` POM and the `Editor: Advanced Post Flow` spec in order to work around editor iframing issues on AT sites.

Key changes
- reduce EXTENDED_EDITOR_WAIT_TIMEOUT value to 20 seconds.
- new constant EXTENDED_EDITOR_WAIT_ATOMIC_TIMEOUT set at 60 seconds.
- instead of a hard switch when obtaining the published post link in `EditorPage.publish`, use a try/catch.
- modify the `Editor: Advanced Post Flow" spec to use the Back button instead of navigating to the editor again from the /posts page. See https://github.com/Automattic/wp-calypso/issues/74925.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E Simple (desktop)
  - [x] Gutenberg E2E Simple (mobile)
  - [x] Gutenberg E2E Atomic (desktop)
  - [x] Gutenberg E2E Atomic (mobile)

### Desktop
![image](https://user-images.githubusercontent.com/6549265/228039498-4093bb87-5f7b-447e-8c7c-fd2cf29b4d5e.png)

### Mobile
![image](https://user-images.githubusercontent.com/6549265/228039545-09f555fa-86c1-426b-a899-57ce3874a6ac.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
