### PR TITLE
Signup Form: Fix issue where Apple Sign In does not work with tailored cases

### DIFF
--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -90,6 +90,8 @@ class SocialSignupForm extends Component {
 		const uxMode = this.shouldUseRedirectFlow() ? 'redirect' : 'popup';
 		const uxModeApple = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : uxMode;
 
+		const params = new URLSearchParams( window.location.search );
+
 		return (
 			// Note: we allow social sign-in on the Desktop app, but not social sign-up. Existing config flags do
 			// not distinguish between sign-in and sign-up but instead use the catch-all `signup/social` flag.
@@ -127,7 +129,9 @@ class SocialSignupForm extends Component {
 							}
 							originalUrlPath={
 								// Set the original URL path for wpcc flow so that we can redirect the user back to /start/wpcc after Apple callback.
-								isWpccFlow( this.props.flowName ) ? window.location.pathname : null
+								isWpccFlow( this.props.flowName )
+									? window.location.pathname
+									: params.get( 'redirect_to' )
 							}
 							// Attach the query string to the state so we can pass it back to the server to show the correct UI.
 							// We need this because Apple doesn't allow to have dynamic parameters in redirect_uri.


### PR DESCRIPTION
The sign in with Apple functionality doesn't work with the tailored cases. After logging in, the user is redirected back to the standard onboarding flow as opposed to the tailored case.

This PR makes a change to set the `originalUrlPath` argument for the Apple sign in button to the `redirect_to` value.

Of note, this may not pass various query args that are also set. It needs more testing.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* If `redirect_to` is set, set that as the `originalUrlPath` argument.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR
* Download ProxyMan app for Mac
* Enable MapRemote tool and set it up with the following arguments
<img width="1469" alt="Screenshot 2023-04-03 at 8 25 05 PM" src="https://user-images.githubusercontent.com/1126811/229675446-9f79f83c-28ce-439f-969c-5feab52cec2d.png">
- Choose a tailored case to work through. This has been tested with Link in Bio so far.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
