### PR TITLE
Site Assembler - All Dotcom patterns and categories with feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
@@ -9,10 +9,6 @@ const useDotcomPatterns = (
 	const { data } = useQuery< any, unknown, Pattern[] >(
 		[ lang, 'patterns' ],
 		() => {
-			if ( ! lang ) {
-				return [];
-			}
-
 			return wpcomRequest( {
 				path: `/ptk/patterns/${ lang }`,
 				method: 'GET',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
@@ -10,7 +10,7 @@ const useDotcomPatterns = (
 		[ lang, 'patterns' ],
 		() => {
 			return wpcomRequest( {
-				path: `/ptk/patterns/es`,
+				path: `/ptk/patterns/${ lang }`,
 				method: 'GET',
 				apiVersion: '1.1',
 				query: new URLSearchParams( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
@@ -10,7 +10,7 @@ const useDotcomPatterns = (
 		[ lang, 'patterns' ],
 		() => {
 			return wpcomRequest( {
-				path: `/ptk/patterns/${ lang }`,
+				path: `/ptk/patterns/es`,
 				method: 'GET',
 				apiVersion: '1.1',
 				query: new URLSearchParams( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
@@ -1,0 +1,40 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { Pattern } from '../types';
+
+const useDotcomPatterns = (
+	lang?: string,
+	queryOptions: UseQueryOptions< any, unknown, Pattern[] > = {}
+): Pattern[] => {
+	const { data } = useQuery< any, unknown, Pattern[] >(
+		[ lang, 'patterns' ],
+		() => {
+			if ( ! lang ) {
+				return [];
+			}
+
+			return wpcomRequest( {
+				path: `/ptk/patterns/${ lang }`,
+				method: 'GET',
+				apiVersion: '1.1',
+				query: new URLSearchParams( {
+					tags: 'pattern',
+					pattern_meta: 'is_web',
+				} ).toString(),
+			} );
+		},
+		{
+			...queryOptions,
+			staleTime: Infinity,
+			enabled: !! lang,
+			meta: {
+				persist: false,
+				...queryOptions.meta,
+			},
+		}
+	);
+
+	return data ?? [];
+};
+
+export default useDotcomPatterns;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-categories.ts
@@ -3,15 +3,14 @@ import wpcom from 'calypso/lib/wp';
 import type { Category } from '../types';
 
 const usePatternCategories = (
-	siteId: number | undefined,
+	siteId: undefined | number = 0,
 	queryOptions: UseQueryOptions< any, unknown, Category[] > = {}
 ): Category[] => {
 	const { data } = useQuery< any, unknown, Category[] >(
 		[ siteId, 'block-patterns', 'categories' ],
 		() => {
 			return wpcom.req.get( {
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				path: `/sites/${ encodeURIComponent( siteId! ) }/block-patterns/categories`,
+				path: `/sites/${ encodeURIComponent( siteId ) }/block-patterns/categories`,
 				apiNamespace: 'wp/v2',
 			} );
 		},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-categories.ts
@@ -1,21 +1,20 @@
-import { useQuery, UseQueryResult, UseQueryOptions } from 'react-query';
+import { useQuery, UseQueryOptions } from 'react-query';
 import wpcom from 'calypso/lib/wp';
+import type { Category } from '../types';
 
 const usePatternCategories = (
 	siteId: number | undefined,
-	queryOptions: UseQueryOptions = {}
-): UseQueryResult => {
-	return useQuery< any, unknown, unknown >(
+	queryOptions: UseQueryOptions< any, unknown, Category[] > = {}
+): Category[] => {
+	const { data } = useQuery< any, unknown, Category[] >(
 		[ siteId, 'block-patterns', 'categories' ],
 		() => {
-			if ( ! siteId ) {
-				return [];
+			if ( siteId ) {
+				return wpcom.req.get( {
+					path: `/sites/${ encodeURIComponent( siteId ) }/block-patterns/categories`,
+					apiNamespace: 'wp/v2',
+				} );
 			}
-
-			return wpcom.req.get( {
-				path: `/sites/${ encodeURIComponent( siteId ) }/block-patterns/categories`,
-				apiNamespace: 'wp/v2',
-			} );
 		},
 		{
 			...queryOptions,
@@ -26,6 +25,7 @@ const usePatternCategories = (
 			},
 		}
 	);
+	return data ?? [];
 };
 
 export default usePatternCategories;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-categories.ts
@@ -9,16 +9,16 @@ const usePatternCategories = (
 	const { data } = useQuery< any, unknown, Category[] >(
 		[ siteId, 'block-patterns', 'categories' ],
 		() => {
-			if ( siteId ) {
-				return wpcom.req.get( {
-					path: `/sites/${ encodeURIComponent( siteId ) }/block-patterns/categories`,
-					apiNamespace: 'wp/v2',
-				} );
-			}
+			return wpcom.req.get( {
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				path: `/sites/${ encodeURIComponent( siteId! ) }/block-patterns/categories`,
+				apiNamespace: 'wp/v2',
+			} );
 		},
 		{
 			...queryOptions,
 			staleTime: Infinity,
+			enabled: !! siteId,
 			meta: {
 				persist: false,
 				...queryOptions.meta,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -77,6 +77,10 @@ const PatternAssembler = ( {
 
 	// Fetching all patterns and categories
 	const allPatterns = useAllPatterns( site?.lang );
+	const patternIds = useMemo(
+		() => allPatterns.map( ( pattern ) => encodePatternId( pattern.ID ) ),
+		[ allPatterns ]
+	);
 	const categories = usePatternCategories( site?.ID );
 	const patternsMapByCategory = usePatternsMapByCategory( allPatterns, categories );
 	const {
@@ -609,7 +613,7 @@ const PatternAssembler = ( {
 				<PatternAssemblerContainer
 					siteId={ site?.ID }
 					stylesheet={ stylesheet }
-					patternIds={ allPatterns.map( ( pattern ) => encodePatternId( pattern.ID ) ) }
+					patternIds={ patternIds }
 					siteInfo={ siteInfo }
 				>
 					{ stepContent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -39,7 +39,7 @@ import ScreenMain from './screen-main';
 import ScreenSection from './screen-section';
 import { encodePatternId } from './utils';
 import withGlobalStylesProvider from './with-global-styles-provider';
-import type { Pattern, Category } from './types';
+import type { Pattern } from './types';
 import type { StepProps } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { DesignRecipe, Design } from '@automattic/design-picker/src/types';
@@ -74,11 +74,10 @@ const PatternAssembler = ( {
 	const siteSlug = useSiteSlugParam();
 	const siteId = useSiteIdParam();
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
-	const allPatterns = useAllPatterns();
 
-	// Fetching the categories so they are ready when ScreenCategoryList loads
-	const categoriesQuery = usePatternCategories( site?.ID );
-	const categories = ( categoriesQuery?.data || [] ) as Category[];
+	// Fetching all patterns and categories
+	const allPatterns = useAllPatterns( site?.lang );
+	const categories = usePatternCategories( site?.ID );
 	const patternsMapByCategory = usePatternsMapByCategory( allPatterns, categories );
 	const {
 		header,
@@ -500,6 +499,7 @@ const PatternAssembler = ( {
 						onBack={ () => onPatternSelectorBack( 'header' ) }
 						onDoneClick={ () => onDoneClick( 'header' ) }
 						updateActivePatternPosition={ () => updateActivePatternPosition( -1 ) }
+						patterns={ patternsMapByCategory[ 'header' ] }
 					/>
 				</NavigatorScreen>
 
@@ -510,6 +510,7 @@ const PatternAssembler = ( {
 						onBack={ () => onPatternSelectorBack( 'footer' ) }
 						onDoneClick={ () => onDoneClick( 'footer' ) }
 						updateActivePatternPosition={ () => activateFooterPosition( !! footer ) }
+						patterns={ patternsMapByCategory[ 'footer' ] }
 					/>
 				</NavigatorScreen>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -499,7 +499,7 @@ const PatternAssembler = ( {
 						onBack={ () => onPatternSelectorBack( 'header' ) }
 						onDoneClick={ () => onDoneClick( 'header' ) }
 						updateActivePatternPosition={ () => updateActivePatternPosition( -1 ) }
-						patterns={ patternsMapByCategory[ 'header' ] }
+						patterns={ patternsMapByCategory[ 'header' ] || [] }
 					/>
 				</NavigatorScreen>
 
@@ -510,7 +510,7 @@ const PatternAssembler = ( {
 						onBack={ () => onPatternSelectorBack( 'footer' ) }
 						onDoneClick={ () => onDoneClick( 'footer' ) }
 						updateActivePatternPosition={ () => activateFooterPosition( !! footer ) }
-						patterns={ patternsMapByCategory[ 'footer' ] }
+						patterns={ patternsMapByCategory[ 'footer' ] || [] }
 					/>
 				</NavigatorScreen>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -10,7 +10,7 @@ type PatternSelectorProps = {
 };
 
 const PatternSelector = ( {
-	patterns,
+	patterns = [],
 	onSelect,
 	selectedPattern,
 	emptyPatternText,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -1,7 +1,9 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useMemo } from 'react';
+import useDotcomPatterns from './hooks/use-dotcom-patterns';
 import type { Pattern } from './types';
 
-const useHeaderPatterns = () => {
+const useHeaderPatterns = ( dotcomHeaderPatterns: Pattern[] ) => {
 	const header = {
 		slug: 'header',
 	};
@@ -79,10 +81,14 @@ const useHeaderPatterns = () => {
 		[]
 	);
 
+	if ( isEnabled( 'pattern-assembler/dotcompatterns' ) ) {
+		return dotcomHeaderPatterns;
+	}
+
 	return headerPatterns;
 };
 
-const useFooterPatterns = () => {
+const useFooterPatterns = ( dotcomFooterPatterns: Pattern[] ) => {
 	const footer = {
 		slug: 'footer',
 	};
@@ -195,6 +201,10 @@ const useFooterPatterns = () => {
 		],
 		[]
 	);
+
+	if ( isEnabled( 'pattern-assembler/dotcompatterns' ) ) {
+		return dotcomFooterPatterns;
+	}
 
 	return footerPatterns;
 };
@@ -574,10 +584,15 @@ const useSectionPatterns = () => {
 	return sectionPatterns;
 };
 
-const useAllPatterns = () => {
-	const headerPatterns = useHeaderPatterns();
+const useAllPatterns = ( lang: string | undefined ) => {
+	const headerPatterns = useHeaderPatterns( [] );
 	const sectionPatterns = useSectionPatterns();
-	const footerPatterns = useFooterPatterns();
+	const footerPatterns = useFooterPatterns( [] );
+	const dotcomPatterns = useDotcomPatterns( lang );
+
+	if ( isEnabled( 'pattern-assembler/dotcompatterns' ) ) {
+		return dotcomPatterns;
+	}
 
 	return [ ...headerPatterns, ...sectionPatterns, ...footerPatterns ];
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-footer.tsx
@@ -13,6 +13,7 @@ interface Props {
 	onBack: () => void;
 	onDoneClick: () => void;
 	updateActivePatternPosition: () => void;
+	patterns: Pattern[];
 }
 
 const ScreenFooter = ( {
@@ -21,9 +22,10 @@ const ScreenFooter = ( {
 	onBack,
 	onDoneClick,
 	updateActivePatternPosition,
+	patterns,
 }: Props ) => {
 	const translate = useTranslate();
-	const patterns = useFooterPatterns();
+	const footerPatterns = useFooterPatterns( patterns );
 	useEffect( () => {
 		updateActivePatternPosition();
 	}, [ updateActivePatternPosition ] );
@@ -39,7 +41,7 @@ const ScreenFooter = ( {
 			/>
 			<div className="screen-container__body">
 				<PatternSelector
-					patterns={ patterns }
+					patterns={ footerPatterns }
 					onSelect={ ( selectedPattern ) => onSelect( 'footer', selectedPattern, 'footer' ) }
 					selectedPattern={ selectedPattern }
 					emptyPatternText={ translate( 'No Footer' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-header.tsx
@@ -13,6 +13,7 @@ interface Props {
 	onBack: () => void;
 	onDoneClick: () => void;
 	updateActivePatternPosition: () => void;
+	patterns: Pattern[];
 }
 
 const ScreenHeader = ( {
@@ -21,9 +22,10 @@ const ScreenHeader = ( {
 	onBack,
 	onDoneClick,
 	updateActivePatternPosition,
+	patterns,
 }: Props ) => {
 	const translate = useTranslate();
-	const patterns = useHeaderPatterns();
+	const headerPatterns = useHeaderPatterns( patterns );
 	useEffect( () => {
 		updateActivePatternPosition();
 	}, [ updateActivePatternPosition ] );
@@ -39,7 +41,7 @@ const ScreenHeader = ( {
 			/>
 			<div className="screen-container__body">
 				<PatternSelector
-					patterns={ patterns }
+					patterns={ headerPatterns }
 					onSelect={ ( selectedPattern ) => onSelect( 'header', selectedPattern, 'header' ) }
 					selectedPattern={ selectedPattern }
 					emptyPatternText={ translate( 'No Header' ) }

--- a/config/development.json
+++ b/config/development.json
@@ -133,6 +133,7 @@
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/color-and-fonts": true,
+		"pattern-assembler/dotcompatterns": true,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/inline-styles": true,
 		"pattern-assembler/notices": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -83,6 +83,7 @@
 		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/color-and-fonts": true,
+		"pattern-assembler/dotcompatterns": true,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/inline-styles": true,
 		"pattern-assembler/notices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -98,6 +98,7 @@
 		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/color-and-fonts": false,
+		"pattern-assembler/dotcompatterns": false,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/inline-styles": false,
 		"pattern-assembler/notices": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -96,6 +96,7 @@
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/color-and-fonts": false,
+		"pattern-assembler/dotcompatterns": false,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/inline-styles": true,
 		"pattern-assembler/notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -107,6 +107,7 @@
 		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/color-and-fonts": true,
+		"pattern-assembler/dotcompatterns": true,
 		"pattern-assembler/logged-out-showcase": true,
 		"pattern-assembler/inline-styles": true,
 		"pattern-assembler/notices": true,

--- a/packages/block-renderer/src/hooks/use-rendered-patterns.ts
+++ b/packages/block-renderer/src/hooks/use-rendered-patterns.ts
@@ -41,11 +41,15 @@ const useRenderedPatterns = (
 ) => {
 	const [ renderedPatterns, setRenderedPatterns ] = useState( {} );
 
-	// If we query too many patterns at once, the endpoint will be very slow.
-	// Hence, do local pagination to ensure the performance.
-	const totalPage = Math.ceil( patternIds.length / PAGE_SIZE );
-
 	useEffect( () => {
+		if ( ! patternIds.length ) {
+			return;
+		}
+
+		// If we query too many patterns at once, the endpoint will be very slow.
+		// Hence, do local pagination to ensure the performance.
+		const totalPage = Math.ceil( patternIds.length / PAGE_SIZE );
+
 		const promises = [];
 		for ( let i = 0; i < totalPage; i++ ) {
 			promises.push( fetchRenderedPatterns( siteId, stylesheet, patternIds, siteInfo, i ) );
@@ -56,7 +60,7 @@ const useRenderedPatterns = (
 				pages.reduce( ( previous, current ) => ( { ...previous, ...current } ), {} )
 			);
 		} );
-	}, [] );
+	}, [ patternIds ] );
 
 	return renderedPatterns;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Related #74957
Closes #74926

https://user-images.githubusercontent.com/1881481/230029846-7bd65b85-a41a-4f85-80bd-8ecee1f5cd05.mov


## Proposed Changes

* Enable the feature flag `pattern-assembler/dotcompatterns` on Calypso and Horizon
* Fetch all `is_web` patterns from `dotcompatterns` using the PTK endpoint

The `is_web` patterns are the same patterns loaded in the editor.



<details>
<summary>Original video demo</summary>

https://user-images.githubusercontent.com/1881481/227953796-6ecb40bb-7648-48fc-a0a9-42f14dc5b5e7.mov
</details>

## Known issues

- Patterns don't appear translated, we'll follow up with another PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Onboarding Flow**

* Use the `Calypso live` link on the [first comment below](https://github.com/Automattic/wp-calypso/pull/74957#issuecomment-1485106698)
* Create a new site and continue until the Design Picker
* Click `Start designing` from the bottom of the design picker 
* Choose a header, then `Save`
* Choose a footer, then `Save`
* Click `Sections` 
* Click `Add patterns` to explore the categories and add patterns
* Replace, order, and delete patterns
* Click `Continue` and verify the patterns are added to a Home template on your site

**Logged-out Theme Showcase Flow**

* Log out
* Head to `wordpress.com/themes`
* Scroll down and click `Start designing`
* Log in
* Click `Sections` 
* Click `Add patterns` to explore the categories and add patterns
* Replace, order, and delete patterns
* Click `Continue` and verify the patterns are added to a Home template on your site

**Virtual Themes Flow**

Note that in a previous [commit](https://github.com/Automattic/wp-calypso/pull/75159/commits/2c27cadec1e2ae2e8c6948f792d5697b578e1213) we avoided adding into the assembler the virtual theme pattern. After this PR is merged, we could follow up with another PR to preselect them.

* Use the `Calypso live` link on the first comment
* Create a new site and continue until the Design Picker
* Add the flag `&flags=virtual-themes/onboarding` in the URL and hit `Enter`, the browser will be refreshed to show virtual themes 
* Click on the category `Single Page` to see the virtual themes. Their name starts with `Design your own:` 
* Click a virtual theme
* Click on `Start designing` to access the assembler to verify that the virtual theme pattern is not preselected. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
