### PR TITLE
Odyssey: Fix missing `currentUser.user.localeSlug` in `intial_state`

### DIFF
--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -30,11 +30,21 @@ async function AppBoot() {
 		sites,
 	} );
 
+	let initialState = config( 'intial_state' );
+	// Fix missing user.localeSlug in `intial_state`.
+	initialState = {
+		...initialState,
+		currentUser: {
+			...initialState.currentUser,
+			user: { localeSlug: config( 'i18n_locale_slug' ) },
+		},
+	};
+
 	const queryClient = new QueryClient();
 
 	const store = createStore(
 		rootReducer,
-		config( 'intial_state' ) ?? {},
+		initialState,
 		compose(
 			consoleDispatcher,
 			addReducerEnhancer,

--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -36,7 +36,7 @@ async function AppBoot() {
 		...initialState,
 		currentUser: {
 			...initialState.currentUser,
-			user: { localeSlug: config( 'i18n_locale_slug' ) },
+			user: { ...initialState.currentUser.user, localeSlug: config( 'i18n_locale_slug' ) },
 		},
 	};
 


### PR DESCRIPTION
## Proposed Changes

`currentUser.user.localeSlug` is used in several places to determine the date format for user in several recent changes, which weren't in the `intial_state` before, for example:

https://github.com/Automattic/wp-calypso/blob/907e7b5adf42921a24bce285845254bea075f4cb/client/my-sites/stats/all-time-highlights-section/index.tsx#L68

The PR adds `currentUser.user.localeSlug` to be the same as the site locale for Odyssey.

## Testing Instructions

* Follow instructions in Option 1 (test locally)
* Open Insights page on Odyssey Stats
* Ensure it doesn't crash
* Open a post detail page
* Ensure it doesn't crash

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
