### PR TITLE
Virtual themes i1: Remove A/B test

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -16,7 +16,7 @@ export function recordPreviewedDesign( {
 	recordTracksEvent( 'calypso_signup_design_preview_select', {
 		...getDesignEventProps( { flow, intent, design, styleVariation } ),
 		...getDesignTypeProps( design ),
-		...getVirtualDesignProps( design, styleVariation ),
+		...getVirtualDesignProps( design ),
 	} );
 }
 
@@ -44,7 +44,7 @@ export function recordSelectedDesign( {
 		recordTracksEvent( 'calypso_signup_select_design', {
 			...getDesignEventProps( { flow, intent, design, styleVariation } ),
 			...getDesignTypeProps( design ),
-			...getVirtualDesignProps( design, styleVariation ),
+			...getVirtualDesignProps( design ),
 			...optionalProps,
 		} );
 
@@ -91,30 +91,15 @@ export function getDesignEventProps( {
 	};
 }
 
-export function getVirtualDesignProps( design: Design, styleVariation?: StyleVariation ) {
-	let is_style_variation = false;
-	let variationSlugSuffix = '';
-	if ( styleVariation && styleVariation.slug !== 'default' ) {
-		is_style_variation = true;
-		variationSlugSuffix = `-${ styleVariation.slug }`;
-	} else if ( ! styleVariation && design.preselected_style_variation ) {
-		is_style_variation = true;
-		variationSlugSuffix = `-${ design.preselected_style_variation.slug }`;
-	}
-
+export function getVirtualDesignProps( design: Design ) {
 	/**
 	 * If the design is virtual, and it has a recipe with pattern_ids,
 	 * then we assume that it's a pattern based virtual theme.
 	 */
-	const virtual_theme_pattern =
-		design.is_virtual && design.recipe?.pattern_ids?.length
-			? design.recipe?.pattern_ids[ 0 ]
-			: null;
+	const virtual_theme_pattern = design.is_virtual ? design.recipe?.pattern_ids?.[ 0 ] : null;
 
 	return {
-		slug: design.slug + variationSlugSuffix,
 		is_virtual: design.is_virtual,
-		is_style_variation: is_style_variation,
 		virtual_theme_pattern,
 	};
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -24,7 +24,6 @@ import WebPreview from 'calypso/components/web-preview/content';
 import { useSiteVerticalQueryById } from 'calypso/data/site-verticals';
 import { ActiveTheme } from 'calypso/data/themes/use-active-theme-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useExperiment } from 'calypso/lib/explat';
 import { urlToSlug } from 'calypso/lib/url';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
 import { setActiveTheme } from 'calypso/state/themes/actions';
@@ -135,23 +134,17 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		return allDesigns;
 	};
 
-	const [ isLoadingVirtualThemesExperiment, virtualThemesExperiment ] = useExperiment(
-		'calypso_signup_design_picker_virtual_themes_v1'
-	);
-
 	const { data: allDesigns, isLoading: isLoadingDesigns } = useStarterDesignsQuery(
 		{
 			vertical_id: siteVerticalId,
 			intent,
 			seed: siteSlugOrId || undefined,
 			_locale: locale,
-			include_virtual_designs: virtualThemesExperiment?.variationName === 'treatment',
 			include_pattern_virtual_designs: isEnabled( 'virtual-themes/onboarding' ),
 		},
 		{
-			enabled: ! isLoadingVirtualThemesExperiment,
+			enabled: true,
 			select: selectStarterDesigns,
-			shouldLimitGlobalStyles,
 		}
 	);
 
@@ -268,20 +261,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	function previewDesign( design: Design, styleVariation?: StyleVariation ) {
 		recordPreviewedDesign( { flow, intent, design, styleVariation } );
 
-		if ( ! design.preselected_style_variation ) {
-			setSelectedDesign( design );
-		} else {
-			const parentDesign = staticDesigns.find(
-				( staticDesign ) =>
-					staticDesign.slug === design.slug && ! staticDesign.preselected_style_variation
-			);
-			setSelectedDesign( parentDesign );
-		}
-
+		setSelectedDesign( design );
 		if ( styleVariation ) {
 			setSelectedStyleVariation( styleVariation );
-		} else if ( design.preselected_style_variation ) {
-			setSelectedStyleVariation( design.preselected_style_variation );
 		}
 
 		setIsPreviewingDesign( true );
@@ -290,7 +272,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	function onChangeVariation( design: Design, styleVariation?: StyleVariation ) {
 		recordTracksEvent( 'calypso_signup_design_picker_style_variation_button_click', {
 			...getEventPropsByDesign( design, styleVariation ),
-			...getVirtualDesignProps( design, styleVariation ),
+			...getVirtualDesignProps( design ),
 		} );
 	}
 
@@ -484,7 +466,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				);
 			}
 			setPendingAction( () => {
-				if ( _selectedDesign.is_virtual && _selectedDesign.recipe?.pattern_ids?.length ) {
+				if ( _selectedDesign.is_virtual ) {
 					return applyThemeWithPatterns(
 						siteSlugOrId,
 						_selectedDesign,
@@ -614,7 +596,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 	// ********** Main render logic
 
 	// Don't render until we've done fetching all the data needed for initial render.
-	if ( ! site || isLoadingSiteVertical || isLoadingDesigns || isLoadingVirtualThemesExperiment ) {
+	if ( ! site || isLoadingSiteVertical || isLoadingDesigns ) {
 		return <StepperLoader />;
 	}
 
@@ -648,9 +630,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			</>
 		);
 
-		const showPatternAssemblerCTA =
-			selectedDesign.is_virtual && selectedDesign.recipe?.pattern_ids?.length;
-		const patternAssemblerCTA = showPatternAssemblerCTA && (
+		const patternAssemblerCTA = selectedDesign.is_virtual && (
 			<PatternAssemblerCta
 				compact={ true }
 				hasPrimaryButton={ false }

--- a/packages/design-picker/src/components/style-variation-badges/index.tsx
+++ b/packages/design-picker/src/components/style-variation-badges/index.tsx
@@ -11,7 +11,6 @@ interface BadgesProps {
 	onMoreClick?: () => void;
 	onClick?: ( variation: StyleVariation ) => void;
 	selectedVariation?: StyleVariation;
-	firstVariation?: StyleVariation;
 }
 
 const Badges: React.FC< BadgesProps > = ( {
@@ -20,20 +19,10 @@ const Badges: React.FC< BadgesProps > = ( {
 	onMoreClick,
 	onClick,
 	selectedVariation,
-	firstVariation,
 } ) => {
 	const variationsToShow = useMemo( () => {
-		if ( firstVariation ) {
-			return [
-				firstVariation,
-				...variations
-					.filter( ( variation ) => variation.slug !== firstVariation.slug )
-					.slice( 0, maxVariationsToShow - 1 ),
-			];
-		}
-
 		return variations.slice( 0, maxVariationsToShow );
-	}, [ variations, maxVariationsToShow, firstVariation ] );
+	}, [ variations, maxVariationsToShow ] );
 
 	return (
 		<>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -118,16 +118,12 @@ const useTrackDesignView = ( {
 
 				const trackingCategory = category === SHOW_ALL_SLUG ? undefined : category;
 
-				const variationSlugSuffix = design.preselected_style_variation
-					? `-${ design.preselected_style_variation.slug }`
-					: '';
-
 				recordTracksEvent( 'calypso_design_picker_design_display', {
 					category: trackingCategory,
 					design_type: design.design_type,
 					is_premium: design.is_premium,
 					is_premium_available: isPremiumThemeAvailable,
-					slug: design.slug + variationSlugSuffix,
+					slug: design.slug,
 					is_virtual: design.is_virtual,
 				} );
 
@@ -176,21 +172,18 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	const { __ } = useI18n();
 	const [ _selectedStyleVariation, setSelectedStyleVariation ] = useState< StyleVariation >();
 
-	const { preselected_style_variation, style_variations = [] } = design;
+	const { style_variations = [] } = design;
 	const currentSiteCanInstallWoo = currentPlanFeatures?.includes( FEATURE_WOOP ) ?? false;
 	const designIsBundledWithWoo = design.is_bundled_with_woo_commerce;
 
-	const selectedStyleVariation = _selectedStyleVariation ?? preselected_style_variation;
+	const selectedStyleVariation = _selectedStyleVariation;
 	const isDefaultVariation = ! selectedStyleVariation || selectedStyleVariation.slug === 'default';
 
 	const title = isDefaultVariation
 		? design.title
 		: `${ design.title } – ${ selectedStyleVariation.title }`;
 
-	let isPremium = design.is_premium || ( shouldLimitGlobalStyles && ! isDefaultVariation );
-	if ( preselected_style_variation && isDefaultVariation ) {
-		isPremium = false;
-	}
+	const isPremium = design.is_premium || ( shouldLimitGlobalStyles && ! isDefaultVariation );
 	const shouldUpgrade = isPremium && ! isPremiumThemeAvailable && ! hasPurchasedTheme;
 
 	function getPricingDescription() {
@@ -215,9 +208,7 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 			badge = <WooCommerceBundledBadge />;
 		} else if ( isPremium ) {
 			const showStyleVariationTooltip =
-				! isDefaultVariation &&
-				shouldUpgrade &&
-				( preselected_style_variation || ! design.is_premium );
+				! isDefaultVariation && shouldUpgrade && ! design.is_premium;
 			const tooltipText = showStyleVariationTooltip
 				? __( 'Unlock this style, and tons of other features, by upgrading to a Premium plan.' )
 				: undefined;
@@ -274,7 +265,6 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 									setSelectedStyleVariation( variation );
 								} }
 								selectedVariation={ selectedStyleVariation }
-								firstVariation={ preselected_style_variation }
 								onMoreClick={ () => onPreview( design ) }
 							/>
 						</div>

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -170,13 +170,12 @@ const DesignButton: React.FC< DesignButtonProps > = ( {
 	shouldLimitGlobalStyles,
 } ) => {
 	const { __ } = useI18n();
-	const [ _selectedStyleVariation, setSelectedStyleVariation ] = useState< StyleVariation >();
+	const [ selectedStyleVariation, setSelectedStyleVariation ] = useState< StyleVariation >();
 
 	const { style_variations = [] } = design;
 	const currentSiteCanInstallWoo = currentPlanFeatures?.includes( FEATURE_WOOP ) ?? false;
 	const designIsBundledWithWoo = design.is_bundled_with_woo_commerce;
 
-	const selectedStyleVariation = _selectedStyleVariation;
 	const isDefaultVariation = ! selectedStyleVariation || selectedStyleVariation.slug === 'default';
 
 	const title = isDefaultVariation

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -99,7 +99,6 @@ export interface Design {
 	software_sets?: SoftwareSet[];
 	is_bundled_with_woo_commerce?: boolean;
 	is_virtual?: boolean;
-	preselected_style_variation?: StyleVariation; // Preselected style variation on virtual themes.
 
 	/** @deprecated used for Gutenboarding (/new flow) */
 	stylesheet?: string;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/75123

## Proposed Changes

We decided to don't go ahead with showing style variations as separated designs (pbxNRc-2n5-p2#comment-4210), since the A/B test has proven that less overall designs are selected, so this PR removes the code needed by the A/B test and simplifies the logic since now we only have one type of virtual themes (pattern-based designs).

## Testing Instructions

- Use the Calypso live link below
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_SLUG>`
- Make sure no style variations are displayed as separate items
- Watch for regressions and make sure you can select a design as before
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_SLUG>&flags=virtual-themes/onboarding`
- Make sure pattern-based virtual themes are displayed as separate items
- Watch for regressions and make sure you can select a pattern-based design as before