### PR TITLE
Components: Update CircularProgressBar Prop Handling

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -117,16 +117,14 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 				<span className="launchpad__sidebar-header-flow-name">{ flowName }</span>
 			</div>
 			<div className="launchpad__sidebar-content-container">
-				{ currentTask && enhancedTasks?.length && (
-					<div className="launchpad__progress-bar-container">
-						<CircularProgressBar
-							size={ 40 }
-							enableDesktopScaling
-							currentStep={ currentTask }
-							numberOfSteps={ enhancedTasks?.length }
-						/>
-					</div>
-				) }
+				<div className="launchpad__progress-bar-container">
+					<CircularProgressBar
+						size={ 40 }
+						enableDesktopScaling
+						currentStep={ currentTask }
+						numberOfSteps={ enhancedTasks?.length }
+					/>
+				</div>
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace*/ }
 				<h1 className="launchpad__sidebar-h1">
 					{ showLaunchTitle && launchTitle ? launchTitle : title }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -122,7 +122,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 						size={ 40 }
 						enableDesktopScaling
 						currentStep={ currentTask }
-						numberOfSteps={ enhancedTasks?.length }
+						numberOfSteps={ enhancedTasks?.length || null }
 					/>
 				</div>
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace*/ }

--- a/packages/components/src/circular-progress-bar/index.tsx
+++ b/packages/components/src/circular-progress-bar/index.tsx
@@ -7,8 +7,8 @@ const CircularProgressBar = ( {
 	size,
 	enableDesktopScaling = false,
 }: {
-	currentStep: number | undefined;
-	numberOfSteps: number | undefined;
+	currentStep: number | null;
+	numberOfSteps: number | null;
 	size: number;
 	enableDesktopScaling?: boolean;
 } ) => {
@@ -17,11 +17,7 @@ const CircularProgressBar = ( {
 	const RADIUS = SIZE / 2 - STROKE_WIDTH / 2;
 	const FULL_ARC = 2 * Math.PI * RADIUS;
 
-	if (
-		typeof numberOfSteps === 'undefined' ||
-		typeof currentStep === 'undefined' ||
-		numberOfSteps === 0
-	) {
+	if ( currentStep === null || ! numberOfSteps ) {
 		return null;
 	}
 

--- a/packages/components/src/circular-progress-bar/index.tsx
+++ b/packages/components/src/circular-progress-bar/index.tsx
@@ -7,8 +7,8 @@ const CircularProgressBar = ( {
 	size,
 	enableDesktopScaling = false,
 }: {
-	currentStep: number;
-	numberOfSteps: number;
+	currentStep: number | undefined;
+	numberOfSteps: number | undefined;
 	size: number;
 	enableDesktopScaling?: boolean;
 } ) => {
@@ -16,6 +16,14 @@ const CircularProgressBar = ( {
 	const STROKE_WIDTH = 4;
 	const RADIUS = SIZE / 2 - STROKE_WIDTH / 2;
 	const FULL_ARC = 2 * Math.PI * RADIUS;
+
+	if (
+		typeof numberOfSteps === 'undefined' ||
+		typeof currentStep === 'undefined' ||
+		numberOfSteps === 0
+	) {
+		return null;
+	}
 
 	return (
 		<div
@@ -41,6 +49,7 @@ const CircularProgressBar = ( {
 				/>
 				<circle
 					style={ {
+						display: currentStep === 0 ? 'none' : 'block',
 						strokeDasharray: `${ FULL_ARC * ( currentStep / numberOfSteps ) }, ${ FULL_ARC }`,
 					} }
 					className="circular__progress-bar-fill-circle"


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/72789

### Time Estimate
Testing: Short
Review: Short

### Summary
This PR updates the **CircularProgressBar** component to improve the behavior with invalid props:
1. If the `currentStep` prop is set to `0`, we display an empty circle. Previously the progress circle was still showing some small amount of progress
2. Move the invalid prop handling inside the component. Previously we had to check if the props are valid before rendering the component but now the component has its own built in logic for handling invalid props. I believe this is a better practice for this particular component because we can provide consistent graceful fallback built into the component. For now we are not rendering the component (returning `null`) if the props are invalid (`numberOfSteps` is `undefined` or `0`, `currentStep` is `undefined`)

### Testing
1. Checkout this branch
2. Arrive at Launchpad on a Launchpad-enabled site
3. Use the `React DevTools` to manually adjust the props of the `CircularProgressBar` component:
3.1. Set the `currentStep` to `0`. Verify the circle progress circle is empty.

![currentStep](https://user-images.githubusercontent.com/20927667/229925879-b0b65988-24c1-46a5-a8d8-56cb930defa6.png)

3.2. Set the `numberOfSteps` to `0`. Verify the `CircularProgressBar` component doesn't render.

![numberOfSteps](https://user-images.githubusercontent.com/20927667/229925890-4bb0cd1a-0a5d-49f4-90ca-fe6dce121c1d.png)

4. Observe the `CircularProgressBar` as you refresh the page. The component would not render until its props are initialized.
5. Checkout trunk. Repeat the above steps and observe the difference in behavior.
6. Verify the `CircularProgressBar` continues to behave properly as you're going through the Launchpad tasks