### PR TITLE
Domains: Create contact verification card

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
@@ -62,7 +62,7 @@ const ContactVerificationCard: FunctionComponent< Props > = ( props ) => {
 				{ renderContactInformation() }
 				<p>
 					{ translate(
-						'Please verify that the above infomration is correct and either {{a}}update it{{/a}} or provide a photo of a document on which the above name and address are clearly visible. Some of the accepted documents are:',
+						'Please verify that the above information is correct and either {{a}}update it{{/a}} or provide a photo of a document on which the above name and address are clearly visible. Some of the accepted documents are:',
 						{
 							components: {
 								a: contactInformationUpdateLink ? (

--- a/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
@@ -122,11 +122,21 @@ const ContactVerificationCard: FunctionComponent< Props > = ( props ) => {
 	};
 
 	const submitFiles = () => {
+		if ( ! selectedFiles || selectedFiles.length === 0 ) {
+			setError( true );
+			return;
+		}
+
+		const formData: [ string, File, string ][] = [];
+		[ ...selectedFiles ].forEach( ( file: File ) => {
+			formData.push( [ 'files[]', file, file.name ] );
+		} );
+
 		wpcom.req.post(
 			{
-				path: '/domains/ownership-verification',
+				path: '/domains/contact-verification',
 				apiVersion: '1.1',
-				formData: [ [ 'files', selectedFiles ] ],
+				formData,
 			},
 			( error: Error ) => {
 				setSubmitting( false );

--- a/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
@@ -1,0 +1,212 @@
+import { Button } from '@automattic/components';
+import { Icon, info } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent, useState } from 'react';
+import FilePicker from 'calypso/components/file-picker';
+import wpcom from 'calypso/lib/wp';
+import type { WhoisData } from '../types';
+
+import './style.scss';
+
+interface Props {
+	contactInformation: WhoisData | undefined;
+	contactInformationUpdateLink: string | undefined;
+}
+
+const ContactVerificationCard: FunctionComponent< Props > = ( props ) => {
+	const translate = useTranslate();
+	const [ selectedFiles, setSelectedFiles ] = useState< FileList | null >( null );
+	const [ submitting, setSubmitting ] = useState( false );
+	const [ submitted, setSubmitted ] = useState( false );
+	const [ error, setError ] = useState( false );
+
+	const renderContactInformation = () => {
+		const { contactInformation } = props;
+
+		if ( ! contactInformation ) {
+			return <div className="ownership-verification-card__contact-information-placeholder" />;
+		}
+
+		return (
+			<div className="ownership-verification-card__contact-information">
+				<p>
+					{ contactInformation.fname } { contactInformation.lname }
+				</p>
+				{ contactInformation.org && <p>{ contactInformation.org }</p> }
+				<p>{ contactInformation.email }</p>
+				<p>{ contactInformation.sa1 }</p>
+				{ contactInformation.sa2 && <p>{ contactInformation.sa2 }</p> }
+				<p>
+					{ contactInformation.city }
+					{ contactInformation.sp && <span>, { contactInformation.sp }</span> }
+					<span> { contactInformation.pc }</span>
+				</p>
+				<p>{ contactInformation.country_code }</p>
+				<p>{ contactInformation.phone }</p>
+				{ contactInformation.fax && <p>{ contactInformation.fax }</p> }
+			</div>
+		);
+	};
+
+	const renderDescription = () => {
+		const { contactInformationUpdateLink } = props;
+
+		return (
+			<div>
+				<p>
+					{ translate(
+						'Nominet, the organization that manages .uk domains, requires us to verify the contact information of your domain.'
+					) }
+				</p>
+				<p>{ translate( 'This is your current contact information:' ) }</p>
+				{ renderContactInformation() }
+				<p>
+					{ translate(
+						'Please verify that the above infomration is correct and either {{a}}update it{{/a}} or provide a photo of a document on which the above name and address are clearly visible. Some of the accepted documents are:',
+						{
+							components: {
+								a: contactInformationUpdateLink ? (
+									<a href={ contactInformationUpdateLink } />
+								) : (
+									<span />
+								),
+							},
+						}
+					) }
+				</p>
+				<ul>
+					<li>{ translate( "Valid drivers' license" ) }</li>
+					<li>{ translate( 'Valid national ID cards (for non-UK residents)' ) }</li>
+					<li>{ translate( 'Utility bills (last 3 months)' ) }</li>
+					<li>{ translate( 'Bank statement (last 3 months)' ) }</li>
+					<li>{ translate( 'HMRC tax notification (last 3 months)' ) }</li>
+				</ul>
+				<p>
+					{ translate(
+						'Click on the button below to upload one or more documents and then click on the "Submit" button. You can upload images and/or PDF files up to 5MB each.'
+					) }
+				</p>
+			</div>
+		);
+	};
+
+	const handleFilesSelected = ( files: FileList ) => {
+		setSelectedFiles( files );
+		setError( false );
+	};
+
+	const renderSelectFilesButton = () => {
+		return (
+			<div>
+				<FilePicker multiple accept="image/*,.pdf" onPick={ handleFilesSelected }>
+					<Button disabled={ submitting || submitted }>{ translate( 'Select files' ) }</Button>
+				</FilePicker>
+			</div>
+		);
+	};
+
+	const renderSelectedFileList = () => {
+		if ( ! selectedFiles || selectedFiles.length === 0 ) {
+			return <p>{ translate( 'No selected files yet' ) }</p>;
+		}
+
+		const fileList = [ ...selectedFiles ].map( ( file: File ) => (
+			<li key={ file.name }>{ file.name }</li>
+		) );
+		return (
+			<div className="ownership-verification-card__selected-files">
+				<p>{ translate( 'Selected files:' ) }</p>
+				<ul>{ fileList }</ul>
+			</div>
+		);
+	};
+
+	const submitFiles = () => {
+		wpcom.req.post(
+			{
+				path: '/domains/ownership-verification',
+				apiVersion: '1.1',
+				formData: [ [ 'files', selectedFiles ] ],
+			},
+			( error: Error ) => {
+				setSubmitting( false );
+
+				if ( error ) {
+					setError( true );
+					return;
+				}
+
+				setSubmitted( true );
+				setError( false );
+			}
+		);
+	};
+
+	const isSubmitFilesButtonDisabled = () => {
+		return ! selectedFiles || selectedFiles.length === 0 || submitting || submitted;
+	};
+
+	const renderSubmitFilesButton = () => {
+		return (
+			<div>
+				<Button
+					onClick={ submitFiles }
+					busy={ submitting }
+					disabled={ isSubmitFilesButtonDisabled() }
+					primary
+				>
+					{ translate( 'Submit' ) }
+				</Button>
+			</div>
+		);
+	};
+
+	const renderSubmittedMessage = () => {
+		return (
+			<div className="ownership-verification-card__message">
+				<Icon
+					icon={ info }
+					size={ 18 }
+					className="ownership-verification-card__message-icon success"
+					viewBox="2 2 20 20"
+				/>
+				<span className="ownership-verification-card__message-text">
+					{ translate(
+						'Thank you for submitting your documents for contact verification! If your domain was suspended, it may take up to a week for it to be unsuspended. Our support team will contact you via email if further actions are needed.'
+					) }
+				</span>
+			</div>
+		);
+	};
+
+	const renderErrorMessage = () => {
+		return (
+			<div className="ownership-verification-card__message">
+				<Icon
+					icon={ info }
+					size={ 18 }
+					className="ownership-verification-card__message-icon error"
+					viewBox="2 2 20 20"
+				/>
+				<span className="ownership-verification-card__message-text">
+					{ translate(
+						'An error occurred when uploading your files. Please try submitting them again. If the error persists, please contact our support team.'
+					) }
+				</span>
+			</div>
+		);
+	};
+
+	return (
+		<div className="ownership-verification-card">
+			{ renderDescription() }
+			{ renderSelectFilesButton() }
+			{ renderSelectedFileList() }
+			{ renderSubmitFilesButton() }
+			{ submitted && renderSubmittedMessage() }
+			{ error && renderErrorMessage() }
+		</div>
+	);
+};
+
+export default ContactVerificationCard;

--- a/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
@@ -11,6 +11,7 @@ import './style.scss';
 interface Props {
 	contactInformation: WhoisData | undefined;
 	contactInformationUpdateLink: string | undefined;
+	selectedDomainName: string;
 }
 
 const ContactVerificationCard: FunctionComponent< Props > = ( props ) => {
@@ -134,7 +135,7 @@ const ContactVerificationCard: FunctionComponent< Props > = ( props ) => {
 
 		wpcom.req.post(
 			{
-				path: '/domains/contact-verification',
+				path: `/domains/${ props.selectedDomainName }/contact-verification`,
 				apiVersion: '1.1',
 				formData,
 			},

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -125,3 +125,55 @@
 		white-space: nowrap;
 	}
 }
+
+.ownership-verification-card {
+	div {
+		margin-bottom: 24px;
+	}
+	div:last-child {
+		margin-bottom: 0;
+	}
+
+	.ownership-verification-card__contact-information-placeholder {
+		width: 100%;
+		height: 64px;
+
+		@include placeholder( --color-neutral-10 );
+	}
+
+	.ownership-verification-card__contact-information {
+		padding: 16px;
+		background-color: var(--studio-gray-0);
+
+		p {
+			margin: 0;
+		}
+	}
+
+	.ownership-verification-card__message {
+		flex-basis: 100%;
+		background-color: var(--studio-gray-0);
+		display: flex;
+		align-items: center;
+		padding: 8px;
+		gap: 8px;
+
+		.ownership-verification-card__message-icon {
+			min-width: 18px;
+
+			&.error {
+				fill: var(--studio-orange-40);
+				transform: rotate(180deg);
+			}
+
+			&.success {
+				fill: var(--studio-green-50);
+			}
+		}
+
+		.ownership-verification-card__message-text {
+			font-size: $font-body-small;
+			color: var(--studio-gray-80);
+		}
+	}
+}

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -20,6 +20,7 @@ import DomainHeader from 'calypso/my-sites/domains/domain-management/components/
 import { WPCOM_DEFAULT_NAMESERVERS_REGEX } from 'calypso/my-sites/domains/domain-management/name-servers/constants';
 import withDomainNameservers from 'calypso/my-sites/domains/domain-management/name-servers/with-domain-nameservers';
 import {
+	domainManagementEditContactInfo,
 	domainManagementList,
 	domainUseMyDomain,
 	isUnderDomainManagementAll,
@@ -37,6 +38,7 @@ import {
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import ConnectedDomainDetails from './cards/connected-domain-details';
 import ContactsPrivacyInfo from './cards/contact-information/contacts-privacy-info';
+import ContactVerificationCard from './cards/contact-verification-card';
 import DomainOnlyConnectCard from './cards/domain-only-connect';
 import DomainSecurityDetails from './cards/domain-security-details';
 import NameServersCard from './cards/name-servers-card';
@@ -390,6 +392,32 @@ const Settings = ( {
 		);
 	};
 
+	const renderContactVerificationSection = () => {
+		// TODO: Remove this when we implement the contact verification domain flag
+		// return null;
+
+		if ( ! domain || ! domain.currentUserCanManage ) {
+			return null;
+		}
+
+		const contactInformationUpdateLink =
+			selectedSite && domain && domainManagementEditContactInfo( selectedSite.slug, domain.name );
+
+		return (
+			<Accordion
+				title={ translate( 'Contact verification', { textOnly: true } ) }
+				subtitle={ translate( 'Additional contact verification required for your domain', {
+					textOnly: true,
+				} ) }
+			>
+				<ContactVerificationCard
+					contactInformation={ contactInformation }
+					contactInformationUpdateLink={ contactInformationUpdateLink }
+				/>
+			</Accordion>
+		);
+	};
+
 	const renderMainContent = () => {
 		// TODO: If it's a registered domain or transfer and the domain's registrar is in maintenance, show maintenance card
 		return (
@@ -401,6 +429,7 @@ const Settings = ( {
 				{ renderNameServersSection() }
 				{ renderDnsRecords() }
 				{ renderContactInformationSecion() }
+				{ renderContactVerificationSection() }
 				{ renderDomainSecuritySection() }
 			</>
 		);

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
@@ -394,7 +395,9 @@ const Settings = ( {
 
 	const renderContactVerificationSection = () => {
 		// TODO: Remove this when we implement the contact verification domain flag
-		// return null;
+		if ( ! config.isEnabled( 'contact-verification-feature' ) ) {
+			return null;
+		}
 
 		if ( ! domain || ! domain.currentUserCanManage ) {
 			return null;

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -416,6 +416,7 @@ const Settings = ( {
 				<ContactVerificationCard
 					contactInformation={ contactInformation }
 					contactInformationUpdateLink={ contactInformationUpdateLink }
+					selectedDomainName={ selectedDomainName }
 				/>
 			</Accordion>
 		);

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -3,7 +3,7 @@ import type { SiteDetails } from '@automattic/data-stores';
 import type { DnsRequest, ResponseDomain } from 'calypso/lib/domains/types';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
-type WhoisData = {
+export type WhoisData = {
 	fname: string;
 	lname: string;
 	org: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR creates a contact verification card which will enable users to send documents to verify the contact information of their domain. This is useful because some registries like e.g. `.uk`'s Nominet require contact verification with documents if they aren't able to verify the information against their databases. More context at pcYYhz-17s-p2.

### Screenshots

- New contact verification card

![Markup on 2023-03-29 at 19:33:10](https://user-images.githubusercontent.com/5324818/228689136-343b4317-2b78-4e24-a08d-bffa31aae477.png)

- Error message (should appear if you try to submit any document as the endpoint is not implemented yet)

<img width="634" alt="Screenshot 2023-03-29 at 19 33 49" src="https://user-images.githubusercontent.com/5324818/228689216-057a0b99-1944-4cec-a39a-a57edf0ecdd6.png">

- Success message

<img width="634" alt="Screenshot 2023-03-29 at 19 35 19" src="https://user-images.githubusercontent.com/5324818/228689363-56a8ede1-000b-40be-ab0e-9bc2780375ec.png">

## Testing Instructions

- Build this branch locally or open the live Calypso link
- Navigate to the domain management page of any domain
- Append `?flags=contact-verification-feature` to the domain management page URL
- Ensure you see the new "Contact verification" card at the bottom
- Choose any PDF or image file and try to submit them
- Ensure you get an error message like in the screenshots above
- If you're running the branch locally, hack the `submitFiles` method to ignore the error and try to submit documents again to see the success message

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
