### PR TITLE
Backup Clone Flow - Remove copy button in Calypso Blue

### DIFF
--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -49,7 +49,7 @@ const ActivityLogV2: FunctionComponent = () => {
 				</div>
 			</div>
 			<div className="activity-log-v2__header-right">
-				{ selectedSiteSlug && (
+				{ isJetpackCloud() && selectedSiteSlug && (
 					<Tooltip
 						text={ translate(
 							'To test your site changes, migrate or keep your data safe in another site'

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -199,27 +199,29 @@ function BackupStatus( {
 	return (
 		<div className="backup__main-wrap">
 			<div className="backup__last-backup-status">
-				<div className="backup__header">
-					<div className="backup__header-left">
-						<div className="backup__header-title">{ translate( 'Latest Backups' ) }</div>
-						<div className="backup__header-text">
-							{ translate( 'This is a list of your latest generated backups' ) }
+				{ isJetpackCloud() && (
+					<div className="backup__header">
+						<div className="backup__header-left">
+							<div className="backup__header-title">{ translate( 'Latest Backups' ) }</div>
+							<div className="backup__header-text">
+								{ translate( 'This is a list of your latest generated backups' ) }
+							</div>
+						</div>
+						<div className="backup__header-right">
+							{ siteSlug && (
+								<Tooltip
+									text={ translate(
+										'To test your site changes, migrate or keep your data safe in another site'
+									) }
+								>
+									<Button className="backup__clone-button" href={ backupClonePath( siteSlug ) }>
+										{ translate( 'Copy this site' ) }
+									</Button>
+								</Tooltip>
+							) }
 						</div>
 					</div>
-					<div className="backup__header-right">
-						{ siteSlug && (
-							<Tooltip
-								text={ translate(
-									'To test your site changes, migrate or keep your data safe in another site'
-								) }
-							>
-								<Button className="backup__clone-button" href={ backupClonePath( siteSlug ) }>
-									{ translate( 'Copy this site' ) }
-								</Button>
-							</Tooltip>
-						) }
-					</div>
-				</div>
+				) }
 
 				{ ! isAtomic && ( needCredentials || areCredentialsInvalid ) && <EnableRestoresBanner /> }
 				{ ! needCredentials && ( ! areCredentialsInvalid || isAtomic ) && hasRealtimeBackups && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This removes the entry point to the new Copy flow we added for Jetpack Cloud on WordPress.com.  There are some updates for WordPress.com styling to the Activity Log we'll want to make before enabling it full.

## Testing Instructions

Check the live branches on a site with Backups enabled to ensure
- Jetpack Cloud Activity Log has a Copy Site button
- Jetpack Cloud Backups page has a Copy Site button
- WordPress.com Activity Log has no Copy Site button
- WordPress.com Backups page has no Copy Site button and no 'Latest Backups' header

Jetpack Cloud
<img width="711" alt="Screen Shot 2023-03-30 at 10 18 45 AM" src="https://user-images.githubusercontent.com/1992658/228866977-f64cb43e-2326-4382-8447-2980fb0d775f.png">
<img width="753" alt="Screen Shot 2023-03-30 at 10 18 38 AM" src="https://user-images.githubusercontent.com/1992658/228867000-c7c8aa6a-fa0e-44c6-81e6-9b7e95efdf58.png">

WordPress.com
<img width="759" alt="Screen Shot 2023-03-30 at 10 18 55 AM" src="https://user-images.githubusercontent.com/1992658/228867056-66aaad24-f726-4290-b4b7-2af9bbfe1356.png">
<img width="1108" alt="Screen Shot 2023-03-30 at 10 19 02 AM" src="https://user-images.githubusercontent.com/1992658/228867075-d631b27c-410e-4e07-a217-20d71749655d.png">



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
