### PR TITLE
Subscription Management: Create DeliveryFrequencyInput component

### DIFF
--- a/client/landing/subscriptions/hooks/use-popover-toggle.ts
+++ b/client/landing/subscriptions/hooks/use-popover-toggle.ts
@@ -1,0 +1,11 @@
+import { useCallback, useState } from 'react';
+
+const usePopoverToggle = () => {
+	const [ showPopover, setShowPopover ] = useState( false );
+	const onToggle = useCallback( () => setShowPopover( ! showPopover ), [ showPopover ] );
+	const onClose = useCallback( () => setShowPopover( false ), [] );
+
+	return { showPopover, onToggle, onClose };
+};
+
+export default usePopoverToggle;

--- a/client/landing/subscriptions/settings-popover/settings-popover.tsx
+++ b/client/landing/subscriptions/settings-popover/settings-popover.tsx
@@ -1,5 +1,7 @@
+import { Gridicon, Popover } from '@automattic/components';
 import classNames from 'classnames';
-import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import { useRef } from 'react';
+import usePopoverToggle from '../hooks/use-popover-toggle';
 import './styles.scss';
 
 type SettingsPopoverProps = {
@@ -7,10 +9,34 @@ type SettingsPopoverProps = {
 	className?: string;
 };
 
-const SettingsPopover = ( { children, className }: SettingsPopoverProps ) => (
-	<EllipsisMenu popoverClassName={ classNames( 'settings-popover', className ) }>
-		{ children }
-	</EllipsisMenu>
-);
+const SettingsPopover = ( { children, className }: SettingsPopoverProps ) => {
+	const { showPopover, onToggle, onClose } = usePopoverToggle();
+	const buttonRef = useRef< HTMLButtonElement >( null );
+
+	return (
+		<div className="settings-popover__container">
+			<button
+				className={ classNames( 'settings-popover__toggle', {
+					'is-popover-visible': showPopover,
+				} ) }
+				onClick={ onToggle }
+				ref={ buttonRef }
+			>
+				<Gridicon icon="ellipsis" size={ 24 } />
+			</button>
+
+			<Popover
+				autoPosition
+				hideArrow
+				onClose={ onClose }
+				isVisible={ showPopover }
+				context={ buttonRef.current }
+				className={ classNames( 'settings-popover', className ) }
+			>
+				{ children }
+			</Popover>
+		</div>
+	);
+};
 
 export default SettingsPopover;

--- a/client/landing/subscriptions/settings-popover/site-settings/delivery-frequency-input.tsx
+++ b/client/landing/subscriptions/settings-popover/site-settings/delivery-frequency-input.tsx
@@ -1,0 +1,72 @@
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import SegmentedControl from 'calypso/components/segmented-control';
+import type { SiteSubscriptionDeliveryFrequency } from '@automattic/data-stores/src/reader/types';
+
+type DeliveryFrequencyOptionProps = {
+	children: React.ReactNode;
+	value: SiteSubscriptionDeliveryFrequency;
+	selected: boolean;
+	onChange: ( value: SiteSubscriptionDeliveryFrequency ) => void;
+};
+
+const DeliveryFrequencyOption = ( {
+	children,
+	selected,
+	value,
+	onChange,
+}: DeliveryFrequencyOptionProps ) => (
+	<SegmentedControl.Item selected={ selected } onClick={ () => onChange( value ) }>
+		{ children }
+	</SegmentedControl.Item>
+);
+
+type DeliveryFrequencyInputProps = {
+	onChange: ( value: SiteSubscriptionDeliveryFrequency ) => void;
+	value: SiteSubscriptionDeliveryFrequency;
+};
+
+type DeliveryFrequencyKeyLabel = {
+	key: SiteSubscriptionDeliveryFrequency;
+	label: string;
+};
+
+const DeliveryFrequencyInput = ( {
+	onChange,
+	value: selectedValue,
+}: DeliveryFrequencyInputProps ) => {
+	const translate = useTranslate();
+	const availableFrequencies = useMemo< DeliveryFrequencyKeyLabel[] >(
+		() => [
+			{
+				key: 'instantly',
+				label: translate( 'Instantly' ),
+			},
+			{
+				key: 'daily',
+				label: translate( 'Daily' ),
+			},
+			{
+				key: 'weekly',
+				label: translate( 'Weekly' ),
+			},
+		],
+		[ translate ]
+	);
+
+	return (
+		<SegmentedControl>
+			{ availableFrequencies.map( ( { key, label } ) => (
+				<DeliveryFrequencyOption
+					selected={ selectedValue === key }
+					value={ key }
+					onChange={ onChange }
+				>
+					{ label }
+				</DeliveryFrequencyOption>
+			) ) }
+		</SegmentedControl>
+	);
+};
+
+export default DeliveryFrequencyInput;

--- a/client/landing/subscriptions/settings-popover/site-settings/delivery-frequency-input.tsx
+++ b/client/landing/subscriptions/settings-popover/site-settings/delivery-frequency-input.tsx
@@ -56,11 +56,12 @@ const DeliveryFrequencyInput = ( {
 
 	return (
 		<SegmentedControl>
-			{ availableFrequencies.map( ( { key, label } ) => (
+			{ availableFrequencies.map( ( { key, label }, index ) => (
 				<DeliveryFrequencyOption
 					selected={ selectedValue === key }
 					value={ key }
 					onChange={ onChange }
+					key={ index }
 				>
 					{ label }
 				</DeliveryFrequencyOption>

--- a/client/landing/subscriptions/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/settings-popover/site-settings/site-settings.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from 'i18n-calypso';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import Separator from 'calypso/components/popover-menu/separator';
 import SettingsPopover from '../settings-popover';
@@ -15,14 +16,22 @@ const SiteSettings = ( {
 	deliveryFrequency,
 	onDeliveryFrequencyChange,
 	onUnfollow,
-}: SiteSettingsProps ) => (
-	<SettingsPopover>
-		<PopoverMenuItem itemComponent="div">
-			<DeliveryFrequencyInput value={ deliveryFrequency } onChange={ onDeliveryFrequencyChange } />
-		</PopoverMenuItem>
-		<Separator />
-		<UnfollowSiteButton onUnfollow={ onUnfollow } />
-	</SettingsPopover>
-);
+}: SiteSettingsProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<SettingsPopover>
+			<PopoverMenuItem itemComponent="div">
+				<p className="settings-popover__item-label">{ translate( 'Email me new posts' ) }</p>
+				<DeliveryFrequencyInput
+					value={ deliveryFrequency }
+					onChange={ onDeliveryFrequencyChange }
+				/>
+			</PopoverMenuItem>
+			<Separator />
+			<UnfollowSiteButton onUnfollow={ onUnfollow } />
+		</SettingsPopover>
+	);
+};
 
 export default SiteSettings;

--- a/client/landing/subscriptions/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/settings-popover/site-settings/site-settings.tsx
@@ -1,15 +1,25 @@
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import Separator from 'calypso/components/popover-menu/separator';
 import SettingsPopover from '../settings-popover';
+import DeliveryFrequencyInput from './delivery-frequency-input';
 import UnfollowSiteButton from './unfollow-site-button';
+import type { SiteSubscriptionDeliveryFrequency } from '@automattic/data-stores/src/reader/types';
 
 type SiteSettingsProps = {
+	deliveryFrequency: SiteSubscriptionDeliveryFrequency;
+	onDeliveryFrequencyChange: ( value: SiteSubscriptionDeliveryFrequency ) => void;
 	onUnfollow: () => void;
 };
 
-const SiteSettings = ( { onUnfollow }: SiteSettingsProps ) => (
+const SiteSettings = ( {
+	deliveryFrequency,
+	onDeliveryFrequencyChange,
+	onUnfollow,
+}: SiteSettingsProps ) => (
 	<SettingsPopover>
-		<PopoverMenuItem itemComponent="div">Delivery Frequency Placeholder</PopoverMenuItem>
+		<PopoverMenuItem itemComponent="div">
+			<DeliveryFrequencyInput value={ deliveryFrequency } onChange={ onDeliveryFrequencyChange } />
+		</PopoverMenuItem>
 		<Separator />
 		<UnfollowSiteButton onUnfollow={ onUnfollow } />
 	</SettingsPopover>

--- a/client/landing/subscriptions/settings-popover/styles.scss
+++ b/client/landing/subscriptions/settings-popover/styles.scss
@@ -51,9 +51,21 @@
 		fill: $studio-gray-50;
 	}
 
+	.settings-popover__item-label,
+	.settings-popover__item-button {
+		font-size: $font-body-small;
+		line-height: $font-title-small;
+	}
+
+	.settings-popover__item-label {
+		margin-bottom: 8px;
+		text-align: left;
+	}
+
 	.segmented-control__link {
 		padding-top: 10px;
 		padding-bottom: 10px;
+		line-height: $font-body;
 	}
 }
 

--- a/client/landing/subscriptions/settings-popover/styles.scss
+++ b/client/landing/subscriptions/settings-popover/styles.scss
@@ -50,6 +50,11 @@
 	.settings-popover__item-icon {
 		fill: $studio-gray-50;
 	}
+
+	.segmented-control__link {
+		padding-top: 10px;
+		padding-bottom: 10px;
+	}
 }
 
 .settings-popover__container {

--- a/client/landing/subscriptions/settings-popover/styles.scss
+++ b/client/landing/subscriptions/settings-popover/styles.scss
@@ -3,10 +3,6 @@
 .settings-popover {
 	width: 305px;
 
-	.popover__arrow {
-		display: none;
-	}
-
 	.popover__inner {
 		border: none;
 		box-shadow: 0 3px 8px rgba($studio-black, 0.12), 0 3px 1px rgba($studio-black, 0.04);
@@ -38,6 +34,8 @@
 		display: flex;
 		align-items: center;
 		gap: 16px;
+		width: 100%;
+		cursor: pointer;
 
 		&:hover,
 		&:focus {
@@ -51,5 +49,21 @@
 
 	.settings-popover__item-icon {
 		fill: $studio-gray-50;
+	}
+}
+
+.settings-popover__container {
+	height: 24px;
+}
+
+.settings-popover__toggle {
+	cursor: pointer;
+
+	.gridicons-ellipsis {
+		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	}
+
+	&.is-popover-visible .gridicons-ellipsis {
+		transform: rotate(90deg);
 	}
 }

--- a/client/landing/subscriptions/site-list/site-row.tsx
+++ b/client/landing/subscriptions/site-list/site-row.tsx
@@ -3,7 +3,10 @@ import { SubscriptionManager } from '@automattic/data-stores';
 import { useMemo } from '@wordpress/element';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { SiteSettings } from '../settings-popover';
-import type { SiteSubscription } from '@automattic/data-stores/src/reader/types';
+import type {
+	SiteSubscription,
+	SiteSubscriptionDeliveryFrequency,
+} from '@automattic/data-stores/src/reader/types';
 
 export default function SiteRow( {
 	blog_ID,
@@ -18,7 +21,8 @@ export default function SiteRow( {
 		() => moment( date_subscribed ).format( 'LL' ),
 		[ date_subscribed, moment ]
 	);
-	const deliveryFrequency = delivery_methods?.email?.post_delivery_frequency;
+	const deliveryFrequency = delivery_methods?.email
+		?.post_delivery_frequency as SiteSubscriptionDeliveryFrequency;
 	const hostname = useMemo( () => new URL( url ).hostname, [ url ] );
 	const siteIcon = useMemo( () => {
 		if ( site_icon ) {
@@ -27,6 +31,8 @@ export default function SiteRow( {
 		return <Gridicon className="icon" icon="globe" size={ 48 } />;
 	}, [ site_icon, name ] );
 
+	const { mutate: updateDeliveryFrequency } =
+		SubscriptionManager.useSiteDeliveryFrequencyMutation();
 	const { mutate: unFollow } = SubscriptionManager.useSiteUnfollowMutation();
 
 	return (
@@ -47,7 +53,13 @@ export default function SiteRow( {
 				{ deliveryFrequency }
 			</span>
 			<span className="actions" role="cell">
-				<SiteSettings onUnfollow={ () => unFollow( { blog_id: blog_ID } ) } />
+				<SiteSettings
+					deliveryFrequency={ deliveryFrequency }
+					onDeliveryFrequencyChange={ ( delivery_frequency ) =>
+						updateDeliveryFrequency( { blog_id: blog_ID, delivery_frequency } )
+					}
+					onUnfollow={ () => unFollow( { blog_id: blog_ID } ) }
+				/>
 			</span>
 		</li>
 	);


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/74971

## Proposed Changes

* Updates sSettingsPopovers to use it's own structure to avoid unwanted click behaviors from `EllipsisMenu`
  * `EllipsisMenu` has a `_setPropsOnChild` which changes the onClick behaviors from its children, causing unexpected popover closing
* Creates `DeliveryFrequencyInput` component
  * Adds temporary `Email me new posts` label to the input
* Apply `DeliveryFrequencyInput` on `SiteSettings`
* Integrate Delivery Frequency mutation on `SiteRow` component

## Testing Instructions

1. Run this PR on your local env
2. Go to http://calypso.localhost:3000/subscriptions/sites
3. Open the settings popover by clicks on ellipsis button
4. Verify if the site settings are rendered as expected
5. Change the delivery frequency and verify if the data was correctly updated, for both the input and the table
    (loading state not implemented)
7. Refresh the page and verify if the new frequency persisted

<img width="505" alt="Screenshot 2023-03-31 at 14 56 30" src="https://user-images.githubusercontent.com/3113712/229194862-8272972c-d407-400a-a00c-1b00197fcaee.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
