### PR TITLE
Shopping Cart: Remove create_new_blog property

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -107,7 +107,11 @@ export default function useCreatePaymentCompleteCallback( {
 			// created site in the Thank You page URL.
 			// TODO: It does not seem like this would be needed for Akismet, but marking to follow up
 			let jetpackTemporarySiteId;
-			if ( sitelessCheckoutType === 'jetpack' && ! siteSlug && responseCart.create_new_blog ) {
+			if (
+				sitelessCheckoutType === 'jetpack' &&
+				! siteSlug &&
+				[ 'no-user', 'no-site' ].includes( String( responseCart.cart_key ) )
+			) {
 				jetpackTemporarySiteId =
 					transactionResult.purchases && Object.keys( transactionResult.purchases ).pop();
 			}

--- a/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
@@ -60,7 +60,6 @@ export async function createWpcomAccountBeforeTransaction(
 			...transactionCart,
 			blog_id: siteId ? String( siteId ) : '0',
 			cart_key: ( siteId ? siteId : 'no-site' ) as CartKey,
-			create_new_blog: siteId ? false : true,
 		};
 	} );
 }

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -65,10 +65,6 @@ export function createTransactionEndpointCartFromResponseCart( {
 		} )
 	) {
 		const isUserLess = responseCart.cart_key === 'no-user';
-		const isSiteLess = responseCart.blog_id === 0;
-		const isSiteLessRenewal = responseCart.products.some( ( product ) => {
-			return product.extra?.purchaseType === 'renewal' && product.extra.isAkismetSitelessCheckout;
-		} );
 
 		// At this point, cart_key will be 'no-user' | blog_id | 'no-site', in that order.
 		const cartKey = isUserLess ? responseCart.cart_key : responseCart.blog_id || 'no-site';
@@ -80,8 +76,6 @@ export function createTransactionEndpointCartFromResponseCart( {
 		return {
 			blog_id: responseCart.blog_id.toString(),
 			cart_key: cartKey as CartKey,
-			// We do NOT need a new blog for a site-less renewal (Right now, this just Akismet renewals)
-			create_new_blog: isSiteLess && ! isSiteLessRenewal,
 			coupon: responseCart.coupon || '',
 			temporary: false,
 			products: responseCart.products.map( ( item ) =>
@@ -94,7 +88,6 @@ export function createTransactionEndpointCartFromResponseCart( {
 	return {
 		blog_id: siteId || '0',
 		cart_key: ( siteId || 'no-site' ) as CartKey,
-		create_new_blog: siteId ? false : true,
 		coupon: responseCart.coupon || '',
 		temporary: false,
 		products: responseCart.products.map( ( item ) =>

--- a/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
@@ -37,7 +37,6 @@ describe( 'existingCardProcessor', () => {
 			blog_id: '0',
 			cart_key: 'no-site',
 			coupon: '',
-			create_new_blog: true,
 			products: [ product ],
 			tax: {
 				location: {},
@@ -190,7 +189,6 @@ describe( 'existingCardProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 			},
 		} );
 	} );
@@ -232,7 +230,6 @@ describe( 'existingCardProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 				tax: { location: { postal_code: 'pr267ry', country_code: 'GB' } },
 			},
 		} );
@@ -264,7 +261,6 @@ describe( 'existingCardProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 				products: [ domainProduct ],
 			},
 			domain_details: basicExpectedDomainDetails,

--- a/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
@@ -43,7 +43,6 @@ describe( 'freePurchaseProcessor', () => {
 			blog_id: '0',
 			cart_key: 'no-site',
 			coupon: '',
-			create_new_blog: true,
 			products: [ product ],
 			tax: {
 				location: {},
@@ -121,7 +120,6 @@ describe( 'freePurchaseProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 			},
 		} );
 	} );
@@ -157,7 +155,6 @@ describe( 'freePurchaseProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 			},
 		} );
 	} );
@@ -197,7 +194,6 @@ describe( 'freePurchaseProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 				products: [ domainProduct ],
 				tax: { location: { postal_code: 'pr267ry', country_code: 'GB' } },
 			},
@@ -231,7 +227,6 @@ describe( 'freePurchaseProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 				products: [ domainProduct ],
 			},
 			domain_details: basicExpectedDomainDetails,

--- a/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
@@ -28,7 +28,6 @@ describe( 'genericRedirectProcessor', () => {
 			blog_id: '0',
 			cart_key: 'no-site',
 			coupon: '',
-			create_new_blog: true,
 			products: [ product ],
 			tax: {
 				location: {},
@@ -147,7 +146,6 @@ describe( 'genericRedirectProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 			},
 			payment: {
 				...basicExpectedStripeRequest.payment,
@@ -184,7 +182,6 @@ describe( 'genericRedirectProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 			},
 			payment: {
 				...basicExpectedStripeRequest.payment,
@@ -223,7 +220,6 @@ describe( 'genericRedirectProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 			},
 			payment: {
 				...basicExpectedStripeRequest.payment,
@@ -270,7 +266,6 @@ describe( 'genericRedirectProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 				tax: { location: { postal_code: 'pr267ry', country_code: 'GB' } },
 			},
 			payment: {
@@ -305,7 +300,6 @@ describe( 'genericRedirectProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 				products: [ domainProduct ],
 			},
 			domain_details: basicExpectedDomainDetails,

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
@@ -120,7 +120,6 @@ describe( 'multiPartnerCardProcessor', () => {
 			blog_id: '0',
 			cart_key: 'no-site',
 			coupon: '',
-			create_new_blog: true,
 			products: [ product ],
 			tax: {
 				location: {},
@@ -335,7 +334,6 @@ describe( 'multiPartnerCardProcessor', () => {
 					blog_id: '1234567',
 					cart_key: 1234567,
 					coupon: '',
-					create_new_blog: false,
 				},
 			} );
 		} );
@@ -404,7 +402,6 @@ describe( 'multiPartnerCardProcessor', () => {
 					blog_id: '1234567',
 					cart_key: 1234567,
 					coupon: '',
-					create_new_blog: false,
 				},
 			} );
 		} );
@@ -464,7 +461,6 @@ describe( 'multiPartnerCardProcessor', () => {
 					blog_id: '1234567',
 					cart_key: '1234567',
 					coupon: '',
-					create_new_blog: false,
 				},
 			} );
 		} );
@@ -507,7 +503,6 @@ describe( 'multiPartnerCardProcessor', () => {
 					blog_id: '1234567',
 					cart_key: '1234567',
 					coupon: '',
-					create_new_blog: false,
 					tax: { location: { postal_code: 'pr267ry', country_code: 'GB' } },
 				},
 			} );
@@ -540,7 +535,6 @@ describe( 'multiPartnerCardProcessor', () => {
 					blog_id: '1234567',
 					cart_key: '1234567',
 					coupon: '',
-					create_new_blog: false,
 					products: [ domainProduct ],
 				},
 				domain_details: basicExpectedDomainDetails,
@@ -681,7 +675,6 @@ describe( 'multiPartnerCardProcessor', () => {
 					blog_id: '1234567',
 					cart_key: '1234567',
 					coupon: '',
-					create_new_blog: false,
 					products: [ product ],
 				},
 			} );
@@ -711,7 +704,6 @@ describe( 'multiPartnerCardProcessor', () => {
 					blog_id: '1234567',
 					cart_key: '1234567',
 					coupon: '',
-					create_new_blog: false,
 					products: [ domainProduct ],
 				},
 				domain_details: basicExpectedDomainDetails,

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -39,7 +39,6 @@ describe( 'payPalExpressProcessor', () => {
 			blog_id: '0',
 			cart_key: 'no-site',
 			coupon: '',
-			create_new_blog: true,
 			products: [ product ],
 			tax: {
 				location: {},
@@ -120,7 +119,6 @@ describe( 'payPalExpressProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 			},
 		} );
 	} );
@@ -158,7 +156,6 @@ describe( 'payPalExpressProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 				tax: { location: { postal_code: 'pr267ry', country_code: 'GB' } },
 			},
 			postal_code: 'PR26 7RY',
@@ -188,7 +185,6 @@ describe( 'payPalExpressProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 				products: [ domainProduct ],
 			},
 			domain_details: basicExpectedDomainDetails,
@@ -219,7 +215,6 @@ describe( 'payPalExpressProcessor', () => {
 				blog_id: '1234567',
 				cart_key: 1234567,
 				coupon: '',
-				create_new_blog: false,
 			},
 		} );
 	} );
@@ -250,7 +245,6 @@ describe( 'payPalExpressProcessor', () => {
 				blog_id: '0',
 				cart_key: 'no-site',
 				coupon: '',
-				create_new_blog: true,
 			},
 		} );
 	} );
@@ -279,7 +273,6 @@ describe( 'payPalExpressProcessor', () => {
 				blog_id: '0',
 				cart_key: 'no-site',
 				coupon: '',
-				create_new_blog: true,
 			},
 			tos: {
 				locale: 'en',
@@ -313,7 +306,6 @@ describe( 'payPalExpressProcessor', () => {
 				blog_id: '0',
 				cart_key: 'no-site',
 				coupon: '',
-				create_new_blog: true,
 			},
 			tos: {
 				locale: 'en',
@@ -353,7 +345,6 @@ describe( 'payPalExpressProcessor', () => {
 				blog_id: '1234567',
 				cart_key: 1234567,
 				coupon: '',
-				create_new_blog: false,
 			},
 		} );
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -354,7 +354,6 @@ export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
 			coupon: requestCoupon,
 			coupon_discounts_integer: [],
 			coupon_savings_total_integer: requestCoupon ? 1000 : 0,
-			create_new_blog: false,
 			credits_integer: 0,
 			currency,
 			is_coupon_applied: true,

--- a/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
@@ -32,7 +32,6 @@ describe( 'weChatProcessor', () => {
 			blog_id: '0',
 			cart_key: 'no-site',
 			coupon: '',
-			create_new_blog: true,
 			products: [ product ],
 			tax: {
 				location: {},
@@ -125,7 +124,6 @@ describe( 'weChatProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 			},
 			payment: {
 				...basicExpectedStripeRequest.payment,
@@ -169,7 +167,6 @@ describe( 'weChatProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 				tax: { location: { postal_code: 'pr267ry', country_code: 'GB' } },
 			},
 			payment: {
@@ -203,7 +200,6 @@ describe( 'weChatProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 				products: [ domainProduct ],
 			},
 			domain_details: basicExpectedDomainDetails,

--- a/client/my-sites/checkout/composite-checkout/test/web-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/web-pay-processor.ts
@@ -31,7 +31,6 @@ describe( 'webPayProcessor', () => {
 			blog_id: '0',
 			cart_key: 'no-site',
 			coupon: '',
-			create_new_blog: true,
 			products: [ product ],
 			tax: {
 				location: {},
@@ -143,7 +142,6 @@ describe( 'webPayProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 			},
 		} );
 	} );
@@ -185,7 +183,6 @@ describe( 'webPayProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 				tax: { location: { postal_code: 'pr267ry', country_code: 'GB' } },
 			},
 		} );
@@ -217,7 +214,6 @@ describe( 'webPayProcessor', () => {
 				blog_id: '1234567',
 				cart_key: '1234567',
 				coupon: '',
-				create_new_blog: false,
 				products: [ domainProduct ],
 			},
 			domain_details: basicExpectedDomainDetails,

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -310,7 +310,8 @@ export default function getThankYouPageUrl( {
 	const isDomainOnly =
 		siteSlug === 'no-site' && getAllCartItems( cart ).every( isDomainRegistration );
 	if (
-		( cart?.create_new_blog || signupFlowName === 'domain' ) &&
+		( [ 'no-user', 'no-site' ].includes( String( cart?.cart_key ?? '' ) ) ||
+			signupFlowName === 'domain' ) &&
 		! isDomainOnly &&
 		urlFromCookie &&
 		receiptIdOrPlaceholder &&

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -17,7 +17,12 @@ import {
 	WPCOM_DIFM_LITE,
 } from '@automattic/calypso-products';
 import { LINK_IN_BIO_FLOW, NEWSLETTER_FLOW, VIDEOPRESS_FLOW } from '@automattic/onboarding';
-import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+import {
+	getEmptyResponseCart,
+	getEmptyResponseCartProduct,
+	ResponseCart,
+	CartKey,
+} from '@automattic/shopping-cart';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/get-thank-you-page-url';
 
@@ -28,6 +33,10 @@ jest.mock( '@automattic/calypso-products', () => ( {
 } ) );
 
 const samplePurchaseId = 12342424241;
+
+function getMockCart(): ResponseCart {
+	return { ...getEmptyResponseCart(), cart_key: 12345 };
+}
 
 const defaultArgs = {
 	getUrlFromCookie: jest.fn( () => undefined ),
@@ -86,7 +95,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to the thank-you page with a placeholder receipt id when a site but no orderId is set and the cart contains the personal plan', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -109,7 +118,7 @@ describe( 'getThankYouPageUrl', () => {
 	// the updated URL.
 	it( 'redirects to the business plan bump offer page with a placeholder receipt id when a site but no orderId is set and the cart contains the premium plan', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -127,7 +136,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to the thank-you page with a placeholder receiptId with a site when the cart is not empty but there is no receipt id', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [ { ...getEmptyResponseCartProduct(), id: 'something' } ],
 		};
 		const url = getThankYouPageUrl( { ...defaultArgs, siteSlug: 'foo.bar', cart } );
@@ -169,7 +178,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to the thank-you page with a feature when a site and a valid feature is set with no receipt but the cart is not empty', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -222,7 +231,7 @@ describe( 'getThankYouPageUrl', () => {
 			purchaseId: samplePurchaseId,
 			isJetpackNotAtomic: true,
 			cart: {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -262,7 +271,7 @@ describe( 'getThankYouPageUrl', () => {
 			purchaseId: samplePurchaseId,
 			isJetpackNotAtomic: true,
 			cart: {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -286,7 +295,7 @@ describe( 'getThankYouPageUrl', () => {
 			purchaseId: samplePurchaseId,
 			isJetpackNotAtomic: true,
 			cart: {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -313,7 +322,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			isJetpackNotAtomic: true,
 			cart: {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -340,7 +349,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			isJetpackNotAtomic: true,
 			cart: {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -367,7 +376,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			isJetpackNotAtomic: true,
 			cart: {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -399,7 +408,7 @@ describe( 'getThankYouPageUrl', () => {
 			purchaseId: samplePurchaseId,
 			isJetpackNotAtomic: true,
 			cart: {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -431,7 +440,7 @@ describe( 'getThankYouPageUrl', () => {
 			purchaseId: samplePurchaseId,
 			isJetpackNotAtomic: true,
 			cart: {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -450,7 +459,7 @@ describe( 'getThankYouPageUrl', () => {
 			purchaseId: samplePurchaseId,
 			isJetpackNotAtomic: true,
 			cart: {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -469,7 +478,7 @@ describe( 'getThankYouPageUrl', () => {
 			purchaseId: samplePurchaseId,
 			isJetpackNotAtomic: true,
 			cart: {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -504,7 +513,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to the afterPurchaseUrl from a cart item if set', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -522,7 +531,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to the afterPurchaseUrl from the most recent cart item if multiple are set', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -557,7 +566,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to internal redirectTo url if set even if afterPurchaseUrl exists on a cart item', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -618,7 +627,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to manage purchase page if there is a renewal', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -634,7 +643,7 @@ describe( 'getThankYouPageUrl', () => {
 	it( 'does not redirect to url from cookie if cart contains a Google Apps product without a domain receipt', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -654,7 +663,7 @@ describe( 'getThankYouPageUrl', () => {
 	it( 'does redirect to url from cookie if cart contains a Google Apps product with a domain receipt', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -677,7 +686,7 @@ describe( 'getThankYouPageUrl', () => {
 	it( 'Redirects to root if there is no purchase and cart contains a Google Apps product without a domain receipt', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -699,7 +708,7 @@ describe( 'getThankYouPageUrl', () => {
 	it( 'redirects to afterPurchaseUrl if set even if there is a url from a cookie', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -720,7 +729,7 @@ describe( 'getThankYouPageUrl', () => {
 	it( 'redirects to url from cookie with notice type set to "purchase-success"', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -740,7 +749,7 @@ describe( 'getThankYouPageUrl', () => {
 	it( 'Should store the current URL in the redirect cookie when called from the editor', () => {
 		const saveUrlToCookie = jest.fn();
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [],
 		};
 		const url = 'http://localhost/editor';
@@ -762,7 +771,7 @@ describe( 'getThankYouPageUrl', () => {
 	it( 'Should store the thank you URL in the redirect cookie when called from the editor with an e-commerce plan', () => {
 		const saveUrlToCookie = jest.fn();
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -780,11 +789,11 @@ describe( 'getThankYouPageUrl', () => {
 		expect( saveUrlToCookie ).toBeCalledWith( '/checkout/thank-you/foo.bar/:receiptId' );
 	} );
 
-	it( 'redirects to url from cookie followed by purchase id if create_new_blog is set', () => {
+	it( 'redirects to url from cookie followed by purchase id if there is no site', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
-			...getEmptyResponseCart(),
-			create_new_blog: true,
+			...getMockCart(),
+			cart_key: 'no-site' as CartKey,
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -802,11 +811,11 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( `/cookie/${ samplePurchaseId }` );
 	} );
 
-	it( 'redirects to url from cookie followed by receipt id if create_new_blog is set', () => {
+	it( 'redirects to url from cookie followed by receipt id if there is no site', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
-			...getEmptyResponseCart(),
-			create_new_blog: true,
+			...getMockCart(),
+			cart_key: 'no-site' as CartKey,
 			products: [ { ...getEmptyResponseCartProduct(), id: '123' } ],
 		};
 		const url = getThankYouPageUrl( {
@@ -819,12 +828,11 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( `/cookie/${ samplePurchaseId }` );
 	} );
 
-	it( 'redirects to url from cookie followed by receipt id if create_new_blog is not set but wpcom_signup_complete_flow_name from session storage is equal to "domain"', () => {
+	it( 'redirects to url from cookie followed by receipt id if there is a site but wpcom_signup_complete_flow_name from session storage is equal to "domain"', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		window.sessionStorage.setItem( 'wpcom_signup_complete_flow_name', 'domain' );
 		const cart = {
-			...getEmptyResponseCart(),
-			create_new_blog: false,
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -842,11 +850,11 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( `/cookie/${ samplePurchaseId }` );
 	} );
 
-	it( 'redirects to url from cookie followed by receipt id placeholder if create_new_blog is set', () => {
+	it( 'redirects to url from cookie followed by receipt id placeholder if there is no site', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
-			...getEmptyResponseCart(),
-			create_new_blog: true,
+			...getMockCart(),
+			cart_key: 'no-site' as CartKey,
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -863,11 +871,11 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( `/cookie/:receiptId` );
 	} );
 
-	it( 'redirects to url from cookie followed by placeholder receiptId if create_new_blog is set and there is no receipt', () => {
+	it( 'redirects to url from cookie followed by placeholder receiptId if there is no site, and there is no receipt', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
-			...getEmptyResponseCart(),
-			create_new_blog: true,
+			...getMockCart(),
+			cart_key: 'no-site' as CartKey,
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -884,10 +892,10 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/cookie/:receiptId' );
 	} );
 
-	it( 'redirects to thank-you page followed by placeholder receiptId if no cookie url is set, create_new_blog is set, and there is no receipt', () => {
+	it( 'redirects to thank-you page followed by placeholder receiptId if no cookie url is set, there is no site, and there is no receipt', () => {
 		const cart = {
-			...getEmptyResponseCart(),
-			create_new_blog: true,
+			...getMockCart(),
+			cart_key: 'no-site' as CartKey,
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -899,10 +907,10 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/:receiptId' );
 	} );
 
-	it( 'redirects to thank-you page followed by purchase id if no cookie url is set, create_new_blog is set, and there is no receipt', () => {
+	it( 'redirects to thank-you page followed by purchase id if no cookie url is set, there is no site, and there is no receipt', () => {
 		const cart = {
-			...getEmptyResponseCart(),
-			create_new_blog: true,
+			...getMockCart(),
+			cart_key: 'no-site' as CartKey,
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -921,7 +929,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to thank-you page for a new site with a domain and some failed purchases', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -943,7 +951,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to thank-you page for a new site without a domain', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -965,7 +973,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to thank-you page for a new site with a domain and no failed purchases but G Suite is not in the cart if user is in invalid country', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -987,7 +995,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to business upgrade nudge if jetpack is not in the cart, and premium is in the cart', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -1007,7 +1015,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to business monthly upgrade nudge if jetpack is not in the cart, and premium monthly is in the cart', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -1029,7 +1037,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to the business upgrade nudge with a placeholder when jetpack is not in the cart and premium is in the cart but there is no receipt', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -1047,7 +1055,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to the thank you page if jetpack is not in the cart, blogger is in the cart, and the previous route is not the nudge', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -1066,7 +1074,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to the thank you page if jetpack is not in the cart, personal is in the cart, and the previous route is not the nudge', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -1136,7 +1144,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'Is displayed if site has eligible domain and Blogger plan is in the cart', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1160,7 +1168,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'Is displayed if site has eligible domain and Personal plan is in the cart', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1184,7 +1192,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'Is displayed if site has eligible domain and Business plan is in the cart', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1208,7 +1216,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'Is displayed if site has eligible domain and eCommerce plan is in the cart', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1232,7 +1240,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'Is displayed if site has domain registration and eligible plan in the cart', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1261,7 +1269,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'Is displayed if user is buying a domain only registration', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1296,7 +1304,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'Is not displayed if Google Workspace is in the cart', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1318,7 +1326,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'Is not displayed if Professional Email is in the cart', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1340,7 +1348,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'Is not displayed if Professional Email is in the cart and email query parameter is present', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1367,7 +1375,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'Is not displayed if Premium plan is in the cart; we show the business upgrade instead', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1389,7 +1397,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'Is not displayed if nudges should be hidden and site has eligible domain and Personal plan is in the cart', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1413,7 +1421,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to thank-you page if jetpack is in the cart', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -1432,7 +1440,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to thank you page if jetpack is not in the cart, personal is in the cart, but hideNudge is true', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -1472,7 +1480,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to the jetpack checkout thank you when jetpack checkout arg is set', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -1491,7 +1499,7 @@ describe( 'getThankYouPageUrl', () => {
 
 	it( 'redirects to the akismet checkout thank you when akismet siteless arg is set', () => {
 		const cart = {
-			...getEmptyResponseCart(),
+			...getMockCart(),
 			products: [
 				{
 					...getEmptyResponseCartProduct(),
@@ -1541,7 +1549,7 @@ describe( 'getThankYouPageUrl', () => {
 	describe( 'Plan Upgrade Upsell Nudge', () => {
 		it( 'offers discounted business plan upgrade when premium plan is purchased.', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1561,7 +1569,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'offers discounted biennial business plan upgrade when biennial premium plan is purchased.', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1583,7 +1591,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'offers discounted monthly business plan upgrade when monthly premium plan is purchased.', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1605,7 +1613,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'Does not offers discounted annual business plan upgrade when annual premium plan and DIFM light is purchased together.', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1635,7 +1643,7 @@ describe( 'getThankYouPageUrl', () => {
 				sessionStorage.setItem( 'wpcom_signup_complete_flow_name', flowName );
 
 				const cart = {
-					...getEmptyResponseCart(),
+					...getMockCart(),
 					products: [
 						{
 							...getEmptyResponseCartProduct(),
@@ -1661,7 +1669,7 @@ describe( 'getThankYouPageUrl', () => {
 	describe( 'Jetpack Siteless Checkout Thank You', () => {
 		it( 'redirects when jetpack checkout arg is set, but siteSlug is undefined.', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1682,7 +1690,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'redirects with receiptId query param when a valid receipt ID is provided', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1704,7 +1712,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'redirects with receiptId query param when a valid receipt ID is provided as a string', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1726,7 +1734,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'redirects without receiptId query param when an invalid receipt ID is provided', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1750,7 +1758,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		it( 'redirects with jetpackTemporarySiteId query param when available', () => {
 			const cart = {
-				...getEmptyResponseCart(),
+				...getMockCart(),
 				products: [
 					{
 						...getEmptyResponseCartProduct(),
@@ -1775,7 +1783,7 @@ describe( 'getThankYouPageUrl', () => {
 			const url = getThankYouPageUrl( {
 				...defaultArgs,
 				cart: {
-					...getEmptyResponseCart(),
+					...getMockCart(),
 					products: [
 						{
 							...getEmptyResponseCartProduct(),
@@ -1793,7 +1801,7 @@ describe( 'getThankYouPageUrl', () => {
 			const url = getThankYouPageUrl( {
 				...defaultArgs,
 				cart: {
-					...getEmptyResponseCart(),
+					...getMockCart(),
 					products: [
 						{
 							...getEmptyResponseCartProduct(),
@@ -1841,7 +1849,7 @@ describe( 'getThankYouPageUrl', () => {
 				getThankYouPageUrl( {
 					...defaultArgs,
 					cart: {
-						...getEmptyResponseCart(),
+						...getMockCart(),
 						products: [
 							{
 								...getEmptyResponseCartProduct(),

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -272,7 +272,6 @@ export interface Cart {
 	credits_display: string;
 	credits_integer: number;
 	allowed_payment_methods: unknown[];
-	create_new_blog: boolean;
 	messages: Record< 'errors' | 'success', unknown >;
 }
 

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -3,7 +3,6 @@ import type { ResponseCart, ResponseCartProduct } from './types';
 export function getEmptyResponseCart(): ResponseCart {
 	return {
 		blog_id: '',
-		create_new_blog: false,
 		cart_generated_at_timestamp: 0,
 		cart_key: 'no-site',
 		products: [],

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -196,7 +196,6 @@ export interface RequestCart {
 	tax: RequestCartTaxData;
 	coupon: string;
 	temporary: false;
-	create_new_blog?: boolean;
 }
 
 export type RequestCartTaxData = null | {
@@ -225,7 +224,6 @@ export type MinimalRequestCartProduct = Partial< RequestCartProduct > &
 
 export interface ResponseCart< P = ResponseCartProduct > {
 	blog_id: number | string;
-	create_new_blog: boolean;
 	cart_key: CartKey;
 	products: P[];
 


### PR DESCRIPTION
## Proposed Changes

A shopping cart request can contain the `create_new_blog` property. The intent of this property was for the transactions endpoint to create a new site for a user as part of the transaction. However, it's just a flag to represent a cart with no `blog_id` and we can more reliably use that instead.. Most of its functionality was already removed by https://github.com/Automattic/wp-calypso/pull/69837 but some still remains and it causes a lot of confusion.

This PR removes all mention of `create_new_blog` from calypso. The server-side use of `create_new_blog` was removed in D106477-code.

Part of the work in https://github.com/Automattic/payments-shilling/issues/759

## Testing Instructions

Reviewers could verify that removing the property has no effect on siteless checkout:

- Visit `/start/domain/domain-only` and complete the flow to purchase a new domain without a site.
- Verify that checkout completes successfully and that you are redirected to a post-checkout page for that domain.