### PR TITLE
WoA Logging i1: Add the ability to expand row to show logs vertical layout.

### DIFF
--- a/client/my-sites/site-logs/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/index.tsx
@@ -1,9 +1,9 @@
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { memo, useMemo } from 'react';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { SiteLogsData } from 'calypso/data/hosting/use-site-logs-query';
 import { useCurrentSiteGmtOffset } from '../../hooks/use-current-site-gmt-offset';
+import SiteLogsTableRow from './site-logs-table-row';
 import { Skeleton } from './skeleton';
 
 import './style.scss';
@@ -19,7 +19,6 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 	logs,
 	isLoading,
 }: SiteLogsTableProps ) {
-	const moment = useLocalizedMoment();
 	const { __ } = useI18n();
 	const columns = useSiteColumns( logs );
 	const siteGmtOffset = useCurrentSiteGmtOffset();
@@ -45,11 +44,12 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 				{ logs?.map( ( log, index ) => (
 					// An index key is ok in this case because it's just as unique to the log entry as a
 					// time stamp.
-					<tr key={ index }>
-						{ columns.map( ( column ) => (
-							<td key={ column }>{ renderCell( column, log[ column ], moment, siteGmtOffset ) }</td>
-						) ) }
-					</tr>
+					<SiteLogsTableRow
+						key={ index }
+						columns={ columns }
+						log={ log }
+						siteGmtOffset={ siteGmtOffset }
+					/>
 				) ) }
 			</tbody>
 		</table>
@@ -83,33 +83,4 @@ function useSiteColumns( logs: SiteLogs | undefined ) {
 
 		return Array.from( columns );
 	}, [ logs ] );
-}
-
-function renderCell(
-	column: string,
-	value: unknown,
-	moment: ReturnType< typeof useLocalizedMoment >,
-	siteGmtOffset: number
-) {
-	if ( value === null || value === undefined || value === '' ) {
-		return <span className="site-logs-table__empty-cell" />;
-	}
-
-	if ( ( column === 'date' || column === 'timestamp' ) && typeof value === 'string' ) {
-		return moment( value )
-			.utcOffset( siteGmtOffset * 60 )
-			.format( 'll @ HH:mm:ss.SSS Z' );
-	}
-
-	switch ( typeof value ) {
-		case 'boolean':
-			return value.toString();
-
-		case 'number':
-		case 'string':
-			return value;
-
-		default:
-			JSON.stringify( value );
-	}
 }

--- a/client/my-sites/site-logs/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/index.tsx
@@ -35,6 +35,7 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 		<table className={ classnames( 'site-logs-table', { 'is-loading': isLoading } ) }>
 			<thead>
 				<tr>
+					<th />
 					{ columns.map( ( column ) => (
 						<th key={ column }>{ column }</th>
 					) ) }

--- a/client/my-sites/site-logs/components/site-logs-table/site-logs-expanded-content.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/site-logs-expanded-content.tsx
@@ -1,0 +1,20 @@
+import './style.scss';
+
+interface Props {
+	log: Record< string, unknown >;
+}
+
+export default function SiteLogsExpandedContent( { log }: Props ) {
+	return (
+		<div className="site-logs-table__expanded-content">
+			{ Object.keys( log ).map( ( key ) => (
+				<tr key={ `expanded-row-${ key }` }>
+					<td>{ key }</td>
+					<td>
+						<div className="site-logs-table__expanded-content-info">{ log[ key ] }</div>
+					</td>
+				</tr>
+			) ) }
+		</div>
+	);
+}

--- a/client/my-sites/site-logs/components/site-logs-table/site-logs-expanded-content.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/site-logs-expanded-content.tsx
@@ -1,7 +1,8 @@
+import { SiteLogsData } from 'calypso/data/hosting/use-site-logs-query';
 import './style.scss';
 
 interface Props {
-	log: Record< string, unknown >;
+	log: SiteLogsData[ 'logs' ][ 0 ];
 }
 
 export default function SiteLogsExpandedContent( { log }: Props ) {
@@ -10,7 +11,7 @@ export default function SiteLogsExpandedContent( { log }: Props ) {
 			{ Object.keys( log ).map( ( key ) => (
 				<tr key={ `expanded-row-${ key }` }>
 					<td>
-						<strong>{ key }</strong>{ ' ' }
+						<strong>{ key }</strong>
 					</td>
 					<td>
 						<div className="site-logs-table__expanded-content-info">{ log[ key ] || '-' }</div>

--- a/client/my-sites/site-logs/components/site-logs-table/site-logs-expanded-content.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/site-logs-expanded-content.tsx
@@ -9,9 +9,11 @@ export default function SiteLogsExpandedContent( { log }: Props ) {
 		<div className="site-logs-table__expanded-content">
 			{ Object.keys( log ).map( ( key ) => (
 				<tr key={ `expanded-row-${ key }` }>
-					<td>{ key }</td>
 					<td>
-						<div className="site-logs-table__expanded-content-info">{ log[ key ] }</div>
+						<strong>{ key }</strong>{ ' ' }
+					</td>
+					<td>
+						<div className="site-logs-table__expanded-content-info">{ log[ key ] || '-' }</div>
 					</td>
 				</tr>
 			) ) }

--- a/client/my-sites/site-logs/components/site-logs-table/site-logs-expanded-content.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/site-logs-expanded-content.tsx
@@ -1,4 +1,6 @@
+import { Fragment } from '@wordpress/element';
 import { SiteLogsData } from 'calypso/data/hosting/use-site-logs-query';
+
 import './style.scss';
 
 interface Props {
@@ -9,16 +11,16 @@ export default function SiteLogsExpandedContent( { log }: Props ) {
 	return (
 		<div className="site-logs-table__expanded-content">
 			{ Object.keys( log ).map( ( key ) => (
-				<tr key={ key }>
-					<td>
+				<Fragment key={ key }>
+					<div>
 						<strong>{ key }</strong>
-					</td>
-					<td>
+					</div>
+					<div>
 						<div className="site-logs-table__expanded-content-info">
 							{ renderCell( key, log[ key ] ) }
 						</div>
-					</td>
-				</tr>
+					</div>
+				</Fragment>
 			) ) }
 		</div>
 	);

--- a/client/my-sites/site-logs/components/site-logs-table/site-logs-expanded-content.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/site-logs-expanded-content.tsx
@@ -14,10 +14,30 @@ export default function SiteLogsExpandedContent( { log }: Props ) {
 						<strong>{ key }</strong>
 					</td>
 					<td>
-						<div className="site-logs-table__expanded-content-info">{ log[ key ] || '-' }</div>
+						<div className="site-logs-table__expanded-content-info">
+							{ renderCell( key, log[ key ] ) }
+						</div>
 					</td>
 				</tr>
 			) ) }
 		</div>
 	);
+}
+
+function renderCell( column: string, value: unknown ) {
+	if ( value === null || value === undefined || value === '' ) {
+		return '-';
+	}
+
+	switch ( typeof value ) {
+		case 'boolean':
+			return value.toString();
+
+		case 'number':
+		case 'string':
+			return value;
+
+		default:
+			JSON.stringify( value );
+	}
 }

--- a/client/my-sites/site-logs/components/site-logs-table/site-logs-expanded-content.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/site-logs-expanded-content.tsx
@@ -9,7 +9,7 @@ export default function SiteLogsExpandedContent( { log }: Props ) {
 	return (
 		<div className="site-logs-table__expanded-content">
 			{ Object.keys( log ).map( ( key ) => (
-				<tr key={ `expanded-row-${ key }` }>
+				<tr key={ key }>
 					<td>
 						<strong>{ key }</strong>
 					</td>

--- a/client/my-sites/site-logs/components/site-logs-table/site-logs-table-row.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/site-logs-table-row.tsx
@@ -1,0 +1,68 @@
+import { Button } from '@automattic/components';
+import { Icon, chevronDown, chevronRight } from '@wordpress/icons';
+import moment from 'moment';
+import { Fragment, useState } from 'react';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import SiteLogsExpandedContent from './site-logs-expanded-content';
+import './style.scss';
+
+interface Props {
+	columns: string[];
+	log: Record< string, unknown >;
+	siteGmtOffset: number;
+}
+
+export default function SiteLogsTableRow( { columns, log, siteGmtOffset }: Props ) {
+	const [ isExpanded, setIsExpanded ] = useState( false );
+	return (
+		<Fragment>
+			<tr>
+				<td>
+					<Button borderless onClick={ () => setIsExpanded( ! isExpanded ) } compact>
+						<Icon icon={ isExpanded ? chevronDown : chevronRight } />
+					</Button>
+				</td>
+				{ columns.map( ( column ) => (
+					<td key={ column }>{ renderCell( column, log[ column ], moment, siteGmtOffset ) }</td>
+				) ) }
+			</tr>
+
+			{ isExpanded && (
+				<tr className="site-logs-table__table-row-expanded">
+					<td colSpan={ Object.keys( log ).length + 1 }>
+						<SiteLogsExpandedContent log={ log } />
+					</td>
+				</tr>
+			) }
+		</Fragment>
+	);
+}
+
+function renderCell(
+	column: string,
+	value: unknown,
+	moment: ReturnType< typeof useLocalizedMoment >,
+	siteGmtOffset: number
+) {
+	if ( value === null || value === undefined || value === '' ) {
+		return <span className="site-logs-table__empty-cell" />;
+	}
+
+	if ( ( column === 'date' || column === 'timestamp' ) && typeof value === 'string' ) {
+		return moment( value )
+			.utcOffset( siteGmtOffset * 60 )
+			.format( 'll @ HH:mm:ss.SSS Z' );
+	}
+
+	switch ( typeof value ) {
+		case 'boolean':
+			return value.toString();
+
+		case 'number':
+		case 'string':
+			return value;
+
+		default:
+			JSON.stringify( value );
+	}
+}

--- a/client/my-sites/site-logs/components/site-logs-table/site-logs-table-row.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/site-logs-table-row.tsx
@@ -3,12 +3,13 @@ import { Icon, chevronDown, chevronRight } from '@wordpress/icons';
 import moment from 'moment';
 import { Fragment, useState } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { SiteLogsData } from 'calypso/data/hosting/use-site-logs-query';
 import SiteLogsExpandedContent from './site-logs-expanded-content';
 import './style.scss';
 
 interface Props {
 	columns: string[];
-	log: Record< string, unknown >;
+	log: SiteLogsData[ 'logs' ][ 0 ];
 	siteGmtOffset: number;
 }
 

--- a/client/my-sites/site-logs/components/site-logs-table/style.scss
+++ b/client/my-sites/site-logs/components/site-logs-table/style.scss
@@ -47,6 +47,7 @@ tr.site-logs-table__table-row-expanded {
 	background: var(--studio-gray-0) !important;
 	td {
 		border-top: none;
+		vertical-align: top;
 	}
 }
 

--- a/client/my-sites/site-logs/components/site-logs-table/style.scss
+++ b/client/my-sites/site-logs/components/site-logs-table/style.scss
@@ -23,6 +23,7 @@ $border-color: #d3dae6;
 .site-logs-table th,
 .site-logs-table td {
 	padding: 0.6em 1em;
+	vertical-align: middle;
 }
 
 .site-logs-table__empty-cell::before {
@@ -40,4 +41,27 @@ $border-color: #d3dae6;
 
 .site-logs-table__skeleton-table-cell {
 	height: 24px;
+}
+
+tr.site-logs-table__table-row-expanded {
+	background: var(--studio-gray-0) !important;
+	td {
+		border-top: none;
+	}
+}
+
+.site-logs-table__expanded-content {
+	padding-left: 30px;
+	font-size: 0.875rem;
+	tr {
+		border: none !important;
+	}
+}
+
+.site-logs-table__expanded-content-info {
+	word-break: break-word;
+	word-wrap: break-word;
+	max-width: 70%;
+	white-space: pre-wrap;
+	display: inline-block;
 }

--- a/client/my-sites/site-logs/components/site-logs-table/style.scss
+++ b/client/my-sites/site-logs/components/site-logs-table/style.scss
@@ -54,15 +54,35 @@ tr.site-logs-table__table-row-expanded {
 .site-logs-table__expanded-content {
 	padding-left: 30px;
 	font-size: 0.875rem;
-	tr {
-		border: none !important;
+	display: grid;
+	grid-template-columns: auto 1fr;
+	gap: 0.6em 1em;
+
+	// This makes the expanded content fit inside the viewport
+	// The 440px takes into account the Calypso sidebar and the necessary table padding
+	width: calc(100vw - 440px);
+
+	@media (max-width: 800px) {
+		padding-left: 16px;
+		width: calc(100vw - 80px);
+	}
+
+	@media (max-width: 600px) {
+		grid-template-columns: 1fr;
 	}
 }
 
 .site-logs-table__expanded-content-info {
 	word-break: break-word;
 	word-wrap: break-word;
-	max-width: 70%;
 	white-space: pre-wrap;
 	display: inline-block;
+}
+
+body.is-sidebar-collapsed .site-logs-table__expanded-content {
+	width: calc(100vw - 200px);
+
+	@media (max-width: 800px) {
+		width: calc(100vw - 80px);
+	}
 }

--- a/client/my-sites/site-logs/test/main.tsx
+++ b/client/my-sites/site-logs/test/main.tsx
@@ -80,7 +80,7 @@ test( 'displays the last 7 days worth of logs in descending order on mount', asy
 	await waitFor( () => expect( screen.getByText( /log entry/ ) ).toBeInTheDocument() );
 } );
 
-test( 'date is always rendered in the first column place', async () => {
+test( 'date is always rendered in the second column place', async () => {
 	mockSuccessfulLogApis( [
 		// API is returning date in the last column
 		{ message_first: 'log entry', date: '2023-03-24T04:36:04.238Z' },
@@ -89,7 +89,7 @@ test( 'date is always rendered in the first column place', async () => {
 	const { container } = render( <SiteLogs />, { initialState: makeTestState() } );
 
 	await waitFor( () =>
-		expect( container.querySelector( 'th:first-child' ) ).toHaveTextContent( 'date' )
+		expect( container.querySelector( 'th:nth-child(2)' ) ).toHaveTextContent( 'date' )
 	);
 } );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/1997

## Proposed Changes

*Add ability to expand rows and view logs vertically

## Testing Instructions

- Go to `/site-logs/:atomicSite`
- Get logs for a date range
- Verify multiple rows can be expanded

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
