### PR TITLE
Use different url for error message

### DIFF
--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -246,7 +246,7 @@ const communityTranslatorJumpstart = {
 			debug( 'loading community translator' );
 			loadjQueryDependentScriptDesktopWrapper( injectUrl, function ( error ) {
 				if ( error || ! window.communityTranslator ) {
-					debug( 'Script ' + error.src + ' failed to load.' );
+					debug( 'Script ' + injectUrl + ' failed to load.' );
 					return;
 				}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
Uses a different URL for an error message. This was caused by a fix earlier for when a url fails to load. I forgot to adjust for the fact that errors aren't the only thing triggering this code path.
