### PR TITLE
Welcome Tour: Fix the Welcome Tour is not shown in the page/post editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -65,7 +65,9 @@ function WelcomeTour() {
 	if ( ! show || isNewPageLayoutModalOpen ) {
 		return null;
 	}
-	if ( siteEditorCanvasMode !== 'edit' ) {
+
+	// Hide the Welcome Tour when not in the edit mode. Note that canvas mode is available only in the site editor
+	if ( siteEditorCanvasMode && siteEditorCanvasMode !== 'edit' ) {
 		return null;
 	}
 

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -100,6 +100,7 @@
 		"@wordpress/nux": "^5.20.0",
 		"@wordpress/plugins": "^4.20.0",
 		"@wordpress/primitives": "^3.20.0",
+		"@wordpress/private-apis": "^0.9.0",
 		"@wordpress/react-i18n": "^3.20.0",
 		"@wordpress/rich-text": "^5.20.0",
 		"@wordpress/scripts": "^24.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,6 +1890,7 @@ __metadata:
     "@wordpress/nux": ^5.20.0
     "@wordpress/plugins": ^4.20.0
     "@wordpress/primitives": ^3.20.0
+    "@wordpress/private-apis": ^0.9.0
     "@wordpress/react-i18n": ^3.20.0
     "@wordpress/readable-js-assets-webpack-plugin": ^2.5.0
     "@wordpress/rich-text": ^5.20.0


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1680005780303299-slack-CRWCHQGUB, https://github.com/Automattic/wp-calypso/pull/74242

## Proposed Changes

* Fix the Welcome Tour is not shown in the page/post editor

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `cd apps/editing-toolkit && yarn dev --sync` to sync the change to your sandbox
* Sandbox the domain of your site
* Head to the page/post editor, and ensure the Welcome Tour is available
* Head to the site editor
  * Ensure the Welcome Tour won't be shown in the view mode
  * Ensure the Welcome Tour is shown in the edit mode

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?