### PR TITLE
Design setup preview: Improve long titles

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -193,18 +193,23 @@ $design-button-primary-color: rgb(17, 122, 201);
 
 			.formatted-header {
 				margin-top: 0;
-			}
 
-			.formatted-header__title {
-				@include onboarding-font-recoleta;
-				color: #101517;
-				font-size: 2rem;
-				font-weight: 400;
-				letter-spacing: 0.2px;
-				margin: 0;
+				.formatted-header__title {
+					@include onboarding-font-recoleta;
+					color: #101517;
+					font-size: 2rem;
+					font-weight: 400;
+					letter-spacing: 0.2px;
+					margin: 0;
 
-				@media ( min-width: 1080px ) {
-					padding: 0;
+					@media ( min-width: 1080px ) {
+						padding: 0;
+					}
+
+					@include break-small {
+						margin: 0 auto;
+						max-width: 60%;
+					}
 				}
 			}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -637,7 +637,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			selectedDesignHasStyleVariations || ( selectedDesign.is_virtual && isXLargeScreen );
 
 		const pickDesignText =
-			selectedDesign.design_type === 'vertical' || hasMoreInfo
+			selectedDesign.design_type === 'vertical' || hasMoreInfo || ! isXLargeScreen
 				? translate( 'Continue' )
 				: translate( 'Start with %(designTitle)s', { args: { designTitle } } );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -14,7 +14,7 @@ import { StepContainer } from '@automattic/onboarding';
 import { useViewportMatch, useMediaQuery } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { ReactChild, useRef, useState, useEffect } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
@@ -583,7 +583,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		recordTracksEvent( eventName, tracksProps );
 	}
 
-	function getPrimaryActionButton( pickDesignText: ReactChild ) {
+	function getPrimaryActionButton() {
 		if ( shouldUpgrade ) {
 			return (
 				<Button primary borderless={ false } onClick={ upgradePlan }>
@@ -606,7 +606,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 		return (
 			<Button primary borderless={ false } onClick={ () => pickDesign() }>
-				{ pickDesignText }
+				{ translate( 'Continue' ) }
 			</Button>
 		);
 	}
@@ -636,15 +636,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		const hasMoreInfo =
 			selectedDesignHasStyleVariations || ( selectedDesign.is_virtual && isXLargeScreen );
 
-		const pickDesignText =
-			selectedDesign.design_type === 'vertical' || hasMoreInfo || ! isXLargeScreen
-				? translate( 'Continue' )
-				: translate( 'Start with %(designTitle)s', { args: { designTitle } } );
-
 		const actionButtons = (
 			<>
 				{ hasMoreInfo && <div className="action-buttons__title">{ headerDesignTitle }</div> }
-				<div>{ getPrimaryActionButton( pickDesignText ) }</div>
+				<div>{ getPrimaryActionButton() }</div>
 			</>
 		);
 
@@ -732,7 +727,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				stepContent={ stepContent }
 				hideSkip
 				className="design-setup__preview"
-				nextLabelText={ pickDesignText }
 				goBack={ handleBackClick }
 				goNext={ () => pickDesign() }
 				formattedHeader={


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/75032

## Proposed Changes

Improves the styles of the design titles during the design setup preview step so long titles look good on mobile and tablet viewports.

Viewport | Before | After
--- | --- | ---
Mobile | <img width="481" alt="Screenshot 2023-03-31 at 12 10 54" src="https://user-images.githubusercontent.com/1233880/229095010-ed37ef85-a078-4189-b0bb-f3836c9a2185.png"> | <img width="479" alt="Screenshot 2023-03-31 at 12 11 02" src="https://user-images.githubusercontent.com/1233880/229095041-7ddbf566-d40c-42e6-9921-1ffe15ae336e.png">
Tablet | <img width="610" alt="Screenshot 2023-03-31 at 12 11 27" src="https://user-images.githubusercontent.com/1233880/229095119-52e6fab1-e3cb-467a-bd2b-a2c5918f2c56.png"> | <img width="609" alt="Screenshot 2023-03-31 at 12 11 47" src="https://user-images.githubusercontent.com/1233880/229095142-458cee64-9e39-4427-ae8c-195bc6ba484b.png">


## Testing Instructions

- Use the Calypso live link below
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>&flags=virtual-themes/onboarding`
- Pick a design with a long title such as "Design your own: Link in Bio"
- On mobile viewports:
  - Make sure the primary button reads as "Continue"
- On table viewports:
  - Make sure the primary button reads as "Continue"
  - Make sure the title does not overlap the primary button
