### PR TITLE
Stats: Add simple empty state messaging.

### DIFF
--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -64,7 +64,7 @@ function transformData( data ) {
 }
 
 export default function SubscribersSection() {
-	const { counts: data, isLoading } = useSubscriberCounts();
+	const { counts, isLoading } = useSubscriberCounts();
 
 	// Determines what is shown in the tooltip on hover.
 	const tooltipHelper = ( datum ) => `Changed: ${ datum.diff }`;
@@ -73,11 +73,11 @@ export default function SubscribersSection() {
 		<div className="subscribers-section">
 			<h1 className="highlight-cards-heading">Subscribers</h1>
 			{ isLoading && <StatsModulePlaceholder className="is-chart" isLoading /> }
-			{ ! isLoading && data.length === 0 && (
+			{ ! isLoading && counts.length === 0 && (
 				<p className="subscribers-section__no-data">No data availble for the specified period.</p>
 			) }
-			{ ! isLoading && data.length !== 0 && (
-				<LineChart data={ data } renderTooltipForDatanum={ tooltipHelper }>
+			{ ! isLoading && counts.length !== 0 && (
+				<LineChart data={ counts } renderTooltipForDatanum={ tooltipHelper }>
 					<StatsEmptyState />
 				</LineChart>
 			) }

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -63,9 +63,17 @@ function transformData( data ) {
 	return [ processedData.reverse() ];
 }
 
-// This component is temporary so we can expose the state in the browser.
-// Once we have things working we can just inline the contained JSX in the caller.
-function SubscribersSectionX( { data, isLoading, tooltipHelper } ) {
+export default function SubscribersSection() {
+	const [ isLoading, setIsLoading ] = useState( true );
+	const data = transformData( isLoading ? [] : getData() );
+
+	// Determines what is shown in the tooltip on hover.
+	const tooltipHelper = ( datum ) => `Changed: ${ datum.diff }`;
+
+	useEffect( () => {
+		setTimeout( () => setIsLoading( false ), 5000 );
+	}, [ isLoading ] );
+
 	return (
 		<div className="subscribers-section">
 			<h1 className="highlight-cards-heading">Subscribers</h1>
@@ -79,21 +87,5 @@ function SubscribersSectionX( { data, isLoading, tooltipHelper } ) {
 				</LineChart>
 			) }
 		</div>
-	);
-}
-
-export default function SubscribersSection() {
-	const [ isLoading, setIsLoading ] = useState( true );
-	const data = transformData( isLoading ? [] : getData() );
-
-	// Determines what is shown in the tooltip on hover.
-	const tooltipHelper = ( datum ) => `Changed: ${ datum.diff }`;
-
-	useEffect( () => {
-		setTimeout( () => setIsLoading( false ), 5000 );
-	}, [ isLoading ] );
-
-	return (
-		<SubscribersSectionX data={ data } isLoading={ isLoading } tooltipHelper={ tooltipHelper } />
 	);
 }

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -64,23 +64,10 @@ function transformData( data ) {
 }
 
 export default function SubscribersSection() {
-	const [ isLoading, setIsLoading ] = useState( true );
-	const [ data, setData ] = useState( [] );
+	const { counts: data, isLoading } = useSubscriberCounts();
 
 	// Determines what is shown in the tooltip on hover.
 	const tooltipHelper = ( datum ) => `Changed: ${ datum.diff }`;
-
-	// Runs only once, thus no dependencies.
-	useEffect( () => {
-		setTimeout( () => setIsLoading( false ), 5000 );
-	}, [] );
-
-	// Runs when isLoading changes.
-	useEffect( () => {
-		if ( ! isLoading ) {
-			setData( transformData( getData() ) );
-		}
-	}, [ isLoading ] );
 
 	return (
 		<div className="subscribers-section">
@@ -96,4 +83,23 @@ export default function SubscribersSection() {
 			) }
 		</div>
 	);
+}
+
+function useSubscriberCounts() {
+	const [ counts, setCounts ] = useState( [] );
+	const [ isLoading, setIsLoading ] = useState( true );
+
+	// Run a timer to simulate hitting the network.
+	useEffect( () => {
+		setTimeout( () => setIsLoading( false ), 5000 );
+	}, [] );
+
+	// Process the data once the request returns.
+	useEffect( () => {
+		if ( ! isLoading ) {
+			setCounts( transformData( getData() ) );
+		}
+	}, [ isLoading ] );
+
+	return { counts, isLoading };
 }

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -72,7 +72,7 @@ export default function SubscribersSection() {
 
 	useEffect( () => {
 		setTimeout( () => setIsLoading( false ), 5000 );
-	}, [ isLoading ] );
+	}, [] );
 
 	return (
 		<div className="subscribers-section">

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -77,9 +77,11 @@ export default function SubscribersSection() {
 	return (
 		<div className="subscribers-section">
 			<h1 className="highlight-cards-heading">Subscribers</h1>
-			{ isLoading ? (
-				<StatsModulePlaceholder className="is-chart" isLoading />
-			) : (
+			{ isLoading && <StatsModulePlaceholder className="is-chart" isLoading /> }
+			{ ! isLoading && data.length === 0 && (
+				<p className="subscribers-section__no-data">No data availble for the specified period.</p>
+			) }
+			{ ! isLoading && data.length !== 0 && (
 				<LineChart data={ data } renderTooltipForDatanum={ tooltipHelper }>
 					<StatsEmptyState />
 				</LineChart>

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -65,14 +65,22 @@ function transformData( data ) {
 
 export default function SubscribersSection() {
 	const [ isLoading, setIsLoading ] = useState( true );
-	const data = transformData( isLoading ? [] : getData() );
+	const [ data, setData ] = useState( [] );
 
 	// Determines what is shown in the tooltip on hover.
 	const tooltipHelper = ( datum ) => `Changed: ${ datum.diff }`;
 
+	// Runs only once, thus no dependencies.
 	useEffect( () => {
 		setTimeout( () => setIsLoading( false ), 5000 );
 	}, [] );
+
+	// Runs when isLoading changes.
+	useEffect( () => {
+		if ( ! isLoading ) {
+			setData( transformData( getData() ) );
+		}
+	}, [ isLoading ] );
 
 	return (
 		<div className="subscribers-section">

--- a/client/my-sites/stats/subscribers-section/index.jsx
+++ b/client/my-sites/stats/subscribers-section/index.jsx
@@ -63,17 +63,9 @@ function transformData( data ) {
 	return [ processedData.reverse() ];
 }
 
-export default function SubscribersSection() {
-	const [ isLoading, setIsLoading ] = useState( true );
-	const data = transformData( isLoading ? [] : getData() );
-
-	// Determines what is shown in the tooltip on hover.
-	const tooltipHelper = ( datum ) => `Changed: ${ datum.diff }`;
-
-	useEffect( () => {
-		setTimeout( () => setIsLoading( false ), 5000 );
-	}, [ isLoading ] );
-
+// This component is temporary so we can expose the state in the browser.
+// Once we have things working we can just inline the contained JSX in the caller.
+function SubscribersSectionX( { data, isLoading, tooltipHelper } ) {
 	return (
 		<div className="subscribers-section">
 			<h1 className="highlight-cards-heading">Subscribers</h1>
@@ -87,5 +79,21 @@ export default function SubscribersSection() {
 				</LineChart>
 			) }
 		</div>
+	);
+}
+
+export default function SubscribersSection() {
+	const [ isLoading, setIsLoading ] = useState( true );
+	const data = transformData( isLoading ? [] : getData() );
+
+	// Determines what is shown in the tooltip on hover.
+	const tooltipHelper = ( datum ) => `Changed: ${ datum.diff }`;
+
+	useEffect( () => {
+		setTimeout( () => setIsLoading( false ), 5000 );
+	}, [ isLoading ] );
+
+	return (
+		<SubscribersSectionX data={ data } isLoading={ isLoading } tooltipHelper={ tooltipHelper } />
 	);
 }

--- a/client/my-sites/stats/subscribers-section/style.scss
+++ b/client/my-sites/stats/subscribers-section/style.scss
@@ -1,3 +1,8 @@
 .subscribers-section {
 	margin-top: 1em;
 }
+
+.subscribers-section__no-data {
+	margin: 3em auto;
+	text-align: center;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74938.

## Proposed Changes

Checks for an empty data set and displays a message instead of an empty chart. Very basic layout/styling pending updates from design.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open Calypso Live branch.
2. Visit Jetpack → Stats.
3. Append following to URL: `?flags=stats/subscribers-section`
4. Scroll to bottom of page to see loading indicator.
5. Confirm the chart loads after 5 seconds.
6. Open React dev tools and select the `SubscribersSection` component.
7. Expand the `SubscriberCounts` section under `hooks`.
8. Expand the array state and hit the 'x' to clear the data.
9. Confirm the chart is replaced with an empty state message.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
