### PR TITLE
Launchpad: Update useQuery implementation for fetching data

### DIFF
--- a/client/data/sites/use-launchpad.ts
+++ b/client/data/sites/use-launchpad.ts
@@ -4,34 +4,18 @@ import wpcom from 'calypso/lib/wp';
 export const fetchLaunchpad = ( siteSlug: string | null ) => {
 	const slug = encodeURIComponent( siteSlug as string );
 
-	return (
-		wpcom.req
-			.get( {
-				path: `/sites/${ slug }/launchpad`,
-				apiNamespace: 'wpcom/v2',
-			} )
-			// There are unidentified situations where the fetch launchpad
-			// get request fail. We introduce error handling that returns
-			// placeholder data as a temporary stopgap to prevent noisy sentry
-			// logs from being generated.
-			.catch( () => {
-				return Promise.resolve( {
-					checklist_statuses: [],
-					launchpad_screen: undefined,
-					site_intent: '',
-				} );
-			} )
-	);
+	return wpcom.req.get( {
+		path: `/sites/${ slug }/launchpad`,
+		apiNamespace: 'wpcom/v2',
+	} );
 };
 
-export const useLaunchpad = ( siteSlug: string | null, cache = true ) => {
+export const useLaunchpad = ( siteSlug: string | null ) => {
 	const key = [ 'launchpad', siteSlug ];
-	return useQuery( key, () => siteSlug && fetchLaunchpad( siteSlug ), {
-		meta: {
-			persist: cache,
-		},
-		enabled: true,
-		placeholderData: {
+	return useQuery( key, () => fetchLaunchpad( siteSlug ), {
+		cacheTime: 0,
+		retry: 3,
+		initialData: {
 			checklist_statuses: [],
 			launchpad_screen: undefined,
 			site_intent: '',

--- a/client/data/sites/use-launchpad.ts
+++ b/client/data/sites/use-launchpad.ts
@@ -13,8 +13,8 @@ export const fetchLaunchpad = ( siteSlug: string | null ) => {
 export const useLaunchpad = ( siteSlug: string | null ) => {
 	const key = [ 'launchpad', siteSlug ];
 	return useQuery( key, () => fetchLaunchpad( siteSlug ), {
-		staleTime: 0,
 		refetchOnMount: true,
+		staleTime: 0,
 		retry: 3,
 		initialData: {
 			checklist_statuses: [],

--- a/client/data/sites/use-launchpad.ts
+++ b/client/data/sites/use-launchpad.ts
@@ -13,7 +13,8 @@ export const fetchLaunchpad = ( siteSlug: string | null ) => {
 export const useLaunchpad = ( siteSlug: string | null ) => {
 	const key = [ 'launchpad', siteSlug ];
 	return useQuery( key, () => fetchLaunchpad( siteSlug ), {
-		cacheTime: 0,
+		staleTime: 0,
+		refetchOnMount: true,
 		retry: 3,
 		initialData: {
 			checklist_statuses: [],

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -35,6 +35,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	const verifiedParam = useQuery().get( 'verified' );
 	const site = useSite();
 	const {
+		isError: launchpadFetchError,
 		data: { launchpad_screen: launchpadScreenOption, checklist_statuses, site_intent },
 	} = useLaunchpad( siteSlug );
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
@@ -47,6 +48,10 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		( select ) => ( select( SITE_STORE ) as SiteSelect ).getFetchingSiteError(),
 		[]
 	);
+
+	if ( ! siteSlug || fetchingSiteError?.error || launchpadFetchError ) {
+		window.location.replace( '/home' );
+	}
 
 	if (
 		! isLoggedIn ||
@@ -66,10 +71,6 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	) {
 		saveSiteSettings( site?.ID, { launchpad_screen: 'off' } );
 		redirectToSiteHome( siteSlug, flow );
-	}
-
-	if ( ! siteSlug || fetchingSiteError?.error ) {
-		window.location.replace( '/home' );
 	}
 
 	function redirectToSiteHome( siteSlug: string | null, flow: string | null ) {


### PR DESCRIPTION
### Proposed Changes

Addresses this issue: https://github.com/Automattic/wp-calypso/issues/75050

This PR tweaks our useLaunchpad hook, which uses react query's useQuery to fetch data from our launchpad endpoint. Specifically, it makes the following changes: 
   - Remove the catch statement from fetchLaunchpad() that was returning data in case of an error. This was added in [this PR](https://github.com/Automattic/wp-calypso/pull/75049) as a quick fix to stop some sentry errors. Those should be resolved more robustly now. 
   - Provide default data via the initialData option rather than placeholderData option. The difference is that if the request fails, the initialData is still be available to our component whereas placeholderData is replaced with undefined in the same situation. Data being undefined is what was triggering the type error in the issue above, because we're trying to immediately destructure that data from the hook. 
   - Added a retry option of 3. This will insure that if our first call to launchpad fails, we'll try to fetch the data twice more before react query returns an error. When we first tried updating this, we found that the first request was sometimes failing the first time you land on the launchpad screen. I'm not 100% sure the reason for the intermittent initial failures, but retrying before sending an error back resolves that. 
   - Set staleTime to zero and refetchOnMount to true. Technically refetchOnMount defaults to true, but it's important enough here that I think it's worth being explicit on that option. These together will just ensure that fresh launchpad data is loaded each time someone comes back to the launchpad screen.
   
Note: one other concern I had with this implementation is that with staleTime: 0, we would be constantly running data fetches on every component re-render. But React Query is smart enough to not do that. There are not excessive data requests with this solution. 
   
### Testing Instructions

**Review Time: Short**
**Testing Time: Short**

1. Checkout this branch and run yarn and yarn start if needed. 
2. Go through a couple of Launchpad flows and confirm that the launchpad screen loads correctly, and that task statuses update correctly as you go through the steps. 
3. Confirm that if you remove the siteSlug from the Launchpad ie, `http://calypso.localhost:3000/setup/free/launchpad?siteSlug=`, you are redirected to /home and no type errors show in the console.
4. Confirm that if you provide a malformed siteSlug, `http://calypso.localhost:3000/setup/free/launchpad?siteSlug=randomstring`,  as part of the Launchpad url, you are redirected to /home and no type errors show in the console. 