### PR TITLE
Update/Subscription site list link details

### DIFF
--- a/client/landing/subscriptions/site-list/site-row.tsx
+++ b/client/landing/subscriptions/site-list/site-row.tsx
@@ -38,7 +38,7 @@ export default function SiteRow( {
 
 	return (
 		<li className="row" role="row">
-			<a href={ url } rel="noreferrer noopener" className="title-box">
+			<a href={ url } rel="noreferrer noopener" className="title-box" target="_blank">
 				<span className="title-box" role="cell">
 					{ siteIcon }
 					<span className="title-column">

--- a/client/landing/subscriptions/site-list/styles.scss
+++ b/client/landing/subscriptions/site-list/styles.scss
@@ -54,6 +54,10 @@ $max-list-width: 1300px;
 					white-space: nowrap;
 					overflow: hidden;
 					padding-right: 10px;
+
+					&:hover {
+						text-decoration: underline;
+					}
 				}
 
 				.url {
@@ -64,6 +68,10 @@ $max-list-width: 1300px;
 					text-overflow: ellipsis;
 					white-space: nowrap;
 					overflow: hidden;
+
+					&:hover {
+						text-decoration: underline;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/75221

# Proposed Changes

- Change anchor tag to open links in a new tab by adding target="_blank" attribute
- Add hover effect (underline) for text inside .title-column and .url classes

Testing Instructions

- Open the list of sites in an incognito browser (you know, with the subkey and such): http://calypso.localhost:3000/subscriptions/sites
- Hover over the text inside the .title-column and .url elements to ensure the underline effect appears
- Click on the link and verify that it opens in a new tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
