### PR TITLE
Extend timeouts in e2e test purchases

### DIFF
--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -69,7 +69,7 @@ describe(
 			} );
 
 			it( 'Make purchase', async function () {
-				await cartCheckoutPage.purchase( { timeout: 60 * 1000 } );
+				await cartCheckoutPage.purchase( { timeout: 75 * 1000 } );
 			} );
 
 			it( 'Skip Onboarding', async function () {

--- a/test/e2e/specs/plans/plans__upgrade.ts
+++ b/test/e2e/specs/plans/plans__upgrade.ts
@@ -105,7 +105,7 @@ describe(
 			} );
 
 			it( 'Make purchase', async function () {
-				await cartCheckoutPage.purchase( { timeout: 60 * 1000 } );
+				await cartCheckoutPage.purchase( { timeout: 75 * 1000 } );
 			} );
 
 			it( 'Return to My Home dashboard', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

### The Flaky Failures 

We've been having some flakiness in our pre-release plan purchasing specs.
The failures usually occur in...
- `plans__upgrade.ts`
- `plans__signup-business.ts`
And always occur at the same step: a timeout when waiting for the purchase to complete.

That error looks like so...
```
page.waitForResponse: Timeout 60000ms exceeded while waiting for event "response"
=========================== logs ===========================
waiting for response /.*me\/transactions.*/
============================================================
at CartCheckoutPage.purchase (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts:303:14)
    at Object.<anonymous> (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/plans/plans__signup-business.ts:72:28)
    at Promise.then.completed (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/utils.js:391:28)
    at callAsyncCircusFn (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/utils.js:316:10)
    at _callCircusTest (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:218:40)
    at _runTest (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:155:3)
    at _runTestsForDescribeBlock (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:66:9)
    at _runTestsForDescribeBlock (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:60:9)
    at _runTestsForDescribeBlock (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:60:9)
    at run (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:25:3)
    at runAndTransformResultsToJestFormat (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:170:21)
    at jestAdapter (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:82:19)
    at runTestInternal (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-runner/build/runTest.js:389:16)
    at runTest (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-runner/build/runTest.js:475:34)
    at Object.worker (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-runner/build/testWorker.js:133:12)
```

I spent a long time looking at these failures, and while they can all look a little different, multiple different sources suggest that the plan purchase and upgrade _does_ in fact actually go through, and it usually happens within ~5 seconds after the 60-second timeout.

I am not as familiar with our billing code, but since a) this only seems to affect purchases when the store is in sandbox mode and is using the stripe test endpoints, b) they tend to clump together, c) stripe has stricter rate-limiting rules for testing requests, and d) they predictably all finish just a little bit after a minute... I'm suspicious we're running into some kind of rate limit.

### The Fix

It feels silly that I spent over an hour debugging something to suggest a two-line change... 😆 But I really think our best bet here is to bump the store purchase timeout a little bit more.

Here is my reasoning:
- As mentioned above, when these have failed recently, the purchase/upgrade _has_ in fact gone through, and usually does so not long after our current 60-second timeout.
- Even though a 75-second timeout may seem long, it's less long than having to re-run all the pre-release tests because you had a flaky failure. In most cases, we won't hit anywhere near this timeout.
- This is a lot cheaper of a fix than any other options I see otherwise at the moment 

## Testing Instructions

- [ ] Pre-release tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
