### PR TITLE
Add useSiteUnfollowMutation()

### DIFF
--- a/client/landing/subscriptions/site-list/site-row.tsx
+++ b/client/landing/subscriptions/site-list/site-row.tsx
@@ -1,7 +1,9 @@
+import { SubscriptionManager } from '@automattic/data-stores';
 import { SiteSettings } from '../settings-popover';
 import type { SiteSubscription } from '@automattic/data-stores/src/reader/types';
 
 export default function SiteRow( {
+	blog_ID,
 	name,
 	site_icon,
 	URL,
@@ -10,6 +12,8 @@ export default function SiteRow( {
 }: SiteSubscription ) {
 	const since = new Date( date_subscribed ).toDateString();
 	const deliveryFrequency = delivery_methods?.email?.post_delivery_frequency;
+
+	const { mutate: unFollow } = SubscriptionManager.useSiteUnfollowMutation();
 
 	return (
 		<li className="row" role="row">
@@ -27,7 +31,7 @@ export default function SiteRow( {
 				{ deliveryFrequency }
 			</span>
 			<span className="actions" role="cell">
-				<SiteSettings onUnfollow={ () => null } />
+				<SiteSettings onUnfollow={ () => unFollow( { blog_id: blog_ID } ) } />
 			</span>
 		</li>
 	);

--- a/client/landing/subscriptions/site-list/site-row.tsx
+++ b/client/landing/subscriptions/site-list/site-row.tsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
+import { SubscriptionManager } from '@automattic/data-stores';
 import { useMemo } from '@wordpress/element';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { SubscriptionManager } from '@automattic/data-stores';
 import { SiteSettings } from '../settings-popover';
 import type { SiteSubscription } from '@automattic/data-stores/src/reader/types';
 

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -1,5 +1,9 @@
 import { useSubscriberEmailAddress } from './hooks';
-import { useSiteDeliveryFrequencyMutation, useUserSettingsMutation } from './mutations';
+import {
+	useSiteDeliveryFrequencyMutation,
+	useSiteUnfollowMutation,
+	useUserSettingsMutation,
+} from './mutations';
 import {
 	useSiteSubscriptionsQuery,
 	useSubscriptionsCountQuery,
@@ -9,6 +13,7 @@ import {
 export const SubscriptionManager = {
 	useSiteDeliveryFrequencyMutation,
 	useSiteSubscriptionsQuery,
+	useSiteUnfollowMutation,
 	useSubscriptionsCountQuery,
 	useSubscriberEmailAddress,
 	useUserSettingsQuery,

--- a/packages/data-stores/src/reader/mutations/index.ts
+++ b/packages/data-stores/src/reader/mutations/index.ts
@@ -1,2 +1,3 @@
 export { default as useSiteDeliveryFrequencyMutation } from './use-site-delivery-frequency-mutation';
+export { default as useSiteUnfollowMutation } from './use-site-unfollow-mutation';
 export { default as useUserSettingsMutation } from './use-user-settings-mutation';

--- a/packages/data-stores/src/reader/mutations/use-site-unfollow-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unfollow-mutation.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQueryClient } from 'react-query';
+import { callApi } from '../helpers';
+import { useIsLoggedIn } from '../hooks';
+
+type SiteSubscriptionUnfollowParams = {
+	blog_id: number | string;
+};
+
+type SiteSubscriptionUnfollowResponse = {
+	success: boolean;
+	subscribed: boolean;
+	subscription: null;
+};
+
+const useSiteUnfollowMutation = () => {
+	const isLoggedIn = useIsLoggedIn();
+	const queryClient = useQueryClient();
+	return useMutation(
+		async ( params: SiteSubscriptionUnfollowParams ) => {
+			if ( ! params.blog_id ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while unsubscribing.'
+				);
+			}
+
+			const response = await callApi< SiteSubscriptionUnfollowResponse >( {
+				path: `/read/site/${ params.blog_id }/post_email_subscriptions/delete`,
+				method: 'POST',
+				isLoggedIn,
+				apiVersion: '1.2',
+			} );
+			if ( ! response.success ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while unsubscribing.'
+				);
+			}
+
+			return response;
+		},
+		{
+			onSuccess: () => {
+				queryClient.invalidateQueries( [ 'read', 'site-subscriptions', isLoggedIn ] );
+				queryClient.invalidateQueries( [ 'read', 'subscriptions-count', isLoggedIn ] );
+			},
+		}
+	);
+};
+
+export default useSiteUnfollowMutation;


### PR DESCRIPTION
Closes [#75009](https://github.com/Automattic/wp-calypso/issues/75009)

## Proposed Changes

This PR adds
*  a `useSiteUnfollowMutation()` that when called with parameter `{ blog_id }` unfollows a site
* The integration in `<SiteRow />`

## Testing Instructions

* Apply this PR
* Make sure you have a subkey cookie set
* Visit `http://calypso.localhost:3000/subscriptions/sites`
* Click the three dots next to a site, and click "Unfollow site"

![CleanShot 2023-03-31 at 10 03 53@2x](https://user-images.githubusercontent.com/528287/229062059-d5904526-f547-4f61-aa34-2fbb57961001.png)

After unfollow, the popup will close, and the site list & tabs counts will refresh.

### Quickly follow site

To quickly follow a site, send an HTTP request to `https://public-api.wordpress.com/rest/v1.2/read/site/<siteid>/post_email_subscriptions/new` (you can use my test site id: `210703284`), with an `Authorization: X-WPSUBKEY <cookie>` header.

<img width="1778" alt="CleanShot 2023-03-31 at 10 06 22@2x" src="https://user-images.githubusercontent.com/528287/229062600-11333c72-b704-4b02-8f45-f6d64f8857dc.png">

### Thoughts

It might be nice to show a loading state, both for this button & site list.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
