### PR TITLE
Subscriptions Manager: Add loading state to unfollow button

### DIFF
--- a/client/landing/subscriptions/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/settings-popover/site-settings/site-settings.tsx
@@ -10,12 +10,14 @@ type SiteSettingsProps = {
 	deliveryFrequency: SiteSubscriptionDeliveryFrequency;
 	onDeliveryFrequencyChange: ( value: SiteSubscriptionDeliveryFrequency ) => void;
 	onUnfollow: () => void;
+	unfollowing: boolean;
 };
 
 const SiteSettings = ( {
 	deliveryFrequency,
 	onDeliveryFrequencyChange,
 	onUnfollow,
+	unfollowing,
 }: SiteSettingsProps ) => {
 	const translate = useTranslate();
 
@@ -29,7 +31,7 @@ const SiteSettings = ( {
 				/>
 			</PopoverMenuItem>
 			<Separator />
-			<UnfollowSiteButton onUnfollow={ onUnfollow } />
+			<UnfollowSiteButton unfollowing={ unfollowing } onUnfollow={ onUnfollow } />
 		</SettingsPopover>
 	);
 };

--- a/client/landing/subscriptions/settings-popover/site-settings/unfollow-site-button.tsx
+++ b/client/landing/subscriptions/settings-popover/site-settings/unfollow-site-button.tsx
@@ -1,17 +1,20 @@
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { UnfollowIcon } from '../icons';
 
 type UnfollowSiteButtonProps = {
 	onUnfollow: () => void;
+	unfollowing: boolean;
 };
 
-const UnfollowSiteButton = ( { onUnfollow }: UnfollowSiteButtonProps ) => {
+const UnfollowSiteButton = ( { onUnfollow, unfollowing }: UnfollowSiteButtonProps ) => {
 	const translate = useTranslate();
 
 	return (
 		<PopoverMenuItem
-			className="settings-popover__item-button"
+			className={ classNames( 'settings-popover__item-button', { 'is-loading': unfollowing } ) }
+			disabled={ unfollowing }
 			icon={ <UnfollowIcon className="settings-popover__item-icon" /> }
 			onClick={ onUnfollow }
 		>

--- a/client/landing/subscriptions/settings-popover/styles.scss
+++ b/client/landing/subscriptions/settings-popover/styles.scss
@@ -37,6 +37,12 @@
 		width: 100%;
 		cursor: pointer;
 
+		&.is-loading {
+			cursor: default;
+			opacity: 0.5;
+			pointer-events: none;
+		}
+
 		&:hover,
 		&:focus {
 			color: $studio-blue-50;

--- a/client/landing/subscriptions/site-list/site-row.tsx
+++ b/client/landing/subscriptions/site-list/site-row.tsx
@@ -33,7 +33,8 @@ export default function SiteRow( {
 
 	const { mutate: updateDeliveryFrequency } =
 		SubscriptionManager.useSiteDeliveryFrequencyMutation();
-	const { mutate: unFollow } = SubscriptionManager.useSiteUnfollowMutation();
+	const { mutate: unFollow, isLoading: unfollowing } =
+		SubscriptionManager.useSiteUnfollowMutation();
 
 	return (
 		<li className="row" role="row">
@@ -59,6 +60,7 @@ export default function SiteRow( {
 						updateDeliveryFrequency( { blog_id: blog_ID, delivery_frequency } )
 					}
 					onUnfollow={ () => unFollow( { blog_id: blog_ID } ) }
+					unfollowing={ unfollowing }
 				/>
 			</span>
 		</li>


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/75220

## Proposed Changes

This PR adds loading state to unfollow button. The button is disabled and opacity changed to 50%.

## Testing Instructions

1. Run this PR on your local env
2. Go to http://calypso.localhost:3000/subscriptions/sites
3. Unfollow a site and verify if the button state changes

<img width="379" alt="image" src="https://user-images.githubusercontent.com/3113712/229629696-dd0ed035-01b0-4863-a416-e690cad4d0cb.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
