### PR TITLE
Jetpack Agency Prices: Remove columns for user pricing

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
@@ -1,6 +1,5 @@
 import { formatCurrency } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -9,81 +8,22 @@ import LicenseBundleCardDescription from 'calypso/jetpack-cloud/sections/partner
 import SelectPartnerKeyDropdown from 'calypso/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown';
 import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
-import { getProductsList } from 'calypso/state/products-list/selectors';
 
 import './style.scss';
 
 export default function Prices() {
 	const translate = useTranslate();
 	const { data: agencyProducts } = useProductsQuery();
-	const userProducts = useSelector( ( state ) => getProductsList( state ) );
 	const currencyFormatOptions = { stripZeros: true };
 
 	const productRows = agencyProducts?.map( ( product ) => {
-		const userYearlyProduct = Object.values( userProducts ).find(
-			( p ) => p.product_id === product.product_id
-		);
-		const userMonthlyProduct =
-			userYearlyProduct &&
-			Object.values( userProducts ).find(
-				( p ) =>
-					p.billing_product_slug === userYearlyProduct.billing_product_slug &&
-					p.product_term === 'month'
-			);
-
 		const dailyAgencyPrice = ( product.amount * 12 ) / 365;
-		const dailyUserMonthlyPrice = userMonthlyProduct ? ( userMonthlyProduct.cost * 12 ) / 365 : 0;
-		const dailyUserYearlyPrice = userYearlyProduct ? userYearlyProduct.cost / 365 : 0;
 
 		return (
 			<tr key={ product.product_id }>
 				<td>
 					<strong>{ product.name }</strong>
 					<LicenseBundleCardDescription product={ product } />
-				</td>
-				<td>
-					<div className="prices__mobile-description">
-						<div>{ translate( 'Jetpack.com Pricing' ) }</div>
-						<span className="prices__th-detail">{ translate( 'billed monthly' ) }</span>
-					</div>
-					<div>
-						{ translate( '%(price)s/day', {
-							args: {
-								price: formatCurrency( dailyUserMonthlyPrice, 'USD', currencyFormatOptions ),
-							},
-						} ) }
-					</div>
-					<div>
-						{ translate( '%(price)s/month', {
-							args: {
-								price:
-									userMonthlyProduct &&
-									formatCurrency( userMonthlyProduct.cost, 'USD', currencyFormatOptions ),
-							},
-						} ) }
-					</div>
-				</td>
-				<td>
-					<div className="prices__mobile-description">
-						<div>{ translate( 'Jetpack.com Pricing' ) }</div>
-						<span className="prices__th-detail">{ translate( 'billed yearly' ) }</span>
-					</div>
-					<div>
-						{ translate( '%(price)s/day', {
-							args: {
-								price: formatCurrency( dailyUserYearlyPrice, 'USD', currencyFormatOptions ),
-							},
-						} ) }
-					</div>
-					<div>
-						{ translate( '%(price)s/year', {
-							args: {
-								price:
-									userYearlyProduct &&
-									formatCurrency( userYearlyProduct.cost, 'USD', currencyFormatOptions ),
-							},
-						} ) }
-					</div>
 				</td>
 				<td>
 					<div className="prices__mobile-description">
@@ -129,14 +69,6 @@ export default function Prices() {
 				<thead>
 					<tr>
 						<th></th>
-						<th>
-							<div>{ translate( 'Jetpack.com Pricing' ) }</div>
-							<span className="prices__th-detail">{ translate( 'billed monthly' ) }</span>
-						</th>
-						<th>
-							<div>{ translate( 'Jetpack.com Pricing' ) }</div>
-							<span className="prices__th-detail">{ translate( 'billed yearly' ) }</span>
-						</th>
 						<th>
 							<div>{ translate( 'Agency/Pro Pricing' ) }</div>
 							<span className="prices__th-detail">{ translate( 'daily pricing' ) }</span>

--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/style.scss
@@ -49,6 +49,11 @@ tr:nth-child(odd) {
 	vertical-align: middle;
 }
 
+.prices__table tr td:last-child,
+.prices__table tr th:last-child {
+	text-align: right;
+}
+
 .prices__table .license-bundle-card-description {
 	margin-top: 0;
 }
@@ -97,5 +102,10 @@ tr:nth-child(odd) {
 		display: block;
 		width: 100%;
 		padding: 0.5rem 0;
+	}
+
+	.prices__table tr td:last-child,
+	.prices__table tr th:last-child {
+		text-align: left;
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* Removes columns that detail monthly and yearly user pricing from the Agency Dashboard prices page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in and view the prices page. The user pricing columns should no longer be present.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
