### PR TITLE
Logging: invalidate query and reset scroll ID when switching tabs

### DIFF
--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -43,7 +43,11 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 		) as SiteLogsTab;
 	} );
 
-	const { data: latestPageData, isLoading } = useSiteLogsQuery( siteId, {
+	const {
+		data: latestPageData,
+		isLoading,
+		invalidateQuery,
+	} = useSiteLogsQuery( siteId, {
 		logType,
 		start: dateRange.startTime,
 		end: dateRange.endTime,
@@ -61,6 +65,7 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 	}, [ latestPageData, isLoading ] );
 
 	const handleTabSelected = ( tabName: SiteLogsTab ) => {
+		invalidateQuery();
 		setLogType( tabName );
 		setCurrentPageIndex( 0 );
 	};

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -43,11 +43,7 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 		) as SiteLogsTab;
 	} );
 
-	const {
-		data: latestPageData,
-		isLoading,
-		invalidateQuery,
-	} = useSiteLogsQuery( siteId, {
+	const { data: latestPageData, isLoading } = useSiteLogsQuery( siteId, {
 		logType,
 		start: dateRange.startTime,
 		end: dateRange.endTime,
@@ -65,7 +61,6 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 	}, [ latestPageData, isLoading ] );
 
 	const handleTabSelected = ( tabName: SiteLogsTab ) => {
-		invalidateQuery();
 		setLogType( tabName );
 		setCurrentPageIndex( 0 );
 	};

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -63,10 +63,13 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 	const handleTabSelected = ( tabName: SiteLogsTab ) => {
 		setLogType( tabName );
 		setCurrentPageIndex( 0 );
+		setCachedPageData( undefined );
 	};
 
 	const handleRefresh = () => {
 		setDateRange( getDateRange() );
+		setCurrentPageIndex( 0 );
+		setCachedPageData( undefined );
 	};
 
 	const handlePageClick = ( nextPageNumber: number ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2065

## Proposed Changes

* Fixes the bug described in https://github.com/Automattic/dotcom-forge/issues/2065 which is caused by both log queries sharing the same `scroll_id`. The app now resets the `scroll_id` and invalidates the old query to free up memory. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On trunk, reproduce the issue by following the steps at https://github.com/Automattic/dotcom-forge/issues/2065
* Switch to this branch and navigate to `/site-logs/:my-atomic-site`
* Verify the issue is fixed and that the total records count now updates for each tab. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
