### PR TITLE
Stepper: Update processing screen background for some flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/index.tsx
@@ -1,9 +1,15 @@
-import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
+import {
+	NEWSLETTER_FLOW,
+	LINK_IN_BIO_FLOW,
+	LINK_IN_BIO_TLD_FLOW,
+	isNewsletterOrLinkInBioFlow,
+} from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import PropTypes from 'prop-types';
 import { useRef, useState, useEffect } from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { LoadingBar } from 'calypso/components/loading-bar';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useInterval } from 'calypso/lib/interval/use-interval';
 import './style.scss';
 
@@ -81,10 +87,14 @@ export default function TailoredFlowPreCheckoutScreen( { flowName }: { flowName:
 		<div className="processing-step__container">
 			<div className="processing-step">
 				<h1 className="processing-step__progress-step">{ steps.current[ currentStep ]?.title }</h1>
-				<LoadingBar
-					className="processing-step__progress-bar"
-					progress={ ! hasStarted ? /* initial 10% progress */ 0.1 : progress }
-				/>
+				{ isNewsletterOrLinkInBioFlow( flowName ) ? (
+					<LoadingBar
+						className="processing-step__progress-bar"
+						progress={ ! hasStarted ? /* initial 10% progress */ 0.1 : progress }
+					/>
+				) : (
+					<LoadingEllipsis />
+				) }
 			</div>
 
 			{ flowName === NEWSLETTER_FLOW && (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/tailored-flow-precheckout-screen/style.scss
@@ -69,9 +69,7 @@
 		}
 	}
 
-	.newsletter,
-	.free,
-	.update-design {
+	.newsletter {
 		.processing-step__container {
 			background-color: #a2dafe;
 			background-image:

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -150,7 +150,9 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 	}
 
 	useEffect( () => {
-		setProgress( 0.1 );
+		if ( ! isFreeFlow( flow ) ) {
+			setProgress( 0.1 );
+		}
 		if ( submit ) {
 			setPendingAction( createSite );
 			submit();


### PR DESCRIPTION
### Proposed Changes

Addresses this issue: https://github.com/Automattic/wp-calypso/issues/75028

This PR includes the following changes: 
  - Use default white background for the processing screen for general flows: free, write, build. 
  - Use default white background for the processing screen for general flows - after you arrive at Launchpad, and then click Select Design to update your theme.
  - For the default processing screens, use ellipsis rather than a progress bar.
  
**For reference, before this change, the processing screen looks like this for certain parts of the free, write, and build flows.**

![228243348-700959a8-5d9a-41c2-a0b3-5f719a958fd4](https://user-images.githubusercontent.com/21228350/228936689-df468986-3918-49af-a24d-be22b6606cab.png)

** After this PR, the processing screen should look roughly like this for all parts of free, write, and build flows.**

<img width="1512" alt="Screenshot on 2023-03-30 at 13-00-21" src="https://user-images.githubusercontent.com/21228350/228937747-025b3622-c171-42e4-95ec-ce3ab43da303.png">


### Testing Instructions

**Review Time: Short**
**Testing Time: Medium** (easy, but need to test many flows)

1. Check out this branch and run yarn and yarn start if needed OR you can use the calypso live link.
2. Start a `free` site at http://calypso.localhost:3000/setup/free/intro, go through to Launchpad. Then click Select Design to update your design. Ensure all processing screens (both in the early part of the flow, and for updating design) are the white version above. 
3. Start a `build` site at http://calypso.localhost:3000/start, go through to Launchpad. Then click Select Design to update your design. Ensure all processing screens (both in the early part of the flow, and for updating design) are the white version above. 
4. Start a `wrute` site at http://calypso.localhost:3000/start, go through to Launchpad. Then click Select Design to update your design. Ensure all processing screens (both in the early part of the flow, and for updating design) are the white version above. 
5. Start a `newsletter` site at http://calypso.localhost:3000/setup/newsletter/intro, go through to Launchpad. Then click Select Design to update your design. Ensure all processing screens (both in the early part of the flow, and for updating design) are the customized newsletter screens (not white). 
6. Start a `link in bio` site at http://calypso.localhost:3000/setup/link-in-bio/intro, go through to Launchpad. Then click Select Design to update your design. Ensure all processing screens (both in the early part of the flow, and for updating design) are the customize LIB screens (note white). 
