### PR TITLE
Site Assembler - Pattern Categories - Review translations

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-categories.ts
@@ -1,5 +1,5 @@
 import { useQuery, UseQueryResult, UseQueryOptions } from 'react-query';
-import wpcomRequest from 'wpcom-proxy-request';
+import wpcom from 'calypso/lib/wp';
 
 const usePatternCategories = (
 	siteId: number | undefined,
@@ -12,9 +12,8 @@ const usePatternCategories = (
 				return [];
 			}
 
-			return wpcomRequest( {
+			return wpcom.req.get( {
 				path: `/sites/${ encodeURIComponent( siteId ) }/block-patterns/categories`,
-				method: 'GET',
 				apiNamespace: 'wp/v2',
 			} );
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #74928

## Proposed Changes

* Use wpcom.get to pass `_locale` automatically in the request to fetch the categories

|BEFORE|AFTER|
|-----|----|
|Partially translated|Fully translated|
|<img width="338" alt="Screenshot 2566-04-03 at 15 28 21" src="https://user-images.githubusercontent.com/1881481/229454686-65db0867-eaaf-4215-aafd-32dda5d73e56.png">|<img width="305" alt="Screenshot 2566-04-03 at 15 11 59" src="https://user-images.githubusercontent.com/1881481/229454684-1801440e-26e0-4d40-998f-5a64b4c5bd03.png">|

## Known issues
In the development environment, the categories are not always translated when accessing the assembler via the logged-out theme showcase (`/setup/with-theme-assembler/` flow). 

The cause is that the `_locale` param that has inconsistent values, sometimes has `en`, the default value, after refreshing the browser a few times in a row. I haven't reproduced it in the Calypso live environment. 

The global team has told me the issue might be because the translations are bundled separately in the development environment but not in production. Following their suggestion, I tried running the development environment with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks yarn start` but it didn't help. 

## Testing Instructions

* Change the interface language from your WordPress.com account (`/me`) 

**Onboarding flow entry**

* Create a new site with any plan
* Continue until the Design Picker
* Scroll down and click `Start designing`
* Click `Sections` 
* Click `Add patterns` to explore the categories and confirm the category names are translated.

**Logged out theme showcase flow entry**

* Log out
* Head to `wordpress.com/themes`
* Scroll down and click `Start designing`
* Log in
* Click `Sections` 
* Click `Add patterns` to explore the categories and confirm the category names are translated.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
