### PR TITLE
DotOrg Theme: Update upsell URL to redirect to the theme installation page

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -48,6 +48,7 @@ import { connectOptions } from 'calypso/my-sites/themes/theme-options';
 import ThemePreview from 'calypso/my-sites/themes/theme-preview';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { isUserPaid } from 'calypso/state/purchases/selectors';
@@ -1236,11 +1237,12 @@ class ThemeSheet extends Component {
 		}
 
 		if ( hasWpOrgThemeUpsellBanner || hasThemeUpsellBannerAtomic ) {
-			const thisPageUrl = `/theme/${ themeId }/${ siteSlug }`;
+			const themeInstallationURL = `/marketplace/theme/${ themeId }/install/${ siteSlug }`;
 			pageUpsellBanner = (
 				<UpsellNudge
 					plan={ PLAN_BUSINESS }
 					className="theme__page-upsell-banner"
+					onClick={ () => this.props.setProductToBeInstalled( themeId, siteSlug ) }
 					title={ translate( 'Access this third-party theme with the Business plan!' ) }
 					description={ preventWidows(
 						translate(
@@ -1252,7 +1254,7 @@ class ThemeSheet extends Component {
 					forceDisplay
 					href={
 						siteId
-							? `/checkout/${ siteSlug }/business?redirect_to=${ thisPageUrl }`
+							? `/checkout/${ siteSlug }/business?redirect_to=${ themeInstallationURL }`
 							: localizeUrl( 'https://wordpress.com/start/business' )
 					}
 					showIcon
@@ -1511,5 +1513,6 @@ export default connect(
 		recordTracksEvent,
 		themeStartActivationSync: themeStartActivationSyncAction,
 		errorNotice,
+		setProductToBeInstalled: productToBeInstalled,
 	}
 )( withSiteGlobalStylesStatus( localize( ThemeSheetWithOptions ) ) );


### PR DESCRIPTION
Fixes [Marketplace: Redirect to the Thank You page after a Plan upgrade](https://github.com/Automattic/dotcom-forge/issues/2046)
Fixes #70759


## Proposed Changes

* Update upsell URL to redirect to the theme installation page
* Set the product to be installed state to have the selected theme

## Testing Instructions

* From a site without a business or e-commerce plan
* Go to a dotorg theme page. Ex: `/theme/astra/:site`
* Click on the Upsell banner

![CleanShot 2023-04-04 at 22 52 02@2x](https://user-images.githubusercontent.com/5039531/229960747-41c8d332-bbce-45ae-8a67-94bfbd65e5a7.png)

* Proceed with the purchase of the business plan
* You should be redirected to the theme installation page (with a progress bar)
* And then redirected to the Thank You page
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
