### PR TITLE
Design Preview: Avoid overlapping of the WordPress logo and style variations on mobile

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -108,7 +108,7 @@ button {
  	 * Signup Header
  	 */
 	.signup-header {
-		z-index: 10;
+		z-index: 1;
 
 		.wordpress-logo {
 			position: absolute;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -297,6 +297,13 @@ $font-family: "SF Pro Text", $sans;
 	}
 
 	/**
+	 * The header of the stepper framework
+	 */
+	.signup-header {
+		z-index: 10; // Increase the z-index to avoid the WordPress Logo being covered by the sidebar
+	}
+
+	/**
 	 * Gutenberg Components
 	 */
 	.components-divider {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Only increase the `z-index` of the header in the Pattern Assembler step to prevent any side effects

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/228191400-2683e10c-b102-4a97-8d2b-ed38eb3531ce.png) | ![image](https://user-images.githubusercontent.com/13596067/228191586-7c1e422f-ddbb-41f9-9665-172664cd6d1f.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_site>
* Continue until you land on the Design Picker
* On the Design Picker screen
  * Select any design with style variations
  * Reduce the width of your window to display the mobile layout
  * Ensure the WordPress logo and the style variations don't overlap

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
