### PR TITLE
Woo Express: Added Woo Express styles to CtA

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -29,6 +29,7 @@ import {
 	PLAN_BIENNIAL_PERIOD,
 	isWooExpressMediumPlan,
 	isWooExpressSmallPlan,
+	isWooExpressPlan,
 } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
@@ -213,6 +214,8 @@ const PlanLogo: React.FunctionComponent< {
 		'is-current-plan': current,
 	} );
 
+	const shouldShowWooLogo = isEcommercePlan( planName ) && ! isWooExpressPlan( planName );
+
 	return (
 		<Container key={ planName } className={ tableItemClasses } isMobile={ isMobile }>
 			<PopularBadge
@@ -230,7 +233,7 @@ const PlanLogo: React.FunctionComponent< {
 						imgAlt="WP Cloud logo"
 					/>
 				) }
-				{ isEcommercePlan( planName ) && (
+				{ shouldShowWooLogo && (
 					<ServiceLogo
 						hoverText={ translate(
 							'Make your online store a reality with the power of WooCommerce.'

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -56,6 +56,23 @@
 				}
 			}
 
+			&.is-wooexpress-medium-plan {
+				background-color: var(--studio-pink-50);
+				color: var(--studio-white);
+				font-weight: 400;
+
+				&:focus {
+					box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-pink-50);
+				}
+			}
+
+			&.is-wooexpress-small-plan {
+				background-color: var(--studio-white);
+				color: var(--studio-pink-50);
+				border: 1px solid  var(--studio-pink-50);
+				font-weight: 400;
+			}
+
 			&.is-ecommerce-plan {
 				background-color: #55347d;
 				color: var(--studio-purple-0);

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -57,19 +57,19 @@
 			}
 
 			&.is-wooexpress-medium-plan {
-				background-color: var(--studio-pink-50);
-				color: var(--studio-white);
+				background-color: var(--color-accent);
+				color: var(--color-text-inverted);
 				font-weight: 400;
 
 				&:focus {
-					box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-pink-50);
+					box-shadow: 0 0 0 2px var(--color-surface), 0 0 0 4px var(--color-accent);
 				}
 			}
 
 			&.is-wooexpress-small-plan {
-				background-color: var(--studio-white);
-				color: var(--studio-pink-50);
-				border: 1px solid  var(--studio-pink-50);
+				background-color: var(--color-surface);
+				color: var(--color-accent);
+				border: 1px solid  var(--color-accent);
 				font-weight: 400;
 			}
 

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -116,6 +116,14 @@ export function getPlanClass( planKey: string ): string {
 		return 'is-business-plan';
 	}
 
+	if ( isWooExpressMediumPlan( planKey ) ) {
+		return 'is-wooexpress-medium-plan';
+	}
+
+	if ( isWooExpressSmallPlan( planKey ) ) {
+		return 'is-wooexpress-small-plan';
+	}
+
 	if ( isEcommercePlan( planKey ) ) {
 		return 'is-ecommerce-plan';
 	}
@@ -313,8 +321,13 @@ export function isWpcomEnterpriseGridPlan( planSlug: string ): boolean {
 export function isWooExpressMediumPlan( planSlug: string ): boolean {
 	return [ PLAN_WOOEXPRESS_MEDIUM, PLAN_WOOEXPRESS_MEDIUM_MONTHLY ].includes( planSlug );
 }
+
 export function isWooExpressSmallPlan( planSlug: string ): boolean {
 	return [ PLAN_WOOEXPRESS_SMALL, PLAN_WOOEXPRESS_SMALL_MONTHLY ].includes( planSlug );
+}
+
+export function isWooExpressPlan( planSlug: string ): boolean {
+	return isWooExpressMediumPlan( planSlug ) || isWooExpressSmallPlan( planSlug );
 }
 
 export function isFlexiblePlan( planSlug: string ): boolean {


### PR DESCRIPTION
* Added Woo Express styles to the plans buttons
* Removed the Woo logo

*This PR is not updating the features' copy. This is going to be handled in a separate PR.

### Testing
* Open the Plans page using a trial site (`plans/site-slug`)
* Make sure the `plans/wooexpress-small` feature flag is enabled.


Before:
![image](https://user-images.githubusercontent.com/3801502/229551349-2fd1e50f-216a-46f1-ad7f-51e4c420d8bd.png)

After:
![image](https://user-images.githubusercontent.com/3801502/229551442-ad15770b-6057-4df0-b35d-79c75702abcc.png)
