### PR TITLE
Woo Express: Added Essential plan to trials Plans page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -1,6 +1,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
-import { plansLink, PLAN_FREE, PLAN_WOOEXPRESS_MEDIUM } from '@automattic/calypso-products';
+import {
+	plansLink,
+	PLAN_WOOEXPRESS_MEDIUM,
+	PLAN_WOOEXPRESS_SMALL,
+} from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
@@ -45,7 +49,7 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 	);
 
 	const plansTableProps = {
-		plans: [ PLAN_FREE, PLAN_WOOEXPRESS_MEDIUM ],
+		plans: [ PLAN_WOOEXPRESS_SMALL, PLAN_WOOEXPRESS_MEDIUM ],
 		hidePlansFeatureComparison: true,
 	};
 

--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -12,17 +12,19 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import ECommercePlanFeatures from 'calypso/my-sites/plans/components/ecommerce-plan-features';
 import ECommerceTrialBanner from './ecommerce-trial-banner';
 import { getWooExpressMediumFeatureSets } from './wx-medium-features';
+import type { Site } from 'calypso/my-sites/scan/types';
 
 import './style.scss';
 
 interface ECommerceTrialPlansPageProps {
 	interval?: 'monthly' | 'yearly';
-	siteSlug: string;
+	site: Site;
 }
 
 const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 	const interval = props.interval ?? 'monthly';
-	const siteSlug = props.siteSlug;
+	const siteSlug = props.site?.slug;
+	const siteId = props.site?.ID;
 
 	const translate = useTranslate();
 
@@ -51,6 +53,7 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 	const plansTableProps = {
 		plans: [ PLAN_WOOEXPRESS_SMALL, PLAN_WOOEXPRESS_MEDIUM ],
 		hidePlansFeatureComparison: true,
+		siteId,
 	};
 
 	const multiPlanFeatures = (

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -292,7 +292,7 @@ class Plans extends Component {
 		// Only accept monthly or yearly for the interval; otherwise let the component provide a default.
 		const interval =
 			intervalType === 'monthly' || intervalType === 'yearly' ? intervalType : undefined;
-		return <ECommerceTrialPlansPage interval={ interval } siteSlug={ selectedSite.slug } />;
+		return <ECommerceTrialPlansPage interval={ interval } site={ selectedSite } />;
 	}
 
 	renderWooExpressMediumPage() {


### PR DESCRIPTION
Added Essential plan to trial's Plans page:

*This PR is not updating the features' copy. This is gonna be handled in a separate PR.

![image](https://user-images.githubusercontent.com/3801502/229508160-37a8a096-1624-47da-be76-4ca2bddee851.png)

### Testing
* Open the Plans page using a trial site (`plans/site-slug`)
* Make sure the `plans/wooexpress-small` feature flag is enabled.
* Clicking the Upgrade button should added the Plan to the cart, associated to the current site.