### PR TITLE
Public tags page: Add the alphabetic tag listing section

### DIFF
--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -83,7 +83,10 @@ export default function AlphabeticTags( { alphabeticTags }: AlphabeticTagsProps 
 	const tagTables: { [ key: string ]: Tag[][] } = {};
 
 	for ( const letter in alphabeticTags ) {
-		tagTables[ letter ] = formatTable( alphabeticTags[ letter ] );
+		const sortedTags = alphabeticTags[ letter ].sort( ( a, b ) => {
+			return a.title.localeCompare( b.title );
+		} );
+		tagTables[ letter ] = formatTable( sortedTags );
 	}
 
 	return (

--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -1,4 +1,7 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import titlecase from 'to-title-case';
+import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { AlphabeticTagsResult, Tag } from './controller';
 
 interface AlphabeticTagsProps {
@@ -18,7 +21,7 @@ interface TagsTableProps {
 }
 
 const TagsColumn = ( props: TagsColProps ) => (
-	<div className="alphabetic-tags__column" key={ props.slug }>
+	<div key={ props.slug }>
 		<a href={ `/tag/${ encodeURIComponent( props.slug ) }` }>
 			<span className="alphabetic-tags__title">{ titlecase( props.title ) }</span>
 		</a>
@@ -28,7 +31,7 @@ const TagsColumn = ( props: TagsColProps ) => (
 const TagsRow = ( props: TagsRowProps ) => (
 	<div className="alphabetic-tags__row">
 		{ props.tags.map( ( tag: Tag | undefined, index ) => (
-			<div key={ 'alphabetic-tags-col-' + index }>
+			<div className="alphabetic-tags__col" key={ 'alphabetic-tags-col-' + index }>
 				{ tag && <TagsColumn slug={ tag.slug } title={ tag.title } /> }
 				{ ! tag && <TagsColumn slug="" title="" /> }
 			</div>
@@ -56,7 +59,18 @@ const formatTable = ( tags: Tag[] ): Tag[][] => {
 	return tagRows;
 };
 
+const scrollToLetter = ( letter: string ) => {
+	const element = document.getElementById( 'alphabetic-tags-table-' + letter );
+	if ( element ) {
+		scrollIntoViewport( element, {
+			behavior: 'smooth',
+			scrollMode: 'if-needed',
+		} );
+	}
+};
+
 export default function AlphabeticTags( { alphabeticTags }: AlphabeticTagsProps ) {
+	const translate = useTranslate();
 	if ( ! alphabeticTags ) {
 		return null;
 	}
@@ -70,9 +84,25 @@ export default function AlphabeticTags( { alphabeticTags }: AlphabeticTagsProps 
 
 	return (
 		<>
+			<div className="alphabetic-tags__header">
+				<h2>{ translate( 'Tags from A — Z' ) }</h2>
+				<div className="alphabetic-tags__tag-links">
+					{ Object.keys( tagTables ).map( ( letter: string ) => (
+						<Button
+							isLink
+							key={ 'alphabetic-tags-link-' + letter }
+							onClick={ () => scrollToLetter( letter ) }
+						>
+							{ letter }
+						</Button>
+					) ) }
+				</div>
+			</div>
 			{ Object.keys( tagTables ).map( ( letter: string ) => (
-				<div key={ 'alphabetic-tags-table-' + letter }>
-					<h2>{ letter }</h2>
+				<div className="alphabetic-tags__table" key={ 'alphabetic-tags-table-' + letter }>
+					<h3 className="alphabetic-tags__letter-title" id={ 'alphabetic-tags-table-' + letter }>
+						{ letter }
+					</h3>
 					<TagsTable tags={ tagTables[ letter ] } />
 				</div>
 			) ) }

--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -66,6 +66,10 @@ const scrollToLetter = ( letter: string ) => {
 			behavior: 'smooth',
 			scrollMode: 'if-needed',
 		} );
+		// setTimeout so that the focus is set after the scrollIntoViewport has completed.
+		setTimeout( () => {
+			element.focus();
+		}, 500 );
 	}
 };
 
@@ -100,7 +104,12 @@ export default function AlphabeticTags( { alphabeticTags }: AlphabeticTagsProps 
 			</div>
 			{ Object.keys( tagTables ).map( ( letter: string ) => (
 				<div className="alphabetic-tags__table" key={ 'alphabetic-tags-table-' + letter }>
-					<h3 className="alphabetic-tags__letter-title" id={ 'alphabetic-tags-table-' + letter }>
+					{ /* eslint-disable jsx-a11y/no-noninteractive-tabindex */ }
+					<h3
+						tabIndex={ 0 }
+						className="alphabetic-tags__letter-title"
+						id={ 'alphabetic-tags-table-' + letter }
+					>
 						{ letter }
 					</h3>
 					<TagsTable tags={ tagTables[ letter ] } />

--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -1,0 +1,81 @@
+import titlecase from 'to-title-case';
+import { AlphabeticTagsResult, Tag } from './controller';
+
+interface AlphabeticTagsProps {
+	alphabeticTags: AlphabeticTagsResult;
+}
+
+interface TagsColProps {
+	slug: string;
+	title: string;
+}
+interface TagsRowProps {
+	tags: ( Tag | undefined )[];
+}
+
+interface TagsTableProps {
+	tags: Tag[][];
+}
+
+const TagsColumn = ( props: TagsColProps ) => (
+	<div className="alphabetic-tags__column" key={ props.slug }>
+		<a href={ `/tag/${ encodeURIComponent( props.slug ) }` }>
+			<span className="alphabetic-tags__title">{ titlecase( props.title ) }</span>
+		</a>
+	</div>
+);
+
+const TagsRow = ( props: TagsRowProps ) => (
+	<div className="alphabetic-tags__row">
+		{ props.tags.map( ( tag: Tag | undefined, index ) => (
+			<div key={ 'alphabetic-tags-col-' + index }>
+				{ tag && <TagsColumn slug={ tag.slug } title={ tag.title } /> }
+				{ ! tag && <TagsColumn slug="" title="" /> }
+			</div>
+		) ) }
+	</div>
+);
+
+const TagsTable = ( props: TagsTableProps ) => (
+	<div>
+		{ props.tags.map( ( tagRow: Tag[], index ) => (
+			<TagsRow key={ 'alphabetic-tags-row-' + index } tags={ tagRow } />
+		) ) }
+	</div>
+);
+
+const formatTable = ( tags: Tag[] ): Tag[][] => {
+	const tagRows: Tag[][] = [];
+	for ( let i = 0; i < tags.length; i += 4 ) {
+		const tagOne = tags[ i ];
+		const tagTwo = tags[ i + 1 ];
+		const tagThree = tags[ i + 2 ];
+		const tagFour = tags[ i + 3 ];
+		tagRows.push( [ tagOne, tagTwo, tagThree, tagFour ] );
+	}
+	return tagRows;
+};
+
+export default function AlphabeticTags( { alphabeticTags }: AlphabeticTagsProps ) {
+	if ( ! alphabeticTags ) {
+		return null;
+	}
+
+	// put the data into a format that can easily be rendered as a four column table.
+	const tagTables: { [ key: string ]: Tag[][] } = {};
+
+	for ( const letter in alphabeticTags ) {
+		tagTables[ letter ] = formatTable( alphabeticTags[ letter ] );
+	}
+
+	return (
+		<>
+			{ Object.keys( tagTables ).map( ( letter: string ) => (
+				<div key={ 'alphabetic-tags-table-' + letter }>
+					<h2>{ letter }</h2>
+					<TagsTable tags={ tagTables[ letter ] } />
+				</div>
+			) ) }
+		</>
+	);
+}

--- a/client/reader/tags/controller.tsx
+++ b/client/reader/tags/controller.tsx
@@ -92,8 +92,7 @@ export const fetchAlphabeticTags = ( context: PageJSContext, next: ( e?: Error )
 
 	context.queryClient
 		.fetchQuery(
-			//fixme: disable caching for dev
-			[ 'alphabetic-tags', currentUserLocale ?? '', new Date().getTime() ],
+			[ 'alphabetic-tags', currentUserLocale ?? '' ],
 			() => {
 				return wpcom.req.get( '/read/tags/alphabetic', {
 					apiVersion: '1.2',

--- a/client/reader/tags/controller.tsx
+++ b/client/reader/tags/controller.tsx
@@ -22,9 +22,18 @@ export interface Tag {
 	title: string;
 }
 
+export interface AlphabeticTagsResult {
+	[ key: string ]: Tag[];
+}
+
 export const tagsListing = ( context: PageJSContext, next: () => void ) => {
 	context.headerSection = renderHeaderSection();
-	context.primary = <TagsPage trendingTags={ context.params.trendingTags } />;
+	context.primary = (
+		<TagsPage
+			trendingTags={ context.params.trendingTags }
+			alphabeticTags={ context.params.alphabeticTags }
+		/>
+	);
 	next();
 };
 
@@ -65,6 +74,36 @@ export const fetchTrendingTags = ( context: PageJSContext, next: ( e?: Error ) =
 		)
 		.then( ( trendingTags: { tags: TagResult[] } ) => {
 			context.params.trendingTags = trendingTags.tags;
+			next();
+		} )
+		.catch( ( error: Error ) => {
+			next( error );
+		} );
+};
+
+export const fetchAlphabeticTags = ( context: PageJSContext, next: ( e?: Error ) => void ) => {
+	if ( context.cachedMarkup ) {
+		debug( 'Skipping alphabetic tags data fetch' );
+		return next();
+	}
+	performanceMark( context as PartialContext, 'fetchAlphabeticTags' );
+
+	const currentUserLocale = getCurrentUserLocale( context.store.getState() );
+
+	context.queryClient
+		.fetchQuery(
+			//fixme: disable caching for dev
+			[ 'alphabetic-tags', currentUserLocale ?? '', new Date().getTime() ],
+			() => {
+				return wpcom.req.get( '/read/tags/alphabetic', {
+					apiVersion: '1.2',
+					lang: currentUserLocale, // Note: undefined will be omitted by the query string builder.
+				} );
+			},
+			{ staleTime: 86400000 } // 24 hours
+		)
+		.then( ( alphabeticTags: AlphabeticTagsResult ) => {
+			context.params.alphabeticTags = alphabeticTags;
 			next();
 		} )
 		.catch( ( error: Error ) => {

--- a/client/reader/tags/index.node.js
+++ b/client/reader/tags/index.node.js
@@ -1,6 +1,6 @@
 import { makeLayout } from 'calypso/controller';
-import { tagsListing, fetchTrendingTags } from './controller';
+import { tagsListing, fetchTrendingTags, fetchAlphabeticTags } from './controller';
 
 export default function ( router ) {
-	router( '/tags', fetchTrendingTags, tagsListing, makeLayout );
+	router( '/tags', fetchTrendingTags, fetchAlphabeticTags, tagsListing, makeLayout );
 }

--- a/client/reader/tags/index.web.js
+++ b/client/reader/tags/index.web.js
@@ -1,6 +1,6 @@
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { tagsListing, fetchTrendingTags } from './controller';
+import { tagsListing, fetchTrendingTags, fetchAlphabeticTags } from './controller';
 
 export default function ( router ) {
-	router( '/tags', fetchTrendingTags, tagsListing, makeLayout, clientRender );
+	router( '/tags', fetchTrendingTags, fetchAlphabeticTags, tagsListing, makeLayout, clientRender );
 }

--- a/client/reader/tags/main.tsx
+++ b/client/reader/tags/main.tsx
@@ -1,13 +1,15 @@
 import { useTranslate } from 'i18n-calypso';
-import { TagResult } from './controller';
+import AlphabeticTags from './alphabetic-tags';
+import { TagResult, AlphabeticTagsResult } from './controller';
 import TrendingTags from './trending-tags';
 import './style.scss';
 
 interface Props {
 	trendingTags: TagResult[];
+	alphabeticTags: AlphabeticTagsResult;
 }
 
-export default function TagsPage( { trendingTags }: Props ) {
+export default function TagsPage( { trendingTags, alphabeticTags }: Props ) {
 	const translate = useTranslate();
 	return (
 		<div className="tags">
@@ -19,6 +21,7 @@ export default function TagsPage( { trendingTags }: Props ) {
 			</h4>
 			<div>
 				<TrendingTags trendingTags={ trendingTags } />
+				<AlphabeticTags alphabeticTags={ alphabeticTags } />
 			</div>
 		</div>
 	);

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -1,8 +1,8 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.wpcom-site {
-	background: #fff;
+.is-section-reader {
+	background: var(--studio-white);
 }
 
 .layout.has-header-section.is-section-reader .layout__header-section-content {
@@ -69,6 +69,83 @@
 		border-bottom: 1px solid var(--studio-gray-5);
 		@include break-small {
 			border-bottom: none;
+		}
+	}
+}
+.alphabetic-tags__header {
+	padding-top: 72px;
+	padding-bottom: 10px;
+	border-bottom: 1px solid var(--studio-gray-5);
+	margin-bottom: 26px;
+	padding-left: 10px;
+	@include break-small {
+		display: flex;
+		flex-direction: row;
+		padding-left: 0;
+	}
+
+	h2 {
+		font-size: 16px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		color: var(--studio-gray-50);
+		font-weight: 500;
+		width: 100%;
+		margin-bottom: 20px;
+		@include break-small {
+			width: 50%;
+			margin-bottom: 0;
+		}
+	}
+	.alphabetic-tags__tag-links {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		width: 100%;
+		@include break-small {
+			width: 50%;
+		}
+		button {
+			font-size: 16px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			color: var(--studio-gray-50);
+			text-decoration: none;
+			font-weight: 500;
+			flex-grow: 1;
+		}
+	}
+}
+.alphabetic-tags__table {
+	padding-bottom: 26px;
+	border-bottom: 1px solid var(--studio-gray-5);
+	margin-bottom: 26px;
+	padding-left: 10px;
+	@include break-small {
+		padding-left: 0;
+	}
+
+	.alphabetic-tags__letter-title {
+		font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		margin-bottom: 22px;
+	}
+	.alphabetic-tags__row {
+		display: flex;
+		flex-wrap: wrap;
+
+		.alphabetic-tags__col {
+			width: 100%;
+			padding: 6px 10px 6px 0;
+			box-sizing: border-box;
+
+			@include break-small {
+				width: 50%;
+			}
+
+			@include break-medium {
+				width: 25%;
+			}
+
+			a {
+				color: var(--studio-gray-80);
+				font-weight: 400;
+			}
 		}
 	}
 }

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -54,11 +54,19 @@
 			border-top: none;
 			padding: 10px 0;
 		}
+		a:focus {
+			outline: none;
+		}
+		a:focus-visible .trending-tags__title {
+			outline: 2px solid #000;
+			outline-offset: 4px;
+		}
 		.trending-tags__title {
 			font-size: 36px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 			font-weight: 600;
 			color: var(--studio-black);
-			padding-right: 14px;
+			margin-right: 12px;
+			padding-right: 2px;
 		}
 		.trending-tags__count {
 			font-size: 16px; /* stylelint-disable-line declaration-property-unit-allowed-list */
@@ -109,6 +117,16 @@
 			text-decoration: none;
 			font-weight: 500;
 			flex-grow: 1;
+			padding-left: 6px;
+
+			&:focus {
+				border-radius: 0;
+				box-shadow: none;
+				outline: none;
+			}
+			&:focus-visible {
+				outline: 2px solid #000;
+			}
 		}
 	}
 }
@@ -145,6 +163,14 @@
 			a {
 				color: var(--studio-gray-80);
 				font-weight: 400;
+
+				&:focus {
+					outline: none;
+				}
+				&:focus-visible {
+					outline: 2px solid #000;
+					outline-offset: 4px;
+				}
 			}
 		}
 	}

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -142,6 +142,9 @@
 	.alphabetic-tags__letter-title {
 		font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		margin-bottom: 22px;
+		&:focus-visible {
+			text-decoration: underline;
+		}
 	}
 	.alphabetic-tags__row {
 		display: flex;


### PR DESCRIPTION
This PR adds the second section of the public tags page being described by pe7F0s-Ed-p2. See figma HraEUs4kh4V57rdlkYEd1p-fi-1692-6254&t=7zzHPcX0IfGYEUv1-0

<img width="1136" alt="Screen Shot 2023-04-04 at 5 14 37 pm" src="https://user-images.githubusercontent.com/22446385/229717099-7241c7cd-8d0f-4cab-9e6d-23a7d147a78f.png">

### Testing instructions 

go to /tags
The page should contain an a-z listing of tags
