### PR TITLE
WIP: Pass redirect url along if using a tailored onboarding flow.

### DIFF
--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { isTailoredSignupFlow } from '@automattic/onboarding';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -127,12 +128,16 @@ class SocialSignupForm extends Component {
 							}
 							originalUrlPath={
 								// Set the original URL path for wpcc flow so that we can redirect the user back to /start/wpcc after Apple callback.
-								isWpccFlow( this.props.flowName ) ? window.location.pathname : null
+								isWpccFlow( this.props.flowName ) || isTailoredSignupFlow( this.props.flowName )
+									? window.location.pathname
+									: null
 							}
 							// Attach the query string to the state so we can pass it back to the server to show the correct UI.
 							// We need this because Apple doesn't allow to have dynamic parameters in redirect_uri.
 							queryString={
-								isWpccFlow( this.props.flowName ) ? window.location.search.slice( 1 ) : null
+								isWpccFlow( this.props.flowName ) || isTailoredSignupFlow( this.props.flowName )
+									? window.location.search.slice( 1 )
+									: null
 							}
 						/>
 						{ ! this.props.isWoo && ! this.props.disableTosText && <SocialSignupToS /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
