### PR TITLE
Staging Sites: Add use-has-valid-quota hook

### DIFF
--- a/client/my-sites/hosting/staging-site-card/test/index.js
+++ b/client/my-sites/hosting/staging-site-card/test/index.js
@@ -4,6 +4,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { useAddStagingSiteMutation } from 'calypso/my-sites/hosting/staging-site-card/use-add-staging-site';
 import { useCheckStagingSiteStatus } from 'calypso/my-sites/hosting/staging-site-card/use-check-staging-site-status';
+import { useHasValidQuotaQuery } from 'calypso/my-sites/hosting/staging-site-card/use-has-valid-quota';
 import { useStagingSite } from 'calypso/my-sites/hosting/staging-site-card/use-staging-site';
 import { StagingSiteCard } from '..';
 import { useHasSiteAccess } from '../use-has-site-access';
@@ -42,6 +43,15 @@ jest.mock( 'calypso/my-sites/hosting/staging-site-card/use-add-staging-site', ()
 	} ),
 } ) );
 
+jest.mock( 'calypso/my-sites/hosting/staging-site-card/use-has-valid-quota', () => ( {
+	__esModule: true,
+	useHasValidQuotaQuery: jest.fn( () => {
+		return {
+			data: true,
+		};
+	} ),
+} ) );
+
 jest.mock( 'calypso/my-sites/hosting/staging-site-card/use-delete-staging-site', () => ( {
 	__esModule: true,
 	useDeleteStagingSite: jest.fn( () => {
@@ -74,7 +84,6 @@ jest.mock( 'calypso/my-sites/hosting/staging-site-card/use-has-site-access', () 
 
 const defaultProps = {
 	disabled: false,
-	spaceQuotaExceededForStaging: false,
 	siteId: 1,
 	translate: ( text ) => text,
 };
@@ -151,13 +160,12 @@ describe( 'StagingSiteCard component', () => {
 	it( 'shows quota exceeded error message', async () => {
 		useStagingSite.mockReturnValue( { data: [], isLoading: false } );
 
-		const { rerender } = render(
-			<StagingSiteCard { ...defaultProps } spaceQuotaExceededForStaging={ false } />
-		);
+		const { rerender } = render( <StagingSiteCard { ...defaultProps } /> );
 
 		expect( screen.queryByTestId( 'quota-message' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( addStagingSiteBtnName ) ).not.toBeDisabled();
-		rerender( <StagingSiteCard { ...defaultProps } spaceQuotaExceededForStaging={ true } /> );
+		useHasValidQuotaQuery.mockReturnValueOnce( { data: false } );
+		rerender( <StagingSiteCard { ...defaultProps } /> );
 
 		expect( screen.getByTestId( 'quota-message' ) ).toBeVisible();
 	} );

--- a/client/my-sites/hosting/staging-site-card/use-has-valid-quota.ts
+++ b/client/my-sites/hosting/staging-site-card/use-has-valid-quota.ts
@@ -8,7 +8,7 @@ export const useHasValidQuotaQuery = ( siteId: number, options: UseQueryOptions 
 		[ USE_VALID_QUOTA_QUERY_KEY, siteId ],
 		() =>
 			wp.req.get( {
-				path: `/sites/${ siteId }/staging-site/valid-quota`,
+				path: `/sites/${ siteId }/staging-site/validate-quota`,
 				apiNamespace: 'wpcom/v2',
 			} ),
 		{

--- a/client/my-sites/hosting/staging-site-card/use-has-valid-quota.ts
+++ b/client/my-sites/hosting/staging-site-card/use-has-valid-quota.ts
@@ -1,0 +1,26 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+import wp from 'calypso/lib/wp';
+
+export const USE_VALID_QUOTA_QUERY_KEY = 'valid-quota';
+
+export const useHasValidQuotaQuery = ( siteId: number, options: UseQueryOptions ) => {
+	return useQuery< boolean, unknown, boolean >(
+		[ USE_VALID_QUOTA_QUERY_KEY, siteId ],
+		() =>
+			wp.req.get( {
+				path: `/sites/${ siteId }/staging-site/valid-quota`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		{
+			enabled: !! siteId && ( options?.enabled ?? true ),
+			select: ( data ) => {
+				return data;
+			},
+			meta: {
+				persist: false,
+			},
+			staleTime: 10 * 1000,
+			onError: options?.onError,
+		}
+	);
+};

--- a/client/my-sites/hosting/staging-site-card/use-has-valid-quota.ts
+++ b/client/my-sites/hosting/staging-site-card/use-has-valid-quota.ts
@@ -7,7 +7,7 @@ export const useHasValidQuotaQuery = ( siteId: number, options: UseQueryOptions 
 	return useQuery< boolean, unknown, boolean >(
 		[ USE_VALID_QUOTA_QUERY_KEY, siteId ],
 		() =>
-			wp.req.get( {
+			wp.req.post( {
 				path: `/sites/${ siteId }/staging-site/validate-quota`,
 				apiNamespace: 'wpcom/v2',
 			} ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2038

## Proposed Changes

In order to avoid checking the media storage necessary to create a staging site to the client, a new hook was added that uses the backend for validation of the space needed.

## Testing Instructions

1. Create a business site and make it atomic.
2. Navigate to `/hosting-config/<your site>`
3. Make sure to apply D106389-code to your sandbox.
4. Change `/valid-quota` endpoint to return false.
5. Ensure that you see the following message:

![exceed_quota](https://user-images.githubusercontent.com/497103/226560748-1a970659-1209-459a-b27b-03bb74b63b7a.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?