### PR TITLE
Update/jetpack cloud presales to availability routing

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -10,6 +10,10 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import type { ConfigData } from '@automattic/create-calypso-config';
 
+type PresalesChatResponse = {
+	is_available: boolean;
+};
+
 function usePresalesAvailabilityQuery() {
 	return useQuery(
 		'presales-availability',
@@ -20,13 +24,13 @@ function usePresalesAvailabilityQuery() {
 			};
 
 			//we are making an unauthenticated call to the API, so we need to set a couple things.
-			const response = await apiFetch( {
+			const response = await apiFetch< PresalesChatResponse >( {
 				credentials: 'same-origin',
 				mode: 'cors',
 				url: addQueryArgs( url, queryObject as Record< string, string > ),
 			} );
-			const isAvailable = await response.is_available;
-			return isAvailable;
+
+			return response.is_available;
 		},
 		{
 			meta: { persist: false },

--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -19,6 +19,7 @@ function usePresalesAvailabilityQuery() {
 				group: 'jp_presales',
 			};
 
+			//we are making an unauthenticated call to the API, so we need to set a couple things.
 			const response = await apiFetch( {
 				credentials: 'same-origin',
 				mode: 'cors',
@@ -26,6 +27,7 @@ function usePresalesAvailabilityQuery() {
 				parse: false, // Disable automatic JSON parsing
 			} );
 
+			//the API returns a simple string of "true" so we need to adjust it for not being JSON
 			const textResponse = await response.text(); // Extract plain text from the response
 
 			// Convert the plain text response to a boolean

--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -14,7 +14,7 @@ function usePresalesAvailabilityQuery() {
 	return useQuery(
 		'presales-availability',
 		async () => {
-			const url = 'https://public-api.wordpress.com/wpcom/v2/presales/availability';
+			const url = 'https://public-api.wordpress.com/wpcom/v2/presales/chat';
 			const queryObject = {
 				group: 'jp_presales',
 			};
@@ -24,15 +24,9 @@ function usePresalesAvailabilityQuery() {
 				credentials: 'same-origin',
 				mode: 'cors',
 				url: addQueryArgs( url, queryObject as Record< string, string > ),
-				parse: false, // Disable automatic JSON parsing
 			} );
-
-			//the API returns a simple string of "true" so we need to adjust it for not being JSON
-			const textResponse = await response.text(); // Extract plain text from the response
-
-			// Convert the plain text response to a boolean
-			const booleanResponse = textResponse.trim().toLowerCase() === 'true';
-			return booleanResponse;
+			const isAvailable = await response.is_available;
+			return isAvailable;
 		},
 		{
 			meta: { persist: false },
@@ -41,10 +35,9 @@ function usePresalesAvailabilityQuery() {
 }
 
 export const ZendeskPreSalesChat: React.VFC = () => {
-	const isStaffed = usePresalesAvailabilityQuery() ?? false;
+	const { data: isStaffed } = usePresalesAvailabilityQuery();
 	const zendeskChatKey = config( 'zendesk_presales_chat_key' ) as keyof ConfigData;
 	const isLoggedIn = useSelector( isUserLoggedIn );
-
 	const shouldShowZendeskPresalesChat = useMemo( () => {
 		const isEnglishLocale = ( config( 'english_locales' ) as string[] ).includes(
 			getLocaleSlug() ?? ''

--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -90,7 +90,6 @@ export const ZendeskPreSalesChat: React.VFC = () => {
 	}
 
 	if ( error ) {
-		console.error( 'Error while fetching presales chat availability:', error );
 		return null;
 	}
 

--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -1,55 +1,57 @@
 import config from '@automattic/calypso-config';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 import { getLocaleSlug } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { useQuery } from 'react-query';
 import { useSelector } from 'react-redux';
 import ZendeskChat from 'calypso/components/presales-zendesk-chat';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import type { ConfigData } from '@automattic/create-calypso-config';
 
-const isWithinAvailableChatDays = ( currentTime: Date ) => {
-	const [ SUNDAY, SATURDAY ] = [ 0, 6 ];
-	//open and close hours, currently 09:00 - 19:00 UTC
-	const [ OPEN_HOUR, CLOSE_HOUR ] = [ 9, 19 ];
-	const utcHour = currentTime.getUTCHours();
-	const utcWeekDay = currentTime.getUTCDay();
+function usePresalesAvailabilityQuery() {
+	return useQuery(
+		'presales-availability',
+		async () => {
+			const url = 'https://public-api.wordpress.com/wpcom/v2/presales/availability';
+			const queryObject = {
+				group: 'jp_presales',
+			};
 
-	//if current hour is within open and close hour range and day is not saturday or sunday, return true
-	return (
-		utcHour >= OPEN_HOUR && utcHour < CLOSE_HOUR && utcWeekDay !== SUNDAY && utcWeekDay !== SATURDAY
+			const response = await apiFetch( {
+				credentials: 'same-origin',
+				mode: 'cors',
+				url: addQueryArgs( url, queryObject as Record< string, string > ),
+				parse: false, // Disable automatic JSON parsing
+			} );
+
+			const textResponse = await response.text(); // Extract plain text from the response
+
+			// Convert the plain text response to a boolean
+			const booleanResponse = textResponse.trim().toLowerCase() === 'true';
+			return booleanResponse;
+		},
+		{
+			meta: { persist: false },
+		}
 	);
-};
-
-const isWithinShutdownDates = ( currentTime: Date ) => {
-	const startTime = new Date( Date.UTC( 2022, 11, 23 ) ); // Thu Dec 22 2022 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
-	const endTime = new Date( Date.UTC( 2023, 0, 2 ) ); // Sun Jan 01 2023 19:00:00 (7:00pm) GMT-0500 (Eastern Standard Time)
-	const currentDateUTC = new Date( currentTime.toUTCString() );
-	if ( currentDateUTC > startTime && currentDateUTC < endTime ) {
-		return true;
-	}
-	return false;
-};
+}
 
 export const ZendeskPreSalesChat: React.VFC = () => {
+	const isStaffed = usePresalesAvailabilityQuery() ?? false;
 	const zendeskChatKey = config( 'zendesk_presales_chat_key' ) as keyof ConfigData;
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const shouldShowZendeskPresalesChat = useMemo( () => {
-		const currentTime = new Date();
-		if ( isWithinShutdownDates( currentTime ) ) {
-			return false;
-		}
 		const isEnglishLocale = ( config( 'english_locales' ) as string[] ).includes(
 			getLocaleSlug() ?? ''
 		);
 
 		return config.isEnabled( 'jetpack/zendesk-chat-for-logged-in-users' )
-			? isEnglishLocale && isJetpackCloud() && isWithinAvailableChatDays( currentTime )
-			: ! isLoggedIn &&
-					isEnglishLocale &&
-					isJetpackCloud() &&
-					isWithinAvailableChatDays( currentTime );
-	}, [ isLoggedIn ] );
+			? isEnglishLocale && isJetpackCloud() && isStaffed
+			: ! isLoggedIn && isEnglishLocale && isJetpackCloud() && isStaffed;
+	}, [ isStaffed, isLoggedIn ] );
 
 	return shouldShowZendeskPresalesChat ? <ZendeskChat chatKey={ zendeskChatKey } /> : null;
 };

--- a/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/zendesk-presales-chat-widget/index.tsx
@@ -1,8 +1,7 @@
 import config from '@automattic/calypso-config';
-import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { getLocaleSlug } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
 import { useSelector } from 'react-redux';
 import ZendeskChat from 'calypso/components/presales-zendesk-chat';
@@ -14,31 +13,33 @@ type PresalesChatResponse = {
 	is_available: boolean;
 };
 
-function usePresalesAvailabilityQuery() {
-	return useQuery(
-		'presales-availability',
-		async () => {
-			const url = 'https://public-api.wordpress.com/wpcom/v2/presales/chat';
-			const queryObject = {
-				group: 'jp_presales',
-			};
+//the API is rate limited if we hit the limit we'll back off and retry
+async function fetchWithRetry(
+	url: string,
+	options: RequestInit,
+	retries = 3,
+	delay = 30000
+): Promise< Response > {
+	try {
+		const response = await fetch( url, options );
 
-			//we are making an unauthenticated call to the API, so we need to set a couple things.
-			const response = await apiFetch< PresalesChatResponse >( {
-				credentials: 'same-origin',
-				mode: 'cors',
-				url: addQueryArgs( url, queryObject as Record< string, string > ),
-			} );
-
-			return response.is_available;
-		},
-		{
-			meta: { persist: false },
+		if ( response.status === 429 && retries > 0 ) {
+			await new Promise( ( resolve ) => setTimeout( resolve, delay ) );
+			return await fetchWithRetry( url, options, retries - 1, delay * 2 );
 		}
-	);
+
+		return response;
+	} catch ( error ) {
+		if ( retries > 0 ) {
+			await new Promise( ( resolve ) => setTimeout( resolve, delay ) );
+			return await fetchWithRetry( url, options, retries - 1, delay * 2 );
+		}
+		throw error;
+	}
 }
 
 export const ZendeskPreSalesChat: React.VFC = () => {
+	const [ error, setError ] = useState( false );
 	const { data: isStaffed } = usePresalesAvailabilityQuery();
 	const zendeskChatKey = config( 'zendesk_presales_chat_key' ) as keyof ConfigData;
 	const isLoggedIn = useSelector( isUserLoggedIn );
@@ -51,6 +52,47 @@ export const ZendeskPreSalesChat: React.VFC = () => {
 			? isEnglishLocale && isJetpackCloud() && isStaffed
 			: ! isLoggedIn && isEnglishLocale && isJetpackCloud() && isStaffed;
 	}, [ isStaffed, isLoggedIn ] );
+
+	function usePresalesAvailabilityQuery() {
+		//adding a safeguard to ensure if there's an unkown error with the widget it won't crash the whole app
+		try {
+			return useQuery< boolean, Error >(
+				'presales-availability',
+				async () => {
+					const url = 'https://public-api.wordpress.com/wpcom/v2/presales/chat';
+					const queryObject = {
+						group: 'jp_presales',
+					};
+
+					const response = await fetchWithRetry(
+						addQueryArgs( url, queryObject as Record< string, string > ),
+						{
+							credentials: 'same-origin',
+							mode: 'cors',
+						}
+					);
+
+					if ( ! response.ok ) {
+						throw new Error( `API request failed with status ${ response.status }` );
+					}
+
+					const data: PresalesChatResponse = await response.json();
+					return data.is_available;
+				},
+				{
+					meta: { persist: false },
+				}
+			);
+		} catch ( error ) {
+			setError( true );
+			return { data: false };
+		}
+	}
+
+	if ( error ) {
+		console.error( 'Error while fetching presales chat availability:', error );
+		return null;
+	}
 
 	return shouldShowZendeskPresalesChat ? <ZendeskChat chatKey={ zendeskChatKey } /> : null;
 };


### PR DESCRIPTION
Related to # pbtFFM-2sD-p2

## Proposed Changes

* This PR updates the chat widget gating to remove time-based display and replace it with availability based display
* The same change has already been implemented on Jetpack.com and the new Akismet.com (coming soon to a browser near you!)
* The time-based gating code was deleted and instead a React Query checks the newly created presales/availability endpoint on WPCOM V2 REST API
* This PR depends on the new API which is D106734-code
* There is no visual change to the chat widget, it just displays as long as someone's around instead of at a certain time

## Testing Instructions

* You'll need a sandbox, and you'll need to run this PR locally
* Switch to the API code on your sandbox via arc patch D106734
* Check out this branch locally and run yarn start-jetpack-cloud
* Head over to jetpack.localhost:3000/pricing (or another cloud page) in a private browsing window (the chat only renders to logged out users)
* If someone is staffing chat you'll see the chat widget in the lower right of the screen.
* If not, you won't
* You can check with the presales team in slack to see if anyone is in chat

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?