### PR TITLE
Add software software and org slugs to plugin object

### DIFF
--- a/client/data/marketplace/constants.ts
+++ b/client/data/marketplace/constants.ts
@@ -54,4 +54,8 @@ export const RETURNABLE_FIELDS = [
 
 	// Marketplace plugin slug for Calypso url
 	'plugin.product_slug',
+
+	// Marketplace software slug
+	'plugin.software_slug',
+	'plugin.org_slug',
 ] as const;

--- a/client/data/marketplace/types.ts
+++ b/client/data/marketplace/types.ts
@@ -11,6 +11,8 @@ export type PluginQueryOptions = {
 export type Plugin = {
 	name?: string;
 	slug: string;
+	software_slug?: string;
+	org_slug?: string;
 	version?: string;
 	author?: string;
 	author_name?: string;
@@ -56,6 +58,8 @@ export type ESIndexResult = {
 	plugin: {
 		store_product_monthly_id?: number;
 		store_product_yearly_id?: number;
+		software_slug?: string;
+		org_slug?: string;
 		author: string;
 		title: string;
 		excerpt: string;

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -44,6 +44,8 @@ const mapIndexResultsToPluginData = ( results: ESHits ): Plugin[] => {
 		const plugin: Plugin = {
 			name: decodeEntities( hit.plugin?.title ), // TODO: add localization
 			slug: decodeEntities( hit.slug ),
+			software_slug: hit.plugin?.software_slug,
+			org_slug: hit.plugin?.org_slug,
 			version: hit[ 'plugin.stable_tag' ],
 			author: hit.author,
 			author_name: hit.plugin?.author,


### PR DESCRIPTION
Related to #75106 

## Proposed Changes

* Add plugin.software_slug and 'plugin.org_slug' to Elastic Search returnable constants.
* Add software_slug and org_slug to the Plugin Object and perform the mapping when getting the data from Elastic Search.

## Testing Instructions

- Apply this patch
- Download Yoast SEO Premium directly from their site: https://yoast.com/wordpress/plugins/seo/
- Install it on AT WordPress.com site.
- Search for yoast in Marketplace /plugins.
- It will display as Installed but Inactive.

<img width="1528" alt="Screenshot 2023-04-03 at 9 58 39 PM" src="https://user-images.githubusercontent.com/351784/229676014-10da42a8-3624-4a25-b679-ae3d17655412.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
