### PR TITLE
Add overlaping Akismet product notice in checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -684,7 +684,7 @@ export default function CheckoutMain( {
 			<QueryJetpackSaleCoupon />
 			<QuerySitePlans siteId={ updatedSiteId } />
 			<QuerySitePurchases siteId={ updatedSiteId } />
-			<QueryUserPurchases />
+			{ isSiteless && <QueryUserPurchases /> }
 			<QueryPlans />
 			<QueryProducts />
 			<QueryContactDetailsCache />

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -16,6 +16,7 @@ import QueryPostCounts from 'calypso/components/data/query-post-counts';
 import QueryProducts from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import { recordAddEvent } from 'calypso/lib/analytics/cart';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import useSiteDomains from 'calypso/my-sites/checkout/composite-checkout/hooks/use-site-domains';
@@ -683,6 +684,7 @@ export default function CheckoutMain( {
 			<QueryJetpackSaleCoupon />
 			<QuerySitePlans siteId={ updatedSiteId } />
 			<QuerySitePurchases siteId={ updatedSiteId } />
+			<QueryUserPurchases />
 			<QueryPlans />
 			<QueryProducts />
 			<QueryContactDetailsCache />

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/akismet-product-overlaps-owned-product-notice.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/akismet-product-overlaps-owned-product-notice.tsx
@@ -1,6 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent } from 'react';
-import { Purchase } from 'calypso/lib/purchases/types';
+import type { FunctionComponent } from 'react';
+import type { Purchase } from 'calypso/lib/purchases/types';
 import PrePurchaseNotice from './prepurchase-notice';
 
 import './style.scss';

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/akismet-product-overlaps-owned-product-notice.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/akismet-product-overlaps-owned-product-notice.tsx
@@ -11,10 +11,7 @@ type Props = {
 
 const AkismetProductOverlapsOwnedProductNotice: FunctionComponent< Props > = ( { purchase } ) => {
 	const translate = useTranslate();
-	const purchaseId = purchase?.id;
-	const subscriptionUrl = purchaseId
-		? `/me/purchases/siteless.akismet.com/${ purchaseId }`
-		: '/me/purchases/';
+	const subscriptionUrl = `/me/purchases/siteless.akismet.com/${ purchase.id }`;
 
 	const message = translate(
 		'The plan you are about to purchase contains all the same features of your current plan. Consider {{link}}removing your %(product)s subscription{{/link}} to avoid paying for both plans.',

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/akismet-product-overlaps-owned-product-notice.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/akismet-product-overlaps-owned-product-notice.tsx
@@ -1,44 +1,30 @@
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
-import { useSelector } from 'react-redux';
-import { getProductBySlug } from 'calypso/state/products-list/selectors';
-import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import { Purchase } from 'calypso/lib/purchases/types';
 import PrePurchaseNotice from './prepurchase-notice';
 
 import './style.scss';
 
 type Props = {
-	overlapingProductSlug: string;
-	cartProductSlug: string;
+	purchase: Purchase;
 };
 
-const AkismetProductOverlapsOwnedProductNotice: FunctionComponent< Props > = ( {
-	overlapingProductSlug,
-	cartProductSlug,
-} ) => {
+const AkismetProductOverlapsOwnedProductNotice: FunctionComponent< Props > = ( { purchase } ) => {
 	const translate = useTranslate();
-	const products = useSelector( ( state ) => ( {
-		overlaping: getProductBySlug( state, overlapingProductSlug ),
-		cart: getProductBySlug( state, cartProductSlug ),
-	} ) );
-	const purchases = useSelector( getUserPurchases );
-	const purchase = Array.isArray( purchases )
-		? purchases.find( ( p ) => p.productSlug === products.overlaping?.product_slug )
-		: null;
 	const purchaseId = purchase?.id;
 	const subscriptionUrl = purchaseId
 		? `/me/purchases/siteless.akismet.com/${ purchaseId }`
 		: '/me/purchases/';
 
 	const message = translate(
-		'You current own {{oldProduct/}}. The plan you are about to purchase {{newProduct/}} contains all the same functionality and benefits of your current plan. Consider {{link}}removing your {{oldProduct/}} subscription{{/link}} to avoid paying for both plans.',
+		'The plan you are about to purchase contains all the same features of your current plan. Consider {{link}}removing your %(product)s subscription{{/link}} to avoid paying for both plans.',
 		{
-			comment:
-				'The `oldProduct` variable refers to the product the customer owns already. The `newProduct` variable refers to the product they are about to purchase.',
+			comment: 'The `product` variable refers to the product the customer owns already.',
 			components: {
 				link: <a href={ subscriptionUrl } />,
-				oldProduct: <>{ products.overlaping?.product_name }</>,
-				newProduct: <>{ products.cart?.product_name }</>,
+			},
+			args: {
+				product: purchase.productName,
 			},
 		}
 	);

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/akismet-product-overlaps-owned-product-notice.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/akismet-product-overlaps-owned-product-notice.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
-import type { FunctionComponent } from 'react';
-import type { Purchase } from 'calypso/lib/purchases/types';
 import PrePurchaseNotice from './prepurchase-notice';
+import type { Purchase } from 'calypso/lib/purchases/types';
+import type { FunctionComponent } from 'react';
 
 import './style.scss';
 

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/akismet-product-overlaps-owned-product-notice.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/akismet-product-overlaps-owned-product-notice.tsx
@@ -1,0 +1,55 @@
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import { useSelector } from 'react-redux';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import PrePurchaseNotice from './prepurchase-notice';
+
+import './style.scss';
+
+type Props = {
+	overlapingProductSlug: string;
+	cartProductSlug: string;
+};
+
+const AkismetProductOverlapsOwnedProductNotice: FunctionComponent< Props > = ( {
+	overlapingProductSlug,
+	cartProductSlug,
+} ) => {
+	const translate = useTranslate();
+	const products = useSelector( ( state ) => ( {
+		overlaping: getProductBySlug( state, overlapingProductSlug ),
+		cart: getProductBySlug( state, cartProductSlug ),
+	} ) );
+	const purchases = useSelector( getUserPurchases );
+	const purchase = Array.isArray( purchases )
+		? purchases.find( ( p ) => p.productSlug === products.overlaping?.product_slug )
+		: null;
+	const purchaseId = purchase?.id;
+	const subscriptionUrl = purchaseId
+		? `/me/purchases/siteless.akismet.com/${ purchaseId }`
+		: '/me/purchases/';
+
+	const message = translate(
+		'You current own {{oldProduct/}}. The plan you are about to purchase {{newProduct/}} contains all the same functionality and benefits of your current plan. Consider {{link}}removing your {{oldProduct/}} subscription{{/link}} to avoid paying for both plans.',
+		{
+			comment:
+				'The `oldProduct` variable refers to the product the customer owns already. The `newProduct` variable refers to the product they are about to purchase.',
+			components: {
+				link: <a href={ subscriptionUrl } />,
+				oldProduct: <>{ products.overlaping?.product_name }</>,
+				newProduct: <>{ products.cart?.product_name }</>,
+			},
+		}
+	);
+
+	return (
+		<PrePurchaseNotice
+			message={ message }
+			linkUrl={ subscriptionUrl }
+			linkText={ translate( 'Manage subscription' ) }
+		/>
+	);
+};
+
+export default AkismetProductOverlapsOwnedProductNotice;

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
@@ -9,12 +9,15 @@ import {
 	WPCOM_FEATURES_ANTISPAM,
 	WPCOM_FEATURES_BACKUPS,
 	WPCOM_FEATURES_SCAN,
+	isAkismetProduct,
+	AKISMET_PRODUCTS_LIST,
 } from '@automattic/calypso-products';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { getUserPurchases } from 'calypso/state/purchases/selectors';
 import { requestRewindCapabilities } from 'calypso/state/rewind/capabilities/actions';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import {
@@ -24,6 +27,7 @@ import {
 	getSiteOption,
 } from 'calypso/state/sites/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
+import AkismetProductOverlapsOwnedProductNotice from './akismet-product-overlaps-owned-product-notice';
 import CartPlanOverlapsOwnedProductNotice from './cart-plan-overlaps-owned-product-notice';
 import JetpackPluginRequiredVersionNotice from './jetpack-plugin-required-version-notice';
 import SitePlanIncludesCartProductNotice from './site-plan-includes-cart-product-notice';
@@ -37,6 +41,9 @@ const PrePurchaseNotices = () => {
 	const dispatch = useDispatch();
 
 	const selectedSite = useSelector( getSelectedSite );
+	const userActivePurchases = useSelector(
+		( state ) => getUserPurchases( state )?.filter( ( purchase ) => purchase.active ) ?? []
+	);
 	const siteId = selectedSite?.ID;
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
@@ -68,6 +75,31 @@ const PrePurchaseNotices = () => {
 		const products = getSiteProducts( state, siteId ) || [];
 		return products.filter( ( p ) => ! p.expired );
 	} );
+
+	const akismetProductSlugThatOverlapsCartProduct = useMemo( () => {
+		const productSlugInCart = cartItemSlugs.find( ( productSlug ) =>
+			isAkismetProduct( { productSlug } )
+		);
+		const akismetPurchases = userActivePurchases.filter( isAkismetProduct );
+
+		// Continue only if the cart includes Akismet product
+		if ( ! productSlugInCart ) {
+			return null;
+		}
+
+		const lowerTierProducts = akismetPurchases.filter(
+			( { productSlug } ) =>
+				AKISMET_PRODUCTS_LIST.indexOf( productSlug ) -
+					AKISMET_PRODUCTS_LIST.indexOf( productSlugInCart ) <
+				0
+		);
+
+		if ( lowerTierProducts.length === 0 ) {
+			return null;
+		}
+
+		return lowerTierProducts[ 0 ].productSlug;
+	}, [ cartItemSlugs, userActivePurchases ] );
 
 	const siteProductThatOverlapsCartPlan = useMemo( () => {
 		const planSlugInCart = cartItemSlugs.find( isJetpackPlanSlug );
@@ -130,6 +162,17 @@ const PrePurchaseNotices = () => {
 			backupPluginActive || isJetpackMinimumVersion( state, siteId, BACKUP_MINIMUM_JETPACK_VERSION )
 		);
 	} );
+
+	if ( akismetProductSlugThatOverlapsCartProduct ) {
+		return (
+			<AkismetProductOverlapsOwnedProductNotice
+				overlapingProductSlug={ akismetProductSlugThatOverlapsCartProduct }
+				cartProductSlug={ cartItemSlugs.find( ( productSlug ) =>
+					isAkismetProduct( { productSlug } )
+				) }
+			/>
+		);
+	}
 
 	// All these notices (and the selectors that drive them)
 	// require a site ID to work. We should *conceptually* always

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
@@ -76,11 +76,13 @@ const PrePurchaseNotices = () => {
 		return products.filter( ( p ) => ! p.expired );
 	} );
 
-	const akismetProductSlugThatOverlapsCartProduct = useMemo( () => {
+	const akismetPurchaseThatOverlapsCartProduct = useMemo( () => {
 		const productSlugInCart = cartItemSlugs.find( ( productSlug ) =>
 			isAkismetProduct( { productSlug } )
 		);
-		const akismetPurchases = userActivePurchases.filter( isAkismetProduct );
+		const akismetPurchases = userActivePurchases.filter(
+			( purchase ) => isAkismetProduct( purchase ) && 'siteless.akismet.com' === purchase.domain
+		);
 
 		// Continue only if the cart includes Akismet product
 		if ( ! productSlugInCart ) {
@@ -89,16 +91,15 @@ const PrePurchaseNotices = () => {
 
 		const lowerTierProducts = akismetPurchases.filter(
 			( { productSlug } ) =>
-				AKISMET_PRODUCTS_LIST.indexOf( productSlug ) -
-					AKISMET_PRODUCTS_LIST.indexOf( productSlugInCart ) <
-				0
+				AKISMET_PRODUCTS_LIST.indexOf( productSlugInCart ) >
+				AKISMET_PRODUCTS_LIST.indexOf( productSlug )
 		);
 
 		if ( lowerTierProducts.length === 0 ) {
 			return null;
 		}
 
-		return lowerTierProducts[ 0 ].productSlug;
+		return lowerTierProducts[ 0 ];
 	}, [ cartItemSlugs, userActivePurchases ] );
 
 	const siteProductThatOverlapsCartPlan = useMemo( () => {
@@ -163,13 +164,10 @@ const PrePurchaseNotices = () => {
 		);
 	} );
 
-	if ( akismetProductSlugThatOverlapsCartProduct ) {
+	if ( akismetPurchaseThatOverlapsCartProduct ) {
 		return (
 			<AkismetProductOverlapsOwnedProductNotice
-				overlapingProductSlug={ akismetProductSlugThatOverlapsCartProduct }
-				cartProductSlug={ cartItemSlugs.find( ( productSlug ) =>
-					isAkismetProduct( { productSlug } )
-				) }
+				purchase={ akismetPurchaseThatOverlapsCartProduct }
 			/>
 		);
 	}

--- a/packages/calypso-products/src/constants/index.ts
+++ b/packages/calypso-products/src/constants/index.ts
@@ -1,3 +1,4 @@
+export * from './akismet';
 export * from './domain';
 export * from './features';
 export * from './cancellation-features';


### PR DESCRIPTION
## Proposed Changes

* Add a notice about old (lower tier) Akismet product when user is about to purchase a higher-tier one

## Testing Instructions

* Sandbox `public-api.wordpress.com`, enable store sandbox on your sandbox
* Purchase Akismet Personal plan (http://calypso.localhost:3000/checkout/akismet/ak_personal_yearly)
* Enter checkout with the Akismet Plus plan (http://calypso.localhost:3000/checkout/akismet/ak_plus_yearly_1)
* Verify that you see the notice encouraging to deactivate Akismet Personal plan:
<img width="564" alt="CleanShot 2023-03-28 at 21 19 06@2x" src="https://user-images.githubusercontent.com/8419292/228418113-3e7180e5-26ac-4171-a631-fec233b3a6cd.png">

* Verify that the link in the notice forwards to the plan management page in `/me/purchases` dashboard

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
