### PR TITLE
One-click checkout: Only bail on email upsell if there are actually cart errors

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -402,10 +402,7 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 				? this.props.paymentMethodsState.paymentMethods[ 0 ]
 				: undefined;
 		if ( this.isEligibleForOneClickUpsell( buttonAction ) && productToAdd && storedCard ) {
-			if ( ! storedCard ) {
-				return;
-			}
-
+			debug( 'accept upsell allows one-click, has a product, and a stored card' );
 			this.setState( {
 				showPurchaseModal: true,
 			} );
@@ -447,10 +444,14 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 			}
 			return;
 		}
+		debug(
+			'accept upsell either does does not allow one-click, does not have a product, or does not have a stored card'
+		);
 
 		// Professional Email needs to add the locally built cartItem to the cart,
 		// as we need to handle validation failures before redirecting to checkout.
 		if ( PROFESSIONAL_EMAIL_UPSELL === upsellType && productToAdd ) {
+			debug( 'accept upsell preparing for email upsell' );
 			// If we don't have an existing destination, calculate the thank you destination for
 			// the original cart contents, and only store it if the cart update succeeds.
 			const destinationFromCookie = retrieveSignupDestination();
@@ -461,8 +462,9 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 			this.props.shoppingCartManager
 				.replaceProductsInCart( [ productToAdd ] )
 				.then( ( newCart ) => {
-					if ( newCart.messages ) {
-						if ( newCart.messages.errors ) {
+					if ( newCart.messages?.errors ) {
+						if ( newCart.messages.errors.length > 0 ) {
+							debug( 'email upsell failed with a cart error in the cart response' );
 							// Stay on the page to let CartMessages show the relevant error.
 							return;
 						}
@@ -475,8 +477,9 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 					debug( 'redirecting because we have professional email' );
 					page( '/checkout/' + siteSlug );
 				} )
-				.catch( () => {
+				.catch( ( error ) => {
 					// Nothing needs to be done here. CartMessages will display the error to the user.
+					debug( 'email upsell failed with a cart error', error );
 				} );
 			return;
 		}


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/74555 we modified a number of lines on the one-click checkout page to correct how it sends data to the cart. However, there was a bug introduced: if the user had no saved cards, the Professional Email upsell would silently fail to redirect to checkout after the upsell was added to the cart. This is because we were checking for `cart.messages.errors`, which is an array, and in JavaScript an empty array is truthy. As a result, the code thought that there were errors adding the product to the cart and stopped its processing (assuming those errors would be displayed by the `CartMessages` component). Since there were no actual errors, the user received no information.

## Proposed Changes

In this PR we change the condition to be `cart.messages.errors.length > 0` instead.

I'm going to add some unit tests to prevent this from happening in the future but I'll do those in another PR so that we can get this fix out faster.

## Screenshots

Upsell page:

<img width="663" alt="Screenshot 2023-04-05 at 11 51 45 AM" src="https://user-images.githubusercontent.com/2036909/230135537-150ec674-79fb-4d28-8cdf-d99b7038f4dd.png">

## Testing Instructions

- First make sure you're using account that has a purchased domain registration on WPcom.
- Second, you'll need to have no saved cards. You can simulate that by applying the following diff on top of these changes:

```diff
--- a/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
@@ -163,7 +163,7 @@ export function useStoredPaymentMethods( {
        } )();

        return {
-               paymentMethods,
+               paymentMethods: [],
                isLoading,
                isDeleting: mutation.isLoading,
                error: errorMessage,
```

- Then visit `/checkout/offer-professional-email/example.com/78805399/example.com`, replacing both `example.com` instances with your registered domain name.
- Click the "Add Professional Email" button.
- Verify that you are redirected to checkout with the email product in your cart.