### PR TITLE
Woo Express: Added interval toggle to Woo Express plans

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -46,7 +46,14 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 		/>
 	);
 
-	const multiPlanFeatures = <WooExpressPlans siteId={ siteId } />;
+	const multiPlanFeatures = (
+		<WooExpressPlans
+			siteId={ siteId }
+			interval={ interval }
+			yearlyControlProps={ { path: plansLink( '/plans', siteSlug, 'yearly', true ) } }
+			monthlyControlProps={ { path: plansLink( '/plans', siteSlug, 'monthly', true ) } }
+		/>
+	);
 
 	const availablePlanFeatures = isEnabled( 'plans/wooexpress-small' )
 		? multiPlanFeatures

--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -1,16 +1,12 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
-import {
-	plansLink,
-	PLAN_WOOEXPRESS_MEDIUM,
-	PLAN_WOOEXPRESS_SMALL,
-} from '@automattic/calypso-products';
+import { plansLink } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
-import AsyncLoad from 'calypso/components/async-load';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import ECommercePlanFeatures from 'calypso/my-sites/plans/components/ecommerce-plan-features';
 import ECommerceTrialBanner from './ecommerce-trial-banner';
+import { WooExpressPlans } from './wooexpress-plans';
 import { getWooExpressMediumFeatureSets } from './wx-medium-features';
 import type { Site } from 'calypso/my-sites/scan/types';
 
@@ -50,17 +46,7 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 		/>
 	);
 
-	const plansTableProps = {
-		plans: [ PLAN_WOOEXPRESS_SMALL, PLAN_WOOEXPRESS_MEDIUM ],
-		hidePlansFeatureComparison: true,
-		siteId,
-	};
-
-	const multiPlanFeatures = (
-		<div className="is-2023-pricing-grid">
-			<AsyncLoad require="calypso/my-sites/plan-features-2023-grid" { ...plansTableProps } />
-		</div>
-	);
+	const multiPlanFeatures = <WooExpressPlans siteId={ siteId } />;
 
 	const availablePlanFeatures = isEnabled( 'plans/wooexpress-small' )
 		? multiPlanFeatures

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -1,0 +1,21 @@
+import { PLAN_WOOEXPRESS_MEDIUM, PLAN_WOOEXPRESS_SMALL } from '@automattic/calypso-products';
+import AsyncLoad from 'calypso/components/async-load';
+
+interface WooExpressPlansProps {
+	siteId: number | string;
+}
+
+export function WooExpressPlans( props: WooExpressPlansProps ) {
+	const { siteId } = props;
+
+	const plansTableProps = {
+		plans: [ PLAN_WOOEXPRESS_SMALL, PLAN_WOOEXPRESS_MEDIUM ],
+		hidePlansFeatureComparison: true,
+		siteId,
+	};
+	return (
+		<div className="is-2023-pricing-grid">
+			<AsyncLoad require="calypso/my-sites/plan-features-2023-grid" { ...plansTableProps } />
+		</div>
+	);
+}

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -1,21 +1,90 @@
-import { PLAN_WOOEXPRESS_MEDIUM, PLAN_WOOEXPRESS_SMALL } from '@automattic/calypso-products';
+import {
+	PLAN_WOOEXPRESS_MEDIUM,
+	PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
+	PLAN_WOOEXPRESS_SMALL,
+	PLAN_WOOEXPRESS_SMALL_MONTHLY,
+	getPlans,
+} from '@automattic/calypso-products';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
+import PlanIntervalSelector from 'calypso/my-sites/plans-features-main/plan-interval-selector';
+import { getPlanRawPrice } from 'calypso/state/plans/selectors';
 
+import './style.scss';
+
+type SegmentedOptionProps = {
+	path?: string;
+	onClick?: () => void;
+};
 interface WooExpressPlansProps {
 	siteId: number | string;
+	interval?: 'monthly' | 'yearly';
+	monthlyControlProps: SegmentedOptionProps;
+	yearlyControlProps: SegmentedOptionProps;
 }
 
 export function WooExpressPlans( props: WooExpressPlansProps ) {
-	const { siteId } = props;
+	const { siteId, interval, monthlyControlProps, yearlyControlProps } = props;
+	const translate = useTranslate();
+
+	const mediumPlanAnnual = getPlans()[ PLAN_WOOEXPRESS_MEDIUM ];
+	const mediumPlanMonthly = getPlans()[ PLAN_WOOEXPRESS_MEDIUM_MONTHLY ];
+	const mediumPlanPrices = useSelector( ( state ) => ( {
+		annualPlanMonthlyPrice: getPlanRawPrice( state, mediumPlanAnnual.getProductId(), true ) || 0,
+		monthlyPlanPrice: getPlanRawPrice( state, mediumPlanMonthly.getProductId() ) || 0,
+	} ) );
+
+	const percentageSavings = Math.floor(
+		( 1 - mediumPlanPrices.annualPlanMonthlyPrice / mediumPlanPrices.monthlyPlanPrice ) * 100
+	);
+
+	const planIntervals = useMemo( () => {
+		return [
+			{
+				interval: 'monthly',
+				...monthlyControlProps,
+				content: <span>{ translate( 'Pay Monthly' ) }</span>,
+				selected: interval === 'monthly',
+			},
+			{
+				interval: 'yearly',
+				...yearlyControlProps,
+				content: (
+					<span>
+						{ translate( 'Pay Annually (Save %(percentageSavings)s%%)', {
+							args: { percentageSavings },
+						} ) }
+					</span>
+				),
+				selected: interval === 'yearly',
+			},
+		];
+	}, [ interval, translate, monthlyControlProps, percentageSavings, yearlyControlProps ] );
+
+	const smallPlan = interval === 'yearly' ? PLAN_WOOEXPRESS_SMALL : PLAN_WOOEXPRESS_SMALL_MONTHLY;
+	const mediumPlan =
+		interval === 'yearly' ? PLAN_WOOEXPRESS_MEDIUM : PLAN_WOOEXPRESS_MEDIUM_MONTHLY;
 
 	const plansTableProps = {
-		plans: [ PLAN_WOOEXPRESS_SMALL, PLAN_WOOEXPRESS_MEDIUM ],
+		plans: [ smallPlan, mediumPlan ],
 		hidePlansFeatureComparison: true,
 		siteId,
 	};
 	return (
-		<div className="is-2023-pricing-grid">
-			<AsyncLoad require="calypso/my-sites/plan-features-2023-grid" { ...plansTableProps } />
-		</div>
+		<>
+			<div className="wooexpress-plans__interval-toggle-wrapper">
+				<PlanIntervalSelector
+					className="wooexpress-plans__interval-toggle price-toggle"
+					intervals={ planIntervals }
+					isPlansInsideStepper={ false }
+					use2023PricingGridStyles={ true }
+				/>
+			</div>
+			<div className="is-2023-pricing-grid">
+				<AsyncLoad require="calypso/my-sites/plan-features-2023-grid" { ...plansTableProps } />
+			</div>
+		</>
 	);
 }

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
@@ -1,0 +1,20 @@
+@import "@wordpress/base-styles/breakpoints";
+
+.wooexpress-plans__interval-toggle-wrapper {
+	display: flex;
+	justify-content: center;
+	margin: 48px 0 32px 0;
+	padding: 0 20px;
+
+	.wooexpress-plans__interval-toggle {
+		font-weight: 500;
+		max-width: -moz-fit-content;
+		max-width: fit-content;
+		width: auto;
+
+		@media (max-width: $break-mobile) {
+			max-width: 100%;
+			width: 100%;
+		}
+	}
+}


### PR DESCRIPTION
Added Interval toggle to trial's Plans page:

*This PR is not updating the features' copy. This is going to be handled in a separate PR.

### Testing
* Open the Plans page using a trial site (`plans/site-slug`)
* Make sure the `plans/wooexpress-small` feature flag is enabled.
* You should see the toggle, and using it should update the prices.

Monthly:
![image](https://user-images.githubusercontent.com/3801502/229542788-fdcd19d6-8a0f-4aa8-832b-7537fdd36456.png)

Yearly:
![image](https://user-images.githubusercontent.com/3801502/229542893-6d1d4098-55ef-41b3-9ebc-faea8a6d7399.png)
