### PR TITLE
Add/ useSiteUnfollowMutation tests

### DIFF
--- a/packages/data-stores/jest.config.js
+++ b/packages/data-stores/jest.config.js
@@ -1,3 +1,10 @@
+const jestPreset = require( '../../test/packages/jest-preset.js' );
+
 module.exports = {
-	preset: '../../test/packages/jest-preset.js',
+	...jestPreset,
+	testPathIgnorePatterns: [
+		...( jestPreset.testPathIgnorePatterns || [] ), // Spread existing ignore patterns (if any)
+		// Ignore test utils files
+		'[a-zA-Z/]*test/utils.ts[x]?',
+	],
 };

--- a/packages/data-stores/src/reader/mutations/use-user-settings-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-user-settings-mutation.ts
@@ -21,7 +21,7 @@ const useUserSettingsMutation = () => {
 				} else {
 					throw new Error(
 						translate( 'Something went wrong.', {
-							context: 'Something went wrong will saving the user settings',
+							context: 'Something went wrong with saving the user settings',
 						} ) as string
 					);
 				}

--- a/packages/data-stores/src/reader/test/use-site-delivery-frequency-mutation.test.tsx
+++ b/packages/data-stores/src/reader/test/use-site-delivery-frequency-mutation.test.tsx
@@ -2,39 +2,32 @@
  * @jest-environment jsdom
  */
 import { render, waitFor } from '@testing-library/react';
-import { useEffect } from 'react';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import React from 'react';
 import { callApi } from '../helpers';
+import { useIsLoggedIn } from '../hooks';
 import useSiteDeliveryFrequencyMutation from '../mutations/use-site-delivery-frequency-mutation';
+import { Parent, buildSkeleton, resetMocks } from './utils';
 
-// Mock the useIsLoggedIn function
 jest.mock( '../hooks', () => ( {
-	useIsLoggedIn: jest.fn().mockReturnValue( true ),
+	useIsLoggedIn: jest.fn(),
 } ) );
 
-// Mock the entire Helpers module
 jest.mock( '../helpers', () => ( {
 	callApi: jest.fn(),
 } ) );
 
-const client = new QueryClient();
-const Parent = ( { children } ) => (
-	<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
-);
+beforeEach( () => {
+	resetMocks();
 
-describe( 'useSubscriptionManagerSiteDeliveryFrequencyMutation()', () => {
+	( useIsLoggedIn as jest.Mock ).mockReturnValue( true );
+} );
+
+describe( 'useSiteDeliveryFrequencyMutation', () => {
 	it( 'calls the right API', async () => {
-		const Skeleton = () => {
-			const { mutate } = useSiteDeliveryFrequencyMutation();
-			useEffect( () => {
-				mutate( {
-					delivery_frequency: 'daily',
-					blog_id: '123',
-				} );
-			}, [ mutate ] );
-
-			return <p></p>;
-		};
+		const Skeleton = buildSkeleton( useSiteDeliveryFrequencyMutation, {
+			delivery_frequency: 'daily',
+			blog_id: '123',
+		} );
 
 		( callApi as jest.Mock ).mockResolvedValue( {
 			success: true,

--- a/packages/data-stores/src/reader/test/use-site-unfollow-mutation.test.tsx
+++ b/packages/data-stores/src/reader/test/use-site-unfollow-mutation.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { callApi } from '../helpers';
+import { useIsLoggedIn } from '../hooks';
+import useSiteUnfollowMutation from '../mutations/use-site-unfollow-mutation';
+import { Parent, buildSkeleton, resetMocks } from './utils';
+
+// Mock the useIsLoggedIn function
+jest.mock( '../hooks', () => ( {
+	useIsLoggedIn: jest.fn(),
+} ) );
+
+// Mock the entire Helpers module
+jest.mock( '../helpers', () => ( {
+	callApi: jest.fn(),
+} ) );
+
+beforeEach( () => {
+	resetMocks();
+
+	( useIsLoggedIn as jest.Mock ).mockReturnValue( true );
+} );
+
+describe( 'useSiteUnfollowMutation', () => {
+	it( 'unfollows a site successfully', async () => {
+		const Skeleton = buildSkeleton( useSiteUnfollowMutation, {
+			blog_id: '123',
+		} );
+
+		( callApi as jest.Mock ).mockResolvedValue( {
+			success: true,
+		} );
+
+		render(
+			<Parent>
+				<Skeleton />
+			</Parent>
+		);
+
+		await waitFor( () =>
+			expect( callApi ).toHaveBeenCalledWith( {
+				apiVersion: '1.2',
+				path: '/read/site/123/post_email_subscriptions/delete',
+				isLoggedIn: true,
+				method: 'POST',
+			} )
+		);
+	} );
+
+	it( 'returns error message on failure from endpoint', async () => {
+		const Skeleton = buildSkeleton( useSiteUnfollowMutation, {
+			blog_id: '123',
+		} );
+
+		// eslint-disable-next-line
+		jest.spyOn( console, 'error' ).mockImplementation( () => null );
+
+		( callApi as jest.Mock ).mockResolvedValue( {
+			success: false,
+		} );
+
+		render(
+			<Parent>
+				<Skeleton />
+			</Parent>
+		);
+
+		await waitFor( () =>
+			// eslint-disable-next-line
+			expect( console.error ).toHaveBeenCalledWith(
+				new Error( 'Something went wrong while unsubscribing.' )
+			)
+		);
+	} );
+
+	it( 'returns error message on wrong parameter', async () => {
+		const Skeleton = buildSkeleton( useSiteUnfollowMutation, {
+			blog_id: null,
+		} );
+
+		// eslint-disable-next-line
+		jest.spyOn( console, 'error' ).mockImplementation( () => null );
+
+		( callApi as jest.Mock ).mockResolvedValue( {
+			success: true,
+		} );
+
+		render(
+			<Parent>
+				<Skeleton />
+			</Parent>
+		);
+
+		await waitFor( () =>
+			// eslint-disable-next-line
+			expect( console.error ).toHaveBeenCalledWith(
+				new Error( 'Something went wrong while unsubscribing.' )
+			)
+		);
+	} );
+} );

--- a/packages/data-stores/src/reader/test/use-user-settings-mutation.test.tsx
+++ b/packages/data-stores/src/reader/test/use-user-settings-mutation.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { callApi } from '../helpers';
+import { useIsLoggedIn } from '../hooks';
+import useUserSettingsMutation from '../mutations/use-user-settings-mutation';
+import { Parent, buildSkeleton, resetMocks } from './utils';
+
+// Mock the useIsLoggedIn function
+jest.mock( '../hooks', () => ( {
+	useIsLoggedIn: jest.fn(),
+} ) );
+
+// Mock the entire Helpers module
+jest.mock( '../helpers', () => ( {
+	callApi: jest.fn(),
+} ) );
+
+beforeEach( () => {
+	resetMocks();
+
+	( useIsLoggedIn as jest.Mock ).mockReturnValue( true );
+} );
+
+describe( 'useUserSettingsMutation', () => {
+	it( 'changes the user settings correctly if provided with proper payload', async () => {
+		const body = {
+			mail_option: 'html',
+			delivery_day: 1,
+			delivery_hour: 3,
+			blocked: false,
+			email: 'user@wordpress.com',
+		};
+		const Skeleton = buildSkeleton( useUserSettingsMutation, body );
+
+		( callApi as jest.Mock ).mockResolvedValue( {
+			settings: {
+				success: true,
+			},
+		} );
+
+		render(
+			<Parent>
+				<Skeleton />
+			</Parent>
+		);
+
+		await waitFor( () =>
+			expect( callApi ).toHaveBeenCalledWith( {
+				path: '/read/email-settings',
+				body,
+				isLoggedIn: true,
+				method: 'POST',
+			} )
+		);
+	} );
+
+	it( "throws an error showing the invalid inputs if that's the case of the failure", async () => {
+		const body = {
+			mail_option: 'html',
+			delivery_day: 1,
+			delivery_hour: 3,
+			blocked: false,
+			email: 'user@wordpress.com',
+		};
+		const Skeleton = buildSkeleton( useUserSettingsMutation, body );
+
+		( callApi as jest.Mock ).mockResolvedValue( {
+			settings: {
+				errors: {
+					invalid_input: [ 'email', 'mail_option' ],
+				},
+			},
+		} );
+
+		render(
+			<Parent>
+				<Skeleton />
+			</Parent>
+		);
+
+		// eslint-disable-next-line
+		jest.spyOn( console, 'error' ).mockImplementation( () => null );
+
+		await waitFor( () =>
+			// eslint-disable-next-line
+			expect( console.error ).toHaveBeenCalledWith( new Error( 'email, mail_option' ) )
+		);
+	} );
+
+	it( 'throws a different error when the error returned by the backend is not related to the inputs being valid', async () => {
+		const body = {
+			mail_option: 'html',
+			delivery_day: 1,
+			delivery_hour: 3,
+			blocked: false,
+			email: 'user@wordpress.com',
+		};
+		const Skeleton = buildSkeleton( useUserSettingsMutation, body );
+
+		( callApi as jest.Mock ).mockResolvedValue( {
+			settings: {
+				errors: {
+					description: 'Any other error',
+				},
+			},
+		} );
+
+		render(
+			<Parent>
+				<Skeleton />
+			</Parent>
+		);
+
+		// eslint-disable-next-line
+		jest.spyOn( console, 'error' ).mockImplementation( () => null );
+
+		await waitFor( () =>
+			// eslint-disable-next-line
+			expect( console.error ).toHaveBeenCalledWith( new Error( 'Something went wrong.' ) )
+		);
+	} );
+} );

--- a/packages/data-stores/src/reader/test/utils.tsx
+++ b/packages/data-stores/src/reader/test/utils.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+export const client = new QueryClient();
+export const Parent = ( { children } ) => (
+	<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
+);
+
+// Builds the test object
+export const buildSkeleton = ( mutation: any, payload: any ) => {
+	const Skeleton = () => {
+		const { mutate } = mutation();
+		useEffect( () => {
+			mutate( payload );
+		}, [ mutate ] );
+
+		return <></>;
+	};
+
+	return Skeleton;
+};
+
+export const resetMocks = () => {
+	jest.resetAllMocks();
+};


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/75212

## Proposed Changes

This PR adds tests for useSiteUnfollowMutation.

<img width="1095" alt="Screenshot 2023-04-03 at 11 11 14" src="https://user-images.githubusercontent.com/3832570/229471222-4b99718a-225f-40d7-a2bd-a21623a851c7.png">

## Testing Instructions

1. Apply these changes.
2. Run the tests with `yarn jest packages/data-stores/src/reader/test/mutations.test.tsx`. They should pass:
<img width="516" alt="Screenshot 2023-04-03 at 11 36 53" src="https://user-images.githubusercontent.com/3832570/229471726-a24921cd-502f-49c6-83ca-5b4629b53935.png">
3. In order to avoid false positives, break them. Some suggestions are:
  - change the `apiVersion` in line 96 to any value other than `1.2`, like `5`.
  - change the `success` in line 113 to `true`.
  - change the `blog_id` in line 132 to `123`.
If they all break after these changes, they weren't false positives.

Thanks for the review! 🤖 💘 

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
