### PR TITLE
Jetpack Pro Dashboard: show not supported on backup expanded card for a multisite

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/expanded-card.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/expanded-card.tsx
@@ -5,8 +5,8 @@ import type { ReactNode } from 'react';
 import './style.scss';
 
 interface Props {
-	header: ReactNode;
-	children: ReactNode;
+	header?: ReactNode;
+	children?: ReactNode;
 	emptyContent?: ReactNode;
 	isEnabled?: boolean;
 	onClick?: () => void;


### PR DESCRIPTION
Related to 1203940061556608-as-1204256456240543

## Proposed Changes

This PR shows `Backup not supported on multisite` if the backup is not enabled already on a site and the site is multisite.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_**  You can always append the live link URL with `?flags=jetpack/pro-dashboard-expandable-block` to test these changes using the live link.

**Instructions**

1. Run `add/backup-expandable-card-multisite-message` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Add a multisite with a plan that usually would include Backup & Scan, e.g. Complete.
4. Expand the site of a multisite -> verify that the Backup shows data as expected. We will show the backup as it is if it is already added - https://href.li/?https://wp.me/pbuNQi-1jg
5. Add another multisite without any plan.
6. Verify that both Backup shows `Backup not supported on multisite`.

<img width="369" alt="Screenshot 2023-03-28 at 1 47 24 PM" src="https://user-images.githubusercontent.com/10586875/228177924-148f04d8-7fad-4a30-ac6e-6540066dbb82.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?