### PR TITLE
Site Assembler - Move the category click event to the events map constant

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
@@ -25,6 +25,11 @@ export const PATTERN_ASSEMBLER_EVENTS = {
 	SCREEN_FONTS_DONE_CLICK: 'calypso_signup_pattern_assembler_screen_fonts_done_click',
 
 	/**
+	 * Screen Category List
+	 */
+	SCREEN_CATEGORY_LIST_CATEGORY_CLICK: 'calypso_signup_pattern_assembler_category_click',
+
+	/**
 	 * Pattern Panels
 	 */
 	PATTERN_ADD_CLICK: 'calypso_signup_pattern_assembler_pattern_add_click',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -4,6 +4,7 @@ import { Icon, chevronRight } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
+import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import useCategoriesOrder from './hooks/use-categories-order';
 import NavigatorHeader from './navigator-header';
 import PatternListPanel from './pattern-list-panel';
@@ -53,7 +54,7 @@ const ScreenCategoryList = ( {
 	};
 
 	const trackEventCategoryClick = ( name: string ) => {
-		recordTracksEvent( 'calypso_signup_pattern_assembler_category_click', {
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_CATEGORY_LIST_CATEGORY_CLICK, {
 			pattern_category: name,
 		} );
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74827

## Proposed Changes

* Move the event `calypso_signup_pattern_assembler_category_click ` to the map `PATTERN_ASSEMBLER_EVENTS`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Click on the Calypso live link on the first comment
- Create a new site and click "Start designing" from the bottom of the design picker
- Click `Sections`, then `Add patterns`
- Click on categories
- Using the extension `Tracks vigilante` verify that the event `calypso_signup_pattern_assembler_category_click` is triggered

<img width="780" alt="Screenshot 2566-03-31 at 14 22 56" src="https://user-images.githubusercontent.com/1881481/229053098-770eec0a-f2d3-471f-ae2c-13c0fc45d3ee.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
