### PR TITLE
Marketplace: Theme Installation page redirecting to the Thank You Page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -37,10 +37,12 @@ export function useThemesThankYouData( themeSlugs: string[] ): ThankYouData {
 
 	const themesSection: ThankYouSectionProps = {
 		sectionKey: 'theme_information',
-		nextSteps: themesList.map( ( theme ) => ( {
-			stepKey: `theme_information_${ theme?.id }`,
-			stepSection: <ThankYouThemeSection theme={ theme } />,
-		} ) ),
+		nextSteps: themesList
+			.filter( ( theme ) => theme )
+			.map( ( theme ) => ( {
+				stepKey: `theme_information_${ theme.id }`,
+				stepSection: <ThankYouThemeSection theme={ theme } />,
+			} ) ),
 	};
 
 	const goBackSection = (

--- a/client/my-sites/marketplace/controller.js
+++ b/client/my-sites/marketplace/controller.js
@@ -17,6 +17,12 @@ export function renderPluginsInstallPage( context, next ) {
 	next();
 }
 
+export function renderThemesInstallPage( context, next ) {
+	const { themeSlug } = context.params;
+	context.primary = <MarketplacePluginInstall themeSlug={ themeSlug } />;
+	next();
+}
+
 export function renderMarketplaceThankYou( context, next ) {
 	const { plugins, themes } = context.query;
 	const pluginSlugs = plugins ? plugins.split( ',' ) : [];

--- a/client/my-sites/marketplace/index.js
+++ b/client/my-sites/marketplace/index.js
@@ -7,6 +7,7 @@ import {
 	renderMarketplaceTestPage,
 	renderMarketplaceThankYou,
 	renderPluginsInstallPage,
+	renderThemesInstallPage,
 	redirectToHome,
 	renderMarketplaceSignupSuccess,
 } from './controller';
@@ -34,6 +35,15 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
+	page(
+		'/marketplace/theme/:themeSlug?/install/:site?',
+		siteSelection,
+		renderThemesInstallPage,
+		makeLayout,
+		clientRender
+	);
+
 	page(
 		'/marketplace/thank-you/:site?',
 		siteSelection,

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -279,16 +279,19 @@ const MarketplacePluginInstall = ( {
 		}
 	}, [ themeSlug, wpOrgTheme, isThemeActive, selectedSiteSlug ] );
 
-	const steps = useMemo(
-		() => [
+	const steps = useMemo( () => {
+		if ( themeSlug ) {
+			return [ translate( 'Setting up theme installation' ), translate( 'Activating theme' ) ];
+		}
+
+		return [
 			isUploadFlow
 				? translate( 'Uploading plugin' )
 				: translate( 'Setting up plugin installation' ),
 			translate( 'Installing plugin' ),
 			translate( 'Activating plugin' ),
-		],
-		[ isUploadFlow, translate ]
-	);
+		];
+	}, [ themeSlug, isUploadFlow, translate ] );
 	const additionalSteps = useMarketplaceAdditionalSteps();
 
 	const renderError = () => {

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -14,6 +14,7 @@ import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query
 import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useInterval } from 'calypso/lib/interval';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
 import useMarketplaceAdditionalSteps from 'calypso/my-sites/marketplace/pages/marketplace-plugin-install/use-marketplace-additional-steps';
@@ -43,6 +44,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	activateTheme,
 	initiateThemeTransfer as initiateTransfer,
+	requestActiveTheme,
 } from 'calypso/state/themes/actions';
 import { getTheme, isThemeActive as getThemeActive } from 'calypso/state/themes/selectors';
 import {
@@ -293,6 +295,14 @@ const MarketplacePluginInstall = ( {
 			);
 		}
 	}, [ themeSlug, wpOrgTheme, isThemeActive, selectedSiteSlug ] );
+
+	// Polling for theme activation status
+	useInterval(
+		() => {
+			dispatch( requestActiveTheme( siteId ) );
+		},
+		! themeSlug || currentStep === 0 || ( themeSlug && wpOrgTheme && isThemeActive ) ? null : 3000
+	);
 
 	const steps = useMemo( () => {
 		if ( themeSlug ) {

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -128,7 +128,8 @@ const MarketplacePluginInstall = ( {
 		}
 		return (
 			pluginInstallationStatus !== MARKETPLACE_ASYNC_PROCESS_STATUS.COMPLETED &&
-			productSlugInstalled === ( productSlug || themeSlug ) &&
+			productSlugInstalled &&
+			[ productSlug, themeSlug ].includes( productSlugInstalled ) &&
 			primaryDomain === selectedSiteSlug
 		);
 	} );

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/types.ts
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/types.ts
@@ -1,3 +1,4 @@
 export type MarketplacePluginInstallProps = {
-	productSlug: string;
+	productSlug?: string;
+	themeSlug?: string;
 };

--- a/client/state/atomic/transfers/actions.ts
+++ b/client/state/atomic/transfers/actions.ts
@@ -24,22 +24,26 @@ export interface AtomicTransferError {
 	code: string; // "no_transfer_record"
 }
 
+export interface InitiateTransfer {
+	softwareSet?: string | 'woo-on-plans';
+	themeSlug?: string;
+	pluginSlug?: string;
+	pluginFile?: File;
+	themeFile?: File;
+}
+
 /**
  * Initiate Atomic transfer, optionally with software set install.
  *
  * @param {string} siteId Site ID.
- * @param {Object} options Transfer options.
- * @param {string} options.softwareSet Software set to install.
+ * @param {InitiateTransfer} initiateTransfer The InitiateTransfer parameters.
  * @returns {Object} An action object.
  */
-export const initiateAtomicTransfer = (
-	siteId: number,
-	{ softwareSet }: { softwareSet: string }
-) =>
+export const initiateAtomicTransfer = ( siteId: number, initiateTransfer: InitiateTransfer ) =>
 	( {
 		type: ATOMIC_TRANSFER_INITIATE_TRANSFER,
 		siteId,
-		softwareSet,
+		...initiateTransfer,
 	} as const );
 
 /**

--- a/client/state/data-layer/wpcom/sites/atomic/test/transfers/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/test/transfers/index.js
@@ -1,0 +1,21 @@
+import { mapToRequestBody } from 'state/data-layer/wpcom/sites/atomic/transfers';
+
+describe( 'AtomicTransfers', () => {
+	test( 'Should map the InitiateTransfer to request body', () => {
+		const initiateTransferWithSoftwareSet = {
+			softwareSet: 'woo-on-all-plans',
+		};
+
+		expect( mapToRequestBody( initiateTransferWithSoftwareSet ) ).toEqual( {
+			software_set: 'woo-on-all-plans',
+		} );
+
+		const initiateTransferWithThemeSlug = {
+			themeSlug: 'foo',
+		};
+
+		expect( mapToRequestBody( initiateTransferWithThemeSlug ) ).toEqual( {
+			theme_slug: 'foo',
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
@@ -8,6 +8,32 @@ import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 
+export const mapToRequestBody = ( action ) => {
+	const requestBody = {};
+
+	if ( action.softwareSet ) {
+		requestBody.software_set = action.softwareSet;
+	}
+
+	if ( action.themeSlug ) {
+		requestBody.theme_slug = action.themeSlug;
+	}
+
+	if ( action.pluginSlug ) {
+		requestBody.plugin_slug = action.pluginSlug;
+	}
+
+	if ( action.themeFile ) {
+		requestBody.theme_file = action.themeFile;
+	}
+
+	if ( action.pluginFile ) {
+		requestBody.plugin_file = action.pluginFile;
+	}
+
+	return requestBody;
+};
+
 const initiateAtomicTransfer = ( action ) =>
 	http(
 		{
@@ -16,9 +42,7 @@ const initiateAtomicTransfer = ( action ) =>
 			path: `/sites/${ action.siteId }/atomic/transfers/`,
 			...( action.softwareSet
 				? {
-						body: {
-							software_set: action.softwareSet,
-						},
+						body: mapToRequestBody( action ),
 				  }
 				: {} ),
 		},

--- a/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
@@ -40,7 +40,7 @@ const initiateAtomicTransfer = ( action ) =>
 			apiNamespace: 'wpcom/v2',
 			method: 'POST',
 			path: `/sites/${ action.siteId }/atomic/transfers/`,
-			...( action.softwareSet
+			...( action.softwareSet || action.themeSlug
 				? {
 						body: mapToRequestBody( action ),
 				  }


### PR DESCRIPTION
Fixes [Marketplace: Transfer to Atomic when activating a Theme#2045](https://github.com/Automattic/dotcom-forge/issues/2045)

## Proposed Changes
* Add an installation route for themes
* Update texts and illustrations for themes
* Add theme installation via direct URL access
* Add atomic transformation for themes

## Testing Instructions

* From an atomic site
* Go to the theme installation route with a dotorg slug. Ex: `/marketplace/theme/astra/install/:site`
* Click to activate the theme
* wait for the theme activation and you should be redirected to the thank you page with the theme selected


---


* From a simple site
* Go to the theme installation route with a dotorg slug. Ex: `/marketplace/theme/astra/install/:site`
* Click to activate the theme
* wait for the theme activation and atomic and you should be redirected to the thank you page with the theme selected, similar to the previous step


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
