### PR TITLE
Site Assembler: Add guidance message when user goes to Colors or Fonts without selected patterns

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -3,3 +3,15 @@ export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
 export const SITE_TAGLINE = 'Site Tagline';
 export const PLACEHOLDER_SITE_ID = 211865921; // blankcanvas3demo.wordpress.com
 export const PATTERN_TYPES = [ 'header', 'footer', 'section' ];
+
+export const NAVIGATOR_PATHS = {
+	MAIN: '/',
+	HEADER: '/header',
+	SECTION: '/section',
+	SECTION_PATTERNS: '/section/patterns',
+	FOOTER: '/footer',
+	COLOR_PALETTES: '/color-palettes',
+	FONT_PAIRINGS: '/font-pairings',
+};
+
+export const STYLES_PATHS = [ NAVIGATOR_PATHS.COLOR_PALETTES, NAVIGATOR_PATHS.FONT_PAIRINGS ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -21,7 +21,7 @@ import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import { recordSelectedDesign } from '../../analytics/record-design';
-import { SITE_TAGLINE, PLACEHOLDER_SITE_ID, PATTERN_TYPES } from './constants';
+import { SITE_TAGLINE, PLACEHOLDER_SITE_ID, PATTERN_TYPES, NAVIGATOR_PATHS } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import useGlobalStylesUpgradeModal from './hooks/use-global-styles-upgrade-modal';
 import usePatternCategories from './hooks/use-pattern-categories';
@@ -55,7 +55,7 @@ const PatternAssembler = ( {
 	noticeList,
 	noticeOperations,
 }: StepProps & withNotices.Props ) => {
-	const [ navigatorPath, setNavigatorPath ] = useState( '/' );
+	const [ navigatorPath, setNavigatorPath ] = useState( NAVIGATOR_PATHS.MAIN );
 	const [ sectionPosition, setSectionPosition ] = useState< number | null >( null );
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
 	const [ activePosition, setActivePosition ] = useState( -1 );
@@ -464,7 +464,8 @@ const PatternAssembler = ( {
 	};
 
 	const stepContent = (
-		<div
+		<NavigatorProvider
+			initialPath={ NAVIGATOR_PATHS.MAIN }
 			className={ classnames( 'pattern-assembler__wrapper', {
 				'pattern-assembler__pattern-panel-list--is-open': isPatternPanelListOpen,
 			} ) }
@@ -474,8 +475,8 @@ const PatternAssembler = ( {
 			{ isEnabled( 'pattern-assembler/notices' ) && (
 				<Notices noticeList={ noticeList } noticeOperations={ noticeOperations } />
 			) }
-			<NavigatorProvider className="pattern-assembler__sidebar" initialPath="/">
-				<NavigatorScreen path="/">
+			<div className="pattern-assembler__sidebar">
+				<NavigatorScreen path={ NAVIGATOR_PATHS.MAIN }>
 					<ScreenMain
 						shouldUnlockGlobalStyles={ shouldUnlockGlobalStyles }
 						onSelect={ onMainItemSelect }
@@ -483,7 +484,7 @@ const PatternAssembler = ( {
 					/>
 				</NavigatorScreen>
 
-				<NavigatorScreen path="/header">
+				<NavigatorScreen path={ NAVIGATOR_PATHS.HEADER }>
 					<ScreenHeader
 						selectedPattern={ header }
 						onSelect={ onSelect }
@@ -492,7 +493,7 @@ const PatternAssembler = ( {
 					/>
 				</NavigatorScreen>
 
-				<NavigatorScreen path="/footer">
+				<NavigatorScreen path={ NAVIGATOR_PATHS.FOOTER }>
 					<ScreenFooter
 						selectedPattern={ footer }
 						onSelect={ onSelect }
@@ -501,7 +502,7 @@ const PatternAssembler = ( {
 					/>
 				</NavigatorScreen>
 
-				<NavigatorScreen path="/section">
+				<NavigatorScreen path={ NAVIGATOR_PATHS.SECTION }>
 					<ScreenSection
 						patterns={ sections }
 						onAddSection={ onAddSection }
@@ -511,7 +512,7 @@ const PatternAssembler = ( {
 						onMoveDownSection={ onMoveDownSection }
 					/>
 				</NavigatorScreen>
-				<NavigatorScreen path="/section/patterns">
+				<NavigatorScreen path={ NAVIGATOR_PATHS.SECTION_PATTERNS }>
 					{ isEnabled( 'pattern-assembler/categories' ) ? (
 						<ScreenCategoryList
 							categories={ categories }
@@ -535,7 +536,7 @@ const PatternAssembler = ( {
 				</NavigatorScreen>
 
 				{ isEnabledColorAndFonts && (
-					<NavigatorScreen path="/color-palettes">
+					<NavigatorScreen path={ NAVIGATOR_PATHS.COLOR_PALETTES }>
 						<AsyncLoad
 							require="./screen-color-palettes"
 							placeholder={ null }
@@ -550,7 +551,7 @@ const PatternAssembler = ( {
 				) }
 
 				{ isEnabledColorAndFonts && (
-					<NavigatorScreen path="/font-pairings">
+					<NavigatorScreen path={ NAVIGATOR_PATHS.FONT_PAIRINGS }>
 						<AsyncLoad
 							require="./screen-font-pairings"
 							placeholder={ null }
@@ -571,7 +572,7 @@ const PatternAssembler = ( {
 						wrapperRef.current?.focus();
 					} }
 				/>
-			</NavigatorProvider>
+			</div>
 			<PatternLargePreview
 				header={ header }
 				sections={ sections }
@@ -584,7 +585,7 @@ const PatternAssembler = ( {
 				onDeleteFooter={ onDeleteFooter }
 			/>
 			<PremiumGlobalStylesUpgradeModal { ...globalStylesUpgradeModalProps } />
-		</div>
+		</NavigatorProvider>
 	);
 
 	if ( ! site?.ID || ! selectedDesign ) {
@@ -595,7 +596,7 @@ const PatternAssembler = ( {
 		<StepContainer
 			className="pattern-assembler__sidebar-revamp"
 			stepName="pattern-assembler"
-			hideBack={ navigatorPath !== '/' || flow === WITH_THEME_ASSEMBLER_FLOW }
+			hideBack={ navigatorPath !== NAVIGATOR_PATHS.MAIN || flow === WITH_THEME_ASSEMBLER_FLOW }
 			goBack={ onBack }
 			goNext={ goNext }
 			isHorizontalLayout={ false }
@@ -612,7 +613,6 @@ const PatternAssembler = ( {
 				</PatternAssemblerContainer>
 			}
 			recordTracksEvent={ recordTracksEvent }
-			stepSectionName={ navigatorPath !== '/' ? 'pattern-selector' : undefined }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -7,7 +7,6 @@
 	padding: 32px 0;
 	margin-inline-end: 32px;
 	margin-inline-start: 10px;
-	margin-top: -60px;
 	box-sizing: border-box;
 	z-index: 1;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -126,8 +126,8 @@
 	}
 
 	span {
+		max-width: 600px;
 		font-size: $font-body;
-		padding: 0 30px;
 		text-align: center;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -1,11 +1,13 @@
 import { PatternRenderer } from '@automattic/block-renderer';
 import { DeviceSwitcher } from '@automattic/components';
 import { useStyle } from '@automattic/global-styles';
+import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
 import { Icon, layout } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useEffect, useState, CSSProperties } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { NAVIGATOR_PATHS, STYLES_PATHS } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import PatternActionBar from './pattern-action-bar';
 import { encodePatternId } from './utils';
@@ -39,7 +41,10 @@ const PatternLargePreview = ( {
 	onDeleteFooter,
 }: Props ) => {
 	const translate = useTranslate();
+	const navigator = useNavigator();
 	const hasSelectedPattern = header || sections.length || footer;
+	const shouldShowSelectPatternHint =
+		! hasSelectedPattern && STYLES_PATHS.includes( navigator.location.path );
 	const frameRef = useRef< HTMLDivElement | null >( null );
 	const listRef = useRef< HTMLUListElement | null >( null );
 	const [ viewportHeight, setViewportHeight ] = useState< number | undefined >( 0 );
@@ -49,6 +54,10 @@ const PatternLargePreview = ( {
 		'--pattern-large-preview-block-gap': blockGap,
 		'--pattern-large-preview-background': backgroundColor,
 	} as CSSProperties );
+
+	const goToSelectPattern = () => {
+		navigator.goTo( NAVIGATOR_PATHS.HEADER );
+	};
 
 	const renderPattern = ( type: string, pattern: Pattern, position = -1 ) => {
 		const key = type === 'section' ? pattern.key : type;
@@ -171,6 +180,29 @@ const PatternLargePreview = ( {
 					<span>
 						{ translate( "It's time to get creative. Add your first pattern to get started." ) }
 					</span>
+					{ shouldShowSelectPatternHint && (
+						<span>
+							{ translate(
+								'{{link}}Select a pattern{{/link}} to apply colors and fonts to your website.',
+								{
+									components: {
+										link: (
+											// eslint-disable-next-line jsx-a11y/anchor-is-valid
+											<a
+												href="#"
+												target="_blank"
+												rel="noopener noreferrer"
+												onClick={ ( event ) => {
+													event.preventDefault();
+													goToSelectPattern();
+												} }
+											/>
+										),
+									},
+								}
+							) }
+						</span>
+					) }
 				</div>
 			) }
 		</DeviceSwitcher>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -55,7 +55,7 @@ const PatternLargePreview = ( {
 		'--pattern-large-preview-background': backgroundColor,
 	} as CSSProperties );
 
-	const goToSelectPattern = () => {
+	const goToSelectHeaderPattern = () => {
 		navigator.goTo( NAVIGATOR_PATHS.HEADER );
 	};
 
@@ -178,31 +178,28 @@ const PatternLargePreview = ( {
 					<Icon className="pattern-large-preview__placeholder-icon" icon={ layout } size={ 72 } />
 					<h2>{ translate( 'Welcome to your blank canvas' ) }</h2>
 					<span>
-						{ translate( "It's time to get creative. Add your first pattern to get started." ) }
+						{ shouldShowSelectPatternHint
+							? translate(
+									'You can view your color and font selections after you select a pattern, get started by {{link}}adding a header pattern{{/link}}',
+									{
+										components: {
+											link: (
+												// eslint-disable-next-line jsx-a11y/anchor-is-valid
+												<a
+													href="#"
+													target="_blank"
+													rel="noopener noreferrer"
+													onClick={ ( event ) => {
+														event.preventDefault();
+														goToSelectHeaderPattern();
+													} }
+												/>
+											),
+										},
+									}
+							  )
+							: translate( "It's time to get creative. Add your first pattern to get started." ) }
 					</span>
-					{ shouldShowSelectPatternHint && (
-						<span>
-							{ translate(
-								'{{link}}Select a pattern{{/link}} to apply colors and fonts to your website.',
-								{
-									components: {
-										link: (
-											// eslint-disable-next-line jsx-a11y/anchor-is-valid
-											<a
-												href="#"
-												target="_blank"
-												rel="noopener noreferrer"
-												onClick={ ( event ) => {
-													event.preventDefault();
-													goToSelectPattern();
-												} }
-											/>
-										),
-									},
-								}
-							) }
-						</span>
-					) }
 				</div>
 			) }
 		</DeviceSwitcher>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-section.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-section.tsx
@@ -4,6 +4,7 @@ import {
 	__experimentalUseNavigator as useNavigator,
 } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { NAVIGATOR_PATHS } from './constants';
 import NavigatorHeader from './navigator-header';
 import PatternLayout from './pattern-layout';
 import type { Pattern } from './types';
@@ -27,7 +28,7 @@ const ScreenSection = ( {
 }: Props ) => {
 	const translate = useTranslate();
 	const navigator = useNavigator();
-	const goToPatternList = () => navigator.goTo( '/section/patterns' );
+	const goToPatternList = () => navigator.goTo( NAVIGATOR_PATHS.SECTION_PATTERNS );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -31,6 +31,8 @@ $font-family: "SF Pro Text", $sans;
 		flex: 1;
 		outline: none;
 		position: relative;
+		height: 100vh;
+		margin-top: -60px;
 	}
 
 	.pattern-assembler__sidebar {
@@ -40,7 +42,6 @@ $font-family: "SF Pro Text", $sans;
 		height: 100vh;
 		box-sizing: border-box;
 		padding: 110px 32px 32px;
-		margin-top: -60px;
 		background-color: var(--color-body-background);
 		position: relative;
 		z-index: 2;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74816#issuecomment-1487852557

## Proposed Changes

* Append a message to the large preview to tell users they have to select a pattern to apply styles
* There is a limitation that the `NavigationProvider` doesn't support replacing the current path. That is, when we open the header screen programmatically, the user will go back to the previous screen (e.g. `Colors` or `Fonts`) when they click on the `<` or `Save` button.

### Screenshots

![image](https://user-images.githubusercontent.com/13596067/229023625-71354f2c-3db9-480f-a710-bc6b064ae976.png)

### Demo

https://user-images.githubusercontent.com/13596067/228726479-3562abdc-8c9e-4735-85ac-e1f8715c3e6b.mov

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/site-setup?siteSlug=<your_site>
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Select `Colors` or `Fonts`
  * Ensure you see `Select a pattern to apply colors and fonts to your website.` shown on the large preview
  * Click on the `Select a pattern` link
  * Ensure you go to the header screen so you're able to select a pattern
  * Click `<` or `Save` button on the header screen
  * Ensure you're back to the previous screen, e.g. `Colors` or `Fonts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
