### PR TITLE
Logging: add refresh button

### DIFF
--- a/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
@@ -1,0 +1,22 @@
+import { Button } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+
+import './style.scss';
+
+type Props = {
+	onRefresh: () => void;
+};
+
+export const SiteLogsToolbar = ( props: Props ) => {
+	const { onRefresh } = props;
+
+	const { __ } = useI18n();
+
+	return (
+		<div className="site-logs-toolbar">
+			<Button isSecondary onClick={ onRefresh }>
+				{ __( 'Refresh' ) }
+			</Button>
+		</div>
+	);
+};

--- a/client/my-sites/site-logs/components/site-logs-toolbar/style.scss
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/style.scss
@@ -1,0 +1,3 @@
+.site-logs-toolbar {
+	padding-bottom: 16px;
+}

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -9,6 +9,7 @@ import { SiteLogsTab, useSiteLogsQuery } from 'calypso/data/hosting/use-site-log
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { SiteLogsTabPanel } from './components/site-logs-tab-panel';
 import { SiteLogsTable } from './components/site-logs-table';
+import { SiteLogsToolbar } from './components/site-logs-toolbar';
 import './style.scss';
 
 export function SiteLogs() {
@@ -16,8 +17,13 @@ export function SiteLogs() {
 	const siteId = useSelector( getSelectedSiteId );
 	const moment = useLocalizedMoment();
 
-	const [ startTime ] = useState( moment().subtract( 7, 'd' ).unix() );
-	const [ endTime ] = useState( moment().unix() );
+	const getDateRange = () => {
+		const startTime = moment().subtract( 7, 'd' ).unix();
+		const endTime = moment().unix();
+		return { startTime, endTime };
+	};
+
+	const [ dateRange, setDateRange ] = useState( getDateRange() );
 
 	const [ logType, setLogType ] = useState< SiteLogsTab >( () => {
 		const queryParam = new URL( window.location.href ).searchParams.get( 'log-type' );
@@ -28,14 +34,18 @@ export function SiteLogs() {
 
 	const { data } = useSiteLogsQuery( siteId, {
 		logType,
-		start: startTime,
-		end: endTime,
+		start: dateRange.startTime,
+		end: dateRange.endTime,
 		sort_order: 'desc',
 		page_size: 10,
 	} );
 
 	const handleTabSelected = ( tabName: SiteLogsTab ) => {
 		setLogType( tabName );
+	};
+
+	const handleRefresh = () => {
+		setDateRange( getDateRange() );
 	};
 
 	const titleHeader = __( 'Site Logs' );
@@ -52,7 +62,12 @@ export function SiteLogs() {
 			/>
 
 			<SiteLogsTabPanel selectedTab={ logType } onSelected={ handleTabSelected }>
-				{ () => <SiteLogsTable logs={ data?.logs } /> }
+				{ () => (
+					<>
+						<SiteLogsToolbar onRefresh={ handleRefresh } />
+						<SiteLogsTable logs={ data?.logs } />
+					</>
+				) }
 			</SiteLogsTabPanel>
 		</Main>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/1990

## Proposed Changes

* Add a refresh button which reloads the logs by moving the date range (and keeping everything else as before)

<img width="749" alt="Screenshot 2566-03-28 at 12 05 31" src="https://user-images.githubusercontent.com/6851384/228133667-f2219d2f-4125-45ff-91be-2a532ce18e38.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Navigate to `/site-logs/:your-atomic-site`
* Note the latest log entry
* Do something on your site that leads to data being logged to the web and php logs
* Hit refresh and verify the new log entries appear






## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
