### PR TITLE
Fix: Complete card mentioning Basic plan instead of Advanced

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-included-product-description-map.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-included-product-description-map.tsx
@@ -76,7 +76,7 @@ export const useIncludedProductDescriptionMap = ( productSlug: string ) => {
 
 			...setTranslation(
 				JETPACK_SOCIAL_PRODUCTS,
-				translate( 'Engage your social followers. Basic plan with 1,000 shares/mo.' )
+				translate( 'Engage your social followers. Advanced plan with unlimited shares.' )
 			),
 
 			...setTranslation(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This small change corrects the Complete card on the Cloud pricing page, so it shows the Advanced plan not Basic.
It was left like this with the introduction of the Advanced plan. With this change it will be the equivalent of the jetpack.com complete card: https://jetpack.com/complete/

## Testing Instructions

Go to https://cloud.jetpack.com/pricing#jetpack_complete, and check that the good plan is described.

![CleanShot 2023-03-31 at 14 25 54 png](https://user-images.githubusercontent.com/36671565/229119561-6233e59a-86ad-441e-9d88-29e9b05268f1.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
