### PR TITLE
Subscription Management: Create NotificationSettings dropdown

### DIFF
--- a/client/landing/subscriptions/hooks/index.ts
+++ b/client/landing/subscriptions/hooks/index.ts
@@ -1,1 +1,2 @@
+export { default as usePopoverToggle } from './use-popover-toggle';
 export { default as useSubheaderText } from './use-subheader-text';

--- a/client/landing/subscriptions/hooks/use-popover-toggle.ts
+++ b/client/landing/subscriptions/hooks/use-popover-toggle.ts
@@ -1,0 +1,11 @@
+import { useCallback, useState } from 'react';
+
+const usePopoverToggle = () => {
+	const [ showPopover, setShowPopover ] = useState( false );
+	const onToggle = useCallback( () => setShowPopover( ! showPopover ), [ showPopover ] );
+	const onClose = useCallback( () => setShowPopover( false ), [] );
+
+	return { showPopover, onToggle, onClose };
+};
+
+export default usePopoverToggle;

--- a/client/landing/subscriptions/notification-settings/email-frequency.tsx
+++ b/client/landing/subscriptions/notification-settings/email-frequency.tsx
@@ -1,0 +1,65 @@
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import SegmentedControl from 'calypso/components/segmented-control';
+import { EmailFrequencyType } from '../types';
+
+type EmailFrequencyOptionProps = {
+	children: React.ReactNode;
+	selected: EmailFrequencyType;
+	value: EmailFrequencyType;
+	onChange: ( value: EmailFrequencyType ) => void;
+};
+
+const EmailFrequencyOption = ( {
+	children,
+	selected,
+	value,
+	onChange,
+}: EmailFrequencyOptionProps ) => (
+	<SegmentedControl.Item selected={ selected === value } onClick={ () => onChange( value ) }>
+		{ children }
+	</SegmentedControl.Item>
+);
+
+type EmailFrequencyProps = {
+	onChange: ( value: EmailFrequencyType ) => void;
+	value: EmailFrequencyType;
+};
+
+type EmailFrequencyKeyLabel = {
+	key: EmailFrequencyType;
+	label: string;
+};
+
+const EmailFrequency = ( { onChange, value: selectedValue }: EmailFrequencyProps ) => {
+	const translate = useTranslate();
+	const availableFrequencies = useMemo< EmailFrequencyKeyLabel[] >(
+		() => [
+			{
+				key: 'instantly',
+				label: translate( 'Instantly' ),
+			},
+			{
+				key: 'daily',
+				label: translate( 'Daily' ),
+			},
+			{
+				key: 'weekly',
+				label: translate( 'Weekly' ),
+			},
+		],
+		[ translate ]
+	);
+
+	return (
+		<SegmentedControl>
+			{ availableFrequencies.map( ( { key, label } ) => (
+				<EmailFrequencyOption selected={ selectedValue } value={ key } onChange={ onChange }>
+					{ label }
+				</EmailFrequencyOption>
+			) ) }
+		</SegmentedControl>
+	);
+};
+
+export default EmailFrequency;

--- a/client/landing/subscriptions/notification-settings/index.tsx
+++ b/client/landing/subscriptions/notification-settings/index.tsx
@@ -1,0 +1,1 @@
+export { default as NotificationSettings } from './notification-settings';

--- a/client/landing/subscriptions/notification-settings/notification-settings.tsx
+++ b/client/landing/subscriptions/notification-settings/notification-settings.tsx
@@ -1,0 +1,118 @@
+import { Gridicon, Popover } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useRef } from 'react';
+import { useSelector } from 'react-redux';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import { usePopoverToggle } from '../hooks';
+import { EmailFrequencyType } from '../types';
+import EmailFrequency from './email-frequency';
+import './styles.scss';
+
+type NotificationSettingsProps = {
+	children?: React.ReactNode;
+	emailFrequency: EmailFrequencyType;
+	sendCommentsByEmail: boolean;
+	sendPostsByEmail: boolean;
+	sendPostsByNotification: boolean;
+	onChangeEmailFrequency: ( emailFrequency: EmailFrequencyType ) => void;
+	onChangeSendCommentsByEmail: ( sendCommentsByEmail: boolean ) => void;
+	onChangeSendPostsByEmail: ( sendPostsByEmail: boolean ) => void;
+	onChangeSendPostsByNotification: ( sendPostsByNotification: boolean ) => void;
+};
+
+const NotificationSettings = ( {
+	children,
+	emailFrequency,
+	sendCommentsByEmail,
+	sendPostsByEmail,
+	sendPostsByNotification,
+	onChangeEmailFrequency,
+	onChangeSendCommentsByEmail,
+	onChangeSendPostsByEmail,
+	onChangeSendPostsByNotification,
+}: NotificationSettingsProps ) => {
+	const isEmailBlocked = useSelector( ( state ) =>
+		getUserSetting( state, 'subscription_delivery_email_blocked' )
+	);
+
+	const { showPopover, onToggle, onClose } = usePopoverToggle();
+
+	const buttonRef = useRef< HTMLButtonElement >( null );
+	const iconRef = useRef< SVGSVGElement >( null );
+	const translate = useTranslate();
+
+	return (
+		<div className="notification-settings__popover-context">
+			<button className="notification-settings__toggle" onClick={ onToggle } ref={ buttonRef }>
+				<Gridicon icon="ellipsis" size={ 24 } ref={ iconRef } />
+			</button>
+
+			<Popover
+				onClose={ onClose }
+				isVisible={ showPopover }
+				context={ iconRef.current }
+				ignoreContext={ buttonRef.current }
+				position="bottom left"
+				className="notification-settings__popover"
+			>
+				<div className="notification-settings__popover-toggle">
+					<ToggleControl
+						onChange={ () => onChangeSendPostsByNotification( ! sendPostsByNotification ) }
+						checked={ sendPostsByNotification }
+						label={ translate( 'Notify me of new posts' ) }
+					/>
+					<p className="notification-settings__popover-hint">
+						{ translate( 'Receive web and mobile notifications for new posts from this site.' ) }
+					</p>
+				</div>
+
+				{ isEmailBlocked && (
+					<div className="notification-settings__popover-instructions">
+						<p className="notification-settings__popover-instructions-title">
+							{ translate( 'Email me new posts' ) }
+						</p>
+						<p className="notification-settings__popover-instructions-text">
+							{ translate(
+								'You currently have email delivery turned off. Visit your {{a}}Notification Settings{{/a}} to turn it back on.',
+								{
+									components: {
+										a: <a href="/me/notifications/subscriptions" />,
+									},
+								}
+							) }
+						</p>
+					</div>
+				) }
+
+				{ ! isEmailBlocked && (
+					<>
+						<div className="notification-settings__popover-toggle">
+							<ToggleControl
+								onChange={ () => onChangeSendPostsByEmail( ! sendPostsByEmail ) }
+								checked={ sendPostsByEmail }
+								label={ translate( 'Email me new posts' ) }
+							/>
+						</div>
+
+						{ sendPostsByEmail && (
+							<EmailFrequency onChange={ onChangeEmailFrequency } value={ emailFrequency } />
+						) }
+
+						<div className="notification-settings__popover-toggle">
+							<ToggleControl
+								onChange={ () => onChangeSendCommentsByEmail( ! sendCommentsByEmail ) }
+								checked={ sendCommentsByEmail }
+								label={ translate( 'Email me new comments' ) }
+							/>
+						</div>
+					</>
+				) }
+
+				{ children }
+			</Popover>
+		</div>
+	);
+};
+
+export default NotificationSettings;

--- a/client/landing/subscriptions/notification-settings/styles.scss
+++ b/client/landing/subscriptions/notification-settings/styles.scss
@@ -1,0 +1,73 @@
+@import "@automattic/color-studio/dist/color-variables";
+
+.notification-settings__popover-context {
+	height: 24px;
+}
+
+.notification-settings__toggle {
+	cursor: pointer;
+}
+
+.notification-settings__popover {
+	width: 305px;
+
+	.popover__arrow {
+		display: none;
+	}
+
+	.popover__inner {
+		border: none;
+		box-shadow: 0 3px 8px rgba($studio-black, 0.12), 0 3px 1px rgba($studio-black, 0.04);
+		padding: 21px;
+	}
+
+	.components-toggle-control {
+		margin-bottom: 0;
+
+		.components-form-toggle__track {
+			background-color: $studio-black !important;
+		}
+	}
+
+	.components-toggle-control__label,
+	.notification-settings__popover-instructions-title {
+		font-size: $font-body-small;
+		line-height: $font-title-small;
+	}
+
+	.notification-settings__popover-hint,
+	.notification-settings__popover-instructions-text {
+		color: $studio-gray-50;
+		font-size: $font-body-extra-small;
+		line-height: $font-body;
+		text-align: left;
+		width: 85%;
+	}
+
+	.notification-settings__popover-hint {
+		margin-top: 16px;
+	}
+
+	.notification-settings__popover-instructions {
+		text-align: left;
+
+		.notification-settings__popover-instructions-text {
+			margin-top: 8px;
+			width: 87%;
+		}
+	}
+
+	.notification-settings__popover-toggle:not(:last-child),
+	.segmented-control {
+		margin-bottom: 16px;
+	}
+
+	.segmented-control__link {
+		padding: 10px 22px;
+
+		.segmented-control__text {
+			font-size: $font-body-extra-small;
+			line-height: $font-body;
+		}
+	}
+}

--- a/client/landing/subscriptions/site-list/site-list.tsx
+++ b/client/landing/subscriptions/site-list/site-list.tsx
@@ -1,6 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
+import { SiteType } from '../types';
 import SiteRow from './site-row';
-import { SiteType } from './site-types';
 import './styles.scss';
 
 type SiteProps = {
@@ -22,9 +22,10 @@ export default function SiteList( { sites }: SiteProps ) {
 				<span className="email-frequency" role="columnheader">
 					{ translate( 'Email frequency' ) }
 				</span>
+				<span className="actions" role="columnheader" />
 			</li>
 			{ sites.map( ( site ) => (
-				<SiteRow key={ site.id } { ...site } />
+				<SiteRow key={ site.id } site={ site } />
 			) ) }
 		</ul>
 	);

--- a/client/landing/subscriptions/site-list/site-row.tsx
+++ b/client/landing/subscriptions/site-list/site-row.tsx
@@ -1,6 +1,13 @@
-import { SiteType } from './site-types';
+import { NotificationSettings } from '../notification-settings';
+import { SiteType } from '../types';
 
-export default function SiteRow( { id, name, icon, url, date, emailFrequency }: SiteType ) {
+type SiteRowProps = {
+	site: SiteType;
+};
+
+export default function SiteRow( { site }: SiteRowProps ) {
+	const { id, icon, name, url, date, emailFrequency } = site;
+
 	return (
 		<li className="row" role="row" key={ id }>
 			<span className="title-box" role="cell">
@@ -15,6 +22,18 @@ export default function SiteRow( { id, name, icon, url, date, emailFrequency }: 
 			</span>
 			<span className="email-frequency" role="cell">
 				{ emailFrequency }
+			</span>
+			<span className="actions" role="cell">
+				<NotificationSettings
+					emailFrequency="instantly"
+					sendCommentsByEmail={ true }
+					sendPostsByEmail={ true }
+					sendPostsByNotification={ true }
+					onChangeEmailFrequency={ () => null }
+					onChangeSendCommentsByEmail={ () => null }
+					onChangeSendPostsByEmail={ () => null }
+					onChangeSendPostsByNotification={ () => null }
+				/>
 			</span>
 		</li>
 	);

--- a/client/landing/subscriptions/site-list/site-types.tsx
+++ b/client/landing/subscriptions/site-list/site-types.tsx
@@ -1,8 +1,0 @@
-export type SiteType = {
-	id: number;
-	name: string;
-	icon: string;
-	url: string;
-	date: Date;
-	emailFrequency: string;
-};

--- a/client/landing/subscriptions/site-list/styles.scss
+++ b/client/landing/subscriptions/site-list/styles.scss
@@ -68,6 +68,15 @@ $max-list-width: 1300px;
 			color: $studio-gray-60;
 		}
 
+		.actions {
+			flex-basis: 36px;
+			flex-grow: initial;
+
+			.gridicon {
+				fill: $studio-gray-50;
+			}
+		}
+
 		&:last-child {
 			border-bottom: none;
 		}

--- a/client/landing/subscriptions/types.ts
+++ b/client/landing/subscriptions/types.ts
@@ -1,0 +1,10 @@
+export type EmailFrequencyType = 'instantly' | 'daily' | 'weekly';
+
+export type SiteType = {
+	id: number;
+	name: string;
+	icon: string;
+	url: string;
+	date: Date;
+	emailFrequency: EmailFrequencyType;
+};


### PR DESCRIPTION
Related to #74973

## Proposed Changes

* Creates `NotificationSettings` dropdown component
  * Based on the `ReaderSiteNotificationSettings`, but decoupling from data-store
  * Uses onChange functions to make the integration easier on other pages
  * Not applied to the existing Reader settings
* Move `site-types` to `types` on the Subscriptions project root
* Apply the `NotificationSettings` component to the Sites tab
  * Not integrated with queries and mutations

## Testing Instructions

1. Run this PR on your local env
2. Go to http://calypso.localhost:3000/subscriptions/sites (you will need a valid subkey cookie on a non-logged session)
3. Verify if the page is rendered as expected
4. Click on ellipsis icon and verify if the dropdown is rendered as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
