### PR TITLE
UniversalHeader: fix lint for args

### DIFF
--- a/apps/happy-blocks/block-library/universal-header/index.php
+++ b/apps/happy-blocks/block-library/universal-header/index.php
@@ -7,6 +7,10 @@
  * @package happy-blocks
  */
 
+if ( ! isset( $args ) ) {
+	$args = array();
+}
+
 ?>
 
 <div id="lpc-header-nav" class="lpc lpc-header-nav">

--- a/apps/phpcs.xml
+++ b/apps/phpcs.xml
@@ -41,13 +41,6 @@
 		<exclude-pattern>editing-toolkit/editing-toolkit-plugin/newspack-blocks/synced-newspack-blocks</exclude-pattern>
 	</rule>
 
-	<!-- templates files get $args variable to hydrate the template -->
-	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis" >
-		<properties>
-			<property name="validUndefinedVariableNames" value="args"/>
-		</properties>
-	</rule>
-
 	<!-- Ignore assset files and undeployed files. -->
 	<exclude-pattern>*.asset.php</exclude-pattern>
 


### PR DESCRIPTION
The happy blocks header file was causing lint issues.
This PR fixes that.

**Testing**
- Checkout this branch
- Login to sandbox
- Run `install-plugin.sh happy-blocks happy-blocks-lint` after the build is done or just run `yarn dev --sync` from happy-blocks
- Run `phpcs` on the installed files. 
