### PR TITLE
Logging: Style Site Logs section header to look like other "modern" sections

### DIFF
--- a/client/my-sites/site-logs/components/site-logs-tab-panel/style.scss
+++ b/client/my-sites/site-logs/components/site-logs-tab-panel/style.scss
@@ -1,7 +1,28 @@
 .site-logs-tab-panel {
+	margin-left: 16px;
+	margin-right: 16px;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		margin-left: 0;
+		margin-right: 0;
+	}
+
 	.components-tab-panel__tabs {
-		overflow-x: auto;
 		margin-bottom: 32px;
+
+		position: relative;
+
+		&::before {
+			content: "";
+			position: absolute;
+			background-color: var(--studio-white);
+			top: -50px;
+			left: -33px;
+			right: -32px;
+			bottom: 0;
+			z-index: -1;
+			box-shadow: inset 0 -1px 0 #0000000d;
+		}
 	}
 
 	.components-tab-panel__tabs-item {
@@ -11,6 +32,7 @@
 		margin-right: 24px;
 		font-size: $font-body-small;
 		flex-shrink: 0;
+		height: 36px;
 	}
 
 	.components-tab-panel__tabs-item:hover,

--- a/client/my-sites/site-logs/components/site-logs-table/style.scss
+++ b/client/my-sites/site-logs/components/site-logs-table/style.scss
@@ -7,6 +7,7 @@ $border-color: #d3dae6;
 	font-family: monospace;
 	border-collapse: collapse;
 	border: 1px solid $border-color;
+	background-color: var(--studio-white);
 }
 
 .site-logs-table thead tr,

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -9,6 +9,7 @@ import { SiteLogsTab, useSiteLogsQuery } from 'calypso/data/hosting/use-site-log
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { SiteLogsTabPanel } from './components/site-logs-tab-panel';
 import { SiteLogsTable } from './components/site-logs-table';
+import './style.scss';
 
 export function SiteLogs() {
 	const { __ } = useI18n();
@@ -47,6 +48,7 @@ export function SiteLogs() {
 				headerText={ titleHeader }
 				subHeaderText={ __( 'View server logs to troubleshoot or debug problems with your site.' ) }
 				align="left"
+				className="site-logs__formatted-header"
 			/>
 
 			<SiteLogsTabPanel selectedTab={ logType } onSelected={ handleTabSelected }>

--- a/client/my-sites/site-logs/style.scss
+++ b/client/my-sites/site-logs/style.scss
@@ -1,0 +1,19 @@
+.site-logs {
+	position: relative;
+
+}
+
+.site-logs__formatted-header {
+	position: relative;
+	& ::before {
+		content: "";
+		display: block;
+		position: absolute;
+		background: var(--studio-white);
+		top: -47px;
+		right: -32px;
+		bottom: 0;
+		left: -33px;
+		z-index: -1;
+	}
+}


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

The latest Jetpack Stats and Plans pages use a white background for header. This PR applies the same sort of styling to the Site Logs section.


![CleanShot 2023-03-28 at 14 34 45@2x](https://user-images.githubusercontent.com/1500769/228104015-bccb995a-9921-4d0b-879e-c859b94d54b8.png)

Unfortunately there are no easily shared styles/components for this. This diff uses `::before` elements to make the background look which without affecting layout.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test `/site-logs` with various screen sizes and themes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
