### PR TITLE
Plugins: Fix non specified plugin in activate toggle component

### DIFF
--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -147,7 +147,7 @@ PluginActivateToggle.defaultProps = {
 
 export default connect(
 	( state, { site, plugin } ) => ( {
-		inProgress: isPluginActionInProgress( state, site.ID, plugin.id, activationActions ),
+		inProgress: plugin && isPluginActionInProgress( state, site.ID, plugin.id, activationActions ),
 	} ),
 	{
 		recordGoogleEvent,


### PR DESCRIPTION
I haven't been able to reproduce, but this addresses issue 3987469998 reported by Sentry.

## Proposed Changes

Check if `plugin` is defined before using it as an object.

## Testing Instructions

* Go to `/plugins/manage/:site` where `:site` is a Jetpack site with installed, both activated and non-activated plugins. 
* Verify it loads correctly with no errors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
