### PR TITLE
Add Golden Token modal to all Jetpack Cloud pages

### DIFF
--- a/client/jetpack-cloud/sections/golden-token/golden-token-modal/index.tsx
+++ b/client/jetpack-cloud/sections/golden-token/golden-token-modal/index.tsx
@@ -22,7 +22,7 @@ const GoldenTokenModal = () => {
 	return (
 		<Dialog
 			additionalClassNames="golden-token-modal"
-			isVisible={ true }
+			isVisible
 			isBackdropVisible={ false }
 			onClose={ noop }
 		>

--- a/client/jetpack-cloud/sections/golden-token/golden-token-modal/index.tsx
+++ b/client/jetpack-cloud/sections/golden-token/golden-token-modal/index.tsx
@@ -1,4 +1,6 @@
 import { Dialog } from '@automattic/components';
+import { useSelector } from 'react-redux';
+import { isJetpackGoldenTokenPendingActivation as isJetpackGoldenTokenPendingActivationSelector } from 'calypso/state/selectors/is-jetpack-golden-token-pending-activation';
 import { GoldenTokenDialog } from '../golden-token-dialog';
 
 import './style.scss';
@@ -9,6 +11,14 @@ import './style.scss';
 const noop = () => {};
 
 export const GoldenTokenModal = () => {
+	const isJetpackGoldenTokenPendingActivation = useSelector(
+		isJetpackGoldenTokenPendingActivationSelector
+	);
+
+	if ( ! isJetpackGoldenTokenPendingActivation ) {
+		return null;
+	}
+
 	return (
 		<Dialog
 			additionalClassNames="golden-token-modal"

--- a/client/jetpack-cloud/sections/golden-token/golden-token-modal/index.tsx
+++ b/client/jetpack-cloud/sections/golden-token/golden-token-modal/index.tsx
@@ -10,7 +10,7 @@ import './style.scss';
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
-export const GoldenTokenModal = () => {
+const GoldenTokenModal = () => {
 	const isJetpackGoldenTokenPendingActivation = useSelector(
 		isJetpackGoldenTokenPendingActivationSelector
 	);
@@ -30,3 +30,5 @@ export const GoldenTokenModal = () => {
 		</Dialog>
 	);
 };
+
+export default GoldenTokenModal;

--- a/client/jetpack-cloud/sections/golden-token/golden-token-modal/index.tsx
+++ b/client/jetpack-cloud/sections/golden-token/golden-token-modal/index.tsx
@@ -1,0 +1,22 @@
+import { Dialog } from '@automattic/components';
+import { GoldenTokenDialog } from '../golden-token-dialog';
+
+import './style.scss';
+
+// Disabled because Dialog requires an onClose prop, but there is not
+// currently anything to do on close here.
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
+export const GoldenTokenModal = () => {
+	return (
+		<Dialog
+			additionalClassNames="golden-token-modal"
+			isVisible={ true }
+			isBackdropVisible={ false }
+			onClose={ noop }
+		>
+			<GoldenTokenDialog />
+		</Dialog>
+	);
+};

--- a/client/jetpack-cloud/sections/golden-token/golden-token-modal/style.scss
+++ b/client/jetpack-cloud/sections/golden-token/golden-token-modal/style.scss
@@ -1,0 +1,7 @@
+.golden-token-modal {
+	height: 100%;
+	width: 100%;
+
+	box-shadow: unset !important;
+	background: unset !important;
+}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -17,6 +17,7 @@ import QuerySites from 'calypso/components/data/query-sites';
 import JetpackCloudMasterbar from 'calypso/components/jetpack/masterbar';
 import { withCurrentRoute } from 'calypso/components/route';
 import SympathyDevWarning from 'calypso/components/sympathy-dev-warning';
+import { GoldenTokenModal } from 'calypso/jetpack-cloud/sections/golden-token/golden-token-modal';
 import { retrieveMobileRedirect } from 'calypso/jetpack-connect/persistence-utils';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import HtmlIsIframeClassname from 'calypso/layout/html-is-iframe-classname';
@@ -337,6 +338,7 @@ class Layout extends Component {
 						placeholder={ null }
 						id="notices"
 					/>
+					{ isJetpackCloud() && <GoldenTokenModal /> }
 					<div id="secondary" className="layout__secondary" role="navigation">
 						{ this.props.secondary }
 					</div>

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -17,7 +17,6 @@ import QuerySites from 'calypso/components/data/query-sites';
 import JetpackCloudMasterbar from 'calypso/components/jetpack/masterbar';
 import { withCurrentRoute } from 'calypso/components/route';
 import SympathyDevWarning from 'calypso/components/sympathy-dev-warning';
-import { GoldenTokenModal } from 'calypso/jetpack-cloud/sections/golden-token/golden-token-modal';
 import { retrieveMobileRedirect } from 'calypso/jetpack-connect/persistence-utils';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import HtmlIsIframeClassname from 'calypso/layout/html-is-iframe-classname';
@@ -338,7 +337,9 @@ class Layout extends Component {
 						placeholder={ null }
 						id="notices"
 					/>
-					{ isJetpackCloud() && <GoldenTokenModal /> }
+					{ isJetpackCloud() && (
+						<AsyncLoad require="calypso/jetpack-cloud/sections/golden-token/golden-token-modal" />
+					) }
 					<div id="secondary" className="layout__secondary" role="navigation">
 						{ this.props.secondary }
 					</div>

--- a/client/state/selectors/is-jetpack-golden-token-pending-activation.ts
+++ b/client/state/selectors/is-jetpack-golden-token-pending-activation.ts
@@ -1,0 +1,3 @@
+export const isJetpackGoldenTokenPendingActivation = () => {
+	return true;
+};

--- a/client/state/selectors/is-jetpack-golden-token-pending-activation.ts
+++ b/client/state/selectors/is-jetpack-golden-token-pending-activation.ts
@@ -1,3 +1,4 @@
 export const isJetpackGoldenTokenPendingActivation = () => {
+	// TODO: implement once token activation status is loaded
 	return true;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR adds the Jetpack Cloud Golden Token as a modal that displays over all Jetpack Cloud pages when there is a pending golden token activation.

<img width="1721" alt="image" src="https://user-images.githubusercontent.com/42627630/229070468-7d57a15b-a2af-4f01-8693-644fda8290d1.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Spin up Jetpack Cloud.
2. Visit any page.
3. Verify that the golden token dialog displays correctly as a modal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
