### PR TITLE
Fix wrong position of popover when window is resized in between mounts

### DIFF
--- a/packages/components/src/popover/index.jsx
+++ b/packages/components/src/popover/index.jsx
@@ -8,6 +8,7 @@ import RootChild from '../root-child';
 import {
 	bindWindowListeners,
 	unbindWindowListeners,
+	onViewportChange,
 	suggested as suggestPosition,
 	constrainLeft,
 	offset,
@@ -58,6 +59,9 @@ class PopoverInner extends Component {
 	};
 
 	componentDidMount() {
+		// make sure to set the viewport when mounting, because it might have been changed between two mounts of this
+		// component, e.g. when the viewport is changed while the popover is hidden
+		onViewportChange();
 		this.bindListeners();
 		this.setPosition();
 		this.show();

--- a/packages/components/src/popover/util.js
+++ b/packages/components/src/popover/util.js
@@ -37,7 +37,7 @@ function getViewport() {
 	return _viewport;
 }
 
-function onViewportChange() {
+export function onViewportChange() {
 	_viewport = updateViewport();
 }
 


### PR DESCRIPTION
Closes #75282

## Proposed Changes

When you resize the window between mounts of the Popover component, the position of the popover may be incorrect. This can occur when you initially have the window at a smaller size, and then resize it to a wider one. The position of the popover is limited by the initial smaller window size.


## Testing Instructions

- Apply this PR and ensure a valid subkey cookie is set. 
- Navigate to `http://calypso.localhost:3000/subscriptions/sites`. 
- Resize your window to a small size (e.g. 320px). 
- Click the three dots. 
- Resize your window to full size. 
- Click the three dots again. 
- The position should be correct and **not** as observed in this screen recording.

https://user-images.githubusercontent.com/3832570/229819323-81f65681-e21b-4e9c-9cc2-c3ca031c4c2d.mov

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
