### PR TITLE
Subscriptions Manager: Fix SettingsPopover position

### DIFF
--- a/client/landing/subscriptions/settings-popover/settings-popover.tsx
+++ b/client/landing/subscriptions/settings-popover/settings-popover.tsx
@@ -26,7 +26,7 @@ const SettingsPopover = ( { children, className }: SettingsPopoverProps ) => {
 			</button>
 
 			<Popover
-				autoPosition
+				position="bottom left"
 				hideArrow
 				onClose={ onClose }
 				isVisible={ showPopover }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/75217

## Proposed Changes

This PR updates the SettingsPopover position to be "bottom left".
Check Calypo DevDocs for more details https://wpcalypso.wordpress.com/devdocs/design/popover.

## Testing Instructions

1. Run this PR on your local env
2. Go to http://calypso.localhost:3000/subscriptions/sites
3. Click on ellipsis icon in a sites row
4. Verify if the popover appears on the expected position
5. Change the window size and verify if the popover behaves as expected

<img width="425" alt="image" src="https://user-images.githubusercontent.com/3113712/229561551-07377aac-fac8-4104-9c51-c5600c3e298d.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
