### PR TITLE
Prefetch large images before rendering patterns

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-prefetch-images.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-prefetch-images.ts
@@ -1,5 +1,19 @@
 import { useEffect } from 'react';
 
+const IMAGE_URLS = [
+	'https://dotcompatterns.files.wordpress.com/2023/03/header-mountains.jpeg',
+
+	'https://blankcanvas3demo.files.wordpress.com/2023/03/mountains_landscape.jpeg?w=1024',
+	'https://blankcanvas3demo.files.wordpress.com/2023/03/mountains_landscape.jpeg',
+	'https://dotcompatterns.files.wordpress.com/2023/03/mountains_landscape.jpeg?w=1024',
+	'https://dotcompatterns.files.wordpress.com/2023/03/mountains_landscape.jpeg',
+
+	'https://dotcompatterns.files.wordpress.com/2023/03/mountains_portrait.jpeg?w=640',
+	'https://dotcompatterns.files.wordpress.com/2023/03/mountains_portrait.jpeg',
+
+	'https://dotcompatterns.files.wordpress.com/2023/03/mountains_square.jpeg?w=800',
+];
+
 /**
  * Prefetches the images that can be bottleneck for the pattern rendering.
  */
@@ -20,19 +34,6 @@ export const usePrefetchImage = () => {
 	};
 
 	useEffect( () => {
-		const IMAGE_URLS = [
-			'https://dotcompatterns.files.wordpress.com/2023/03/header-mountains.jpeg',
-
-			'https://blankcanvas3demo.files.wordpress.com/2023/03/mountains_landscape.jpeg?w=1024',
-			'https://blankcanvas3demo.files.wordpress.com/2023/03/mountains_landscape.jpeg',
-			'https://dotcompatterns.files.wordpress.com/2023/03/mountains_landscape.jpeg?w=1024',
-			'https://dotcompatterns.files.wordpress.com/2023/03/mountains_landscape.jpeg',
-
-			'https://dotcompatterns.files.wordpress.com/2023/03/mountains_portrait.jpeg?w=640',
-			'https://dotcompatterns.files.wordpress.com/2023/03/mountains_portrait.jpeg',
-
-			'https://dotcompatterns.files.wordpress.com/2023/03/mountains_square.jpeg?w=800',
-		];
 		IMAGE_URLS.forEach( ( url ) => prefetchImage( url ) );
 		return () => {
 			IMAGE_URLS.forEach( ( url ) => removeLinks( url ) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-prefetch-images.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-prefetch-images.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+
+/**
+ * Prefetches the images that can be bottleneck for the pattern rendering.
+ */
+export const usePrefetchImage = () => {
+	const prefetchImage = ( url: string ) => {
+		const link = document.createElement( 'link' );
+		link.rel = 'prefetch';
+		link.as = 'image';
+		link.href = url;
+		document.head.appendChild( link );
+	};
+
+	const removeLinks = ( url: string ) => {
+		const link = document.querySelector( `link[href="${ url }"]` );
+		if ( link ) {
+			document.head.removeChild( link );
+		}
+	};
+
+	useEffect( () => {
+		const IMAGE_URLS = [
+			'https://dotcompatterns.files.wordpress.com/2022/07/header-mountains.jpeg',
+
+			'https://blankcanvas3demo.files.wordpress.com/2023/01/mountains_landscape.jpg?w=1024',
+			'https://blankcanvas3demo.files.wordpress.com/2023/01/mountains_landscape.jpg',
+			'https://dotcompatterns.files.wordpress.com/2023/02/mountains_landscape.jpg?w=1024',
+			'https://dotcompatterns.files.wordpress.com/2023/02/mountains_landscape.jpg',
+
+			'https://dotcompatterns.files.wordpress.com/2023/02/mountains_portrait.jpg?w=640',
+			'https://dotcompatterns.files.wordpress.com/2023/02/mountains_portrait.jpg',
+
+			'https://dotcompatterns.files.wordpress.com/2023/02/mountains_square.jpg?w=800',
+		];
+		IMAGE_URLS.forEach( ( url ) => prefetchImage( url ) );
+		return () => {
+			IMAGE_URLS.forEach( ( url ) => removeLinks( url ) );
+		};
+	}, [] );
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-prefetch-images.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-prefetch-images.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 const IMAGE_URLS = [
 	'https://dotcompatterns.files.wordpress.com/2023/03/header-mountains.jpeg',
@@ -18,7 +18,7 @@ const IMAGE_URLS = [
  * Prefetches the images that can be bottleneck for the pattern rendering.
  */
 export const usePrefetchImages = () => {
-	const [ links, setLinks ] = useState< HTMLLinkElement[] >( [] );
+	const linksRef = useRef< HTMLLinkElement[] >( [] );
 
 	const prefetchImage = ( url: string ) => {
 		const link = document.createElement( 'link' );
@@ -26,7 +26,7 @@ export const usePrefetchImages = () => {
 		link.as = 'image';
 		link.href = url;
 		document.head.appendChild( link );
-		setLinks( ( links ) => [ ...links, link ] );
+		return link;
 	};
 
 	const removeLinks = ( link: HTMLLinkElement ) => {
@@ -34,14 +34,11 @@ export const usePrefetchImages = () => {
 	};
 
 	useEffect( () => {
-		IMAGE_URLS.forEach( ( url ) => {
-			prefetchImage( url );
-		} );
-	}, [] );
+		const newLinks = IMAGE_URLS.map( ( url ) => prefetchImage( url ) );
+		linksRef.current = [ ...linksRef.current, ...newLinks ];
 
-	useEffect( () => {
 		return () => {
-			links.forEach( ( link ) => removeLinks( link ) );
+			linksRef.current.forEach( ( link ) => removeLinks( link ) );
 		};
-	}, [ links ] );
+	}, [] );
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-prefetch-images.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-prefetch-images.ts
@@ -20,13 +20,13 @@ const IMAGE_URLS = [
 export const usePrefetchImages = () => {
 	const [ links, setLinks ] = useState< HTMLLinkElement[] >( [] );
 
-	const prefetchImage = ( url: string, links: HTMLLinkElement[] ) => {
+	const prefetchImage = ( url: string ) => {
 		const link = document.createElement( 'link' );
 		link.rel = 'prefetch';
 		link.as = 'image';
 		link.href = url;
 		document.head.appendChild( link );
-		setLinks( [ ...links, link ] );
+		setLinks( ( links ) => [ ...links, link ] );
 	};
 
 	const removeLinks = ( link: HTMLLinkElement ) => {
@@ -35,7 +35,7 @@ export const usePrefetchImages = () => {
 
 	useEffect( () => {
 		IMAGE_URLS.forEach( ( url ) => {
-			prefetchImage( url, links );
+			prefetchImage( url );
 		} );
 	}, [] );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-prefetch-images.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-prefetch-images.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 const IMAGE_URLS = [
 	'https://dotcompatterns.files.wordpress.com/2023/03/header-mountains.jpeg',
@@ -18,25 +18,30 @@ const IMAGE_URLS = [
  * Prefetches the images that can be bottleneck for the pattern rendering.
  */
 export const usePrefetchImage = () => {
-	const prefetchImage = ( url: string ) => {
+	const [ links, setLinks ] = useState< HTMLLinkElement[] >( [] );
+
+	const prefetchImage = ( url: string, links: HTMLLinkElement[] ) => {
 		const link = document.createElement( 'link' );
 		link.rel = 'prefetch';
 		link.as = 'image';
 		link.href = url;
 		document.head.appendChild( link );
+		setLinks( [ ...links, link ] );
 	};
 
-	const removeLinks = ( url: string ) => {
-		const link = document.querySelector( `link[href="${ url }"]` );
-		if ( link ) {
-			document.head.removeChild( link );
-		}
+	const removeLinks = ( link: HTMLLinkElement ) => {
+		document.head.removeChild( link );
 	};
 
 	useEffect( () => {
-		IMAGE_URLS.forEach( ( url ) => prefetchImage( url ) );
-		return () => {
-			IMAGE_URLS.forEach( ( url ) => removeLinks( url ) );
-		};
+		IMAGE_URLS.forEach( ( url ) => {
+			prefetchImage( url, links );
+		} );
 	}, [] );
+
+	useEffect( () => {
+		return () => {
+			links.forEach( ( link ) => removeLinks( link ) );
+		};
+	}, [ links ] );
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-prefetch-images.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-prefetch-images.ts
@@ -21,17 +21,17 @@ export const usePrefetchImage = () => {
 
 	useEffect( () => {
 		const IMAGE_URLS = [
-			'https://dotcompatterns.files.wordpress.com/2022/07/header-mountains.jpeg',
+			'https://dotcompatterns.files.wordpress.com/2023/03/header-mountains.jpeg',
 
-			'https://blankcanvas3demo.files.wordpress.com/2023/01/mountains_landscape.jpg?w=1024',
-			'https://blankcanvas3demo.files.wordpress.com/2023/01/mountains_landscape.jpg',
-			'https://dotcompatterns.files.wordpress.com/2023/02/mountains_landscape.jpg?w=1024',
-			'https://dotcompatterns.files.wordpress.com/2023/02/mountains_landscape.jpg',
+			'https://blankcanvas3demo.files.wordpress.com/2023/03/mountains_landscape.jpeg?w=1024',
+			'https://blankcanvas3demo.files.wordpress.com/2023/03/mountains_landscape.jpeg',
+			'https://dotcompatterns.files.wordpress.com/2023/03/mountains_landscape.jpeg?w=1024',
+			'https://dotcompatterns.files.wordpress.com/2023/03/mountains_landscape.jpeg',
 
-			'https://dotcompatterns.files.wordpress.com/2023/02/mountains_portrait.jpg?w=640',
-			'https://dotcompatterns.files.wordpress.com/2023/02/mountains_portrait.jpg',
+			'https://dotcompatterns.files.wordpress.com/2023/03/mountains_portrait.jpeg?w=640',
+			'https://dotcompatterns.files.wordpress.com/2023/03/mountains_portrait.jpeg',
 
-			'https://dotcompatterns.files.wordpress.com/2023/02/mountains_square.jpg?w=800',
+			'https://dotcompatterns.files.wordpress.com/2023/03/mountains_square.jpeg?w=800',
 		];
 		IMAGE_URLS.forEach( ( url ) => prefetchImage( url ) );
 		return () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-prefetch-images.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-prefetch-images.ts
@@ -17,7 +17,7 @@ const IMAGE_URLS = [
 /**
  * Prefetches the images that can be bottleneck for the pattern rendering.
  */
-export const usePrefetchImage = () => {
+export const usePrefetchImages = () => {
 	const [ links, setLinks ] = useState< HTMLLinkElement[] >( [] );
 
 	const prefetchImage = ( url: string, links: HTMLLinkElement[] ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -25,7 +25,7 @@ import { SITE_TAGLINE, PLACEHOLDER_SITE_ID, PATTERN_TYPES } from './constants';
 import useGlobalStylesUpgradeModal from './hooks/use-global-styles-upgrade-modal';
 import usePatternCategories from './hooks/use-pattern-categories';
 import usePatternsMapByCategory from './hooks/use-patterns-map-by-category';
-import { usePrefetchImage } from './hooks/use-prefetch-images';
+import { usePrefetchImages } from './hooks/use-prefetch-images';
 import NavigatorListener from './navigator-listener';
 import Notices, { getNoticeContent } from './notices/notices';
 import PatternAssemblerContainer from './pattern-assembler-container';
@@ -131,7 +131,7 @@ const PatternAssembler = ( {
 		isEnabledColorAndFonts
 	);
 
-	usePrefetchImage();
+	usePrefetchImages();
 
 	const siteInfo = {
 		title: site?.name,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -25,6 +25,7 @@ import { SITE_TAGLINE, PLACEHOLDER_SITE_ID, PATTERN_TYPES } from './constants';
 import useGlobalStylesUpgradeModal from './hooks/use-global-styles-upgrade-modal';
 import usePatternCategories from './hooks/use-pattern-categories';
 import usePatternsMapByCategory from './hooks/use-patterns-map-by-category';
+import { usePrefetchImage } from './hooks/use-prefetch-images';
 import NavigatorListener from './navigator-listener';
 import Notices, { getNoticeContent } from './notices/notices';
 import PatternAssemblerContainer from './pattern-assembler-container';
@@ -129,6 +130,8 @@ const PatternAssembler = ( {
 		selectedVariations,
 		isEnabledColorAndFonts
 	);
+
+	usePrefetchImage();
 
 	const siteInfo = {
 		title: site?.name,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74870

## Proposed Changes

Prefetch especially large images before rendering pattern as described in this post pbxlJb-3GJ-p2 , and the comment pbxlJb-3GJ-p2#comment-2471 .

Also optimized the size of the images with `ffmpeg`.

- header-mountains.jpeg: 189kb -> 121kb (-35%)
- mountains_landscape.jpeg: 321kb -> 139kb (-56%)
- mountains_portrait.jpeg: 224kb -> 92kb (-58%)
- mountains_square.jpeg: 243kb -> 98kb (-59%)

As the post says, in the future, it might be better to request the appropriate images for its screen size. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a new site and go to the Site Assembler
- Simulate "Slow 3G" on the Network tab in the Chrome Dev Tool
- Click `Header` or `Sections` to see the thumb

As it's cached by prefetch, it's always fast where `prefetch` is [available](https://caniuse.com/link-rel-prefetch).

before

https://user-images.githubusercontent.com/5287479/228437332-c0b004ab-1b81-4b9c-9a4e-0c838fb408b1.mov

after

https://user-images.githubusercontent.com/5287479/228437207-4ec73724-d1bb-42e5-aec8-675f8f5f2bfd.mov


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?