### PR TITLE
Jetpack Pro Dashboard: create and use date offset hook for a site in the latest backup expandable card.

### DIFF
--- a/client/components/jetpack/daily-backup-status/use-get-display-date.js
+++ b/client/components/jetpack/daily-backup-status/use-get-display-date.js
@@ -6,11 +6,11 @@ import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
-export default function useGetDisplayDate() {
+export default function useGetDisplayDate( selectedSiteId = null ) {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 
-	const siteId = useSelector( getSelectedSiteId );
+	const siteId = useSelector( ( state ) => selectedSiteId ?? getSelectedSiteId( state ) );
 	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );
 	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ) );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -6,7 +6,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import useRewindableActivityLogQuery from 'calypso/data/activity-log/use-rewindable-activity-log-query';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { isSuccessfulRealtimeBackup } from 'calypso/lib/jetpack/backup-utils';
-import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
+import useDateOffsetForSite from 'calypso/lib/jetpack/hooks/use-date-offset-for-site';
 import { urlToSlug } from 'calypso/lib/url';
 import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import { useDashboardAddRemoveLicense } from '../../hooks';
@@ -33,8 +33,8 @@ const BackupStorageContent = ( {
 	const translate = useTranslate();
 
 	const moment = useLocalizedMoment();
-	const endDate = useDateWithOffset( moment().endOf( 'day' ) );
-	const startDate = useDateWithOffset( moment().subtract( 1, 'day' ).startOf( 'day' ) );
+	const endDate = useDateOffsetForSite( moment().endOf( 'day' ), siteId );
+	const startDate = useDateOffsetForSite( moment().subtract( 1, 'day' ).startOf( 'day' ), siteId );
 
 	const { isLoading, data } = useRewindableActivityLogQuery(
 		siteId,
@@ -50,7 +50,7 @@ const BackupStorageContent = ( {
 
 	const backup = data?.[ 0 ] ?? null;
 
-	const lastBackupDate = useDateWithOffset( backup?.activityTs );
+	const lastBackupDate = useDateOffsetForSite( backup?.activityTs, siteId );
 	const getDisplayDate = useGetDisplayDate();
 	const displayDate = getDisplayDate( lastBackupDate, false );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -51,7 +51,10 @@ const BackupStorageContent = ( {
 	const backup = data?.[ 0 ] ?? null;
 
 	const lastBackupDate = useDateOffsetForSite( backup?.activityTs, siteId );
-	const getDisplayDate = useGetDisplayDate();
+	// Ignore type checking because TypeScript is incorrectly inferring the prop type due to .js usage in use-get-display-date
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	const getDisplayDate = useGetDisplayDate( siteId );
 	const displayDate = getDisplayDate( lastBackupDate, false );
 
 	// Show plugin name only if it is a activity from a plugin

--- a/client/lib/jetpack/hooks/use-date-offset-for-site.ts
+++ b/client/lib/jetpack/hooks/use-date-offset-for-site.ts
@@ -1,0 +1,26 @@
+import { Moment } from 'moment';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { applySiteOffset } from 'calypso/lib/site/timezone';
+import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
+import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
+
+export default function useDateOffsetForSite(
+	date: Moment | undefined | null,
+	siteId: number,
+	{ keepLocalTime = false } = {}
+): Moment | undefined {
+	const timezone = useSelector( ( state ) =>
+		siteId ? getSiteTimezoneValue( state, siteId ) : null
+	);
+	const gmtOffset = useSelector( ( state ) =>
+		siteId ? getSiteGmtOffset( state, siteId ) : null
+	);
+
+	const dateWithOffset = useMemo(
+		() => ( date ? applySiteOffset( date, { timezone, gmtOffset, keepLocalTime } ) : undefined ),
+		[ date, timezone, gmtOffset, keepLocalTime ]
+	);
+
+	return dateWithOffset;
+}


### PR DESCRIPTION
Related to 1203940061556608-as-1204327223097394

## Proposed Changes

- Create a new hook that accepts the site id and returns the date offset based on the site provided
- Use the newly created hook to get the date offset in the latest backup expandable card.
- Update the `useGetDisplayDate` hook to accept the site id as an argument

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/hook-to-get-site-with-date-offset` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on the expand icon on any site, and verify that you can see the `Latest backup ` card and you can see the latest backup for the site

<img width="340" alt="Screenshot 2023-04-04 at 3 17 57 PM" src="https://user-images.githubusercontent.com/10586875/229754543-a30d0eef-129c-4a03-ad70-3f13fe4888b0.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?