### PR TITLE
Subscriptions Manager: Remove temporary redirect from Sites tab.

### DIFF
--- a/client/landing/subscriptions/tabs-switcher/tabs-switcher.tsx
+++ b/client/landing/subscriptions/tabs-switcher/tabs-switcher.tsx
@@ -18,8 +18,8 @@ type TabsSwitcherProps = {
 
 const getRoute = ( baseRoute: string, path: string ): string => {
 	// This is a temporary redirect to the re-skinned Subscription Management portal.
-	// Once the new "Commnets" and "Sites" views are ready, this will be removed.
-	const temporaryRedirect = [ 'comments', 'sites' ];
+	// Once the new "Commnets" views is ready, this will be removed.
+	const temporaryRedirect = [ 'comments' ];
 	if ( temporaryRedirect.includes( path ) ) {
 		return `https://wordpress.com/email-subscriptions/?option=${ path }`;
 	}

--- a/client/landing/subscriptions/tabs-switcher/tabs-switcher.tsx
+++ b/client/landing/subscriptions/tabs-switcher/tabs-switcher.tsx
@@ -18,7 +18,7 @@ type TabsSwitcherProps = {
 
 const getRoute = ( baseRoute: string, path: string ): string => {
 	// This is a temporary redirect to the re-skinned Subscription Management portal.
-	// Once the new "Commnets" views is ready, this will be removed.
+	// Once the new "Comments" view is ready, this will be removed.
 	const temporaryRedirect = [ 'comments' ];
 	if ( temporaryRedirect.includes( path ) ) {
 		return `https://wordpress.com/email-subscriptions/?option=${ path }`;


### PR DESCRIPTION
### Merging this PR means releasing the feature, so let's just merge it on the shipping date. 
Details here: p7DVsv-_hyI-p2

Closes https://github.com/Automattic/wp-calypso/issues/75226

## Proposed Changes

This PR removes the temporary redirect from Sites tab.

## Testing Instructions

1. Run this PR on your local env
2. Go to http://calypso.localhost:3000/subscriptions/sites
3. Using tabs, navigate to Settings and then navigate back to Sites
4. Verify if you aren't redirected to the Reskinned portal
5. Go to http://calypso.localhost:3000/subscriptions/settings
6. Navigate to Site using tabs
7. Verify if you aren't redirected to the Reskinned portal
8. Verify if the Comments tab continues to redirect to the Reskinned portal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?