### PR TITLE
Site Assembler: Make the arrow icon accessible to the RTL language

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/style.scss
@@ -38,3 +38,13 @@
 		letter-spacing: -0.15px;
 	}
 }
+
+.rtl {
+	.pattern-assembler {
+		.navigator-header__heading {
+			.gridicon {
+				transform: rotate(180deg);
+			}
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/style.scss
@@ -38,13 +38,3 @@
 		letter-spacing: -0.15px;
 	}
 }
-
-.rtl {
-	.pattern-assembler {
-		.navigator-header__heading {
-			.gridicon {
-				transform: rotate(180deg);
-			}
-		}
-	}
-}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.scss
@@ -13,5 +13,14 @@
 			background-color: var(--studio-blue-0);
 			color: var(--studio-blue-50);
 		}
+
+	}
+}
+
+.rtl {
+	.screen-category-list__category-button {
+		.screen-category-list__arrow-icon {
+			transform: rotate(180deg);
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -114,7 +114,11 @@ const ScreenCategoryList = ( {
 							} }
 						>
 							<span>{ label }</span>
-							<Icon icon={ chevronRight } size={ 24 } />
+							<Icon
+								className="screen-category-list__arrow-icon"
+								icon={ chevronRight }
+								size={ 24 }
+							/>
 						</Button>
 					);
 				} ) }

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -30,6 +30,7 @@ import { requestSites } from 'calypso/state/sites/actions';
 import { isAnchorFmFlow } from './declarative-flow/anchor-fm-flow';
 import { FlowRenderer } from './declarative-flow/internals';
 import 'calypso/components/environment-badge/style.scss';
+import 'calypso/assets/stylesheets/style.scss';
 import availableFlows from './declarative-flow/registered-flows';
 import { useQuery } from './hooks/use-query';
 import { ONBOARD_STORE, USER_STORE } from './stores';

--- a/packages/block-renderer/src/components/block-renderer-container.scss
+++ b/packages/block-renderer/src/components/block-renderer-container.scss
@@ -13,6 +13,7 @@
 		min-height: auto;
 
 		iframe {
+			max-width: initial;
 			border: none;
 			transition: opacity 0.15s ease-in-out;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74320

## Proposed Changes

* Rotate the arrow icons when a user sets their language RTL language.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Set your language to `العربية` in `Me → Account`
- Create a new site and go to the Site Assembler
- Click `Header`, `Sections`, `Footer` to see the icon

| before | after |
|--------|--------|
| header <img width="311" alt="Screen Shot 2023-03-30 at 14 48 03" src="https://user-images.githubusercontent.com/5287479/228741301-978dc9d4-92cd-48f9-8013-3dceb4265872.png"> | <img width="332" alt="Screen Shot 2023-03-30 at 14 45 36" src="https://user-images.githubusercontent.com/5287479/228741017-3739e08d-738f-400d-895a-8247fb57bfee.png"> |
| sections <img width="320" alt="Screen Shot 2023-03-30 at 14 48 41" src="https://user-images.githubusercontent.com/5287479/228741440-a46b32c1-b018-44f6-a614-77270ce2f50f.png"> | <img width="322" alt="Screen Shot 2023-03-30 at 14 45 48" src="https://user-images.githubusercontent.com/5287479/228741110-1443c018-a073-4e75-b463-5f29286a06fe.png"> |
| pattern list <img width="331" alt="Screen Shot 2023-03-30 at 14 48 47" src="https://user-images.githubusercontent.com/5287479/228741445-c2a78fff-d271-4af0-9ec3-783e79edc31f.png"> | <img width="321" alt="Screen Shot 2023-03-30 at 14 46 05" src="https://user-images.githubusercontent.com/5287479/228741155-b895b041-592c-439c-b996-44beb1a2c594.png"> | 
|overview (pattern list) ![Image](https://user-images.githubusercontent.com/1881481/224267714-c5046c47-9074-4b3e-8a10-cecf9f6f78ad.png) |<img width="1430" alt="Screen Shot 2023-03-30 at 14 51 38" src="https://user-images.githubusercontent.com/5287479/228741937-411d2139-d9fb-4463-99d1-8cf8343841cb.png">|





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
