### PR TITLE
Checkout: add tests for one click professional email upsell

### DIFF
--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -331,6 +331,42 @@ export const planLevel2Biannual: ResponseCartProduct = {
 	months_per_bill_period: 24,
 };
 
+export const professionalEmailAnnual: ResponseCartProduct = {
+	...getEmptyResponseCartProduct(),
+	product_name: 'Professional Email',
+	product_slug: 'wp_titan_mail_yearly',
+	currency: 'USD',
+	extra: {
+		email_users: [],
+		new_quantity: 1,
+	},
+	meta: 'example.com',
+	product_id: 401,
+	volume: 1,
+	item_original_cost_integer: 3500,
+	item_subtotal_integer: 3500,
+	bill_period: '365',
+	months_per_bill_period: 12,
+};
+
+export const professionalEmailMonthly: ResponseCartProduct = {
+	...getEmptyResponseCartProduct(),
+	product_name: 'Professional Email',
+	product_slug: 'wp_titan_mail_monthly',
+	currency: 'USD',
+	extra: {
+		email_users: [],
+		new_quantity: 1,
+	},
+	meta: 'example.com',
+	product_id: 400,
+	volume: 1,
+	item_original_cost_integer: 350,
+	item_subtotal_integer: 350,
+	bill_period: '31',
+	months_per_bill_period: 1,
+};
+
 export const fetchStripeConfiguration = async () => stripeConfiguration;
 
 export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
@@ -849,6 +885,40 @@ function convertRequestProductToResponseProduct(
 					meta: product.meta,
 					volume: 1,
 					extra: {},
+				};
+			case professionalEmailAnnual.product_slug:
+				return {
+					...getEmptyResponseCartProduct(),
+					product_id: professionalEmailAnnual.product_id,
+					product_name: professionalEmailAnnual.product_name,
+					product_slug: professionalEmailAnnual.product_slug,
+					currency: currency,
+					is_domain_registration: false,
+					item_original_cost_integer: professionalEmailAnnual.item_original_cost_integer,
+					item_subtotal_integer: professionalEmailAnnual.item_subtotal_integer,
+					bill_period: professionalEmailAnnual.bill_period,
+					months_per_bill_period: professionalEmailAnnual.months_per_bill_period,
+					item_tax: 0,
+					meta: product.meta,
+					volume: 1,
+					extra: product.extra,
+				};
+			case professionalEmailMonthly.product_slug:
+				return {
+					...getEmptyResponseCartProduct(),
+					product_id: professionalEmailMonthly.product_id,
+					product_name: professionalEmailMonthly.product_name,
+					product_slug: professionalEmailMonthly.product_slug,
+					currency: currency,
+					is_domain_registration: false,
+					item_original_cost_integer: professionalEmailMonthly.item_original_cost_integer,
+					item_subtotal_integer: professionalEmailMonthly.item_subtotal_integer,
+					bill_period: professionalEmailMonthly.bill_period,
+					months_per_bill_period: professionalEmailMonthly.months_per_bill_period,
+					item_tax: 0,
+					meta: product.meta,
+					volume: 1,
+					extra: product.extra,
 				};
 		}
 

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -409,6 +409,7 @@ export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
 			total_tax_breakdown: [],
 			total_tax_integer: taxInteger,
 			next_domain_condition: '',
+			messages: { errors: [], success: [] },
 		};
 	};
 }

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -494,8 +494,13 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 		const { product, siteSlug, upsellType } = this.props;
 		const { cartItem } = this.state;
 
-		if ( ! product || ( upsellType === PROFESSIONAL_EMAIL_UPSELL && ! cartItem ) ) {
+		if ( ! product && upsellType !== PROFESSIONAL_EMAIL_UPSELL ) {
 			debug( 'not eligible for one-click upsell because no product exists' );
+			return false;
+		}
+
+		if ( upsellType === PROFESSIONAL_EMAIL_UPSELL && ! cartItem ) {
+			debug( 'not eligible for one-click upsell because no email product exists' );
 			return false;
 		}
 

--- a/client/my-sites/checkout/upsell-nudge/test/upsell-nudge.tsx
+++ b/client/my-sites/checkout/upsell-nudge/test/upsell-nudge.tsx
@@ -297,9 +297,9 @@ describe( 'UpsellNudge', () => {
 			</ReduxProvider>
 		);
 
-		await user.type( await screen.findByLabelText( 'Enter email address' ), 'testuser' );
+		await user.type( await screen.findByLabelText( /Enter email address/ ), 'testuser' );
 		await user.type(
-			await screen.findByLabelText( 'Set password' ),
+			await screen.findByLabelText( /Set password/ ),
 			'aadjhaduhaidwahdawdhakjdbakdjbw'
 		);
 		await user.click( await screen.findByText( 'Add Professional Email' ) );
@@ -336,9 +336,9 @@ describe( 'UpsellNudge', () => {
 			</ReduxProvider>
 		);
 
-		await user.type( await screen.findByLabelText( 'Enter email address' ), 'testuser' );
+		await user.type( await screen.findByLabelText( /Enter email address/ ), 'testuser' );
 		await user.type(
-			await screen.findByLabelText( 'Set password' ),
+			await screen.findByLabelText( /Set password/ ),
 			'aadjhaduhaidwahdawdhakjdbakdjbw'
 		);
 		await user.click( await screen.findByText( 'Add Professional Email' ) );

--- a/client/my-sites/checkout/upsell-nudge/test/upsell-nudge.tsx
+++ b/client/my-sites/checkout/upsell-nudge/test/upsell-nudge.tsx
@@ -312,9 +312,15 @@ describe( 'UpsellNudge', () => {
 			'aadjhaduhaidwahdawdhakjdbakdjbw'
 		);
 		await user.click( await screen.findByText( 'Add Professional Email' ) );
-		expect(
-			screen.findByText( mockProducts[ 'wp_titan_mail_yearly' ].product_name )
-		).toNeverAppear();
+		expect( screen.findByText( mockProducts.wp_titan_mail_monthly.product_name ) ).toNeverAppear();
 		expect( page ).toHaveBeenCalledWith( `/checkout/example.com` );
+		expect(
+			shoppingCartClient
+				.forCartKey( siteId )
+				.getState()
+				.responseCart.products.some(
+					( product ) => product.product_id === mockProducts.wp_titan_mail_monthly.product_id
+				)
+		).toBeTruthy();
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

This PR adds tests for the professional email one-click post-checkout upsell.

This will prevent the regression fixed by https://github.com/Automattic/wp-calypso/pull/75340

## Testing Instructions

Since this mostly adds tests, all that should be necessary is making sure the tests pass.
