### PR TITLE
Logging: Add auto-refresh feature to the site logs view

### DIFF
--- a/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { Button, ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import DateRange from 'calypso/components/date-range';
@@ -35,7 +35,8 @@ const SiteLogsToolbarDownloadProgress = ( {
 };
 
 type Props = {
-	onRefresh: () => void;
+	autoRefresh: boolean;
+	onAutoRefreshChange: ( isChecked: boolean ) => void;
 	onDateTimeCommit?: ( startDate: Date, endDate: Date ) => void;
 	logType: SiteLogsTab;
 	startDateTime: Moment;
@@ -43,7 +44,8 @@ type Props = {
 };
 
 export const SiteLogsToolbar = ( {
-	onRefresh,
+	autoRefresh,
+	onAutoRefreshChange,
 	onDateTimeCommit,
 	logType,
 	startDateTime,
@@ -74,28 +76,33 @@ export const SiteLogsToolbar = ( {
 
 	return (
 		<div className="site-logs-toolbar">
-			<DateRange
-				showTriggerClear={ false }
-				selectedStartDate={ startDateTime.toDate() }
-				selectedEndDate={ endDateTime.toDate() }
-				lastSelectableDate={ moment().toDate() }
-				dateFormat="ll @ HH:mm:ss"
-				onDateCommit={ handleDateRangeCommit }
+			<div className="site-logs-toolbar__top-row">
+				<DateRange
+					showTriggerClear={ false }
+					selectedStartDate={ startDateTime.toDate() }
+					selectedEndDate={ endDateTime.toDate() }
+					lastSelectableDate={ moment().toDate() }
+					dateFormat="ll @ HH:mm:ss"
+					onDateCommit={ handleDateRangeCommit }
+				/>
+
+				<Button
+					disabled={ isDownloading }
+					isBusy={ isDownloading }
+					isPrimary
+					onClick={ () => downloadLogs( { logType, startDateTime, endDateTime } ) }
+				>
+					{ translate( 'Download' ) }
+				</Button>
+
+				{ isDownloading && <SiteLogsToolbarDownloadProgress { ...state } /> }
+			</div>
+			<ToggleControl
+				className="site-logs-toolbar__auto-refresh"
+				label={ translate( 'Auto-refresh' ) }
+				checked={ autoRefresh }
+				onChange={ onAutoRefreshChange }
 			/>
-
-			<Button isSecondary onClick={ onRefresh } className="site-logs-toolbar__refresh">
-				{ translate( 'Refresh' ) }
-			</Button>
-
-			<Button
-				disabled={ isDownloading }
-				isBusy={ isDownloading }
-				isPrimary
-				onClick={ () => downloadLogs( { logType, startDateTime, endDateTime } ) }
-			>
-				{ translate( 'Download' ) }
-			</Button>
-			{ isDownloading && <SiteLogsToolbarDownloadProgress { ...state } /> }
 		</div>
 	);
 };

--- a/client/my-sites/site-logs/components/site-logs-toolbar/style.scss
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/style.scss
@@ -1,11 +1,14 @@
 .site-logs-toolbar {
-	display: flex;
-	align-items: stretch;
-	padding-bottom: 16px;
-	flex-wrap: wrap;
-	justify-content: flex-start;
-	gap: 8px;
-	margin-bottom: 1em;
+	margin-bottom: 1.5em;
+
+	.site-logs-toolbar__top-row {
+		display: flex;
+		align-items: stretch;
+		flex-wrap: wrap;
+		justify-content: flex-start;
+		gap: 16px;
+		padding-bottom: 16px;
+	}
 
 	button {
 		height: initial;

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -100,6 +100,8 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 		) {
 			setCurrentPageIndex( currentPageIndex + 1 );
 		}
+
+		setAutoRefresh( false );
 	};
 
 	const titleHeader = __( 'Site Logs' );
@@ -126,6 +128,7 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 			startTime: formattedStartDate ?? dateRange.startTime,
 			endTime: formattedEndDate ?? dateRange.endTime,
 		} );
+		setAutoRefresh( false );
 	};
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/2079

## Proposed Changes

See pet6gk-le-p2 for discussion

* When auto-refresh is checked the table reloads the latest logs every 10 seconds
* When manually setting a time auto-refresh is automatically unchecked
* When manually changing pages auto-refresh is automatically unchecked
* Adds toggle to a second toolbar row for now. This is so we don't interfere with the download progress text which appears to the right of the download button.

<img width="1166" alt="CleanShot 2023-03-30 at 12 12 22@2x" src="https://user-images.githubusercontent.com/1500769/228688261-de94f903-10cc-4011-a93e-f26f9e65f3a6.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test feature at `/site-logs`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~