### PR TITLE
Subscription management: Create empty state for Sites

### DIFF
--- a/client/landing/subscriptions/notice/notice.tsx
+++ b/client/landing/subscriptions/notice/notice.tsx
@@ -9,26 +9,28 @@ type NoticeProps = {
 	children: React.ReactNode;
 	action?: React.ReactNode;
 	type?: 'success' | 'warning' | 'error';
-	onClose: () => void;
-	visible: boolean;
+	onClose?: () => void;
+	visible?: boolean;
 };
 
 const Notice = ( { children, action, type = 'success', onClose, visible = true }: NoticeProps ) => {
 	return visible ? (
 		<div className={ `subscription-management__notice subscription-management__notice--${ type }` }>
-			<a
-				className="subscription-management__notice-close"
-				href="#close"
-				onClick={ ( e ) => {
-					e.preventDefault();
-					onClose();
-				} }
-			>
-				<img
-					src={ closeIcon }
-					alt={ translate( 'Close', { context: 'Hide the notice' } ) as string }
-				/>
-			</a>
+			{ onClose && (
+				<a
+					className="subscription-management__notice-close"
+					href="#close"
+					onClick={ ( e ) => {
+						e.preventDefault();
+						onClose?.();
+					} }
+				>
+					<img
+						src={ closeIcon }
+						alt={ translate( 'Close', { context: 'Hide the notice' } ) as string }
+					/>
+				</a>
+			) }
 			<div className="subscription-management__notice-icon">
 				<img
 					src={ { success: successIcon, warning: warningIcon, error: errorIcon }[ type ] }

--- a/client/landing/subscriptions/tab-views/sites.tsx
+++ b/client/landing/subscriptions/tab-views/sites.tsx
@@ -1,8 +1,29 @@
 import { SubscriptionManager } from '@automattic/data-stores';
+import { Spinner } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { Notice } from '../notice';
 import SiteList from '../site-list/site-list';
 
 export default function SitesView() {
-	const { data: sites } = SubscriptionManager.useSiteSubscriptionsQuery();
+	const translate = useTranslate();
+	const { data: sites, isLoading, error } = SubscriptionManager.useSiteSubscriptionsQuery();
+
+	if ( error ) {
+		// todo: translate when we have agreed on the error message
+		return <Notice type="error">An error occurred while fetching your subscriptions.</Notice>;
+	}
+
+	if ( isLoading ) {
+		return (
+			<div className="user-settings">
+				<Spinner />
+			</div>
+		);
+	}
+
+	if ( ! sites || ! sites.length ) {
+		return <Notice type="warning">{ translate( 'You are not subscribed to any sites.' ) }</Notice>;
+	}
 
 	return <SiteList sites={ sites } />;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
![Screen Shot 2023-04-03 at 20 09 51](https://user-images.githubusercontent.com/2019970/229591874-cc59b7d3-f97f-4261-856f-b6d2ece3d23a.png)


Resolves https://github.com/Automattic/wp-calypso/issues/75233

## Proposed Changes

* display warning type notice when a user with no sites subscriptions has the **Sites** tab open

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/subscriptions/sites, ensuring you have a valid `subkey` value in your cookie which is pointing to `calypso.localhost`
* When you have no subscsribed-to sites, then you should see the notice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
