### PR TITLE
Launchpad: Update Checkmark Icon & Font Size for Pending Custom Domain

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -173,7 +173,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 				</div>
 				{ isDomainSSLProcessing && (
 					<div className="launchpad__domain-notification">
-						<div>
+						<div className="launchpad__domain-notification-icon">
 							<Gridicon className="launchpad__domain-checkmark-icon" icon="checkmark" size={ 18 } />
 						</div>
 						<p>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -173,10 +173,13 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 				</div>
 				{ isDomainSSLProcessing && (
 					<div className="launchpad__domain-notification">
-						<Gridicon className="launchpad__domain-checkmark-icon" icon="checkmark-circle" />
+						<div>
+							<Gridicon className="launchpad__domain-checkmark-icon" icon="checkmark" size={ 18 } />
+						</div>
 						<p>
 							{ translate(
-								'We are currently setting up your new domain! It may take a few minutes before it is ready.'
+								'We are currently setting up your new domain!{{br/}}It may take a few minutes before it is ready.',
+								{ components: { br: <br /> } }
 							) }
 						</p>
 					</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -242,6 +242,8 @@
 
 .launchpad__domain-notification {
 	display: flex;
+	gap: 8px;
+	font-size: 0.875rem;
 	margin-bottom: 16px;
 
 	@include break-large {
@@ -250,8 +252,7 @@
 }
 
 .launchpad__domain-checkmark-icon {
-	flex: 0 0 36px;
-	fill: var(--studio-green-40);
+	fill: var(--studio-green-50);
 }
 
 .launchpad__domain-upgrade-badge {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -245,6 +245,10 @@
 	gap: 8px;
 	font-size: 0.875rem;
 	margin-bottom: 36px;
+
+	&-icon {
+		padding-top: 2px;
+	}
 }
 
 .launchpad__domain-checkmark-icon {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -244,11 +244,7 @@
 	display: flex;
 	gap: 8px;
 	font-size: 0.875rem;
-	margin-bottom: 16px;
-
-	@include break-large {
-		margin-bottom: 10px;
-	}
+	margin-bottom: 36px;
 }
 
 .launchpad__domain-checkmark-icon {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -199,7 +199,7 @@ describe( 'Sidebar', () => {
 			} );
 
 			const domainProcessingNotification = screen.queryByText(
-				/We are currently setting up your new domain! It may take a few minutes before it is ready./i
+				/We are currently setting up your new domain!/i
 			);
 
 			expect( domainProcessingNotification ).not.toBeInTheDocument();
@@ -232,7 +232,7 @@ describe( 'Sidebar', () => {
 				} );
 
 				const domainProcessingNotification = screen.getByText(
-					/We are currently setting up your new domain! It may take a few minutes before it is ready./i
+					/We are currently setting up your new domain!/i
 				);
 
 				expect( domainProcessingNotification ).toBeInTheDocument();
@@ -266,7 +266,7 @@ describe( 'Sidebar', () => {
 				} );
 
 				const domainProcessingNotification = screen.queryByText(
-					/We are currently setting up your new domain! It may take a few minutes before it is ready./i
+					/We are currently setting up your new domain!/i
 				);
 
 				expect( domainProcessingNotification ).not.toBeInTheDocument();


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/74529

### Time Estimate
Test: Short
Review: Short

### Proposed Changes
Update the Launchpad message when the custom domain is being processed
• Change the font size to 14px
• Change the checkmark icon

![beaf](https://user-images.githubusercontent.com/20927667/228679414-cb583449-488a-4556-8bb1-a40eca71b6d9.png)

### Testing
1. Checkout this branch
2. Go through the flow to create a new Launchpad site with a custom domain
3. Once you arrive at Launchpad compare the styling between `http://calypso.localhost:3000/` and `http://wordpress.com/`
4. Verify the local styling looks good