### PR TITLE
Fix Happy Blocks assets path

### DIFF
--- a/apps/happy-blocks/block-library/universal-header/includes.php
+++ b/apps/happy-blocks/block-library/universal-header/includes.php
@@ -15,7 +15,7 @@ if ( ! function_exists( 'happy_blocks_get_asset' ) ) {
 	 */
 	function happy_blocks_get_asset( $file ) {
 		return array(
-			'path'    => "https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-library/universal-header/build/$file",
+			'path'    => "https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-library/universal-header/$file",
 			'version' => filemtime( __DIR__ . "/build/$file" ),
 		);
 	}


### PR DESCRIPTION
The `build` path isn't needed in prod.