### PR TITLE
Plans 2023: Fix calculation errors and cleanup price descriptions

### DIFF
--- a/client/my-sites/plan-features-2023-grid/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/billing-timeframe.tsx
@@ -11,8 +11,8 @@ import { formatCurrency } from '@automattic/format-currency';
 import { localize, TranslateResult, useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
+import usePlanPrices from 'calypso/my-sites/plans/hooks/use-plan-prices';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import usePlanPrices from '../plans/hooks/use-plan-prices';
 
 interface Props {
 	planName: string;

--- a/client/my-sites/plan-features-2023-grid/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/billing-timeframe.tsx
@@ -65,7 +65,7 @@ function usePerMonthDescription( {
 			planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice || planPrices.rawPrice;
 		const fullTermPriceText =
 			currencyCode && maybeDiscountedPrice
-				? formatCurrency( maybeDiscountedPrice, currencyCode )
+				? formatCurrency( maybeDiscountedPrice, currencyCode, { stripZeros: true } )
 				: null;
 
 		if ( fullTermPriceText ) {

--- a/client/my-sites/plan-features-2023-grid/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/billing-timeframe.tsx
@@ -43,7 +43,9 @@ function usePerMonthDescription( {
 	}
 
 	if ( isMonthlyPlan ) {
-		// we want the raw price (discounted or not) for the yearly variant, not the site-plan discounted one
+		// We want `yearlyVariantMaybeDiscountedPricePerMonth` to be the raw price the user
+		// would pay if they choose an annual plan instead of the monthly one. So pro-rated
+		// (or site-plan specific) credits should not be taken into account.
 		const yearlyVariantMaybeDiscountedPricePerMonth =
 			planYearlyVariantPricesPerMonth.discountedRawPrice ||
 			planYearlyVariantPricesPerMonth.rawPrice;
@@ -89,7 +91,7 @@ function usePerMonthDescription( {
 const PlanFeatures2023GridBillingTimeframe: FunctionComponent< Props > = ( props ) => {
 	const { planName, billingTimeframe } = props;
 	const translate = useTranslate();
-	const perMonthDescription = usePerMonthDescription( props );
+	const perMonthDescription = usePerMonthDescription( props ) || billingTimeframe;
 	const price = formatCurrency( 25000, 'USD' );
 
 	if ( isWpcomEnterpriseGridPlan( planName ) ) {
@@ -104,7 +106,7 @@ const PlanFeatures2023GridBillingTimeframe: FunctionComponent< Props > = ( props
 		);
 	}
 
-	return <div>{ perMonthDescription || billingTimeframe }</div>;
+	return <div>{ perMonthDescription }</div>;
 };
 
 export default localize( PlanFeatures2023GridBillingTimeframe );

--- a/client/my-sites/plan-features-2023-grid/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/billing-timeframe.tsx
@@ -35,7 +35,7 @@ function usePerMonthDescription( {
 	const planYearlyVariantPrices = usePlanPrices( {
 		planSlug:
 			getPlanSlugForTermVariant( planName as PlanSlug, TERM_ANNUALLY ) ?? ( '' as PlanSlug ),
-		monthly: true,
+		returnMonthly: true,
 	} );
 	const maybeDiscountedPrice =
 		planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice || planPrices.rawPrice;

--- a/client/my-sites/plan-features-2023-grid/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/header-price.tsx
@@ -2,8 +2,8 @@ import { isWpcomEnterpriseGridPlan, PlanSlug } from '@automattic/calypso-product
 import styled from '@emotion/styled';
 import { useSelector } from 'react-redux';
 import PlanPrice from 'calypso/my-sites/plan-price';
+import usePlanPrices from 'calypso/my-sites/plans/hooks/use-plan-prices';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import usePlanPrices from '../plans/hooks/use-plan-prices';
 import { PlanProperties } from './types';
 
 interface PlanFeatures2023GridHeaderPriceProps {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -1,7 +1,6 @@
 import {
 	applyTestFiltersToPlansList,
 	getMonthlyPlanByYearly,
-	getYearlyPlanByMonthly,
 	findPlansKeys,
 	getPlan as getPlanFromKey,
 	getPlanClass,
@@ -68,15 +67,10 @@ import {
 	getPlanBySlug,
 	getPlanRawPrice,
 	getPlanSlug,
-	getDiscountedRawPrice,
 } from 'calypso/state/plans/selectors';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import {
-	getCurrentPlan,
-	isCurrentUserCurrentPlanOwner,
-	getPlanDiscountedRawPrice,
-} from 'calypso/state/sites/plans/selectors';
+import { getCurrentPlan, isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import isPlanAvailableForPurchase from 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase';
 import {
 	getSiteSlug,
@@ -532,8 +526,7 @@ export class PlanFeatures2023Grid extends Component<
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( properties ) => {
-				const { planConstantObj, planName, annualPricePerMonth, isMonthlyPlan, billingPeriod } =
-					properties;
+				const { planConstantObj, planName, isMonthlyPlan, billingPeriod } = properties;
 
 				const classes = classNames(
 					'plan-features-2023-grid__table-item',
@@ -543,7 +536,6 @@ export class PlanFeatures2023Grid extends Component<
 				return (
 					<Container className={ classes } isMobile={ options?.isMobile } key={ planName }>
 						<PlanFeatures2023GridBillingTimeframe
-							annualPricePerMonth={ annualPricePerMonth }
 							isMonthlyPlan={ isMonthlyPlan }
 							planName={ planName }
 							billingTimeframe={ planConstantObj.getBillingTimeFrame() }
@@ -1053,26 +1045,6 @@ const ConnectedPlanFeatures2023Grid = connect(
 			);
 
 			const rawPrice = getPlanRawPrice( state, planProductId, showMonthlyPrice );
-			const isMonthlyObj = { returnMonthly: showMonthlyPrice };
-
-			const discountPrice = siteId
-				? getPlanDiscountedRawPrice( state, siteId, plan, isMonthlyObj )
-				: getDiscountedRawPrice( state, planProductId, showMonthlyPrice );
-
-			let annualPricePerMonth = discountPrice || rawPrice;
-			if ( isMonthlyPlan ) {
-				// Get annual price per month for comparison
-				const yearlyPlan = getPlanBySlug( state, getYearlyPlanByMonthly( plan ) );
-				if ( yearlyPlan ) {
-					const yearlyPlanDiscount = getDiscountedRawPrice(
-						state,
-						yearlyPlan.product_id,
-						showMonthlyPrice
-					);
-					annualPricePerMonth =
-						yearlyPlanDiscount || getPlanRawPrice( state, yearlyPlan.product_id, showMonthlyPrice );
-				}
-			}
 
 			const monthlyPlanKey = findPlansKeys( {
 				group: planConstantObj.group,
@@ -1146,7 +1118,6 @@ const ConnectedPlanFeatures2023Grid = connect(
 				rawPrice,
 				rawPriceForMonthlyPlan,
 				relatedMonthlyPlan,
-				annualPricePerMonth,
 				isMonthlyPlan,
 				tagline,
 				storageOptions,

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -17,7 +17,6 @@ import {
 	PLAN_FREE,
 	PLAN_ENTERPRISE_GRID_WPCOM,
 	isPremiumPlan,
-	PLAN_BIENNIAL_PERIOD,
 	isWooExpressMediumPlan,
 	isWooExpressSmallPlan,
 	isWooExpressPlan,
@@ -533,15 +532,8 @@ export class PlanFeatures2023Grid extends Component<
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( properties ) => {
-				const {
-					planConstantObj,
-					planName,
-					rawPrice,
-					maybeDiscountedFullTermPrice,
-					annualPricePerMonth,
-					isMonthlyPlan,
-					billingPeriod,
-				} = properties;
+				const { planConstantObj, planName, annualPricePerMonth, isMonthlyPlan, billingPeriod } =
+					properties;
 
 				const classes = classNames(
 					'plan-features-2023-grid__table-item',
@@ -551,8 +543,6 @@ export class PlanFeatures2023Grid extends Component<
 				return (
 					<Container className={ classes } isMobile={ options?.isMobile } key={ planName }>
 						<PlanFeatures2023GridBillingTimeframe
-							rawPrice={ rawPrice }
-							maybeDiscountedFullTermPrice={ maybeDiscountedFullTermPrice }
 							annualPricePerMonth={ annualPricePerMonth }
 							isMonthlyPlan={ isMonthlyPlan }
 							planName={ planName }
@@ -1124,11 +1114,6 @@ const ConnectedPlanFeatures2023Grid = connect(
 				);
 			}
 
-			const maybeDiscountedFullTermPrice =
-				null !== discountPrice
-					? discountPrice * ( PLAN_BIENNIAL_PERIOD === billingPeriod ? 24 : 12 )
-					: getPlanRawPrice( state, planProductId, false );
-
 			const tagline = planConstantObj.getPlanTagline?.() ?? '';
 			const product_name_short =
 				isWpcomEnterpriseGridPlan( plan ) && planConstantObj.getPathSlug
@@ -1159,7 +1144,6 @@ const ConnectedPlanFeatures2023Grid = connect(
 				product_name_short,
 				hideMonthly: false,
 				rawPrice,
-				maybeDiscountedFullTermPrice,
 				rawPriceForMonthlyPlan,
 				relatedMonthlyPlan,
 				annualPricePerMonth,

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -376,7 +376,6 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 			<div className="plan-comparison-grid__billing-info">
 				<PlanFeatures2023GridBillingTimeframe
 					planName={ planName }
-					annualPricePerMonth={ planPropertiesObj.annualPricePerMonth }
 					isMonthlyPlan={ planPropertiesObj.isMonthlyPlan }
 					billingTimeframe={ planConstantObj.getBillingTimeFrame() }
 					billingPeriod={ planPropertiesObj.billingPeriod }

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -329,7 +329,6 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 	const popularBadgeClasses = classNames( {
 		'is-current-plan': current,
 	} );
-	const rawPrice = planPropertiesObj.rawPrice;
 	const showPlanSelect = ! allVisible && ! current;
 
 	return (

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -376,8 +376,6 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 			<div className="plan-comparison-grid__billing-info">
 				<PlanFeatures2023GridBillingTimeframe
 					planName={ planName }
-					rawPrice={ rawPrice }
-					maybeDiscountedFullTermPrice={ planPropertiesObj.maybeDiscountedFullTermPrice }
 					annualPricePerMonth={ planPropertiesObj.annualPricePerMonth }
 					isMonthlyPlan={ planPropertiesObj.isMonthlyPlan }
 					billingTimeframe={ planConstantObj.getBillingTimeFrame() }

--- a/client/my-sites/plan-features-2023-grid/test/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/test/billing-timeframe.tsx
@@ -1,0 +1,131 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Default mock implementations
+ */
+jest.mock( 'calypso/state/currency-code/selectors', () => ( {
+	getCurrentUserCurrencyCode: jest.fn(),
+} ) );
+jest.mock( 'i18n-calypso', () => ( {
+	...jest.requireActual( 'i18n-calypso' ),
+} ) );
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useSelector: jest.fn( ( selector ) => selector() ),
+} ) );
+jest.mock( 'calypso/my-sites/plans/hooks/use-plan-prices', () => jest.fn() );
+
+import {
+	PLAN_ANNUAL_PERIOD,
+	PLAN_BIENNIAL_PERIOD,
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_BUSINESS_MONTHLY,
+	PLAN_MONTHLY_PERIOD,
+} from '@automattic/calypso-products';
+import { formatCurrency } from '@automattic/format-currency';
+import { render } from '@testing-library/react';
+import React from 'react';
+import usePlanPrices, { PlanPrices } from 'calypso/my-sites/plans/hooks/use-plan-prices';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import PlanFeatures2023GridBillingTimeframe from '../billing-timeframe';
+
+describe( 'PlanFeatures2023GridBillingTimeframe', () => {
+	const defaultProps = {
+		billingTimeframe: 'per month, billed annually',
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		getCurrentUserCurrencyCode.mockImplementation( jest.fn( () => 'INR' ) );
+	} );
+
+	test( `should show savings with yearly when plan is monthly`, () => {
+		const planMonthlyPrices: PlanPrices = {
+			planDiscountedRawPrice: 100,
+			discountedRawPrice: 150,
+			rawPrice: 200,
+		};
+		const planYearlyPrices: PlanPrices = {
+			planDiscountedRawPrice: 50,
+			discountedRawPrice: 100,
+			rawPrice: 150,
+		};
+
+		usePlanPrices.mockImplementation(
+			jest.fn( ( { planSlug } ) => {
+				if ( planSlug === PLAN_BUSINESS_MONTHLY ) {
+					return planMonthlyPrices;
+				}
+				return planYearlyPrices;
+			} )
+		);
+
+		const { container } = render(
+			<PlanFeatures2023GridBillingTimeframe
+				{ ...defaultProps }
+				planName={ PLAN_BUSINESS_MONTHLY }
+				isMonthlyPlan={ true }
+				billingPeriod={ PLAN_MONTHLY_PERIOD }
+			/>
+		);
+		const savings =
+			( 100 * ( planMonthlyPrices.rawPrice - planYearlyPrices.discountedRawPrice ) ) /
+			planMonthlyPrices.rawPrice;
+
+		expect( container ).toHaveTextContent( `Save ${ savings }%` );
+	} );
+
+	test( 'should show full-term discounted price when plan is yearly', () => {
+		const planPrices: PlanPrices = {
+			planDiscountedRawPrice: 100,
+			discountedRawPrice: 150,
+			rawPrice: 200,
+		};
+
+		usePlanPrices.mockImplementation( jest.fn( () => planPrices ) );
+
+		const { container } = render(
+			<PlanFeatures2023GridBillingTimeframe
+				{ ...defaultProps }
+				planName={ PLAN_BUSINESS }
+				isMonthlyPlan={ false }
+				billingPeriod={ PLAN_ANNUAL_PERIOD }
+			/>
+		);
+
+		expect( container ).toHaveTextContent(
+			`per month, ${ formatCurrency(
+				planPrices.planDiscountedRawPrice,
+				getCurrentUserCurrencyCode()
+			) } billed annually`
+		);
+	} );
+
+	test( 'should show full-term discounted price when plan is 2-yearly', () => {
+		const planPrices: PlanPrices = {
+			planDiscountedRawPrice: 100,
+			discountedRawPrice: 150,
+			rawPrice: 200,
+		};
+
+		usePlanPrices.mockImplementation( jest.fn( () => planPrices ) );
+
+		const { container } = render(
+			<PlanFeatures2023GridBillingTimeframe
+				{ ...defaultProps }
+				planName={ PLAN_BUSINESS_2_YEARS }
+				isMonthlyPlan={ false }
+				billingPeriod={ PLAN_BIENNIAL_PERIOD }
+			/>
+		);
+
+		expect( container ).toHaveTextContent(
+			`per month, ${ formatCurrency(
+				planPrices.planDiscountedRawPrice,
+				getCurrentUserCurrencyCode()
+			) } billed every two years`
+		);
+	} );
+} );

--- a/client/my-sites/plan-features-2023-grid/test/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/test/billing-timeframe.tsx
@@ -27,8 +27,9 @@ import {
 import { formatCurrency } from '@automattic/format-currency';
 import { render } from '@testing-library/react';
 import React from 'react';
-import usePlanPrices, { PlanPrices } from 'calypso/my-sites/plans/hooks/use-plan-prices';
+import usePlanPrices from 'calypso/my-sites/plans/hooks/use-plan-prices';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import { PlanPrices } from 'calypso/state/plans/types';
 import PlanFeatures2023GridBillingTimeframe from '../billing-timeframe';
 
 describe( 'PlanFeatures2023GridBillingTimeframe', () => {
@@ -98,7 +99,8 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		expect( container ).toHaveTextContent(
 			`per month, ${ formatCurrency(
 				planPrices.planDiscountedRawPrice,
-				getCurrentUserCurrencyCode()
+				getCurrentUserCurrencyCode(),
+				{ stripZeros: true }
 			) } billed annually`
 		);
 	} );
@@ -124,7 +126,8 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		expect( container ).toHaveTextContent(
 			`per month, ${ formatCurrency(
 				planPrices.planDiscountedRawPrice,
-				getCurrentUserCurrencyCode()
+				getCurrentUserCurrencyCode(),
+				{ stripZeros: true }
 			) } billed every two years`
 		);
 	} );

--- a/client/my-sites/plan-features-2023-grid/test/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/test/header-price.tsx
@@ -15,11 +15,11 @@ jest.mock( 'react-redux', () => ( {
 	...jest.requireActual( 'react-redux' ),
 	useSelector: jest.fn(),
 } ) );
-jest.mock( '../../plans/hooks/use-plan-prices', () => jest.fn() );
+jest.mock( 'calypso/my-sites/plans/hooks/use-plan-prices', () => jest.fn() );
 
 import { render } from '@testing-library/react';
 import React from 'react';
-import usePlanPrices, { PlanPrices } from '../../plans/hooks/use-plan-prices';
+import usePlanPrices, { PlanPrices } from 'calypso/my-sites/plans/hooks/use-plan-prices';
 import PlanFeatures2023GridHeaderPrice from '../header-price';
 import { PlanProperties } from '../types';
 

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -26,7 +26,6 @@ export type PlanProperties = {
 	rawPrice: number | null;
 	rawPriceForMonthlyPlan: number | null;
 	relatedMonthlyPlan: null | PricedAPIPlan | undefined;
-	annualPricePerMonth: number | null;
 	isMonthlyPlan: boolean;
 	tagline: string;
 	storageOptions: string[];

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -24,7 +24,6 @@ export type PlanProperties = {
 	product_name_short: string;
 	hideMonthly?: boolean;
 	rawPrice: number | null;
-	maybeDiscountedFullTermPrice: number | null;
 	rawPriceForMonthlyPlan: number | null;
 	relatedMonthlyPlan: null | PricedAPIPlan | undefined;
 	annualPricePerMonth: number | null;

--- a/client/state/plans/types.ts
+++ b/client/state/plans/types.ts
@@ -7,3 +7,5 @@ export type Plan = {
 	user_is_owner: boolean;
 	// TODO: complete
 };
+
+export type { PlanPrices } from './selectors/get-plan-prices';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/martech#1648

## Proposed Changes

Fixes a calculation error in price descriptions and moves billing timeframe/savings properties to the respective component. These seem sensitive parts and we are moving around price computations. hopefully, nothing was missed.

The PR is based on https://github.com/Automattic/wp-calypso/pull/74960, which introduces the `usePlanPrices` hook that's used here.

### TODO

- [x] Some unit/UI tests while touching these parts

### Media

**Before**

<img width="700" alt="Screenshot 2023-03-29 at 3 42 56 PM" src="https://user-images.githubusercontent.com/1705499/228538864-28d364ea-1d06-4bcd-a800-1776094e7bb6.png">

**After**

<img width="700" alt="Screenshot 2023-03-29 at 3 42 06 PM" src="https://user-images.githubusercontent.com/1705499/228538584-82c0b0c3-e99a-4026-8043-f3ec1a7851a6.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/[TERM]][SITE]` and confirm price descriptions are produced as expected.
* Switch to INR currency and confirm the price shows up correctly.
* Confirm prices, in general, are displayed correctly (this should also serve as additional checks for the changes introduced by https://github.com/Automattic/wp-calypso/pull/74960)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
