### PR TITLE
Subscriptions Site list to mobile

### DIFF
--- a/client/landing/subscriptions/site-list/styles.scss
+++ b/client/landing/subscriptions/site-list/styles.scss
@@ -1,5 +1,6 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
 
 $max-list-width: 1300px;
 
@@ -69,6 +70,18 @@ $max-list-width: 1300px;
 
 		&:last-child {
 			border-bottom: none;
+		}
+	}
+
+	@media (max-width: $break-medium) {
+		.email-frequency {
+			display: none;
+		}
+	}
+
+	@media (max-width: $break-small) {
+		.date {
+			display: none;
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/74968

## Proposed Changes

This PR makes the Subscription Site List show as expected in the Figma design:
<img width="329" alt="Screenshot 2023-03-29 at 11 52 54" src="https://user-images.githubusercontent.com/3832570/228497333-8690ecda-f18a-4515-a6a4-dbf0435edb17.png">

Note: the scope of this task doesn't include the meatball button on the right of each site.

https://user-images.githubusercontent.com/3832570/228497498-bc7e61f3-04c8-43da-a985-1fe6554df121.mov

## Testing Instructions
- Apply these changes.
- Go to `http://calypso.localhost:3000/subscriptions/sites`.
- Resize the window to see how the columns disappear as the space for them shrinks (extra points if you test the change in iOS or Android simulator).
