### PR TITLE
Update checkout exit to redirect to launchpad based on redirect_to param

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/leave-checkout.ts
@@ -1,4 +1,5 @@
 import { isTailoredSignupFlow } from '@automattic/onboarding';
+import { getQueryArg } from '@wordpress/url';
 import debugFactory from 'debug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { navigate } from 'calypso/lib/navigate';
@@ -32,12 +33,21 @@ export const leaveCheckout = ( {
 	} );
 
 	const signupFlowName = getSignupCompleteFlowName();
+	const redirectToParam = getQueryArg( window.location.href, 'redirect_to' );
+	const launchpadURLRegex = /setup\/(.*)\/launchpad\b/g;
+	const launchpadURLRegexMatch = redirectToParam?.toString().match( launchpadURLRegex );
 
 	if ( isTailoredSignupFlow( signupFlowName ) ) {
 		const urlFromCookie = retrieveSignupDestination();
 		if ( urlFromCookie ) {
 			window.location.assign( urlFromCookie );
 		}
+	}
+
+	if ( redirectToParam && launchpadURLRegexMatch ) {
+		const launchpadUrl = redirectToParam?.toString();
+		window.location.assign( launchpadUrl );
+		return;
 	}
 
 	if ( forceCheckoutBackUrl ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74962

## Proposed Changes

* "For the "Choose a domain" task flow of launchpad, if the user exits checkout they are redirected into calypso."
These changes ensure the user is redirected to the launchpad screen if they exit out of the checkout screen.

![image](https://user-images.githubusercontent.com/10482592/228065911-a6716495-bc7b-4352-84a4-1b1a890c8596.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Create a write flow launchpad-enabled site or use an existing site
* Navigate to the launchpad screen
* Click the "Choose a domain" task, select a domain, then select a plan.
* Click the "x" icon on the top left side of the masterbar on the checkout screen. A modal confirming that you want to exit the checkout flow should appear.
* Verify the "Empty Cart" button redirects to the launchpad screen
* Verify the "Leave Items" button redirects to the launchpad screen

<img width="311" alt="CleanShot 2023-03-27 at 17 07 20@2x" src="https://user-images.githubusercontent.com/10482592/228066807-233e044b-64c2-45f3-bb8d-a3d914f608e2.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
