### PR TITLE
Update retention settings to show message for 2-day retention

### DIFF
--- a/client/components/backup-retention-management/index.tsx
+++ b/client/components/backup-retention-management/index.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useStorageText } from 'calypso/components/backup-storage-space/hooks';
 import { UpsellPrice } from 'calypso/components/backup-storage-space/usage-warning/upsell';
 import QuerySiteProducts from 'calypso/components/data/query-site-products';
+import ExternalLink from 'calypso/components/external-link';
 import { addQueryArgs } from 'calypso/lib/route';
 import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
@@ -311,6 +312,28 @@ const BackupRetentionManagement: FunctionComponent< OwnProps > = ( {
 						<div className="retention-form__instructions">
 							{ translate( 'Select the number of days you would like your backups to be saved.' ) }
 						</div>
+						{ 2 === currentRetentionPlan && (
+							<div className="retention-form__short-retention-notice">
+								{ translate(
+									"You're currently saving only {{span}}%(currentRetentionPlan)d days{{/span}} of backups as a way to stay within your storage limits. You can change this by selecting a different setting below. Learn more about {{ExternalLink}}Backup Storage and Retention{{/ExternalLink}}",
+									{
+										components: {
+											ExternalLink: (
+												<ExternalLink
+													href="https://jetpack.com/support/backup/jetpack-vaultpress-backup-storage-and-retention/"
+													target="_blank"
+													rel="noopener noreferrer"
+													icon
+													size={ 14 }
+												/>
+											),
+											span: <span className="highlight-days" />,
+										},
+										args: { currentRetentionPlan },
+									}
+								) }
+							</div>
+						) }
 						<RetentionOptionsControl
 							currentRetentionPlan={ currentRetentionPlan }
 							onChange={ onRetentionSelectionChange }

--- a/client/components/backup-retention-management/style.scss
+++ b/client/components/backup-retention-management/style.scss
@@ -53,7 +53,7 @@
 
 .backup-retention-management .retention-form {
 	&__instructions {
-		margin-bottom: 24px;
+		margin-bottom: 16px;
 		font-size: 1rem;
 		font-weight: 400;
 		line-height: 24px;
@@ -78,6 +78,32 @@
 
 	&__submit {
 		text-align: right;
+	}
+
+	&__short-retention-notice {
+		font-size: 0.75rem;
+		margin-bottom: 16px;
+		background: #f7ebec;
+		padding: 12px;
+		font-weight: 400;
+		color: var(--studio-gray-80);
+
+		a {
+			font-weight: 600;
+			text-decoration: underline;
+			color: var(--studio-gray-80);
+
+			.gridicon {
+				position: relative;
+				top: 4px;
+				height: 16px;
+				margin-left: 1px;
+			}
+		}
+
+		.highlight-days {
+			color: var(--studio-red-50);
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

When a customer sets a 2-day retention from the cancellation flow, we need to display that they have selected a 2-day retention on the settings page, since this option would be only available on the cancellation flow, we can't add this as an additional option on the settings section instead we'll show a message as below:

```
You’re currently saving only 2 days of backups as a way to stay within your storage limits. You can change this by selecting a different setting below. Learn more about Backup Storage and Retention
```

## Testing Instructions

1. For a test site, set retention to 2 days either by using WPCOM API or vpshell.
2. Open Jetpack Cloud's setting page for your site, it should display the new message (as per the 'After' screenshot below)
3. Set any other retention than 2, and verify the message is not displayed.
4. Check the link on 'Backup Storage and Retention' it should lead to https://jetpack.com/support/backup/jetpack-vaultpress-backup-storage-and-retention/

### Before this change (when retention is set to 2 days)

<img width="719" alt="Screenshot 2023-04-05 at 7 37 36 PM" src="https://user-images.githubusercontent.com/13975226/230106679-7217d101-c981-4d96-994a-83dfe2be31a1.png">

### After this change (when retention is set to 2 days)

<img width="712" alt="Screenshot 2023-04-05 at 7 38 20 PM" src="https://user-images.githubusercontent.com/13975226/230106840-ce0b0116-1586-4cfd-9a31-6b7f66d6820e.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

