### PR TITLE
Fix blogging prompt style in search stream

### DIFF
--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -731,10 +731,19 @@
 	clear: both;
 	display: flex;
 	flex-direction: column;
-	margin-top: 6px;
+	flex-basis: calc(50% - 15px);
+	margin: 6px 0 0 0;
 
 	@include breakpoint-deprecated(">660px") {
 		padding: 12px 0 4px 0;
+	}
+
+	@include breakpoint-deprecated( ">960px" ) {
+		margin: 6px 0 0 15px;
+
+		&:nth-child(2n) {
+			margin: 6px 15px 0 0;
+		}
 	}
 
 	.blogging-prompt__menu {


### PR DESCRIPTION
This PR fixes spacing with blogging prompt in the search stream.

**Before**
<img width="651" alt="Screenshot 2023-04-04 at 15 07 17" src="https://user-images.githubusercontent.com/5560595/229818916-2f21bd35-2f8c-44ac-b87d-e8fd18da4ebb.png">

**After**

<img width="746" alt="Screenshot 2023-04-04 at 14 51 06" src="https://user-images.githubusercontent.com/5560595/229819024-9bd4f53f-c9ca-4597-b48f-766bd982c495.png">
<img width="869" alt="Screenshot 2023-04-04 at 14 38 35" src="https://user-images.githubusercontent.com/5560595/229819039-e46b7d69-1733-4f5d-af95-1ba54d28a8ea.png">
<img width="988" alt="Screenshot 2023-04-04 at 14 38 12" src="https://user-images.githubusercontent.com/5560595/229819046-92af7e32-066f-4f04-b340-63298f87737f.png">
