### PR TITLE
Logging: Add `woa-logging-moved` flag for hiding log downloading from `/hosting-config`

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -198,7 +198,9 @@ class Hosting extends Component {
 								<WebServerSettingsCard disabled={ isDisabled } />
 								<RestorePlanSoftwareCard disabled={ isDisabled } />
 								<CacheCard disabled={ isDisabled } />
-								<WebServerLogsCard disabled={ isDisabled } />
+								{ ! isEnabled( 'woa-logging-moved' ) && (
+									<WebServerLogsCard disabled={ isDisabled } />
+								) }
 							</Column>
 							<Column type="sidebar">
 								<SiteBackupCard disabled={ isDisabled } />

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -34,6 +34,7 @@ import {
 	getManagePluginsUrl,
 	getPluginsUrl,
 	getSettingsUrl,
+	getSiteLogsUrl,
 	isCustomDomain,
 	isNotAtomicJetpack,
 	isP2Site,
@@ -89,6 +90,19 @@ const SettingsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_settings_click' ) }
 		>
 			{ __( 'Settings' ) }
+		</MenuItemLink>
+	);
+};
+
+const SiteLogsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
+	const { __ } = useI18n();
+
+	return (
+		<MenuItemLink
+			href={ getSiteLogsUrl( site.slug ) }
+			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_site_logs_click' ) }
+		>
+			{ __( 'Site logs' ) }
 		</MenuItemLink>
 	);
 };
@@ -289,6 +303,7 @@ function useSubmenuItems( site: SiteExcerptData ) {
 				sectionName: 'cache',
 			},
 			{
+				condition: ! isEnabled( 'woa-logging-moved' ),
 				label: __( 'Web server logs' ),
 				href: `/hosting-config/${ siteSlug }#web-server-logs`,
 				sectionName: 'logs',
@@ -387,7 +402,7 @@ export const SitesEllipsisMenu = ( {
 		recordTracks,
 	};
 
-	const hasHostingPage = ! isNotAtomicJetpack( site ) && ! isP2Site( site );
+	const hasHostingFeatures = ! isNotAtomicJetpack( site ) && ! isP2Site( site );
 	const { shouldShowSiteCopyItem, startSiteCopy } = useSiteCopy( site );
 	const hasCustomDomain = isCustomDomain( site.slug );
 	const isLaunched = site.launch_status !== 'unlaunched';
@@ -403,7 +418,8 @@ export const SitesEllipsisMenu = ( {
 				<SiteMenuGroup>
 					{ ! isWpcomStagingSite && ! isLaunched && <LaunchItem { ...props } /> }
 					<SettingsItem { ...props } />
-					{ hasHostingPage && <HostingConfigurationSubmenu { ...props } /> }
+					{ hasHostingFeatures && <HostingConfigurationSubmenu { ...props } /> }
+					{ hasHostingFeatures && isEnabled( 'woa-logging' ) && <SiteLogsItem { ...props } /> }
 					{ ! isP2Site( site ) && <ManagePluginsItem { ...props } /> }
 					{ site.is_coming_soon && <PreviewSiteModalItem { ...props } /> }
 					{ ! isWpcomStagingSite && shouldShowSiteCopyItem && (

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -12,6 +12,10 @@ export const getSettingsUrl = ( slug: string ) => {
 	return `/settings/general/${ slug }`;
 };
 
+export const getSiteLogsUrl = ( slug: string ) => {
+	return `/site-logs/${ slug }`;
+};
+
 export const getPluginsUrl = ( slug: string ) => {
 	return `/plugins/${ slug }`;
 };

--- a/config/development.json
+++ b/config/development.json
@@ -201,6 +201,7 @@
 		"wpcom-user-bootstrap": false,
 		"yolo/staging-sites-i1": true,
 		"newsletter/stats": true,
-		"woa-logging": true
+		"woa-logging": true,
+		"woa-logging-moved": true
 	}
 }


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/2001

## Proposed Changes

* Adds new `woa-logging-moved`
* This flag
  * Hides `Web server logs` from `/hosting-config`
  * Hides `Hosting configuration > Web server logs` menu item from SMP
* The `woa-logging` flag now
   * Adds `Site logs` menu item to SMP

The reason there are two flags, rather than hanging everything off the one `woa-logging` flag, is that deploying this project is going to take multiple steps and so we need to be able to control only hiding the Web server log card from `/hosting-config` once we're 100% sure the "Site logs" menu item is available in the sidebar.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Should be no changes in production
* Check the right things show and hide based on flag settings.
* You can test on `calypso.live` by appending `?flags=woa-logging` or `?flags=woa-logging-moved` to the URL

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
