### PR TITLE
Add couple of tweaks to reader notifications

### DIFF
--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -30,6 +30,7 @@ class MasterbarItemNotifications extends Component {
 	state = {
 		animationState: 0,
 		newNote: this.props.hasUnseenNotifications,
+		forceIsActive: window.location.pathname === '/read/notifications',
 	};
 
 	componentDidUpdate( prevProps ) {
@@ -110,7 +111,7 @@ class MasterbarItemNotifications extends Component {
 
 	render() {
 		const classes = classNames( this.props.className, 'masterbar-notifications', {
-			'is-active': this.props.isNotificationsOpen,
+			'is-active': this.props.isNotificationsOpen || this.state.forceIsActive,
 			'has-unread': this.state.newNote,
 			'is-initial-load': this.state.animationState === -1,
 		} );

--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -30,7 +30,6 @@ class MasterbarItemNotifications extends Component {
 	state = {
 		animationState: 0,
 		newNote: this.props.hasUnseenNotifications,
-		forceIsActive: window.location.pathname === '/read/notifications',
 	};
 
 	componentDidUpdate( prevProps ) {
@@ -111,7 +110,8 @@ class MasterbarItemNotifications extends Component {
 
 	render() {
 		const classes = classNames( this.props.className, 'masterbar-notifications', {
-			'is-active': this.props.isNotificationsOpen || this.state.forceIsActive,
+			'is-active':
+				this.props.isNotificationsOpen || window.location.pathname === '/read/notifications',
 			'has-unread': this.state.newNote,
 			'is-initial-load': this.state.animationState === -1,
 		} );

--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -1,4 +1,5 @@
 import AsyncLoad from 'calypso/components/async-load';
+import DocumentHead from 'calypso/components/data/document-head';
 import { sectionify } from 'calypso/lib/route';
 import { trackPageLoad } from 'calypso/reader/controller-helper';
 import { recordTrack } from 'calypso/reader/stats';
@@ -11,15 +12,18 @@ export function notifications( context, next ) {
 	recordTrack( 'calypso_reader_notifications_viewed' );
 
 	context.primary = (
-		<div className="reader-notifications__panel">
-			<AsyncLoad
-				require="calypso/notifications"
-				isShowing={ true }
-				checkToggle={ () => {} }
-				setIndicator={ () => {} }
-				placeholder={ null }
-			/>
-		</div>
+		<>
+			<DocumentHead title="Notifications" />
+			<div className="reader-notifications__panel">
+				<AsyncLoad
+					require="calypso/notifications"
+					isShowing={ true }
+					checkToggle={ () => {} }
+					setIndicator={ () => {} }
+					placeholder={ null }
+				/>
+			</div>
+		</>
 	);
 	next();
 }

--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -1,3 +1,4 @@
+import { useTranslate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import { sectionify } from 'calypso/lib/route';
@@ -11,9 +12,22 @@ export function notifications( context, next ) {
 	trackPageLoad( basePath, 'Reader > Notifications', mcKey );
 	recordTrack( 'calypso_reader_notifications_viewed' );
 
+	const NotificationTitle = () => {
+		const translate = useTranslate();
+		return (
+			<DocumentHead
+				title={ translate( '%s ‹ Reader', {
+					args: 'Notifications',
+					comment: '%s is the section name. For example: "My Likes"',
+					textOnly: true,
+				} ) }
+			/>
+		);
+	};
+
 	context.primary = (
 		<>
-			<DocumentHead title="Notifications" />
+			<NotificationTitle />
 			<div className="reader-notifications__panel">
 				<AsyncLoad
 					require="calypso/notifications"


### PR DESCRIPTION
This PR does 2 things;

* Adds page title to the reader notifications page - https://calypso.localhost/read/notifications/
* Forces the bell/notification icon to active to highlight the fact that these notifications are the same as the iframed notifications

<img width="894" alt="Screenshot 2023-03-28 at 10 17 01" src="https://user-images.githubusercontent.com/5560595/228189874-74147aba-4747-4321-88b2-d5cb7627ba83.png">

