### PR TITLE
Plans grid: Fix styling for decimal prices

### DIFF
--- a/client/my-sites/plan-features-2023-grid/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/header-price.tsx
@@ -92,7 +92,7 @@ const HeaderPriceContainer = styled.div`
 
 	.plan-price.is-large-currency {
 		.plan-price__integer {
-			font-size: 38px;
+			font-size: 30px;
 		}
 		&.is-original {
 			.plan-price__integer {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -80,6 +80,7 @@ import {
 	isJetpackSite,
 } from 'calypso/state/sites/selectors';
 import CalypsoShoppingCartProvider from '../checkout/calypso-shopping-cart-provider';
+import useIsLargeCurrency from '../plans/hooks/use-is-large-currency';
 import { getManagePurchaseUrlFor } from '../purchases/paths';
 import PlanFeatures2023GridActions from './actions';
 import PlanFeatures2023GridBillingTimeframe from './billing-timeframe';
@@ -242,6 +243,51 @@ const PlanLogo: React.FunctionComponent< {
 				) }
 			</header>
 		</Container>
+	);
+};
+
+const PlanPricesRow = function ( {
+	planPropertiesObj,
+	options,
+	isReskinned,
+}: {
+	planPropertiesObj: PlanProperties[];
+	options?: PlanRowOptions;
+	isReskinned: boolean;
+} ) {
+	const isLargeCurrency = useIsLargeCurrency(
+		planPropertiesObj.map( ( properties ) => properties.planName as PlanSlug )
+	);
+
+	return (
+		<>
+			{ planPropertiesObj
+				.filter( ( { isVisible } ) => isVisible )
+				.map( ( properties ) => {
+					const { planName, rawPrice } = properties;
+					const classes = classNames( 'plan-features-2023-grid__table-item', 'is-bottom-aligned', {
+						'has-border-top': ! isReskinned,
+					} );
+					const hasNoPrice = rawPrice === undefined || rawPrice === null;
+
+					return (
+						<Container
+							scope="col"
+							key={ planName }
+							className={ classes }
+							isMobile={ options?.isMobile }
+						>
+							{ ! hasNoPrice && (
+								<PlanFeatures2023GridHeaderPrice
+									planProperties={ properties }
+									is2023OnboardingPricingGrid={ true }
+									isLargeCurrency={ isLargeCurrency }
+								/>
+							) }
+						</Container>
+					);
+				} ) }
+		</>
 	);
 };
 
@@ -489,38 +535,15 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderPlanPrice( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
-		const { isReskinned, is2023OnboardingPricingGrid } = this.props;
+		const { isReskinned } = this.props;
 
-		const isLargeCurrency = planPropertiesObj.some(
-			( properties ) => properties?.rawPrice && properties?.rawPrice > 99000
+		return (
+			<PlanPricesRow
+				planPropertiesObj={ planPropertiesObj }
+				isReskinned={ isReskinned }
+				options={ options }
+			/>
 		);
-
-		return planPropertiesObj
-			.filter( ( { isVisible } ) => isVisible )
-			.map( ( properties ) => {
-				const { planName, rawPrice } = properties;
-				const classes = classNames( 'plan-features-2023-grid__table-item', 'is-bottom-aligned', {
-					'has-border-top': ! isReskinned,
-				} );
-				const hasNoPrice = rawPrice === undefined || rawPrice === null;
-
-				return (
-					<Container
-						scope="col"
-						key={ planName }
-						className={ classes }
-						isMobile={ options?.isMobile }
-					>
-						{ ! hasNoPrice && (
-							<PlanFeatures2023GridHeaderPrice
-								planProperties={ properties }
-								is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
-								isLargeCurrency={ isLargeCurrency }
-							/>
-						) }
-					</Container>
-				);
-			} );
 	}
 
 	renderBillingTimeframe( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -1015,7 +1015,7 @@ export class PlanFeatures2023Grid extends Component<
 }
 
 const withIsLargeCurrency = ( Component: LocalizedComponent< typeof PlanFeatures2023Grid > ) => {
-	return function ( props: PlanFeatures2023GridConnectedProps ) {
+	return function ( props: PlanFeatures2023GridType ) {
 		const isLargeCurrency = useIsLargeCurrency(
 			( props.planProperties || [] ).map( ( properties ) => properties.planName as PlanSlug )
 		);

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -7,6 +7,7 @@ import {
 	FEATURE_GROUP_ESSENTIAL_FEATURES,
 	getPlanFeaturesGrouped,
 	PLAN_ENTERPRISE_GRID_WPCOM,
+	PlanSlug,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { css } from '@emotion/react';
@@ -19,6 +20,7 @@ import JetpackLogo from 'calypso/components/jetpack-logo';
 import { FeatureObject, getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/plan-type-selector';
 import TermExperimentPlanTypeSelector from 'calypso/my-sites/plans-features-main/term-experiment-plan-type-selector';
+import useIsLargeCurrency from '../plans/hooks/use-is-large-currency';
 import PlanFeatures2023GridActions from './actions';
 import PlanFeatures2023GridBillingTimeframe from './billing-timeframe';
 import PopularBadge from './components/popular-badge';
@@ -420,8 +422,8 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 } ) => {
 	const allVisible = visiblePlansProperties.length === displayedPlansProperties.length;
 
-	const isLargeCurrency = displayedPlansProperties.some(
-		( properties ) => properties?.rawPrice && properties?.rawPrice > 99000
+	const isLargeCurrency = useIsLargeCurrency(
+		displayedPlansProperties.map( ( properties ) => properties.planName as PlanSlug )
 	);
 
 	return (

--- a/client/my-sites/plan-price/index.tsx
+++ b/client/my-sites/plan-price/index.tsx
@@ -391,10 +391,10 @@ function HtmlPriceDisplay( {
 	if ( is2023OnboardingPricingGrid ) {
 		return (
 			<div className="plan-price__integer-fraction">
-				<span className="plan-price__integer">{ priceObj.integer }</span>
-				<sup className="plan-price__fraction">
+				<span className="plan-price__integer">
+					{ priceObj.integer }
 					{ priceObj.hasNonZeroFraction && priceObj.fraction }
-				</sup>
+				</span>
 			</div>
 		);
 	}

--- a/client/my-sites/plans-comparison/use-plan-prices.tsx
+++ b/client/my-sites/plans-comparison/use-plan-prices.tsx
@@ -33,6 +33,9 @@ function toMonthlyPrice( plan: WPComPlan ) {
 	};
 }
 
+/**
+ * @deprecated
+ */
 export default function usePlanPrices( plans: WPComPlan[] ): PlanPrices[] {
 	return useSelector( ( state: IAppState ) => {
 		return plans.map( ( plan ) => {

--- a/client/my-sites/plans/hooks/use-is-large-currency.ts
+++ b/client/my-sites/plans/hooks/use-is-large-currency.ts
@@ -11,14 +11,14 @@ const LARGE_CURRENCY_CHARS = 5;
  * of any of the plan slugs exceeds 5 characters.
  * This is primarily used for lowering the font-size of "large" display prices.
  */
-export default function useIsLargeCurrency( planSlugs: PlanSlug[] ): boolean {
+export default function useIsLargeCurrency( planSlugs: PlanSlug[], returnMonthly = true ): boolean {
 	return useSelector( ( state: IAppState ) => {
 		const siteId = getSelectedSiteId( state ) ?? null;
 		return planSlugs.some( ( planSlug ) => {
 			const { discountedRawPrice, planDiscountedRawPrice, rawPrice } = getPlanPrices( state, {
 				planSlug,
 				siteId,
-				returnMonthly: true,
+				returnMonthly,
 			} );
 			return [ rawPrice, discountedRawPrice, planDiscountedRawPrice ].some(
 				( price ) => price?.toString().length > LARGE_CURRENCY_CHARS

--- a/client/my-sites/plans/hooks/use-is-large-currency.ts
+++ b/client/my-sites/plans/hooks/use-is-large-currency.ts
@@ -4,7 +4,7 @@ import { IAppState } from 'calypso/state/types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { PlanSlug } from '@automattic/calypso-products';
 
-const LARGE_CURRENCY_CHARS = 5;
+const LARGE_CURRENCY_CHAR_THRESHOLD = 5;
 
 /**
  * Hook that returns true if the string representation of any price (discounted/undiscounted)
@@ -21,7 +21,7 @@ export default function useIsLargeCurrency( planSlugs: PlanSlug[], returnMonthly
 				returnMonthly,
 			} );
 			return [ rawPrice, discountedRawPrice, planDiscountedRawPrice ].some(
-				( price ) => price?.toString().length > LARGE_CURRENCY_CHARS
+				( price ) => price?.toString().length > LARGE_CURRENCY_CHAR_THRESHOLD
 			);
 		} );
 	} );

--- a/client/my-sites/plans/hooks/use-is-large-currency.ts
+++ b/client/my-sites/plans/hooks/use-is-large-currency.ts
@@ -1,0 +1,28 @@
+import { useSelector } from 'react-redux';
+import { getPlanPrices } from 'calypso/state/plans/selectors';
+import { IAppState } from 'calypso/state/types';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type { PlanSlug } from '@automattic/calypso-products';
+
+const LARGE_CURRENCY_CHARS = 5;
+
+/**
+ * Hook that returns true if the string representation of any price (discounted/undiscounted)
+ * of any of the plan slugs exceeds 5 characters.
+ * This is primarily used for lowering the font-size of "large" display prices.
+ */
+export default function useIsLargeCurrency( planSlugs: PlanSlug[] ): boolean {
+	return useSelector( ( state: IAppState ) => {
+		const siteId = getSelectedSiteId( state ) ?? null;
+		return planSlugs.some( ( planSlug ) => {
+			const { discountedRawPrice, planDiscountedRawPrice, rawPrice } = getPlanPrices( state, {
+				planSlug,
+				siteId,
+				returnMonthly: true,
+			} );
+			return [ rawPrice, discountedRawPrice, planDiscountedRawPrice ].some(
+				( price ) => price?.toString().length > LARGE_CURRENCY_CHARS
+			);
+		} );
+	} );
+}

--- a/client/my-sites/plans/hooks/use-plan-prices.ts
+++ b/client/my-sites/plans/hooks/use-plan-prices.ts
@@ -1,16 +1,9 @@
-import { getPlan, PlanSlug } from '@automattic/calypso-products';
 import { useSelector } from 'react-redux';
-import { getPlanRawPrice, getDiscountedRawPrice } from 'calypso/state/plans/selectors';
-import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
+import { getPlanPrices } from 'calypso/state/plans/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type { PlanSlug } from '@automattic/calypso-products';
+import type { PlanPrices } from 'calypso/state/plans/selectors/get-plan-prices';
 import type { IAppState } from 'calypso/state/types';
-
-export interface PlanPrices {
-	rawPrice: number;
-	discountedRawPrice: number; // discounted on yearly-monthly conversion
-	planDiscountedRawPrice: number; // discounted on site plan upgrade
-}
-
 interface Props {
 	planSlug: PlanSlug;
 	returnMonthly: boolean; // defaults to true
@@ -18,20 +11,8 @@ interface Props {
 
 const usePlanPrices = ( { planSlug, returnMonthly }: Props ): PlanPrices => {
 	return useSelector( ( state: IAppState ) => {
-		const siteId = getSelectedSiteId( state ) ?? undefined;
-		const plan = getPlan( planSlug );
-		const productId = plan?.getProductId();
-
-		return {
-			rawPrice: ( productId && getPlanRawPrice( state, productId, returnMonthly ) ) || 0,
-			discountedRawPrice:
-				( productId && getDiscountedRawPrice( state, productId, returnMonthly ) ) || 0,
-			planDiscountedRawPrice:
-				( siteId &&
-					planSlug &&
-					getPlanDiscountedRawPrice( state, siteId, planSlug, { returnMonthly } ) ) ||
-				0,
-		};
+		const siteId = getSelectedSiteId( state ) ?? null;
+		return getPlanPrices( state, { planSlug, siteId, returnMonthly } );
 	} );
 };
 

--- a/client/my-sites/plans/test/use-is-large-currency.ts
+++ b/client/my-sites/plans/test/use-is-large-currency.ts
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Default mock implementations
+ */
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useSelector: ( selector ) => selector(),
+} ) );
+jest.mock( 'calypso/state/plans/selectors', () => ( {
+	getPlanPrices: jest.fn(),
+} ) );
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSiteId: jest.fn( () => 1 ),
+} ) );
+
+import { PlanSlug, PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
+import { getPlanPrices } from 'calypso/state/plans/selectors';
+import useIsLargeCurrency from '../hooks/use-is-large-currency';
+
+describe( 'useIsLargeCurrency', () => {
+	const defaultProps: PlanSlug[] = [ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM ];
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'should return false for small values', () => {
+		getPlanPrices.mockImplementation( () => ( {
+			rawPrice: 9000,
+			discountedRawPrice: 5000,
+			planDiscountedRawPrice: 7000,
+		} ) );
+
+		expect( useIsLargeCurrency( defaultProps ) ).toEqual( false );
+	} );
+
+	test( 'should return true for large values', () => {
+		getPlanPrices.mockImplementation( () => ( {
+			rawPrice: 900.01,
+			discountedRawPrice: 500.01,
+			planDiscountedRawPrice: 700.01,
+		} ) );
+
+		expect( useIsLargeCurrency( defaultProps ) ).toEqual( true );
+	} );
+} );

--- a/client/my-sites/plans/test/use-plan-prices.ts
+++ b/client/my-sites/plans/test/use-plan-prices.ts
@@ -9,19 +9,14 @@ jest.mock( 'react-redux', () => ( {
 	useSelector: ( selector ) => selector(),
 } ) );
 jest.mock( 'calypso/state/plans/selectors', () => ( {
-	getPlanRawPrice: jest.fn(),
-	getDiscountedRawPrice: jest.fn(),
-} ) );
-jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
-	getPlanDiscountedRawPrice: jest.fn(),
+	getPlanPrices: jest.fn(),
 } ) );
 jest.mock( 'calypso/state/ui/selectors', () => ( {
 	getSelectedSiteId: jest.fn( () => 1 ),
 } ) );
 
 import { PLAN_PREMIUM } from '@automattic/calypso-products';
-import { getPlanRawPrice, getDiscountedRawPrice } from 'calypso/state/plans/selectors';
-import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
+import { getPlanPrices } from 'calypso/state/plans/selectors';
 import usePlanPrices from '../hooks/use-plan-prices';
 
 describe( 'usePlanPrices', () => {
@@ -35,9 +30,11 @@ describe( 'usePlanPrices', () => {
 	} );
 
 	test( 'should return correct pricing structure', () => {
-		getPlanRawPrice.mockImplementation( () => 300 );
-		getDiscountedRawPrice.mockImplementation( () => 200 );
-		getPlanDiscountedRawPrice.mockImplementation( () => 100 );
+		getPlanPrices.mockImplementation( () => ( {
+			rawPrice: 300,
+			discountedRawPrice: 200,
+			planDiscountedRawPrice: 100,
+		} ) );
 
 		const planPrices = usePlanPrices( defaultProps );
 

--- a/client/state/plans/selectors/get-plan-prices.ts
+++ b/client/state/plans/selectors/get-plan-prices.ts
@@ -1,0 +1,40 @@
+import 'calypso/state/plans/init';
+import { getPlan, PlanSlug } from '@automattic/calypso-products';
+import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
+import { getDiscountedRawPrice } from './get-discounted-raw-price';
+import { getPlanRawPrice } from './get-plan-raw-price';
+import type { IAppState } from 'calypso/state/types';
+import type { SiteId } from 'calypso/types';
+
+export interface PlanPrices {
+	rawPrice: number;
+	discountedRawPrice: number; // discounted on yearly-monthly conversion
+	planDiscountedRawPrice: number; // discounted on site plan upgrade
+}
+
+/**
+ * A convenience function that returns the undiscounted and discounted prices
+ * for a given plan and site.
+ */
+export function getPlanPrices(
+	state: IAppState,
+	{
+		planSlug,
+		siteId,
+		returnMonthly,
+	}: { planSlug: PlanSlug; siteId: SiteId | null; returnMonthly: boolean }
+): PlanPrices {
+	const plan = getPlan( planSlug );
+	const productId = plan?.getProductId();
+
+	return {
+		rawPrice: ( productId && getPlanRawPrice( state, productId, returnMonthly ) ) || 0,
+		discountedRawPrice:
+			( productId && getDiscountedRawPrice( state, productId, returnMonthly ) ) || 0,
+		planDiscountedRawPrice:
+			( siteId &&
+				planSlug &&
+				getPlanDiscountedRawPrice( state, siteId, planSlug, { isMonthly: returnMonthly } ) ) ||
+			0,
+	};
+}

--- a/client/state/plans/selectors/get-plan-prices.ts
+++ b/client/state/plans/selectors/get-plan-prices.ts
@@ -34,7 +34,7 @@ export function getPlanPrices(
 		planDiscountedRawPrice:
 			( siteId &&
 				planSlug &&
-				getPlanDiscountedRawPrice( state, siteId, planSlug, { isMonthly: returnMonthly } ) ) ||
+				getPlanDiscountedRawPrice( state, siteId, planSlug, { returnMonthly } ) ) ||
 			0,
 	};
 }

--- a/client/state/plans/selectors/index.js
+++ b/client/state/plans/selectors/index.js
@@ -8,4 +8,5 @@ export {
 } from './plan';
 export { getPlanRawPrice } from './get-plan-raw-price';
 export { getDiscountedRawPrice } from './get-discounted-raw-price';
+export { getPlanPrices } from './get-plan-prices';
 export { default as getJetpackStorageUpgradeUrl } from './get-jetpack-storage-upgrade-url';

--- a/client/state/plans/selectors/test/index.js
+++ b/client/state/plans/selectors/test/index.js
@@ -1,4 +1,5 @@
-import { getDiscountedRawPrice, getPlanRawPrice, getPlanBillPeriod } from '../';
+import { PLAN_BUSINESS } from '@automattic/calypso-products';
+import { getDiscountedRawPrice, getPlanRawPrice, getPlanBillPeriod, getPlanPrices } from '../';
 
 describe( 'selectors', () => {
 	describe( '#getPlanBillPeriod()', () => {
@@ -119,6 +120,76 @@ describe( 'selectors', () => {
 		it( 'should return monthly raw_price if there is no discount', () => {
 			const rawPrice = getPlanRawPrice( state, 1003, true );
 			expect( rawPrice ).toEqual( 8 );
+		} );
+	} );
+
+	describe( '#getPlanPrices', () => {
+		const state = {
+			plans: {
+				items: [
+					{
+						product_id: 1008,
+						product_slug: 'business-bundle',
+						raw_price: 300,
+						orig_cost: 324,
+					},
+					{
+						product_id: 1028,
+						product_slug: 'business-bundle-2y',
+						raw_price: 480,
+						orig_cost: 540,
+					},
+					{
+						product_id: 1003,
+						product_slug: 'value_bundle',
+						raw_price: 96,
+					},
+				],
+			},
+		};
+
+		it( 'should return plan prices when siteId is null', () => {
+			expect(
+				getPlanPrices( state, {
+					planSlug: PLAN_BUSINESS,
+					siteId: null,
+					returnMonthly: true,
+				} )
+			).toEqual( {
+				rawPrice: 27,
+				discountedRawPrice: 25,
+				planDiscountedRawPrice: 0,
+			} );
+		} );
+
+		it( 'should return plan prices when siteId is passed', () => {
+			const stateWithSiteId = {
+				...state,
+				sites: {
+					plans: {
+						1: {
+							data: [
+								{
+									productSlug: 'business-bundle',
+									rawPrice: 288,
+									rawDiscount: 1,
+								},
+							],
+						},
+					},
+				},
+			};
+			expect(
+				getPlanPrices( stateWithSiteId, {
+					planSlug: PLAN_BUSINESS,
+					siteId: 1,
+					returnMonthly: true,
+				} )
+			).toEqual( {
+				rawPrice: 27,
+				discountedRawPrice: 25,
+				planDiscountedRawPrice: 24,
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1653
Fixes Automattic/martech#1674

## Proposed Changes

* This PR displays prices in a reduced font size when any of the displayed plan prices exceed a certain character limit. If the string representation of a price (without currency symbol) is greater than 5 chars, it's classified as a "large" currency. Examples: `10,000`, `100.50`, `100000`. This check cannot be applied independently for each price since it will result in inconsistent styling.
* Introduces a new hook, `useIsLargeCurrency( planSlugs )`, that returns true if any of the prices (discounted/undiscounted) of any of the `planSlugs` is greater than 5 characters.
* Extracted a selector function(`getPlanPrices`) from the existing `usePlanPrices` hook so that it can be used in the `useIsLargeCurrency` hook.
* Changed the font size of "large" currencies to 30px. (Ref: https://github.com/Automattic/martech/issues/1653#issuecomment-1492401794)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check `/plans/yearly/<site slug>` where <site slug> is on a monthly plan and has pro-rated credits available in a few different currencies.
* IDR
<img width="1507" alt="image" src="https://user-images.githubusercontent.com/5436027/229451495-7de64eee-0561-4192-b9c0-0a2fe779145d.png">

* USD
<img width="1468" alt="image" src="https://user-images.githubusercontent.com/5436027/229452310-ed2cdb78-d4f0-4a35-919e-c764bb898f25.png">

* INR
<img width="1499" alt="image" src="https://user-images.githubusercontent.com/5436027/229452869-2c364665-69f0-4940-bfb8-b62c8032072f.png">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
