### PR TITLE
Checkout: Add errorMessage to callback in CheckoutPaymentMethods error boundary

### DIFF
--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -43,6 +43,13 @@ const { colors } = colorStudio;
 const jetpackColors = isJetpackCloud() ? { highlight: colors[ 'Jetpack Green 50' ] } : {};
 const theme = { ...checkoutTheme, colors: { ...checkoutTheme.colors, ...jetpackColors } };
 
+function convertErrorToString( error: Error ): string {
+	if ( error.cause ) {
+		return `${ error.message }; ${ error.cause }`;
+	}
+	return error.message;
+}
+
 function useLogError( message: string ): CheckoutPageErrorCallback {
 	return useCallback(
 		( errorType, errorMessage ) => {
@@ -53,7 +60,7 @@ function useLogError( message: string ): CheckoutPageErrorCallback {
 				extra: {
 					env: config( 'env_id' ),
 					type: 'payment_method_selector',
-					message: String( errorMessage ),
+					message: convertErrorToString( errorMessage ),
 					errorType,
 				},
 			} );

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -45,14 +45,14 @@ const theme = { ...checkoutTheme, colors: { ...checkoutTheme.colors, ...jetpackC
 
 function convertErrorToString( error: Error ): string {
 	if ( error.cause ) {
-		return `${ error.message }; ${ error.cause }`;
+		return `${ error.message }; Cause: ${ error.cause }`;
 	}
 	return error.message;
 }
 
 function useLogError( message: string ): CheckoutPageErrorCallback {
 	return useCallback(
-		( errorType, errorMessage ) => {
+		( errorType, error ) => {
 			logToLogstash( {
 				feature: 'calypso_client',
 				message,
@@ -60,7 +60,7 @@ function useLogError( message: string ): CheckoutPageErrorCallback {
 				extra: {
 					env: config( 'env_id' ),
 					type: 'payment_method_selector',
-					message: convertErrorToString( errorMessage ),
+					message: convertErrorToString( error ),
 					errorType,
 				},
 			} );

--- a/client/my-sites/checkout/composite-checkout/lib/analytics.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/analytics.ts
@@ -8,6 +8,13 @@ import {
 import type { CheckoutPaymentMethodSlug } from '@automattic/wpcom-checkout';
 import type { CalypsoDispatch } from 'calypso/state/types';
 
+function convertErrorToString( error: Error ): string {
+	if ( error.cause ) {
+		return `${ error.message }; Cause: ${ error.cause }; Stack: ${ error.stack }`;
+	}
+	return `${ error.message }; Stack: ${ error.stack }`;
+}
+
 export function logStashLoadErrorEvent(
 	errorType: string,
 	error: Error,
@@ -16,7 +23,7 @@ export function logStashLoadErrorEvent(
 	return logStashEvent( 'composite checkout load error', {
 		...additionalData,
 		type: errorType,
-		message: error.message + '; Stack: ' + error.stack,
+		message: convertErrorToString( error ),
 	} );
 }
 

--- a/packages/calypso-typescript-config/js-package.json
+++ b/packages/calypso-typescript-config/js-package.json
@@ -7,9 +7,9 @@
 
 		"noEmit": true,
 
-		"lib": [ "ES2020", "DOM", "DOM.Iterable" ],
-		"module": "ES2020",
-		"target": "ES2020",
+		"lib": [ "ES2022", "DOM", "DOM.Iterable" ],
+		"module": "ES2022",
+		"target": "ES2022",
 		"esModuleInterop": true,
 		"jsx": "react-jsx",
 		"allowJs": true,

--- a/packages/calypso-typescript-config/ts-package.json
+++ b/packages/calypso-typescript-config/ts-package.json
@@ -13,7 +13,7 @@
 		"noEmitHelpers": true,
 		"skipLibCheck": true,
 
-		"lib": [ "ES2020", "DOM", "DOM.Iterable" ],
+		"lib": [ "ES2022", "DOM", "DOM.Iterable" ],
 		"module": "ES2020",
 		"target": "ES2020",
 		"esModuleInterop": true,

--- a/packages/calypso-typescript-config/ts-package.json
+++ b/packages/calypso-typescript-config/ts-package.json
@@ -14,8 +14,8 @@
 		"skipLibCheck": true,
 
 		"lib": [ "ES2022", "DOM", "DOM.Iterable" ],
-		"module": "ES2020",
-		"target": "ES2020",
+		"module": "ES2022",
+		"target": "ES2022",
 		"esModuleInterop": true,
 		"jsx": "react-jsx",
 		"resolveJsonModule": true,

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -121,7 +121,7 @@ It has the following props.
 - `onPaymentComplete?: ({paymentMethodId: string | null, transactionLastResponse: unknown }) => null`. A function to call for non-redirect payment methods when payment is successful. Passed the current payment method id and the transaction response as set by the payment processor function.
 - `onPaymentRedirect?: ({paymentMethodId: string | null, transactionLastResponse: unknown }) => null`. A function to call for redirect payment methods when payment begins to redirect. Passed the current payment method id and the transaction response as set by the payment processor function.
 - `onPaymentError?: ({paymentMethodId: string | null, transactionError: string | null }) => null`. A function to call for payment methods when payment is not successful.
-- `onPageLoadError?: ( errorType: string, errorMessage: string, errorData?: Record< string, string | number | undefined > ) => void`. A function to call when an internal error boundary triggered.
+- `onPageLoadError?: ( errorType: string, errorMessage: Error, errorData?: Record< string, string | number | undefined > ) => void`. A function to call when an internal error boundary triggered.
 - `onStepChanged?: ({ stepNumber: number | null; previousStepNumber: number; paymentMethodId: string }) => void`. A function to call when the active checkout step is changed.
 - `onPaymentMethodChanged?: (method: string) => void`. A function to call when the active payment method is changed. The argument will be the method's id.
 - `paymentMethods: object[]`. An array of [Payment Method objects](#payment-methods). Can be disabled by [useTogglePaymentMethod](#useTogglePaymentMethod).

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -121,7 +121,7 @@ It has the following props.
 - `onPaymentComplete?: ({paymentMethodId: string | null, transactionLastResponse: unknown }) => null`. A function to call for non-redirect payment methods when payment is successful. Passed the current payment method id and the transaction response as set by the payment processor function.
 - `onPaymentRedirect?: ({paymentMethodId: string | null, transactionLastResponse: unknown }) => null`. A function to call for redirect payment methods when payment begins to redirect. Passed the current payment method id and the transaction response as set by the payment processor function.
 - `onPaymentError?: ({paymentMethodId: string | null, transactionError: string | null }) => null`. A function to call for payment methods when payment is not successful.
-- `onPageLoadError?: ( errorType: string, errorMessage: Error, errorData?: Record< string, string | number | undefined > ) => void`. A function to call when an internal error boundary triggered.
+- `onPageLoadError?: ( errorType: string, error: Error, errorData?: Record< string, string | number | undefined > ) => void`. A function to call when an internal error boundary triggered.
 - `onStepChanged?: ({ stepNumber: number | null; previousStepNumber: number; paymentMethodId: string }) => void`. A function to call when the active checkout step is changed.
 - `onPaymentMethodChanged?: (method: string) => void`. A function to call when the active payment method is changed. The argument will be the method's id.
 - `paymentMethods: object[]`. An array of [Payment Method objects](#payment-methods). Can be disabled by [useTogglePaymentMethod](#useTogglePaymentMethod).

--- a/packages/composite-checkout/src/components/checkout-error-boundary.tsx
+++ b/packages/composite-checkout/src/components/checkout-error-boundary.tsx
@@ -22,8 +22,8 @@ export default class CheckoutErrorBoundary extends Component< CheckoutErrorBound
 		if ( this.props.onError ) {
 			const errorContext =
 				typeof this.props.errorMessage === 'string' ? this.props.errorMessage : error.message;
-			error = new Error( errorContext, { cause: error } );
-			this.props.onError( error );
+			const errorWithCause = new Error( errorContext, { cause: error } );
+			this.props.onError( errorWithCause );
 		}
 	}
 

--- a/packages/composite-checkout/src/components/checkout-error-boundary.tsx
+++ b/packages/composite-checkout/src/components/checkout-error-boundary.tsx
@@ -21,8 +21,9 @@ export default class CheckoutErrorBoundary extends Component< CheckoutErrorBound
 	componentDidCatch( error: Error ): void {
 		if ( this.props.onError ) {
 			const errorContext =
-				typeof this.props.errorMessage === 'string' ? this.props.errorMessage : undefined;
-			this.props.onError( error, errorContext );
+				typeof this.props.errorMessage === 'string' ? this.props.errorMessage : error.message;
+			error = new Error( errorContext, { cause: error } );
+			this.props.onError( error );
 		}
 	}
 
@@ -36,7 +37,7 @@ export default class CheckoutErrorBoundary extends Component< CheckoutErrorBound
 
 interface CheckoutErrorBoundaryProps {
 	errorMessage: ReactNode;
-	onError?: ( error: Error, errorContext?: string ) => void;
+	onError?: ( error: Error ) => void;
 	children?: ReactNode;
 }
 

--- a/packages/composite-checkout/src/components/checkout-error-boundary.tsx
+++ b/packages/composite-checkout/src/components/checkout-error-boundary.tsx
@@ -20,7 +20,9 @@ export default class CheckoutErrorBoundary extends Component< CheckoutErrorBound
 
 	componentDidCatch( error: Error ): void {
 		if ( this.props.onError ) {
-			this.props.onError( error );
+			const errorContext =
+				typeof this.props.errorMessage === 'string' ? this.props.errorMessage : undefined;
+			this.props.onError( error, errorContext );
 		}
 	}
 
@@ -34,7 +36,7 @@ export default class CheckoutErrorBoundary extends Component< CheckoutErrorBound
 
 interface CheckoutErrorBoundaryProps {
 	errorMessage: ReactNode;
-	onError?: ( error: Error ) => void;
+	onError?: ( error: Error, errorContext?: string ) => void;
 	children?: ReactNode;
 }
 

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -37,7 +37,8 @@ export default function CheckoutPaymentMethods( {
 	const { __ } = useI18n();
 	const { onPageLoadError, onPaymentMethodChanged } = useContext( CheckoutContext );
 	const onError = useCallback(
-		( error: Error ) => onPageLoadError?.( 'payment_method_load', error ),
+		( error: Error, context?: string ) =>
+			onPageLoadError?.( 'payment_method_load', error, { context } ),
 		[ onPageLoadError ]
 	);
 

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -37,8 +37,7 @@ export default function CheckoutPaymentMethods( {
 	const { __ } = useI18n();
 	const { onPageLoadError, onPaymentMethodChanged } = useContext( CheckoutContext );
 	const onError = useCallback(
-		( error: Error, context?: string ) =>
-			onPageLoadError?.( 'payment_method_load', error, { context } ),
+		( error: Error ) => onPageLoadError?.( 'payment_method_load', error ),
 		[ onPageLoadError ]
 	);
 


### PR DESCRIPTION
## Proposed Changes

The `CheckoutErrorBoundary` component is a React error boundary that does two things if there is an error during render: it renders its `errorMessage` prop to the user and it (optionally) calls its `onError` callback prop, passing the error itself as an argument. The callback typically logs this message for debugging purposes.

Most of the time this is fine, as the error contains all the information needed to figure it out. However, sometimes the `errorMessage` prop contains contextual information that would further help debug the issue.

In this PR, we add the `errorMessage` (iff it's a string) to the error passed to the callback so that it can be logged also.

**NOTE**: in order to have TypeScript allow us to use `error.cause`, we have to update its config to allow using `ES2022`. Apparently we already allow ES2022 inside the `client` directory (although I can't understand how), but not in `packages` so this should be safe, but please speak up in review if you think it's a bad idea.

## Testing Instructions

We need to cause an error and verify that it gets logged with both `error.message` and `error.cause`. To do that, add an error to checkout in a locally running version of calypso on this branch like the following:

```diff
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -203,6 +203,8 @@ export default function WPCheckout( {
        const [ isSummaryVisible, setIsSummaryVisible ] = useState( false );
        const { formStatus } = useFormStatus();

+       throw new Error( 'this is a test' );
+
        const onReviewError = useCallback(
                ( error: Error ) =>
                        onPageLoadError( 'step_load', error, {
```

Then, visit checkout with your browser's network devtools open. Look for a connection to the `logstash` endpoint with a body that includes both the message and the test error as a `Cause`. For example:

<img width="740" alt="Screenshot 2023-04-04 at 3 45 53 PM" src="https://user-images.githubusercontent.com/2036909/229903682-a50705b8-331a-45dd-9790-1bff8dfc3015.png">
