### PR TITLE
AT E2E: accommodate difference between AT and Simple for the Dynamic HR block.

### DIFF
--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
@@ -68,10 +68,21 @@ describe( 'CoBlocks: Blocks', function () {
 	} );
 
 	it( `Insert ${ DynamicHRBlock.blockName } block`, async function () {
-		await editorPage.addBlockFromSidebar(
-			DynamicHRBlock.blockName,
-			DynamicHRBlock.blockEditorSelector
-		);
+		// Manual override of the Dyanmic HR/Separator block that comes with CoBlocks.
+		// On AT, the block is called Dynamic Separator.
+		// On Simple, the block is called Dynamic HR.
+		// See: https://github.com/Automattic/wp-calypso/issues/75092
+		if ( features.siteType === 'atomic' ) {
+			await editorPage.addBlockFromSidebar(
+				'Dynamic Separator',
+				'[aria-label="Block: Dynamic Separator"]'
+			);
+		} else {
+			await editorPage.addBlockFromSidebar(
+				DynamicHRBlock.blockName,
+				DynamicHRBlock.blockEditorSelector
+			);
+		}
 	} );
 
 	it( `Insert ${ HeroBlock.blockName } block and enter heading`, async function () {


### PR DESCRIPTION
Related to #https://github.com/Automattic/wp-calypso/issues/75092

## Proposed Changes

This PR accommodates the difference in the Dynamic HR/Separator block between AT and Simple sites.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E AT (desktop)
  - [x] Gutenberg E2E AT (mobile)
  - [x] Gutenberg E2E Simple (desktop)
  - [x] Gutenberg E2E Simple (mobile)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
