### PR TITLE
Plans 2023: Notice reskin

### DIFF
--- a/client/components/notice/README.md
+++ b/client/components/notice/README.md
@@ -28,6 +28,7 @@ function MyNotice() {
 | `text`           | `string`   | null    | The message that shows in the notice.                                                 |
 | `showDismiss`    | `bool`     | true    | Whether to show a close action on the right of the notice.                            |
 | `isCompact`      | `bool`     | false   | Whether this is a compact notice (smaller and not full width).                        |
+| `isReskinned`    | `bool`     | false   | Whether to use the newer/updated version used for the plans pages.                    |
 | `duration`       | `integer`  | 0       | How long to show the notice for in milliseconds.                                      |
 | `onDismissClick` | `function` | null    | A function to call when the notice is dismissed.                                      |
 | `children`       | `string`   | null    | You can also pass the content on the notice within children.                          |

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -36,6 +36,7 @@ export class Notice extends Component {
 		onDismissClick: noop,
 		status: null,
 		text: null,
+		isReskinned: false,
 	};
 
 	static propTypes = {
@@ -49,6 +50,7 @@ export class Notice extends Component {
 		status: PropTypes.oneOf( [ 'is-error', 'is-info', 'is-success', 'is-warning', 'is-plain' ] ),
 		text: PropTypes.node,
 		translate: PropTypes.func.isRequired,
+		isReskinned: PropTypes.bool,
 	};
 
 	dismissTimeout = null;
@@ -109,11 +111,13 @@ export class Notice extends Component {
 			status,
 			text,
 			translate,
+			isReskinned,
 		} = this.props;
 		const classes = classnames( 'notice', status, className, {
 			'is-compact': isCompact,
 			'is-loading': isLoading,
 			'is-dismissable': showDismiss,
+			'is-reskinned': isReskinned,
 		} );
 
 		const iconName = icon || this.getIcon();

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -345,6 +345,11 @@ a.notice__action {
 			color: var(--studio-red-40);
 		}
 	}
+	&.is-plain {
+		.notice__icon-wrapper {
+			color: inherit;
+		}
+	}
 
 	// "X" for dismissing a notice
 	.notice__dismiss {

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -316,11 +316,15 @@ a.notice__action {
 	color: inherit;
 	border-radius: 4px;
 
+	.notice__content {
+		padding: 13px 0;
+	}
+
 	.notice__icon-wrapper {
 		border-top-left-radius: 4px;
 		border-bottom-left-radius: 4px;
 		background: var(--studio-gray-0);
-		padding: 13px;
+		padding: 16px;
 		align-items: flex-start;
 		width: unset;
 	}
@@ -346,7 +350,7 @@ a.notice__action {
 	.notice__dismiss {
 		display: flex;
 		flex-shrink: 0;
-		padding: 13px;
+		padding: 16px;
 		cursor: pointer;
 
 		.gridicon {

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -333,21 +333,37 @@ a.notice__action {
 	&.is-success {
 		.notice__icon-wrapper {
 			color: var(--studio-green-40);
+			background: var(--studio-gray-0);
+			.notice__icon-wrapper-drop {
+				background: var(--color-text-inverted);
+			}
 		}
 	}
 	&.is-warning {
 		.notice__icon-wrapper {
 			color: var(--studio-orange-40);
+			background: var(--studio-gray-0);
+			.notice__icon-wrapper-drop {
+				background: var(--color-text-inverted);
+			}
 		}
 	}
 	&.is-error {
 		.notice__icon-wrapper {
 			color: var(--studio-red-40);
+			background: var(--studio-gray-0);
+			.notice__icon-wrapper-drop {
+				background: var(--color-text-inverted);
+			}
 		}
 	}
 	&.is-plain {
 		.notice__icon-wrapper {
 			color: inherit;
+			background: var(--studio-gray-0);
+			.notice__icon-wrapper-drop {
+				background: var(--color-text-inverted);
+			}
 		}
 	}
 

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -310,3 +310,48 @@ a.notice__action {
 		}
 	}
 }
+
+.notice.is-reskinned {
+	background: var(--studio-gray-0);
+	color: inherit;
+	border-radius: 4px;
+
+	.notice__icon-wrapper {
+		border-top-left-radius: 4px;
+		border-bottom-left-radius: 4px;
+		background: var(--studio-gray-0);
+		padding: 13px;
+		align-items: flex-start;
+		width: unset;
+	}
+
+	&.is-info,
+	&.is-success {
+		.notice__icon-wrapper {
+			color: var(--studio-green-40);
+		}
+	}
+	&.is-warning {
+		.notice__icon-wrapper {
+			color: var(--studio-orange-40);
+		}
+	}
+	&.is-error {
+		.notice__icon-wrapper {
+			color: var(--studio-red-40);
+		}
+	}
+
+	// "X" for dismissing a notice
+	.notice__dismiss {
+		display: flex;
+		flex-shrink: 0;
+		padding: 13px;
+		cursor: pointer;
+
+		.gridicon {
+			width: 18px;
+			height: 18px;
+		}
+	}
+}

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -171,12 +171,12 @@
 
 .is-2023-pricing-grid .plans-wrapper {
 	margin: 0 auto;
-	padding: 28px 0 10px;
+	padding: 0 0 10px;
 	transform: translateY(-20px);
 	overflow-x: visible;
 
 	@include plans-2023-break-small {
-		padding-top: 60px;
+		padding-top: 35px; // enough to cover `plan-features-2023-grid__popular-badge` repositioning (top: -35px)
 	}
 }
 

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -176,7 +176,7 @@
 	overflow-x: visible;
 
 	@include plans-2023-break-small {
-		padding-top: 64px;
+		padding-top: 60px;
 	}
 }
 

--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -48,7 +48,7 @@ export default function PlanNotice( {
 				className="plan-features-main__notice"
 				showDismiss={ true }
 				onDismissClick={ handleDismissNotice }
-				status="is-info"
+				icon="info-outline"
 				isReskinned={ true }
 			>
 				{ translate(

--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -45,7 +45,7 @@ export default function PlanNotice( {
 	} else if ( ! canUserPurchasePlan ) {
 		return (
 			<Notice
-				className="plan-features__notice"
+				className="plan-features-main__notice"
 				showDismiss={ true }
 				onDismissClick={ handleDismissNotice }
 				status="is-info"
@@ -59,7 +59,7 @@ export default function PlanNotice( {
 	} else if ( activeDiscount ) {
 		return (
 			<Notice
-				className="plan-features__notice-credits"
+				className="plan-features-main__notice"
 				showDismiss={ true }
 				onDismissClick={ handleDismissNotice }
 				icon="info-outline"
@@ -78,7 +78,7 @@ export default function PlanNotice( {
 	} else if ( isPlanUpgradeCreditEligible ) {
 		return (
 			<Notice
-				className="plan-features__notice-credits"
+				className="plan-features-main__notice"
 				showDismiss={ true }
 				onDismissClick={ handleDismissNotice }
 				icon="info-outline"

--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -49,6 +49,7 @@ export default function PlanNotice( {
 				showDismiss={ true }
 				onDismissClick={ handleDismissNotice }
 				icon="info-outline"
+				status="is-success"
 				isReskinned={ true }
 			>
 				{ translate(

--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -49,6 +49,7 @@ export default function PlanNotice( {
 				showDismiss={ true }
 				onDismissClick={ handleDismissNotice }
 				status="is-info"
+				isReskinned={ true }
 			>
 				{ translate(
 					'This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner.'
@@ -63,6 +64,7 @@ export default function PlanNotice( {
 				onDismissClick={ handleDismissNotice }
 				icon="info-outline"
 				status="is-success"
+				isReskinned={ true }
 			>
 				{ activeDiscount?.plansPageNoticeTextTitle && (
 					<strong>
@@ -81,6 +83,7 @@ export default function PlanNotice( {
 				onDismissClick={ handleDismissNotice }
 				icon="info-outline"
 				status="is-success"
+				isReskinned={ true }
 			>
 				{ translate(
 					'You have {{b}}%(amountInCurrency)s{{/b}} of pro-rated credits available from your current plan. ' +

--- a/client/my-sites/plans-features-main/components/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/components/plan-type-selector.tsx
@@ -323,7 +323,7 @@ const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSig
 	display: ${ ( { isInSignup } ) => ( isInSignup ? 'flex' : 'block' ) };
 	align-content: space-between;
 	justify-content: center;
-	margin: 0 20px;
+	margin: 20px 20px 0;
 
 	> .segmented-control.is-compact:not( .is-signup ) {
 		margin: 8px auto 16px;

--- a/client/my-sites/plans-features-main/components/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/components/plan-type-selector.tsx
@@ -323,7 +323,7 @@ const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSig
 	display: ${ ( { isInSignup } ) => ( isInSignup ? 'flex' : 'block' ) };
 	align-content: space-between;
 	justify-content: center;
-	margin: 20px 20px 0;
+	margin: 0 20px 24px;
 
 	> .segmented-control.is-compact:not( .is-signup ) {
 		margin: 8px auto 16px;

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -15,7 +15,6 @@
 
 .plan-features-main__notice {
 	margin: 0;
-	width: 100%;
 }
 
 /*TODO: Remove the section below when the 2023 pricing grid is live to all locales */

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -15,6 +15,7 @@
 
 .plan-features-main__notice {
 	margin: 0;
+	width: 100%;
 }
 
 /*TODO: Remove the section below when the 2023 pricing grid is live to all locales */

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -87,6 +87,7 @@
 
 .plans-features-main__group.is-wpcom.is-2023-pricing-grid {
 	padding-top: 19px;
+	margin-top: 24px;
 }
 
 .plans-features-main__group.is-wpcom:not(.is-2023-pricing-grid) {

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -13,8 +13,13 @@
 	}
 }
 
-.plan-features-main__notice {
-	margin: 0;
+.notice.plan-features-main__notice {
+	margin: 0 20px;
+	width: unset;
+	@include plans-section-custom-mobile-breakpoint {
+		margin: 0;
+		width: 100%;
+	}
 }
 
 /*TODO: Remove the section below when the 2023 pricing grid is live to all locales */

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -14,10 +14,11 @@
 }
 
 .notice.plan-features-main__notice {
-	margin: 0 20px;
+	margin: 0 20px 24px;
 	width: unset;
+
 	@include plans-section-custom-mobile-breakpoint {
-		margin: 0;
+		margin: 0 0 24px;
 		width: 100%;
 	}
 }
@@ -84,16 +85,16 @@
 
 }
 
+.plans-features-main__group.is-wpcom.is-2023-pricing-grid {
+	padding-top: 19px;
+}
+
 .plans-features-main__group.is-wpcom:not(.is-2023-pricing-grid) {
 	padding-top: 26px;
 
 	@media ( min-width: 880px ) {
 		padding-top: 19px;
 	}
-}
-
-.plans-features-main__group.is-wpcom.is-2023-pricing-grid {
-	padding-top: 19px;
 }
 
 // Required additional specificity

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -13,6 +13,10 @@
 	}
 }
 
+.plan-features-main__notice {
+	margin: 0;
+}
+
 /*TODO: Remove the section below when the 2023 pricing grid is live to all locales */
 .plans-features-main__group.is-scrollable:not(.is-2023-pricing-grid) {
 	position: relative;

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .plans main {
-	padding-top: 17px;
+	padding-top: 24px;
 	// a formatted-header instance used within main (not as section header)
 	.plans__formatted-header {
 		&.is-domain-upsell {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/martech#1528

## Proposed Changes

- Updates the Notice bar to more closely match the design in Figma (xkhhUlDowF13dRoXJqlRDM-fi-1_95).
- Uses the Gridicons from previously, so the icons aren't being updated.
- Adds the changes behind a `isReskinned` property that we can enable/test gradually outside of the plans page. Alternatively, we can refactor the base styles directly and enable them across the whole.

### Before

<img width="500" alt="Screenshot 2023-04-06 at 1 23 50 PM" src="https://user-images.githubusercontent.com/1705499/230367556-a3ea8252-028d-444f-9251-69e82f5f2bf3.png">

### After

<img width="500" alt="Screenshot 2023-04-06 at 1 24 32 PM" src="https://user-images.githubusercontent.com/1705499/230367602-fc4c65f2-a977-40e2-a656-71b43cddb9de.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/[SITE]` with a site on a paid plan and pro-rated credits available
* Confirm the Notice bar matches the media above
* (maybe) Confirm a Notice bar elsewhere and ensure it renders the old style

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?