### PR TITLE
Checkout: Show helpful error message for renewal URLs with incorrect site

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -179,6 +179,7 @@ export default function CheckoutMain( {
 		productsForCart,
 		isLoading: areCartProductsPreparing,
 		error: cartProductPrepError,
+		addingRenewals,
 	} = usePrepareProductsForCart( {
 		productAliasFromUrl,
 		purchaseId,
@@ -218,6 +219,7 @@ export default function CheckoutMain( {
 		couponCodeFromUrl,
 		applyCoupon,
 		addProductsToCart,
+		addingRenewals,
 	} );
 
 	useRecordCartLoaded( {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -95,6 +95,7 @@ export default function useAddProductsFromUrl( {
 			// renewals prepared. This is because if a renewal was requested by URL
 			// and was invalid, we don't want them to see what may have been in their
 			// cart previously to avoid the appearance that the URL succeeded.
+			debug( 'clearing the cart due to a renewal request with no products' );
 			cartPromises.push( replaceProductsInCart( [] ) );
 		}
 		if ( productsForCart.length > 0 ) {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -8,9 +8,9 @@ import debugFactory from 'debug';
 import { useEffect, useRef, useState } from 'react';
 import useCartKey from '../../use-cart-key';
 
-const debug = debugFactory( 'calypso:composite-checkout:use-add-products-from-url' );
+const debug = debugFactory( 'calypso:use-add-products-from-url' );
 
-export type isPendingAddingProductsFromUrl = boolean;
+export type IsPendingAddingProductsFromUrl = boolean;
 
 /**
  * Product requests can be sent to checkout using various methods including URL
@@ -39,7 +39,7 @@ export default function useAddProductsFromUrl( {
 	applyCoupon: ApplyCouponToCart;
 	addProductsToCart: AddProductsToCart;
 	addingRenewals: boolean;
-} ): isPendingAddingProductsFromUrl {
+} ): IsPendingAddingProductsFromUrl {
 	const cartKey = useCartKey();
 	const { updateLocation, replaceProductsInCart } = useShoppingCart( cartKey );
 	const isMounted = useRef( true );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-add-products-from-url.ts
@@ -29,6 +29,7 @@ export default function useAddProductsFromUrl( {
 	couponCodeFromUrl,
 	applyCoupon,
 	addProductsToCart,
+	addingRenewals,
 }: {
 	isLoadingCart: boolean;
 	isCartPendingUpdate: boolean;
@@ -37,9 +38,10 @@ export default function useAddProductsFromUrl( {
 	couponCodeFromUrl: string | null | undefined;
 	applyCoupon: ApplyCouponToCart;
 	addProductsToCart: AddProductsToCart;
+	addingRenewals: boolean;
 } ): isPendingAddingProductsFromUrl {
 	const cartKey = useCartKey();
-	const { updateLocation } = useShoppingCart( cartKey );
+	const { updateLocation, replaceProductsInCart } = useShoppingCart( cartKey );
 	const isMounted = useRef( true );
 	useEffect( () => {
 		isMounted.current = true;
@@ -88,6 +90,13 @@ export default function useAddProductsFromUrl( {
 		}
 		debug( 'adding initial products to cart', productsForCart );
 		const cartPromises = [];
+		if ( addingRenewals && productsForCart.length === 0 ) {
+			// Clear the cart if a renewal was requested but there are no valid
+			// renewals prepared. This is because if a renewal was requested by URL
+			// and was invalid, we don't want them to see what may have been in their
+			// cart previously to avoid the appearance that the URL succeeded.
+			cartPromises.push( replaceProductsInCart( [] ) );
+		}
 		if ( productsForCart.length > 0 ) {
 			// When this hook adds products to the cart, we have just loaded checkout
 			// and we haven't yet confirmed the user's tax details. The cart may
@@ -116,6 +125,8 @@ export default function useAddProductsFromUrl( {
 			} );
 		hasRequestedInitialProducts.current = true;
 	}, [
+		replaceProductsInCart,
+		addingRenewals,
 		updateLocation,
 		isLoading,
 		areCartProductsPreparing,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -76,14 +76,12 @@ export default function usePrepareProductsForCart( {
 			originalPurchaseId,
 			'and isLoggedOutCart',
 			isLoggedOutCart,
-			'and isAkismetSitelessCheckout',
-			sitelessCheckoutType === 'akismet',
+			'and sitelessCheckoutType',
+			sitelessCheckoutType,
 			'and siteSlug',
 			siteSlug,
 			'and isNoSiteCart',
 			isNoSiteCart,
-			'and isJetpackCheckout',
-			sitelessCheckoutType === 'jetpack',
 			'and jetpackSiteSlug',
 			jetpackSiteSlug,
 			'and jetpackPurchaseToken',
@@ -313,7 +311,7 @@ function useAddRenewalItems( {
 
 		// Renewals cannot be purchased without a site.
 		const isThereASite = cartKey && typeof cartKey === 'number';
-		if ( ! isThereASite && ! isGiftPurchase ) {
+		if ( ! isThereASite && ! isGiftPurchase && ! sitelessCheckoutType ) {
 			debug( 'creating renewal products failed because there is no site', productAlias );
 			dispatch( {
 				type: 'RENEWALS_ADD_ERROR',

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -68,26 +68,28 @@ export default function usePrepareProductsForCart( {
 } ): PreparedProductsForCart {
 	const [ state, dispatch ] = useReducer( preparedProductsReducer, initialPreparedProductsState );
 
-	debug(
-		'preparing products for cart from url string',
-		productAliasFromUrl,
-		'and purchase id',
-		originalPurchaseId,
-		'and isLoggedOutCart',
-		isLoggedOutCart,
-		'and isAkismetSitelessCheckout',
-		sitelessCheckoutType === 'akismet',
-		'and siteSlug',
-		siteSlug,
-		'and isNoSiteCart',
-		isNoSiteCart,
-		'and isJetpackCheckout',
-		sitelessCheckoutType === 'jetpack',
-		'and jetpackSiteSlug',
-		jetpackSiteSlug,
-		'and jetpackPurchaseToken',
-		jetpackPurchaseToken
-	);
+	if ( ! state.isLoading || state.error ) {
+		debug(
+			'preparing products for cart from url string',
+			productAliasFromUrl,
+			'and purchase id',
+			originalPurchaseId,
+			'and isLoggedOutCart',
+			isLoggedOutCart,
+			'and isAkismetSitelessCheckout',
+			sitelessCheckoutType === 'akismet',
+			'and siteSlug',
+			siteSlug,
+			'and isNoSiteCart',
+			isNoSiteCart,
+			'and isJetpackCheckout',
+			sitelessCheckoutType === 'jetpack',
+			'and jetpackSiteSlug',
+			jetpackSiteSlug,
+			'and jetpackPurchaseToken',
+			jetpackPurchaseToken
+		);
+	}
 
 	const addHandler = chooseAddHandler( {
 		isLoading: state.isLoading,
@@ -138,6 +140,9 @@ export default function usePrepareProductsForCart( {
 	);
 	useStripProductsFromUrl( siteSlug, doNotStripProducts );
 
+	if ( ! state.isLoading ) {
+		debug( 'returning loaded data', state );
+	}
 	return state;
 }
 
@@ -210,10 +215,14 @@ function chooseAddHandler( {
 	}
 
 	/*
-	 * As Gifting purchases are actually renewals and validate the subscriptionID + product
-	 * with the server, we have to avoid using localStorage.
+	 * As Gifting purchases are actually renewals and validate the subscriptionID
+	 * and product with the server, we have to avoid using localStorage.
 	 */
-	if ( ( ! isGiftPurchase && isLoggedOutCart ) || isNoSiteCart ) {
+	if ( ! isGiftPurchase && isLoggedOutCart ) {
+		return 'addFromLocalStorage';
+	}
+
+	if ( isNoSiteCart ) {
 		return 'addFromLocalStorage';
 	}
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -10,7 +10,7 @@ import useStripProductsFromUrl from './use-strip-products-from-url';
 import type { RequestCartProduct, RequestCartProductExtra } from '@automattic/shopping-cart';
 import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
 
-const debug = debugFactory( 'calypso:composite-checkout:use-prepare-products-for-cart' );
+const debug = debugFactory( 'calypso:use-prepare-products-for-cart' );
 
 interface PreparedProductsForCart {
 	addingRenewals: boolean;
@@ -312,7 +312,12 @@ function useAddRenewalItems( {
 		// Renewals cannot be purchased without a site.
 		const isThereASite = cartKey && typeof cartKey === 'number';
 		if ( ! isThereASite && ! isGiftPurchase && ! sitelessCheckoutType ) {
-			debug( 'creating renewal products failed because there is no site', productAlias );
+			debug(
+				'creating renewal products failed because there is no site. products:',
+				productAlias,
+				'cartKey:',
+				cartKey
+			);
 			dispatch( {
 				type: 'RENEWALS_ADD_ERROR',
 				message: translate(

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -171,12 +171,12 @@ function preparedProductsReducer(
 			if ( ! state.isLoading ) {
 				return state;
 			}
-			return { ...state, isLoading: false, error: action.message };
+			return { ...state, isLoading: false, error: action.message, addingRenewals: true };
 		case 'PRODUCTS_ADD_ERROR':
 			if ( ! state.isLoading ) {
 				return state;
 			}
-			return { ...state, isLoading: false, error: action.message, addingRenewals: true };
+			return { ...state, isLoading: false, error: action.message };
 		default:
 			return state;
 	}

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-autocomplete.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-autocomplete.tsx
@@ -49,7 +49,6 @@ describe( 'Checkout contact step', () => {
 	const mainCartKey = 'foo.com' as CartKey;
 	const initialCart = getBasicCart();
 	const defaultPropsForMockCheckout = {
-		mainCartKey,
 		initialCart,
 	};
 
@@ -60,11 +59,11 @@ describe( 'Checkout contact step', () => {
 	getDomainsBySiteId.mockImplementation( () => [] );
 	isMarketplaceProduct.mockImplementation( () => false );
 	isJetpackSite.mockImplementation( () => false );
-	useCartKey.mockImplementation( () => mainCartKey );
 	mockMatchMediaOnWindow();
 
 	beforeEach( () => {
 		dispatch( CHECKOUT_STORE ).reset();
+		( useCartKey as jest.Mock ).mockImplementation( () => mainCartKey );
 		nock.cleanAll();
 		mockGetVatInfoEndpoint( {} );
 		mockGetPaymentMethodsEndpoint( [] );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-autocomplete.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-autocomplete.tsx
@@ -25,7 +25,6 @@ import {
 	mockLogStashEndpoint,
 	mockGetSupportedCountriesEndpoint,
 	mockGetPaymentMethodsEndpoint,
-	mockStoredPaymentMethodsEndpoint,
 } from './util';
 import { MockCheckout } from './util/mock-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
@@ -67,7 +66,6 @@ describe( 'Checkout contact step', () => {
 	beforeEach( () => {
 		dispatch( CHECKOUT_STORE ).reset();
 		nock.cleanAll();
-		mockStoredPaymentMethodsEndpoint( [] );
 		mockGetVatInfoEndpoint( {} );
 		mockGetPaymentMethodsEndpoint( [] );
 		mockLogStashEndpoint();

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-autocomplete.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-autocomplete.tsx
@@ -25,6 +25,7 @@ import {
 	mockLogStashEndpoint,
 	mockGetSupportedCountriesEndpoint,
 	mockGetPaymentMethodsEndpoint,
+	mockStoredPaymentMethodsEndpoint,
 } from './util';
 import { MockCheckout } from './util/mock-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
@@ -66,6 +67,7 @@ describe( 'Checkout contact step', () => {
 	beforeEach( () => {
 		dispatch( CHECKOUT_STORE ).reset();
 		nock.cleanAll();
+		mockStoredPaymentMethodsEndpoint( [] );
 		mockGetVatInfoEndpoint( {} );
 		mockGetPaymentMethodsEndpoint( [] );
 		mockLogStashEndpoint();

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.tsx
@@ -41,7 +41,6 @@ describe( 'Checkout contact step', () => {
 	const mainCartKey = 'foo.com' as CartKey;
 	const initialCart = getBasicCart();
 	const defaultPropsForMockCheckout = {
-		mainCartKey,
 		initialCart,
 	};
 
@@ -52,7 +51,7 @@ describe( 'Checkout contact step', () => {
 	getDomainsBySiteId.mockImplementation( () => [] );
 	isMarketplaceProduct.mockImplementation( () => false );
 	isJetpackSite.mockImplementation( () => false );
-	useCartKey.mockImplementation( () => mainCartKey );
+	( useCartKey as jest.Mock ).mockImplementation( () => mainCartKey );
 	mockMatchMediaOnWindow();
 
 	beforeEach( () => {

--- a/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
@@ -51,7 +51,6 @@ describe( 'Checkout contact step extra tax fields', () => {
 	const mainCartKey: CartKey = 'foo.com' as CartKey;
 	const initialCart = getBasicCart();
 	const defaultPropsForMockCheckout = {
-		mainCartKey,
 		initialCart,
 	};
 
@@ -62,7 +61,6 @@ describe( 'Checkout contact step extra tax fields', () => {
 	getDomainsBySiteId.mockImplementation( () => [] );
 	isMarketplaceProduct.mockImplementation( () => false );
 	isJetpackSite.mockImplementation( () => false );
-	useCartKey.mockImplementation( () => mainCartKey );
 	mockMatchMediaOnWindow();
 
 	const mockSetCartEndpoint = mockSetCartEndpointWith( {
@@ -72,6 +70,7 @@ describe( 'Checkout contact step extra tax fields', () => {
 
 	beforeEach( () => {
 		dispatch( CHECKOUT_STORE ).reset();
+		( useCartKey as jest.Mock ).mockImplementation( () => mainCartKey );
 		nock.cleanAll();
 		mockGetPaymentMethodsEndpoint( [] );
 		mockLogStashEndpoint();

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -25,6 +25,7 @@ import {
 	mockGetVatInfoEndpoint,
 	mockGetSupportedCountriesEndpoint,
 	mockLogStashEndpoint,
+	mockStoredPaymentMethodsEndpoint,
 } from './util';
 import { MockCheckout } from './util/mock-checkout';
 import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
@@ -58,6 +59,7 @@ describe( 'CheckoutMain', () => {
 		( isMarketplaceProduct as jest.Mock ).mockImplementation( () => false );
 		( isJetpackSite as jest.Mock ).mockImplementation( () => false );
 
+		mockStoredPaymentMethodsEndpoint( [] );
 		mockGetPaymentMethodsEndpoint( [] );
 		mockLogStashEndpoint();
 		mockGetVatInfoEndpoint( {} );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -27,7 +27,6 @@ import {
 	mockGetVatInfoEndpoint,
 	mockGetSupportedCountriesEndpoint,
 	mockLogStashEndpoint,
-	mockStoredPaymentMethodsEndpoint,
 } from './util';
 import { MockCheckout } from './util/mock-checkout';
 import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
@@ -68,7 +67,6 @@ describe( 'CheckoutMain', () => {
 		( isMarketplaceProduct as jest.Mock ).mockImplementation( () => false );
 		( isJetpackSite as jest.Mock ).mockImplementation( () => false );
 
-		mockStoredPaymentMethodsEndpoint( [] );
 		mockGetPaymentMethodsEndpoint( [] );
 		mockLogStashEndpoint();
 		mockGetVatInfoEndpoint( {} );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { dispatch } from '@wordpress/data';
 import React from 'react';
 import { navigate } from 'calypso/lib/navigate';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -66,6 +67,7 @@ describe( 'CheckoutMain', () => {
 		( getDomainsBySiteId as jest.Mock ).mockImplementation( () => [] );
 		( isMarketplaceProduct as jest.Mock ).mockImplementation( () => false );
 		( isJetpackSite as jest.Mock ).mockImplementation( () => false );
+		( useCartKey as jest.Mock ).mockImplementation( () => mainCartKey );
 
 		mockGetPaymentMethodsEndpoint( [] );
 		mockLogStashEndpoint();
@@ -75,13 +77,7 @@ describe( 'CheckoutMain', () => {
 	} );
 
 	it( 'renders the line items with prices', async () => {
-		render(
-			<MockCheckout
-				mainCartKey={ mainCartKey }
-				initialCart={ initialCart }
-				setCart={ mockSetCartEndpoint }
-			/>
-		);
+		render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
 		await waitFor( () => {
 			screen
 				.getAllByLabelText( 'WordPress.com Personal' )
@@ -93,7 +89,6 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [] };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				cartChanges={ cartChanges }
 				useUndefinedSiteId
@@ -112,13 +107,7 @@ describe( 'CheckoutMain', () => {
 	} );
 
 	it( 'renders the tax amount', async () => {
-		render(
-			<MockCheckout
-				mainCartKey={ mainCartKey }
-				initialCart={ initialCart }
-				setCart={ mockSetCartEndpoint }
-			/>
-		);
+		render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
 		await waitFor( () => {
 			screen
 				.getAllByLabelText( 'Tax' )
@@ -127,13 +116,7 @@ describe( 'CheckoutMain', () => {
 	} );
 
 	it( 'renders the total amount', async () => {
-		render(
-			<MockCheckout
-				mainCartKey={ mainCartKey }
-				initialCart={ initialCart }
-				setCart={ mockSetCartEndpoint }
-			/>
-		);
+		render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
 		await waitFor( () => {
 			screen
 				.getAllByLabelText( 'Total' )
@@ -142,13 +125,7 @@ describe( 'CheckoutMain', () => {
 	} );
 
 	it( 'renders the checkout summary', async () => {
-		render(
-			<MockCheckout
-				mainCartKey={ mainCartKey }
-				initialCart={ initialCart }
-				setCart={ mockSetCartEndpoint }
-			/>
-		);
+		render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
 		expect( await screen.findByText( 'Purchase Details' ) ).toBeInTheDocument();
 		expect( navigate ).not.toHaveBeenCalled();
 	} );
@@ -157,7 +134,6 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -182,7 +158,6 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -206,7 +181,6 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -230,7 +204,6 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [] };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -246,7 +219,6 @@ describe( 'CheckoutMain', () => {
 		const additionalProps = { productAliasFromUrl: 'personal' };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -263,7 +235,6 @@ describe( 'CheckoutMain', () => {
 		const additionalProps = { productAliasFromUrl: 'personal' };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -285,7 +256,6 @@ describe( 'CheckoutMain', () => {
 		const additionalProps = { productAliasFromUrl: 'jetpack_scan' };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -307,7 +277,6 @@ describe( 'CheckoutMain', () => {
 		const additionalProps = { productAliasFromUrl: 'jetpack_scan,jetpack_backup_daily' };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -334,7 +303,6 @@ describe( 'CheckoutMain', () => {
 
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -359,7 +327,6 @@ describe( 'CheckoutMain', () => {
 
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -380,7 +347,6 @@ describe( 'CheckoutMain', () => {
 		await act( async () => {
 			render(
 				<MockCheckout
-					mainCartKey={ mainCartKey }
 					initialCart={ initialCart }
 					setCart={ mockSetCartEndpoint }
 					cartChanges={ cartChanges }
@@ -396,7 +362,6 @@ describe( 'CheckoutMain', () => {
 		const additionalProps = { productAliasFromUrl: 'concierge-session' };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -419,7 +384,6 @@ describe( 'CheckoutMain', () => {
 		await act( async () => {
 			render(
 				<MockCheckout
-					mainCartKey={ mainCartKey }
 					initialCart={ initialCart }
 					setCart={ mockSetCartEndpoint }
 					cartChanges={ cartChanges }
@@ -435,7 +399,6 @@ describe( 'CheckoutMain', () => {
 		const additionalProps = { productAliasFromUrl: 'theme:ovation' };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -461,7 +424,6 @@ describe( 'CheckoutMain', () => {
 		};
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				additionalProps={ additionalProps }
@@ -482,7 +444,6 @@ describe( 'CheckoutMain', () => {
 		};
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				additionalProps={ additionalProps }
@@ -499,7 +460,6 @@ describe( 'CheckoutMain', () => {
 		await act( async () => {
 			render(
 				<MockCheckout
-					mainCartKey={ mainCartKey }
 					initialCart={ initialCart }
 					setCart={ mockSetCartEndpoint }
 					cartChanges={ cartChanges }
@@ -515,7 +475,6 @@ describe( 'CheckoutMain', () => {
 		const additionalProps = { productAliasFromUrl: 'domain-mapping:bar.com' };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -538,7 +497,6 @@ describe( 'CheckoutMain', () => {
 		const additionalProps = { productAliasFromUrl: 'personal-bundle', purchaseId: '12345' };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -557,7 +515,6 @@ describe( 'CheckoutMain', () => {
 		const additionalProps = { productAliasFromUrl: 'domain_reg:foo.cash', purchaseId: '12345' };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -575,7 +532,6 @@ describe( 'CheckoutMain', () => {
 		const additionalProps = { productAliasFromUrl: 'domain_map:bar.com', purchaseId: '12345' };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -596,7 +552,6 @@ describe( 'CheckoutMain', () => {
 		};
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -617,9 +572,10 @@ describe( 'CheckoutMain', () => {
 			purchaseId: '12345',
 			siteId: 0,
 		};
+
+		( useCartKey as jest.Mock ).mockImplementation( () => 'no-site' );
 		render(
 			<MockCheckout
-				mainCartKey="no-site"
 				cartChanges={ cartChanges }
 				additionalProps={ additionalProps }
 				initialCart={ initialCart }
@@ -660,9 +616,10 @@ describe( 'CheckoutMain', () => {
 			isNoSiteCart: false,
 			isGiftPurchase: true,
 		};
+
+		( useCartKey as jest.Mock ).mockImplementation( () => 'no-site' );
 		render(
 			<MockCheckout
-				mainCartKey="no-site"
 				cartChanges={ cartChanges }
 				additionalProps={ additionalProps }
 				initialCart={ initialCart }
@@ -686,7 +643,6 @@ describe( 'CheckoutMain', () => {
 		};
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -704,14 +660,9 @@ describe( 'CheckoutMain', () => {
 	} );
 
 	it( 'displays loading while cart key is undefined (eg: when cart store has pending updates)', async () => {
+		( useCartKey as jest.Mock ).mockImplementation( () => undefined );
 		await act( async () => {
-			render(
-				<MockCheckout
-					mainCartKey={ undefined }
-					initialCart={ initialCart }
-					setCart={ mockSetCartEndpoint }
-				/>
-			);
+			render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
 		} );
 		expect( screen.getByText( 'Loading checkout' ) ).toBeInTheDocument();
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -650,6 +650,35 @@ describe( 'CheckoutMain', () => {
 		);
 	} );
 
+	it( 'adds the product to the cart for a gift renewal', async () => {
+		const cartChanges = { products: [] };
+		const additionalProps = {
+			productAliasFromUrl: 'personal-bundle',
+			purchaseId: '12345',
+			siteId: 0,
+			siteSlug: 'no-site',
+			couponCode: null,
+			isLoggedOutCart: false,
+			isNoSiteCart: false,
+			isGiftPurchase: true,
+		};
+		render(
+			<MockCheckout
+				mainCartKey="no-site"
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+			/>
+		);
+		await waitFor( async () => {
+			expect( navigate ).not.toHaveBeenCalled();
+		} );
+		expect( await screen.findByText( /WordPress.com Personal/ ) ).toBeInTheDocument();
+		expect( await screen.findByText( 'Gift' ) ).toBeInTheDocument();
+		expect( errorNotice ).not.toHaveBeenCalled();
+	} );
+
 	it( 'adds the coupon to the cart when the url has a coupon code', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		const additionalProps = {

--- a/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.tsx
@@ -3,6 +3,7 @@
  */
 import { render, screen, waitFor } from '@testing-library/react';
 import { dispatch } from '@wordpress/data';
+import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
@@ -51,6 +52,7 @@ describe( 'Checkout payment methods list', () => {
 		getDomainsBySiteId.mockImplementation( () => [] );
 		isMarketplaceProduct.mockImplementation( () => false );
 		isJetpackSite.mockImplementation( () => false );
+		( useCartKey as jest.Mock ).mockImplementation( () => mainCartKey );
 
 		mockGetPaymentMethodsEndpoint( [] );
 		mockLogStashEndpoint();
@@ -60,26 +62,14 @@ describe( 'Checkout payment methods list', () => {
 	} );
 
 	it( 'renders the paypal payment method option', async () => {
-		render(
-			<MockCheckout
-				mainCartKey={ mainCartKey }
-				initialCart={ initialCart }
-				setCart={ mockSetCartEndpoint }
-			/>
-		);
+		render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
 		await waitFor( () => {
 			expect( screen.getByText( 'PayPal' ) ).toBeInTheDocument();
 		} );
 	} );
 
 	it( 'does not render the full credits payment method option when no credits are available', async () => {
-		render(
-			<MockCheckout
-				mainCartKey={ mainCartKey }
-				initialCart={ initialCart }
-				setCart={ mockSetCartEndpoint }
-			/>
-		);
+		render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
 		await waitFor( () => {
 			expect( screen.queryByText( /WordPress.com Credits:/ ) ).not.toBeInTheDocument();
 		} );
@@ -89,7 +79,6 @@ describe( 'Checkout payment methods list', () => {
 		const cartChanges = { credits_integer: 15400, credits_display: 'R$154' };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -104,7 +93,6 @@ describe( 'Checkout payment methods list', () => {
 		const cartChanges = { credits_integer: 15400, credits_display: 'R$154' };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -124,7 +112,6 @@ describe( 'Checkout payment methods list', () => {
 		};
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -144,7 +131,6 @@ describe( 'Checkout payment methods list', () => {
 		};
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -156,13 +142,7 @@ describe( 'Checkout payment methods list', () => {
 	} );
 
 	it( 'does not render the free payment method option when the purchase is not free', async () => {
-		render(
-			<MockCheckout
-				mainCartKey={ mainCartKey }
-				initialCart={ initialCart }
-				setCart={ mockSetCartEndpoint }
-			/>
-		);
+		render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
 		await waitFor( () => {
 			expect( screen.queryByText( 'Free Purchase' ) ).not.toBeInTheDocument();
 		} );
@@ -172,7 +152,6 @@ describe( 'Checkout payment methods list', () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -196,7 +175,6 @@ describe( 'Checkout payment methods list', () => {
 		};
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -211,7 +189,6 @@ describe( 'Checkout payment methods list', () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }
@@ -226,7 +203,6 @@ describe( 'Checkout payment methods list', () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
 		render(
 			<MockCheckout
-				mainCartKey={ mainCartKey }
 				initialCart={ initialCart }
 				setCart={ mockSetCartEndpoint }
 				cartChanges={ cartChanges }

--- a/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
@@ -50,7 +50,6 @@ describe( 'Checkout contact step VAT form', () => {
 	const mainCartKey: CartKey = 'foo.com' as CartKey;
 	const initialCart = getBasicCart();
 	const defaultPropsForMockCheckout = {
-		mainCartKey,
 		initialCart,
 	};
 
@@ -61,7 +60,6 @@ describe( 'Checkout contact step VAT form', () => {
 	getDomainsBySiteId.mockImplementation( () => [] );
 	isMarketplaceProduct.mockImplementation( () => false );
 	isJetpackSite.mockImplementation( () => false );
-	useCartKey.mockImplementation( () => mainCartKey );
 	mockMatchMediaOnWindow();
 
 	const mockSetCartEndpoint = mockSetCartEndpointWith( {
@@ -71,6 +69,7 @@ describe( 'Checkout contact step VAT form', () => {
 
 	beforeEach( () => {
 		dispatch( CHECKOUT_STORE ).reset();
+		( useCartKey as jest.Mock ).mockImplementation( () => mainCartKey );
 		nock.cleanAll();
 		mockGetPaymentMethodsEndpoint( [] );
 		mockLogStashEndpoint();

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -10,7 +10,6 @@ import nock from 'nock';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import domainManagementReducer from 'calypso/state/domains/management/reducer';
-import type { StoredPaymentMethod } from '../../../../../lib/checkout/payment-methods';
 import type { PricedAPIPlan, StorePlanSlug } from '@automattic/data-stores';
 import type {
 	CartKey,
@@ -1602,16 +1601,6 @@ export const expectedCreateAccountRequest = {
 		viewport: '0x0',
 	},
 };
-
-export function mockStoredPaymentMethodsEndpoint( responseData: StoredPaymentMethod[] ): void {
-	const endpoint = jest.fn();
-	endpoint.mockReturnValue( true );
-	const mockResponse = () => [ 200, responseData ];
-	nock( 'https://public-api.wordpress.com' )
-		.persist()
-		.get( new RegExp( '^/rest/v1.2/me/payment-methods' ) )
-		.reply( mockResponse );
-}
 
 export function mockCachedContactDetailsEndpoint( responseData ): void {
 	const endpoint = jest.fn();

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -380,6 +380,8 @@ export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
 		const { products: requestProducts, coupon: requestCoupon } = requestCart;
 		const products = requestProducts.map( convertRequestProductToResponseProduct( currency ) );
 
+		const is_gift_purchase = requestProducts.some( ( product ) => product.extra.isGiftPurchase );
+
 		const taxInteger = products.reduce( ( accum, current ) => {
 			return accum + current.item_tax;
 		}, 0 );
@@ -389,6 +391,7 @@ export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
 		}, taxInteger );
 
 		return {
+			is_gift_purchase,
 			allowed_payment_methods: normalAllowedPaymentMethods,
 			blog_id: 1234,
 			cart_generated_at_timestamp: 12345,
@@ -838,7 +841,7 @@ function convertRequestProductToResponseProduct(
 					item_tax: 0,
 					meta: product.meta,
 					volume: 1,
-					extra: {},
+					extra: product.extra,
 				};
 			case 'domain_map':
 				return {

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -10,6 +10,7 @@ import nock from 'nock';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import domainManagementReducer from 'calypso/state/domains/management/reducer';
+import type { StoredPaymentMethod } from '../../../../../lib/checkout/payment-methods';
 import type { PricedAPIPlan, StorePlanSlug } from '@automattic/data-stores';
 import type {
 	CartKey,
@@ -1598,6 +1599,16 @@ export const expectedCreateAccountRequest = {
 		viewport: '0x0',
 	},
 };
+
+export function mockStoredPaymentMethodsEndpoint( responseData: StoredPaymentMethod[] ): void {
+	const endpoint = jest.fn();
+	endpoint.mockReturnValue( true );
+	const mockResponse = () => [ 200, responseData ];
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( new RegExp( '^/rest/v1.2/me/payment-methods' ) )
+		.reply( mockResponse );
+}
 
 export function mockCachedContactDetailsEndpoint( responseData ): void {
 	const endpoint = jest.fn();

--- a/client/my-sites/checkout/composite-checkout/test/util/mock-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/util/mock-checkout.tsx
@@ -12,18 +12,16 @@ import {
 	mockSetCartEndpointWith,
 	createTestReduxStore,
 } from './index';
-import type { CartKey, SetCart, ResponseCart } from '@automattic/shopping-cart';
+import type { SetCart, ResponseCart } from '@automattic/shopping-cart';
 
 export function MockCheckout( {
 	initialCart,
-	mainCartKey,
 	cartChanges,
 	additionalProps,
 	setCart,
 	useUndefinedSiteId,
 }: {
 	initialCart: ResponseCart;
-	mainCartKey: CartKey;
 	cartChanges?: Partial< ResponseCart >;
 	additionalProps?: Partial< PropsOf< typeof CheckoutMain > >;
 	setCart?: SetCart;
@@ -43,12 +41,7 @@ export function MockCheckout( {
 	return (
 		<ReduxProvider store={ reduxStore }>
 			<QueryClientProvider client={ queryClient }>
-				<ShoppingCartProvider
-					managerClient={ managerClient }
-					options={ {
-						defaultCartKey: mainCartKey,
-					} }
-				>
+				<ShoppingCartProvider managerClient={ managerClient }>
 					<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
 						<CheckoutMain
 							siteId={ useUndefinedSiteId ? undefined : siteId }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -118,6 +118,7 @@ export function checkout( context, next ) {
 	const jetpackSiteSlug = context.params.siteSlug;
 
 	const isGiftPurchase = context.pathname.includes( '/gift/' );
+	const isRenewal = context.pathname.includes( '/renew/' );
 
 	// Do not use Jetpack checkout for Jetpack Anti Spam
 	if ( 'jetpack_anti_spam' === context.params.productSlug ) {
@@ -133,6 +134,11 @@ export function checkout( context, next ) {
 			return true;
 		}
 		if ( isGiftPurchase ) {
+			return true;
+		}
+		// We allow renewals without a site through because we want to show these
+		// users an error message on the checkout page.
+		if ( isRenewal ) {
 			return true;
 		}
 		return false;

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -278,8 +278,16 @@ export default function () {
 		clientRender
 	);
 
-	// Visiting /renew without a domain is invalid and should be redirected to /me/purchases
-	page( '/checkout/:product/renew/:purchaseId', '/me/purchases' );
+	// A renewal link without a site is not allowed, but we send the user to
+	// checkout anyway so they can see a helpful error message.
+	page(
+		'/checkout/:product/renew/:purchaseId',
+		redirectLoggedOut,
+		noSite,
+		checkout,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		'/checkout/:product/renew/:purchaseId/:domain',

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -454,12 +454,16 @@ export function noSite( context, next ) {
 	const isJetpackCheckoutFlow = context.pathname.includes( '/checkout/jetpack' );
 	const isAkismetCheckoutFlow = context.pathname.includes( '/checkout/akismet' );
 	const isGiftCheckoutFlow = context.pathname.includes( '/gift/' );
+	const isRenewal = context.pathname.includes( '/renew/' );
 
 	if (
 		! isDomainOnlyFlow &&
 		! isJetpackCheckoutFlow &&
 		! isAkismetCheckoutFlow &&
 		! isGiftCheckoutFlow &&
+		// We allow renewals without a site through because we want to show these
+		// users an error message on the checkout page.
+		! isRenewal &&
 		hasSite
 	) {
 		siteSelection( context, next );


### PR DESCRIPTION
## Proposed Changes

When loading a checkout renewal URL where the site does not belong to the logged-in user, currently the user is redirected to their own `/me/purchases` page without an explanation. This is confusing and can cause problems if the user then tries to renew something they did not intend to.

In this PR we modify checkout so that renewal URLs (that are not gifts or siteless checkouts) with an invalid site (or with no site) will instead reach checkout and display a specific error message.

In addition, this alters checkout so that if it attempts to add renewal products from the URL and no valid renewal products exist (as is the case with an invalid site URL) it will clear the cart. This is because while the error message is being displayed, checkout will be showing the current cart for the `'no-site'` cart key, which could potentially have something in it from some previous operation. If that's the case, we don't want the user to see something in the cart that could imply their renewal URL was successful.

Fixes https://github.com/Automattic/wp-calypso/issues/75240

<img width="895" alt="Screenshot 2023-04-26 at 4 46 36 PM" src="https://user-images.githubusercontent.com/2036909/234698417-b431b2cf-d537-43b8-983b-985cab1bd406.png">

## Testing Instructions

Automated tests are included but you can test this manually.

- Visit an invalid renewal URL like `/checkout/personal-bundle/renew/12345/example.com`.
- Verify that you see an error message that tells you that the renewal is invalid and that the cart is empty.

- Add a gift purchase to your cart (instructions for gift purchases can be found in D92011-code). The URL will look something like `/checkout/personal-bundle/gift/12345`.
- Verify that checkout loads without an error message and that you see the "Gift" badge next to the product in the cart.
