### PR TITLE
Checkout: Refactor Jetpack pre-purchase notice not showing warning in some cases

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
@@ -13,7 +13,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { requestRewindCapabilities } from 'calypso/state/rewind/capabilities/actions';
-// import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import {
 	getSitePlan,
 	getSiteProducts,
@@ -71,11 +70,12 @@ const PrePurchaseNotices = () => {
 		}
 
 		const getMatchingProducts = ( siteProducts, planSlug ) => {
-			// Get all features and products for the plan in the cart
+			// Get all features for the plan in the cart
 			const planFeatures = getAllFeaturesForPlan( planSlug );
 
 			// Filter the site products to only include those in the plan items or are inferior features to the plan feature
 			const matchingProducts = siteProducts.filter( ( product ) => {
+				//check for generic backup and scan slugs
 				const isBackup = isJetpackBackupSlug( product.productSlug );
 				const isScan = isJetpackScanSlug( product.productSlug );
 
@@ -103,7 +103,7 @@ const PrePurchaseNotices = () => {
 		}
 
 		const getMatchingProducts = ( cartItems, planSlug ) => {
-			// Get all features and products for the site plan
+			// Get all features for the site plan
 			const planFeatures = getAllFeaturesForPlan( planSlug );
 
 			// Filter the cart items to only include those in the plan items or are inferior features to the plan feature
@@ -116,7 +116,7 @@ const PrePurchaseNotices = () => {
 				return (
 					planFeatures.includes( productSlug ) ||
 					planHasSuperiorFeature( planSlug, productSlug ) ||
-					// there are too many variations on the following, so checking against WPCOM_features
+					// there are too many variations on the following, so checking generic slugs
 					isBackup ||
 					isScan ||
 					isAntiSpam

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
@@ -69,16 +69,13 @@ const PrePurchaseNotices = () => {
 
 		return items.filter( ( item ) => {
 			const productSlug = isCartItem ? item.product_slug : item.productSlug;
-			const isBackup = isJetpackBackupSlug( productSlug );
-			const isScan = isJetpackScanSlug( productSlug );
-			const isAntiSpam = isJetpackAntiSpamSlug( productSlug );
-
+			//some products have had many variations over the years so we need to check an abstraction for backup, scan and Akismet.
 			return (
 				planFeatures.includes( productSlug ) ||
 				planHasSuperiorFeature( planSlug, productSlug ) ||
-				isBackup ||
-				isScan ||
-				isAntiSpam
+				isJetpackBackupSlug( productSlug ) ||
+				isJetpackScanSlug( productSlug ) ||
+				isJetpackAntiSpamSlug( productSlug )
 			);
 		} );
 	};

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1803,8 +1803,6 @@ const getPlanJetpackCompleteDetails = (): IncompleteJetpackPlan => ( {
 		FEATURE_BACKUP_ARCHIVE_30,
 		FEATURE_JETPACK_SOCIAL_BASIC,
 		FEATURE_JETPACK_SOCIAL_BASIC_MONTHLY,
-		FEATURE_JETPACK_BACKUP_T1_MONTHLY,
-		FEATURE_JETPACK_BACKUP_T1_YEARLY,
 	],
 	getBenefits: () => [
 		translate( 'Protect your revenue stream and content' ),

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1803,6 +1803,8 @@ const getPlanJetpackCompleteDetails = (): IncompleteJetpackPlan => ( {
 		FEATURE_BACKUP_ARCHIVE_30,
 		FEATURE_JETPACK_SOCIAL_BASIC,
 		FEATURE_JETPACK_SOCIAL_BASIC_MONTHLY,
+		FEATURE_JETPACK_BACKUP_T1_MONTHLY,
+		FEATURE_JETPACK_BACKUP_T1_YEARLY,
 	],
 	getBenefits: () => [
 		translate( 'Protect your revenue stream and content' ),


### PR DESCRIPTION
Related to # 1202858161751496-as-1204291444198693/f

It was reported via slack, that in some scenarios, the cart warning wouldn't display when it should.  The example given was when you have backups and you add Jetpack Complete, there's no warnings.

The root cause was that Backup_t1_... was not set as inferior to Backup_t2.

However, there are a lot of legacy backup plans running around, as well as similar scenarios with things like scan which would requiring adding a lot of things.  The original code handled it on a case-by-case basis.  https://github.com/Automattic/wp-calypso/pull/74164 was merged which aimed to make the checks more modular, however it relies on the inferior plan check.

Therefore, it was determined the best way forward was to use the existing isJetpack[product]Slug hooks.  

That part of the code was refactored to use the hooks, and then the hook that checks the converse (cart products overlapping plans) was refactored to work the same way.  During testing, it was noted the cart code was updated to convert a jetpack plan in cart to add on storage if the site already had backup, so that check was removed.

## Proposed Changes

* Add handling for a larger number of products such as backups, scan and antispam to the overlapping plan check.
* Refactor the item in cart overlaps the plan on site check
* Remove unused imports

The results:

![Screenshot 2023-03-29 at 12 23 23 PM](https://user-images.githubusercontent.com/12895386/228609853-65fd0752-30a7-447c-91cb-2c18db11765c.png)

![Screenshot 2023-03-29 at 12 25 10 PM](https://user-images.githubusercontent.com/12895386/228609885-140c1343-27f3-467f-b824-45f890e2749c.png)


## Testing Instructions

Testing cart plan overlap:
* Use a JN or other Jetpack Site, connect jetpack and add Vaultpress Backup to the site. 
* Add Jetpack Complete to your cart, Head on over to the Calypso Live Link (or roll your own with this PR) and append the slug /checkout/[your site here] and you should see the warning at the top of the cart

Testing cart product overlap
- remove the item on your site and add Jetpack Complete.
- Again on Calypso live or locally, add /checkoutetpack_anti_spam/[your site here]
- You should now see the overlap warning for antispam already being in your site plan.

Feel free to mix and match different combinations for things that should overlap.  As a reminder, if you add a backup plan to your cart and you already have backup, it'll just get converted to add on storage.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?