### PR TITLE
Staging sites: update error text

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -260,7 +260,7 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 			<Notice status="is-error" showDismiss={ false }>
 				<div data-testid="staging-sites-access-message">
 					{ translate(
-						'Unable to access the staging site {{a}}%(stagingSiteName)s{{/a}}. Please contact with the site owner.',
+						'Unable to access the staging site {{a}}%(stagingSiteName)s{{/a}}. Please contact the site owner.',
 						{
 							args: {
 								stagingSiteName: stagingSite.url,


### PR DESCRIPTION
- Related to https://github.com/Automattic/wp-calypso/pull/74908/

## Proposed Changes

- Update error text on staging site card

<img width="752" alt="Screenshot 2023-04-03 at 15 27 47" src="https://user-images.githubusercontent.com/779993/229525319-6f9aa2b6-6834-4bbc-a579-46925c1e9bf3.png"> |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a staging site on a business site
* Invite a second user as administrator to the production site. Do not invite the user to the staging site.
* With that second user, accept the invitation and access to Hosting configuration
* Observe the error text 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
