### PR TITLE
Logging: if clear is pressed in the date picker, use initial value

### DIFF
--- a/client/my-sites/site-logs/main.tsx
+++ b/client/my-sites/site-logs/main.tsx
@@ -132,6 +132,13 @@ export function SiteLogs( { pageSize = DEFAULT_PAGE_SIZE }: { pageSize?: number 
 			: null;
 
 	const handleDateTimeChange = ( startTime: Moment, endTime: Moment ) => {
+		// check for "clear" pressed
+		if ( ! startTime.isValid() ) {
+			startTime = getLatestDateRange().startTime;
+		}
+		if ( ! endTime.isValid() ) {
+			endTime = getLatestDateRange().endTime;
+		}
 		setDateRange( { startTime, endTime } );
 		setAutoRefresh( false );
 		updateDateRangeQueryParam( { startTime, endTime } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* if the user clicked "clear" then it produced an invalid Moment date, which then caused an infinite loop. This PR checks for an invalid date and replaces it with the initial value. 

![image](https://user-images.githubusercontent.com/6851384/229021274-738bff65-9052-4321-a778-ab3a1f53d883.png)

## Testing Instructions

* First reproduce it on trunk by going to `site-logs/:my-atomic-site` and pressing "clear" on any date picker. You should see a WSOD
* Checkout this branch and see the initial value is used instead

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
