### PR TITLE
Update Pro plan copy to reflect that the plan itself is no longer available

### DIFF
--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -198,8 +198,8 @@ class CancelPurchase extends Component {
 
 		const { purchase, isJetpackPurchase } = this.props;
 		const purchaseName = getName( purchase );
-		const plan = getPlan( purchase.productSlug );
-		const planDescription = plan.getPlanCancellationDescription?.();
+		const plan = getPlan( purchase?.productSlug );
+		const planDescription = plan?.getPlanCancellationDescription?.();
 		const { siteName, siteId } = purchase;
 
 		let heading;

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -5,6 +5,7 @@ import {
 	hasMarketplaceProduct,
 	isJetpackPlan,
 	isJetpackProduct,
+	getPlan,
 } from '@automattic/calypso-products';
 import { Card, CompactCard } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
@@ -197,6 +198,8 @@ class CancelPurchase extends Component {
 
 		const { purchase, isJetpackPurchase } = this.props;
 		const purchaseName = getName( purchase );
+		const plan = getPlan( purchase.productSlug );
+		const planDescription = plan.getPlanCancellationDescription?.();
 		const { siteName, siteId } = purchase;
 
 		let heading;
@@ -247,6 +250,9 @@ class CancelPurchase extends Component {
 				<CompactCard className="cancel-purchase__product-information">
 					<div className="cancel-purchase__purchase-name">{ purchaseName }</div>
 					<div className="cancel-purchase__description">{ purchaseType( purchase ) }</div>
+					{ planDescription && (
+						<div className="cancel-purchase__plan-description">{ planDescription }</div>
+					) }
 					<ProductLink purchase={ purchase } selectedSite={ this.props.site } />
 				</CompactCard>
 				<CompactCard className="cancel-purchase__footer">

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -48,6 +48,7 @@
 }
 
 .cancel-purchase__refund-information,
+.cancel-purchase__plan-description,
 .cancel-purchase__support-information {
 	font-size: $font-body-small;
 }

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1388,7 +1388,9 @@ const getPlanProDetails = (): IncompleteWPcomPlan => ( {
 		),
 	getDescription: () =>
 		i18n.translate(
-			'Unlock the full power of WordPress with plugins, custom themes and much more.'
+			'You’ve got our best deal on hosting! ' +
+				'Your Pro plan includes access to all the most popular features WordPress.com has to offer, including premium themes and access to over 50,000 plugins. ' +
+				'As an existing customer, you can keep your site on this plan as long as your subscription remains active.'
 		),
 	getSubTitle: () => i18n.translate( 'Unlimited features. Unbeatable value.' ),
 	getPlanCompareFeatures: () => [

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1447,7 +1447,7 @@ const getPlanProDetails = (): IncompleteWPcomPlan => ( {
 	],
 	getPlanCancellationDescription: () =>
 		i18n.translate(
-			'Heads up—you’re currently on a legacy plan that is no longer available for new subscribers. ' +
+			'Heads up — you are currently on a legacy plan that is no longer available for new subscribers. ' +
 				'Your Pro plan includes access to all the most popular features WordPress.com has to offer, ' +
 				'including premium themes and access to over 50,000 plugins. As an existing Pro plan subscriber, ' +
 				'you can keep your site on this legacy plan as long as your subscription remains active. ' +

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1382,6 +1382,10 @@ const getPlanProDetails = (): IncompleteWPcomPlan => ( {
 	group: GROUP_WPCOM,
 	type: TYPE_PRO,
 	getTitle: () => i18n.translate( 'WordPress Pro' ),
+	getTagline: () =>
+		i18n.translate(
+			'This plan gives you access to our most powerful features at an affordable price for an unmatched value you won’t get anywhere else. No longer available to new users.'
+		),
 	getDescription: () =>
 		i18n.translate(
 			'Unlock the full power of WordPress with plugins, custom themes and much more.'

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1443,6 +1443,14 @@ const getPlanProDetails = (): IncompleteWPcomPlan => ( {
 		WPCOM_FEATURES_ANTISPAM,
 		WPCOM_FEATURES_BACKUPS,
 	],
+	getPlanCancellationDescription: () =>
+		i18n.translate(
+			'Heads up—you’re currently on a legacy plan that is no longer available for new subscribers. ' +
+				'Your Pro plan includes access to all the most popular features WordPress.com has to offer, ' +
+				'including premium themes and access to over 50,000 plugins. As an existing Pro plan subscriber, ' +
+				'you can keep your site on this legacy plan as long as your subscription remains active. ' +
+				'If canceled, the WordPress.com Pro plan can no longer be added to your account.'
+		),
 	getCancellationFeatureList: (): CancellationFeatureLists => ( {
 		monthly: {
 			featureList: [

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -59,7 +59,10 @@ export interface WPComPlan extends Plan {
 }
 
 export type IncompleteWPcomPlan = Partial< WPComPlan > &
-	Pick< WPComPlan, 'group' | 'type' | 'getTitle' | 'getDescription' >;
+	Pick<
+		WPComPlan,
+		'group' | 'type' | 'getTitle' | 'getDescription' | 'getPlanCancellationDescription'
+	>;
 
 // Jetpack
 export type JetpackProductSlug = ( typeof JETPACK_PRODUCTS_LIST )[ number ];
@@ -196,6 +199,7 @@ export type Plan = BillingTerm & {
 	getShortDescription?: () => TranslateResult;
 	getFeaturedDescription?: () => TranslateResult;
 	getLightboxDescription?: () => TranslateResult;
+	getPlanCancellationDescription?: () => TranslateResult;
 	getProductsIncluded?: () => ReadonlyArray< string >;
 	getWhatIsIncluded?: () => Array< TranslateResult >;
 	getBenefits?: () => Array< TranslateResult >;


### PR DESCRIPTION
This is a work in progress, the styling needs to be confirmed.

## Proposed Changes

* Add copy to my-plans according to pebzTe-TI-p2
* Add copy to me/purchases -> Cancel

See https://github.com/Automattic/dotcom-forge/issues/2034

## Testing Instructions

1. Add yourself a Pro plan from SA
2. Go to http://calypso.localhost:3000/plans/my-plan/YOUR SITE
3. You should see the first copy (the tagline) displayed instead of the default one
4. Go to purchases
5. You should see the new copy in the Purchase Details section
6. Click Cancel
7. You should see the second copy, the cancellation description

<img width="1064" alt="Screenshot 2023-03-28 at 18 18 57" src="https://user-images.githubusercontent.com/82778/228286086-cc82f4ba-0948-4c80-8e46-c90fd8131369.png">

<img width="1051" alt="Screenshot 2023-03-29 at 15 42 48" src="https://user-images.githubusercontent.com/82778/228539129-fd45822e-524f-4b65-bf12-2f99c2252d7c.png">

<img width="1071" alt="Screenshot 2023-03-28 at 18 19 24" src="https://user-images.githubusercontent.com/82778/228286209-13d05a89-c151-4866-8c17-74d96f32bb07.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
