### PR TITLE
Site Editor: test loading without iframes

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -285,3 +285,26 @@ export const exitPost = ( context, next ) => {
 	}
 	next();
 };
+
+/**
+ * Redirects to the un-iframed Site Editor if the config is enabled.
+ *
+ * @param {Object} context Shared context in the route.
+ * @param {Function} next  Next registered callback for the route.
+ * @returns {*}            Whatever the next callback returns.
+ */
+export const redirectSiteEditor = ( context, next ) => {
+	// bail if the config for this is not enabled.
+	if ( ! isEnabled( 'block-editor/un-iframed-site-editor' ) ) {
+		return next();
+	}
+
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	// We aren't using `getSiteEditorUrl` because it still thinks we should gutenframe the Site Editor.
+	const siteAdminUrl = getSiteAdminUrl( state, siteId );
+	let siteEditorUrl = `${ siteAdminUrl }site-editor.php`;
+	// Helps the Site Editor maintain Calypso environment context.
+	siteEditorUrl = addQueryArgs( { calypso_origin: location.origin }, siteEditorUrl );
+	return location.assign( siteEditorUrl );
+};

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -294,17 +294,20 @@ export const exitPost = ( context, next ) => {
  * @returns {*}            Whatever the next callback returns.
  */
 export const redirectSiteEditor = ( context, next ) => {
-	// bail if the config for this is not enabled.
-	if ( ! isEnabled( 'block-editor/un-iframed-site-editor' ) ) {
-		return next();
-	}
-
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
-	// We aren't using `getSiteEditorUrl` because it still thinks we should gutenframe the Site Editor.
-	const siteAdminUrl = getSiteAdminUrl( state, siteId );
-	let siteEditorUrl = `${ siteAdminUrl }site-editor.php`;
-	// Helps the Site Editor maintain Calypso environment context.
-	siteEditorUrl = addQueryArgs( { calypso_origin: location.origin }, siteEditorUrl );
-	return location.assign( siteEditorUrl );
+	const isJetpack = isJetpackSite( state, siteId );
+	const configEnabled = isEnabled( 'block-editor/un-iframed-site-editor' );
+
+	// Ditch the iframe for all Jetpack sites, or if the config is enabled.
+	if ( isJetpack || configEnabled ) {
+		// We aren't using `getSiteEditorUrl` because it still thinks we should gutenframe the Site Editor.
+		const siteAdminUrl = getSiteAdminUrl( state, siteId );
+		let siteEditorUrl = `${ siteAdminUrl }site-editor.php`;
+		// Helps the Site Editor maintain Calypso environment context.
+		siteEditorUrl = addQueryArgs( { calypso_origin: location.origin }, siteEditorUrl );
+		return location.assign( siteEditorUrl );
+	}
+
+	return next();
 };

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -1,12 +1,20 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { siteSelection, sites } from 'calypso/my-sites/controller';
-import { authenticate, post, redirect, siteEditor, exitPost } from './controller';
+import {
+	authenticate,
+	post,
+	redirect,
+	siteEditor,
+	exitPost,
+	redirectSiteEditor,
+} from './controller';
 
 export default function () {
 	page(
 		'/site-editor/:site?',
 		siteSelection,
+		redirectSiteEditor,
 		redirect,
 		authenticate,
 		siteEditor,

--- a/config/development.json
+++ b/config/development.json
@@ -28,6 +28,7 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
+		"block-editor/un-iframed-site-editor": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -16,6 +16,7 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": false,
+		"block-editor/un-iframed-site-editor": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
@@ -2,7 +2,7 @@ import { Page, Locator } from 'playwright';
 
 const selectors = {
 	exitButton: `a[aria-label="Go back to the dashboard"]`,
-	templatePartsItem: 'button[id="/template-parts"]',
+	templatePartsItem: 'button[id="/wp_template_part"]',
 	manageAllTemplatePartsItem: 'button:text("Manage all template parts")',
 };
 

--- a/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
@@ -4,6 +4,7 @@ const selectors = {
 	exitButton: `a[aria-label="Go back to the dashboard"]`,
 	templatePartsItem: 'button[id="/wp_template_part"]',
 	manageAllTemplatePartsItem: 'button:text("Manage all template parts")',
+	navigationScreenTitle: '.edit-site-sidebar-navigation-screen__title',
 };
 
 /**
@@ -36,5 +37,42 @@ export class FullSiteEditorNavSidebarComponent {
 	async navigateToTemplatePartsManager(): Promise< void > {
 		await this.editor.locator( selectors.templatePartsItem ).click();
 		await this.editor.locator( selectors.manageAllTemplatePartsItem ).click();
+	}
+
+	/**
+	 * Ensures that the nav sidebar is at the top level ("Design")
+	 */
+	async ensureNavigationTopLevel(): Promise< void > {
+		const waitForNavigationTopLevel = async () => {
+			await this.editor.locator( selectors.exitButton ).waitFor();
+		};
+
+		const headerLocator = this.editor.locator( selectors.navigationScreenTitle );
+		await headerLocator.waitFor();
+		const headerText = await headerLocator.innerText();
+		if ( headerText === 'Design' ) {
+			return;
+		}
+
+		if (
+			headerText === 'Navigation' ||
+			headerText === 'Templates' ||
+			headerText === 'Template parts'
+		) {
+			await this.clickNavButtonByExactText( 'Back' );
+			await waitForNavigationTopLevel();
+			return;
+		}
+
+		await this.clickNavButtonByExactText( 'Back' );
+		await this.clickNavButtonByExactText( 'Back' );
+		await waitForNavigationTopLevel();
+	}
+
+	/**
+	 * Clicks on a button with the exact name.
+	 */
+	async clickNavButtonByExactText( text: string ): Promise< void > {
+		await this.editor.getByRole( 'button', { name: text, exact: true } ).click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -5,7 +5,6 @@ import {
 	EditorSidebarBlockInserterComponent,
 	EditorToolbarComponent,
 	EditorWelcomeTourComponent,
-	SiteType,
 	EditorPopoverMenuComponent,
 	EditorSiteStylesComponent,
 	ColorSettings,
@@ -22,7 +21,6 @@ import {
 	DimensionsSettings,
 	CookieBannerComponent,
 } from '..';
-import { getCalypsoURL } from '../../data-helper';
 import { getIdFromBlock } from '../../element-helper';
 import envVariables from '../../env-variables';
 
@@ -32,7 +30,7 @@ const selectors = {
 	editorIframe: `iframe.is-loaded[src*="${ wpAdminPath }"]`,
 	editorRoot: 'body.block-editor-page',
 	editorCanvasIframe: 'iframe[name="editor-canvas"]',
-	editorCanvasRoot: '.wp-site-blocks',
+	editorCanvasRoot: 'body.block-editor-iframe__body',
 	templateLoadingSpinner: '[aria-label="Block: Template Part"] .components-spinner',
 	closeStylesWelcomeGuideButton:
 		'[aria-label="Welcome to styles"] button[aria-label="Close dialog"]',
@@ -72,21 +70,11 @@ export class FullSiteEditorPage {
 	 * Constructs an instance of the page POM class.
 	 *
 	 * @param {Page} page The underlying page.
-	 * @param {Object} param0 Keyed object parameter.
-	 * @param {SiteType} param0.target Target editor type. Defaults to 'simple'.
 	 */
-	constructor( page: Page, { target = 'simple' }: { target?: SiteType } = {} ) {
+	constructor( page: Page ) {
 		this.page = page;
 
-		if ( target === 'atomic' ) {
-			// For Atomic editors, there is no iFrame - the editor is
-			// part of the page DOM and is thus accessible directly.
-			this.editor = page.locator( selectors.editorRoot );
-		} else {
-			// For Simple editors, the editor is located within an iFrame
-			// and thus it must first be extracted.
-			this.editor = page.frameLocator( selectors.editorIframe ).locator( selectors.editorRoot );
-		}
+		this.editor = page.locator( selectors.editorRoot );
 
 		this.editorCanvas = this.editor
 			.frameLocator( selectors.editorCanvasIframe )
@@ -123,12 +111,21 @@ export class FullSiteEditorPage {
 	/**
 	 * Visit the site editor by URL directly.
 	 *
-	 * @param {string} siteHostName Host name of the site, without scheme. (e.g. testsite.wordpress.com)
+	 * @param {string} siteHostWithProtocol Host name of the site, with protocol. (e.g. https://testsite.wordpress.com)
 	 */
-	async visit( siteHostName: string ): Promise< void > {
-		await this.page.goto( getCalypsoURL( `site-editor/${ siteHostName }` ), {
-			timeout: 60 * 1000,
-		} );
+	async visit( siteHostWithProtocol: string ): Promise< void > {
+		let url: URL;
+		try {
+			url = new URL( '/wp-admin/site-editor.php', siteHostWithProtocol );
+		} catch ( error ) {
+			throw new Error(
+				`Invalid site host URL provided: "${ siteHostWithProtocol }". Did you remember to include the protocol?`
+			);
+		}
+
+		url.searchParams.set( 'calypso_origin', envVariables.CALYPSO_BASE_URL );
+
+		await this.page.goto( url.href, { timeout: 60 * 1000 } );
 	}
 
 	/**
@@ -404,19 +401,17 @@ export class FullSiteEditorPage {
 	 */
 	async openNavSidebar(): Promise< void > {
 		const openButton = this.editor.locator( 'button[aria-label="Open Navigation Sidebar"]' );
-		const closeButton = this.editor.locator( '.edit-site-site-hub button.is-primary' );
 
-		await Promise.race( [ closeButton.waitFor(), openButton.click() ] );
+		await openButton.click();
 	}
 
 	/**
-	 * Close the navigation sidebar.
+	 * Close the navigation sidebar. To do this, you actually just click on the editor canvas!
 	 */
 	async closeNavSidebar(): Promise< void > {
 		const openButton = this.editor.locator( 'button[aria-label="Open Navigation Sidebar"]' );
-		const closeButton = this.editor.locator( '.edit-site-site-hub button.is-primary' );
 
-		await Promise.race( [ openButton.waitFor(), closeButton.click() ] );
+		await Promise.race( [ openButton.waitFor(), this.editorCanvas.click() ] );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -175,7 +175,14 @@ export class FullSiteEditorPage {
 	 * Clicks on a button with the exact name.
 	 */
 	async clickFullSiteNavigatorButton( text: string ): Promise< void > {
-		await this.editor.getByRole( 'button', { name: text, exact: true } ).click();
+		await this.fullSiteEditorNavSidebarComponent.clickNavButtonByExactText( text );
+	}
+
+	/**
+	 * Ensures the nav sidebar is at the top level ("Design")
+	 */
+	async ensureNavigationTopLevel(): Promise< void > {
+		await this.fullSiteEditorNavSidebarComponent.ensureNavigationTopLevel();
 	}
 
 	//#endregion
@@ -406,9 +413,15 @@ export class FullSiteEditorPage {
 	}
 
 	/**
-	 * Close the navigation sidebar. To do this, you actually just click on the editor canvas!
+	 * Close the navigation sidebar. To do this, you actually just click on the editor canvas! This only works on desktop.
+	 * On mobile, there is not standardized way to close the sidebar.
 	 */
 	async closeNavSidebar(): Promise< void > {
+		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			throw new Error(
+				'There is no standardized way to close the site editor navigation sidebar on mobile. Navigate to a template or template part instead.'
+			);
+		}
 		const openButton = this.editor.locator( 'button[aria-label="Open Navigation Sidebar"]' );
 
 		await Promise.race( [ openButton.waitFor(), this.editorCanvas.click() ] );

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -74,7 +74,15 @@ export class FullSiteEditorPage {
 	constructor( page: Page ) {
 		this.page = page;
 
-		this.editor = page.locator( selectors.editorRoot );
+		if (
+			! envVariables.TEST_ON_ATOMIC &&
+			envVariables.CALYPSO_BASE_URL === 'https://wordpress.com'
+		) {
+			// The only place we are preserving the Site Editor iFrame is Simple sites on staging/production.
+			this.editor = page.frameLocator( selectors.editorIframe ).locator( selectors.editorRoot );
+		} else {
+			this.editor = page.locator( selectors.editorRoot );
+		}
 
 		this.editorCanvas = this.editor
 			.frameLocator( selectors.editorCanvasIframe )

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -663,8 +663,10 @@ export class FullSiteEditorPage {
 	 * TODO: Temp check -- we will delete when we un-iframe everywhere
 	 */
 	private shouldUseIframe(): boolean {
-		// We continue to use the iFrame on prod / staging
-		return envVariables.CALYPSO_BASE_URL === 'https://wordpress.com';
+		// The only place we are preserving the Site Editor iFrame is Simple sites on staging/production.
+		return (
+			! envVariables.TEST_ON_ATOMIC && envVariables.CALYPSO_BASE_URL === 'https://wordpress.com'
+		);
 	}
 
 	//#endregion

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -663,10 +663,8 @@ export class FullSiteEditorPage {
 	 * TODO: Temp check -- we will delete when we un-iframe everywhere
 	 */
 	private shouldUseIframe(): boolean {
-		// The only place we are preserving the Site Editor iFrame is Simple sites on staging/production.
-		return (
-			! envVariables.TEST_ON_ATOMIC && envVariables.CALYPSO_BASE_URL === 'https://wordpress.com'
-		);
+		// We continue to use the iFrame on prod / staging
+		return envVariables.CALYPSO_BASE_URL === 'https://wordpress.com';
 	}
 
 	//#endregion

--- a/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
@@ -207,7 +207,7 @@ describe(
 				await testAccount.authenticate( page );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
-				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+				fullSiteEditorPage = new FullSiteEditorPage( page );
 			} );
 
 			afterAll( async () => {
@@ -218,7 +218,7 @@ describe(
 			} );
 
 			it( 'Visit the site editor', async function () {
-				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 			} );
 

--- a/test/e2e/specs/editor-tracking/editor-tracking__document-actions-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__document-actions-events.ts
@@ -34,11 +34,11 @@ describe(
 				await testAccount.authenticate( page );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
-				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+				fullSiteEditorPage = new FullSiteEditorPage( page );
 			} );
 
 			it( 'Visit the site editor', async function () {
-				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 			} );
 
@@ -74,11 +74,11 @@ describe(
 				testAccount = new TestAccount( accountName );
 				await testAccount.authenticate( page );
 				editorTracksEventManager = new EditorTracksEventManager( page );
-				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+				fullSiteEditorPage = new FullSiteEditorPage( page );
 			} );
 
 			it( 'Visit the site editor', async function () {
-				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 			} );
 
@@ -125,11 +125,11 @@ describe(
 				testAccount = new TestAccount( accountName );
 				await testAccount.authenticate( page );
 				editorTracksEventManager = new EditorTracksEventManager( page );
-				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+				fullSiteEditorPage = new FullSiteEditorPage( page );
 			} );
 
 			it( 'Visit the site editor', async function () {
-				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 			} );
 
@@ -182,11 +182,11 @@ describe(
 				testAccount = new TestAccount( accountName );
 				await testAccount.authenticate( page );
 				editorTracksEventManager = new EditorTracksEventManager( page );
-				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+				fullSiteEditorPage = new FullSiteEditorPage( page );
 			} );
 
 			it( 'Visit the site editor', async function () {
-				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 			} );
 

--- a/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__fse-template-events.ts
@@ -37,8 +37,8 @@ describe(
 				const testAccount = new TestAccount( accountName );
 				await testAccount.authenticate( page );
 
-				const fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
-				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+				const fullSiteEditorPage = new FullSiteEditorPage( page );
+				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 
 				console.info( `Deleting created template parts: ${ createdTemplateParts.join( ', ' ) }` );
@@ -62,13 +62,13 @@ describe(
 				await testAccount.authenticate( page );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
-				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+				fullSiteEditorPage = new FullSiteEditorPage( page );
 
 				templatePartName = createTemplatePartName();
 			} );
 
 			it( 'Visit the site editor', async function () {
-				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 			} );
 
@@ -116,11 +116,11 @@ describe(
 				await testAccount.authenticate( page );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
-				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+				fullSiteEditorPage = new FullSiteEditorPage( page );
 			} );
 
 			it( 'Visit the site editor', async function () {
-				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 			} );
 
@@ -204,13 +204,13 @@ describe(
 				await testAccount.authenticate( page );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
-				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+				fullSiteEditorPage = new FullSiteEditorPage( page );
 
 				templatePartName = createTemplatePartName();
 			} );
 
 			it( 'Visit the site editor', async function () {
-				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 			} );
 

--- a/test/e2e/specs/editor-tracking/editor-tracking__global-styles-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__global-styles-events.ts
@@ -33,11 +33,11 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			await testAccount.authenticate( page );
 
 			editorTracksEventManager = new EditorTracksEventManager( page );
-			fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+			fullSiteEditorPage = new FullSiteEditorPage( page );
 		} );
 
 		it( 'Visit the site editor', async function () {
-			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 			await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 		} );
 
@@ -95,11 +95,11 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			await testAccount.authenticate( page );
 
 			editorTracksEventManager = new EditorTracksEventManager( page );
-			fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+			fullSiteEditorPage = new FullSiteEditorPage( page );
 		} );
 
 		it( 'Visit the site editor', async function () {
-			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 			await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 		} );
 
@@ -165,11 +165,11 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			await testAccount.authenticate( page );
 
 			editorTracksEventManager = new EditorTracksEventManager( page );
-			fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+			fullSiteEditorPage = new FullSiteEditorPage( page );
 		} );
 
 		it( 'Visit the site editor', async function () {
-			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 			await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 		} );
 
@@ -285,7 +285,7 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 			await testAccount.authenticate( page );
 
 			editorTracksEventManager = new EditorTracksEventManager( page );
-			fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+			fullSiteEditorPage = new FullSiteEditorPage( page );
 		} );
 
 		afterAll( async function () {
@@ -298,7 +298,7 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Global styles events' )
 		} );
 
 		it( 'Visit the site editor', async function () {
-			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 			await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 		} );
 

--- a/test/e2e/specs/editor-tracking/editor-tracking__other-block-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__other-block-events.ts
@@ -91,11 +91,11 @@ describe(
 				await testAccount.authenticate( page );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
-				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+				fullSiteEditorPage = new FullSiteEditorPage( page );
 			} );
 
 			it( 'Go to the site editor', async function () {
-				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 			} );
 

--- a/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__toolbar-events.ts
@@ -116,11 +116,11 @@ skipDescribeIf( envVariables.VIEWPORT_NAME === 'mobile' )(
 				await testAccount.authenticate( page );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
-				fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+				fullSiteEditorPage = new FullSiteEditorPage( page );
 			} );
 
 			it( 'Go to site editor', async function () {
-				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+				await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 				await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 			} );
 

--- a/test/e2e/specs/fse/fse__limited-global-styles.ts
+++ b/test/e2e/specs/fse/fse__limited-global-styles.ts
@@ -23,7 +23,6 @@ describe( DataHelper.createSuiteTitle( 'Site Editor: Limited Global Styles' ), f
 
 	it( 'Visit the site editor', async function () {
 		await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
-		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Edit' );
 		await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 		await fullSiteEditorPage.closeNavSidebar();
 	} );

--- a/test/e2e/specs/fse/fse__limited-global-styles.ts
+++ b/test/e2e/specs/fse/fse__limited-global-styles.ts
@@ -15,7 +15,7 @@ describe( DataHelper.createSuiteTitle( 'Site Editor: Limited Global Styles' ), f
 	beforeAll( async () => {
 		page = await browser.newPage();
 
-		const testAccount = new TestAccount( 'simpleSiteFreePlanUser' );
+		testAccount = new TestAccount( 'simpleSiteFreePlanUser' );
 		await testAccount.authenticate( page );
 
 		fullSiteEditorPage = new FullSiteEditorPage( page );

--- a/test/e2e/specs/fse/fse__limited-global-styles.ts
+++ b/test/e2e/specs/fse/fse__limited-global-styles.ts
@@ -24,7 +24,11 @@ describe( DataHelper.createSuiteTitle( 'Site Editor: Limited Global Styles' ), f
 	it( 'Visit the site editor', async function () {
 		await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 		await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
-		await fullSiteEditorPage.closeNavSidebar();
+
+		await fullSiteEditorPage.ensureNavigationTopLevel();
+		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Templates' );
+		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Page' );
+		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Edit' );
 	} );
 
 	it( 'Open site styles', async function () {

--- a/test/e2e/specs/fse/fse__limited-global-styles.ts
+++ b/test/e2e/specs/fse/fse__limited-global-styles.ts
@@ -2,12 +2,7 @@
  * @group gutenberg
  */
 
-import {
-	DataHelper,
-	TestAccount,
-	FullSiteEditorPage,
-	SecretsManager,
-} from '@automattic/calypso-e2e';
+import { DataHelper, TestAccount, FullSiteEditorPage } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
 declare const browser: Browser;
@@ -15,8 +10,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Site Editor: Limited Global Styles' ), function () {
 	let page: Page;
 	let fullSiteEditorPage: FullSiteEditorPage;
-	const credentials = SecretsManager.secrets.testAccounts.simpleSiteFreePlanUser;
-	const siteSlug = credentials.testSites?.primary?.url as string;
+	let testAccount: TestAccount;
 
 	beforeAll( async () => {
 		page = await browser.newPage();
@@ -28,7 +22,7 @@ describe( DataHelper.createSuiteTitle( 'Site Editor: Limited Global Styles' ), f
 	} );
 
 	it( 'Visit the site editor', async function () {
-		await fullSiteEditorPage.visit( siteSlug );
+		await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Edit' );
 		await fullSiteEditorPage.prepareForInteraction( { leaveWithoutSaving: true } );
 		await fullSiteEditorPage.closeNavSidebar();

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -49,7 +49,7 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	} );
 
 	it( 'Open the Page template', async function () {
-		fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
+		fullSiteEditorPage = new FullSiteEditorPage( page );
 
 		await fullSiteEditorPage.prepareForInteraction();
 
@@ -61,8 +61,6 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	} );
 
 	it( 'Editor canvas loads', async function () {
-		fullSiteEditorPage = new FullSiteEditorPage( page, { target: features.siteType } );
-
 		await fullSiteEditorPage.waitUntilLoaded();
 	} );
 } );

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -53,8 +53,7 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 
 		await fullSiteEditorPage.prepareForInteraction();
 
-		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Back' );
-		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Back' );
+		await fullSiteEditorPage.ensureNavigationTopLevel();
 		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Templates' );
 		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Page' );
 		await fullSiteEditorPage.clickFullSiteNavigatorButton( 'Edit' );


### PR DESCRIPTION
Related to #74413

## Proposed Changes

Load the Site Editor without the iframe. Enabled in local dev or wpcalypso (incl. `*.calypso.live`) envs.

## Testing Instructions

Load the Site Editor through this PR or in the calypso.live branch below. 

* Try to access the Site Editor via the admin menu or Launchpad or any other place you know of. 
* Ensure that everything works as expected (the media library is of course different). 
* Try to buy upgrades via premium blocks.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
