### PR TITLE
Site Assembler: Preserve the selected layout and styles after the checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.ts
@@ -6,10 +6,11 @@ import { PATTERN_ASSEMBLER_EVENTS } from '../events';
 
 interface Props {
 	recordTracksEvent: ( eventName: string, eventProps?: { [ key: string ]: unknown } ) => void;
+	onCheckout?: () => void;
 	onSubmit: () => void;
 }
 
-const useGlobalStylesUpgradeModal = ( { recordTracksEvent, onSubmit }: Props ) => {
+const useGlobalStylesUpgradeModal = ( { recordTracksEvent, onCheckout, onSubmit }: Props ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const site = useSite();
 	const siteSlug = useSiteSlugParam();
@@ -27,6 +28,7 @@ const useGlobalStylesUpgradeModal = ( { recordTracksEvent, onSubmit }: Props ) =
 
 	const checkout = () => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.GLOBAL_STYLES_GATING_MODAL_CHECKOUT_BUTTON_CLICK );
+		onCheckout?.();
 
 		// When the user is done with checkout, send them back to the current url
 		const destUrl = new URL( window.location.href );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -1,0 +1,130 @@
+import { useColorPaletteVariations, useFontPairingVariations } from '@automattic/global-styles';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { ONBOARD_STORE } from '../../../../../stores';
+import type { Pattern } from '../types';
+import type { OnboardSelect } from '@automattic/data-stores';
+import type { Design } from '@automattic/design-picker/src/types';
+import type { GlobalStylesObject } from '@automattic/global-styles';
+
+const useRecipe = ( siteId = 0, patterns: Pattern[] ) => {
+	const incrementIndexRef = useRef( 0 );
+	const [ header, setHeader ] = useState< Pattern | null >( null );
+	const [ footer, setFooter ] = useState< Pattern | null >( null );
+	const [ sections, setSections ] = useState< Pattern[] >( [] );
+	const [ colorVariation, setColorVariation ] = useState< GlobalStylesObject | null >( null );
+	const [ fontVariation, setFontVariation ] = useState< GlobalStylesObject | null >( null );
+	const selectedDesign = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
+		[]
+	);
+
+	const {
+		stylesheet = '',
+		header_pattern_ids = [],
+		footer_pattern_ids = [],
+		pattern_ids = [],
+		color_variation_title = '',
+		font_variation_title = '',
+	} = selectedDesign?.recipe || {};
+
+	const colorVariations = useColorPaletteVariations( siteId, stylesheet );
+
+	const fontVariations = useFontPairingVariations( siteId, stylesheet );
+
+	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
+
+	const selectedDesignRef = useRef< Design | undefined >( selectedDesign );
+
+	selectedDesignRef.current = {
+		...selectedDesign,
+		recipe: {
+			...selectedDesign?.recipe,
+			header_pattern_ids: header ? [ header.id ] : [],
+			footer_pattern_ids: footer ? [ footer.id ] : [],
+			pattern_ids: sections.map( ( section ) => section.id ),
+			color_variation_title: colorVariation?.title,
+			font_variation_title: fontVariation?.title,
+		},
+	} as Design;
+
+	const snapshotRecipe = useCallback( () => setSelectedDesign( selectedDesignRef.current ), [] );
+
+	/**
+	 * Initialize the default value from the recipe of the selected design when the patterns are ready
+	 */
+	useEffect( () => {
+		if ( patterns.length === 0 || ! selectedDesign?.recipe ) {
+			return;
+		}
+
+		const patternsById: { [ key: string ]: Pattern } = patterns.reduce(
+			( acc, pattern ) => ( {
+				...acc,
+				[ pattern.id ]: pattern,
+			} ),
+			{}
+		);
+
+		if ( patternsById[ header_pattern_ids[ 0 ] ] ) {
+			setHeader( patternsById[ header_pattern_ids[ 0 ] ] );
+		}
+
+		if ( patternsById[ footer_pattern_ids[ 0 ] ] ) {
+			setFooter( patternsById[ footer_pattern_ids[ 0 ] ] );
+		}
+
+		setSections(
+			pattern_ids.map( ( patternId: string | number ) => {
+				const pattern = patternsById[ patternId ];
+				return {
+					...pattern,
+					key: `${ incrementIndexRef.current }-${ pattern.id }`,
+				};
+			} )
+		);
+	}, [ patterns.length ] );
+
+	useEffect( () => {
+		if ( ! colorVariations || ! color_variation_title ) {
+			return;
+		}
+
+		const initialColorVariation = colorVariations.find(
+			( { title } ) => title === color_variation_title
+		);
+		if ( initialColorVariation ) {
+			setColorVariation( initialColorVariation );
+		}
+	}, [ colorVariations ] );
+
+	useEffect( () => {
+		if ( ! fontVariations || ! font_variation_title ) {
+			return;
+		}
+
+		const initialFontVariation = fontVariations.find(
+			( { title } ) => title === font_variation_title
+		);
+		if ( initialFontVariation ) {
+			setFontVariation( initialFontVariation );
+		}
+	}, [ fontVariations ] );
+
+	return {
+		header,
+		footer,
+		sections,
+		colorVariation,
+		fontVariation,
+		incrementIndexRef,
+		setHeader,
+		setFooter,
+		setSections,
+		setColorVariation,
+		setFontVariation,
+		snapshotRecipe,
+	};
+};
+
+export default useRecipe;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -1,13 +1,14 @@
 import { useColorPaletteVariations, useFontPairingVariations } from '@automattic/global-styles';
 import { useDispatch, useSelect } from '@wordpress/data';
+import keyBy from 'lodash/keyBy';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { ONBOARD_STORE } from '../../../../../stores';
-import type { Pattern } from '../types';
+import type { Pattern, Category } from '../types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { Design } from '@automattic/design-picker/src/types';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 
-const useRecipe = ( siteId = 0, patterns: Pattern[] ) => {
+const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) => {
 	const incrementIndexRef = useRef( 0 );
 	const [ header, setHeader ] = useState< Pattern | null >( null );
 	const [ footer, setFooter ] = useState< Pattern | null >( null );
@@ -56,20 +57,15 @@ const useRecipe = ( siteId = 0, patterns: Pattern[] ) => {
 	const snapshotRecipe = useCallback( () => setSelectedDesign( selectedDesignRef.current ), [] );
 
 	/**
-	 * Initialize the default value from the recipe of the selected design when the patterns are ready
+	 * Initialize the default value from the recipe of the selected design when both patterns and categories are ready
 	 */
 	useEffect( () => {
-		if ( patterns.length === 0 || ! selectedDesign?.recipe ) {
+		if ( patterns.length === 0 || categories.length === 0 || ! selectedDesign?.recipe ) {
 			return;
 		}
 
-		const patternsById: { [ key: string ]: Pattern } = patterns.reduce(
-			( acc, pattern ) => ( {
-				...acc,
-				[ pattern.id ]: pattern,
-			} ),
-			{}
-		);
+		const patternsById = keyBy( patterns, 'id' );
+		const categoriesByName = keyBy( categories, 'name' );
 
 		if ( patternsById[ header_pattern_ids[ 0 ] ] ) {
 			setHeader( patternsById[ header_pattern_ids[ 0 ] ] );
@@ -82,13 +78,15 @@ const useRecipe = ( siteId = 0, patterns: Pattern[] ) => {
 		setSections(
 			pattern_ids.map( ( patternId: string | number ) => {
 				const pattern = patternsById[ patternId ];
+				const category = categoriesByName[ pattern.categories[ 0 ] ];
 				return {
 					...pattern,
 					key: generateKey( pattern ),
+					category,
 				};
 			} )
 		);
-	}, [ patterns.length ] );
+	}, [ patterns.length, categories ] );
 
 	useEffect( () => {
 		if ( ! colorVariations || ! color_variation_title ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -1,6 +1,6 @@
 import { useColorPaletteVariations, useFontPairingVariations } from '@automattic/global-styles';
+import { keyBy } from '@automattic/js-utils';
 import { useDispatch, useSelect } from '@wordpress/data';
-import keyBy from 'lodash/keyBy';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { ONBOARD_STORE } from '../../../../../stores';
 import type { Pattern, Category } from '../types';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -48,6 +48,11 @@ const useRecipe = ( siteId = 0, patterns: Pattern[] ) => {
 		},
 	} as Design;
 
+	const generateKey = ( pattern: Pattern ) => {
+		incrementIndexRef.current++;
+		return `${ incrementIndexRef.current }-${ pattern.id }`;
+	};
+
 	const snapshotRecipe = useCallback( () => setSelectedDesign( selectedDesignRef.current ), [] );
 
 	/**
@@ -79,7 +84,7 @@ const useRecipe = ( siteId = 0, patterns: Pattern[] ) => {
 				const pattern = patternsById[ patternId ];
 				return {
 					...pattern,
-					key: `${ incrementIndexRef.current }-${ pattern.id }`,
+					key: generateKey( pattern ),
 				};
 			} )
 		);
@@ -117,12 +122,12 @@ const useRecipe = ( siteId = 0, patterns: Pattern[] ) => {
 		sections,
 		colorVariation,
 		fontVariation,
-		incrementIndexRef,
 		setHeader,
 		setFooter,
 		setSections,
 		setColorVariation,
 		setFontVariation,
+		generateKey,
 		snapshotRecipe,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -433,10 +433,10 @@ const PatternAssembler = ( {
 
 	const onDeleteFooter = () => onSelect( 'footer', null );
 
-	const onScreenColorsSelect = ( variation: GlobalStylesObject ) => {
+	const onScreenColorsSelect = ( variation: GlobalStylesObject | null ) => {
 		setColorVariation( variation );
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_COLORS_PREVIEW_CLICK, {
-			title: variation.title,
+			title: variation?.title,
 		} );
 	};
 
@@ -448,10 +448,10 @@ const PatternAssembler = ( {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_COLORS_DONE_CLICK );
 	};
 
-	const onScreenFontsSelect = ( variation: GlobalStylesObject ) => {
+	const onScreenFontsSelect = ( variation: GlobalStylesObject | null ) => {
 		setFontVariation( variation );
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_FONTS_PREVIEW_CLICK, {
-			title: variation.title,
+			title: variation?.title,
 		} );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -27,6 +27,7 @@ import useGlobalStylesUpgradeModal from './hooks/use-global-styles-upgrade-modal
 import usePatternCategories from './hooks/use-pattern-categories';
 import usePatternsMapByCategory from './hooks/use-patterns-map-by-category';
 import { usePrefetchImages } from './hooks/use-prefetch-images';
+import useRecipe from './hooks/use-recipe';
 import NavigatorListener from './navigator-listener';
 import Notices, { getNoticeContent } from './notices/notices';
 import PatternAssemblerContainer from './pattern-assembler-container';
@@ -55,12 +56,8 @@ const PatternAssembler = ( {
 	noticeOperations,
 }: StepProps & withNotices.Props ) => {
 	const [ navigatorPath, setNavigatorPath ] = useState( '/' );
-	const [ header, setHeader ] = useState< Pattern | null >( null );
-	const [ footer, setFooter ] = useState< Pattern | null >( null );
-	const [ sections, setSections ] = useState< Pattern[] >( [] );
 	const [ sectionPosition, setSectionPosition ] = useState< number | null >( null );
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
-	const incrementIndexRef = useRef( 0 );
 	const [ activePosition, setActivePosition ] = useState( -1 );
 	const [ isPatternPanelListOpen, setIsPatternPanelListOpen ] = useState( false );
 	const { goBack, goNext, submit } = navigation;
@@ -81,6 +78,20 @@ const PatternAssembler = ( {
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 	const allPatterns = useAllPatterns();
 	const sectionPatterns = useSectionPatterns();
+	const {
+		header,
+		footer,
+		sections,
+		colorVariation,
+		fontVariation,
+		incrementIndexRef,
+		setHeader,
+		setFooter,
+		setSections,
+		setColorVariation,
+		setFontVariation,
+		snapshotRecipe,
+	} = useRecipe( site?.ID, allPatterns );
 
 	// Fetching the categories so they are ready when ScreenCategoryList loads
 	const categoriesQuery = usePatternCategories( site?.ID );
@@ -91,11 +102,6 @@ const PatternAssembler = ( {
 
 	const isEnabledColorAndFonts = isEnabled( 'pattern-assembler/color-and-fonts' );
 
-	const [ selectedColorPaletteVariation, setSelectedColorPaletteVariation ] =
-		useState< GlobalStylesObject | null >( null );
-	const [ selectedFontPairingVariation, setSelectedFontPairingVariation ] =
-		useState< GlobalStylesObject | null >( null );
-
 	const recordTracksEvent = useMemo(
 		() =>
 			createRecordTracksEvent( {
@@ -103,25 +109,15 @@ const PatternAssembler = ( {
 				step: stepName,
 				intent,
 				stylesheet,
-				color_style_title: selectedColorPaletteVariation?.title,
-				font_style_title: selectedFontPairingVariation?.title,
+				color_variation_title: colorVariation?.title,
+				font_variation_title: fontVariation?.title,
 			} ),
-		[
-			flow,
-			stepName,
-			intent,
-			stylesheet,
-			selectedColorPaletteVariation,
-			selectedFontPairingVariation,
-		]
+		[ flow, stepName, intent, stylesheet, colorVariation, fontVariation ]
 	);
 
 	const selectedVariations = useMemo(
-		() =>
-			[ selectedColorPaletteVariation, selectedFontPairingVariation ].filter(
-				Boolean
-			) as GlobalStylesObject[],
-		[ selectedColorPaletteVariation, selectedFontPairingVariation ]
+		() => [ colorVariation, fontVariation ].filter( Boolean ) as GlobalStylesObject[],
+		[ colorVariation, fontVariation ]
 	);
 
 	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles();
@@ -372,6 +368,7 @@ const PatternAssembler = ( {
 
 	const { openModal: openGlobalStylesUpgradeModal, ...globalStylesUpgradeModalProps } =
 		useGlobalStylesUpgradeModal( {
+			onCheckout: snapshotRecipe,
 			onSubmit,
 			recordTracksEvent,
 		} );
@@ -438,7 +435,7 @@ const PatternAssembler = ( {
 	const onDeleteFooter = () => onSelect( 'footer', null );
 
 	const onScreenColorsSelect = ( variation: GlobalStylesObject ) => {
-		setSelectedColorPaletteVariation( variation );
+		setColorVariation( variation );
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_COLORS_PREVIEW_CLICK, {
 			title: variation.title,
 		} );
@@ -453,7 +450,7 @@ const PatternAssembler = ( {
 	};
 
 	const onScreenFontsSelect = ( variation: GlobalStylesObject ) => {
-		setSelectedFontPairingVariation( variation );
+		setFontVariation( variation );
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_FONTS_PREVIEW_CLICK, {
 			title: variation.title,
 		} );
@@ -545,7 +542,7 @@ const PatternAssembler = ( {
 							placeholder={ null }
 							siteId={ site?.ID }
 							stylesheet={ stylesheet }
-							selectedColorPaletteVariation={ selectedColorPaletteVariation }
+							selectedColorPaletteVariation={ colorVariation }
 							onSelect={ onScreenColorsSelect }
 							onBack={ onScreenColorsBack }
 							onDoneClick={ onScreenColorsDone }
@@ -560,7 +557,7 @@ const PatternAssembler = ( {
 							placeholder={ null }
 							siteId={ site?.ID }
 							stylesheet={ stylesheet }
-							selectedFontPairingVariation={ selectedFontPairingVariation }
+							selectedFontPairingVariation={ fontVariation }
 							onSelect={ onScreenFontsSelect }
 							onBack={ onScreenFontsBack }
 							onDoneClick={ onScreenFontsDone }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -84,12 +84,12 @@ const PatternAssembler = ( {
 		sections,
 		colorVariation,
 		fontVariation,
-		incrementIndexRef,
 		setHeader,
 		setFooter,
 		setSections,
 		setColorVariation,
 		setFontVariation,
+		generateKey,
 		snapshotRecipe,
 	} = useRecipe( site?.ID, allPatterns );
 
@@ -260,12 +260,11 @@ const PatternAssembler = ( {
 	};
 
 	const addSection = ( pattern: Pattern ) => {
-		incrementIndexRef.current++;
 		setSections( [
 			...( sections as Pattern[] ),
 			{
 				...pattern,
-				key: `${ incrementIndexRef.current }-${ pattern.id }`,
+				key: generateKey( pattern ),
 			},
 		] );
 		updateActivePatternPosition( sections.length );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -78,6 +78,11 @@ const PatternAssembler = ( {
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 	const allPatterns = useAllPatterns();
 	const sectionPatterns = useSectionPatterns();
+
+	// Fetching the categories so they are ready when ScreenCategoryList loads
+	const categoriesQuery = usePatternCategories( site?.ID );
+	const categories = ( categoriesQuery?.data || [] ) as Category[];
+	const sectionsMapByCategory = usePatternsMapByCategory( sectionPatterns, categories );
 	const {
 		header,
 		footer,
@@ -91,12 +96,7 @@ const PatternAssembler = ( {
 		setFontVariation,
 		generateKey,
 		snapshotRecipe,
-	} = useRecipe( site?.ID, allPatterns );
-
-	// Fetching the categories so they are ready when ScreenCategoryList loads
-	const categoriesQuery = usePatternCategories( site?.ID );
-	const categories = ( categoriesQuery?.data || [] ) as Category[];
-	const sectionsMapByCategory = usePatternsMapByCategory( sectionPatterns, categories );
+	} = useRecipe( site?.ID, allPatterns, categories );
 
 	const stylesheet = selectedDesign?.recipe?.stylesheet || '';
 

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -60,6 +60,8 @@ export interface DesignRecipe {
 	pattern_ids?: number[] | string[];
 	header_pattern_ids?: number[] | string[];
 	footer_pattern_ids?: number[] | string[];
+	color_variation_title?: string;
+	font_variation_title?: string;
 }
 
 export interface SoftwareSet {

--- a/packages/global-styles/src/index.tsx
+++ b/packages/global-styles/src/index.tsx
@@ -1,5 +1,10 @@
 // Re-export useStyle from `@automattic/global-styles` to avoid calypso using `@wordpress/edit-site` directly
 export { useStyle } from '@wordpress/edit-site/build-module/components/global-styles/hooks';
 export * from './components';
-export { useSyncGlobalStylesUserConfig } from './hooks';
+export {
+	useColorPaletteVariations,
+	useFontPairingVariations,
+	useSyncGlobalStylesUserConfig,
+} from './hooks';
+
 export * from './types';

--- a/packages/js-utils/src/index.ts
+++ b/packages/js-utils/src/index.ts
@@ -1,4 +1,5 @@
 export { default as camelToSnakeCase } from './camel-to-snake-case';
+export { default as keyBy } from './key-by';
 export { default as mapRecordKeysRecursively } from './map-record-keys-recursively';
 export { default as shuffle } from './shuffle';
 export { default as snakeToCamelCase } from './snake-to-camel-case';

--- a/packages/js-utils/src/key-by.ts
+++ b/packages/js-utils/src/key-by.ts
@@ -1,0 +1,34 @@
+/**
+ * See https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_keyBy
+ */
+type Collection< T > = T[] | { [ key in PropertyKey ]: T };
+
+type Iteratee< T, TResult > = TResult | ( ( value: T ) => TResult );
+
+const isObject = ( value: unknown ) => value != null && typeof value === 'object';
+
+const arrayKeyBy = < T >( array: T[], iteratee: Iteratee< T, PropertyKey > ) =>
+	( array || [] ).reduce( ( result, value ) => {
+		let key;
+		if ( typeof iteratee === 'function' ) {
+			key = iteratee( value );
+		} else if ( isObject( value ) ) {
+			key = ( value as any )[ iteratee ];
+		} else {
+			throw new Error(
+				`keyBy(): ${ String( iteratee ) } can't be used to index non-object value: ${ value }`
+			);
+		}
+
+		return { ...result, [ key ]: value };
+	}, {} );
+
+const collectionKeyBy = < T >(
+	collection: Collection< T >,
+	iteratee: Iteratee< T, PropertyKey >
+): { [ key in PropertyKey ]: T } =>
+	Array.isArray( collection )
+		? arrayKeyBy( collection, iteratee )
+		: arrayKeyBy( Object.values( collection || {} ), iteratee );
+
+export default collectionKeyBy;

--- a/packages/js-utils/src/test/key-by.ts
+++ b/packages/js-utils/src/test/key-by.ts
@@ -1,0 +1,49 @@
+import keyBy from '../key-by';
+
+describe( 'keyBy', () => {
+	const array = [
+		{ dir: 'left', code: 97 },
+		{ dir: 'right', code: 100 },
+	];
+
+	it( 'should transform keys by `iteratee`', () => {
+		const expected = { a: { dir: 'left', code: 97 }, d: { dir: 'right', code: 100 } };
+		const actual = keyBy( array, ( object ) => {
+			return String.fromCharCode( object.code );
+		} );
+
+		expect( actual ).toEqual( expected );
+	} );
+
+	it( 'should work with `_.property` shorthands', () => {
+		const expected = { left: { dir: 'left', code: 97 }, right: { dir: 'right', code: 100 } };
+		const actual = keyBy( array, 'dir' );
+
+		expect( actual ).toEqual( expected );
+	} );
+
+	it( 'should only add values to own, not inherited, properties', () => {
+		const actual = keyBy( [ 6.1, 4.2, 6.3 ], ( n ) => {
+			return Math.floor( n ) > 4 ? 'hasOwnProperty' : 'constructor';
+		} );
+
+		expect( actual.constructor ).toEqual( 4.2 );
+		expect( actual.hasOwnProperty ).toEqual( 6.3 );
+	} );
+
+	it( 'should work with a number for `iteratee`', () => {
+		const array = [
+			[ 1, 'a' ],
+			[ 2, 'a' ],
+			[ 2, 'b' ],
+		];
+
+		expect( keyBy( array, 0 ) ).toEqual( { '1': [ 1, 'a' ], '2': [ 2, 'b' ] } );
+		expect( keyBy( array, 1 ) ).toEqual( { a: [ 2, 'a' ], b: [ 2, 'b' ] } );
+	} );
+
+	it( 'should work with an object for `collection`', () => {
+		const actual = keyBy( { a: 6.1, b: 4.2, c: 6.3 }, Math.floor );
+		expect( actual ).toEqual( { '4': 4.2, '6': 6.3 } );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74946, p1679976634888699-slack-CRWCHQGUB

## Proposed Changes

Preserve the selected header, sections, footer, colors, and fonts after the checkout

### How

Here are possible ways to persist the data
1. Add the selected data to the query string of the returned URL
2. Add the selected data to the recipe since the recipe supports header, sections, and footer already.
3. Use the checkout modal (it worked before but it's broken after migrating to the stepper framework), and we don't need to persist any data since the user is still in the pattern assembler screen.

This PR uses the (2) option to persist the data since we might need to support editing the virtual theme in the PA screen. The virtual theme uses the `pattern_ids` in the recipe to display the patterns. Hence, we can use the same mechanism to store the selected header, sections, and footer. However, the recipe doesn't support color & font variation before, so I introduce new properties to the recipe, called `color_variation_title` and `font_variation_title`. If you have any concerns about new properties, I can just create a new store to keep this information but I guess it's fine because the virtual theme might need to support something like style variation in the future. Thus, I assume it's good to introduce them to the recipe.

Next, when the user enters the Pattern Assembler screen, we will restore the preserved data from the recipe to initialize the selected header, sections, footer, color, and font. While the user heads to the checkout, we will call the `snapshotRecipe` function to persist the selected data

Any thoughts?

### Demo

https://user-images.githubusercontent.com/13596067/228460284-33898e83-b1cc-45cf-8c96-fdf97d482407.mov

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/site-setup?siteSlug=<your_site>&flags=no-force-sympathy`
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Select a header
  * Select sections
  * Select a footer
  * Select a color variation
  * Select a font variation
  * Click on `Unlock this style` > `Upgrade plan`
* On the checkout screen
  * Use the browser back button to go back to the Pattern Assembler screen, ensure the selected data is preserved
  * Finish the checkout, and ensure you're redirected back to the Pattern Assembler screen the selected data is preserved as well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?