### PR TITLE
Add VCS triggers to run Jetpack E2Es automagically

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -12,7 +12,9 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
 import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.buildReportTab
+import jetbrains.buildServer.configs.kotlin.v2019_2.Triggers
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object WPComTests : Project({
 	id("WPComTests")
@@ -184,6 +186,49 @@ fun editorTrackingBuildType( targetDevice: String, buildUuid: String, atomic: Bo
 fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpackTarget: String = "wpcom-production" ): E2EBuildType {
 	val idSafeJetpackTarget = jetpackTarget.replace( "-", "_" );
 	val targetJestGroup = if (jetpackTarget == "remote-site") "jetpack-remote-site" else "jetpack-wpcom-integration";
+
+	val triggers: Triggers.() -> Unit = {
+		if (jetpackTarget == "wpcom-staging") {
+			vcs {
+				// Trigger only when the "trunk" branch is modified, i.e. -- merges
+				branchFilter = """
+					+:trunk
+				""".trimIndent()
+
+				// Trigger only when changes are made to the Jetpack staging directories in our WPCOM SVN connection
+				triggerRules = """
+					+:root=%WPCOM_VCS_ROOT_ID%:%WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH%/staging/**
+					+:root=%WPCOM_VCS_ROOT_ID%:%WPCOM_JETPACK_PLUGIN_PATH%/staging/**
+				""".trimIndent()
+			}
+		} else if (jetpackTarget == "wpcom-production") {
+			vcs {
+				// Trigger only when the "trunk" branch is modified, i.e. -- merges
+				branchFilter = """
+					+:trunk
+				""".trimIndent()
+
+				// Trigger only when changes are made to the Jetpack prod directories in our WPCOM SVN connection
+				triggerRules = """
+					+:root=%WPCOM_VCS_ROOT_ID%:%WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH%/production/**
+					+:root=%WPCOM_VCS_ROOT_ID%:%WPCOM_JETPACK_PLUGIN_PATH%/production/**
+				""".trimIndent()
+			}
+		} else {
+			// For remote-site tests, we are just running daily for now. 
+			schedule {
+				schedulingPolicy = daily {
+					hour = 5
+				}
+				branchFilter = """
+					+:trunk
+				""".trimIndent()
+				triggerBuild = always()
+				withPendingChangesOnly = false
+			}
+		}
+	}
+
 	return E2EBuildType (
 		buildId = "WPComTests_jetpack_Playwright_${idSafeJetpackTarget}_$targetDevice",
 		buildUuid = buildUuid,
@@ -202,18 +247,7 @@ fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpack
 			param("env.JETPACK_TARGET", jetpackTarget)
 		},
 		buildFeatures = {},
-		buildTriggers = {
-		schedule {
-			schedulingPolicy = daily {
-				hour = 5
-			}
-			branchFilter = """
-				+:trunk
-			""".trimIndent()
-			triggerBuild = always()
-			withPendingChangesOnly = false
-		}
-	}
+		buildTriggers = triggers
 	)
 }
 

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -190,12 +190,12 @@ fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpack
 	val triggers: Triggers.() -> Unit = {
 		if (jetpackTarget == "wpcom-staging") {
 			vcs {
-				// Trigger only when the "trunk" branch is modified, i.e. -- merges
+				// Trigger only when the "trunk" branch is modified, i.e. back-end merges
 				branchFilter = """
 					+:trunk
 				""".trimIndent()
 
-				// Trigger only when changes are made to the Jetpack staging directories in our WPCOM SVN connection
+				// Trigger only when changes are made to the Jetpack staging directories in our WPCOM connection
 				triggerRules = """
 					+:root=%WPCOM_VCS_ROOT_ID%:%WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH%/staging/**
 					+:root=%WPCOM_VCS_ROOT_ID%:%WPCOM_JETPACK_PLUGIN_PATH%/staging/**
@@ -203,19 +203,19 @@ fun jetpackPlaywrightBuildType( targetDevice: String, buildUuid: String, jetpack
 			}
 		} else if (jetpackTarget == "wpcom-production") {
 			vcs {
-				// Trigger only when the "trunk" branch is modified, i.e. -- merges
+				// Trigger only when the "trunk" branch is modified, i.e. back-end merges
 				branchFilter = """
 					+:trunk
 				""".trimIndent()
 
-				// Trigger only when changes are made to the Jetpack prod directories in our WPCOM SVN connection
+				// Trigger only when changes are made to the Jetpack prod directories in our WPCOM connection
 				triggerRules = """
 					+:root=%WPCOM_VCS_ROOT_ID%:%WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH%/production/**
 					+:root=%WPCOM_VCS_ROOT_ID%:%WPCOM_JETPACK_PLUGIN_PATH%/production/**
 				""".trimIndent()
 			}
 		} else {
-			// For remote-site tests, we are just running daily for now. 
+			// For remote-site tests, we are just running daily for now. They aren't related to Jetpack releases on DotCom.
 			schedule {
 				schedulingPolicy = daily {
 					hour = 5

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -90,6 +90,11 @@ project {
 		password("CALYPSO_E2E_DASHBOARD_AWS_S3_SECRET_ACCESS_KEY", "credentialsJSON:782b4bde-b73d-4326-9970-5a79251bdf07", display = ParameterDisplay.HIDDEN)
 		password("MATTICBOT_GITHUB_BEARER_TOKEN", "credentialsJSON:34cb38a5-9124-41c4-8497-74ed6289d751", display = ParameterDisplay.HIDDEN, label = "Matticbot GitHub Bearer Token")
 		text("CALYPSO_E2E_DASHBOARD_AWS_S3_ROOT", "s3://a8c-calypso-e2e-reports", label = "Calypso E2E Dashboard S3 bucket root")
+
+		// Values related to the WPCOM VCS
+		password("WPCOM_VCS_ROOT_ID", "credentialsJSON:f7437cc0-c8f2-4b10-bdfa-271946bb5f72", display = ParameterDisplay.HIDDEN)
+		password("WPCOM_JETPACK_PLUGIN_PATH", "credentialsJSON:db955a02-2a79-4167-a823-ac4840fd71d7", display = ParameterDisplay.HIDDEN)
+		password("WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH", "credentialsJSON:81683f57-784e-4535-9af0-26212c9e599b", display = ParameterDisplay.HIDDEN)
 	}
 
 	features {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This P2 has a lot of good context: p3topS-1uY-p2

In short, we want to take our spiffy new Jetpack E2E builds that we use during Jetpack releases on DotCom, and trigger them automatically!

To do that, I'm tapping into a VCS connection for WPCOM configured at the TeamCity root project. 

Is it overkill to use secrets for all the configuration info? Probably. But there seemed to be a desire to keep that stuff as private as possible, so I'm opting to do so -- it shouldn't add too much overhead!

Oh, and one other note: let's get the triggering working first, then I will cut a new PR to add Slack notifications! 👍 

## Testing Instructions

Other than compilation, we can't test until we merge to trunk. 😅  Who's ready to place bets on the odds this works the first time? I'm putting the over-under at 15% 😆 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?