### PR TITLE
Stats: Add loading states to Subs section

### DIFF
--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -77,10 +77,13 @@ export default function SubscribersSection() {
 	return (
 		<div className="subscribers-section">
 			<h1 className="highlight-cards-heading">Subscribers</h1>
-			<StatsModulePlaceholder className="is-chart" isLoading={ isLoading } />
-			<LineChart data={ data } renderTooltipForDatanum={ tooltipHelper }>
-				<StatsEmptyState />
-			</LineChart>
+			{ isLoading ? (
+				<StatsModulePlaceholder className="is-chart" isLoading />
+			) : (
+				<LineChart data={ data } renderTooltipForDatanum={ tooltipHelper }>
+					<StatsEmptyState />
+				</LineChart>
+			) }
 		</div>
 	);
 }

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import LineChart from 'calypso/components/line-chart';
 import StatsEmptyState from '../stats-empty-state';
 import './style.scss';
@@ -62,10 +63,15 @@ function transformData( data ) {
 }
 
 export default function SubscribersSection() {
-	const data = transformData( getData() );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const data = transformData( isLoading ? [] : getData() );
 
 	// Determines what is shown in the tooltip on hover.
 	const tooltipHelper = ( datum ) => `Changed: ${ datum.diff }`;
+
+	useEffect( () => {
+		setTimeout( () => setIsLoading( false ), 5000 );
+	}, [ isLoading ] );
 
 	return (
 		<div className="subscribers-section">

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import LineChart from 'calypso/components/line-chart';
 import StatsEmptyState from '../stats-empty-state';
+import StatsModulePlaceholder from '../stats-module/placeholder';
 import './style.scss';
 
 // New Subscriber Stats
@@ -76,6 +77,7 @@ export default function SubscribersSection() {
 	return (
 		<div className="subscribers-section">
 			<h1 className="highlight-cards-heading">Subscribers</h1>
+			<StatsModulePlaceholder className="is-chart" isLoading={ isLoading } />
 			<LineChart data={ data } renderTooltipForDatanum={ tooltipHelper }>
 				<StatsEmptyState />
 			</LineChart>

--- a/client/my-sites/stats/subscribers-section/style.scss
+++ b/client/my-sites/stats/subscribers-section/style.scss
@@ -1,8 +1,3 @@
 .subscribers-section {
-	margin-top: 32px;
-
-	.is-chart {
-		height: 32px;
-		min-height: 32px;
-	}
+	margin-top: 1em;
 }

--- a/client/my-sites/stats/subscribers-section/style.scss
+++ b/client/my-sites/stats/subscribers-section/style.scss
@@ -1,3 +1,8 @@
 .subscribers-section {
 	margin-top: 32px;
+
+	.is-chart {
+		height: 32px;
+		min-height: 32px;
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74937

## Proposed Changes

Adds a delay before loading the data to mock up a loading state. Adds a spinner to the UI while loading.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link.
* Visit the Jetpack → Stats page.
* Scroll to the bottom to view the Subscribers chart.
* Confirm it displays a spinner (delay is 5 seconds) before drawing the full chart.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
