### PR TITLE
Add Woo Express plans grid to expired trial page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
 import { PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState } from 'react';
@@ -9,6 +10,7 @@ import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import ECommercePlanFeatures from 'calypso/my-sites/plans/components/ecommerce-plan-features';
+import { WooExpressPlans } from 'calypso/my-sites/plans/ecommerce-trial/wooexpress-plans';
 import { getExpiredTrialWooExpressMediumFeatureSets } from 'calypso/my-sites/plans/ecommerce-trial/wx-medium-features';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -50,6 +52,27 @@ const ECommerceTrialExpired = (): JSX.Element => {
 		} );
 	}, [] );
 
+	const plansContent = isEnabled( 'plans/wooexpress-small' ) ? (
+		<WooExpressPlans
+			interval={ interval }
+			monthlyControlProps={ monthlyControlProps }
+			siteId={ siteId ?? 0 }
+			yearlyControlProps={ yearlyControlProps }
+		/>
+	) : (
+		<ECommercePlanFeatures
+			interval={ interval }
+			monthlyControlProps={ monthlyControlProps }
+			planFeatureSets={ expiredTrialWooExpressMediumPlanFeatureSets }
+			priceCardSubtitle={ translate(
+				'Kickstart your growth with the world’s most-trusted ecommerce platform.'
+			) }
+			siteSlug={ siteSlug }
+			triggerTracksEvent={ triggerTracksEvent }
+			yearlyControlProps={ yearlyControlProps }
+		/>
+	);
+
 	return (
 		<>
 			<QueryPlans />
@@ -82,17 +105,7 @@ const ECommerceTrialExpired = (): JSX.Element => {
 					</div>
 				</div>
 
-				<ECommercePlanFeatures
-					interval={ interval }
-					monthlyControlProps={ monthlyControlProps }
-					planFeatureSets={ expiredTrialWooExpressMediumPlanFeatureSets }
-					priceCardSubtitle={ translate(
-						'Kickstart your growth with the world’s most-trusted ecommerce platform.'
-					) }
-					siteSlug={ siteSlug }
-					triggerTracksEvent={ triggerTracksEvent }
-					yearlyControlProps={ yearlyControlProps }
-				/>
+				{ plansContent }
 			</Main>
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76246

## Proposed Changes

* This PR builds on the changes in #75246 to use the new Woo Express plans grid in the expired eCommerce trial page. The new grid will only be displayed when the `plans/wooexpress-small` feature flag is enabled

### Screenshots

#### Before
<img width="1467" alt="Screenshot 2023-04-03 at 23 05 11" src="https://user-images.githubusercontent.com/3376401/229627506-e857c56e-035b-41c2-8b9b-fdf0f796d949.png">

#### After
<img width="1467" alt="Screenshot 2023-04-03 at 23 04 11" src="https://user-images.githubusercontent.com/3376401/229627317-549b6d3b-8231-4407-8944-7bb19a0ed07f.png">

## Testing Instructions

* Ensure that you have a site with an expired eCommerce trial plan
* Run Calypso locally or via Calypso.live, and try to navigate to a Calypso page for your site
* Verify that you're redirected to the expired trial page at `/plans/my-plan/trial-expired/:siteSlug`
* Ensure that the `plans/wooexpress-small` feature flag is enabled by adding `?flags=plans/wooexpress-small` to the URL
* Verify that you see the plans grid
* Verify that you can toggle the billing interval between monthly and annual
* Verify that you can add both Essential and Performance plans to your cart by clicking on the relevant CTA(s)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [N/A] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?