### PR TITLE
Reader: Fix open in new window shortcut with non-selected post

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -253,7 +253,10 @@ class ReaderStream extends Component {
 	};
 
 	handleOpenSelectionNewTab = () => {
-		window.open( this.props.selectedPostKey.url, '_blank', 'noreferrer,noopener' );
+		const { selectedPostKey } = this.props;
+		if ( selectedPostKey ) {
+			window.open( selectedPostKey.url, '_blank', 'noreferrer,noopener' );
+		}
 	};
 
 	handleOpenSelection = () => {


### PR DESCRIPTION
Currently, if you open the reader (`/read`) and press `v` to open the selected post it will crash, because there is no selected post:

<img width="544" alt="Screenshot 2023-03-29 at 12 56 32" src="https://user-images.githubusercontent.com/8436925/228512859-ecc101b6-5f7b-4992-b9b3-502673a7e498.png">

This was introduced in #61112.

## Proposed Changes

This PR fixes the `v` shortcut handling by changing it to not do anything when a post is not selected.

## Testing Instructions

* Go to `/read`
* Press `v`
* Verify you don't see an error in the console.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?