### PR TITLE
Stats: Fix hover functionality for subscriber count uPlot

### DIFF
--- a/client/my-sites/stats/subscribers-section/index.tsx
+++ b/client/my-sites/stats/subscribers-section/index.tsx
@@ -7,7 +7,6 @@ import './style.scss';
 
 // New Subscriber Stats
 // We don't have any data yet so we are just using some test data.
-// Currently using the LineChart component from the Calypso library.
 
 function getData(): [ string, number, number ][] {
 	// From https://code.a8c.com/D105106 -- Work in progress on new endpoint.
@@ -66,7 +65,9 @@ export default function SubscribersSection() {
 			{ ! isLoading && counts.length === 0 && (
 				<p className="subscribers-section__no-data">No data availble for the specified period.</p>
 			) }
-			{ ! isLoading && counts.length !== 0 && <UplotLineChart data={ counts } /> }
+			{ ! isLoading && counts.length !== 0 && (
+				<UplotLineChart data={ counts } options={ { legend: { show: false } } } />
+			) }
 		</div>
 	);
 }

--- a/client/my-sites/stats/subscribers-section/index.tsx
+++ b/client/my-sites/stats/subscribers-section/index.tsx
@@ -48,9 +48,11 @@ function getData(): [ string, number, number ][] {
 
 function transformData( data: [ string, number, number ][] ): uPlot.AlignedData {
 	// Transform the data into the format required by uPlot.
-	// Note that the incoming data is ordered from newest to oldest.
-	const x: number[] = data.map( ( point ) => Number( new Date( point[ 0 ] ) ) / 1000 );
-	const y: number[] = data.map( ( point ) => Number( point[ 1 ] ) );
+	//
+	// Note that the incoming data is ordered ascending (newest to oldest)
+	// but uPlot expects descending in its deafult configuration.
+	const x: number[] = data.map( ( point ) => Number( new Date( point[ 0 ] ) ) / 1000 ).reverse();
+	const y: number[] = data.map( ( point ) => Number( point[ 1 ] ) ).reverse();
 	return [ x, y ];
 }
 
@@ -64,10 +66,7 @@ export default function SubscribersSection() {
 			{ ! isLoading && counts.length === 0 && (
 				<p className="subscribers-section__no-data">No data availble for the specified period.</p>
 			) }
-			{ ! isLoading && counts.length !== 0 && (
-				// TODO: Figure out why hover only breaks in the subscriber section and not in Storybook.
-				<UplotLineChart data={ counts } options={ { legend: { show: false } } } />
-			) }
+			{ ! isLoading && counts.length !== 0 && <UplotLineChart data={ counts } /> }
 		</div>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75245.

## Proposed Changes

* uPlot expects series sorted ascending by default. Feeding it data sorted descending was causing unpredictable behavior on chart hover.
* This PR adds an ascending sort to the data before passing to uPlot.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the live branch for this PR.
* Navigate to the traffic stats page at `/stats/day/:siteSlug` and add the query string `?flags=stats/subscribers-section` to enable the subscriber counts section.
* Ensure that the new chart works as expected, including upon being hovered.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
