### PR TITLE
Launchpad: Wait for data to fetch before rendering celebration modal

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -57,7 +57,11 @@ const Home = ( {
 
 	const { data: layout, isLoading } = useHomeLayoutQuery( siteId );
 
-	const { data: allDomains = [], isSuccess } = useGetDomainsQuery( site?.ID ?? null, {
+	const {
+		data: allDomains = [],
+		isSuccess,
+		isFetching,
+	} = useGetDomainsQuery( site?.ID ?? null, {
 		retry: false,
 	} );
 
@@ -83,10 +87,10 @@ const Home = ( {
 	}, [ detectedCountryCode, sitePlan, isNew7DUser ] );
 
 	useEffect( () => {
-		if ( getQueryArgs().celebrateLaunch === 'true' && isSuccess ) {
+		if ( getQueryArgs().celebrateLaunch === 'true' && ! isFetching && isSuccess ) {
 			setCelebrateLaunchModalIsOpen( true );
 		}
-	}, [ isSuccess ] );
+	}, [ isFetching, isSuccess ] );
 
 	if ( ! canUserUseCustomerHome ) {
 		const title = translate( 'This page is not available on this site.' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74712

## Proposed Changes

* Prevent Launchpad celebration modal from rendering until requisite data has been fetched

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* `yarn start`
* Create a launchpad site through any flow that requires the site to be launched ( [write](wordpress.com/start), [build](wordpress.com/start), `link-in-bio`, etc. )
* Launch the site from the Launchpad
* Confirm that the domain upsell is rendered
* Verify that the upsell text is correct and that the upsell button behaves as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
