### PR TITLE
Marketplace Thank You: Isolate logic for atomic transfer to use it for plugins or themes

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { waitFor } from 'calypso/my-sites/marketplace/util';
+import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
+import {
+	getAutomatedTransferStatus,
+	isFetchingAutomatedTransferStatus,
+} from 'calypso/state/automated-transfer/selectors';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export function useAtomicTransfer( isAtomicNeeded: boolean ) {
+	const dispatch = useDispatch();
+	const siteId = useSelector( getSelectedSiteId );
+
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
+	const isJetpackSelfHosted = isJetpack && ! isAtomic;
+	const isFetchingTransferStatus = useSelector( ( state ) =>
+		isFetchingAutomatedTransferStatus( state, siteId )
+	);
+
+	const [ isAtomicTransferCheckComplete, setIsAtomicTransferCheckComplete ] = useState(
+		! isAtomicNeeded
+	);
+	const transferStatus = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
+
+	useEffect( () => {
+		setIsAtomicTransferCheckComplete( ! isAtomicNeeded );
+	}, [ isAtomicNeeded ] );
+
+	// Site is transferring to Atomic.
+	// Poll the transfer status.
+	useEffect( () => {
+		if ( siteId && transferStatus === transferStates.COMPLETE ) {
+			setIsAtomicTransferCheckComplete( true );
+		}
+
+		if (
+			! siteId ||
+			transferStatus === transferStates.COMPLETE ||
+			isJetpackSelfHosted ||
+			! isAtomicNeeded
+		) {
+			return;
+		}
+
+		if ( ! isFetchingTransferStatus ) {
+			waitFor( 2 ).then( () => dispatch( fetchAutomatedTransferStatus( siteId ) ) );
+		}
+	}, [
+		siteId,
+		dispatch,
+		transferStatus,
+		isFetchingTransferStatus,
+		isJetpackSelfHosted,
+		isAtomicNeeded,
+	] );
+
+	return isAtomicTransferCheckComplete;
+}

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -5,12 +5,8 @@ import { useSelector, useDispatch } from 'react-redux';
 import { ThankYouSectionProps } from 'calypso/components/thank-you/types';
 import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
-import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
-import {
-	getAutomatedTransferStatus,
-	isFetchingAutomatedTransferStatus,
-} from 'calypso/state/automated-transfer/selectors';
+import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { pluginInstallationStateChange } from 'calypso/state/marketplace/purchase-flow/actions';
 import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
@@ -25,7 +21,7 @@ import MasterbarStyled from './masterbar-styled';
 
 export function usePluginsThankYouData(
 	pluginSlugs: string[]
-): [ ThankYouSectionProps, boolean, JSX.Element, string, string ] {
+): [ ThankYouSectionProps, boolean, JSX.Element, string, string , boolean ] {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
@@ -70,9 +66,6 @@ export function usePluginsThankYouData(
 		areFetching( state, pluginSlugs )
 	);
 	const areAllWporgPluginsFetched = areWporgPluginsFetched.every( Boolean );
-	const isFetchingTransferStatus = useSelector( ( state ) =>
-		isFetchingAutomatedTransferStatus( state, siteId )
-	);
 
 	const allPluginsFetched = pluginsOnSite.every( ( pluginOnSite ) => !! pluginOnSite );
 
@@ -122,29 +115,6 @@ export function usePluginsThankYouData(
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ areAllWporgPluginsFetched, areWporgPluginsFetched, pluginSlugs, dispatch, wporgPlugins ] );
 
-	// Site is transferring to Atomic.
-	// Poll the transfer status.
-	useEffect( () => {
-		if (
-			! siteId ||
-			transferStatus === transferStates.COMPLETE ||
-			isJetpackSelfHosted ||
-			pluginSlugs.length === 0
-		) {
-			return;
-		}
-		if ( ! isFetchingTransferStatus ) {
-			waitFor( 2 ).then( () => dispatch( fetchAutomatedTransferStatus( siteId ) ) );
-		}
-	}, [
-		siteId,
-		dispatch,
-		transferStatus,
-		isFetchingTransferStatus,
-		isJetpackSelfHosted,
-		pluginSlugs,
-	] );
-
 	// Site is already Atomic (or just transferred).
 	// Poll the plugin installation status.
 	useEffect( () => {
@@ -187,7 +157,11 @@ export function usePluginsThankYouData(
 		/>
 	);
 
-	return [ pluginsSection, allPluginsFetched, goBackSection, title, subtitle ];
+	// Plugins are only installed in atomic sites
+	// so atomic is always needed as long as we have plugins
+	const isAtomicNeeded = pluginSlugs.length > 0;
+
+	return [ pluginsSection, allPluginsFetched, goBackSection, title, subtitle, isAtomicNeeded ];
 }
 
 type Plugin = {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -21,7 +21,7 @@ import MasterbarStyled from './masterbar-styled';
 
 export function usePluginsThankYouData(
 	pluginSlugs: string[]
-): [ ThankYouSectionProps, boolean, JSX.Element, string, string , boolean ] {
+): [ ThankYouSectionProps, boolean, JSX.Element, string, string, boolean ] {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -5,13 +5,14 @@ import { useSelector } from 'react-redux';
 import { useQueryThemes } from 'calypso/components/data/query-theme';
 import { ThankYouSectionProps } from 'calypso/components/thank-you/types';
 import { getThemes } from 'calypso/state/themes/selectors';
+import { hasExternallyManagedThemes as getHasExternallyManagedThemes } from 'calypso/state/themes/selectors/is-externally-managed-theme';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { ThankYouThemeSection } from './marketplace-thank-you-theme-section';
 import MasterbarStyled from './masterbar-styled';
 
 export function useThemesThankYouData(
 	themeSlugs: string[]
-): [ ThankYouSectionProps, boolean, JSX.Element, string, string ] {
+): [ ThankYouSectionProps, boolean, JSX.Element, string, string, boolean ] {
 	const translate = useTranslate();
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
@@ -49,5 +50,13 @@ export function useThemesThankYouData(
 		/>
 	);
 
-	return [ themesSection, allThemesFetched, goBackSection, title, subtitle ];
+	// DotOrg and Externay managed themes
+	// needs an atomic site to be installed.
+	const hasDotOrgThemes = dotOrgThemes.some( ( theme: any ) => !! theme );
+	const hasExternallyManagedThemes = useSelector( ( state ) =>
+		getHasExternallyManagedThemes( state, themeSlugs )
+	);
+	const isAtomicNeeded = hasDotOrgThemes || hasExternallyManagedThemes;
+
+	return [ themesSection, allThemesFetched, goBackSection, title, subtitle, isAtomicNeeded ];
 }

--- a/client/state/themes/selectors/is-externally-managed-theme.tsx
+++ b/client/state/themes/selectors/is-externally-managed-theme.tsx
@@ -35,3 +35,14 @@ export function isExternallyManagedTheme( state = {}, themeId: string ): boolean
 	const themeType: ThemeTypes = theme.theme_type;
 	return themeType === 'managed-external';
 }
+
+/**
+ * Check if any of a list of themes is externally managed.
+ *
+ * @param {Object} state Global state tree
+ * @param {string} themeIds list of theme ids
+ * @returns {boolean} True if the theme is externally managed.
+ */
+export function hasExternallyManagedThemes( state = {}, themeIds: string[] ): boolean {
+	return themeIds.some( ( themeId ) => isExternallyManagedTheme( state, themeId ) );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [Marketplace: Transfer to Atomic when activating a Theme#2045](https://github.com/Automattic/dotcom-forge/issues/2045)

## Proposed Changes

* Create a hook for handling atomic transfer
* Handle progress bar steps inside this hook
* Update Plugins and Themes hooks to tells when they need atomic transfer

## Testing Instructions

* Check if plugin installation on a non-atomic site still working as usual with 4 steps being shown on the progress bar. 
* Cherry-picking the changes of this PR on top of #74725 and installing a Marketplace theme should work the same way as plugins

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
