### PR TITLE
Launchpad: Update Copy Icon & Fix Tooltip Z-index

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,5 +1,6 @@
 import { Gridicon, CircularProgressBar } from '@automattic/components';
 import { useRef, useState } from '@wordpress/element';
+import { Icon, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
@@ -151,7 +152,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 									onMouseLeave={ () => setClipboardCopied( false ) }
 									ref={ clipboardButtonEl }
 								>
-									<Gridicon icon="clipboard" />
+									<Icon icon={ copy } size={ 18 } />
 								</ClipboardButton>
 								<Tooltip
 									context={ clipboardButtonEl.current }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -203,6 +203,8 @@
 
 	.launchpad__url-box-domain {
 		display: flex;
+		flex-direction: row;
+		align-items: center;
 		flex-grow: 1;
 		width: 0;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -214,27 +214,21 @@
 		white-space: nowrap;
 		overflow: hidden;
 		padding: 4px 0;
-		padding-right: 12px;
+		padding-right: 8px;
 		letter-spacing: -0.24px;
 		font-size: $font-body-small;
 	}
 
 	.launchpad__url-box-domain:hover > .launchpad__clipboard-button {
-		position: inherit;
-		top: 0;
+		opacity: 1;
 	}
 
 	.launchpad__clipboard-button:focus {
-		position: inherit;
-		top: 0;
+		opacity: 1;
 	}
 
 	.launchpad__clipboard-button {
-		padding-left: 8px;
-		padding-right: 8px;
-		position: absolute;
-		top: -1000em;
-		min-width: 34px;
+		opacity: 0;
 	}
 }
 

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -1,5 +1,6 @@
 import { Gridicon, ConfettiAnimation } from '@automattic/components';
 import { Button, Modal } from '@wordpress/components';
+import { Icon, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useRef } from 'react';
 import { useDispatch } from 'react-redux';
@@ -122,7 +123,7 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 								onMouseLeave={ () => setClipboardCopied( false ) }
 								ref={ clipboardButtonEl }
 							>
-								<Gridicon icon="clipboard" />
+								<Icon icon={ copy } size={ 18 } />
 							</ClipboardButton>
 							<Tooltip
 								context={ clipboardButtonEl.current }

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.scss
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.scss
@@ -122,3 +122,7 @@
 		text-decoration: underline;
 	}
 }
+
+.tooltip.popover {
+	z-index: 100000;
+}

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.scss
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.scss
@@ -68,6 +68,20 @@
 		align-items: center;
 	}
 
+	.launchpad__clipboard-button {
+		opacity: 0;
+	}
+
+	.launchpad__clipboard-button:focus {
+		opacity: 1;
+	}
+
+	&-site:hover {
+		.launchpad__clipboard-button {
+			opacity: 1;
+		}
+	}
+
 	&-customize {
 		color: var(--studio-blue-50);
 		font-size: 0.875rem;


### PR DESCRIPTION
### Time Estimate
Review: Short
Test: Short

### Summary
• Update the clipboard button's icon to use `@wordpress/icons`
• Fix tooltip's Z index inside the celebration modal (It was previously invisible)

![image](https://user-images.githubusercontent.com/20927667/229786022-a90cf6de-4087-4882-8bfe-ea6cbf34c1aa.png)
![image](https://user-images.githubusercontent.com/20927667/229786429-229494c2-8469-407e-989b-4a59c3929794.png)


### Testing
1. Checkout this branch
2. Create a new Launchpad site
3. Once you arrive at Launchpad, hover over the domain container and verify the copy icon is updated. Verify the copy functionality continues to work as expected
4. Launch your site
5. Once you see the celebration modal, hover over the domain container and verify the copy icon is updated. Verify the copy functionality continues to work as expected. Verify you can see the tooltip when you copy the domain