### PR TITLE
Show upload button on all plans

### DIFF
--- a/client/blocks/eligibility-warnings/index.tsx
+++ b/client/blocks/eligibility-warnings/index.tsx
@@ -115,7 +115,11 @@ export const EligibilityWarnings = ( {
 		if ( siteRequiresUpgrade( listHolds ) ) {
 			recordUpgradeClick( ctaName, feature );
 			const planSlug = eligibleForProPlan ? PLAN_WPCOM_PRO : PLAN_BUSINESS;
-			page.redirect( `/checkout/${ siteSlug }/${ planSlug }` );
+			let redirectUrl = `/checkout/${ siteSlug }/${ planSlug }`;
+			if ( context === 'plugins-upload' ) {
+				redirectUrl = `${ redirectUrl }?redirect_to=/plugins/upload/${ siteSlug }`;
+			}
+			page.redirect( redirectUrl );
 			return;
 		}
 		if ( siteRequiresLaunch( listHolds ) ) {
@@ -412,7 +416,7 @@ function mergeProps(
 			: FEATURE_INSTALL_PLUGINS;
 		ctaName = 'calypso-plugin-details-eligibility-upgrade-nudge';
 	} else if ( includes( ownProps.backUrl, 'plugins' ) ) {
-		context = 'plugins';
+		context = 'plugins-upload';
 		feature = FEATURE_UPLOAD_PLUGINS;
 		ctaName = 'calypso-plugin-eligibility-upgrade-nudge';
 	} else if ( includes( ownProps.backUrl, 'themes' ) ) {

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -1,4 +1,3 @@
-import { WPCOM_FEATURES_UPLOAD_PLUGINS } from '@automattic/calypso-products/src';
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { isEmpty, flowRight } from 'lodash';
@@ -25,8 +24,6 @@ import getPluginUploadError from 'calypso/state/selectors/get-plugin-upload-erro
 import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id';
 import isPluginUploadComplete from 'calypso/state/selectors/is-plugin-upload-complete';
 import isPluginUploadInProgress from 'calypso/state/selectors/is-plugin-upload-in-progress';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import {
 	getSiteAdminUrl,
 	isJetpackSite,
@@ -96,12 +93,8 @@ class PluginUpload extends Component {
 	}
 
 	render() {
-		const { translate, isJetpackMultisite, siteId, siteSlug, hasUploadPlugins } = this.props;
+		const { translate, isJetpackMultisite, siteId, siteSlug } = this.props;
 		const { showEligibility } = this.state;
-
-		if ( ! hasUploadPlugins ) {
-			page( `/plugins/${ siteSlug }` );
-		}
 
 		return (
 			<Main>
@@ -125,7 +118,6 @@ const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const error = getPluginUploadError( state, siteId );
 	const isJetpack = isJetpackSite( state, siteId );
-	const jetpackNonAtomic = isJetpack && ! isAtomicSite( state, siteId );
 	const isJetpackMultisite = isJetpackSiteMultiSite( state, siteId );
 	const { eligibilityHolds, eligibilityWarnings } = getEligibility( state, siteId );
 	// Use this selector to take advantage of eligibility card placeholders
@@ -134,8 +126,6 @@ const mapStateToProps = ( state ) => {
 	const hasEligibilityMessages = ! (
 		isEmpty( eligibilityHolds ) && isEmpty( eligibilityWarnings )
 	);
-	const hasUploadPlugins =
-		siteHasFeature( state, siteId, WPCOM_FEATURES_UPLOAD_PLUGINS ) || jetpackNonAtomic;
 
 	return {
 		siteId,
@@ -150,7 +140,6 @@ const mapStateToProps = ( state ) => {
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		showEligibility: ! isJetpack && ( hasEligibilityMessages || ! isEligible ),
 		automatedTransferStatus: getAutomatedTransferStatus( state, siteId ),
-		hasUploadPlugins,
 	};
 };
 

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -186,7 +186,7 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 				<UploadPluginButton
 					isMobile={ isMobile }
 					siteSlug={ selectedSite?.slug }
-					hasUploadPlugins={ !!selectedSite  }
+					hasUploadPlugins={ !! selectedSite }
 				/>
 			</div>
 		</FixedNavigationHeader>

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -1,7 +1,6 @@
 import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 	WPCOM_FEATURES_MANAGE_PLUGINS,
-	WPCOM_FEATURES_UPLOAD_PLUGINS,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
@@ -89,11 +88,6 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 	const jetpackNonAtomic = useSelector(
 		( state ) =>
 			isJetpackSite( state, selectedSite?.ID ) && ! isAtomicSite( state, selectedSite?.ID )
-	);
-
-	const hasUploadPlugins = useSelector(
-		( state ) =>
-			siteHasFeature( state, selectedSite?.ID, WPCOM_FEATURES_UPLOAD_PLUGINS ) || jetpackNonAtomic
 	);
 
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, selectedSite?.ID ) );
@@ -192,7 +186,7 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 				<UploadPluginButton
 					isMobile={ isMobile }
 					siteSlug={ selectedSite?.slug }
-					hasUploadPlugins={ hasUploadPlugins }
+					hasUploadPlugins={ selectedSite }
 				/>
 			</div>
 		</FixedNavigationHeader>

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -186,7 +186,7 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 				<UploadPluginButton
 					isMobile={ isMobile }
 					siteSlug={ selectedSite?.slug }
-					hasUploadPlugins={ selectedSite }
+					hasUploadPlugins={ !!selectedSite  }
 				/>
 			</div>
 		</FixedNavigationHeader>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #68553

## Proposed Changes

- The /plugins upload button is now shown for all plans
- The /plugins upload button is not shown in all sites view, or when a site is not selected
- When clicking upload on a lower than business plan the upload page is shown (It will show warnings and a button that should take you to the checkout)
- The warnings section CTA button text is updated to "Upgrade and continue"
- The checkout flow redirects back to the upload page on completion

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**On a free site**
- Navigate to `/plugins`
- Check that the Upload button is shown on the navbar
- Click the Upload button
- Check that the plugin upload page is loaded, and the eligibility warnings are shown
- Click the Upgrade and continue button
- Check that on the checkout page, the `redirect_to` parameter is added to the URL
- Complete the checkout
- Check that you're redirected to the plugins upload page, and that the eligibility warnings are shown for the site URL
- Click continue
- Check that the upload area is shown

**On a simple business or ecom site**
- Navigate to `/plugins`
- Check that the Upload button is shown on the navbar
- Click the Upload button
- Check that the plugin upload page is loaded, and that the eligibility warnings are shown for the site URL
- Click continue
- Check that the upload area is shown

**On an atomic business or ecom site**
- Navigate to `/plugins`
- Check that the Upload button is shown on the navbar
- Click the Upload button
- Check that the plugin upload page is loaded, and the upload area is shown

**Without selecting a site**
- Navigate to `plugins`
- Check that the Upload button is not shown on the navbar

| Step | Free site | Simple business site | Atomic business site |
|--------|--------|--------|--------|
| `/plugins` page navbar | <img width="1061" alt="CleanShot 2023-03-30 at 14 02 15@2x" src="https://user-images.githubusercontent.com/11555574/228844423-09a5a2c5-bc6c-47bc-b019-1756aa37f1cb.png"> | <img width="1061" alt="CleanShot 2023-03-30 at 14 02 15@2x" src="https://user-images.githubusercontent.com/11555574/228844423-09a5a2c5-bc6c-47bc-b019-1756aa37f1cb.png"> | <img width="1068" alt="CleanShot 2023-03-30 at 14 02 04@2x" src="https://user-images.githubusercontent.com/11555574/228844369-7ec05c2c-d020-4a64-b79c-4fbe82988e69.png"> |
| `/plugins/upload` page | ![CleanShot 2023-03-30 at 13 56 01@2x](https://user-images.githubusercontent.com/11555574/228842783-904dd009-3bff-419f-9903-9656fe36e51c.png) | <img alt="CleanShot 2023-03-30 at 13 39 47@2x" src="https://user-images.githubusercontent.com/11555574/228843064-3bee1368-4fc3-45a5-9300-09d12c25769f.png"> | <img alt="CleanShot 2023-03-30 at 13 56 45@2x" src="https://user-images.githubusercontent.com/11555574/228842981-9f01e75d-fff3-40d1-ad2d-e12c48881b3c.png"> |
| After checkout | <img alt="CleanShot 2023-03-30 at 13 39 47@2x" src="https://user-images.githubusercontent.com/11555574/228843064-3bee1368-4fc3-45a5-9300-09d12c25769f.png"> | N/A | N/A |
| Clicking Continue | <img alt="CleanShot 2023-03-30 at 13 56 45@2x" src="https://user-images.githubusercontent.com/11555574/228842981-9f01e75d-fff3-40d1-ad2d-e12c48881b3c.png"> | <img alt="CleanShot 2023-03-30 at 13 56 45@2x" src="https://user-images.githubusercontent.com/11555574/228842981-9f01e75d-fff3-40d1-ad2d-e12c48881b3c.png"> | N/A |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
