### PR TITLE
Woo Express Performance: Plans page copy changes

### DIFF
--- a/client/my-sites/plans/components/plans-header/index.tsx
+++ b/client/my-sites/plans/components/plans-header/index.tsx
@@ -58,11 +58,12 @@ const DomainUpsellHeader: React.FunctionComponent = () => {
 
 const PlansHeader: React.FunctionComponent< {
 	domainFromHomeUpsellFlow?: string;
-} > = ( { domainFromHomeUpsellFlow } ) => {
+	subHeaderText?: string;
+} > = ( { domainFromHomeUpsellFlow, subHeaderText } ) => {
 	const translate = useTranslate();
-	const plansDescription = translate(
-		'See and compare the features available on each WordPress.com plan.'
-	);
+	const plansDescription =
+		subHeaderText ??
+		translate( 'See and compare the features available on each WordPress.com plan.' );
 
 	if ( domainFromHomeUpsellFlow ) {
 		return <DomainUpsellHeader />;

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -338,6 +338,11 @@ class Plans extends Component {
 			PLAN_WOOEXPRESS_SMALL,
 			PLAN_WOOEXPRESS_SMALL_MONTHLY,
 		].includes( currentPlanSlug );
+		const wooExpressSubHeaderText = translate(
+			"Discover what's available in your Woo Express plan."
+		);
+		// Use the Woo Express subheader text if the current plan has the Performance or trial plans or fallback to the default subheader text.
+		const subHeaderText = isWooExpressPlan || isEcommerceTrial ? wooExpressSubHeaderText : null;
 
 		const allDomains = isDomainAndPlanPackageFlow ? getDomainRegistrations( this.props.cart ) : [];
 		const yourDomainName = allDomains.length
@@ -371,7 +376,7 @@ class Plans extends Component {
 				{ isDomainUpsell && <DomainUpsellDialog domain={ selectedSite.slug } /> }
 				{ canAccessPlans && (
 					<div>
-						{ ! isDomainAndPlanPackageFlow && <PlansHeader /> }
+						{ ! isDomainAndPlanPackageFlow && <PlansHeader subHeaderText={ subHeaderText } /> }
 						{ isDomainAndPlanPackageFlow && (
 							<>
 								<div className="plans__header">

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -891,7 +891,7 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 } );
 const getPlanWooExpressMediumDetails = (): IncompleteWPcomPlan => ( {
 	...getPlanEcommerceDetails(),
-	getTitle: () => i18n.translate( 'Woo Express Performance' ),
+	getTitle: () => i18n.translate( 'Performance' ),
 	getTagline: () =>
 		i18n.translate(
 			'Learn more about everything included with Woo Express Performance and take advantage of its powerful marketplace features.'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #74899

## Proposed Changes

* Update the plan name in the plans-list (Woo Express Performance to Performance)
* Change the plans sub header text for Performance and trial plan sites

Original subheader copy
> See and compare the features available on each WordPress.com plan.

Woo Express subheader copy
> Discover what's available in your Woo Express plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch or use the calypso.live link.

## Non-Woo Express site
* Create any non-Woo Express site. A free site is the easiest.
* Go to `/plans/:siteSlug`.
* You should see the original plans subheader copy.

![image](https://user-images.githubusercontent.com/917632/228223458-7a77ba88-7ddb-4977-ba02-76b25269207c.png)

## Woo Express Trial site
* Create a Woo Express trial site by going to `/setup/wooexpress`.
* Go to `/plans/:siteSlug`.
* You should see the new subheader copy.
* The name of the plan should also just be "Performance".

![image](https://user-images.githubusercontent.com/917632/228223667-afc049f1-2456-4d35-97a5-2133d07f3ff7.png)

## Woo Express Performance site
* Upgrade the trial site created previously (or go to an existing Performance plan site).
* Go to `/plans/:siteSlug`.
* You should see the new subheader copy.
* The name of the plan should also just be "Performance".

![image](https://user-images.githubusercontent.com/917632/228223975-80bcbf21-7f77-405b-9d49-471b011cec8d.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
