### PR TITLE
PoC: Create the `useScreenHandler` hook

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen-handler.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen-handler.ts
@@ -1,0 +1,146 @@
+import { PATTERN_ASSEMBLER_EVENTS } from './events';
+import type { Pattern, Category } from './types';
+
+type Arguments = {
+	categories: Category[];
+	footer: Pattern | null;
+	generateKey: ( pattern: Pattern ) => string;
+	header: Pattern | null;
+	recordTracksEvent: ( eventName: string, eventProperties: Record< string, unknown > ) => void;
+	sectionPosition: number | null;
+	sections: Pattern[];
+	setFooter: ( pattern: Pattern | null ) => void;
+	setHeader: ( pattern: Pattern | null ) => void;
+	setSections: ( sections: Pattern[] ) => void;
+	showNotice: ( action: string, pattern: Pattern ) => void;
+	updateActivePatternPosition: ( position: number ) => void;
+};
+
+export const useScreenHandler = ( {
+	categories,
+	footer,
+	generateKey,
+	header,
+	recordTracksEvent,
+	sectionPosition,
+	sections,
+	setFooter,
+	setHeader,
+	setSections,
+	showNotice,
+	updateActivePatternPosition,
+}: Arguments ) => {
+	const trackEventPatternSelect = ( {
+		patternType,
+		patternId,
+		patternName,
+		patternCategory,
+	}: {
+		patternType: string;
+		patternId: number;
+		patternName: string;
+		patternCategory: string | undefined;
+	} ) => {
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_SELECT_CLICK, {
+			pattern_type: patternType,
+			pattern_id: patternId,
+			pattern_name: patternName,
+			pattern_category: patternCategory,
+		} );
+	};
+
+	const updateHeader = ( pattern: Pattern | null ) => {
+		setHeader( pattern );
+		updateActivePatternPosition( -1 );
+		if ( pattern ) {
+			if ( header ) {
+				showNotice( 'replace', pattern );
+			} else {
+				showNotice( 'add', pattern );
+			}
+		} else if ( header ) {
+			showNotice( 'remove', header );
+		}
+	};
+
+	const updateFooter = ( pattern: Pattern | null ) => {
+		setFooter( pattern );
+		updateActivePatternPosition( sections.length );
+		if ( pattern ) {
+			if ( footer ) {
+				showNotice( 'replace', pattern );
+			} else {
+				showNotice( 'add', pattern );
+			}
+		} else if ( footer ) {
+			showNotice( 'remove', footer );
+		}
+	};
+
+	const replaceSection = ( pattern: Pattern ) => {
+		if ( sectionPosition !== null ) {
+			setSections( [
+				...sections.slice( 0, sectionPosition ),
+				{
+					...pattern,
+					key: sections[ sectionPosition ].key,
+				},
+				...sections.slice( sectionPosition + 1 ),
+			] );
+			updateActivePatternPosition( sectionPosition );
+			showNotice( 'replace', pattern );
+		}
+	};
+
+	const addSection = ( pattern: Pattern ) => {
+		setSections( [
+			...( sections as Pattern[] ),
+			{
+				...pattern,
+				key: generateKey( pattern ),
+			},
+		] );
+		updateActivePatternPosition( sections.length );
+		showNotice( 'add', pattern );
+	};
+
+	const onSelect = (
+		type: string,
+		selectedPattern: Pattern | null,
+		selectedCategory?: string | null
+	) => {
+		if ( selectedPattern ) {
+			// Inject the selected pattern category or the first category
+			// because it's used in tracks and as pattern name in the list
+			selectedPattern.category = categories.find(
+				( { name } ) => name === ( selectedCategory || selectedPattern.categories[ 0 ] )
+			);
+
+			trackEventPatternSelect( {
+				patternType: type,
+				patternId: selectedPattern.id,
+				patternName: selectedPattern.name,
+				patternCategory: selectedPattern.category?.name,
+			} );
+
+			if ( 'section' === type ) {
+				if ( sectionPosition !== null ) {
+					replaceSection( selectedPattern );
+				} else {
+					addSection( selectedPattern );
+				}
+			}
+		}
+
+		if ( 'header' === type ) {
+			updateHeader( selectedPattern );
+		}
+		if ( 'footer' === type ) {
+			updateFooter( selectedPattern );
+		}
+	};
+
+	return {
+		onSelect,
+	};
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74831

## Proposed Changes

**Created the `useScreenHandler` hook to handle "screen"-related interactions.** 

* Extracted only `onSelect` in this PR, but other candidates that should be included in this hook are:
	* `onPatternSelectorBack`
	* `onDoneClick`
	* `onContinueClick`. 
* We can add hooks that are more specific to each screen: e.g. 
	* `useSectionScreenHandler` 
		* which includes `onDeleteSection`, `onMoveUpSection`, `onMoveDownSection`, `onDeleteHeader`, `onDeleteFooter`
	* `useColorPalettesScreenHandler` 
		* which includes `onScreenColorsSelect`, `onScreenColorsBack`, `onScreenColorsDone`
	* Each should be a small responsibility hook.

```ts
// The final code would look like this;
export const useScreenHandler = () => {
	const {...} = useSectionScreenHandler()
	const {...} = useColorPalettesScreenHandler()
	const {...} = useFontPairingScreenHandler()
	...
	return {...}
}
```

### Why

- Currently, all the hooks (which seem to have different responsibilities) are in a single file, and that might be affecting the readability.
- Since the hooks are not divided into small groups, it is difficult to add tests for individual hooks.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
