### PR TITLE
DotOrg Theme: Active theme on the Marketplace Theme Installation page

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -64,6 +64,17 @@ class ThanksModal extends Component {
 	}
 
 	static getDerivedStateFromProps( nextProps, prevState ) {
+		/**
+		 * Clear activation status and don't show the modal if the theme is not a WPCOM theme.
+		 */
+		if ( ! nextProps.isThemeWpcom && nextProps.siteId ) {
+			nextProps.clearActivated( nextProps.siteId );
+			return {
+				isVisible: false,
+				wasInstalling: nextProps.isInstalling,
+			};
+		}
+
 		if ( nextProps.isInstalling || nextProps.isActivating || nextProps.hasActivated ) {
 			return {
 				isVisible: true,

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import page from 'page';
+import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import { activateTheme } from 'calypso/state/themes/actions/activate-theme';
@@ -61,6 +62,8 @@ export function activate(
 		const isDotOrgTheme = !! getTheme( getState(), 'wporg', themeId );
 		if ( isDotOrgTheme ) {
 			const siteSlug = getSiteSlug( getState(), siteId );
+
+			dispatch( productToBeInstalled( themeId, siteSlug ) );
 			return page( `/marketplace/theme/${ themeId }/install/${ siteSlug }` );
 		}
 

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
+import page from 'page';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import { activateTheme } from 'calypso/state/themes/actions/activate-theme';
 import { installAndActivateTheme } from 'calypso/state/themes/actions/install-and-activate-theme';
 import { showAutoLoadingHomepageWarning } from 'calypso/state/themes/actions/show-auto-loading-homepage-warning';
@@ -54,6 +55,13 @@ export function activate(
 			! hasAutoLoadingHomepageModalAccepted( getState(), themeId )
 		) {
 			return dispatch( showAutoLoadingHomepageWarning( themeId ) );
+		}
+
+		// Check if the theme is a .org Theme and redirect it to the Marketplace theme installation page
+		const isDotOrgTheme = !! getTheme( getState(), 'wporg', themeId );
+		if ( isDotOrgTheme ) {
+			const siteSlug = getSiteSlug( getState(), siteId );
+			return page( `/marketplace/theme/${ themeId }/install/${ siteSlug }` );
 		}
 
 		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {


### PR DESCRIPTION
Fixes [Marketplace: Redirect to the Thank You page after activating a dotOrg Theme#2047](https://github.com/Automattic/dotcom-forge/issues/2047)

## Proposed Changes

* Redirect .org themes to the Marketplace Installation page
* Add intention to install a theme to be read on the Installation page


## Testing Instructions

* From a site with a business or e-commerce plan
* Go to a dotorg theme page. Ex: `/theme/astra/:site`
* Click on `Activate this design`
* You should be redirected to the theme installation page (with a progress bar)
* And then redirected to the Thank You page

![CleanShot 2023-04-04 at 23 13 48@2x](https://user-images.githubusercontent.com/5039531/229963662-bbafca22-e9cf-4be3-90f6-ff4840f82d04.png)


* Search for a dotorg plugin slug. Ex: `astra`
* From the card, click on the `activate` option
* You should see the same behavior as above

![CleanShot 2023-04-04 at 23 14 30@2x](https://user-images.githubusercontent.com/5039531/229963666-77ef56c9-112c-4eab-aee6-f970d691ea0d.png)

 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
