### PR TITLE
Assembler: Add sidenav subheadings to differentiate between Structure and Styles

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-header/style.scss
@@ -28,7 +28,7 @@
 		line-height: 24px;
 		letter-spacing: -0.1px;
 		color: var(--color-neutral-60);
-		padding-bottom: 24px;
+		padding-bottom: 16px;
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/index.tsx
@@ -1,0 +1,19 @@
+// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import './style.scss';
+
+type Props = {
+	children: React.ReactNode;
+	title: string;
+};
+
+export const NavigatorItemGroup = ( { children, title }: Props ) => {
+	return (
+		<section>
+			<VStack spacing="0">
+				<h3 className="pattern-layout__label">{ title }</h3>
+				{ children }
+			</VStack>
+		</section>
+	);
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/index.tsx
@@ -13,7 +13,7 @@ export const NavigatorItemGroup = ( { children, title }: Props ) => {
 	return (
 		<section>
 			<HStack direction="column" alignment="top" spacing="0">
-				<h3 className="pattern-layout__label">{ title }</h3>
+				<h3 className="pattern-layout__navigator-item-group">{ title }</h3>
 				<ItemGroup>{ children }</ItemGroup>
 			</HStack>
 		</section>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/index.tsx
@@ -1,4 +1,7 @@
-import { __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalItemGroup as ItemGroup,
+} from '@wordpress/components';
 import './style.scss';
 
 type Props = {
@@ -11,7 +14,7 @@ export const NavigatorItemGroup = ( { children, title }: Props ) => {
 		<section>
 			<HStack direction="column" alignment="top" spacing="0">
 				<h3 className="pattern-layout__label">{ title }</h3>
-				{ children }
+				<ItemGroup>{ children }</ItemGroup>
 			</HStack>
 		</section>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/index.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import './style.scss';
 
 type Props = {
@@ -10,10 +9,10 @@ type Props = {
 export const NavigatorItemGroup = ( { children, title }: Props ) => {
 	return (
 		<section>
-			<VStack spacing="0">
+			<HStack direction="column" alignment="top" spacing="0">
 				<h3 className="pattern-layout__label">{ title }</h3>
 				{ children }
-			</VStack>
+			</HStack>
 		</section>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/style.scss
@@ -1,7 +1,7 @@
 @import "@automattic/typography/styles/fonts";
 
 .pattern-assembler {
-	.pattern-layout__label {
+	.pattern-layout__navigator-item-group {
 		color: var(--color-neutral-100);
 		font-size: $font-body-small;
 		font-weight: 500;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/style.scss
@@ -1,0 +1,12 @@
+@import "@automattic/typography/styles/fonts";
+
+.pattern-assembler {
+	.pattern-layout__label {
+		color: var(--color-neutral-100);
+		font-size: $font-body-small;
+		font-weight: 500;
+		letter-spacing: -0.15px;
+		line-height: 1.4;
+		padding: 0 10px;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -1,9 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
-import {
-	__experimentalItemGroup as ItemGroup,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { header, footer, layout, color, typography } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { NavigationButtonAsItem } from './navigator-buttons';
@@ -50,58 +47,52 @@ const ScreenMain = ( {
 			<div className="screen-container__body screen-container__body--align-sides">
 				<HStack direction="column" alignment="top" spacing="4">
 					<NavigatorItemGroup title={ translate( 'Layout' ) }>
-						<ItemGroup>
-							<NavigationButtonAsItem
-								path="/header"
-								icon={ header }
-								aria-label={ translate( 'Header' ) }
-								onClick={ () => onSelect( 'header' ) }
-							>
-								<span className="pattern-layout__list-item-text">{ translate( 'Header' ) }</span>
-							</NavigationButtonAsItem>
-							<NavigationButtonAsItem
-								path="/section"
-								icon={ layout }
-								aria-label={ translate( 'Sections' ) }
-								onClick={ () => onSelect( 'section' ) }
-							>
-								<span className="pattern-layout__list-item-text">{ translate( 'Sections' ) }</span>
-							</NavigationButtonAsItem>
-							<NavigationButtonAsItem
-								path="/footer"
-								icon={ footer }
-								aria-label={ translate( 'Footer' ) }
-								onClick={ () => onSelect( 'footer' ) }
-							>
-								<span className="pattern-layout__list-item-text">{ translate( 'Footer' ) }</span>
-							</NavigationButtonAsItem>
-						</ItemGroup>
+						<NavigationButtonAsItem
+							path="/header"
+							icon={ header }
+							aria-label={ translate( 'Header' ) }
+							onClick={ () => onSelect( 'header' ) }
+						>
+							<span className="pattern-layout__list-item-text">{ translate( 'Header' ) }</span>
+						</NavigationButtonAsItem>
+						<NavigationButtonAsItem
+							path="/section"
+							icon={ layout }
+							aria-label={ translate( 'Sections' ) }
+							onClick={ () => onSelect( 'section' ) }
+						>
+							<span className="pattern-layout__list-item-text">{ translate( 'Sections' ) }</span>
+						</NavigationButtonAsItem>
+						<NavigationButtonAsItem
+							path="/footer"
+							icon={ footer }
+							aria-label={ translate( 'Footer' ) }
+							onClick={ () => onSelect( 'footer' ) }
+						>
+							<span className="pattern-layout__list-item-text">{ translate( 'Footer' ) }</span>
+						</NavigationButtonAsItem>
 					</NavigatorItemGroup>
 					<NavigatorItemGroup title={ translate( 'Style' ) }>
-						<ItemGroup>
-							{ isEnabled( 'pattern-assembler/color-and-fonts' ) && (
-								<>
-									<NavigationButtonAsItem
-										path="/color-palettes"
-										icon={ color }
-										aria-label={ translate( 'Colors' ) }
-										onClick={ () => onSelect( 'color-palettes' ) }
-									>
-										<span className="pattern-layout__list-item-text">
-											{ translate( 'Colors' ) }
-										</span>
-									</NavigationButtonAsItem>
-									<NavigationButtonAsItem
-										path="/font-pairings"
-										icon={ typography }
-										aria-label={ translate( 'Fonts' ) }
-										onClick={ () => onSelect( 'font-pairings' ) }
-									>
-										<span className="pattern-layout__list-item-text">{ translate( 'Fonts' ) }</span>
-									</NavigationButtonAsItem>
-								</>
-							) }
-						</ItemGroup>
+						{ isEnabled( 'pattern-assembler/color-and-fonts' ) && (
+							<>
+								<NavigationButtonAsItem
+									path="/color-palettes"
+									icon={ color }
+									aria-label={ translate( 'Colors' ) }
+									onClick={ () => onSelect( 'color-palettes' ) }
+								>
+									<span className="pattern-layout__list-item-text">{ translate( 'Colors' ) }</span>
+								</NavigationButtonAsItem>
+								<NavigationButtonAsItem
+									path="/font-pairings"
+									icon={ typography }
+									aria-label={ translate( 'Fonts' ) }
+									onClick={ () => onSelect( 'font-pairings' ) }
+								>
+									<span className="pattern-layout__list-item-text">{ translate( 'Fonts' ) }</span>
+								</NavigationButtonAsItem>
+							</>
+						) }
 					</NavigatorItemGroup>
 				</HStack>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -2,8 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import {
 	__experimentalItemGroup as ItemGroup,
-	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
-	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { header, footer, layout, color, typography } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -49,7 +48,7 @@ const ScreenMain = ( {
 				hideBack
 			/>
 			<div className="screen-container__body screen-container__body--align-sides">
-				<VStack spacing="4">
+				<HStack direction="column" alignment="top" spacing="4">
 					<NavigatorItemGroup title={ translate( 'Layout' ) }>
 						<ItemGroup>
 							<NavigationButtonAsItem
@@ -104,7 +103,7 @@ const ScreenMain = ( {
 							) }
 						</ItemGroup>
 					</NavigatorItemGroup>
-				</VStack>
+				</HStack>
 			</div>
 			<div className="screen-container__footer">
 				<span className="screen-container__description">{ getDescription() }</span>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -1,10 +1,15 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
-import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
+import {
+	__experimentalItemGroup as ItemGroup,
+	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { header, footer, layout, color, typography } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { NavigationButtonAsItem } from './navigator-buttons';
 import NavigatorHeader from './navigator-header';
+import { NavigatorItemGroup } from './navigator-item-group';
 
 interface Props {
 	shouldUnlockGlobalStyles: boolean;
@@ -44,52 +49,62 @@ const ScreenMain = ( {
 				hideBack
 			/>
 			<div className="screen-container__body screen-container__body--align-sides">
-				<ItemGroup>
-					<NavigationButtonAsItem
-						path="/header"
-						icon={ header }
-						aria-label={ translate( 'Header' ) }
-						onClick={ () => onSelect( 'header' ) }
-					>
-						<span className="pattern-layout__list-item-text">{ translate( 'Header' ) }</span>
-					</NavigationButtonAsItem>
-					<NavigationButtonAsItem
-						path="/section"
-						icon={ layout }
-						aria-label={ translate( 'Sections' ) }
-						onClick={ () => onSelect( 'section' ) }
-					>
-						<span className="pattern-layout__list-item-text">{ translate( 'Sections' ) }</span>
-					</NavigationButtonAsItem>
-					<NavigationButtonAsItem
-						path="/footer"
-						icon={ footer }
-						aria-label={ translate( 'Footer' ) }
-						onClick={ () => onSelect( 'footer' ) }
-					>
-						<span className="pattern-layout__list-item-text">{ translate( 'Footer' ) }</span>
-					</NavigationButtonAsItem>
-					{ isEnabled( 'pattern-assembler/color-and-fonts' ) && (
-						<>
+				<VStack spacing="4">
+					<NavigatorItemGroup title={ translate( 'Layout' ) }>
+						<ItemGroup>
 							<NavigationButtonAsItem
-								path="/color-palettes"
-								icon={ color }
-								aria-label={ translate( 'Colors' ) }
-								onClick={ () => onSelect( 'color-palettes' ) }
+								path="/header"
+								icon={ header }
+								aria-label={ translate( 'Header' ) }
+								onClick={ () => onSelect( 'header' ) }
 							>
-								<span className="pattern-layout__list-item-text">{ translate( 'Colors' ) }</span>
+								<span className="pattern-layout__list-item-text">{ translate( 'Header' ) }</span>
 							</NavigationButtonAsItem>
 							<NavigationButtonAsItem
-								path="/font-pairings"
-								icon={ typography }
-								aria-label={ translate( 'Fonts' ) }
-								onClick={ () => onSelect( 'font-pairings' ) }
+								path="/section"
+								icon={ layout }
+								aria-label={ translate( 'Sections' ) }
+								onClick={ () => onSelect( 'section' ) }
 							>
-								<span className="pattern-layout__list-item-text">{ translate( 'Fonts' ) }</span>
+								<span className="pattern-layout__list-item-text">{ translate( 'Sections' ) }</span>
 							</NavigationButtonAsItem>
-						</>
-					) }
-				</ItemGroup>
+							<NavigationButtonAsItem
+								path="/footer"
+								icon={ footer }
+								aria-label={ translate( 'Footer' ) }
+								onClick={ () => onSelect( 'footer' ) }
+							>
+								<span className="pattern-layout__list-item-text">{ translate( 'Footer' ) }</span>
+							</NavigationButtonAsItem>
+						</ItemGroup>
+					</NavigatorItemGroup>
+					<NavigatorItemGroup title={ translate( 'Style' ) }>
+						<ItemGroup>
+							{ isEnabled( 'pattern-assembler/color-and-fonts' ) && (
+								<>
+									<NavigationButtonAsItem
+										path="/color-palettes"
+										icon={ color }
+										aria-label={ translate( 'Colors' ) }
+										onClick={ () => onSelect( 'color-palettes' ) }
+									>
+										<span className="pattern-layout__list-item-text">
+											{ translate( 'Colors' ) }
+										</span>
+									</NavigationButtonAsItem>
+									<NavigationButtonAsItem
+										path="/font-pairings"
+										icon={ typography }
+										aria-label={ translate( 'Fonts' ) }
+										onClick={ () => onSelect( 'font-pairings' ) }
+									>
+										<span className="pattern-layout__list-item-text">{ translate( 'Fonts' ) }</span>
+									</NavigationButtonAsItem>
+								</>
+							) }
+						</ItemGroup>
+					</NavigatorItemGroup>
+				</VStack>
 			</div>
 			<div className="screen-container__footer">
 				<span className="screen-container__description">{ getDescription() }</span>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -72,8 +72,8 @@ const ScreenMain = ( {
 							<span className="pattern-layout__list-item-text">{ translate( 'Footer' ) }</span>
 						</NavigationButtonAsItem>
 					</NavigatorItemGroup>
-					<NavigatorItemGroup title={ translate( 'Style' ) }>
-						{ isEnabled( 'pattern-assembler/color-and-fonts' ) && (
+					{ isEnabled( 'pattern-assembler/color-and-fonts' ) && (
+						<NavigatorItemGroup title={ translate( 'Style' ) }>
 							<>
 								<NavigationButtonAsItem
 									path="/color-palettes"
@@ -92,8 +92,8 @@ const ScreenMain = ( {
 									<span className="pattern-layout__list-item-text">{ translate( 'Fonts' ) }</span>
 								</NavigationButtonAsItem>
 							</>
-						) }
-					</NavigatorItemGroup>
+						</NavigatorItemGroup>
+					) }
 				</HStack>
 			</div>
 			<div className="screen-container__footer">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74945

## Proposed Changes

* Provide visual space and subheadings to differentiate between Structure and Styles.

(We better review this PR with [hiding white space](https://github.com/Automattic/wp-calypso/pull/75321/files?w=1).)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a new site and go to the Site Assembler
- See subheadings: `Layout`, `Styles`

c.f. the Figma link: p1680279755023999-slack-CRWCHQGUB

| Before | After |
|--------|--------|
| <img width="316" alt="Screen Shot 2023-04-12 at 16 34 20" src="https://user-images.githubusercontent.com/5287479/231385645-8ed1c6a0-a2d1-487f-8e4e-9195cd5f2358.png"> | <img width="354" alt="Screen Shot 2023-04-05 at 14 19 57" src="https://user-images.githubusercontent.com/5287479/229987810-10a7261e-55b1-4f97-b1c5-a1a800fb8be0.png"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?