### PR TITLE
Virtual themes i2: Release

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -139,6 +139,7 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"use-translation-chunks": true,
 		"user-management-revamp": true,
+		"virtual-themes/onboarding": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,

--- a/config/production.json
+++ b/config/production.json
@@ -161,6 +161,7 @@
 		"upsell/concierge-session": true,
 		"use-translation-chunks": true,
 		"user-management-revamp": true,
+		"virtual-themes/onboarding": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -157,6 +157,7 @@
 		"upsell/concierge-session": true,
 		"use-translation-chunks": true,
 		"user-management-revamp": true,
+		"virtual-themes/onboarding": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,

--- a/config/test.json
+++ b/config/test.json
@@ -108,6 +108,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
+		"virtual-themes/onboarding": true,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
 		"woa-logging": true

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -171,6 +171,7 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"yolo/staging-sites-i1": true,
+		"virtual-themes/onboarding": true,
 		"woa-logging": true
 	},
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
## Proposed Changes

Enables the `virtual-themes/onboarding` feature flag in all environments, including production, so we can release the inclusion of pattern-based virtual themes to all users entering the site creation flow.

See p7DVsv-h0m-p2

## Testing Instructions

- Use the Calypso live link below
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>`
- Make sure pattern-based virtual themes are displated