### PR TITLE
Logging: Make `/site-logs` available to all users

### DIFF
--- a/client/my-sites/site-logs/controller.tsx
+++ b/client/my-sites/site-logs/controller.tsx
@@ -1,4 +1,7 @@
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { SiteLogs } from './main';
 
 export const siteLogs: PageJS.Callback = ( context, next ) => {
@@ -8,5 +11,22 @@ export const siteLogs: PageJS.Callback = ( context, next ) => {
 			<SiteLogs />
 		</>
 	);
+	next();
+};
+
+export const redirectHomeIfIneligible: PageJS.Callback = ( context, next ) => {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+
+	if ( isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } ) ) {
+		context.page.replace( `/stats/day/${ context.params.siteId }` );
+		return;
+	}
+
+	if ( ! isAtomicSite( state, siteId ) ) {
+		context.page.replace( `/home/${ context.params.siteId }` );
+		return;
+	}
+
 	next();
 };

--- a/client/my-sites/site-logs/index.ts
+++ b/client/my-sites/site-logs/index.ts
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
-import { siteLogs } from './controller';
+import { redirectHomeIfIneligible, siteLogs } from './controller';
 
 export default function () {
 	if ( ! isEnabled( 'woa-logging' ) ) {
@@ -15,5 +15,13 @@ export default function () {
 
 	page( '/site-logs', siteSelection, sites, makeLayout, clientRender );
 
-	page( '/site-logs/:siteId', siteSelection, navigation, siteLogs, makeLayout, clientRender );
+	page(
+		'/site-logs/:siteId',
+		siteSelection,
+		redirectHomeIfIneligible,
+		navigation,
+		siteLogs,
+		makeLayout,
+		clientRender
+	);
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -142,7 +142,8 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"newsletter/stats": true
+		"newsletter/stats": true,
+		"woa-logging": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/production.json
+++ b/config/production.json
@@ -164,7 +164,8 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"newsletter/stats": false
+		"newsletter/stats": false,
+		"woa-logging": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -160,7 +160,8 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"newsletter/stats": false
+		"newsletter/stats": false,
+		"woa-logging": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/test.json
+++ b/config/test.json
@@ -109,6 +109,7 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"wordpress-action-search": false,
-		"wpcom-user-bootstrap": false
+		"wpcom-user-bootstrap": false,
+		"woa-logging": true
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -170,7 +170,8 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/staging-sites-i1": true
+		"yolo/staging-sites-i1": true,
+		"woa-logging": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Part of launching the Site Logs feature pet6gk-3g-p2

* Enable `woa-logging` flag in all environments
* Redirect away from `/site-logs` if site isn't eligible to see

The visibility of the Site Logs section could be gated by only the `isAtomic` selector, since the logging we're using is a feature of the Atomic platform. However the `isJetpack` selector is useful so we don't round-trip Jetpack sites through `/home` only to be bounced on to `/stats/day`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test in pre-production environments and confirm Calypso now allows WoA sites to see the Site Logs section.
* Test a Jurassic Ninja site
* Test a simple site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~