### PR TITLE
Plans 2023: The 1y/2y term presentation test

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.tsx
@@ -14,6 +14,7 @@ import {
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useState } from 'react';
+import { dangerouslyGetExperimentAssignment } from 'calypso/lib/explat';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { useGetProductVariants } from 'calypso/my-sites/checkout/composite-checkout/hooks/product-variants';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
@@ -201,6 +202,21 @@ function LineItemWrapper( {
 		if ( isJetpack || isAkismet ) {
 			return true;
 		}
+
+		try {
+			const { variationName } = dangerouslyGetExperimentAssignment( 'calypso_plans_2yr_toggle' );
+
+			if ( variationName === 'toggle_and_checkout' ) {
+				return true;
+			}
+		} catch {
+			// The error is intentionally ignore here. For this particular experiment,
+			// the experience should start from the 2023 version of plans page to the checkout.
+			// Thus, for any other flow that leads to the checkout, they shouldn't be affected.
+			// That also means chances are that we can't load or preload the experiment earlier
+			// so that `dangerouslyGetExperimentAssignment` doesn't throw.
+		}
+
 		return variant.termIntervalInMonths >= initialVariantTerm;
 	} );
 

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	applyTestFiltersToPlansList,
 	FeatureGroup,
@@ -18,9 +17,8 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback, useEffect, ChangeEvent } from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { FeatureObject, getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
-import PlanTypeSelector, {
-	PlanTypeSelectorProps,
-} from 'calypso/my-sites/plans-features-main/plan-type-selector';
+import { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/plan-type-selector';
+import TermExperimentPlanTypeSelector from 'calypso/my-sites/plans-features-main/term-experiment-plan-type-selector';
 import PlanFeatures2023GridActions from './actions';
 import PlanFeatures2023GridBillingTimeframe from './billing-timeframe';
 import PopularBadge from './components/popular-badge';
@@ -756,20 +754,11 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 			<PlanComparisonHeader className="wp-brand-font">
 				{ translate( 'Compare our plans and find yours' ) }
 			</PlanComparisonHeader>
-			<PlanTypeSelector
+			<TermExperimentPlanTypeSelector
+				isEligible={ true }
 				kind="interval"
 				plans={ displayedPlansProperties.map( ( { planName } ) => planName ) }
-				isInSignup={ planTypeSelectorProps.isInSignup }
-				isStepperUpgradeFlow={ planTypeSelectorProps.isStepperUpgradeFlow }
-				eligibleForWpcomMonthlyPlans={ planTypeSelectorProps.eligibleForWpcomMonthlyPlans }
-				isPlansInsideStepper={ planTypeSelectorProps.isPlansInsideStepper }
-				intervalType={ planTypeSelectorProps.intervalType }
-				customerType={ planTypeSelectorProps.customerType }
-				hidePersonalPlan={ planTypeSelectorProps.hidePersonalPlan }
-				basePlansPath={ planTypeSelectorProps.basePlansPath }
-				siteSlug={ planTypeSelectorProps.siteSlug }
-				hideDiscountLabel={ false }
-				showBiannualToggle={ config.isEnabled( 'plans/biannual-toggle' ) }
+				planTypeSelectorProps={ planTypeSelectorProps }
 			/>
 			<Grid isInSignup={ isInSignup }>
 				<PlanComparisonGridHeader

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -622,7 +622,7 @@ export class PlansFeaturesMain extends Component {
 				{ ! hidePlanSelector && (
 					<TermExperimentPlanTypeSelector
 						isEligible={ is2023PricingGridVisible }
-						selectorKind={ kindOfPlanTypeSelector }
+						kind={ kindOfPlanTypeSelector }
 						plans={ visiblePlans }
 						planTypeSelectorProps={ planTypeSelectorProps }
 					/>
@@ -732,7 +732,6 @@ export default connect(
 			customerType: customerType,
 			hidePersonalPlan: props.hidePersonalPlan,
 			siteSlug,
-			showBiannualToggle: isEnabled( 'plans/biannual-toggle' ) && is2023PricingGridVisible,
 		};
 
 		return {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -48,6 +48,7 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import HappychatConnection from 'calypso/components/happychat/connection-connected';
 import Notice from 'calypso/components/notice';
 import { getTld } from 'calypso/lib/domains';
+import { ProvideExperimentData } from 'calypso/lib/explat';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
 import PlanFeatures from 'calypso/my-sites/plan-features';
 import PlanFeaturesComparison from 'calypso/my-sites/plan-features-comparison';
@@ -620,11 +621,32 @@ export class PlansFeaturesMain extends Component {
 				<HappychatConnection />
 				<div className="plans-features-main__notice" />
 				{ ! hidePlanSelector && (
-					<PlanTypeSelector
-						{ ...planTypeSelectorProps }
-						kind={ kindOfPlanTypeSelector }
-						plans={ visiblePlans }
-					/>
+					<ProvideExperimentData
+						name="calypso_plans_2yr_toggle"
+						options={ { isEligible: is2023PricingGridVisible } }
+					>
+						{ ( isLoading, experimentData ) => {
+							if ( isLoading ) {
+								return <></>;
+							}
+
+							const { variationName } = experimentData;
+
+							const propsWithBiannualToggle = {
+								...planTypeSelectorProps,
+								showBiannualToggle:
+									variationName === 'toggle_and_checkout' || variationName === 'toggle_only',
+							};
+
+							return (
+								<PlanTypeSelector
+									{ ...propsWithBiannualToggle }
+									kind={ kindOfPlanTypeSelector }
+									plans={ visiblePlans }
+								/>
+							);
+						} }
+					</ProvideExperimentData>
 				) }
 				{ this.renderPlansGrid() }
 				{ this.mayRenderFAQ() }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -48,7 +48,6 @@ import FormattedHeader from 'calypso/components/formatted-header';
 import HappychatConnection from 'calypso/components/happychat/connection-connected';
 import Notice from 'calypso/components/notice';
 import { getTld } from 'calypso/lib/domains';
-import { ProvideExperimentData } from 'calypso/lib/explat';
 import { isValidFeatureKey } from 'calypso/lib/plans/features-list';
 import PlanFeatures from 'calypso/my-sites/plan-features';
 import PlanFeaturesComparison from 'calypso/my-sites/plan-features-comparison';
@@ -67,8 +66,8 @@ import {
 	isJetpackSite,
 	isJetpackSiteMultiSite,
 } from 'calypso/state/sites/selectors';
-import PlanTypeSelector from './plan-type-selector';
 import PlanFAQ from './plansStepFaq';
+import TermExperimentPlanTypeSelector from './term-experiment-plan-type-selector';
 import WpcomFAQ from './wpcom-faq';
 
 import './style.scss';
@@ -621,32 +620,12 @@ export class PlansFeaturesMain extends Component {
 				<HappychatConnection />
 				<div className="plans-features-main__notice" />
 				{ ! hidePlanSelector && (
-					<ProvideExperimentData
-						name="calypso_plans_2yr_toggle"
-						options={ { isEligible: is2023PricingGridVisible } }
-					>
-						{ ( isLoading, experimentData ) => {
-							if ( isLoading ) {
-								return <></>;
-							}
-
-							const { variationName } = experimentData;
-
-							const propsWithBiannualToggle = {
-								...planTypeSelectorProps,
-								showBiannualToggle:
-									variationName === 'toggle_and_checkout' || variationName === 'toggle_only',
-							};
-
-							return (
-								<PlanTypeSelector
-									{ ...propsWithBiannualToggle }
-									kind={ kindOfPlanTypeSelector }
-									plans={ visiblePlans }
-								/>
-							);
-						} }
-					</ProvideExperimentData>
+					<TermExperimentPlanTypeSelector
+						isEligible={ is2023PricingGridVisible }
+						selectorKind={ kindOfPlanTypeSelector }
+						plans={ visiblePlans }
+						planTypeSelectorProps={ planTypeSelectorProps }
+					/>
 				) }
 				{ this.renderPlansGrid() }
 				{ this.mayRenderFAQ() }

--- a/client/my-sites/plans-features-main/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/plan-type-selector.tsx
@@ -11,12 +11,13 @@ import styled from '@emotion/styled';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { omit } from 'lodash';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 import CSSTransition from 'react-transition-group/CSSTransition';
 import { Primitive } from 'utility-types';
 import SegmentedControl from 'calypso/components/segmented-control';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ProvideExperimentData } from 'calypso/lib/explat';
 import { addQueryArgs } from 'calypso/lib/url';
 import {
@@ -267,6 +268,12 @@ const PlanTypeSelector: React.FunctionComponent< PlanTypeSelectorProps > = ( {
 	kind,
 	...props
 } ) => {
+	useEffect( () => {
+		recordTracksEvent( 'calypso_plans_plan_type_selector_view', {
+			kind,
+		} );
+	}, [] );
+
 	if ( kind === 'interval' ) {
 		return <IntervalTypeToggle { ...props } />;
 	}

--- a/client/my-sites/plans-features-main/term-experiment-plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/term-experiment-plan-type-selector.tsx
@@ -3,10 +3,10 @@ import PlanTypeSelector, { PlanTypeSelectorProps } from './plan-type-selector';
 
 const TermExperimentPlanTypeSelector: React.FunctionComponent< {
 	isEligible: boolean;
-	selectorKind: string;
+	kind: string;
 	plans: string[];
 	planTypeSelectorProps: PlanTypeSelectorProps;
-} > = ( { isEligible, selectorKind, plans, planTypeSelectorProps } ) => (
+} > = ( { isEligible, kind, plans, planTypeSelectorProps } ) => (
 	<ProvideExperimentData name="calypso_plans_2yr_toggle" options={ { isEligible } }>
 		{ ( isLoading, experimentData ) => {
 			if ( isLoading ) {
@@ -21,9 +21,7 @@ const TermExperimentPlanTypeSelector: React.FunctionComponent< {
 					variationName === 'toggle_and_checkout' || variationName === 'toggle_only',
 			};
 
-			return (
-				<PlanTypeSelector { ...propsWithBiannualToggle } kind={ selectorKind } plans={ plans } />
-			);
+			return <PlanTypeSelector { ...propsWithBiannualToggle } kind={ kind } plans={ plans } />;
 		} }
 	</ProvideExperimentData>
 );

--- a/client/my-sites/plans-features-main/term-experiment-plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/term-experiment-plan-type-selector.tsx
@@ -10,7 +10,7 @@ const PlanSelectorLoadingEllipsis = styled( LoadingEllipsis )`
 
 const TermExperimentPlanTypeSelector: React.FunctionComponent< {
 	isEligible: boolean;
-	kind: string;
+	kind: 'interval' | 'customer';
 	plans: string[];
 	planTypeSelectorProps: PlanTypeSelectorProps;
 } > = ( { isEligible, kind, plans, planTypeSelectorProps } ) => (

--- a/client/my-sites/plans-features-main/term-experiment-plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/term-experiment-plan-type-selector.tsx
@@ -1,3 +1,4 @@
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { ProvideExperimentData } from 'calypso/lib/explat';
 import PlanTypeSelector, { PlanTypeSelectorProps } from './plan-type-selector';
 
@@ -10,7 +11,7 @@ const TermExperimentPlanTypeSelector: React.FunctionComponent< {
 	<ProvideExperimentData name="calypso_plans_2yr_toggle" options={ { isEligible } }>
 		{ ( isLoading, experimentData ) => {
 			if ( isLoading ) {
-				return <></>;
+				return <LoadingEllipsis />;
 			}
 
 			const { variationName } = experimentData;

--- a/client/my-sites/plans-features-main/term-experiment-plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/term-experiment-plan-type-selector.tsx
@@ -1,0 +1,31 @@
+import { ProvideExperimentData } from 'calypso/lib/explat';
+import PlanTypeSelector, { PlanTypeSelectorProps } from './plan-type-selector';
+
+const TermExperimentPlanTypeSelector: React.FunctionComponent< {
+	isEligible: boolean;
+	selectorKind: string;
+	plans: string[];
+	planTypeSelectorProps: PlanTypeSelectorProps;
+} > = ( { isEligible, selectorKind, plans, planTypeSelectorProps } ) => (
+	<ProvideExperimentData name="calypso_plans_2yr_toggle" options={ { isEligible } }>
+		{ ( isLoading, experimentData ) => {
+			if ( isLoading ) {
+				return <></>;
+			}
+
+			const { variationName } = experimentData;
+
+			const propsWithBiannualToggle = {
+				...planTypeSelectorProps,
+				showBiannualToggle:
+					variationName === 'toggle_and_checkout' || variationName === 'toggle_only',
+			};
+
+			return (
+				<PlanTypeSelector { ...propsWithBiannualToggle } kind={ selectorKind } plans={ plans } />
+			);
+		} }
+	</ProvideExperimentData>
+);
+
+export default TermExperimentPlanTypeSelector;

--- a/client/my-sites/plans-features-main/term-experiment-plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/term-experiment-plan-type-selector.tsx
@@ -1,6 +1,12 @@
+import styled from '@emotion/styled';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { ProvideExperimentData } from 'calypso/lib/explat';
 import PlanTypeSelector, { PlanTypeSelectorProps } from './plan-type-selector';
+
+const PlanSelectorLoadingEllipsis = styled( LoadingEllipsis )`
+	margin: auto;
+	display: block;
+`;
 
 const TermExperimentPlanTypeSelector: React.FunctionComponent< {
 	isEligible: boolean;
@@ -11,7 +17,7 @@ const TermExperimentPlanTypeSelector: React.FunctionComponent< {
 	<ProvideExperimentData name="calypso_plans_2yr_toggle" options={ { isEligible } }>
 		{ ( isLoading, experimentData ) => {
 			if ( isLoading ) {
-				return <LoadingEllipsis />;
+				return <PlanSelectorLoadingEllipsis />;
 			}
 
 			const { variationName } = experimentData;

--- a/client/my-sites/plans-features-main/term-experiment-plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/term-experiment-plan-type-selector.tsx
@@ -20,7 +20,7 @@ const TermExperimentPlanTypeSelector: React.FunctionComponent< {
 				return <PlanSelectorLoadingEllipsis />;
 			}
 
-			const { variationName } = experimentData;
+			const variationName = experimentData?.variationName;
 
 			const propsWithBiannualToggle = {
 				...planTypeSelectorProps,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -36,6 +36,7 @@ import {
 	recordSignupProcessingScreen,
 	recordSignupPlanChange,
 } from 'calypso/lib/analytics/signup';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import * as oauthToken from 'calypso/lib/oauth-token';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import SignupFlowController from 'calypso/lib/signup/flow-controller';
@@ -206,6 +207,11 @@ class Signup extends Component {
 					this.getCurrentFlowSupportedQueryParams()
 				)
 			);
+		}
+
+		// preload the experiment to minimize the perceived loading time
+		if ( this.props.flowName === flows.defaultFlowName ) {
+			loadExperimentAssignment( 'calypso_plans_2yr_toggle' );
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74264 

## Proposed Changes

This PR implements the A/B/n test proposed in p2-pbxNRc-2qr. There are two variations introduced:

* `toggle_only`: The term toggle shows 1y/2y in `/start/plans` and `/plans`
* `toggle_and_checkout`: The term toggle shows 1y/2y in `/start/plans` and `/plans`. In the checkout, the terms lower than the selected one show. e.g. picking an 2yr plan, both the yearly and the monthly options will show in the checkout.

Note that I only preload the experiment for the onboarding flow, but not for cases when users are already logged-in. We want to make sure that the checkout experience is only altered when the users are from either the onboarding flow or `/plans`. While it's easy to restrict and to preload the experiment within the onboarding flow, there are countless other places that lead to the checkout page once outside the flow. Thus I found it hard to find a safe place to preload outside the onboarding flow. Chances are that I've overlooked something, of course 🙃 

## Testing Instructions

In general, use ExPlat to enforce variation. The instance is linked in p2-pbxNRc-2qr.

1.  For both variations, the 1y/2y term toggle should show for `/start/plans` and `/plans`, while the default variation shows the monthly/annually one.  
2. For `toggle_and_checkout` variation, make sure the lower terms comparing to what you have picked are shown. e.g. if you pick a 2yearly plan, the monthly option. For the `toggle_only` and the default variation, it stays the way it works currently.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
