### PR TITLE
Staging sites: Fix when we show the space quota message

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -59,7 +59,7 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
 	const [ loadingError, setLoadingError ] = useState( false );
-	const [ loadingValidQuotaError, setLoadingValidQuotaError ] = useState( false );
+	const [ isErrorValidQuota, setIsErrorValidQuota ] = useState( false );
 
 	const { data: hasValidQuota, isLoading: isLoadingQuotaValidation } = useHasValidQuotaQuery(
 		siteId,

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -66,7 +66,7 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 		{
 			enabled: ! disabled,
 			onError: ( error ) => {
-				setLoadingValidQuotaError( error );
+				setLoadingValidQuotaError( true );
 			},
 		}
 	);

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -58,8 +58,18 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
-	const { data: hasValidQuota } = useHasValidQuotaQuery( siteId );
 	const [ loadingError, setLoadingError ] = useState( false );
+	const [ loadingValidQuotaError, setLoadingValidQuotaError ] = useState( false );
+
+	const { data: hasValidQuota, isLoading: isLoadingQuotaValidation } = useHasValidQuotaQuery(
+		siteId,
+		{
+			enabled: ! disabled,
+			onError: ( error ) => {
+				setLoadingValidQuotaError( error );
+			},
+		}
+	);
 
 	const { data: stagingSites, isLoading: isLoadingStagingSites } = useStagingSite( siteId, {
 		enabled: ! disabled,
@@ -78,8 +88,10 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 	}, [ stagingSites ] );
 	const hasSiteAccess = useHasSiteAccess( stagingSite.id );
 
-	const showAddStagingSite = ! isLoadingStagingSites && stagingSites?.length === 0;
-	const showManageStagingSite = ! isLoadingStagingSites && stagingSites?.length > 0;
+	const showAddStagingSite =
+		! isLoadingStagingSites && ! isLoadingQuotaValidation && stagingSites?.length === 0;
+	const showManageStagingSite =
+		! isLoadingStagingSites && ! isLoadingQuotaValidation && stagingSites?.length > 0;
 
 	const [ wasCreating, setWasCreating ] = useState( false );
 	const [ progress, setProgress ] = useState( 0.1 );
@@ -168,7 +180,7 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 				</p>
 				<Button
 					primary
-					disabled={ disabled || addingStagingSite || ! hasValidQuota }
+					disabled={ disabled || addingStagingSite || isLoadingQuotaValidation || ! hasValidQuota }
 					onClick={ () => {
 						dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_click' ) );
 						setWasCreating( true );
@@ -178,7 +190,7 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 				>
 					<span>{ translate( 'Add staging site' ) }</span>
 				</Button>
-				{ ! hasValidQuota && getExceedQuotaErrorContent() }
+				{ ! hasValidQuota && ! isLoadingQuotaValidation && getExceedQuotaErrorContent() }
 			</>
 		);
 	};
@@ -245,12 +257,10 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 		);
 	};
 
-	const getLoadingErrorContent = () => {
+	const getLoadingErrorContent = ( message ) => {
 		return (
 			<Notice status="is-error" showDismiss={ false }>
-				{ __(
-					'Unable to load staging sites. Please contact support if you believe you are seeing this message in error.'
-				) }
+				{ message }
 			</Notice>
 		);
 	};
@@ -277,7 +287,17 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 
 	let stagingSiteCardContent;
 	if ( ! isLoadingStagingSites && loadingError ) {
-		stagingSiteCardContent = getLoadingErrorContent();
+		stagingSiteCardContent = getLoadingErrorContent(
+			__(
+				'Unable to load staging sites. Please contact support if you believe you are seeing this message in error.'
+			)
+		);
+	} else if ( ! isLoadingQuotaValidation && loadingValidQuotaError ) {
+		stagingSiteCardContent = getLoadingErrorContent(
+			__(
+				'Unable to validate your site quota. Please contact support if you believe you are seeing this message in error.'
+			)
+		);
 	} else if ( ! wasCreating && ! hasSiteAccess && transferStatus !== null ) {
 		stagingSiteCardContent = getAccessError();
 	} else if ( addingStagingSite || isTrasferInProgress || isReverting ) {

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -65,8 +65,8 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 		siteId,
 		{
 			enabled: ! disabled,
-			onError: ( error ) => {
-				setLoadingValidQuotaError( true );
+			onError: () => {
+				setIsErrorValidQuota( true );
 			},
 		}
 	);
@@ -292,7 +292,7 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 				'Unable to load staging sites. Please contact support if you believe you are seeing this message in error.'
 			)
 		);
-	} else if ( ! isLoadingQuotaValidation && loadingValidQuotaError ) {
+	} else if ( ! isLoadingQuotaValidation && isErrorValidQuota ) {
 		stagingSiteCardContent = getLoadingErrorContent(
 			__(
 				'Unable to validate your site quota. Please contact support if you believe you are seeing this message in error.'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead, attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2098

## Proposed Changes

This pr fixes the incorrect display of the invalid space quota message when the site is loading.

## Testing Instructions

### Test 1: Space quota is sufficient

- Create an atomic site.
- Navigate to the `/hosting-config` of your site.
- Ensure that you don't see the insufficient space quota message when loading (To be 100% sure that you correctly test that, enable "Fast 3g" in your dev console)
- Ensure that `Add staging site` button is enabled after page load
- Ensure that the warning message about space quota is not visible

### Test 2: Space quota is insufficient

- Create an atomic site.
- Navigate to the `/hosting-config` of your site.
- Ensure that you change your `validate_quota` function (in your sandbox) to return `false`
- Ensure that you don't see the insufficient space quota message when loading (To be 100% sure that you correctly test that, enable "Fast 3g" in your dev console)
- Ensure that the `Add staging site` button is disabled
- Ensure that the space quota warning message is visible

### Test 3: Space quota validation error

- Create an atomic site.
- Navigate to the `/hosting-config` of your site.
- Ensure that you change your `validate_quota` function (in your sandbox) to return an  error: eg: 
```
    return new WP_Error( 'test','test' );
```
- Ensure that you don't see the insufficient space quota message when loading.
- Ensure that you keep seeing the loading skeleton until you see the following error message:
```
Unable to validate your site quota. Please contact support if you believe you are seeing this message in error.
```
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Error**:

![Screenshot 2023-04-04 at 12 42 08](https://user-images.githubusercontent.com/779993/229772882-c78c3351-cc88-4e67-87b3-b4dfccd66450.png)

**Not valid quota**:

![Screenshot 2023-04-04 at 12 25 40](https://user-images.githubusercontent.com/779993/229772914-2265c0ae-c9a1-4575-aa01-15a25bbee789.png)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
