### PR TITLE
Site Assembler: Add source prop to the action bar events

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.tsx
@@ -13,6 +13,7 @@ type PatternActionBarProps = {
 	disableMoveDown?: boolean;
 	patternType: string;
 	isRemoveButtonTextOnly?: boolean;
+	source: 'list' | 'large_preview';
 };
 
 const PatternActionBar = ( {
@@ -24,6 +25,7 @@ const PatternActionBar = ( {
 	disableMoveDown,
 	patternType,
 	isRemoveButtonTextOnly,
+	source,
 }: PatternActionBarProps ) => {
 	const translate = useTranslate();
 	return (
@@ -40,7 +42,9 @@ const PatternActionBar = ( {
 						role="menuitem"
 						label={ translate( 'Move up' ) }
 						onClick={ () => {
-							recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_moveup_click' );
+							recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_moveup_click', {
+								source,
+							} );
 							onMoveUp?.();
 						} }
 						icon={ chevronUp }
@@ -52,7 +56,9 @@ const PatternActionBar = ( {
 						role="menuitem"
 						label={ translate( 'Move down' ) }
 						onClick={ () => {
-							recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_movedown_click' );
+							recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_movedown_click', {
+								source,
+							} );
 							onMoveDown?.();
 						} }
 						icon={ chevronDown }
@@ -68,6 +74,7 @@ const PatternActionBar = ( {
 					onClick={ () => {
 						recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_replace_click', {
 							pattern_type: patternType,
+							source,
 						} );
 						onReplace();
 					} }
@@ -82,6 +89,7 @@ const PatternActionBar = ( {
 				onClick={ () => {
 					recordTracksEvent( 'calypso_signup_pattern_assembler_pattern_delete_click', {
 						pattern_type: patternType,
+						source,
 					} );
 					onDelete();
 				} }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -81,7 +81,12 @@ const PatternLargePreview = ( {
 					// Disable default max-height
 					maxHeight="none"
 				/>
-				<PatternActionBar patternType={ type } isRemoveButtonTextOnly { ...getActionBarProps() } />
+				<PatternActionBar
+					patternType={ type }
+					isRemoveButtonTextOnly
+					source="large_preview"
+					{ ...getActionBarProps() }
+				/>
 			</li>
 		);
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-layout.tsx
@@ -50,6 +50,7 @@ const PatternLayout = ( {
 										</span>
 										<PatternActionBar
 											patternType="section"
+											source="list"
 											onReplace={ () => onReplaceSection( index ) }
 											onDelete={ () => onDeleteSection( index ) }
 											onMoveUp={ () => onMoveUpSection( index ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1679972044654749/1679917315.841599-slack-CRWCHQGUB

## Proposed Changes

* Add the `source` prop to the following events since we want to differentiate where the events are fired
  * calypso_signup_pattern_assembler_pattern_moveup_click
  * calypso_signup_pattern_assembler_pattern_movedown_click
  * calypso_signup_pattern_assembler_pattern_replace_click
  * calypso_signup_pattern_assembler_pattern_delete_click

| Source | Move up | Move down | Replace | Delete |
| - | - | - | - | - |
| List | ![image](https://user-images.githubusercontent.com/13596067/228156564-e362ec42-801c-4924-9b29-aebbc242a81a.png) |![image](https://user-images.githubusercontent.com/13596067/228156607-c5a8372c-54ba-4f96-9c25-ed7f6f3c32bc.png) | ![image](https://user-images.githubusercontent.com/13596067/228156368-5e428517-f620-4dd1-9e89-a0f57af77dad.png) | ![image](https://user-images.githubusercontent.com/13596067/228156433-2bf11833-a444-44d3-bc23-76711a0141e0.png) |
| Large Preview | ![image](https://user-images.githubusercontent.com/13596067/228156794-378e2838-0bfd-407f-b6aa-326584aaccca.png) | ![image](https://user-images.githubusercontent.com/13596067/228156709-f2c746bd-e72e-4daa-8810-47c25df9151e.png) | - | ![image](https://user-images.githubusercontent.com/13596067/228156847-b3e1dc6c-9854-4bf7-a810-1ce5d9e4fe3f.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_site>&flags=pattern-assembler/color-and-fonts
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Select `Sections`
  * Insert any patterns
  * Hover any selected pattern on the list, and click the action on the action bar. Verify the event is fired with `source=list`
  * Hover any selected pattern on the large preview, and click the action on the action bar. Verify the event is fired with `source=large_preview`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?