### PR TITLE
Virtual Theme: Fix error due to pattern not found when going to the pattern assembler

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -3,6 +3,7 @@ import { keyBy } from '@automattic/js-utils';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { ONBOARD_STORE } from '../../../../../stores';
+import { decodePatternId } from '../utils';
 import type { Pattern, Category } from '../types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { Design } from '@automattic/design-picker/src/types';
@@ -66,25 +67,29 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 
 		const patternsById = keyBy( patterns, 'id' );
 		const categoriesByName = keyBy( categories, 'name' );
+		const selectedHeader = patternsById[ decodePatternId( header_pattern_ids[ 0 ] ) ];
+		const selectedFooter = patternsById[ decodePatternId( footer_pattern_ids[ 0 ] ) ];
 
-		if ( patternsById[ header_pattern_ids[ 0 ] ] ) {
-			setHeader( patternsById[ header_pattern_ids[ 0 ] ] );
+		if ( selectedHeader ) {
+			setHeader( selectedHeader );
 		}
 
-		if ( patternsById[ footer_pattern_ids[ 0 ] ] ) {
-			setFooter( patternsById[ footer_pattern_ids[ 0 ] ] );
+		if ( selectedFooter ) {
+			setFooter( selectedFooter );
 		}
 
 		setSections(
-			pattern_ids.map( ( patternId: string | number ) => {
-				const pattern = patternsById[ patternId ];
-				const category = categoriesByName[ pattern.categories[ 0 ] ];
-				return {
-					...pattern,
-					key: generateKey( pattern ),
-					category,
-				};
-			} )
+			pattern_ids
+				.map( ( patternId: string | number ) => patternsById[ decodePatternId( patternId ) ] )
+				.filter( Boolean )
+				.map( ( pattern: Pattern ) => {
+					const category = categoriesByName[ pattern?.categories[ 0 ] ];
+					return {
+						...pattern,
+						key: generateKey( pattern ),
+						category,
+					};
+				} )
 		);
 	}, [ patterns.length, categories ] );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -61,7 +61,13 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 	 * Initialize the default value from the recipe of the selected design when both patterns and categories are ready
 	 */
 	useEffect( () => {
-		if ( patterns.length === 0 || categories.length === 0 || ! selectedDesign?.recipe ) {
+		if (
+			patterns.length === 0 ||
+			categories.length === 0 ||
+			! selectedDesignRef.current?.recipe ||
+			// Avoid adding the preselected patterns from the virtual theme for now
+			selectedDesignRef.current?.is_virtual
+		) {
 			return;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -2,3 +2,6 @@ import { PATTERN_SOURCE_SITE_ID } from './constants';
 
 export const encodePatternId = ( patternId: number ) =>
 	`${ patternId }-${ PATTERN_SOURCE_SITE_ID }`;
+
+export const decodePatternId = ( encodedPatternId: number | string ) =>
+	`${ encodedPatternId }`.split( '-' )[ 0 ];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* When going to the Pattern Assembler from previewing the virtual theme, there is an error due to the pattern not being found. The reason is we try to restore the preselected patterns and styles from the recipe and we expected the pattern should be found but it's not true.
![Screenshot 2023-03-31 at 1 13 18 PM](https://user-images.githubusercontent.com/13596067/229029072-8616b590-4988-46f4-bdf2-b95003753f73.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup?siteSlug=<your_site>`
* Continue until you land on the Design Picker
* Select a virtual theme, e.g. Design your own: Link in Bio
* Select "Start designing" on the sidebar
* Ensure you're able to land on the Pattern Assembler successfully

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
