### PR TITLE
Tailored flows: Add title spacing to Newsletter flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -16,10 +16,10 @@
 		}
 
 		.step-container__header {
-			margin: 25px 24px 30px 20px;
+			margin: 20px 24px 40px 20px;
 
 			@include break-small {
-				margin: 36px 0 40px 0;
+				margin: 36px 0 58px 0;
 			}
 
 			.formatted-header__title {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -3,7 +3,7 @@
 .newsletter-setup {
 
 	.step-container {
-		padding-top: 25px;
+		padding-top: 20px;
 		@include break-medium {
 			padding-top: 0;
 		}
@@ -14,10 +14,10 @@
 	}
 
 	.step-container__header {
-		margin-bottom: 32px;
-
+		margin-bottom: 40px;
 		@include break-medium {
 			margin-top: 36px;
+			margin-bottom: 58px;
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -6,15 +6,11 @@
 		padding: 0;
 
 		.step-wrapper__header {
-			margin: 9px 20px;
-
-			@include break-large {
-				margin: 8px 20px;
-			}
 
 			.formatted-header {
+				margin: 20px 0 40px 0;
 				@include break-small {
-					margin-top: 28px;
+					margin: 36px 0 58px 0;
 				}
 
 				h1.formatted-header__title {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
@@ -1,10 +1,10 @@
 @import "../style";
 .subscribers {
 	.add-subscriber__title-container {
-		margin-top: 25px;
+		margin: 20px 0 40px 0 !important;
 
-		@include break-medium {
-			margin-top: 36px;
+		@include break-small {
+			margin: 36px auto 58px auto !important;
 		}
 	}
 	.step-container {


### PR DESCRIPTION
## Proposed Changes

Fixes Newsletter titles spacing that according to [designs](HSljkKnYECEEegL3DqP2xC-fi-7819-77766) are:

Figma:

> Desktop:
> <img width="1328" alt="image" src="https://user-images.githubusercontent.com/2653810/228813117-2240ad72-ed92-4ee7-95fa-03efa876b656.png">
> 
> Mobile:
> <img width="521" alt="image" src="https://user-images.githubusercontent.com/2653810/228813162-a9e2c907-dc5b-4d6f-89c6-c6d70a45ebcb.png">



## Testing Instructions

Pull and run this branch or use calypso live links
It should look and match the screenshots bellow

Browser:

> Desktop:
> <img width="1032" alt="image" src="https://user-images.githubusercontent.com/2653810/228813587-93baffcf-4044-4cfa-8e14-c49c1d5487c4.png">
> <img width="1100" alt="image" src="https://user-images.githubusercontent.com/2653810/228813763-9573557e-8d21-43be-a0dc-992a884372af.png">

Mobile:
<img width="607" alt="image" src="https://user-images.githubusercontent.com/2653810/228814035-180c5268-008b-49c8-85c8-e784f4e82cc1.png">
<img width="595" alt="image" src="https://user-images.githubusercontent.com/2653810/228814189-8338dc85-a20e-43e9-a849-b506f77f5013.png">

Fixes #75018 