### PR TITLE
Signup: Attempt to handle redirect after Apple sign in

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1097,6 +1097,7 @@ class SignupForm extends Component {
 								handleResponse={ this.handleWooCommerceSocialConnect }
 								socialService={ this.props.socialService }
 								socialServiceResponse={ this.props.socialServiceResponse }
+								redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
 							/>
 						) }
 					</LoggedOutForm>
@@ -1170,6 +1171,7 @@ class SignupForm extends Component {
 							socialService={ this.props.socialService }
 							socialServiceResponse={ this.props.socialServiceResponse }
 							isReskinned={ this.props.isReskinned }
+							redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
 						/>
 					) }
 					{ this.props.footerLink || this.footerLink() }
@@ -1210,6 +1212,7 @@ class SignupForm extends Component {
 							isReskinned={ this.props.isReskinned }
 							flowName={ this.props.flowName }
 							compact={ this.props.isWoo }
+							redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
 						/>
 					</Fragment>
 				) }

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -117,7 +117,9 @@ class SocialSignupForm extends Component {
 							responseHandler={ this.handleGoogleResponse }
 							uxMode={ uxMode }
 							redirectUri={ this.getRedirectUri( 'google' ) }
-							onClick={ this.trackLoginAndRememberRedirect.bind( null, 'google' ) }
+							onClick={ () => {
+								this.trackLoginAndRememberRedirect( 'google' );
+							} }
 							socialServiceResponse={
 								this.props.socialService === 'google' ? this.props.socialServiceResponse : null
 							}
@@ -130,7 +132,9 @@ class SocialSignupForm extends Component {
 							responseHandler={ this.handleAppleResponse }
 							uxMode={ uxModeApple }
 							redirectUri={ this.getRedirectUri( 'apple' ) }
-							onClick={ this.trackLoginAndRememberRedirect.bind( null, 'apple' ) }
+							onClick={ () => {
+								this.trackLoginAndRememberRedirect( 'apple' );
+							} }
 							socialServiceResponse={
 								this.props.socialService === 'apple' ? this.props.socialServiceResponse : null
 							}

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -349,12 +349,18 @@ export class UserStep extends Component {
 			return;
 		}
 
+		const query = initialContext?.query || {};
+		if ( typeof window !== 'undefined' && window.sessionStorage.getItem( 'signup_redirect_to' ) ) {
+			query.redirect_to = window.sessionStorage.getItem( 'signup_redirect_to' );
+			window.sessionStorage.removeItem( 'signup_redirect_to' );
+		}
+
 		this.submit( {
 			service,
 			access_token,
 			id_token,
 			userData,
-			queryArgs: initialContext?.query || {},
+			queryArgs: query,
 		} );
 	};
 


### PR DESCRIPTION
There were several reports that using Apple sign in would break flows. The root issue here seems to be that we would default to redirecting the user back to `/start/user` after the social login was complete. While the user would be successfully logged in, this meant that the user was now in the main onboarding flow as opposed to whichever flow the user had entered from.

The biggest change here is to send the user back to the current flow and step that they're on after social signup, from which we then submit the signup step, which then allows us to continue on the flow. This is at least my best understanding.

One other change that is made in this PR is to persist the `redirect_to` query arg. This is useful in the case of the `/start/account/user` step and is used to allow us to redirect within WordPress.com after the user creates an account.

## Proposed Changes

* Support redirect after sign in with Apple.

## Testing Instructions

* Checkout PR
* Download ProxyMan app for Mac
* Enable MapRemote tool and set it up with the following arguments
<img width="1469" alt="Screenshot 2023-04-03 at 8 25 05 PM" src="https://user-images.githubusercontent.com/1126811/229675446-9f79f83c-28ce-439f-969c-5feab52cec2d.png">
- Choose a tailored case to work through. This has been tested with Link in Bio, Newsletter, and VideoPress, eCommerce, p2, and a few other flows so far.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
