### PR TITLE
Site Assembler - Add category_count prop to the tracks event calypso_signup_pattern_assembler_category_click

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -178,13 +178,16 @@ const PatternAssembler = ( {
 
 	const trackEventContinue = () => {
 		const patterns = getPatterns();
+		const categories = patterns.map( ( { category } ) => category?.name );
+
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.CONTINUE_CLICK, {
 			pattern_types: [ header && 'header', sections.length && 'section', footer && 'footer' ]
 				.filter( Boolean )
 				.join( ',' ),
 			pattern_ids: patterns.map( ( { id } ) => id ).join( ',' ),
 			pattern_names: patterns.map( ( { name } ) => name ).join( ',' ),
-			pattern_categories: patterns.map( ( { category } ) => category?.name ).join( ',' ),
+			pattern_categories: categories.join( ',' ),
+			category_count: categories.length,
 			pattern_count: patterns.length,
 		} );
 		patterns.forEach( ( { id, name, category } ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -178,7 +178,7 @@ const PatternAssembler = ( {
 
 	const trackEventContinue = () => {
 		const patterns = getPatterns();
-		const categories = patterns.map( ( { category } ) => category?.name );
+		const categories = Array.from( new Set( patterns.map( ( { category } ) => category?.name ) ) );
 
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.CONTINUE_CLICK, {
 			pattern_types: [ header && 'header', sections.length && 'section', footer && 'footer' ]


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74827

## Proposed Changes

* Added a new prop called `category_count` to the event `calypso_signup_pattern_assembler_category_click` with the unique categories of the patterns added to the user's site

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Click on the Calypso live link on the first comment
- Create a new site and click "Start designing" from the bottom of the design picker
- Click `Sections`, then `Add patterns`
- Click on different categories to add **multiple** patterns from **multiple** categories
<img width="327" alt="Screenshot 2566-03-31 at 13 30 00" src="https://user-images.githubusercontent.com/1881481/229046564-bf43870d-61b4-4173-8325-d0a9f1f57d38.png">


- Using the extension Tracks vigilante verify that the event `calypso_signup_pattern_assembler_category_click` contains the prop `category_count` with the number of **unique** categories added.
<img width="777" alt="Screenshot 2566-03-31 at 13 32 06" src="https://user-images.githubusercontent.com/1881481/229046588-d3e1e8e2-586c-470b-9bbc-ec7ead0c35f1.png">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
