### PR TITLE
Newsletter flow: Grey progress bar on signup step

### DIFF
--- a/client/signup/signup-header/style.scss
+++ b/client/signup/signup-header/style.scss
@@ -19,6 +19,9 @@
 		pointer-events: none;
 	}
 
+	.newsletter.progress-bar,
+	.link-in-bio.progress-bar,
+	.link-in-bio-tld.progress-bar,
 	.import.progress-bar,
 	.free.progress-bar {
 		position: absolute;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52076348/228298879-bf07e5d7-e80a-45dc-a36d-3e4b83e8bbed.png)

We are showing a grey progress bar on signup step on link in bio and newsletter flows.
Error was introduced [here](https://github.com/Automattic/wp-calypso/pull/74466). This PR fixes this.

## Testing
1. Calypso Live link
2. Go through the newsletter and the link in bio flows
3. Verify that the grey bar is gone

Fixes https://github.com/Automattic/wp-calypso/issues/75017