### PR TITLE
Subscription management: Fix an exception on settings view

### DIFF
--- a/client/landing/subscriptions/tab-views/settings.tsx
+++ b/client/landing/subscriptions/tab-views/settings.tsx
@@ -1,9 +1,27 @@
 import { SubscriptionManager } from '@automattic/data-stores';
+import { Spinner } from '@wordpress/components';
+import { Notice } from '../notice';
 import { UserSettings } from '../user-settings';
 
 const Settings = () => {
-	const { data: settings, isIdle, isLoading } = SubscriptionManager.useUserSettingsQuery();
-	return <UserSettings loading={ isIdle || isLoading } value={ settings } />;
+	const { data: settings, isIdle, isLoading, error } = SubscriptionManager.useUserSettingsQuery();
+
+	if ( error ) {
+		// todo: translate when we have agreed on the error message
+		return (
+			<Notice type="error">An error occurred while fetching your subscription settings.</Notice>
+		);
+	}
+
+	if ( isIdle || isLoading ) {
+		return (
+			<div className="user-settings">
+				<Spinner />
+			</div>
+		);
+	}
+
+	return <UserSettings value={ settings } />;
 };
 
 export default Settings;

--- a/client/landing/subscriptions/user-settings/user-settings.tsx
+++ b/client/landing/subscriptions/user-settings/user-settings.tsx
@@ -14,8 +14,8 @@ type DeliveryWindowHourType = Reader.DeliveryWindowHourType;
 
 type SubscriptionUserSettings = Partial< {
 	mail_option: EmailFormatType;
-	delivery_day: DeliveryWindowDayType; // 0-6, 0 is Sunday
-	delivery_hour: DeliveryWindowHourType; // 0-23, 0 is midnight
+	delivery_day: DeliveryWindowDayType;
+	delivery_hour: DeliveryWindowHourType;
 	blocked: boolean;
 	email: string;
 } >;
@@ -33,7 +33,7 @@ const DEFAULT_VALUE = {};
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- until we start using any of these props
 const UserSettings = ( { value = DEFAULT_VALUE }: UserSettingsProps ) => {
-	const [ formState, setFormState ] = useState< SubscriptionUserSettings >( value );
+	const [ formState, setFormState ] = useState( value );
 	const { mutate, isLoading, isSuccess, error } = SubscriptionManager.useUserSettingsMutation();
 	const [ notice, setNotice ] = useState< NoticeProps | null >( null );
 

--- a/client/landing/subscriptions/user-settings/user-settings.tsx
+++ b/client/landing/subscriptions/user-settings/user-settings.tsx
@@ -1,4 +1,4 @@
-import { Spinner, Button } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import { useState, useCallback, useEffect } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
@@ -22,7 +22,6 @@ type SubscriptionUserSettings = Partial< {
 
 type UserSettingsProps = {
 	value?: SubscriptionUserSettings;
-	loading: boolean;
 };
 
 type NoticeProps = {
@@ -30,8 +29,10 @@ type NoticeProps = {
 	message: string;
 };
 
+const DEFAULT_VALUE = {};
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- until we start using any of these props
-const UserSettings = ( { value = {}, loading }: UserSettingsProps ) => {
+const UserSettings = ( { value = DEFAULT_VALUE }: UserSettingsProps ) => {
 	const [ formState, setFormState ] = useState< SubscriptionUserSettings >( value );
 	const { mutate, isLoading, isSuccess, error } = SubscriptionManager.useUserSettingsMutation();
 	const [ notice, setNotice ] = useState< NoticeProps | null >( null );
@@ -59,14 +60,6 @@ const UserSettings = ( { value = {}, loading }: UserSettingsProps ) => {
 	const onSubmit = useCallback( () => {
 		mutate( formState );
 	}, [ formState, mutate ] );
-
-	if ( loading ) {
-		return (
-			<div className="user-settings">
-				<Spinner />
-			</div>
-		);
-	}
 
 	return (
 		<div className="user-settings">


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/75264

## Proposed Changes

* Provide the same default value object every time subscriptions settings view is rendered (see at [this line](https://github.com/Automattic/wp-calypso/pull/75265/files#diff-7568e3bf99595024b881d2c7fb9115136dc9856d999235b0532a92c55a4a1c8fR35))
* Refactor handling of different subscription settings fetching states

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/subscriptions/settings, ensuring you have a valid subkey value in your cookie which is pointing to calypso.localhost, and that your user has no site subscriptions ATM
* Ensure that you see no exception in your browser's dev tools console

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
