### PR TITLE
Site Assembler: Group the event names

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
@@ -1,0 +1,55 @@
+/**
+ * See PekYwv-WG-p2
+ */
+export const PATTERN_ASSEMBLER_EVENTS = {
+	/**
+	 * Screen Main
+	 */
+	MAIN_ITEM_SELECT: 'calypso_signup_pattern_assembler_main_item_select',
+	CONTINUE_CLICK: 'calypso_signup_pattern_assembler_continue_click',
+	BACK_CLICK: 'calypso_signup_pattern_assembler_back_click',
+	PATTERN_FINAL_SELECT: 'calypso_signup_pattern_assembler_pattern_final_select',
+
+	/**
+	 * Screen Colors
+	 */
+	SCREEN_COLORS_PREVIEW_CLICK: 'calypso_signup_pattern_assembler_screen_colors_preview_click',
+	SCREEN_COLORS_BACK_CLICK: 'calypso_signup_pattern_assembler_screen_colors_back_click',
+	SCREEN_COLORS_DONE_CLICK: 'calypso_signup_pattern_assembler_screen_colors_done_click',
+
+	/**
+	 * Screen Fonts
+	 */
+	SCREEN_FONTS_PREVIEW_CLICK: 'calypso_signup_pattern_assembler_screen_fonts_preview_click',
+	SCREEN_FONTS_BACK_CLICK: 'calypso_signup_pattern_assembler_screen_fonts_back_click',
+	SCREEN_FONTS_DONE_CLICK: 'calypso_signup_pattern_assembler_screen_fonts_done_click',
+
+	/**
+	 * Pattern Panels
+	 */
+	PATTERN_ADD_CLICK: 'calypso_signup_pattern_assembler_pattern_add_click',
+	PATTERN_SELECT_CLICK: 'calypso_signup_pattern_assembler_pattern_select_click',
+	PATTERN_SELECT_BACK_CLICK: 'calypso_signup_pattern_assembler_pattern_select_back_click',
+	PATTERN_SELECT_DONE_CLICK: 'calypso_signup_pattern_assembler_pattern_select_done_click',
+
+	/**
+	 * Pattern Actions
+	 */
+	PATTERN_MOVEUP_CLICK: 'calypso_signup_pattern_assembler_pattern_moveup_click',
+	PATTERN_MOVEDOWN_CLICK: 'calypso_signup_pattern_assembler_pattern_movedown_click',
+	PATTERN_REPLACE_CLICK: 'calypso_signup_pattern_assembler_pattern_replace_click',
+	PATTERN_DELETE_CLICK: 'calypso_signup_pattern_assembler_pattern_delete_click',
+	PREVIEW_DEVICE_CLICK: 'calypso_signup_pattern_assembler_preview_device_click',
+
+	/**
+	 * Global Styles Gating Modal
+	 */
+	GLOBAL_STYLES_GATING_MODAL_SHOW:
+		'calypso_signup_pattern_assembler_global_styles_gating_modal_show',
+	GLOBAL_STYLES_GATING_MODAL_CLOSE_BUTTON_CLICK:
+		'calypso_signup_pattern_assembler_global_styles_gating_modal_close_button_click',
+	GLOBAL_STYLES_GATING_MODAL_CHECKOUT_BUTTON_CLICK:
+		'calypso_signup_pattern_assembler_global_styles_gating_modal_checkout_button_click',
+	GLOBAL_STYLES_GATING_MODAL_TRY_BUTTON_CLICK:
+		'calypso_signup_pattern_assembler_global_styles_gating_modal_try_button_click',
+} as const;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { urlToSlug } from 'calypso/lib/url';
 import { useSite } from '../../../../../hooks/use-site';
 import { useSiteSlugParam } from '../../../../../hooks/use-site-slug-param';
+import { PATTERN_ASSEMBLER_EVENTS } from '../events';
 
 interface Props {
 	recordTracksEvent: ( eventName: string, eventProps?: { [ key: string ]: unknown } ) => void;
@@ -15,21 +16,17 @@ const useGlobalStylesUpgradeModal = ( { recordTracksEvent, onSubmit }: Props ) =
 	const siteUrl = siteSlug || urlToSlug( site?.URL || '' ) || '';
 
 	const openModal = () => {
-		recordTracksEvent( 'calypso_signup_pattern_assembler_global_styles_gating_modal_show' );
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.GLOBAL_STYLES_GATING_MODAL_SHOW );
 		setIsOpen( true );
 	};
 
 	const closeModal = () => {
-		recordTracksEvent(
-			'calypso_signup_pattern_assembler_global_styles_gating_modal_close_button_click'
-		);
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.GLOBAL_STYLES_GATING_MODAL_CLOSE_BUTTON_CLICK );
 		setIsOpen( false );
 	};
 
 	const checkout = () => {
-		recordTracksEvent(
-			'calypso_signup_pattern_assembler_global_styles_gating_modal_checkout_button_click'
-		);
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.GLOBAL_STYLES_GATING_MODAL_CHECKOUT_BUTTON_CLICK );
 
 		// When the user is done with checkout, send them back to the current url
 		const destUrl = new URL( window.location.href );
@@ -44,10 +41,7 @@ const useGlobalStylesUpgradeModal = ( { recordTracksEvent, onSubmit }: Props ) =
 	};
 
 	const tryStyle = () => {
-		recordTracksEvent(
-			'calypso_signup_pattern_assembler_global_styles_gating_modal_try_button_click'
-		);
-
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.GLOBAL_STYLES_GATING_MODAL_TRY_BUTTON_CLICK );
 		onSubmit();
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -22,6 +22,7 @@ import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import { recordSelectedDesign } from '../../analytics/record-design';
 import { SITE_TAGLINE, PLACEHOLDER_SITE_ID, PATTERN_TYPES } from './constants';
+import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import useGlobalStylesUpgradeModal from './hooks/use-global-styles-upgrade-modal';
 import usePatternCategories from './hooks/use-pattern-categories';
 import usePatternsMapByCategory from './hooks/use-patterns-map-by-category';
@@ -152,7 +153,7 @@ const PatternAssembler = ( {
 	};
 
 	const trackEventPatternAdd = ( patternType: string ) => {
-		recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_add_click', {
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_ADD_CLICK, {
 			pattern_type: patternType,
 		} );
 	};
@@ -168,7 +169,7 @@ const PatternAssembler = ( {
 		patternName: string;
 		patternCategory: string | undefined;
 	} ) => {
-		recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_select_click', {
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_SELECT_CLICK, {
 			pattern_type: patternType,
 			pattern_id: patternId,
 			pattern_name: patternName,
@@ -178,7 +179,7 @@ const PatternAssembler = ( {
 
 	const trackEventContinue = () => {
 		const patterns = getPatterns();
-		recordTracksEvent( 'calypso_signup_pattern_assembler_continue_click', {
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.CONTINUE_CLICK, {
 			pattern_types: [ header && 'header', sections.length && 'section', footer && 'footer' ]
 				.filter( Boolean )
 				.join( ',' ),
@@ -188,7 +189,7 @@ const PatternAssembler = ( {
 			pattern_count: patterns.length,
 		} );
 		patterns.forEach( ( { id, name, category } ) => {
-			recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_final_select', {
+			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_FINAL_SELECT, {
 				pattern_id: id,
 				pattern_name: name,
 				pattern_category: category?.name,
@@ -338,7 +339,7 @@ const PatternAssembler = ( {
 
 	const onBack = () => {
 		const patterns = getPatterns();
-		recordTracksEvent( 'calypso_signup_pattern_assembler_back_click', {
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.BACK_CLICK, {
 			has_selected_patterns: patterns.length > 0,
 			pattern_count: patterns.length,
 		} );
@@ -373,14 +374,14 @@ const PatternAssembler = ( {
 		} );
 
 	const onPatternSelectorBack = ( type: string ) => {
-		recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_select_back_click', {
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_SELECT_BACK_CLICK, {
 			pattern_type: type,
 		} );
 	};
 
 	const onDoneClick = ( type: string ) => {
 		const patterns = getPatterns( type );
-		recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_select_done_click', {
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_SELECT_DONE_CLICK, {
 			pattern_type: type,
 			pattern_ids: patterns.map( ( { id } ) => id ).join( ',' ),
 			pattern_names: patterns.map( ( { name } ) => name ).join( ',' ),
@@ -404,7 +405,7 @@ const PatternAssembler = ( {
 			trackEventPatternAdd( name );
 		}
 
-		recordTracksEvent( 'calypso_signup_pattern_assembler_main_item_select', { name } );
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.MAIN_ITEM_SELECT, { name } );
 	};
 
 	const onAddSection = () => {
@@ -435,32 +436,32 @@ const PatternAssembler = ( {
 
 	const onScreenColorsSelect = ( variation: GlobalStylesObject ) => {
 		setSelectedColorPaletteVariation( variation );
-		recordTracksEvent( 'calypso_signup_pattern_assembler_screen_colors_preview_click', {
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_COLORS_PREVIEW_CLICK, {
 			title: variation.title,
 		} );
 	};
 
 	const onScreenColorsBack = () => {
-		recordTracksEvent( 'calypso_signup_pattern_assembler_screen_colors_back_click' );
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_COLORS_BACK_CLICK );
 	};
 
 	const onScreenColorsDone = () => {
-		recordTracksEvent( 'calypso_signup_pattern_assembler_screen_colors_done_click' );
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_COLORS_DONE_CLICK );
 	};
 
 	const onScreenFontsSelect = ( variation: GlobalStylesObject ) => {
 		setSelectedFontPairingVariation( variation );
-		recordTracksEvent( 'calypso_signup_pattern_assembler_screen_fonts_preview_click', {
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_FONTS_PREVIEW_CLICK, {
 			title: variation.title,
 		} );
 	};
 
 	const onScreenFontsBack = () => {
-		recordTracksEvent( 'calypso_signup_pattern_assembler_screen_fonts_back_click' );
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_FONTS_BACK_CLICK );
 	};
 
 	const onScreenFontsDone = () => {
-		recordTracksEvent( 'calypso_signup_pattern_assembler_screen_fonts_done_click' );
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_FONTS_DONE_CLICK );
 	};
 
 	const stepContent = (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
@@ -2,6 +2,7 @@ import { Button } from '@wordpress/components';
 import { chevronUp, chevronDown, close, edit } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import './pattern-action-bar.scss';
 
 type PatternActionBarProps = {
@@ -42,7 +43,7 @@ const PatternActionBar = ( {
 						role="menuitem"
 						label={ translate( 'Move up' ) }
 						onClick={ () => {
-							recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_moveup_click', {
+							recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_MOVEUP_CLICK, {
 								source,
 							} );
 							onMoveUp?.();
@@ -56,7 +57,7 @@ const PatternActionBar = ( {
 						role="menuitem"
 						label={ translate( 'Move down' ) }
 						onClick={ () => {
-							recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_movedown_click', {
+							recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_MOVEDOWN_CLICK, {
 								source,
 							} );
 							onMoveDown?.();
@@ -72,7 +73,7 @@ const PatternActionBar = ( {
 					role="menuitem"
 					label={ translate( 'Replace' ) }
 					onClick={ () => {
-						recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_replace_click', {
+						recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_REPLACE_CLICK, {
 							pattern_type: patternType,
 							source,
 						} );
@@ -87,7 +88,7 @@ const PatternActionBar = ( {
 				role="menuitem"
 				label={ translate( 'Remove' ) }
 				onClick={ () => {
-					recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_delete_click', {
+					recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_DELETE_CLICK, {
 						pattern_type: patternType,
 						source,
 					} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useEffect, useState, CSSProperties } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import PatternActionBar from './pattern-action-bar';
 import { encodePatternId } from './utils';
 import type { Pattern } from './types';
@@ -148,7 +149,7 @@ const PatternLargePreview = ( {
 			isShowFrameBorder
 			frameRef={ frameRef }
 			onDeviceChange={ ( device ) => {
-				recordTracksEvent( 'calypso_signup_pattern_assembler_preview_device_click', { device } );
+				recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PREVIEW_DEVICE_CLICK, { device } );
 				// Wait for the animation to end in 200ms
 				window.setTimeout( updateViewportHeight, 205 );
 			} }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/74950#discussion_r1149930263

## Proposed Changes

* Group the event names for the better references

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_site>&flags=pattern-assembler/color-and-fonts
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen, verify all events still works as before


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
