### PR TITLE
WoA Logging i1: Fix download logs

### DIFF
--- a/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
@@ -91,7 +91,9 @@ export const SiteLogsToolbar = ( {
 					disabled={ isDownloading }
 					isBusy={ isDownloading }
 					isPrimary
-					onClick={ () => downloadLogs( { logType, startDateTime, endDateTime } ) }
+					onClick={ () =>
+						downloadLogs( { logType, startDateTime, endDateTime, sortOrder: 'desc' } )
+					}
 				>
 					{ translate( 'Download' ) }
 				</Button>

--- a/client/my-sites/site-logs/hooks/use-site-logs-downloader.ts
+++ b/client/my-sites/site-logs/hooks/use-site-logs-downloader.ts
@@ -81,6 +81,7 @@ interface UseSiteLogsDownloaderArgs {
 	logType: SiteLogsTab;
 	startDateTime: Moment;
 	endDateTime: Moment;
+	sortOrder?: 'asc' | 'desc';
 }
 
 export const useSiteLogsDownloader = () => {
@@ -114,6 +115,7 @@ export const useSiteLogsDownloader = () => {
 		logType,
 		startDateTime,
 		endDateTime,
+		sortOrder = 'asc',
 	}: UseSiteLogsDownloaderArgs ) => {
 		dispatch( {
 			type: 'DOWNLOAD_START',
@@ -132,8 +134,8 @@ export const useSiteLogsDownloader = () => {
 			return;
 		}
 
-		const startMoment = moment.utc( startDateTime, localeDateFormat ).startOf( 'day' );
-		const endMoment = moment.utc( endDateTime, localeDateFormat ).endOf( 'day' );
+		const startMoment = moment.utc( startDateTime, localeDateFormat );
+		const endMoment = moment.utc( endDateTime, localeDateFormat );
 
 		const dateFormat = 'YYYYMMDDHHmmss';
 		const startString = startMoment.format( dateFormat );
@@ -169,6 +171,7 @@ export const useSiteLogsDownloader = () => {
 					{
 						start: startTime,
 						end: endTime,
+						sort_order: sortOrder,
 						page_size: 10000,
 						scroll_id: scrollId,
 					}


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/2073

## Proposed Changes

- remove StartOfDay method that was fetching more records than displayed on the UI
- set the sort order to same as the UI for consistency

## Testing Instructions

- Go to /site-logs/:atomicSite
- Set dates to view some logs
- Download the logs
- Verify the number of logs download are the same as the UI

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
