### PR TITLE
Woo Express: Add bottom margin to price card on Plans page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
@@ -28,3 +28,9 @@
 		font-family: $sans;
 	}
 }
+
+.is-section-plans .wooexpress-plans__grid.is-2023-pricing-grid .plan-features-2023-grid__mobile-view {
+	@media (max-width: $break-mobile) {
+		margin-top: 3em;
+	}
+}

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
@@ -28,9 +28,3 @@
 		font-family: $sans;
 	}
 }
-
-.is-section-plans .wooexpress-plans__grid.is-2023-pricing-grid .plan-features-2023-grid__mobile-view {
-	@media (max-width: $break-mobile) {
-		margin-top: 3em;
-	}
-}

--- a/client/my-sites/plans/woo-express-plans-page/style.scss
+++ b/client/my-sites/plans/woo-express-plans-page/style.scss
@@ -30,7 +30,7 @@ body.is-section-plans.is-woo-express-plan {
 		flex-wrap: wrap;
 		border-radius: 2px 2px 0 0;
 		padding: 24px 32px;
-		margin: 40px 0 0 0;
+		margin: 40px 0;
 
 		@media (max-width: $break-mobile) {
 			flex-direction: column;

--- a/client/my-sites/plans/woo-express-plans-page/style.scss
+++ b/client/my-sites/plans/woo-express-plans-page/style.scss
@@ -34,7 +34,7 @@ body.is-section-plans.is-woo-express-plan {
 
 		@media (max-width: $break-mobile) {
 			flex-direction: column;
-			margin: 0 20px;
+			margin: 0 20px 40px;
 			padding: 32px 20px;
 		}
 


### PR DESCRIPTION
Related to #75284

## Proposed Changes

* Quick follow-up to #75284, add a bottom margin to the pricing card so there's more breathing room between the price card and the plans grid when no interval toggle is visible. This was particularly noticeable when on the Essential annual plan.

**Before**

<img width="1294" alt="Screen Shot 2023-04-05 at 1 37 54 PM" src="https://user-images.githubusercontent.com/2124984/230160405-f75aa444-90ff-48d1-84b3-0624789d2309.png">

**After**

<img width="1297" alt="Screen Shot 2023-04-05 at 1 37 25 PM" src="https://user-images.githubusercontent.com/2124984/230160375-8c779cbe-7133-4058-b4dc-1b1a1b7c67a7.png">

<img width="1275" alt="Screen Shot 2023-04-05 at 1 32 56 PM" src="https://user-images.githubusercontent.com/2124984/230160461-75cc9a2c-ec62-48c9-8693-51b0b168ab0c.png">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR.
* Create a Woo Express trial site from `/setup/wooexpress`
* If working locally, enable the feature flag: `?flags=plans/wooexpress-small`
* Visit the `/plans` page on your trial site; you should see the interval toggle, spacing should look OK.
* Upgrade to Essential monthly, then go back to `/plans`; you should still see the interval toggle and the spacing should look about the same as for the trial.
* Upgrade to Essential annual, go back to `/plans`; you should no longer see the interval toggle, but the spacing should still look good and not too cramped.
* Test with a Performance monthly/Performance annual plan to check the spacing there, too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- N/A [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- N/A Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- N/A Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- N/A For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
