### PR TITLE
VAT Info: Use string interpolation for tax names

### DIFF
--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -12,6 +12,7 @@ import { vatDetails as vatDetailsPath, billingHistoryReceipt } from 'calypso/me/
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
 import titles from 'calypso/me/purchases/titles';
 import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
+import { getVatVendorInfo } from './vat-vendor-details';
 
 import './style.scss';
 
@@ -32,8 +33,18 @@ export function BillingHistoryContent( {
 function BillingHistory() {
 	const translate = useTranslate();
 	const { vatDetails } = useVatDetails();
-	const editVatText = translate( 'Edit Business Tax ID details' );
-	const addVatText = translate( 'Add Business Tax ID details' );
+	const vendorInfo = getVatVendorInfo( vatDetails.country ?? 'GB', 'now', translate );
+
+	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+	const editVatText = translate( 'Edit %s details', {
+		textOnly: true,
+		args: [ vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } ) ],
+	} );
+	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+	const addVatText = translate( 'Add %s details', {
+		textOnly: true,
+		args: [ vendorInfo?.taxName ?? translate( 'VAT', { textOnly: true } ) ],
+	} );
 	const vatText = vatDetails.id ? editVatText : addVatText;
 
 	return (

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -6,6 +6,7 @@ import QueryBillingTransactions from 'calypso/components/data/query-billing-tran
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import BillingHistoryList from 'calypso/me/purchases/billing-history/billing-history-list';
 import { vatDetails as vatDetailsPath, billingHistoryReceipt } from 'calypso/me/purchases/paths';
@@ -33,7 +34,12 @@ export function BillingHistoryContent( {
 function BillingHistory() {
 	const translate = useTranslate();
 	const { vatDetails } = useVatDetails();
-	const vendorInfo = getVatVendorInfo( vatDetails.country ?? 'GB', 'now', translate );
+	const { data: geoData } = useGeoLocationQuery();
+	const vendorInfo = getVatVendorInfo(
+		vatDetails.country ?? geoData?.country_short ?? 'GB',
+		'now',
+		translate
+	);
 
 	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
 	const editVatText = translate( 'Edit %s details', {

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -55,9 +55,6 @@ Object.defineProperties( titles, {
 	paymentMethods: {
 		get: () => i18n.translate( 'Payment Methods' ),
 	},
-	vatDetails: {
-		get: () => i18n.translate( 'Business Tax ID details' ),
-	},
 } );
 
 export default titles;

--- a/client/me/purchases/vat-info/index.tsx
+++ b/client/me/purchases/vat-info/index.tsx
@@ -10,6 +10,7 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
+import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import useCountryList, {
 	isVatSupported,
@@ -25,10 +26,11 @@ import './style.scss';
 
 export default function VatInfoPage() {
 	const translate = useTranslate();
+	const { data: geoData } = useGeoLocationQuery();
 	const { isLoading, fetchError, vatDetails } = useVatDetails();
 	const [ currentVatDetails, setCurrentVatDetails ] = useState< VatDetails >( {} );
 	const vendorInfo = getVatVendorInfo(
-		currentVatDetails.country ?? vatDetails.country ?? 'GB',
+		currentVatDetails.country ?? vatDetails.country ?? geoData?.country_short ?? 'GB',
 		'now',
 		translate
 	);
@@ -100,10 +102,11 @@ function VatForm( {
 } ) {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
+	const { data: geoData } = useGeoLocationQuery();
 	const { vatDetails, isUpdating, isUpdateSuccessful, setVatDetails, updateError } =
 		useVatDetails();
 	const vendorInfo = getVatVendorInfo(
-		currentVatDetails.country ?? vatDetails.country ?? 'GB',
+		currentVatDetails.country ?? vatDetails.country ?? geoData?.country_short ?? 'GB',
 		'now',
 		translate
 	);
@@ -272,8 +275,13 @@ function useDisplayVatNotices( {
 } ) {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
+	const { data: geoData } = useGeoLocationQuery();
 	const { vatDetails } = useVatDetails();
-	const vendorInfo = getVatVendorInfo( vatDetails.country ?? 'GB', 'now', translate );
+	const vendorInfo = getVatVendorInfo(
+		vatDetails.country ?? geoData?.country_short ?? 'GB',
+		'now',
+		translate
+	);
 
 	useEffect( () => {
 		if ( error ) {


### PR DESCRIPTION
## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/74538 which localized the "VAT" term in checkout. Because the name of VAT changes based on country, it would be better to use a localized term. In https://github.com/Automattic/wp-calypso/pull/73686 we modified the labels for the VAT form use use the more generic term "Business Tax", but this is still a little unclear.

In this PR we switch each of these labels to replace "Business Tax" with the selected country's term for VAT (eg: "GST", "CT", etc.) on the user-level VAT form.

**NOTE:** This can only localize once a country is selected... which means that the button to reach the form will always read "Add VAT details" before the user reaches the form. To resolve that case, we use the [useGeoLocationQuery() hook](https://github.com/Automattic/wp-calypso/blob/136443bd1dfb5792563475a4a4981e0ffded1750/client/data/geo/use-geolocation-query.js#L3) to provide a fallback country.

This is part of https://github.com/Automattic/payments-shilling/issues/1475 and https://github.com/Automattic/payments-shilling/issues/1474

## Screenshots

<img width="488" alt="Screenshot 2023-03-28 at 1 10 40 PM" src="https://user-images.githubusercontent.com/2036909/228316681-295179bb-f65a-4404-880c-60519ad466d2.png">

<img width="970" alt="Screenshot 2023-03-28 at 2 12 32 PM" src="https://user-images.githubusercontent.com/2036909/228330096-0155ddd9-cc45-4faa-99f4-f0b7a5137778.png">

<img width="970" alt="Screenshot 2023-03-28 at 1 11 02 PM" src="https://user-images.githubusercontent.com/2036909/228316742-086ea960-573f-4645-aebe-feaa2cbf91ea.png">

<img width="958" alt="Screenshot 2023-03-28 at 1 11 09 PM" src="https://user-images.githubusercontent.com/2036909/228316760-fe3aff04-3768-4537-9b63-f0dfd148676c.png">

<img width="968" alt="Screenshot 2023-03-28 at 2 12 24 PM" src="https://user-images.githubusercontent.com/2036909/228330074-ee752810-6e5e-4ae2-9a09-04621d6c73bf.png">

## Testing Instructions

- Visit `/me/purchases/vat-details`.
- Select a country that uses the term "VAT" like the United Kingdom.
- Verify that all the form labels use the word "VAT".
- Select a country that uses a different term like Australia, which uses "GST".
- Verify that all the form labels use the word "GST" (except for the title, which won't change until the details are saved).
- Visit `/me/purchases/billing` and set your geolocation (eg: using a VPN) to somewhere that is in a country that does not use "VAT" (eg: Australia).
- Verify that the button at the bottom reads "Add GST details".