### PR TITLE
Launchpad: Add tracking to launchpad celebration modal upsell

### DIFF
--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -2,14 +2,17 @@ import { Gridicon, ConfettiAnimation } from '@automattic/components';
 import { Button, Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useRef } from 'react';
+import { useDispatch } from 'react-redux';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import Tooltip from 'calypso/components/tooltip';
 import { omitUrlParams } from 'calypso/lib/url';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { createSiteDomainObject } from 'calypso/state/sites/domains/assembler';
 
 import './celebrate-launch-modal.scss';
 
 function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const isPaidPlan = ! site?.plan?.is_free;
 	const isBilledMonthly = site?.plan?.product_slug?.includes( 'monthly' );
@@ -75,7 +78,18 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 		return (
 			<div className="launched__modal-upsell">
 				<div className="launched__modal-upsell-content">{ contentElement }</div>
-				<Button isLarge isPrimary href={ buttonHref }>
+				<Button
+					isLarge
+					isPrimary
+					href={ buttonHref }
+					onClick={ () =>
+						dispatch(
+							recordTracksEvent( `calypso_launchpad_celebration_modal_upsell_clicked`, {
+								product_slug: site?.plan?.product_slug,
+							} )
+						)
+					}
+				>
 					<span>{ buttonText }</span>
 				</Button>
 			</div>


### PR DESCRIPTION
## Estimated Time to Test / Review:
- Test -> Short
- Review -> Short 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74712

## Proposed Changes

* Dispatches tracks event when celebration modal upsell button is clicked

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new launchpad enabled site calypso.localhost:3000/setup/free/intro
* Follow onboarding steps until you reach the Launchpad
* Launch the site
* Verify that the celebration modal appears as expected
* Open tracks vigilante chrome dev tool
* Click on the claim a domain button in the celebration modal
* Verify that the tracks event is being dispatched ( search for `calypso_launchpad_celebration_modal_upsell_clicked` in the vigilante UI )

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
