### PR TITLE
Woo Express Small: Added logic behind `plans/woexpress-small` flag

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -33,7 +33,7 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 		return getWooExpressMediumFeatureSets( { translate, interval } );
 	}, [ translate, interval ] );
 
-	const performanceOnlyOption = (
+	const performanceOnlyFeatures = (
 		<ECommercePlanFeatures
 			interval={ interval }
 			monthlyControlProps={ { path: plansLink( '/plans', siteSlug, 'monthly', true ) } }
@@ -44,20 +44,20 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 		/>
 	);
 
-	const tableProps = {
+	const plansTableProps = {
 		plans: [ PLAN_FREE, PLAN_WOOEXPRESS_MEDIUM ],
 		hidePlansFeatureComparison: true,
 	};
 
-	const performanceAndEssentialOption = (
+	const multiPlanFeatures = (
 		<div className="is-2023-pricing-grid">
-			<AsyncLoad require="calypso/my-sites/plan-features-2023-grid" { ...tableProps } />
+			<AsyncLoad require="calypso/my-sites/plan-features-2023-grid" { ...plansTableProps } />
 		</div>
 	);
 
-	const upgradeOptions = isEnabled( 'plans/wooexpress-small' )
-		? performanceAndEssentialOption
-		: performanceOnlyOption;
+	const availablePlanFeatures = isEnabled( 'plans/wooexpress-small' )
+		? multiPlanFeatures
+		: performanceOnlyFeatures;
 
 	return (
 		<>
@@ -67,7 +67,7 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 				<ECommerceTrialBanner />
 			</div>
 
-			{ upgradeOptions }
+			{ availablePlanFeatures }
 		</>
 	);
 };

--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -1,10 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
-import { getPlans, plansLink, PLAN_WOOEXPRESS_MEDIUM } from '@automattic/calypso-products';
+import { plansLink, PLAN_FREE, PLAN_WOOEXPRESS_MEDIUM } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
+import AsyncLoad from 'calypso/components/async-load';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
-import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import ECommercePlanFeatures from 'calypso/my-sites/plans/components/ecommerce-plan-features';
 import ECommerceTrialBanner from './ecommerce-trial-banner';
 import { getWooExpressMediumFeatureSets } from './wx-medium-features';
@@ -44,31 +44,15 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 		/>
 	);
 
-	const mediumPlan = getPlans()[ PLAN_WOOEXPRESS_MEDIUM ];
-	// const smallPlan = getPlans()[ PLAN_WOOEXPRESS_SMALL ];
-	const mediumFeaturesRaw = [
-		...( mediumPlan?.getInferiorFeatures?.() || [] ),
-		...( mediumPlan?.getIncludedFeatures?.() || [] ),
-	];
-	const mediumFeatureList = getPlanFeaturesObject( mediumFeaturesRaw ).map( ( f, i ) => ( {
-		feature: mediumFeaturesRaw?.[ i ],
-		title: f?.getTitle?.(),
-		description: f?.getDescription?.(),
-	} ) );
+	const tableProps = {
+		plans: [ PLAN_FREE, PLAN_WOOEXPRESS_MEDIUM ],
+		hidePlansFeatureComparison: true,
+	};
 
 	const performanceAndEssentialOption = (
-		<table>
-			<tr>
-				<td>Performance</td>
-			</tr>
-			{ mediumFeatureList.map( ( item ) => {
-				return (
-					<tr>
-						<td>{ item?.title || item?.feature }</td>
-					</tr>
-				);
-			} ) }
-		</table>
+		<div className="is-2023-pricing-grid">
+			<AsyncLoad require="calypso/my-sites/plan-features-2023-grid" { ...tableProps } />
+		</div>
 	);
 
 	const upgradeOptions = isEnabled( 'plans/wooexpress-small' )


### PR DESCRIPTION
## Proposed Changes

* Added the logic to show a different Plans page for sites on trial
* Added some PoC code to show plan's features table
* Works behind the `plan/wooexpress-small` feature flag

## Testing Instructions

* With the flag enabled, open the Plans site using a site that is on trial: `/plans/<site-slug>?flags=plans/wooexpress-small`
* You should see a list of features (Not the final list yet!)
 
![image](https://user-images.githubusercontent.com/3801502/228346130-8ab6b9c7-601d-4a35-a873-1f7108769b4d.png)


* With the flag disabled (`flags=-plans/wooexpress-small`) you should see the relugar page
![image](https://user-images.githubusercontent.com/3801502/228222181-d0707661-fe99-433b-9e21-27f46f9d7302.png)

