### PR TITLE
Logging: tidy log downloading changes

### DIFF
--- a/client/my-sites/hosting/web-server-logs-card/index.js
+++ b/client/my-sites/hosting/web-server-logs-card/index.js
@@ -1,5 +1,5 @@
 import { Button, Card, FormInputValidation, ProgressBar } from '@automattic/components';
-import { localize, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import CardHeading from 'calypso/components/card-heading';
@@ -391,4 +391,4 @@ export const WebServerLogsCard = () => {
 	);
 };
 
-export default localize( WebServerLogsCard );
+export default WebServerLogsCard;

--- a/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
@@ -45,22 +45,20 @@ export const SiteLogsToolbar = ( { onRefresh, ...downloadProps }: Props ) => {
 	const isDownloading = state.status === 'downloading';
 
 	return (
-		<>
-			<div className="site-logs-toolbar">
-				<Button isSecondary onClick={ onRefresh }>
-					{ translate( 'Refresh' ) }
-				</Button>
+		<div className="site-logs-toolbar">
+			<Button isSecondary onClick={ onRefresh }>
+				{ translate( 'Refresh' ) }
+			</Button>
 
-				<Button
-					disabled={ isDownloading }
-					isBusy={ isDownloading }
-					isPrimary
-					onClick={ () => downloadLogs( downloadProps ) }
-				>
-					{ translate( 'Download' ) }
-				</Button>
-				{ isDownloading && <SiteLogsToolbarDownloadProgress { ...state } /> }
-			</div>
-		</>
+			<Button
+				disabled={ isDownloading }
+				isBusy={ isDownloading }
+				isPrimary
+				onClick={ () => downloadLogs( downloadProps ) }
+			>
+				{ translate( 'Download' ) }
+			</Button>
+			{ isDownloading && <SiteLogsToolbarDownloadProgress { ...state } /> }
+		</div>
 	);
 };

--- a/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
@@ -1,8 +1,8 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { Moment } from 'moment';
 import { SiteLogsTab } from 'calypso/data/hosting/use-site-logs-query';
 import { useSiteLogsDownloader } from '../../hooks/use-site-logs-downloader';
+import type { Moment } from 'moment';
 
 import './style.scss';
 

--- a/client/my-sites/site-logs/hooks/use-site-logs-downloader.ts
+++ b/client/my-sites/site-logs/hooks/use-site-logs-downloader.ts
@@ -202,7 +202,7 @@ export const useSiteLogsDownloader = () => {
 						},
 					} );
 				} )
-				.catch( ( error: Error ) => {
+				.catch( ( error: unknown ) => {
 					isError = true;
 					const message = get( error, 'message', 'Could not retrieve logs.' );
 					downloadErrorNotice( message );

--- a/client/my-sites/site-logs/hooks/use-site-logs-downloader.ts
+++ b/client/my-sites/site-logs/hooks/use-site-logs-downloader.ts
@@ -1,6 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
 import { get, isEmpty, map } from 'lodash';
-import { Moment } from 'moment';
 import { useReducer } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -9,6 +8,7 @@ import wpcom from 'calypso/lib/wp';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import type { Moment } from 'moment';
 
 interface LogsAPIResponse {
 	data: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75006

## Proposed Changes

Some small changes I was going to make to #75006 before it merged. But @mpkelly was too quick for me 😄 

* Remove unnecessary `<>` wrapper
* Import `Moment` as type only (`'moment'` is a large package so I don't want to depend on it directly; but I'm sure we still have a transitory dependency on it)
* Change type annotation for `lib/wp` error type
* Remove unnecessary `localize` wrapper

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* There should be no observable change

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
