### PR TITLE
Plugins: Fix missing plugin prop in `PluginActivateToggle`

### DIFF
--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -104,11 +104,11 @@ export class PluginActivateToggle extends Component {
 	render() {
 		const { inProgress, site, plugin, disabled, translate, hideLabel, isJetpackCloud } = this.props;
 
-		if ( ! site ) {
+		if ( ! site || ! plugin ) {
 			return null;
 		}
 
-		const isJetpackPlugin = plugin && 'jetpack' === plugin.slug;
+		const isJetpackPlugin = 'jetpack' === plugin.slug;
 
 		if ( ! isJetpackCloud && isJetpackPlugin ) {
 			return (
@@ -126,7 +126,7 @@ export class PluginActivateToggle extends Component {
 				className="plugin-activate-toggle"
 				label={ translate( 'Active', { context: 'plugin status' } ) }
 				inProgress={ inProgress }
-				status={ plugin && plugin.active }
+				status={ plugin.active }
 				action={ this.toggleActivation }
 				htmlFor={ 'activate-' + plugin.slug + '-' + site.ID }
 				hideLabel={ hideLabel }


### PR DESCRIPTION
Currently, we still get errors that `plugin` is not defined, but we're relying on it to be defined in `PluginActivateToggle`.

## Proposed Changes

Update `PluginActivateToggle` to render nothing if the required `plugin` prop is undefined.

## Testing Instructions

* Go to `/plugins/manage/:site` where `:site` is a Jetpack site with installed, both activated and non-activated plugins. 
* Verify it loads correctly with no errors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
