### PR TITLE
Stats Widget: remove redux for stats widget

### DIFF
--- a/apps/odyssey-stats/package.json
+++ b/apps/odyssey-stats/package.json
@@ -31,6 +31,7 @@
 		"calypso": "workspace:^",
 		"classnames": "^2.3.1",
 		"debug": "^4.3.4",
+		"moment": "^2.26.0",
 		"page": "^1.11.5",
 		"prop-types": "^15.8.1",
 		"react": "^17.0.2",

--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -22,6 +22,8 @@ import registerStatsPages from './routes';
 import 'calypso/assets/stylesheets/style.scss';
 import './app.scss';
 
+const localeSlug = config( 'i18n_locale_slug' ) || config( 'i18n_default_locale_slug' ) || 'en';
+
 async function AppBoot() {
 	const siteId = config( 'blog_id' );
 
@@ -36,7 +38,7 @@ async function AppBoot() {
 		...initialState,
 		currentUser: {
 			...initialState.currentUser,
-			user: { ...initialState.currentUser.user, localeSlug: config( 'i18n_locale_slug' ) },
+			user: { ...initialState.currentUser.user, localeSlug },
 		},
 	};
 
@@ -53,7 +55,6 @@ async function AppBoot() {
 	);
 
 	setStore( store );
-	setLocale( store.dispatch );
 	setupContextMiddleware( store, queryClient );
 
 	if ( ! window.location?.hash ) {
@@ -73,4 +74,4 @@ async function AppBoot() {
 	page.show( `${ getPathWithUpdatedQueryString( {}, window.location.hash.substring( 2 ) ) }` );
 }
 
-AppBoot();
+setLocale( localeSlug ).then( AppBoot );

--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -57,7 +57,7 @@ async function AppBoot() {
 	setupContextMiddleware( store, queryClient );
 
 	// Ensure locale files are loaded before rendering.
-	setLocale( localeSlug ).then( () => {
+	setLocale( localeSlug ).finally( () => {
 		if ( ! window.location?.hash ) {
 			window.location.hash = `#!/stats/day/${ siteId }`;
 		} else {

--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -22,10 +22,9 @@ import registerStatsPages from './routes';
 import 'calypso/assets/stylesheets/style.scss';
 import './app.scss';
 
-const localeSlug = config( 'i18n_locale_slug' ) || config( 'i18n_default_locale_slug' ) || 'en';
-
 async function AppBoot() {
 	const siteId = config( 'blog_id' );
+	const localeSlug = config( 'i18n_locale_slug' ) || config( 'i18n_default_locale_slug' ) || 'en';
 
 	const rootReducer = combineReducers( {
 		currentUser,
@@ -57,21 +56,24 @@ async function AppBoot() {
 	setStore( store );
 	setupContextMiddleware( store, queryClient );
 
-	if ( ! window.location?.hash ) {
-		window.location.hash = `#!/stats/day/${ siteId }`;
-	} else {
-		// The URL could already get broken by page.js by the appended `?page=stats`.
-		window.location.hash = `#!${ getPathWithUpdatedQueryString(
-			{},
-			window.location.hash.substring( 2 )
-		) }`;
-	}
+	// Ensure locale files are loaded before rendering.
+	setLocale( localeSlug ).then( () => {
+		if ( ! window.location?.hash ) {
+			window.location.hash = `#!/stats/day/${ siteId }`;
+		} else {
+			// The URL could already get broken by page.js by the appended `?page=stats`.
+			window.location.hash = `#!${ getPathWithUpdatedQueryString(
+				{},
+				window.location.hash.substring( 2 )
+			) }`;
+		}
 
-	registerStatsPages( window.location.pathname + window.location.search );
+		registerStatsPages( window.location.pathname + window.location.search );
 
-	// HACK: getPathWithUpdatedQueryString filters duplicate query parameters added by `page.js`.
-	// It has to come after `registerStatsPages` because the duplicate string added in the function.
-	page.show( `${ getPathWithUpdatedQueryString( {}, window.location.hash.substring( 2 ) ) }` );
+		// HACK: getPathWithUpdatedQueryString filters duplicate query parameters added by `page.js`.
+		// It has to come after `registerStatsPages` because the duplicate string added in the function.
+		page.show( `${ getPathWithUpdatedQueryString( {}, window.location.hash.substring( 2 ) ) }` );
+	} );
 }
 
-setLocale( localeSlug ).then( AppBoot );
+AppBoot();

--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -57,7 +57,7 @@ async function AppBoot() {
 	setupContextMiddleware( store, queryClient );
 
 	// Ensure locale files are loaded before rendering.
-	setLocale( localeSlug ).finally( () => {
+	setLocale( localeSlug ).then( () => {
 		if ( ! window.location?.hash ) {
 			window.location.hash = `#!/stats/day/${ siteId }`;
 		} else {

--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -56,18 +56,19 @@ async function AppBoot() {
 	setStore( store );
 	setupContextMiddleware( store, queryClient );
 
+	if ( ! window.location?.hash ) {
+		// Redirect to the default stats page.
+		window.location.hash = `#!/stats/day/${ siteId }`;
+	} else {
+		// The URL could already gets broken by page.js by the appended `?page=stats`.
+		window.location.hash = `#!${ getPathWithUpdatedQueryString(
+			{},
+			window.location.hash.substring( 2 )
+		) }`;
+	}
+
 	// Ensure locale files are loaded before rendering.
 	setLocale( localeSlug ).then( () => {
-		if ( ! window.location?.hash ) {
-			window.location.hash = `#!/stats/day/${ siteId }`;
-		} else {
-			// The URL could already get broken by page.js by the appended `?page=stats`.
-			window.location.hash = `#!${ getPathWithUpdatedQueryString(
-				{},
-				window.location.hash.substring( 2 )
-			) }`;
-		}
-
 		registerStatsPages( window.location.pathname + window.location.search );
 
 		// HACK: getPathWithUpdatedQueryString filters duplicate query parameters added by `page.js`.

--- a/apps/odyssey-stats/src/lib/set-locale.js
+++ b/apps/odyssey-stats/src/lib/set-locale.js
@@ -29,7 +29,7 @@ const loadLanguageFile = ( localeSlug ) => {
 
 export default ( localeSlug ) => {
 	if ( localeSlug === DEFAULT_LOCALE ) {
-		return;
+		return Promise.resolve();
 	}
 
 	return Promise.all( loadLanguageFile( localeSlug ), loadMomentLocale( localeSlug ) )

--- a/apps/odyssey-stats/src/lib/set-locale.js
+++ b/apps/odyssey-stats/src/lib/set-locale.js
@@ -13,7 +13,6 @@ const setMomentLocale = async ( localeSlug ) => {
 
 	debug( 'Loading moment locale for %s', localeSlug );
 	try {
-		// expose the import load promise as instance property. Useful for tests that wait for it
 		import(
 			/* webpackChunkName: "moment-locale-[request]", webpackInclude: /\.js$/ */ `moment/locale/${ localeSlug }`
 		).then( () => moment.locale( localeSlug ) );

--- a/apps/odyssey-stats/src/lib/set-locale.js
+++ b/apps/odyssey-stats/src/lib/set-locale.js
@@ -6,7 +6,7 @@ const debug = debugFactory( 'apps:odyssey' );
 
 const DEFAULT_LOCALE = 'en';
 
-const loadMomentLocale = async ( localeSlug ) => {
+const loadMomentLocale = ( localeSlug ) => {
 	return import(
 		/* webpackChunkName: "moment-locale-[request]", webpackInclude: /\.js$/ */ `moment/locale/${ localeSlug }`
 	).then( () => moment.locale( localeSlug ) );
@@ -27,7 +27,7 @@ const loadLanguageFile = ( localeSlug ) => {
 	} );
 };
 
-export default async ( localeSlug ) => {
+export default ( localeSlug ) => {
 	if ( localeSlug === DEFAULT_LOCALE ) {
 		return;
 	}

--- a/apps/odyssey-stats/src/widget/index.jsx
+++ b/apps/odyssey-stats/src/widget/index.jsx
@@ -19,7 +19,7 @@ export function init() {
 	const queryClient = new QueryClient();
 
 	// Ensure locale files are loaded before rendering.
-	setLocale( localeSlug ).then( () =>
+	setLocale( localeSlug ).finally( () =>
 		render(
 			<QueryClientProvider client={ queryClient }>
 				<div>

--- a/apps/odyssey-stats/src/widget/index.jsx
+++ b/apps/odyssey-stats/src/widget/index.jsx
@@ -19,7 +19,7 @@ export function init() {
 	const queryClient = new QueryClient();
 
 	// Ensure locale files are loaded before rendering.
-	setLocale( localeSlug ).finally( () =>
+	setLocale( localeSlug ).then( () =>
 		render(
 			<QueryClientProvider client={ queryClient }>
 				<div>

--- a/apps/odyssey-stats/src/widget/index.jsx
+++ b/apps/odyssey-stats/src/widget/index.jsx
@@ -18,14 +18,15 @@ export function init() {
 	const currentSiteId = config( 'blog_id' );
 	const queryClient = new QueryClient();
 
-	render(
-		<QueryClientProvider client={ queryClient }>
-			<div>
-				[{ moment().format( 'LLLL' ) }] Stats widget placeholder for site No. { currentSiteId }.
-			</div>
-		</QueryClientProvider>,
-		document.getElementById( 'dashboard_stats' )
+	// Ensure locale files are loaded before rendering.
+	setLocale( localeSlug ).then( () =>
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<div>
+					[{ moment().format( 'LLLL' ) }] Stats widget placeholder for site No. { currentSiteId }.
+				</div>
+			</QueryClientProvider>,
+			document.getElementById( 'dashboard_stats' )
+		)
 	);
 }
-
-setLocale( localeSlug ).then( init );

--- a/apps/odyssey-stats/src/widget/index.jsx
+++ b/apps/odyssey-stats/src/widget/index.jsx
@@ -1,45 +1,31 @@
 import '../load-config';
 import config from '@automattic/calypso-config';
 import '@automattic/calypso-polyfills';
+import moment from 'moment';
 import { render } from 'react-dom';
-import { Provider } from 'react-redux';
-import { createStore, applyMiddleware, compose } from 'redux';
-import thunkMiddleware from 'redux-thunk';
-import MomentProvider from 'calypso/components/localized-moment/provider';
-import StatsWidget from 'calypso/my-sites/customer-home/cards/features/stats';
-import wpcomApiMiddleware from 'calypso/state/data-layer/wpcom-api-middleware';
-import { setStore } from 'calypso/state/redux-store';
-import sites from 'calypso/state/sites/reducer';
-import { setSelectedSiteId } from 'calypso/state/ui/actions';
-import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import setLocale from '../lib/set-locale';
 
 import 'calypso/assets/stylesheets/style.scss';
 import './style.scss';
 
+const localeSlug = config( 'i18n_locale_slug' ) || config( 'i18n_default_locale_slug' ) || 'en';
+
 /**
  * Loads and runs the main chunk for Stats Widget.
  */
 export function init() {
-	const store = createStore(
-		combineReducers( {
-			// TODO: look at implementing a simple reducer to replace this.
-			sites,
-		} ),
-		config( 'intial_state' ),
-		compose( addReducerEnhancer, applyMiddleware( thunkMiddleware, wpcomApiMiddleware ) )
-	);
-
-	setStore( store );
-	setLocale( store.dispatch );
-	store.dispatch( setSelectedSiteId( config( 'blog_id' ) ) );
+	const currentSiteId = config( 'blog_id' );
+	const queryClient = new QueryClient();
 
 	render(
-		<Provider store={ store }>
-			<MomentProvider>
-				<StatsWidget />
-			</MomentProvider>
-		</Provider>,
+		<QueryClientProvider client={ queryClient }>
+			<div>
+				[{ moment().format( 'LLLL' ) }] Stats widget placeholder for site No. { currentSiteId }.
+			</div>
+		</QueryClientProvider>,
 		document.getElementById( 'dashboard_stats' )
 	);
 }
+
+setLocale( localeSlug ).then( init );

--- a/apps/odyssey-stats/src/widget/index.jsx
+++ b/apps/odyssey-stats/src/widget/index.jsx
@@ -9,14 +9,13 @@ import setLocale from '../lib/set-locale';
 import 'calypso/assets/stylesheets/style.scss';
 import './style.scss';
 
-const localeSlug = config( 'i18n_locale_slug' ) || config( 'i18n_default_locale_slug' ) || 'en';
-
 /**
  * Loads and runs the main chunk for Stats Widget.
  */
 export function init() {
 	const currentSiteId = config( 'blog_id' );
 	const queryClient = new QueryClient();
+	const localeSlug = config( 'i18n_locale_slug' ) || config( 'i18n_default_locale_slug' ) || 'en';
 
 	// Ensure locale files are loaded before rendering.
 	setLocale( localeSlug ).then( () =>

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
 		"jsdom": "^20.0.1",
 		"lodash": "^4.17.21",
 		"lottie-web": "^5.9.6",
+		"moment": "^2.26.0",
 		"photon": "workspace:^",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1187,6 +1187,7 @@ __metadata:
     jest: ^27.2.4
     lodash: ^4.17.21
     mkdirp: ^1.0.4
+    moment: ^2.26.0
     node-fetch: ^2.6.6
     page: ^1.11.5
     path-browserify: ^1.0.1
@@ -33723,6 +33724,7 @@ fsevents@^1.2.7:
     lunr: ^2.3.8
     mixedindentlint: ^1.2.0
     mkdirp: ^1.0.4
+    moment: ^2.26.0
     ncp: ^2.0.0
     nock: ^12.0.3
     node-fetch: ^2.6.6


### PR DESCRIPTION
## Proposed Changes

Changes `setLocale` to load locales for `moment` as well, so that we could remove `redux` from widget totally. It also changes Odyssey Stats accordingly.

## Testing Instructions

- Please test with this Jetpack branch: https://github.com/Automattic/jetpack/pull/29772
- You many need to rebuild Jetpack `jetpack build plugins/jetpack`
- Ensure Odyssey Stats works okay
- Ensure Stats widget renders something like the following
- Ensure the date and time are localized.

<img width="441" alt="image" src="https://user-images.githubusercontent.com/1425433/229674523-37cf0eae-fb4e-4c18-8486-d291757c4930.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
