### PR TITLE
Update required Jetpack version to 12.0 for Unified Importer

### DIFF
--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -64,7 +64,7 @@ const getImporterTypeForEngine = ( engine ) => `importer-type-${ engine }`;
  *
  * @see https://github.com/Automattic/jetpack/pull/28824#issuecomment-1439031413
  */
-const JETPACK_IMPORT_MIN_PLUGIN_VERSION = '11.9-a.5';
+const JETPACK_IMPORT_MIN_PLUGIN_VERSION = '12.0';
 
 class SectionImport extends Component {
 	static propTypes = {

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -61,8 +61,6 @@ const getImporterTypeForEngine = ( engine ) => `importer-type-${ engine }`;
 
 /**
  * The minimum version of the Jetpack plugin required to use the Jetpack Importer API.
- *
- * @see https://github.com/Automattic/jetpack/pull/28824#issuecomment-1439031413
  */
 const JETPACK_IMPORT_MIN_PLUGIN_VERSION = '12.0';
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/73802

## Proposed Changes

* Update the minimum required version to 12.0
* This seems to be rolled out in beta to all Jetpack folks and seems to be live on WPCOM, see: p1680496222554289-slack-C01A60HCGUA

## Testing Instructions

* Use Jetpack Beta plugin to tweak the Jetpack version on JN
* Test before and after cases.

## Pre-merge Checklist


- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
~~- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
~~- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
~~- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
~~- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~