### PR TITLE
Woo Express: Update redirect post-checkout, add Tracks events

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
@@ -52,11 +52,20 @@ const ECommerceTrialExpired = (): JSX.Element => {
 		} );
 	}, [] );
 
+	const triggerPlansGridTracksEvent = useCallback( ( planSlug: string ) => {
+		recordTracksEvent( 'calypso_wooexpress_expired_trial_upgrade_cta_clicked', {
+			location: 'plans_grid',
+			plan_slug: planSlug,
+		} );
+	}, [] );
+
 	const plansContent = isEnabled( 'plans/wooexpress-small' ) ? (
 		<WooExpressPlans
 			interval={ interval }
 			monthlyControlProps={ monthlyControlProps }
 			siteId={ siteId ?? 0 }
+			siteSlug={ siteSlug ?? '' }
+			triggerTracksEvent={ triggerPlansGridTracksEvent }
 			yearlyControlProps={ yearlyControlProps }
 		/>
 	) : (

--- a/client/my-sites/plans/ecommerce-trial/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/index.tsx
@@ -30,6 +30,13 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 		} );
 	}, [] );
 
+	const triggerPlansGridTracksEvent = useCallback( ( planSlug: string ) => {
+		recordTracksEvent( 'calypso_wooexpress_plans_page_upgrade_cta_clicked', {
+			location: 'plans_grid',
+			plan_slug: planSlug,
+		} );
+	}, [] );
+
 	// WX Medium and Commerce have the same features
 	const wooExpressMediumPlanFeatureSets = useMemo( () => {
 		return getWooExpressMediumFeatureSets( { translate, interval } );
@@ -49,10 +56,12 @@ const ECommerceTrialPlansPage = ( props: ECommerceTrialPlansPageProps ) => {
 	const multiPlanFeatures = (
 		<WooExpressPlans
 			siteId={ siteId }
+			siteSlug={ siteSlug }
 			interval={ interval }
 			yearlyControlProps={ { path: plansLink( '/plans', siteSlug, 'yearly', true ) } }
 			monthlyControlProps={ { path: plansLink( '/plans', siteSlug, 'monthly', true ) } }
 			showIntervalToggle={ true }
+			triggerTracksEvent={ triggerPlansGridTracksEvent }
 		/>
 	);
 

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -4,9 +4,11 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConfirmationTask from './confirmation-task';
 import { getConfirmationTasks } from './confirmation-tasks';
+import type { AppState } from 'calypso/types';
 
 import './style.scss';
 
@@ -23,7 +25,14 @@ const TrialUpgradeConfirmation = () => {
 		wooAdminUrl: selectedSite?.URL ? selectedSite.URL + '/wp-admin/admin.php?page=wc-admin' : '',
 	};
 
-	const currentPlanName = selectedSite?.plan?.product_name_short ?? '';
+	const isFetchingSitePlan = useSelector( ( state: AppState ) => {
+		if ( ! selectedSite?.ID ) {
+			return false;
+		}
+		return isRequestingSitePlans( state, selectedSite.ID );
+	} );
+
+	const currentPlanName = isFetchingSitePlan ? '' : selectedSite?.plan?.product_name_short ?? '';
 
 	return (
 		<>

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -32,7 +32,7 @@ const TrialUpgradeConfirmation = () => {
 			<Main wideLayout>
 				<PageViewTracker
 					path="/plans/my-plan/trial-upgraded/:site"
-					title="Plans > Ecommerce Trial Post Upgrade Actions" //Should this string be made available for translation?
+					title="Plans > Ecommerce Trial Post Upgrade Actions"
 				/>
 				<div className="trial-upgrade-confirmation__header">
 					<h1 className="trial-upgrade-confirmation__title">

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -49,13 +49,14 @@ const TrialUpgradeConfirmation = () => {
 					</h1>
 					<div className="trial-upgrade-confirmation__subtitle">
 						<span className="trial-upgrade-confirmation__subtitle-line">
-							{ translate(
-								"Your purchase is complete and you're now on the {{strong}}%(planName)s plan{{/strong}}. Now it's time to take your store to the next level. What would you like to do next?",
-								{
-									args: { planName: currentPlanName },
-									components: { strong: <strong /> },
-								}
-							) }
+							{ currentPlanName &&
+								translate(
+									"Your purchase is complete and you're now on the {{strong}}%(planName)s plan{{/strong}}. Now it's time to take your store to the next level. What would you like to do next?",
+									{
+										args: { planName: currentPlanName },
+										components: { strong: <strong /> },
+									}
+								) }
 						</span>
 					</div>
 				</div>

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -22,9 +23,12 @@ const TrialUpgradeConfirmation = () => {
 		wooAdminUrl: selectedSite?.URL ? selectedSite.URL + '/wp-admin/admin.php?page=wc-admin' : '',
 	};
 
+	const currentPlanName = selectedSite?.plan?.product_name_short ?? '';
+
 	return (
 		<>
 			<BodySectionCssClass bodyClass={ [ 'ecommerce-trial-upgraded' ] } />
+			<QuerySitePlans siteId={ selectedSite?.ID ?? 0 } />
 			<Main wideLayout>
 				<PageViewTracker
 					path="/plans/my-plan/trial-upgraded/:site"
@@ -39,7 +43,7 @@ const TrialUpgradeConfirmation = () => {
 							{ translate(
 								"Your purchase is complete and you're now on the {{strong}}%(planName)s plan{{/strong}}. Now it's time to take your store to the next level. What would you like to do next?",
 								{
-									args: { planName: 'Performance' },
+									args: { planName: currentPlanName },
 									components: { strong: <strong /> },
 								}
 							) }

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -32,7 +32,7 @@ const TrialUpgradeConfirmation = () => {
 			<Main wideLayout>
 				<PageViewTracker
 					path="/plans/my-plan/trial-upgraded/:site"
-					title="Plans > Ecommerce Trial Post Upgrade Actions"
+					title="Plans > Ecommerce Trial Post Upgrade Actions" //Should this string be made available for translation?
 				/>
 				<div className="trial-upgrade-confirmation__header">
 					<h1 className="trial-upgrade-confirmation__title">

--- a/client/my-sites/plans/woo-express-plans-page/index.tsx
+++ b/client/my-sites/plans/woo-express-plans-page/index.tsx
@@ -112,10 +112,6 @@ const WooExpressPlansPage = ( {
 				}
 		  );
 
-	const triggerTracksEvent = useCallback( ( planSlug: string ) => {
-		recordTracksEvent( 'calypso_wooexpress_plans_plan_cta_click', { plan_slug: planSlug } );
-	}, [] );
-
 	const triggerPlansGridTracksEvent = useCallback( ( planSlug: string ) => {
 		recordTracksEvent( 'calypso_wooexpress_plans_page_upgrade_cta_clicked', {
 			location: 'plans_grid',

--- a/client/my-sites/plans/woo-express-plans-page/index.tsx
+++ b/client/my-sites/plans/woo-express-plans-page/index.tsx
@@ -116,6 +116,13 @@ const WooExpressPlansPage = ( {
 		recordTracksEvent( 'calypso_wooexpress_plans_plan_cta_click', { plan_slug: planSlug } );
 	}, [] );
 
+	const triggerPlansGridTracksEvent = useCallback( ( planSlug: string ) => {
+		recordTracksEvent( 'calypso_wooexpress_plans_page_upgrade_cta_clicked', {
+			location: 'plans_grid',
+			plan_slug: planSlug,
+		} );
+	}, [] );
+
 	const planFeatures =
 		isEnabled( 'plans/wooexpress-small' ) || isWooExpressSmallPlan( currentPlan.productSlug ) ? (
 			<WooExpressPlans
@@ -123,7 +130,7 @@ const WooExpressPlansPage = ( {
 				monthlyControlProps={ { path: plansLink( '/plans', selectedSite.slug, 'monthly', true ) } }
 				siteId={ selectedSite.ID }
 				siteSlug={ selectedSite.slug }
-				triggerTracksEvent={ triggerTracksEvent }
+				triggerTracksEvent={ triggerPlansGridTracksEvent }
 				yearlyControlProps={ { path: plansLink( '/plans', selectedSite.slug, 'yearly', true ) } }
 				showIntervalToggle={ showIntervalToggle }
 			/>

--- a/client/my-sites/plans/woo-express-plans-page/index.tsx
+++ b/client/my-sites/plans/woo-express-plans-page/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
 import {
 	getPlans,
@@ -14,7 +15,7 @@ import { formatCurrency } from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import getInTouch from 'calypso/assets/images/plans/wpcom/get-in-touch.png';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
@@ -111,12 +112,18 @@ const WooExpressPlansPage = ( {
 				}
 		  );
 
+	const triggerTracksEvent = useCallback( ( planSlug: string ) => {
+		recordTracksEvent( 'calypso_wooexpress_plans_plan_cta_click', { plan_slug: planSlug } );
+	}, [] );
+
 	const planFeatures =
 		isEnabled( 'plans/wooexpress-small' ) || isWooExpressSmallPlan( currentPlan.productSlug ) ? (
 			<WooExpressPlans
 				interval={ interval ? interval : planInterval }
 				monthlyControlProps={ { path: plansLink( '/plans', selectedSite.slug, 'monthly', true ) } }
 				siteId={ selectedSite.ID }
+				siteSlug={ selectedSite.slug }
+				triggerTracksEvent={ triggerTracksEvent }
 				yearlyControlProps={ { path: plansLink( '/plans', selectedSite.slug, 'yearly', true ) } }
 				showIntervalToggle={ showIntervalToggle }
 			/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #75281

## Proposed Changes

* This PR ensures that when users purchase a Woo Express plan, we redirect them to the Woo Express post-purchase page.
* The PR also makes the following small changes:
  - The plan name displayed on the post-purchase page is now dynamic and derived from the current plan for the site
  - We trigger Tracks events when selecting a plan from the plans grid -- the events use the existing event name on the expired trial and free trial pages, but use a value of `plans_grid` for the `location` event prop, as well as adding a `plan_slug` prop to identify which plan was selected.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Perform all of the following steps in the Calypso live environment, as the `plans/wooexpress-small` feature flag is enabled there
* Navigate to _Upgrades_ -> _Plans_ for an eCommerce trial site
* Click on a plan CTA in the plans grid
* Verify that you get an appropriate Tracks event with the correct plan slug and location

<img width="1026" alt="Screen Shot 2023-04-04 at 12 37 51 PM" src="https://user-images.githubusercontent.com/2124984/229859952-9be09d7d-fcd5-45ee-beef-d9171075ce64.png">

* Verify that the right plan is added to your cart
* Complete the purchase
* Verify that after the purchase completes, you are redirected to the Woo Express post-purchase page
* Verify that the plan name reflects the plan you purchased, especially if you purchased an Essential plan:

<img width="1061" alt="Screen Shot 2023-04-04 at 12 41 22 PM" src="https://user-images.githubusercontent.com/2124984/229859910-354261b4-7a8b-4869-8227-e53b3937a642.png">

* For an expired eCommerce trial site, try to navigate to a page in Calypso - this should redirect you to the expired trial page:

<img width="1106" alt="Screen Shot 2023-04-04 at 12 42 30 PM" src="https://user-images.githubusercontent.com/2124984/229860089-05cdbd11-eca1-402c-84fe-7915c885c0f9.png">

* Click on a plan CTA in the plans grid - it should not be the same product as above (i.e. it should be Essential if you purchased Performance above - just an interval is not sufficient)
* Verify that a Tracks event is triggered with the correct plan slug and location:

<img width="989" alt="Screen Shot 2023-04-04 at 12 43 06 PM" src="https://user-images.githubusercontent.com/2124984/229860261-d1b86a88-05d4-4d9a-9323-a0fd86dc9565.png">

* Complete the purchase
* Verify that after the purchase completes, you are redirected to the Woo Express post-purchase page
* Verify that the plan name reflects the plan you purchased, especially if you purchased an Essential plan:

<img width="1142" alt="Screen Shot 2023-04-04 at 12 43 54 PM" src="https://user-images.githubusercontent.com/2124984/229860436-828e46cd-e80f-49fc-971f-06d03f6b6191.png">

* For the site where you purchased the Essential plan, navigate to _Upgrades_ -> _Plans_
* The Essential plan options should be disabled, so click on the plan CTA for a Performance plan
* Verify that you get an appropriate Tracks event with the correct plan slug and location:

<img width="862" alt="Screen Shot 2023-04-04 at 1 07 55 PM" src="https://user-images.githubusercontent.com/2124984/229866154-e4055841-2dad-48a8-bdb8-f0885334da2a.png">

* Verify that the right plan is added to your cart
* Complete the purchase
* Verify that after the purchase completes, you are redirected to the Woo Express post-purchase page
* Verify that the plan name reflects the plan you purchased:

<img width="1097" alt="Screen Shot 2023-04-04 at 12 47 43 PM" src="https://user-images.githubusercontent.com/2124984/229861341-c0e50587-e6f9-4c74-89e9-929e8cbd146a.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
