### PR TITLE
Apply responsive styles to dedicated notifications page

### DIFF
--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -216,4 +216,18 @@ div.reader-notifications__panel {
 		}
 	}
 }
-
+@media only screen and (max-width: 783px) {
+	div.reader-notifications__panel #wpnc-panel.wpnc__main {
+		&.wpnt-open {
+			left: 0;
+			min-width: 100%;
+		}
+		.wpnc__list-view .wpnc__selected-note {
+			box-shadow: none;
+		}
+		.wpnc__single-view {
+			animation-name: wpnc__slideIn;
+			left: 0;
+		}
+	}
+}

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -225,6 +225,10 @@ div.reader-notifications__panel {
 		.wpnc__list-view .wpnc__selected-note {
 			box-shadow: none;
 		}
+		.wpnc__note-list {
+			max-width: 400px;
+			right: 0;
+		}
 		.wpnc__single-view {
 			animation-name: wpnc__slideIn;
 			left: 0;


### PR DESCRIPTION
## Description

We just deployed the new dedicated notifications page, but failed to add responsive styles. This PR should remedy that.

### Before

<img width="392" alt="before" src="https://user-images.githubusercontent.com/5634774/228873298-65eb9899-82bc-408a-8b17-d0750f6e84f0.png">

### After

![after](https://user-images.githubusercontent.com/5634774/228873332-8d44bf8b-edd4-49e3-b113-31892a2a2bcd.gif)
