### PR TITLE
Themes: Avoid duplicate themes.

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -84,15 +84,13 @@ export const ThemesList = ( props ) => {
 
 	const matchingWpOrgThemes = useMemo( () => {
 		const themeSlugs = props.themes.map( ( theme ) => theme.id );
-		// Avoid duplicate themes. Some free themes are available in both wpcom and wporg.
-		if ( themeSlugs.includes( props.searchTerm.toLowerCase() ) ) {
-			return [];
-		}
+
 		return (
 			props.wpOrgThemes?.filter(
 				( wpOrgTheme ) =>
-					wpOrgTheme?.name?.toLowerCase() === props.searchTerm.toLowerCase() ||
-					wpOrgTheme?.id?.toLowerCase() === props.searchTerm.toLowerCase()
+					! themeSlugs.includes( wpOrgTheme?.id?.toLowerCase() ) && // Avoid duplicate themes. Some free themes are available in both wpcom and wporg.
+					( wpOrgTheme?.name?.toLowerCase() === props.searchTerm.toLowerCase() ||
+						wpOrgTheme?.id?.toLowerCase() === props.searchTerm.toLowerCase() )
 			) || []
 		);
 	}, [ props.wpOrgThemes, props.searchTerm, props.themes ] );

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -82,15 +82,21 @@ export const ThemesList = ( props ) => {
 		window.location.assign( `/start/${ WITH_THEME_ASSEMBLER_FLOW }?${ params }` );
 	};
 
-	const matchingWpOrgThemes = useMemo(
-		() =>
+	const matchingWpOrgThemes = useMemo( () => {
+		const themeSlugs = props.themes.map( ( theme ) => theme.id );
+		// Avoid duplicate themes. Some free themes are available in both wpcom and wporg.
+		if ( themeSlugs.includes( props.searchTerm.toLowerCase() ) ) {
+			return [];
+		}
+		return (
 			props.wpOrgThemes?.filter(
 				( wpOrgTheme ) =>
 					wpOrgTheme?.name?.toLowerCase() === props.searchTerm.toLowerCase() ||
 					wpOrgTheme?.id?.toLowerCase() === props.searchTerm.toLowerCase()
-			) || [],
-		[ props.wpOrgThemes, props.searchTerm ]
-	);
+			) || []
+		);
+	}, [ props.wpOrgThemes, props.searchTerm, props.themes ] );
+
 	const themes = useMemo(
 		() => [ ...props.themes, ...matchingWpOrgThemes ],
 		[ props.themes, matchingWpOrgThemes ]


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1680236275456529-slack-C029FM1EH

## Proposed Changes

* Don't display .org themes if there is already a free theme available

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**This Fix**
* In /themes/site:id
* Search for `stewart`
* It should return only one result

![CleanShot 2023-03-31 at 13 42 32@2x](https://user-images.githubusercontent.com/12430020/229099204-11166a8e-fd44-4775-8657-6c64a2dd9572.jpg)

* In /themes/site:id
* Search for `Twenty Fifteen`
* It should return only one result

![CleanShot 2023-03-31 at 18 44 15@2x](https://user-images.githubusercontent.com/12430020/229167697-a30574ed-968f-4944-975c-74bad50b1bfb.jpg)



**Check for regressions**
* Search for `astra`
* It should return Vastra and Astra

![CleanShot 2023-03-31 at 13 42 45@2x](https://user-images.githubusercontent.com/12430020/229099242-4c65aa6c-bf8a-42e1-902b-41a018905152.jpg)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?