### PR TITLE
Hide variant picker for Akismet Personal plans

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -1,4 +1,8 @@
-import { isAkismetProduct, isJetpackPurchasableItem } from '@automattic/calypso-products';
+import {
+	isAkismetPersonalProduct,
+	isAkismetProduct,
+	isJetpackPurchasableItem,
+} from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { isCopySiteFlow } from '@automattic/onboarding';
 import {
@@ -17,7 +21,7 @@ import { useState } from 'react';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
-import { ItemVariationPicker } from './item-variation-picker';
+import { ItemVariationPicker, WPCOMProductVariant } from './item-variation-picker';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { Theme } from '@automattic/composite-checkout';
 import type {
@@ -189,6 +193,10 @@ function LineItemWrapper( {
 		isJetpackPurchasableItem( product.product_slug )
 	);
 
+	const hasEligibleAkismetVariant = ( variant: WPCOMProductVariant ) => {
+		return isAkismetProduct( variant ) && ! isAkismetPersonalProduct( variant );
+	};
+
 	const variants = useGetProductVariants( product, ( variant ) => {
 		// Only show term variants which are equal to or longer than the variant that
 		// was in the cart when checkout finished loading (not necessarily the
@@ -197,10 +205,11 @@ function LineItemWrapper( {
 		if ( ! initialVariantTerm ) {
 			return true;
 		}
-		const isAkismet = isAkismetProduct( { product_slug: variant.productSlug } );
-		if ( isJetpack || isAkismet ) {
+
+		if ( isJetpack || hasEligibleAkismetVariant( variant ) ) {
 			return true;
 		}
+
 		return variant.termIntervalInMonths >= initialVariantTerm;
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker-dropdown.tsx
@@ -7,6 +7,7 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { dispatch } from '@wordpress/data';
 import nock from 'nock';
+import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -17,6 +18,7 @@ import CheckoutMain from '../components/checkout-main';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
 import {
 	siteId,
+	akismetPersonalProduct,
 	domainProduct,
 	planWithoutDomain,
 	fetchStripeConfiguration,
@@ -292,6 +294,13 @@ describe( 'CheckoutMain with a variant picker', () => {
 	it( 'does not render the variant picker for a renewal of the current plan', async () => {
 		const currentPlanRenewal = { ...planWithoutDomain, extra: { purchaseType: 'renewal' } };
 		const cartChanges = { products: [ currentPlanRenewal ] };
+		render( <MyCheckout cartChanges={ cartChanges } /> );
+
+		await expect( screen.findByLabelText( 'Pick a product term' ) ).toNeverAppear();
+	} );
+
+	it( 'does not render the variant picker for akismet personal plans', async () => {
+		const cartChanges = { products: [ akismetPersonalProduct ] };
 		render( <MyCheckout cartChanges={ cartChanges } /> );
 
 		await expect( screen.findByLabelText( 'Pick a product term' ) ).toNeverAppear();

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -127,6 +127,24 @@ export const stateList = {
 
 export const siteId = 13579;
 
+export const akismetPersonalProduct: ResponseCartProduct = {
+	...getEmptyResponseCartProduct(),
+	product_name: 'Akismet Personal (Paid)',
+	product_slug: 'ak_personal_yearly',
+	currency: 'USD',
+	extra: {
+		isAkismetSitelessCheckout: true,
+	},
+	meta: 'foo.com',
+	product_id: 2310,
+	volume: 30,
+	is_domain_registration: false,
+	item_original_cost_integer: 30000,
+	item_subtotal_integer: 30000,
+	bill_period: '365',
+	months_per_bill_period: 12,
+};
+
 export const domainProduct: ResponseCartProduct = {
 	...getEmptyResponseCartProduct(),
 	product_name: '.cash Domain',

--- a/packages/calypso-products/src/is-akismet-personal-product.ts
+++ b/packages/calypso-products/src/is-akismet-personal-product.ts
@@ -1,0 +1,11 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
+import { AKISMET_PERSONAL_PRODUCTS } from './constants/akismet';
+import type { WithCamelCaseSlug, WithSnakeCaseSlug } from './types';
+
+export function isAkismetPersonalProduct(
+	product: WithSnakeCaseSlug | WithCamelCaseSlug
+): boolean {
+	return ( AKISMET_PERSONAL_PRODUCTS as ReadonlyArray< string > ).includes(
+		camelOrSnakeSlug( product )
+	);
+}

--- a/packages/calypso-products/src/is-akismet-product.ts
+++ b/packages/calypso-products/src/is-akismet-product.ts
@@ -1,8 +1,8 @@
 import { camelOrSnakeSlug } from './camel-or-snake-slug';
 import { AKISMET_PRODUCTS_LIST } from './constants/akismet';
-import type { WithSnakeCaseSlug } from './types';
+import type { WithCamelCaseSlug, WithSnakeCaseSlug } from './types';
 
-export function isAkismetProduct( product: WithSnakeCaseSlug ): boolean {
+export function isAkismetProduct( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
 	return ( AKISMET_PRODUCTS_LIST as ReadonlyArray< string > ).includes(
 		camelOrSnakeSlug( product )
 	);

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -20,6 +20,7 @@ export { getProductFromSlug } from './get-product-from-slug';
 export { getProductsSlugs } from './get-products-slugs';
 export { isAddOn } from './is-add-on';
 export { isAkismetProduct } from './is-akismet-product';
+export { isAkismetPersonalProduct } from './is-akismet-personal-product';
 export { isBiennially } from './is-biennially';
 export { isBlogger } from './is-blogger';
 export { isBundled } from './is-bundled';


### PR DESCRIPTION
## Proposed Changes

This diff removes the product variant picker for Akismet Personal plans, as we are only planning on selling yearly plans for now

Notes:
 * There is a bug right now where a yearly plan is pro-rated due to wpcom detecting the first Akismet Personal subscription ever purchased and reducing the price based on that. A fix for that is in progress
 * The variant picker will still currently show for Akismet Personal Monthly plans, but this product will automatically be removed from the cart when some new validation is added soon: 1201210512993648-as-1204264517688090/f

## Testing Instructions

1. Checkout this branch
2. Sandbox `public-api.wordpress.com`
3. Make sure you are using the Store Sandbox
4. Head to http://calypso.localhost:3000/checkout/akismet/ak_personal_yearly:-q-36
5. Make sure the display of the pricing is not confusing and makes sense (this is where the pro-rated discount mentioned in the `Proposed Changes` section will show up, you can ignore this aspect)
![image](https://user-images.githubusercontent.com/65001528/228069513-e240923f-0611-4ca8-9e9d-e88b4b3deee2.png)
6. Make sure the variant picker does not show up
7. Go to http://calypso.localhost:3000/me/purchases and find your new subscription
8. Open the manage purchase page associated with it and make sure everything looks good
![image](https://user-images.githubusercontent.com/65001528/228069872-e4008ec8-e8a4-4cc6-8727-25d9214fedb8.png)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?