### PR TITLE
Use Math.floor() for user-facing days left computation

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/index.tsx
@@ -26,7 +26,7 @@ const ECommerceTrialBanner = ( props: ECommerceTrialBannerProps ) => {
 		useSelector( ( state ) => ( {
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
 			isTrialExpired: isECommerceTrialExpired( state, selectedSiteId ),
-			eCommerceTrialDaysLeft: Math.round( getECommerceTrialDaysLeft( state, selectedSiteId ) || 0 ),
+			eCommerceTrialDaysLeft: getECommerceTrialDaysLeft( state, selectedSiteId ) || 0,
 			eCommerceTrialExpiration: getECommerceTrialExpiration( state, selectedSiteId ),
 		} ) );
 

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/index.tsx
@@ -26,7 +26,7 @@ const ECommerceTrialBanner = ( props: ECommerceTrialBannerProps ) => {
 		useSelector( ( state ) => ( {
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
 			isTrialExpired: isECommerceTrialExpired( state, selectedSiteId ),
-			eCommerceTrialDaysLeft: getECommerceTrialDaysLeft( state, selectedSiteId ) || 0,
+			eCommerceTrialDaysLeft: Math.floor( getECommerceTrialDaysLeft( state, selectedSiteId ) || 0 ),
 			eCommerceTrialExpiration: getECommerceTrialExpiration( state, selectedSiteId ),
 		} ) );
 

--- a/client/state/sites/plans/selectors/get-ecommerce-trial-days-left.ts
+++ b/client/state/sites/plans/selectors/get-ecommerce-trial-days-left.ts
@@ -3,11 +3,11 @@ import { AppState } from 'calypso/types';
 import getECommerceTrialExpiration from './get-ecommerce-trial-expiration';
 
 /**
- * Get the number of days left in the ECommerce trial. If the trial is not active, returns null.
+ * Get the number of full days left in the ECommerce trial. If the trial is not active, returns null.
  *
  * @param {AppState} state - Global state tree
  * @param {number} siteId - Site ID
- * @returns {null|number} Exact number of days left in the trial, or null if the trial is not active.
+ * @returns {null|number} Number of days left in the trial, or null if the trial is not active.
  */
 export default function getECommerceTrialDaysLeft(
 	state: AppState,
@@ -18,27 +18,8 @@ export default function getECommerceTrialDaysLeft(
 		return null;
 	}
 
-	const currentTimeUtc = moment().utc();
-	let startTimeUtc;
-
-	// If the current time is 00:00:00.000 that should be our start time.
-	if (
-		currentTimeUtc.hour() === 0 &&
-		currentTimeUtc.minute() === 0 &&
-		currentTimeUtc.second() === 0 &&
-		currentTimeUtc.millisecond() === 0
-	) {
-		startTimeUtc = currentTimeUtc.clone();
-	} else {
-		// We need start time to be 00:00:00.000 of the next day so we only count full days.
-		startTimeUtc = currentTimeUtc
-			.clone()
-			.add( 1, 'days' )
-			.hour( 0 )
-			.minute( 0 )
-			.second( 0 )
-			.millisecond( 0 );
-	}
-
-	return trialExpirationDate.diff( startTimeUtc, 'days', true );
+	// Use Math.floor() so we get an integer number of days.
+	// The result of diff() will include partial days, like 13.7, which is not
+	// a useful return value from this function.
+	return Math.floor( trialExpirationDate.diff( moment().utc(), 'days', true ) );
 }

--- a/client/state/sites/plans/selectors/get-ecommerce-trial-days-left.ts
+++ b/client/state/sites/plans/selectors/get-ecommerce-trial-days-left.ts
@@ -1,13 +1,14 @@
-import moment, { Moment } from 'moment';
-import { AppState } from 'calypso/types';
+import moment from 'moment';
 import getECommerceTrialExpiration from './get-ecommerce-trial-expiration';
+import type { AppState } from 'calypso/types';
+import type { Moment } from 'moment';
 
 /**
- * Get the number of full days left in the ECommerce trial. If the trial is not active, returns null.
+ * Get the number of days left in the ECommerce trial. If the trial is not active, returns null.
  *
  * @param {AppState} state - Global state tree
  * @param {number} siteId - Site ID
- * @returns {null|number} Number of days left in the trial, or null if the trial is not active.
+ * @returns {null|number} Number of days left in the trial as a float, or null if the trial is not active.
  */
 export default function getECommerceTrialDaysLeft(
 	state: AppState,
@@ -18,8 +19,5 @@ export default function getECommerceTrialDaysLeft(
 		return null;
 	}
 
-	// Use Math.floor() so we get an integer number of days.
-	// The result of diff() will include partial days, like 13.7, which is not
-	// a useful return value from this function.
-	return Math.floor( trialExpirationDate.diff( moment().utc(), 'days', true ) );
+	return trialExpirationDate.diff( moment().utc(), 'days', true );
 }

--- a/client/state/sites/plans/selectors/get-ecommerce-trial-days-left.ts
+++ b/client/state/sites/plans/selectors/get-ecommerce-trial-days-left.ts
@@ -7,7 +7,7 @@ import getECommerceTrialExpiration from './get-ecommerce-trial-expiration';
  *
  * @param {AppState} state - Global state tree
  * @param {number} siteId - Site ID
- * @returns {null|number} Number of days left in the trial, or null if the trial is not active.
+ * @returns {null|number} Exact number of days left in the trial, or null if the trial is not active.
  */
 export default function getECommerceTrialDaysLeft(
 	state: AppState,
@@ -18,5 +18,27 @@ export default function getECommerceTrialDaysLeft(
 		return null;
 	}
 
-	return trialExpirationDate.diff( moment().utc(), 'days', true );
+	const currentTimeUtc = moment().utc();
+	let startTimeUtc;
+
+	// If the current time is 00:00:00.000 that should be our start time.
+	if (
+		currentTimeUtc.hour() === 0 &&
+		currentTimeUtc.minute() === 0 &&
+		currentTimeUtc.second() === 0 &&
+		currentTimeUtc.millisecond() === 0
+	) {
+		startTimeUtc = currentTimeUtc.clone();
+	} else {
+		// We need start time to be 00:00:00.000 of the next day so we only count full days.
+		startTimeUtc = currentTimeUtc
+			.clone()
+			.add( 1, 'days' )
+			.hour( 0 )
+			.minute( 0 )
+			.second( 0 )
+			.millisecond( 0 );
+	}
+
+	return trialExpirationDate.diff( startTimeUtc, 'days', true );
 }

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -856,7 +856,7 @@ describe( 'selectors', () => {
 
 	describe( '#getECommerceTrialDaysLeft()', () => {
 		const siteId = 1337;
-		jest.useFakeTimers().setSystemTime( new Date( '2022-01-10T13:07:00+00:00' ) );
+		jest.useFakeTimers().setSystemTime( new Date( '2022-01-10T00:00:00+00:00' ) );
 
 		test( 'Should return the correct number of days left before the trial expires', () => {
 			const expiryDate = '2022-02-10T00:00:00+00:00';
@@ -888,7 +888,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getECommerceTrialDaysLeft( state, siteId ) ).toBe( 30 );
+			expect( getECommerceTrialDaysLeft( state, siteId ) ).toBe( 31 );
 		} );
 	} );
 

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -856,7 +856,7 @@ describe( 'selectors', () => {
 
 	describe( '#getECommerceTrialDaysLeft()', () => {
 		const siteId = 1337;
-		jest.useFakeTimers().setSystemTime( new Date( '2022-01-10T00:00:00+00:00' ) );
+		jest.useFakeTimers().setSystemTime( new Date( '2022-01-10T13:07:00+00:00' ) );
 
 		test( 'Should return the correct number of days left before the trial expires', () => {
 			const expiryDate = '2022-02-10T00:00:00+00:00';
@@ -888,7 +888,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getECommerceTrialDaysLeft( state, siteId ) ).toBe( 31 );
+			expect( getECommerceTrialDaysLeft( state, siteId ) ).toBe( 30 );
 		} );
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #74770

## Proposed Changes

* This PR ensures that we show the correct number of days remaining in the user's trial in the banner used on the Plans and My Plans pages. It does so by switching from `Math.round()` to `Math.floor()` in the banner code, as we want to reflect the whole number of remaining days.
  - It's worth noting that I explored changing `getECommerceTrialDaysLeft()` to return an integer, but `isECommerceTrialExpired()` depends on the selector, so that got messy.

## Testing Instructions

This is a tricky one to test, because the issue only manifests when the _current time_ is before 12:00:00 UTC. I tested this as follows:
* If you're testing this before 12:00 UTC, visit `/plans/:siteSlug` on the Calypso.live branch for a site on the eCommerce trial
  - Verify that the number of days remaining is a whole number that matches the number of the sidebar nudge
* Otherwise, you need to run Calypso locally, and will need to manipulate the code to produce the error condition. To do that, you should modify `getECommerceTrialDaysLeft()` as follows:
```diff
-	return trialExpirationDate.diff( moment().utc(), 'days', true );
+	const mockTime = moment().utc().hour( 2 );
+	return trialExpirationDate.diff( mockTime, 'days', true );
```
  - With that code in place, visit `/plans/:siteSlug`
  - Verify that the number of days shown in the plans page banner matches the nudge in the left sidebar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?