### PR TITLE
Limited Global Styles: Get blog ID of Atomic site from blog option

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -26,9 +26,16 @@ function wpcom_should_limit_global_styles( $blog_id = 0 ) {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			$blog_id = get_current_blog_id();
 		} elseif ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-			$blog_id = method_exists( 'Jetpack_Options', 'get_option' )
-				? (int) Jetpack_Options::get_option( 'id' )
-				: get_current_blog_id();
+			/*
+			 * Atomic sites have the WP.com blog ID stored as a Jetpack option. This code deliberately
+			 * doesn't use `Jetpack_Options::get_option` so it works even when Jetpack has not been loaded.
+			 */
+			$jetpack_options = get_option( 'jetpack_options' );
+			if ( is_array( $jetpack_options ) && isset( $jetpack_options['id'] ) ) {
+				$blog_id = (int) $jetpack_options['id'];
+			} else {
+				$blog_id = get_current_blog_id();
+			}
 		} else {
 			return false;
 		}


### PR DESCRIPTION
See p9F6qB-byy-p2

## Proposed Changes

Changes the logic that checks whether Global Styles are available to ensure that the expected WP.com blog ID is passed to the `wpcom_site_has_feature` function when it runs on an Atomic site with Jetpack deactivated.

## Testing Instructions

- Apply these changes to a WoA dev site.
- Deactivate Jetpack.
- Try to reactivate Jetpack.
- Make sure you don't get any fatal and Jetpack is correctly activated.