### PR TITLE
Woo Express: Hide interval toggle for sites already on annual plans

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -52,6 +52,7 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 			interval={ interval }
 			yearlyControlProps={ { path: plansLink( '/plans', siteSlug, 'yearly', true ) } }
 			monthlyControlProps={ { path: plansLink( '/plans', siteSlug, 'monthly', true ) } }
+			showIntervalToggle={ true }
 		/>
 	);
 

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -23,7 +23,7 @@ interface WooExpressPlansProps {
 	interval?: 'monthly' | 'yearly';
 	monthlyControlProps: SegmentedOptionProps;
 	yearlyControlProps: SegmentedOptionProps;
-	showIntervalToggle: boolean;
+	showIntervalToggle?: boolean;
 }
 
 export function WooExpressPlans( props: WooExpressPlansProps ) {

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -23,10 +23,17 @@ interface WooExpressPlansProps {
 	interval?: 'monthly' | 'yearly';
 	monthlyControlProps: SegmentedOptionProps;
 	yearlyControlProps: SegmentedOptionProps;
+	isSiteEligibleForMonthlyPlan: boolean;
 }
 
 export function WooExpressPlans( props: WooExpressPlansProps ) {
-	const { siteId, interval, monthlyControlProps, yearlyControlProps } = props;
+	const {
+		siteId,
+		interval,
+		monthlyControlProps,
+		yearlyControlProps,
+		isSiteEligibleForMonthlyPlan,
+	} = props;
 	const translate = useTranslate();
 
 	const mediumPlanAnnual = getPlans()[ PLAN_WOOEXPRESS_MEDIUM ];
@@ -74,14 +81,16 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 	};
 	return (
 		<>
-			<div className="wooexpress-plans__interval-toggle-wrapper">
-				<PlanIntervalSelector
-					className="wooexpress-plans__interval-toggle price-toggle"
-					intervals={ planIntervals }
-					isPlansInsideStepper={ false }
-					use2023PricingGridStyles={ true }
-				/>
-			</div>
+			{ isSiteEligibleForMonthlyPlan && (
+				<div className="wooexpress-plans__interval-toggle-wrapper">
+					<PlanIntervalSelector
+						className="wooexpress-plans__interval-toggle price-toggle"
+						intervals={ planIntervals }
+						isPlansInsideStepper={ false }
+						use2023PricingGridStyles={ true }
+					/>
+				</div>
+			) }
 			<div className="wooexpress-plans__grid is-2023-pricing-grid">
 				<AsyncLoad require="calypso/my-sites/plan-features-2023-grid" { ...plansTableProps } />
 			</div>

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -23,17 +23,11 @@ interface WooExpressPlansProps {
 	interval?: 'monthly' | 'yearly';
 	monthlyControlProps: SegmentedOptionProps;
 	yearlyControlProps: SegmentedOptionProps;
-	isSiteEligibleForMonthlyPlan: boolean;
+	showIntervalToggle: boolean;
 }
 
 export function WooExpressPlans( props: WooExpressPlansProps ) {
-	const {
-		siteId,
-		interval,
-		monthlyControlProps,
-		yearlyControlProps,
-		isSiteEligibleForMonthlyPlan,
-	} = props;
+	const { siteId, interval, monthlyControlProps, yearlyControlProps, showIntervalToggle } = props;
 	const translate = useTranslate();
 
 	const mediumPlanAnnual = getPlans()[ PLAN_WOOEXPRESS_MEDIUM ];
@@ -79,9 +73,10 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 		hidePlansFeatureComparison: true,
 		siteId,
 	};
+
 	return (
 		<>
-			{ isSiteEligibleForMonthlyPlan && (
+			{ showIntervalToggle && (
 				<div className="wooexpress-plans__interval-toggle-wrapper">
 					<PlanIntervalSelector
 						className="wooexpress-plans__interval-toggle price-toggle"

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -307,7 +307,7 @@ class Plans extends Component {
 	}
 
 	renderWooExpressPlansPage() {
-		const { currentPlan, selectedSite } = this.props;
+		const { currentPlan, selectedSite, isSiteEligibleForMonthlyPlan } = this.props;
 
 		if ( ! selectedSite ) {
 			return this.renderPlaceholder();
@@ -320,6 +320,7 @@ class Plans extends Component {
 				currentPlan={ currentPlan }
 				interval={ interval }
 				selectedSite={ selectedSite }
+				isSiteEligibleForMonthlyPlan={ isSiteEligibleForMonthlyPlan }
 			/>
 		);
 	}

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -320,7 +320,7 @@ class Plans extends Component {
 				currentPlan={ currentPlan }
 				interval={ interval }
 				selectedSite={ selectedSite }
-				isSiteEligibleForMonthlyPlan={ isSiteEligibleForMonthlyPlan }
+				showIntervalToggle={ isSiteEligibleForMonthlyPlan }
 			/>
 		);
 	}

--- a/client/my-sites/plans/woo-express-plans-page/index.tsx
+++ b/client/my-sites/plans/woo-express-plans-page/index.tsx
@@ -31,12 +31,14 @@ interface WooExpressPlansPageProps {
 	currentPlan: SitePlanData;
 	interval?: 'monthly' | 'yearly';
 	selectedSite: SiteDetails;
+	isSiteEligibleForMonthlyPlan: boolean;
 }
 
 const WooExpressPlansPage = ( {
 	currentPlan,
 	interval,
 	selectedSite,
+	isSiteEligibleForMonthlyPlan,
 }: WooExpressPlansPageProps ) => {
 	const translate = useTranslate();
 
@@ -116,6 +118,7 @@ const WooExpressPlansPage = ( {
 				monthlyControlProps={ { path: plansLink( '/plans', selectedSite.slug, 'monthly', true ) } }
 				siteId={ selectedSite.ID }
 				yearlyControlProps={ { path: plansLink( '/plans', selectedSite.slug, 'yearly', true ) } }
+				isSiteEligibleForMonthlyPlan={ isSiteEligibleForMonthlyPlan }
 			/>
 		) : (
 			<>

--- a/client/my-sites/plans/woo-express-plans-page/index.tsx
+++ b/client/my-sites/plans/woo-express-plans-page/index.tsx
@@ -31,14 +31,14 @@ interface WooExpressPlansPageProps {
 	currentPlan: SitePlanData;
 	interval?: 'monthly' | 'yearly';
 	selectedSite: SiteDetails;
-	isSiteEligibleForMonthlyPlan: boolean;
+	showIntervalToggle: boolean;
 }
 
 const WooExpressPlansPage = ( {
 	currentPlan,
 	interval,
 	selectedSite,
-	isSiteEligibleForMonthlyPlan,
+	showIntervalToggle,
 }: WooExpressPlansPageProps ) => {
 	const translate = useTranslate();
 
@@ -118,7 +118,7 @@ const WooExpressPlansPage = ( {
 				monthlyControlProps={ { path: plansLink( '/plans', selectedSite.slug, 'monthly', true ) } }
 				siteId={ selectedSite.ID }
 				yearlyControlProps={ { path: plansLink( '/plans', selectedSite.slug, 'yearly', true ) } }
-				isSiteEligibleForMonthlyPlan={ isSiteEligibleForMonthlyPlan }
+				showIntervalToggle={ showIntervalToggle }
 			/>
 		) : (
 			<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* When viewing the Woo Express plans page, don't show the interval toggle (monthly/annually) for sites that already have an annual plan. This matches what we do with the other WordPress.com plans pages.
* Add an optional `showIntervalToggle` prop to check before we show the plan interval toggle. 

## Testing Instructions

* Switch to this PR
* Ensure the `plans/wooexpress-small` flag is enabled on your environment (note it will always be enabled on `calypso.localhost`: `?flags=plans/wooexpress-small`
* Visit the `/plans` page on a site that has the Woo Express Trial. You should see the toggle and it should work:

<img width="1267" alt="Screen Shot 2023-04-04 at 11 26 40 AM" src="https://user-images.githubusercontent.com/2124984/229841581-ff27e2b6-c034-459f-984f-6ff0a0272c49.png">


* Switch to a site on a Woo Express monthly plan. You should still see the toggle and it should work:

<img width="1265" alt="Screen Shot 2023-04-04 at 10 42 14 AM" src="https://user-images.githubusercontent.com/2124984/229835036-0bf19a7b-a643-4f0a-83ca-f7ba7c89a58d.png">

* Switch to a site on a Woo Express annual plan. The toggle should not be visible:

<img width="1270" alt="Screen Shot 2023-04-04 at 10 37 49 AM" src="https://user-images.githubusercontent.com/2124984/229834985-a05f910a-76eb-4d74-818c-afd905270433.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
