### PR TITLE
Jetpack Pro Dashboard: add track events to the expandable block changes

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -11,6 +11,7 @@ import {
 	getSelectedLicensesSiteId,
 } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
+import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
 import SiteActions from '../site-actions';
 import SiteErrorContent from '../site-error-content';
 import SiteExpandedContent from '../site-expanded-content';
@@ -29,6 +30,8 @@ export default function SiteCard( { rows, columns }: Props ) {
 	const dispatch = useDispatch();
 	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
 
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, true );
+
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ expandedColumn, setExpandedColumn ] = useState< AllowedTypes | null >( null );
 	const blogId = rows.site.value.blog_id;
@@ -39,6 +42,11 @@ export default function SiteCard( { rows, columns }: Props ) {
 	const isSiteConnected = data ? data.connected : true;
 
 	const handleSetExpandedColumn = ( column: AllowedTypes ) => {
+		recordEvent( 'expandable_block_column_toggled', {
+			column,
+			expanded: expandedColumn !== column,
+			site_id: blogId,
+		} );
 		setExpandedColumn( expandedColumn === column ? null : column );
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -16,11 +16,20 @@ import type { Site, Backup } from '../types';
 
 interface Props {
 	site: Site;
+	trackEvent: ( eventName: string ) => void;
 }
 
 const BACKUP_ERROR_STATUSES = [ 'rewind_backup_error', 'backup_only_error' ];
 
-const BackupStorageContent = ( { siteId, siteUrl }: { siteId: number; siteUrl: string } ) => {
+const BackupStorageContent = ( {
+	siteId,
+	siteUrl,
+	trackEvent,
+}: {
+	siteId: number;
+	siteUrl: string;
+	trackEvent: ( eventName: string ) => void;
+} ) => {
 	const translate = useTranslate();
 
 	const moment = useLocalizedMoment();
@@ -72,6 +81,7 @@ const BackupStorageContent = ( { siteId, siteUrl }: { siteId: number; siteUrl: s
 			</div>
 			<div className="site-expanded-content__card-footer">
 				<Button
+					onClick={ () => trackEvent( 'expandable_block_activity_log_click' ) }
 					href={ `/activity-log/${ siteUrl }` }
 					className="site-expanded-content__card-button"
 					compact
@@ -83,7 +93,7 @@ const BackupStorageContent = ( { siteId, siteUrl }: { siteId: number; siteUrl: s
 	);
 };
 
-export default function BackupStorage( { site }: Props ) {
+export default function BackupStorage( { site, trackEvent }: Props ) {
 	const {
 		blog_id: siteId,
 		url: siteUrl,
@@ -154,7 +164,13 @@ export default function BackupStorage( { site }: Props ) {
 			onClick={ ! isBackupEnabled ? handleOnClick : undefined }
 			href={ link }
 		>
-			{ isBackupEnabled && <BackupStorageContent siteId={ siteId } siteUrl={ siteUrl } /> }
+			{ isBackupEnabled && (
+				<BackupStorageContent
+					siteId={ site.blog_id }
+					siteUrl={ site.url }
+					trackEvent={ trackEvent }
+				/>
+			) }
 		</ExpandedCard>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -131,7 +131,22 @@ export default function BackupStorage( { site, trackEvent }: Props ) {
 		} )
 	);
 
+	const handleTrackEvent = () => {
+		let trackName;
+		if ( hasBackupError ) {
+			trackName = 'expandable_block_backup_error_click';
+		} else if ( ! hasBackup ) {
+			trackName = isLicenseSelected
+				? 'expandable_block_backup_remove_click'
+				: 'expandable_block_backup_add_click';
+		}
+		if ( trackName ) {
+			return trackEvent( trackName );
+		}
+	};
+
 	const handleOnClick = () => {
+		handleTrackEvent();
 		// If the backup is not enabled, we want to add the license
 		if ( ! hasBackup ) {
 			handleAddLicenseAction();

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -14,6 +14,7 @@ interface Props {
 	hasBoost: boolean;
 	siteId: number;
 	siteUrlWithScheme: string;
+	trackEvent: ( eventName: string ) => void;
 }
 
 export default function BoostSitePerformance( {
@@ -21,6 +22,7 @@ export default function BoostSitePerformance( {
 	hasBoost,
 	siteId,
 	siteUrlWithScheme,
+	trackEvent,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -110,6 +112,7 @@ export default function BoostSitePerformance( {
 					<Button
 						href={ href }
 						target="_blank"
+						onClick={ () => trackEvent( 'expandable_block_optimize_css_click' ) }
 						className="site-expanded-content__card-button"
 						compact
 					>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
 import BackupStorage from './backup-storage';
 import BoostSitePerformance from './boost-site-performance';
 import InsightsStats from './insights-stats';
@@ -19,9 +20,15 @@ export default function SiteExpandedContent( {
 	columns = defaultColumns,
 	isSmallScreen = false,
 }: Props ) {
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], ! isSmallScreen );
+
 	const stats = site.site_stats;
 	const boostData = site.jetpack_boost_scores;
 	const siteUrlWithScheme = site.url_with_scheme;
+
+	const trackEvent = ( eventName: string ) => {
+		recordEvent( eventName );
+	};
 
 	return (
 		<div
@@ -40,7 +47,9 @@ export default function SiteExpandedContent( {
 					hasBoost={ site.has_boost }
 				/>
 			) }
-			{ columns.includes( 'backup' ) && stats && <BackupStorage site={ site } /> }
+			{ columns.includes( 'backup' ) && stats && (
+				<BackupStorage site={ site } trackEvent={ trackEvent } />
+			) }
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -37,7 +37,11 @@ export default function SiteExpandedContent( {
 			} ) }
 		>
 			{ columns.includes( 'stats' ) && stats && (
-				<InsightsStats stats={ stats } siteUrlWithScheme={ siteUrlWithScheme } />
+				<InsightsStats
+					stats={ stats }
+					siteUrlWithScheme={ siteUrlWithScheme }
+					trackEvent={ trackEvent }
+				/>
 			) }
 			{ columns.includes( 'boost' ) && (
 				<BoostSitePerformance

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -45,6 +45,7 @@ export default function SiteExpandedContent( {
 					siteId={ site.blog_id }
 					siteUrlWithScheme={ siteUrlWithScheme }
 					hasBoost={ site.has_boost }
+					trackEvent={ trackEvent }
 				/>
 			) }
 			{ columns.includes( 'backup' ) && stats && (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats.tsx
@@ -8,9 +8,10 @@ import type { SiteStats } from '../types';
 interface Props {
 	stats: SiteStats;
 	siteUrlWithScheme: string;
+	trackEvent: ( eventName: string ) => void;
 }
 
-export default function InsightsStats( { stats, siteUrlWithScheme }: Props ) {
+export default function InsightsStats( { stats, siteUrlWithScheme, trackEvent }: Props ) {
 	const translate = useTranslate();
 
 	const data = {
@@ -82,6 +83,7 @@ export default function InsightsStats( { stats, siteUrlWithScheme }: Props ) {
 					<Button
 						href={ href }
 						target="_blank"
+						onClick={ () => trackEvent( 'expandable_block_see_all_stats_click' ) }
 						className="site-expanded-content__card-button"
 						compact
 					>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -5,6 +5,7 @@ import { useContext, useState, forwardRef, Ref } from 'react';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import './style.scss';
 import EditButton from '../../dashboard-bulk-actions/edit-button';
+import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
 import SitesOverviewContext from '../context';
 import SiteBulkSelect from '../site-bulk-select';
 import SiteSort from '../site-sort';
@@ -20,9 +21,15 @@ interface Props {
 const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableElement > ) => {
 	const { isBulkManagementActive } = useContext( SitesOverviewContext );
 
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, true );
+
 	const [ expandedRow, setExpandedRow ] = useState< number | null >( null );
 
 	const setExpanded = ( blogId: number ) => {
+		recordEvent( 'expandable_block_toggled', {
+			expanded: expandedRow !== blogId,
+			site_id: blogId,
+		} );
 		setExpandedRow( expandedRow === blogId ? null : blogId );
 	};
 


### PR DESCRIPTION
Related to 1203940061556608-as-1203942568423011

#### Proposed Changes

This PR adds tracking events to the expandable block changes

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

> **_NOTE:_**  You can always append the live link URL with `?flags=jetpack/pro-dashboard-expandable-block` to test these changes using the live link.

**Instructions**

1. Run `git checkout add/track-events-to-expandable-block` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
4. Open the dev tool, go to the network tab, and apply the filters - `jetpack-cloud-development` as search and select `Img` filters.

<img width="751" alt="Screenshot 2023-03-28 at 5 26 32 PM" src="https://user-images.githubusercontent.com/10586875/228228501-4010d182-1555-40eb-87f5-1c5e435dc283.png">

5. Perform the below actions and verify that the API call to track the event is made with the right action names. 

`L: Large screen(>1280px)`
`S: Small Screen(<1280px)`

----

#### Toggle expandable block

Click expand site row on the table(large screen)

<img width="276" alt="Screenshot 2023-03-28 at 5 41 59 PM" src="https://user-images.githubusercontent.com/10586875/228232274-e7fad55e-7cef-4c33-b86e-195e90e3e1b5.png">

`calypso_jetpack_agency_dashboard_expandable_block_toggled_large_screen`

Click expand site row on the table(small screen)

<img width="287" alt="Screenshot 2023-03-28 at 5 43 05 PM" src="https://user-images.githubusercontent.com/10586875/228232446-71d7e8eb-40f8-4884-894f-ad87fb7cbb19.png">


`calypso_jetpack_agency_dashboard_expandable_block_column_toggled_small_screen`

----

#### Click the `Activity log` button

<img width="353" alt="Screenshot 2023-03-27 at 7 01 11 PM" src="https://user-images.githubusercontent.com/10586875/228231532-ed5a9f41-3a0f-4f5b-8787-170b74415fd4.png">

`Event names`

L: calypso_jetpack_agency_dashboard_expandable_block_activity_log_click_large_screen
S: calypso_jetpack_agency_dashboard_expandable_block_activity_log_click_small_screen

----

#### Click the `Optimize CSS` button

<img width="408" alt="Screenshot 2023-03-20 at 4 44 44 PM" src="https://user-images.githubusercontent.com/10586875/228231620-2dd8698c-cd85-4edd-85ce-64890f485729.png">

`Event names`

L: calypso_jetpack_agency_dashboard_expandable_block_optimize_css_click_large_screen
S: calypso_jetpack_agency_dashboard_expandable_block_optimize_css_click_small_screen

----

#### Click the `See all stats` button

<img width="374" alt="Screenshot 2023-02-24 at 1 37 08 PM" src="https://user-images.githubusercontent.com/10586875/228231727-1c2164e6-50e7-45ac-bdb5-d5b36351490d.png">

`Event names`

L: calypso_jetpack_agency_dashboard_expandable_block_see_all_stats_click_large_screen
S: calypso_jetpack_agency_dashboard_expandable_block_see_all_stats_click_small_screen

----

#### Click on the backup card to add Backup

<img width="333" alt="Screenshot 2023-03-27 at 2 33 17 PM" src="https://user-images.githubusercontent.com/10586875/228231835-bd1fd385-eba3-4f81-96eb-f1c8df4095d3.png">

`Event names`

L: calypso_jetpack_agency_dashboard_expandable_block_backup_add_click_large_screen
S: calypso_jetpack_agency_dashboard_expandable_block_backup_add_click_small_screen

----

#### Click on the backup card to remove Backup

<img width="346" alt="Screenshot 2023-03-27 at 3 22 54 PM" src="https://user-images.githubusercontent.com/10586875/228231906-0842795e-f0f9-4bd5-a9b4-476a1925a679.png">

`Event names`

L: calypso_jetpack_agency_dashboard_expandable_block_backup_remove_click_large_screen
S: calypso_jetpack_agency_dashboard_expandable_block_backup_remove_click_small_screen

----

#### Click on the backup card when there is an error

<img width="336" alt="Screenshot 2023-03-27 at 2 33 09 PM" src="https://user-images.githubusercontent.com/10586875/228231962-e40beaff-7aff-40a7-979c-5efa86483773.png">

`Event names`

L: calypso_jetpack_agency_dashboard_expandable_block_backup_error_click_large_screen
S: calypso_jetpack_agency_dashboard_expandable_block_backup_error_click_small_screen

----

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?