### PR TITLE
Support inlineCss for GlobalStylesVariationPreview

### DIFF
--- a/packages/global-styles/src/components/global-styles-variation-container/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variation-container/index.tsx
@@ -9,6 +9,7 @@ import './style.scss';
 interface Props {
 	width: number | null;
 	height: number;
+	inlineCss?: string;
 	containerResizeListener: JSX.Element;
 	children: JSX.Element;
 }
@@ -16,6 +17,7 @@ interface Props {
 const GlobalStylesVariationContainer = ( {
 	width,
 	height,
+	inlineCss,
 	containerResizeListener,
 	children,
 	...props
@@ -27,6 +29,14 @@ const GlobalStylesVariationContainer = ( {
 		if ( styles ) {
 			return [
 				...styles,
+				...( inlineCss
+					? [
+							{
+								css: inlineCss,
+								isGlobalStyles: true,
+							},
+					  ]
+					: [] ),
 				{
 					css: 'html{overflow:hidden}body{min-width: 0;padding: 0;border: none;transform:scale(1);}',
 					isGlobalStyles: true,

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -77,6 +77,7 @@ const GlobalStylesVariation = ( {
 				<GlobalStylesContext.Provider value={ context }>
 					<GlobalStylesVariationPreview
 						title={ globalStylesVariation.title }
+						inlineCss={ globalStylesVariation.inline_css }
 						isFocused={ isFocused || showOnlyHoverView }
 					/>
 				</GlobalStylesContext.Provider>

--- a/packages/global-styles/src/components/global-styles-variations/preview.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/preview.tsx
@@ -50,10 +50,11 @@ const normalizedColorSwatchSize = 32;
 
 interface Props {
 	title?: string;
+	inlineCss?: string;
 	isFocused?: boolean;
 }
 
-const GlobalStylesVariationPreview = ( { title, isFocused }: Props ) => {
+const GlobalStylesVariationPreview = ( { title, inlineCss, isFocused }: Props ) => {
 	const [ fontWeight ] = useStyle( 'typography.fontWeight' );
 	const [ fontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
 	const [ headingFontFamily = fontFamily ] = useStyle( 'elements.h1.typography.fontFamily' );
@@ -84,6 +85,7 @@ const GlobalStylesVariationPreview = ( { title, isFocused }: Props ) => {
 		<GlobalStylesVariationContainer
 			width={ width }
 			height={ normalizedHeight * ratio }
+			inlineCss={ inlineCss }
 			containerResizeListener={ containerResizeListener }
 		>
 			<motion.div

--- a/packages/global-styles/src/types.ts
+++ b/packages/global-styles/src/types.ts
@@ -22,6 +22,7 @@ export interface GlobalStylesObject {
 	id?: number;
 	slug?: string;
 	title?: string;
+	inline_css?: string;
 	settings: {
 		color?: {
 			palette: {


### PR DESCRIPTION
## Proposed Changes

As a follow-up of #74882, in this PR we add the support of passing custom CSS string to the `<GlobalStylesVariationPreview />` component. The purpose of passing custom CSS is for `@font-face` declarations obtained from the API endpoint.

Note: There are some edge cases where the `@font-face` declarations are missing (see: https://github.com/Automattic/wp-calypso/pull/74882#issuecomment-1484530990, https://github.com/Automattic/wp-calypso/pull/74882#pullrequestreview-1358661771), those will be address in a follow-up diff that updates the endpoint payload).

Related wpcom work:
- [ ] D106365-code

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Click on any theme with style variations.
* Ensure that the font render works as intended.

![Screenshot 2023-03-29 at 1 35 54 PM](https://user-images.githubusercontent.com/797888/228436592-d6f5aa5d-c1b2-406c-a096-04f801a41514.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?