### PR TITLE
Logging: Render basic "is empty" state for Site Logs

### DIFF
--- a/client/my-sites/site-logs/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/index.tsx
@@ -1,3 +1,4 @@
+import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { memo, useMemo } from 'react';
 import { useSelector } from 'react-redux';
@@ -21,6 +22,7 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 	isLoading,
 }: SiteLogsTableProps ) {
 	const moment = useLocalizedMoment();
+	const { __ } = useI18n();
 	const columns = useSiteColumns( logs );
 	const siteGmtOffset = useSelector( ( state ) => {
 		const siteId = getSelectedSiteId( state );
@@ -29,6 +31,10 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 
 	if ( isLoading && ! logs?.length ) {
 		return <Skeleton />;
+	}
+
+	if ( ! isLoading && ! logs?.length ) {
+		return <>{ __( 'No log entries within this time range.' ) }</>;
 	}
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/1996

## Proposed Changes

* Renders a very basic "is empty" state in the Site Logs section

It's fairly basic but good to get something in there before shipping. Feel free to tweak this PR to make improvements.

<img width="958" alt="CleanShot 2023-03-31 at 11 11 13@2x" src="https://user-images.githubusercontent.com/1500769/228975454-b08fb6bf-6232-4f7d-85ea-4c9fe4bdbb06.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/site-logs`
* Check that when there are no logs you see the empty state.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
