### PR TITLE
Loggign: Site logs download button label: "Download logs"

### DIFF
--- a/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-toolbar/index.tsx
@@ -93,7 +93,7 @@ export const SiteLogsToolbar = ( {
 					isPrimary
 					onClick={ () => downloadLogs( { logType, startDateTime, endDateTime } ) }
 				>
-					{ translate( 'Download' ) }
+					{ translate( 'Download logs' ) }
 				</Button>
 
 				{ isDownloading && <SiteLogsToolbarDownloadProgress { ...state } /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


A suggestion from @zaguiini to change the download button copy to "Download logs". This makes the button larger and therefore more prominent.

![CleanShot 2023-03-31 at 18 14 32@2x](https://user-images.githubusercontent.com/1500769/229029253-887fa2ee-0d2a-4e15-a64d-f31fcb6fe909.png)

I don't personally mind too much either way. Although as a `primary` button I think it's already pretty prominent.
