### PR TITLE
Use domcontentloaded as load event when checking ssr in e2e tests

### DIFF
--- a/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts
@@ -21,7 +21,7 @@ describe( DataHelper.createSuiteTitle( 'Server-side Rendering' ), function () {
 		${ DataHelper.getCalypsoURL( 'themes' ) }
 		${ DataHelper.getCalypsoURL( 'theme/twentytwenty' ) }
 	`( 'Check endpoint: $endpoint', async function ( { endpoint } ) {
-		await page.goto( endpoint );
+		await page.goto( endpoint, { waitUntil: 'domcontentloaded' } );
 		await page.locator( '#wpcom[data-calypso-ssr="true"]' ).waitFor( { timeout: 15 * 1000 } );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

### The Flaky Tests

`infrastructure__ssr-enabled.ts` has been flaky recently, with failures that look like this...

```
page.goto: Timeout 10000ms exceeded.
=========================== logs ===========================
navigating to "https://container-serene-margulis.calypso.live/theme/twentytwenty", waiting until "load"
============================================================
at /home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.ts:24:14
    at Object.<anonymous> (/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-each/build/bind.js:79:13)
    at Promise.then.completed (/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/utils.js:391:28)
    at callAsyncCircusFn (/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/utils.js:316:10)
    at _callCircusTest (/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:218:40)
    at _runTest (/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:155:3)
    at _runTestsForDescribeBlock (/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:66:9)
    at _runTestsForDescribeBlock (/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:60:9)
    at run (/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:25:3)
    at runAndTransformResultsToJestFormat (/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:170:21)
    at jestAdapter (/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:82:19)
    at runTestInternal (/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-runner/build/runTest.js:389:16)
    at runTest (/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-runner/build/runTest.js:475:34)
    at Object.worker (/home/teamcity-3/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-runner/build/testWorker.js:133:12)
```

What's happening is that this specific theme page has a _lot_ of images and stylesheets that get loaded. It's a relatively expensive page to just load from scratch! Our tests used to wait for the `load` event, which means all the image and stylesheet loads had to finish. In the network was dragging (it happens), it could take over the 10-second timeout. 

### The Fix

The trick is that we actually don't need to wait for the `load` event here! `domcontentload` is enough for the SSR tests, and on expensive pages like the twenty-twenty theme page, will fire _way_ sooner. 

These tests are essentially just a smoke test that our SSR is working. To check that, we look for a custom HTML attribute that is set during the SSR process. That element and attribute is part of the initial DOM tree, so `domcontentload` is safe and sufficient! 👍 

## Testing Instructions

- [ ] PR tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
