### PR TITLE
Subscription Management: Create NotificationSettings dropdown

### DIFF
--- a/client/landing/subscriptions/notification-settings/index.tsx
+++ b/client/landing/subscriptions/notification-settings/index.tsx
@@ -1,0 +1,1 @@
+export { default as NotificationSettings } from './notification-settings';

--- a/client/landing/subscriptions/notification-settings/notification-settings.tsx
+++ b/client/landing/subscriptions/notification-settings/notification-settings.tsx
@@ -1,0 +1,13 @@
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import './styles.scss';
+
+const NotificationSettings = () => {
+	return (
+		<EllipsisMenu popoverClassName="notification-settings__popover">
+			<PopoverMenuItem>Item</PopoverMenuItem>
+		</EllipsisMenu>
+	);
+};
+
+export default NotificationSettings;

--- a/client/landing/subscriptions/notification-settings/styles.scss
+++ b/client/landing/subscriptions/notification-settings/styles.scss
@@ -1,0 +1,15 @@
+@import "@automattic/color-studio/dist/color-variables";
+
+.notification-settings__popover {
+	width: 305px;
+
+	.popover__arrow {
+		display: none;
+	}
+
+	.popover__inner {
+		border: none;
+		box-shadow: 0 3px 8px rgba($studio-black, 0.12), 0 3px 1px rgba($studio-black, 0.04);
+		padding: 21px;
+	}
+}

--- a/client/landing/subscriptions/notification-settings/styles.scss
+++ b/client/landing/subscriptions/notification-settings/styles.scss
@@ -10,6 +10,5 @@
 	.popover__inner {
 		border: none;
 		box-shadow: 0 3px 8px rgba($studio-black, 0.12), 0 3px 1px rgba($studio-black, 0.04);
-		padding: 21px;
 	}
 }

--- a/client/landing/subscriptions/site-list/site-list.tsx
+++ b/client/landing/subscriptions/site-list/site-list.tsx
@@ -22,6 +22,7 @@ export default function SiteList( { sites }: SiteProps ) {
 				<span className="email-frequency" role="columnheader">
 					{ translate( 'Email frequency' ) }
 				</span>
+				<span className="actions" role="columnheader" />
 			</li>
 			{ sites.map( ( site ) => (
 				<SiteRow key={ site.id } { ...site } />

--- a/client/landing/subscriptions/site-list/site-row.tsx
+++ b/client/landing/subscriptions/site-list/site-row.tsx
@@ -1,3 +1,4 @@
+import { NotificationSettings } from '../notification-settings';
 import { SiteType } from './site-types';
 
 export default function SiteRow( { id, name, icon, url, date, emailFrequency }: SiteType ) {
@@ -15,6 +16,9 @@ export default function SiteRow( { id, name, icon, url, date, emailFrequency }: 
 			</span>
 			<span className="email-frequency" role="cell">
 				{ emailFrequency }
+			</span>
+			<span className="actions" role="cell">
+				<NotificationSettings />
 			</span>
 		</li>
 	);

--- a/client/landing/subscriptions/site-list/styles.scss
+++ b/client/landing/subscriptions/site-list/styles.scss
@@ -68,6 +68,15 @@ $max-list-width: 1300px;
 			color: $studio-gray-60;
 		}
 
+		.actions {
+			flex-basis: 36px;
+			flex-grow: initial;
+
+			.gridicon {
+				fill: $studio-gray-50;
+			}
+		}
+
 		&:last-child {
 			border-bottom: none;
 		}


### PR DESCRIPTION
Resolves #74973

## Proposed Changes

* Creates `NotificationSettings` dropdown component
  * Uses `EllipsisMenu` calypso component
  * Adds a mock item to the menu body
* Move `site-types` to `types` on the Subscriptions project root
* Apply the `NotificationSettings` component to the Sites tab

## Testing Instructions

1. Run this PR on your local env
2. Go to http://calypso.localhost:3000/subscriptions/sites (you will need a valid subkey cookie on a non-logged session)
3. Verify if the page is rendered as expected
4. Click on ellipsis icon and verify if the dropdown is rendered as expected

<img width="868" alt="image" src="https://user-images.githubusercontent.com/3113712/228647264-44478c26-5f58-4897-9572-0d77b888d378.png">
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
