### PR TITLE
Launchpad: Update fetch launchpad options error handling

### DIFF
--- a/client/data/sites/use-launchpad.ts
+++ b/client/data/sites/use-launchpad.ts
@@ -1,12 +1,27 @@
 import { useQuery } from 'react-query';
 import wpcom from 'calypso/lib/wp';
 
-export const fetchLaunchpad = ( siteSlug: string ) => {
+export const fetchLaunchpad = ( siteSlug: string | null ) => {
 	const slug = encodeURIComponent( siteSlug as string );
-	return wpcom.req.get( {
-		path: `/sites/${ slug }/launchpad`,
-		apiNamespace: 'wpcom/v2',
-	} );
+
+	return (
+		wpcom.req
+			.get( {
+				path: `/sites/${ slug }/launchpad`,
+				apiNamespace: 'wpcom/v2',
+			} )
+			// There are unidentified situations where the fetch launchpad
+			// get request fail. We introduce error handling that returns
+			// placeholder data as a temporary stopgap to prevent noisy sentry
+			// logs from being generated.
+			.catch( () => {
+				return Promise.resolve( {
+					checklist_statuses: [],
+					launchpad_screen: undefined,
+					site_intent: '',
+				} );
+			} )
+	);
 };
 
 export const useLaunchpad = ( siteSlug: string | null, cache = true ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/75050

## Context
* We were spotting an error `Cannot read properties of undefined (reading 'launchpad_screen')`. 
* According to our logging service, it was being generated by [this line](https://github.com/Automattic/wp-calypso/blob/2c1934f2a5b128511ffa0d6d25991c156423d342/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx#L38) in `launchpad/index.tsx` ( it invokes the hook for our new endpoint and returns the `launchpad_screen` option )
* We're still unsure of the root cause, and for the time being, we're simply catching errors and returning placeholder data so that runtime errors stop occurring

## Proposed Changes

* Catch errors being returned by fetch launchpad and return placeholder data instead

## Testing Instructions

We know that the error Cannot read properties of undefined (reading 'launchpad_screen') is generated when a falsey siteSlug value is passed to useLaunchpad.

- Comment out references to `fetchingSiteError` ( unsure why this is necessary to emulate the error, but we think it has to do with race conditions )
- Add the `cacheTime: 0` setting to the `useQuery` call in https://github.com/Automattic/wp-calypso/blob/trunk/client/data/sites/use-launchpad.ts#L14
- Force siteSlug to be an `undefined` value in the `useLaunchpad` hook
- Use the free flow to create a new site calypso.localhost:3000/setup/free/intro
- Open chrome dev tools
- Finish all steps and get to the Launchpad
- Ensure that the `Cannot read properties of undefined (reading 'launchpad_screen')` error does not appear in the dev console

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
