### PR TITLE
Update categories dropdown menu z-index

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -101,6 +101,7 @@ $z-layers: (
 		".site-selector": 10,
 		".layout__secondary .site-selector": 10,
 		".range__label": 10,
+		".categories__menu .components-popover": 10,
 		".sticky-panel.is-sticky .sticky-panel__content": 20,
 
 		".main": 20,

--- a/client/my-sites/plugins/categories/index.tsx
+++ b/client/my-sites/plugins/categories/index.tsx
@@ -5,6 +5,8 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { ALLOWED_CATEGORIES, useCategories } from './use-categories';
 import { useGetCategoryUrl } from './use-get-category-url';
 
+import './style.scss';
+
 export type Category = {
 	menu: string;
 	title: string;

--- a/client/my-sites/plugins/categories/style.scss
+++ b/client/my-sites/plugins/categories/style.scss
@@ -1,0 +1,5 @@
+.categories__menu {
+	.components-popover {
+		z-index: z-index( 'root', '.categories__menu .components-popover' );
+	}
+}

--- a/client/my-sites/plugins/categories/style.scss
+++ b/client/my-sites/plugins/categories/style.scss
@@ -1,5 +1,5 @@
 .categories__menu {
 	.components-popover {
-		z-index: z-index( 'root', '.categories__menu .components-popover' );
+		z-index: z-index("root", ".categories__menu .components-popover");
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #69528

## Proposed Changes

This PR updates the z-index value of the categories dropdown menu. As the original z-index value is defined in the dropdown component, additional CSS needed to be added to the categories component to override the menu's z-index via specificity.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins`
* Click the **More ** button on the right side of the categories toolbar
* Scroll the page down
* Check that the dropdown menu is displayed below both the search header and the masterbar

| Before | After |
|--------|--------|
| ![CleanShot 2023-03-30 at 16 01 15@2x](https://user-images.githubusercontent.com/11555574/228879159-21266bac-304c-4a70-81ab-316809aa5911.png) | ![CleanShot 2023-03-30 at 16 00 54@2x](https://user-images.githubusercontent.com/11555574/228879180-7a67880e-6245-4f4f-9e0d-42b457991dcf.png) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
