### PR TITLE
Logging: Time range of downloaded logs should match what's shown in UI

### DIFF
--- a/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
@@ -49,7 +49,7 @@ export const SiteLogsToolbar = ( {
 }: Props ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
-	const { downloadLogs, state } = useSiteLogsDownloader();
+	const { downloadLogs, state } = useSiteLogsDownloader( { roundDateRangeToWholeDays: false } );
 	const siteGmtOffset = useCurrentSiteGmtOffset();
 
 	const isDownloading = state.status === 'downloading';

--- a/client/my-sites/site-logs/hooks/use-site-logs-downloader.ts
+++ b/client/my-sites/site-logs/hooks/use-site-logs-downloader.ts
@@ -83,7 +83,9 @@ interface UseSiteLogsDownloaderArgs {
 	endDateTime: Moment;
 }
 
-export const useSiteLogsDownloader = () => {
+export const useSiteLogsDownloader = ( {
+	roundDateRangeToWholeDays = true,
+}: { roundDateRangeToWholeDays?: boolean } = {} ) => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 	const localeDateFormat = moment.localeData().longDateFormat( 'L' );
@@ -132,8 +134,12 @@ export const useSiteLogsDownloader = () => {
 			return;
 		}
 
-		const startMoment = moment.utc( startDateTime, localeDateFormat ).startOf( 'day' );
-		const endMoment = moment.utc( endDateTime, localeDateFormat ).endOf( 'day' );
+		const startMoment = roundDateRangeToWholeDays
+			? moment.utc( startDateTime, localeDateFormat ).startOf( 'day' )
+			: moment.utc( startDateTime, localeDateFormat );
+		const endMoment = roundDateRangeToWholeDays
+			? moment.utc( endDateTime, localeDateFormat ).endOf( 'day' )
+			: moment.utc( endDateTime, localeDateFormat );
 
 		const dateFormat = 'YYYYMMDDHHmmss';
 		const startString = startMoment.format( dateFormat );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/dotcom-forge#2000
Fixes Automattic/dotcom-forge#2073

## Proposed Changes

* Add `roundDateRangeToWholeDays` mode to the `useSiteLogsDownloader` hook
* With mode enabled, we do the existing behaviour of rounding the downloaded log range to the nearest day. This prevents and change in behaviour to the logging UI in `/hosting-config`
* When the mode is disabled, we download logs using the exact time ranges passed to the download function
* Disables `roundDateRangeToWholeDays` on the Site Logs page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Download logs from `/hosting-config` is unchanged
* Downloading logs from `/site-logs` now matches the exact time range shown in the UI

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
