### PR TITLE
Improvements in subscription site list

### DIFF
--- a/client/landing/subscriptions/site-list/site-row.tsx
+++ b/client/landing/subscriptions/site-list/site-row.tsx
@@ -27,7 +27,7 @@ export default function SiteRow( {
 
 	return (
 		<li className="row" role="row">
-			<a href={ url } className="title-box">
+			<a href={ url } rel="noreferrer noopener" className="title-box">
 				<span className="title-box" role="cell">
 					{ siteIcon }
 					<span className="title-column">

--- a/client/landing/subscriptions/site-list/site-row.tsx
+++ b/client/landing/subscriptions/site-list/site-row.tsx
@@ -1,25 +1,41 @@
+import { Gridicon } from '@automattic/components';
+import { useMemo } from '@wordpress/element';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { SiteSettings } from '../settings-popover';
 import type { SiteSubscription } from '@automattic/data-stores/src/reader/types';
 
 export default function SiteRow( {
 	name,
 	site_icon,
-	URL,
+	URL: url,
 	date_subscribed,
 	delivery_methods,
 }: SiteSubscription ) {
-	const since = new Date( date_subscribed ).toDateString();
+	const moment = useLocalizedMoment();
+	const since = useMemo(
+		() => moment( date_subscribed ).format( 'LL' ),
+		[ date_subscribed, moment ]
+	);
 	const deliveryFrequency = delivery_methods?.email?.post_delivery_frequency;
+	const hostname = useMemo( () => new URL( url ).hostname, [ url ] );
+	const siteIcon = useMemo( () => {
+		if ( site_icon ) {
+			return <img className="icon" src={ site_icon } alt={ name } />;
+		}
+		return <Gridicon className="icon" icon="globe" size={ 48 } />;
+	}, [ site_icon, name ] );
 
 	return (
 		<li className="row" role="row">
-			<span className="title-box" role="cell">
-				<img className="icon" src={ site_icon } alt={ name } />
-				<span className="title-column">
-					<span className="name">{ name }</span>
-					<span className="url">{ URL }</span>
+			<a href={ url } className="title-box">
+				<span className="title-box" role="cell">
+					{ siteIcon }
+					<span className="title-column">
+						<span className="name">{ name }</span>
+						<span className="url">{ hostname }</span>
+					</span>
 				</span>
-			</span>
+			</a>
 			<span className="date" role="cell">
 				{ since }
 			</span>

--- a/client/landing/subscriptions/site-list/styles.scss
+++ b/client/landing/subscriptions/site-list/styles.scss
@@ -28,18 +28,21 @@ $max-list-width: 1300px;
 			display: flex;
 			align-items: center;
 			flex: 1.83;
+			min-width: 0;
 
 			.icon {
 				fill: var(--color-text-subtle);
 				width: 40px;
 				height: 40px;
-				padding-right: 12px;
 				flex: none;
+				border-radius: 50%;
 			}
 
 			.title-column {
 				display: flex;
 				flex-direction: column;
+				min-width: 0;
+				padding-left: 12px;
 
 				.name {
 					font-weight: 600;
@@ -47,6 +50,10 @@ $max-list-width: 1300px;
 					line-height: 22px;
 					color: $studio-gray-100;
 					letter-spacing: -0.24px;
+					text-overflow: ellipsis;
+					white-space: nowrap;
+					overflow: hidden;
+					padding-right: 10px;
 				}
 
 				.url {
@@ -54,6 +61,9 @@ $max-list-width: 1300px;
 					font-size: $font-body-extra-small;
 					line-height: 18px;
 					color: $studio-gray-40;
+					text-overflow: ellipsis;
+					white-space: nowrap;
+					overflow: hidden;
 				}
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/74966

## Proposed Changes

This pull request addresses several improvements to the way sites are displayed. The following points have been fixed:

1. **Handle a site with no logo**: Sites that don't have a logo will now be displayed correctly, with a default globe icon (like in Reader).
2. **Display site logos with a circular mask applied**: Site logos will now be displayed with a circular mask, giving a consistent and visually appealing appearance.
3. **Display the date with the expected date format applied**: The site's date will now be displayed using the expected date format, improving readability and consistency across the application. **Note**: the format is using en-US for now. When we can access real data, we will use the user locale instead.
4. **Handle long text**: Long site names and other text elements are handled gracefully, ensuring the layout remains clean and uncluttered. We are using ellipsis for this.
5. **Handle site logo, site name, and site URL click**: Clicking on the site logo, site name, or site URL will trigger the appropriate event or action, providing a better user experience.
6. **Only the site's domain name should be displayed**: To improve readability and focus on the essential information, only the site's domain name will be displayed rather than the full URL.

<img width="1053" alt="Screenshot 2023-03-30 at 12 45 29" src="https://user-images.githubusercontent.com/3832570/228812529-5901adb9-bbb6-451f-951f-e30204196fcd.png">

## Testing Instructions

- Apply these changes.
- Please check the 6 points described above, making sure the experience is now closer to the Figma design.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React ,or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
