### PR TITLE
Add optimistic UI updates to the mutations

### DIFF
--- a/client/landing/subscriptions/settings-popover/site-settings/delivery-frequency-input.tsx
+++ b/client/landing/subscriptions/settings-popover/site-settings/delivery-frequency-input.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import SegmentedControl from 'calypso/components/segmented-control';
@@ -24,6 +25,7 @@ const DeliveryFrequencyOption = ( {
 type DeliveryFrequencyInputProps = {
 	onChange: ( value: SiteSubscriptionDeliveryFrequency ) => void;
 	value: SiteSubscriptionDeliveryFrequency;
+	isUpdating: boolean;
 };
 
 type DeliveryFrequencyKeyLabel = {
@@ -34,6 +36,7 @@ type DeliveryFrequencyKeyLabel = {
 const DeliveryFrequencyInput = ( {
 	onChange,
 	value: selectedValue,
+	isUpdating,
 }: DeliveryFrequencyInputProps ) => {
 	const translate = useTranslate();
 	const availableFrequencies = useMemo< DeliveryFrequencyKeyLabel[] >(
@@ -55,7 +58,11 @@ const DeliveryFrequencyInput = ( {
 	);
 
 	return (
-		<SegmentedControl>
+		<SegmentedControl
+			className={ classNames( 'settings-popover__delivery-frequency-control', {
+				'is-loading': isUpdating,
+			} ) }
+		>
 			{ availableFrequencies.map( ( { key, label }, index ) => (
 				<DeliveryFrequencyOption
 					selected={ selectedValue === key }

--- a/client/landing/subscriptions/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/settings-popover/site-settings/site-settings.tsx
@@ -11,6 +11,7 @@ type SiteSettingsProps = {
 	onDeliveryFrequencyChange: ( value: SiteSubscriptionDeliveryFrequency ) => void;
 	onUnfollow: () => void;
 	unfollowing: boolean;
+	updatingFrequency: boolean;
 };
 
 const SiteSettings = ( {
@@ -18,6 +19,7 @@ const SiteSettings = ( {
 	onDeliveryFrequencyChange,
 	onUnfollow,
 	unfollowing,
+	updatingFrequency,
 }: SiteSettingsProps ) => {
 	const translate = useTranslate();
 
@@ -28,6 +30,7 @@ const SiteSettings = ( {
 				<DeliveryFrequencyInput
 					value={ deliveryFrequency }
 					onChange={ onDeliveryFrequencyChange }
+					isUpdating={ updatingFrequency }
 				/>
 			</PopoverMenuItem>
 			<Separator />

--- a/client/landing/subscriptions/settings-popover/styles.scss
+++ b/client/landing/subscriptions/settings-popover/styles.scss
@@ -30,18 +30,21 @@
 		width: calc(100% - 42px);
 	}
 
+	.settings-popover__delivery-frequency-control,
+	.settings-popover__item-button {
+		&.is-loading {
+			cursor: default;
+			opacity: 0.5;
+			pointer-events: none;
+		}
+	}
+
 	.settings-popover__item-button {
 		display: flex;
 		align-items: center;
 		gap: 16px;
 		width: 100%;
 		cursor: pointer;
-
-		&.is-loading {
-			cursor: default;
-			opacity: 0.5;
-			pointer-events: none;
-		}
 
 		&:hover,
 		&:focus {

--- a/client/landing/subscriptions/site-list/site-row.tsx
+++ b/client/landing/subscriptions/site-list/site-row.tsx
@@ -31,7 +31,7 @@ export default function SiteRow( {
 		return <Gridicon className="icon" icon="globe" size={ 48 } />;
 	}, [ site_icon, name ] );
 
-	const { mutate: updateDeliveryFrequency } =
+	const { mutate: updateDeliveryFrequency, isLoading: updatingFrequency } =
 		SubscriptionManager.useSiteDeliveryFrequencyMutation();
 	const { mutate: unFollow, isLoading: unfollowing } =
 		SubscriptionManager.useSiteUnfollowMutation();
@@ -59,6 +59,7 @@ export default function SiteRow( {
 					onDeliveryFrequencyChange={ ( delivery_frequency ) =>
 						updateDeliveryFrequency( { blog_id: blog_ID, delivery_frequency } )
 					}
+					updatingFrequency={ updatingFrequency }
 					onUnfollow={ () => unFollow( { blog_id: blog_ID } ) }
 					unfollowing={ unfollowing }
 				/>


### PR DESCRIPTION
Resolves #75236

## Proposed Changes

This PR adds optimistic UI updates to the three mutations. Optimistic UI updates are changes to the user interface that occur before the server confirms the change has been successfully made. 

It also adds a `isUpdating` property to `<DeliveryFrequencyInput />`. This property is set to true when the mutation is running. When set, the opacity of the segmented control is reduced, and you cant' click it.

## Testing Instructions

1. Apply this PR and make sure you have a subkey cookie set
2. Navigate to http://calypso.localhost:3000/subscriptions/sites
3. Change the delivery frequency of one of your subscriptions. When clicking you should see the change instantly, the opacity of the control will be reduced while the server is updating.

![CleanShot 2023-04-04 at 13 12 46](https://user-images.githubusercontent.com/528287/229774690-ff6d4731-d03f-4832-ad8c-ddbe5b1b3668.gif)

As for the other mutations:
- Removing a subscription should remove it from the list instantly, and the count in the tab should also decrement straight away
- Settings is hard to test, since we're already showing the desired result of the mutation in the form. This makes optimistic UI less needed here, but it's implemented.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
