### PR TITLE
Logging: Show placeholder UI while loading logs

### DIFF
--- a/client/my-sites/site-logs/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/index.tsx
@@ -5,6 +5,8 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { SiteLogsData } from 'calypso/data/hosting/use-site-logs-query';
 import getSiteSetting from 'calypso/state/selectors/get-site-setting';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { Skeleton } from './skeleton';
+
 import './style.scss';
 
 type SiteLogs = SiteLogsData[ 'logs' ];
@@ -24,6 +26,10 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 		const siteId = getSelectedSiteId( state );
 		return ( getSiteSetting( state, siteId ?? 0, 'gmt_offset' ) as number | null ) ?? 0;
 	} );
+
+	if ( isLoading ) {
+		return <Skeleton />;
+	}
 
 	return (
 		<table className={ classnames( 'site-logs-table', { 'is-loading': isLoading } ) }>

--- a/client/my-sites/site-logs/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/index.tsx
@@ -27,7 +27,7 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 		return ( getSiteSetting( state, siteId ?? 0, 'gmt_offset' ) as number | null ) ?? 0;
 	} );
 
-	if ( isLoading ) {
+	if ( isLoading && ! logs?.length ) {
 		return <Skeleton />;
 	}
 

--- a/client/my-sites/site-logs/components/site-logs-table/skeleton.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/skeleton.tsx
@@ -3,18 +3,21 @@ import { LoadingPlaceholder } from '@automattic/components';
 export const Skeleton = () => {
 	return (
 		<div className="site-logs-table__skeleton">
-			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
-
-			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
-			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
-			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
-			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
-			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
-			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
-			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
-			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
-			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
-			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-cell" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-cell" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-cell" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-cell" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-cell" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-cell" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-cell" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-cell" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-cell" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-cell" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-cell" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-cell" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-cell" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-cell" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-cell" />
 		</div>
 	);
 };

--- a/client/my-sites/site-logs/components/site-logs-table/skeleton.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/skeleton.tsx
@@ -1,0 +1,20 @@
+import { LoadingPlaceholder } from '@automattic/components';
+
+export const Skeleton = () => {
+	return (
+		<div className="site-logs-table__skeleton">
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
+
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
+			<LoadingPlaceholder className="site-logs-table__skeleton-table-row" />
+		</div>
+	);
+};

--- a/client/my-sites/site-logs/components/site-logs-table/style.scss
+++ b/client/my-sites/site-logs/components/site-logs-table/style.scss
@@ -31,12 +31,13 @@ $border-color: #d3dae6;
 }
 
 .site-logs-table__skeleton {
-	display: flex;
-	flex-direction: column;
-	gap: 1px;
-	height: 100%;
+	display: grid;
+	grid-template-columns: 400px 3fr 1fr;
+	gap: 20px;
+	overflow: hidden;
+	margin-top: 10px;
 }
 
-.site-logs-table__skeleton-table-row {
-	height: 43px;
+.site-logs-table__skeleton-table-cell {
+	height: 24px;
 }

--- a/client/my-sites/site-logs/components/site-logs-table/style.scss
+++ b/client/my-sites/site-logs/components/site-logs-table/style.scss
@@ -29,3 +29,14 @@ $border-color: #d3dae6;
 	content: "\2012";
 	opacity: 0.5;
 }
+
+.site-logs-table__skeleton {
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+	height: 100%;
+}
+
+.site-logs-table__skeleton-table-row {
+	height: 43px;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/1995

## Proposed Changes

* Show a placeholder skeleton view of the table fetching data. Just basic bars for now. Maybe we can use columns in a later version. 


https://user-images.githubusercontent.com/6851384/228236254-bc086c76-d26e-496b-8e04-39d7a542b70c.mp4



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using this branch, navigate to `/site-logs/:my-atomic-site`
* Verify loading bars are shown like the video
* Try changing tabs or changing page and verify they are shown also. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?