### PR TITLE
Woo Express Trial: Hide 'Renew plan' link on /sites

### DIFF
--- a/client/sites-dashboard/components/sites-plan-renew-nag.tsx
+++ b/client/sites-dashboard/components/sites-plan-renew-nag.tsx
@@ -12,6 +12,7 @@ interface PlanRenewProps {
 	plan: Site.SiteDetailsPlan;
 	isSiteOwner: boolean;
 	checkoutUrl: string;
+	hideRenewLink?: boolean;
 }
 
 const PlanRenewContainer = styled.div( {
@@ -49,7 +50,12 @@ const PlanRenewNoticeExpireText = styled.div( {
 	overflow: 'hidden',
 } );
 
-export const PlanRenewNag = ( { isSiteOwner, plan, checkoutUrl }: PlanRenewProps ) => {
+export const PlanRenewNag = ( {
+	isSiteOwner,
+	plan,
+	checkoutUrl,
+	hideRenewLink,
+}: PlanRenewProps ) => {
 	const { __ } = useI18n();
 	const trackCallback = useCallback(
 		() =>
@@ -79,7 +85,7 @@ export const PlanRenewNag = ( { isSiteOwner, plan, checkoutUrl }: PlanRenewProps
 						) }
 					</PlanRenewNoticeExpireText>
 				</PlanRenewNoticeTextContainer>
-				{ isSiteOwner && (
+				{ isSiteOwner && ! hideRenewLink && (
 					<PlanRenewLink
 						onClick={ () => {
 							recordTracksEvent( PLAN_RENEW_NAG_EVENT_NAMES.ON_CLICK, {

--- a/client/sites-dashboard/components/sites-site-plan.tsx
+++ b/client/sites-dashboard/components/sites-site-plan.tsx
@@ -1,3 +1,4 @@
+import { PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { useSelector } from 'react-redux';
 import JetpackLogo from 'calypso/components/jetpack-logo';
@@ -32,6 +33,8 @@ const STAGING_PLAN_LABEL = 'Staging';
 
 export const SitePlan = ( { site, userId }: SitePlanProps ) => {
 	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, site.ID ) );
+	const isECommerceTrialSite = site.plan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
+
 	return (
 		<SitePlanContainer>
 			{ ! isWpcomStagingSite ? (
@@ -47,6 +50,7 @@ export const SitePlan = ( { site, userId }: SitePlanProps ) => {
 								plan={ site.plan }
 								isSiteOwner={ site?.site_owner === userId }
 								checkoutUrl={ `/checkout/${ site.slug }/${ site.plan?.product_slug }` }
+								hideRenewLink={ isECommerceTrialSite }
 							/>
 						</PlanRenewNagContainer>
 					) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #73893

## Proposed Changes

When viewing `/sites`, hide the 'Renew plan' link for expired trial sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Apply this patch and access calypso.localhost or use the calypso.live link.

* Use an existing trial site or create a new trial by visiting https://wordpress.com/setup/wooexpress/.
* Locate the site in the network admin (`https://wordpress.com/wp-admin/network/sites.php?s=:siteSlug`) and click the "SA" (Store Admin) link.
* Find the site with `:siteSlug` in the page.
* Set the trial to be expired.
* Use or create another site with a paid plan (Performance, Business, etc).
* Locate this paid site in the Store Admin and set the plan to be expired.
* Visit `/sites`.

The expired site should show as expired but _not_ have a "Renew plan" link. The other expired paid site should show as expired _and_ have the "Renew plan" link.

![image](https://user-images.githubusercontent.com/917632/228613295-e2a566a9-c6bc-4754-b542-6152e83313a4.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
