### PR TITLE
Logging: Remove log download UI from Hosting Configuration

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -143,7 +143,8 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"newsletter/stats": true,
-		"woa-logging": true
+		"woa-logging": true,
+		"woa-logging-moved": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/production.json
+++ b/config/production.json
@@ -165,7 +165,8 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"newsletter/stats": false,
-		"woa-logging": true
+		"woa-logging": true,
+		"woa-logging-moved": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"oauth_client_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -161,7 +161,8 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"newsletter/stats": false,
-		"woa-logging": true
+		"woa-logging": true,
+		"woa-logging-moved": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",

--- a/config/test.json
+++ b/config/test.json
@@ -111,6 +111,7 @@
 		"virtual-themes/onboarding": true,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
-		"woa-logging": true
+		"woa-logging": true,
+		"woa-logging-moved": true
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -172,7 +172,8 @@
 		"wpcom-user-bootstrap": true,
 		"yolo/staging-sites-i1": true,
 		"virtual-themes/onboarding": true,
-		"woa-logging": true
+		"woa-logging": true,
+		"woa-logging-moved": true
 	},
 	"siftscience_key": "e00e878351",
 	"oauth_client_id": "39911",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

> Do not deploy until #75200 and Automattic/wpcomsh#1330 have been deployed

## Proposed Changes

Part of launching the Site Logs feature pet6gk-3g-p2

* Enable `woa-logging-moved` flag in all environments

This will hide the log download feature from `/hosting-config`, finalising the move of the logging UI from Hosting Config to Site Logs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test in pre-production environments and confirm Calypso no longer shows logs in `/hosting-config`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
