### PR TITLE
@automattic/components: Make Dialog onClose optional

### DIFF
--- a/packages/components/src/dialog/index.tsx
+++ b/packages/components/src/dialog/index.tsx
@@ -19,7 +19,7 @@ type Props = {
 	isVisible: boolean;
 	label?: string;
 	leaveTimeout?: number;
-	onClose: ( action?: string ) => void;
+	onClose?: ( action?: string ) => void;
 	shouldCloseOnEsc?: boolean;
 	showCloseIcon?: boolean;
 };
@@ -75,7 +75,7 @@ const Dialog = ( {
 			shouldCloseOnEsc={ shouldCloseOnEsc }
 		>
 			{ showCloseIcon && (
-				<button className="dialog__action-buttons-close" onClick={ () => onClose( this ) }>
+				<button className="dialog__action-buttons-close" onClick={ () => onClose?.( this ) }>
 					<Gridicon icon="cross" size={ 24 } />
 				</button>
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR makes the `onClose` prop of the `Dialog` component optional instead of required.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify by code review that every use of `onClose` in the `Dialog` component is guarded by optional chaining.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
