### PR TITLE
Add/ability to remove subscription if auto renewal is off

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -423,6 +423,16 @@ export function isCancelable( purchase: Purchase ) {
 }
 
 /**
+ * Checks if a purchase is attached to a siteless holding site
+ *
+ * @param purchase The purchase to check
+ *
+ * @returns {boolean} True if the purchase is attached to a siteless holding site
+ */
+export function isSiteless( purchase: Purchase ): boolean {
+	return purchase.domain.includes( 'siteless' );
+}
+/**
  * Similar to isCancelable, but doesn't rely on the purchase's cancelability
  * Checks if auto-renew is enabled for purchase, returns true if auto-renew is ON
  * Returns false if purchase is included in plan, purchases included with a plan can't be cancelled

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -423,16 +423,6 @@ export function isCancelable( purchase: Purchase ) {
 }
 
 /**
- * Checks if a purchase is attached to a siteless holding site
- *
- * @param purchase The purchase to check
- *
- * @returns {boolean} True if the purchase is attached to a siteless holding site
- */
-export function isSiteless( purchase: Purchase ): boolean {
-	return purchase.domain.includes( 'siteless' );
-}
-/**
  * Similar to isCancelable, but doesn't rely on the purchase's cancelability
  * Checks if auto-renew is enabled for purchase, returns true if auto-renew is ON
  * Returns false if purchase is included in plan, purchases included with a plan can't be cancelled

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -175,7 +175,6 @@ describe( 'Purchase Management Buttons', () => {
 			domain: 'siteless.akismet.com',
 			product_id: 2311, // Akismet Plus Plan
 			product_slug: 'ak_plus_yearly_1',
-			product_type: 'akismet',
 			auto_renew: 0,
 		} );
 

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -170,14 +170,10 @@ describe( 'Purchase Management Buttons', () => {
 			.get( '/rest/v1.1/me/payment-methods?expired=include' )
 			.reply( 200 );
 
-		purchase.domain = 'siteless.akismet.com';
-		purchase.product_id = 2311; // Akismet Personal Plus plan
-		purchase.product_slug = 'ak_plus_yearly_1';
-
 		const store = createMockReduxStoreForPurchase( {
 			...purchase,
 			domain: 'siteless.akismet.com',
-			product_id: 2311,
+			product_id: 2311, // Akismet Plus Plan
 			product_slug: 'ak_plus_yearly_1',
 			auto_renew: 0,
 		} );

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -165,10 +165,15 @@ describe( 'Purchase Management Buttons', () => {
 		expect( screen.queryByText( /Cancel/ ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders a remove button when auto-renew is OFF, and the purchase is an Akismet purchase and attached to an akismet siteless holding site', async () => {
+	it( 'renders a remove button when auto-renew is OFF and the purchase is an Akismet purchase attached to an akismet siteless holding site', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.1/me/payment-methods?expired=include' )
 			.reply( 200 );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/akismet/get-key?_envelope=1' )
+			.reply( 200, {
+				body: '123456789123',
+			} );
 
 		const store = createMockReduxStoreForPurchase( {
 			...purchase,

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -164,4 +164,35 @@ describe( 'Purchase Management Buttons', () => {
 		expect( await screen.findByText( /Remove/ ) ).toBeInTheDocument();
 		expect( screen.queryByText( /Cancel/ ) ).not.toBeInTheDocument();
 	} );
+
+	it( 'renders a remove button when auto-renew is OFF, and the purchase is an Akismet purchase and attached to an akismet siteless holding site', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/payment-methods?expired=include' )
+			.reply( 200 );
+
+		purchase.domain = 'siteless.akismet.com';
+		purchase.product_id = 2311; // Akismet Personal Plus plan
+		purchase.product_slug = 'ak_plus_yearly_1';
+
+		const store = createMockReduxStoreForPurchase( {
+			...purchase,
+			domain: 'siteless.akismet.com',
+			product_id: 2311,
+			product_slug: 'ak_plus_yearly_1',
+			auto_renew: 0,
+		} );
+
+		render(
+			<ReduxProvider store={ store }>
+				<ManagePurchase
+					purchaseId={ Number( purchase.ID ) }
+					isSiteLevel
+					siteSlug="siteless.akismet.com"
+				/>
+			</ReduxProvider>
+		);
+
+		expect( await screen.findByText( /Remove/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Cancel/ ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -175,6 +175,7 @@ describe( 'Purchase Management Buttons', () => {
 			domain: 'siteless.akismet.com',
 			product_id: 2311, // Akismet Plus Plan
 			product_slug: 'ak_plus_yearly_1',
+			product_type: 'akismet',
 			auto_renew: 0,
 		} );
 

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -169,11 +169,6 @@ describe( 'Purchase Management Buttons', () => {
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.1/me/payment-methods?expired=include' )
 			.reply( 200 );
-		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/akismet/get-key?_envelope=1' )
-			.reply( 200, {
-				body: '123456789123',
-			} );
 
 		const store = createMockReduxStoreForPurchase( {
 			...purchase,

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -179,13 +179,15 @@ describe( 'Purchase Management Buttons', () => {
 		} );
 
 		render(
-			<ReduxProvider store={ store }>
-				<ManagePurchase
-					purchaseId={ Number( purchase.ID ) }
-					isSiteLevel
-					siteSlug="siteless.akismet.com"
-				/>
-			</ReduxProvider>
+			<QueryClientProvider client={ queryClient }>
+				<ReduxProvider store={ store }>
+					<ManagePurchase
+						purchaseId={ Number( purchase.ID ) }
+						isSiteLevel
+						siteSlug="siteless.akismet.com"
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
 		);
 
 		expect( await screen.findByText( /Remove/ ) ).toBeInTheDocument();

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -24,7 +24,7 @@ import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-pur
 import PrecancellationChatButton from 'calypso/components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
 import GSuiteCancellationPurchaseDialog from 'calypso/components/marketing-survey/gsuite-cancel-purchase-dialog';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
-import { getName, isRemovable } from 'calypso/lib/purchases';
+import { getName, isRemovable, isSiteless } from 'calypso/lib/purchases';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import WordAdsEligibilityWarningDialog from 'calypso/me/purchases/wordads-eligibility-warning-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -200,7 +200,7 @@ class RemovePurchase extends Component {
 			components: { siteName: <em>{ purchase.domain }</em> },
 		} );
 
-		if ( purchase.domain.includes( 'siteless' ) ) {
+		if ( isSiteless( purchase ) ) {
 			successMessage = translate( '%(productName)s was removed from your account.', {
 				args: { productName },
 			} );

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -9,6 +9,7 @@ import {
 	isJetpackProduct,
 	isPlan,
 	isTitanMail,
+	isAkismetProduct,
 } from '@automattic/calypso-products';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
@@ -194,6 +195,17 @@ class RemovePurchase extends Component {
 			return;
 		}
 
+		successMessage = translate( '%(productName)s was removed from {{siteName/}}.', {
+			args: { productName },
+			components: { siteName: <em>{ purchase.domain }</em> },
+		} );
+
+		if ( purchase.domain.includes( 'siteless' ) ) {
+			successMessage = translate( '%(productName)s was removed from your account.', {
+				args: { productName },
+			} );
+		}
+
 		if ( isDomainRegistration( purchase ) ) {
 			if ( isDomainOnlySite ) {
 				this.props.receiveDeletedSite( purchase.siteId );
@@ -202,11 +214,6 @@ class RemovePurchase extends Component {
 
 			successMessage = translate( 'The domain {{domain/}} was removed from your account.', {
 				components: { domain: <em>{ productName }</em> },
-			} );
-		} else {
-			successMessage = translate( '%(productName)s was removed from {{siteName/}}.', {
-				args: { productName },
-				components: { siteName: <em>{ purchase.domain }</em> },
 			} );
 		}
 
@@ -416,7 +423,7 @@ class RemovePurchase extends Component {
 		}
 
 		// If we have a disconnected site that is _not_ a Jetpack purchase, no removal allowed.
-		if ( ! this.props.site && ! this.props.isJetpack ) {
+		if ( ! this.props.site && ! this.props.isJetpack && ! this.props.isAkismet ) {
 			return null;
 		}
 
@@ -474,11 +481,13 @@ class RemovePurchase extends Component {
 export default connect(
 	( state, { purchase } ) => {
 		const isJetpack = purchase && ( isJetpackPlan( purchase ) || isJetpackProduct( purchase ) );
+		const isAkismet = purchase && isAkismetProduct( purchase );
 		return {
 			isDomainOnlySite: purchase && isDomainOnly( state, purchase.siteId ),
 			isAtomicSite: isSiteAutomatedTransfer( state, purchase.siteId ),
 			isChatAvailable: isHappychatAvailable( state ),
 			isJetpack,
+			isAkismet,
 			purchasesError: getPurchasesError( state ),
 			userId: getCurrentUserId( state ),
 			primaryDomain: getPrimaryDomainBySiteId( state, purchase.siteId ),

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -24,7 +24,7 @@ import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-pur
 import PrecancellationChatButton from 'calypso/components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
 import GSuiteCancellationPurchaseDialog from 'calypso/components/marketing-survey/gsuite-cancel-purchase-dialog';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
-import { getName, isRemovable, isSiteless } from 'calypso/lib/purchases';
+import { getName, isRemovable } from 'calypso/lib/purchases';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import WordAdsEligibilityWarningDialog from 'calypso/me/purchases/wordads-eligibility-warning-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -41,9 +41,8 @@ import { setAllSitesSelected } from 'calypso/state/ui/actions';
 import { MarketPlaceSubscriptionsDialog } from '../marketplace-subscriptions-dialog';
 import { purchasesRoot } from '../paths';
 import { PreCancellationDialog } from '../pre-cancellation-dialog';
-import { isDataLoading } from '../utils';
+import { isDataLoading, isAkismetTemporarySitePurchase } from '../utils';
 import RemoveDomainDialog from './remove-domain-dialog';
-
 import './style.scss';
 
 class RemovePurchase extends Component {
@@ -200,7 +199,7 @@ class RemovePurchase extends Component {
 			components: { siteName: <em>{ purchase.domain }</em> },
 		} );
 
-		if ( isSiteless( purchase ) ) {
+		if ( isAkismetTemporarySitePurchase( purchase ) ) {
 			successMessage = translate( '%(productName)s was removed from your account.', {
 				args: { productName },
 			} );

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -422,7 +422,7 @@ class RemovePurchase extends Component {
 			return null;
 		}
 
-		// If we have a disconnected site that is _not_ a Jetpack purchase, no removal allowed.
+		// If we have a disconnected site that is _not_ a Jetpack purchase _or_ an Akismet purchase, no removal allowed.
 		if ( ! this.props.site && ! this.props.isJetpack && ! this.props.isAkismet ) {
 			return null;
 		}

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -41,7 +41,11 @@ import { setAllSitesSelected } from 'calypso/state/ui/actions';
 import { MarketPlaceSubscriptionsDialog } from '../marketplace-subscriptions-dialog';
 import { purchasesRoot } from '../paths';
 import { PreCancellationDialog } from '../pre-cancellation-dialog';
-import { isDataLoading, isAkismetTemporarySitePurchase } from '../utils';
+import {
+	isDataLoading,
+	isAkismetTemporarySitePurchase,
+	isJetpackTemporarySitePurchase,
+} from '../utils';
 import RemoveDomainDialog from './remove-domain-dialog';
 import './style.scss';
 
@@ -199,7 +203,10 @@ class RemovePurchase extends Component {
 			components: { siteName: <em>{ purchase.domain }</em> },
 		} );
 
-		if ( isAkismetTemporarySitePurchase( purchase ) ) {
+		if (
+			isAkismetTemporarySitePurchase( purchase ) ||
+			isJetpackTemporarySitePurchase( purchase )
+		) {
 			successMessage = translate( '%(productName)s was removed from your account.', {
 				args: { productName },
 			} );


### PR DESCRIPTION
## Proposed Changes

This diff adds the ability to remove an Akismet purchase from your account

## Testing Instructions

1. Checkout this branch
2. Get your local environment running

** If you already have an Akismet purchase, you can ignore steps 3-6
3. Sandbox `public-api.wordpress.com`
4. Make sure you are using the store Sandbox
5. Go to `/checkout/akismet/ak_plus_yearly_1`
6. Complete the checkout

7. On the WPCOM backend, go to line 1595 in this file: fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Snqzva%2Qcyhtvaf%2Sjcpbz%2Qovyyvat%2Sfgber%2Qfhofpevcgvba.cuc%3Se%3Qs9rorpr0%231595-og and make that function return `false` immediately. This ensures the product won't be refunded and automatically removed from your account, because that's not what we are testing 😄 
8. Go to `/me/purchases` and select the Akismet Product
![image](https://user-images.githubusercontent.com/65001528/228615247-3ca93490-ea25-4409-ba6b-a37c1d1afc7c.png)
9. Turn Auto-Renew off, and choose any reason you'd like
![image](https://user-images.githubusercontent.com/65001528/228615387-b9dc14ab-442c-4460-8aeb-ef6a9a524e97.png)
![image](https://user-images.githubusercontent.com/65001528/228615417-488abd6f-0804-4008-b2d0-fad9a2edb5a1.png)
10. Now you should see "Remove Subscription" instead of "Cancel Subscription" at the bottom
![image](https://user-images.githubusercontent.com/65001528/228615542-fbd07390-e557-4777-8f6d-50c9eb412204.png)
11. Click on it and remove the product. It should now be gone from the purchase management page
![image](https://user-images.githubusercontent.com/65001528/228615654-9512b38a-0093-4938-86cc-03d905f3f19e.png)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?