### PR TITLE
Subscriptions Management: Create CommentsView component

### DIFF
--- a/client/landing/subscriptions/subscription-manager/subscription-manager.tsx
+++ b/client/landing/subscriptions/subscription-manager/subscription-manager.tsx
@@ -6,12 +6,9 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import { useSubheaderText } from '../hooks';
-import { Settings } from '../tab-views';
-import Sites from '../tab-views/sites';
+import { Comments, Settings, Sites } from '../tab-views';
 import { TabsSwitcher } from '../tabs-switcher';
 import './styles.scss';
-
-const CommentsView = () => <span>Comments View</span>;
 
 const SubscriptionManagementPage = () => {
 	const translate = useTranslate();
@@ -27,7 +24,7 @@ const SubscriptionManagementPage = () => {
 			{
 				label: translate( 'Comments' ),
 				path: 'comments',
-				view: CommentsView,
+				view: Comments,
 				count: counts?.comments || undefined,
 			},
 			{

--- a/client/landing/subscriptions/tab-views/comments.tsx
+++ b/client/landing/subscriptions/tab-views/comments.tsx
@@ -1,0 +1,9 @@
+import TabView from './tab-view';
+
+const Comments = () => (
+	<TabView errorMessage="" isLoading={ false }>
+		<>Comments Tab</>
+	</TabView>
+);
+
+export default Comments;

--- a/client/landing/subscriptions/tab-views/index.tsx
+++ b/client/landing/subscriptions/tab-views/index.tsx
@@ -1,1 +1,3 @@
+export { default as Comments } from './comments';
 export { default as Settings } from './settings';
+export { default as Sites } from './sites';

--- a/client/landing/subscriptions/tab-views/settings.tsx
+++ b/client/landing/subscriptions/tab-views/settings.tsx
@@ -1,27 +1,18 @@
 import { SubscriptionManager } from '@automattic/data-stores';
-import { Spinner } from '@wordpress/components';
-import { Notice } from '../notice';
 import { UserSettings } from '../user-settings';
+import TabView from './tab-view';
 
 const Settings = () => {
 	const { data: settings, isIdle, isLoading, error } = SubscriptionManager.useUserSettingsQuery();
 
-	if ( error ) {
-		// todo: translate when we have agreed on the error message
-		return (
-			<Notice type="error">An error occurred while fetching your subscription settings.</Notice>
-		);
-	}
+	// todo: translate when we have agreed on the error message
+	const errorMessage = error ? 'An error occurred while fetching your subscription settings.' : '';
 
-	if ( isIdle || isLoading ) {
-		return (
-			<div className="user-settings">
-				<Spinner />
-			</div>
-		);
-	}
-
-	return <UserSettings value={ settings } />;
+	return (
+		<TabView errorMessage={ errorMessage } isLoading={ isIdle || isLoading }>
+			<UserSettings value={ settings } />
+		</TabView>
+	);
 };
 
 export default Settings;

--- a/client/landing/subscriptions/tab-views/sites.tsx
+++ b/client/landing/subscriptions/tab-views/sites.tsx
@@ -1,29 +1,25 @@
 import { SubscriptionManager } from '@automattic/data-stores';
-import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { Notice } from '../notice';
 import SiteList from '../site-list/site-list';
+import TabView from './tab-view';
 
-export default function SitesView() {
+const SitesView = () => {
 	const translate = useTranslate();
 	const { data: sites, isLoading, error } = SubscriptionManager.useSiteSubscriptionsQuery();
 
-	if ( error ) {
-		// todo: translate when we have agreed on the error message
-		return <Notice type="error">An error occurred while fetching your subscriptions.</Notice>;
-	}
+	// todo: translate when we have agreed on the error message
+	const errorMessage = error ? 'An error occurred while fetching your subscriptions.' : '';
 
-	if ( isLoading ) {
-		return (
-			<div className="user-settings">
-				<Spinner />
-			</div>
-		);
-	}
-
-	if ( ! sites || ! sites.length ) {
+	if ( ! isLoading && ( ! sites || ! sites.length ) ) {
 		return <Notice type="warning">{ translate( 'You are not subscribed to any sites.' ) }</Notice>;
 	}
 
-	return <SiteList sites={ sites } />;
-}
+	return (
+		<TabView errorMessage={ errorMessage } isLoading={ isLoading }>
+			<SiteList sites={ sites } />
+		</TabView>
+	);
+};
+
+export default SitesView;

--- a/client/landing/subscriptions/tab-views/sites.tsx
+++ b/client/landing/subscriptions/tab-views/sites.tsx
@@ -4,7 +4,7 @@ import { Notice } from '../notice';
 import SiteList from '../site-list/site-list';
 import TabView from './tab-view';
 
-const SitesView = () => {
+const Sites = () => {
 	const translate = useTranslate();
 	const { data: sites, isLoading, error } = SubscriptionManager.useSiteSubscriptionsQuery();
 
@@ -22,4 +22,4 @@ const SitesView = () => {
 	);
 };
 
-export default SitesView;
+export default Sites;

--- a/client/landing/subscriptions/tab-views/styles.scss
+++ b/client/landing/subscriptions/tab-views/styles.scss
@@ -1,0 +1,3 @@
+.loading-container {
+	text-align: center;
+}

--- a/client/landing/subscriptions/tab-views/tab-view.tsx
+++ b/client/landing/subscriptions/tab-views/tab-view.tsx
@@ -1,0 +1,27 @@
+import { Spinner } from '@wordpress/components';
+import { Notice } from '../notice';
+import './styles.scss';
+
+type TabViewProps = {
+	children: JSX.Element;
+	errorMessage: string;
+	isLoading: boolean;
+};
+
+const TabView = ( { children, errorMessage, isLoading }: TabViewProps ) => {
+	if ( errorMessage ) {
+		return <Notice type="error">{ errorMessage }</Notice>;
+	}
+
+	if ( isLoading ) {
+		return (
+			<div className="loading-container">
+				<Spinner />
+			</div>
+		);
+	}
+
+	return children;
+};
+
+export default TabView;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/75343

## Proposed Changes

* Extract tab view structure to a reusable component `TabView`
* Fix loading spinner position
* Update existing tabs to use `TabView`
* Hide empty list notice when the site list is still loading
* Create Comments view component
* Apply the Comments view to the related tab/route on `SubscriptionManagementPage`
  * Page only accessible through the `/subscriptions/comments` route
  * Does not affect the existing redirect to the Reskinned Portal when clicking on Comments tab

## Testing Instructions

* Run this PR on your local env
* Go to http://calypso.localhost:3000/subscriptions/sites with a valid external user
* Click on Comments Tab
  * You should be redirected to the reskinned portal
* Go to http://calypso.localhost:3000/subscriptions/comments
  * The Comments tab should be displayed (no redirect)
  * Change the TabView component props to test different states (errorMessage and isLoading)

<img width="609" alt="image" src="https://user-images.githubusercontent.com/3113712/230180875-10732bf0-6bba-428e-94fb-d13958e0339c.png">

**Regression Test**
* Verify if the Sites tab is working as expected
  * Verify loading and error states and check the empty view
* Verify if the Settings tab is working as expected
  * Verify loading and error states

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
