### PR TITLE
Logging: Switch from `<DateRange>` component to `<input type="datetime-local">`

### DIFF
--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -70,7 +70,7 @@ export function useSiteLogsQuery(
 			);
 		},
 		{
-			enabled: !! siteId,
+			enabled: !! siteId && params.start <= params.end,
 			staleTime: Infinity, // The logs within a specified time range never change.
 			select( { data } ) {
 				return {

--- a/client/my-sites/site-logs/components/site-logs-tab-panel/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-tab-panel/index.tsx
@@ -1,7 +1,7 @@
 import { TabPanel } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-import page from 'page';
+import { updateLogTypeQueryParam } from '../../site-logs-filter-params';
 import type { SiteLogsTab } from 'calypso/data/hosting/use-site-logs-query';
 import './style.scss';
 
@@ -28,8 +28,8 @@ export const SiteLogsTabPanel = ( {
 			initialTabName={ selectedTab }
 			className={ classnames( 'site-logs-tab-panel', className ) }
 			tabs={ tabs }
-			onSelect={ ( tabName ) => {
-				onTabSelected( tabName );
+			onSelect={ ( tabName: SiteLogsTab ) => {
+				updateLogTypeQueryParam( tabName );
 				onSelected?.( tabName as SiteLogsTab );
 			} }
 		>
@@ -37,9 +37,3 @@ export const SiteLogsTabPanel = ( {
 		</TabPanel>
 	);
 };
-
-function onTabSelected( tabName: string ) {
-	const url = new URL( window.location.href );
-	url.searchParams.set( 'log-type', tabName );
-	page.replace( url.pathname + url.search );
-}

--- a/client/my-sites/site-logs/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/index.tsx
@@ -1,10 +1,8 @@
 import classnames from 'classnames';
 import { memo, useMemo } from 'react';
-import { useSelector } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { SiteLogsData } from 'calypso/data/hosting/use-site-logs-query';
-import getSiteSetting from 'calypso/state/selectors/get-site-setting';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { useCurrentSiteGmtOffset } from '../../hooks/use-current-site-gmt-offset';
 import { Skeleton } from './skeleton';
 
 import './style.scss';
@@ -22,10 +20,7 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 }: SiteLogsTableProps ) {
 	const moment = useLocalizedMoment();
 	const columns = useSiteColumns( logs );
-	const siteGmtOffset = useSelector( ( state ) => {
-		const siteId = getSelectedSiteId( state );
-		return ( getSiteSetting( state, siteId ?? 0, 'gmt_offset' ) as number | null ) ?? 0;
-	} );
+	const siteGmtOffset = useCurrentSiteGmtOffset();
 
 	if ( isLoading && ! logs?.length ) {
 		return <Skeleton />;

--- a/client/my-sites/site-logs/components/site-logs-toolbar/date-time-picker.tsx
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/date-time-picker.tsx
@@ -1,0 +1,27 @@
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import type { Moment } from 'moment';
+
+interface Props extends Omit< React.HTMLAttributes< HTMLInputElement >, 'value' | 'onChange' > {
+	value: Moment;
+	onChange: ( value: Moment ) => void;
+}
+
+// The datetime-local input expects this specific format
+const INPUT_DATE_FORMAT = 'YYYY-MM-DDThh:mm:ss';
+
+export function DateTimePicker( { value, onChange, ...rest }: Props ) {
+	const moment = useLocalizedMoment();
+
+	return (
+		<input
+			type="datetime-local"
+			value={ value.format( INPUT_DATE_FORMAT ) }
+			max={ moment().format( INPUT_DATE_FORMAT ) }
+			step={ 1 } // support 1 second granularity
+			onChange={ ( event ) => {
+				onChange( moment( event.currentTarget.value, INPUT_DATE_FORMAT ) );
+			} }
+			{ ...rest }
+		/>
+	);
+}

--- a/client/my-sites/site-logs/components/site-logs-toolbar/date-time-picker.tsx
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/date-time-picker.tsx
@@ -1,25 +1,40 @@
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import type { Moment } from 'moment';
 
-interface Props extends Omit< React.HTMLAttributes< HTMLInputElement >, 'value' | 'onChange' > {
+interface Props
+	extends Omit< React.HTMLAttributes< HTMLInputElement >, 'value' | 'onChange' | 'max' | 'min' > {
 	value: Moment;
+	max?: Moment;
+	min?: Moment;
 	onChange: ( value: Moment ) => void;
+
+	// datetime-local inputs don't understand timezones, but this prop will cause the component
+	// to display values, and return values with onChange, in this timezone.
+	// gmtOffset is in hours.
+	gmtOffset?: number;
 }
 
 // The datetime-local input expects this specific format
-const INPUT_DATE_FORMAT = 'YYYY-MM-DDThh:mm:ss';
+const INPUT_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 
-export function DateTimePicker( { value, onChange, ...rest }: Props ) {
+export function DateTimePicker( { value, onChange, gmtOffset = 0, max, min, ...rest }: Props ) {
 	const moment = useLocalizedMoment();
 
 	return (
 		<input
 			type="datetime-local"
-			value={ value.format( INPUT_DATE_FORMAT ) }
-			max={ moment().format( INPUT_DATE_FORMAT ) }
+			value={ value.utcOffset( gmtOffset * 60 ).format( INPUT_DATE_FORMAT ) }
+			{ ...( min && {
+				min: min.utcOffset( gmtOffset * 60 ).format( INPUT_DATE_FORMAT ),
+			} ) }
+			{ ...( max && {
+				max: max.utcOffset( gmtOffset * 60 ).format( INPUT_DATE_FORMAT ),
+			} ) }
 			step={ 1 } // support 1 second granularity
 			onChange={ ( event ) => {
-				onChange( moment( event.currentTarget.value, INPUT_DATE_FORMAT ) );
+				onChange(
+					moment( event.currentTarget.value, INPUT_DATE_FORMAT ).utcOffset( gmtOffset * 60, true )
+				);
 			} }
 			{ ...rest }
 		/>

--- a/client/my-sites/site-logs/components/site-logs-toolbar/date-time-picker.tsx
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/date-time-picker.tsx
@@ -22,6 +22,7 @@ export function DateTimePicker( { value, onChange, gmtOffset = 0, max, min, ...r
 
 	return (
 		<input
+			className="button"
 			type="datetime-local"
 			value={ value.utcOffset( gmtOffset * 60 ).format( INPUT_DATE_FORMAT ) }
 			{ ...( min && {

--- a/client/my-sites/site-logs/components/site-logs-toolbar/date-time-picker.tsx
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/date-time-picker.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import type { Moment } from 'moment';
 
@@ -7,7 +6,7 @@ interface Props
 	value: Moment;
 	max?: Moment;
 	min?: Moment;
-	onChange: ( value: Moment | null ) => void;
+	onChange: ( value: Moment ) => void;
 
 	// datetime-local inputs don't understand timezones, but this prop will cause the component
 	// to display values, and return values with onChange, in this timezone.
@@ -20,15 +19,9 @@ const INPUT_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 
 export function DateTimePicker( { value, onChange, gmtOffset = 0, max, min, ...rest }: Props ) {
 	const moment = useLocalizedMoment();
-	const [ dateValue, setDateValue ] = useState( value );
 
 	const onDateChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		const newDate = moment( event.currentTarget.value, INPUT_DATE_FORMAT );
-		setDateValue( newDate );
-		if ( ! event.target.validity.valid ) {
-			onChange( null );
-			return;
-		}
 		onChange( newDate );
 	};
 
@@ -36,7 +29,7 @@ export function DateTimePicker( { value, onChange, gmtOffset = 0, max, min, ...r
 		<input
 			className="button"
 			type="datetime-local"
-			value={ dateValue.utcOffset( gmtOffset * 60 ).format( INPUT_DATE_FORMAT ) }
+			value={ value.utcOffset( gmtOffset * 60 ).format( INPUT_DATE_FORMAT ) }
 			{ ...( min && {
 				min: min.utcOffset( gmtOffset * 60 ).format( INPUT_DATE_FORMAT ),
 			} ) }

--- a/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
@@ -1,4 +1,4 @@
-import { Button, ToggleControl } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { SiteLogsTab } from 'calypso/data/hosting/use-site-logs-query';
@@ -35,8 +35,6 @@ const SiteLogsToolbarDownloadProgress = ( {
 };
 
 type Props = {
-	autoRefresh: boolean;
-	onAutoRefreshChange: ( isChecked: boolean ) => void;
 	onDateTimeChange: ( startDateTime: Moment, endDateTime: Moment ) => void;
 	logType: SiteLogsTab;
 	startDateTime: Moment;
@@ -44,8 +42,6 @@ type Props = {
 };
 
 export const SiteLogsToolbar = ( {
-	autoRefresh,
-	onAutoRefreshChange,
 	onDateTimeChange,
 	logType,
 	startDateTime,
@@ -102,12 +98,6 @@ export const SiteLogsToolbar = ( {
 
 				{ isDownloading && <SiteLogsToolbarDownloadProgress { ...state } /> }
 			</div>
-			<ToggleControl
-				className="site-logs-toolbar__auto-refresh"
-				label={ translate( 'Auto-refresh' ) }
-				checked={ autoRefresh }
-				onChange={ onAutoRefreshChange }
-			/>
 		</div>
 	);
 };

--- a/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
@@ -1,6 +1,8 @@
 import { Button, ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { SiteLogsTab } from 'calypso/data/hosting/use-site-logs-query';
+import { useCurrentSiteGmtOffset } from '../../hooks/use-current-site-gmt-offset';
 import { useSiteLogsDownloader } from '../../hooks/use-site-logs-downloader';
 import { DateTimePicker } from './date-time-picker';
 import type { Moment } from 'moment';
@@ -50,7 +52,9 @@ export const SiteLogsToolbar = ( {
 	endDateTime,
 }: Props ) => {
 	const translate = useTranslate();
+	const moment = useLocalizedMoment();
 	const { downloadLogs, state } = useSiteLogsDownloader();
+	const siteGmtOffset = useCurrentSiteGmtOffset();
 
 	const isDownloading = state.status === 'downloading';
 
@@ -73,12 +77,18 @@ export const SiteLogsToolbar = ( {
 					id="from"
 					value={ startDateTime }
 					onChange={ ( value ) => handleTimeRangeChange( value, null ) }
+					gmtOffset={ siteGmtOffset }
+					min={ moment.unix( 0 ) } // The UI goes weird when the unix timestamps go negative, so don't allow it
+					max={ endDateTime }
 				/>
 				<label htmlFor="to">{ translate( 'To' ) }</label>
 				<DateTimePicker
 					id="to"
 					value={ endDateTime }
 					onChange={ ( value ) => handleTimeRangeChange( null, value ) }
+					gmtOffset={ siteGmtOffset }
+					max={ moment() }
+					min={ startDateTime }
 				/>
 
 				<Button

--- a/client/my-sites/site-logs/components/site-logs-toolbar/style.scss
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/style.scss
@@ -3,7 +3,7 @@
 
 	.site-logs-toolbar__top-row {
 		display: flex;
-		align-items: stretch;
+		align-items: center;
 		flex-wrap: wrap;
 		justify-content: flex-start;
 		gap: 16px;
@@ -11,22 +11,7 @@
 	}
 
 	button {
-		height: initial;
-	}
-
-	.toggle-visible .date-range__trigger-btn {
-		background-color: var(--color-surface);
-	}
-
-	//prevent button from jumping when toggling date picker
-	.button-group {
-		.button:first-child,
-		:last-child {
-			&:active {
-				border-right-width: 1px;
-				border-left-width: 1px;
-			}
-		}
+		height: 42px;
 	}
 }
 

--- a/client/my-sites/site-logs/components/site-logs-toolbar/style.scss
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/style.scss
@@ -10,8 +10,16 @@
 		padding-bottom: 16px;
 	}
 
+	@media screen and ( max-width: 600px ) {
+		.site-logs-toolbar__top-row {
+			flex-direction: column;
+			align-items: stretch;
+		}
+	}
+
 	button {
 		height: 42px;
+		justify-content: center;
 	}
 }
 

--- a/client/my-sites/site-logs/components/site-logs-toolbar/style.scss
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/style.scss
@@ -21,3 +21,15 @@
 	color: var(--color-neutral-50);
 	font-size: 0.875rem;
 }
+
+input:invalid {
+	background-color: var(--color-accent-5);
+	color: var(--color-accent-70);
+	border-color: var(--color-accent-60);
+}
+
+input:valid {
+	background-color: var(--color-surface);
+	color: var(--color-neutral-70);
+	border-color: var(--color-neutral-10);
+}

--- a/client/my-sites/site-logs/hooks/use-current-site-gmt-offset.ts
+++ b/client/my-sites/site-logs/hooks/use-current-site-gmt-offset.ts
@@ -1,0 +1,13 @@
+import { useSelector } from 'react-redux';
+import getSiteSetting from 'calypso/state/selectors/get-site-setting';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+
+/**
+ * Returns the current site's GMT offset in hours.
+ */
+export function useCurrentSiteGmtOffset(): number {
+	return useSelector( ( state ) => {
+		const siteId = getSelectedSiteId( state );
+		return ( getSiteSetting( state, siteId ?? 0, 'gmt_offset' ) as number | null ) ?? 0;
+	} );
+}

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -92,9 +92,12 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 		if ( isChecked ) {
 			setDateRange( getLatestDateRange() );
 			updateDateRangeQueryParam( null );
+			setCurrentPageIndex( 0 );
+		} else {
+			updateDateRangeQueryParam( dateRange );
 		}
+
 		setAutoRefresh( isChecked );
-		setCurrentPageIndex( 0 );
 	};
 
 	const handlePageClick = ( nextPageNumber: number ) => {

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -18,6 +18,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { SiteLogsTabPanel } from './components/site-logs-tab-panel';
 import { SiteLogsTable } from './components/site-logs-table';
 import { SiteLogsToolbar } from './components/site-logs-toolbar';
+import type { Moment } from 'moment';
 
 import './style.scss';
 
@@ -116,17 +117,10 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 			  } )
 			: null;
 
-	const handleDateRangeCommit = ( startDate: Date, endDate: Date ) => {
-		const formattedStartDate = startDate ? moment( startDate ) : null;
-		const formattedEndDate = endDate ? moment( endDate ) : null;
-
-		if ( ! formattedStartDate && ! formattedEndDate ) {
-			return;
-		}
-
+	const handleDateTimeChange = ( startDate: Moment, endDate: Moment ) => {
 		setDateRange( {
-			startTime: formattedStartDate ?? dateRange.startTime,
-			endTime: formattedEndDate ?? dateRange.endTime,
+			startTime: startDate,
+			endTime: endDate,
 		} );
 		setAutoRefresh( false );
 	};
@@ -151,7 +145,7 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 							logType={ logType }
 							startDateTime={ dateRange.startTime }
 							endDateTime={ dateRange.endTime }
-							onDateTimeCommit={ handleDateRangeCommit }
+							onDateTimeChange={ handleDateTimeChange }
 						/>
 						<SiteLogsTable logs={ data?.logs } isLoading={ isLoading } />
 						{ paginationText && (

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -1,3 +1,4 @@
+import { ToggleControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -146,14 +147,19 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 				subHeaderText={ __( 'View server logs to troubleshoot or debug problems with your site.' ) }
 				align="left"
 				className="site-logs__formatted-header"
-			/>
+			>
+				<ToggleControl
+					className="site-logs__auto-refresh"
+					label={ __( 'Auto-refresh' ) }
+					checked={ autoRefresh }
+					onChange={ handleAutoRefreshClick }
+				/>
+			</FormattedHeader>
 
 			<SiteLogsTabPanel selectedTab={ logType } onSelected={ handleTabSelected }>
 				{ () => (
 					<>
 						<SiteLogsToolbar
-							autoRefresh={ autoRefresh }
-							onAutoRefreshChange={ handleAutoRefreshClick }
 							logType={ logType }
 							startDateTime={ dateRange.startTime }
 							endDateTime={ dateRange.endTime }

--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
+import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
@@ -135,6 +136,7 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 	return (
 		<Main fullWidthLayout className={ classnames( 'site-logs', { 'is-loading': isLoading } ) }>
 			<DocumentHead title={ titleHeader } />
+			{ siteId && <QuerySiteSettings siteId={ siteId } /> }
 			<FormattedHeader
 				brandFont
 				headerText={ titleHeader }

--- a/client/my-sites/site-logs/site-logs-filter-params.ts
+++ b/client/my-sites/site-logs/site-logs-filter-params.ts
@@ -24,8 +24,8 @@ export function getDateRangeQueryParam( moment: typeof import('moment') ): {
 	const to = parseInt( searchParams.get( 'to' ) || '', 10 );
 
 	return {
-		startTime: isNaN( from ) ? null : moment( from ),
-		endTime: isNaN( to ) ? null : moment( to ),
+		startTime: isNaN( from ) ? null : moment.unix( from ),
+		endTime: isNaN( to ) ? null : moment.unix( to ),
 	};
 }
 
@@ -35,8 +35,8 @@ export function updateDateRangeQueryParam(
 	const url = new URL( window.location.href );
 
 	if ( dateRange ) {
-		url.searchParams.set( 'from', dateRange.startTime.utc().unix().toString( 10 ) );
-		url.searchParams.set( 'to', dateRange.endTime.utc().unix().toString( 10 ) );
+		url.searchParams.set( 'from', dateRange.startTime.unix().toString( 10 ) );
+		url.searchParams.set( 'to', dateRange.endTime.unix().toString( 10 ) );
 	} else {
 		url.searchParams.delete( 'from' );
 		url.searchParams.delete( 'to' );

--- a/client/my-sites/site-logs/site-logs-filter-params.ts
+++ b/client/my-sites/site-logs/site-logs-filter-params.ts
@@ -35,8 +35,14 @@ export function updateDateRangeQueryParam(
 	const url = new URL( window.location.href );
 
 	if ( dateRange ) {
-		url.searchParams.set( 'from', dateRange.startTime.unix().toString( 10 ) );
-		url.searchParams.set( 'to', dateRange.endTime.unix().toString( 10 ) );
+		const { startTime, endTime } = dateRange;
+		if ( ! startTime.isValid() || ! endTime.isValid() || startTime.isAfter( endTime ) ) {
+			// Don't save invalid date ranges
+			return;
+		}
+
+		url.searchParams.set( 'from', startTime.unix().toString( 10 ) );
+		url.searchParams.set( 'to', endTime.unix().toString( 10 ) );
 	} else {
 		url.searchParams.delete( 'from' );
 		url.searchParams.delete( 'to' );

--- a/client/my-sites/site-logs/site-logs-filter-params.ts
+++ b/client/my-sites/site-logs/site-logs-filter-params.ts
@@ -1,0 +1,46 @@
+import page from 'page';
+import type { SiteLogsTab } from 'calypso/data/hosting/use-site-logs-query';
+import type { Moment } from 'moment';
+
+export function getLogTypeQueryParam(): SiteLogsTab | null {
+	const logTypeParam = new URL( window.location.href ).searchParams.get( 'log-type' );
+	return logTypeParam && [ 'php', 'web' ].includes( logTypeParam )
+		? ( logTypeParam as SiteLogsTab )
+		: null;
+}
+
+export function updateLogTypeQueryParam( tabName: SiteLogsTab ) {
+	const url = new URL( window.location.href );
+	url.searchParams.set( 'log-type', tabName );
+	page.replace( url.pathname + url.search );
+}
+
+export function getDateRangeQueryParam( moment: typeof import('moment') ): {
+	startTime: Moment | null;
+	endTime: Moment | null;
+} {
+	const { searchParams } = new URL( window.location.href );
+	const from = parseInt( searchParams.get( 'from' ) || '', 10 );
+	const to = parseInt( searchParams.get( 'to' ) || '', 10 );
+
+	return {
+		startTime: isNaN( from ) ? null : moment( from ),
+		endTime: isNaN( to ) ? null : moment( to ),
+	};
+}
+
+export function updateDateRangeQueryParam(
+	dateRange: { startTime: Moment; endTime: Moment } | null
+) {
+	const url = new URL( window.location.href );
+
+	if ( dateRange ) {
+		url.searchParams.set( 'from', dateRange.startTime.utc().unix().toString( 10 ) );
+		url.searchParams.set( 'to', dateRange.endTime.utc().unix().toString( 10 ) );
+	} else {
+		url.searchParams.delete( 'from' );
+		url.searchParams.delete( 'to' );
+	}
+
+	page.replace( url.pathname + url.search );
+}

--- a/client/my-sites/site-logs/style.scss
+++ b/client/my-sites/site-logs/style.scss
@@ -7,7 +7,7 @@
 		background: var(--studio-white);
 		top: -47px;
 		right: -32px;
-		bottom: 0;
+		bottom: 20px;
 		left: -33px;
 		z-index: -1;
 	}
@@ -37,4 +37,10 @@
 			opacity: 0.5;
 		}
 	}
+}
+
+.site-logs__auto-refresh {
+	position: absolute;
+	right: 0;
+	bottom: -59px;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/2080
Closes https://github.com/Automattic/dotcom-forge/issues/2074

## Proposed Changes

Replaces the `<DatePicker>` component with two standard `<input type="datetime-local">` elements.

<img width="1415" alt="CleanShot 2023-03-30 at 20 39 21@2x" src="https://user-images.githubusercontent.com/1500769/228764685-69899bab-05f4-4d1a-b9fb-7fd258c58341.png">

#### `datetime-local`

This is the first time I've used this input type but it seems to work quite well, especially on Chromium browsers. It doesn't understand timezones, but from the docs this seems like it was intentionally left out. The element's `value` attribute is a `string` which must be written in a very specific format. The browser is then responsible for rendering the control in a locale appropriate way, so just because `value` is specified as `YYYYMMDD` the user doesn't see it that way.

Chromium has a nice UI for specifying the date _and_ the time. Firefox and Safari only have nice UIs for the date and users have to type the time. But this is no worse than the `<DateRange>`, so on average users will have a better experience with the `<input>`.

All evergreen browsers support `datetime-local`, but it was designed to gracefully fallback. If the browser doesn't support `datetime-local` then it falls back to a `<input type="text">` and the user isn't totally lost because they can type in the timestamp they want.

#### Time zones and time stamps

The strategy I landed on for dealing with timezones was to represent timestamps everywhere as `Moment` objects and not worry about what timezone they happened to be in while in memory. They are transformed into the required timezone at the last minute right before the interface with some external API.

- Query params: timestamps are converted to UTC unix timestamps before writing them to the URL. I'm using UTC in the URL to make the links more shareable.
- `<input>` elements: the internal representation of `startTime` and `endTime` Moment objects are switched to the site's timezone immediately before being formatted for the `<input>` elements
- API request param: the logging endpoints accept time ranges in unix time, so the Moment objects are converted to unix timestamps immediately before being passed to the `useSiteLogsQuery` hook

Something that tripped me up for a while was that I didn't realise is that "unix time" implies UTC. So when you use the `.unix()` method, you don't need to do any timezone transformations first. It's always UTC.

Another Moment.js thing to beware: some of the methods take unix timestamps in seconds and some in milliseconds 😬 

#### Query params

I've moved the query param handling to a separate `site-logs-filter-params.ts` module. We can do all the careful serialisation and deserialisation in there.

I separated the time time range into two separate query params rather than a json encoded object. That way there's fewer `%` symbols escaping all the special characters in the URL.

#### Validation

There's no validation of the input boxes yet. Fingers crossed we don't need too much 🤞. You can set a `min` and `max` time on the `datetime-local` controls which prevent users from selecting invalid times, which means I think I've made it impossible to pick a start time that's greater than the end time in the first place. Could do with more testing though.

Because it's a standard HTML element you can probably style invalid states using the `input:invalid` selector.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test at `/site-logs`
* Check refreshing
* Check timezones (things should appear in the site's timezone)
* Try to make invalid ranges
* Layout at smaller screen sizes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
