### PR TITLE
Fix possibly undefined content window

### DIFF
--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -358,6 +358,10 @@ function onload() {
  */
 
 function onmessage( e ) {
+	// If the iframe was never loaded, this message might be unrelated.
+	if ( ! iframe?.contentWindow ) {
+		return;
+	}
 	debug( 'onmessage' );
 
 	// Filter out messages from different origins


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Fixes a sentry error. We are listening to window message events, which trigger `onmessage`, but this isn't directly related to the iframe. As a result, we need to do a quick check that the iframe actually loaded before doing anything.

## Testing Instructions
Verify code 