### PR TITLE
Scroll to top/bottom to show the current header/footer

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -211,7 +211,13 @@ const PatternAssembler = ( {
 		} as Design );
 
 	const updateActivePatternPosition = ( position: number ) => {
-		const patternPosition = header ? position + 1 : position;
+		let patternPosition = position;
+		if ( header ) {
+			patternPosition += 1;
+		}
+		if ( ! footer ) {
+			patternPosition -= 1;
+		}
 		setActivePosition( Math.max( patternPosition, 0 ) );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -501,6 +501,7 @@ const PatternAssembler = ( {
 						onSelect={ onSelect }
 						onBack={ () => onPatternSelectorBack( 'header' ) }
 						onDoneClick={ () => onDoneClick( 'header' ) }
+						updateActivePatternPosition={ () => updateActivePatternPosition( -1 ) }
 					/>
 				</NavigatorScreen>
 
@@ -510,6 +511,7 @@ const PatternAssembler = ( {
 						onSelect={ onSelect }
 						onBack={ () => onPatternSelectorBack( 'footer' ) }
 						onDoneClick={ () => onDoneClick( 'footer' ) }
+						updateActivePatternPosition={ () => updateActivePatternPosition( sections.length ) }
 					/>
 				</NavigatorScreen>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -211,13 +211,7 @@ const PatternAssembler = ( {
 		} as Design );
 
 	const updateActivePatternPosition = ( position: number ) => {
-		let patternPosition = position;
-		if ( header ) {
-			patternPosition += 1;
-		}
-		if ( ! footer ) {
-			patternPosition -= 1;
-		}
+		const patternPosition = header ? position + 1 : position;
 		setActivePosition( Math.max( patternPosition, 0 ) );
 	};
 
@@ -235,9 +229,14 @@ const PatternAssembler = ( {
 		}
 	};
 
+	const activateFooterPosition = ( hasFooter: boolean ) => {
+		const lastPosition = hasFooter ? sections.length : sections.length - 1;
+		updateActivePatternPosition( lastPosition );
+	};
+
 	const updateFooter = ( pattern: Pattern | null ) => {
 		setFooter( pattern );
-		updateActivePatternPosition( sections.length );
+		activateFooterPosition( !! pattern );
 		if ( pattern ) {
 			if ( footer ) {
 				showNotice( 'replace', pattern );
@@ -511,7 +510,7 @@ const PatternAssembler = ( {
 						onSelect={ onSelect }
 						onBack={ () => onPatternSelectorBack( 'footer' ) }
 						onDoneClick={ () => onDoneClick( 'footer' ) }
-						updateActivePatternPosition={ () => updateActivePatternPosition( sections.length ) }
+						updateActivePatternPosition={ () => activateFooterPosition( !! footer ) }
 					/>
 				</NavigatorScreen>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { __experimentalNavigatorBackButton as NavigatorBackButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import NavigatorHeader from './navigator-header';
 import PatternSelector from './pattern-selector';
 import { useFooterPatterns } from './patterns-data';
@@ -11,11 +12,21 @@ interface Props {
 	onSelect: ( type: string, selectedPattern: Pattern | null, selectedCategory: string ) => void;
 	onBack: () => void;
 	onDoneClick: () => void;
+	updateActivePatternPosition: () => void;
 }
 
-const ScreenFooter = ( { selectedPattern, onSelect, onBack, onDoneClick }: Props ) => {
+const ScreenFooter = ( {
+	selectedPattern,
+	onSelect,
+	onBack,
+	onDoneClick,
+	updateActivePatternPosition,
+}: Props ) => {
 	const translate = useTranslate();
 	const patterns = useFooterPatterns();
+	useEffect( () => {
+		updateActivePatternPosition();
+	}, [ updateActivePatternPosition ] );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { __experimentalNavigatorBackButton as NavigatorBackButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import NavigatorHeader from './navigator-header';
 import PatternSelector from './pattern-selector';
 import { useHeaderPatterns } from './patterns-data';
@@ -11,11 +12,21 @@ interface Props {
 	onSelect: ( type: string, selectedPattern: Pattern | null, selectedCategory: string ) => void;
 	onBack: () => void;
 	onDoneClick: () => void;
+	updateActivePatternPosition: () => void;
 }
 
-const ScreenHeader = ( { selectedPattern, onSelect, onBack, onDoneClick }: Props ) => {
+const ScreenHeader = ( {
+	selectedPattern,
+	onSelect,
+	onBack,
+	onDoneClick,
+	updateActivePatternPosition,
+}: Props ) => {
 	const translate = useTranslate();
 	const patterns = useHeaderPatterns();
+	useEffect( () => {
+		updateActivePatternPosition();
+	}, [ updateActivePatternPosition ] );
 
 	return (
 		<>


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/74831

## Proposed Changes

- Scroll to the top/bottom automatically before adding/replacing the header/footer.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site and click `Continue` until you land on the Design Picker
* Go to the Site Assembler by clicking `Start designing` from the bottom
* Add some `Sections`
* Open `Header`/`Footer` and see it scrolls to the top/bottom
	* You can also see what happens when you add/replace/remove `Header`/`Footer`

https://user-images.githubusercontent.com/5287479/229421432-dd789551-6c9b-4e59-85f2-412873164cce.mov

 or without footer

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
