### PR TITLE
Launchpad: Remove Choose Domain Task for Flows that include a Domain Step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -1,8 +1,6 @@
 import { LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import { LaunchpadFlowTaskList, Task } from './types';
 
-export const DOMAIN_UPSELL = 'domain_upsell';
-
 export const tasks: Task[] = [
 	{
 		id: 'setup_newsletter',
@@ -90,7 +88,7 @@ export const tasks: Task[] = [
 		disabled: true,
 	},
 	{
-		id: DOMAIN_UPSELL,
+		id: 'domain_upsell',
 		completed: false,
 		disabled: false,
 	},
@@ -134,7 +132,7 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 	free: [
 		'setup_free',
 		'design_selected',
-		DOMAIN_UPSELL,
+		'domain_upsell',
 		'first_post_published',
 		'design_edited',
 		'site_launched',
@@ -142,17 +140,10 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 	build: [
 		'setup_general',
 		'design_selected',
-		DOMAIN_UPSELL,
 		'first_post_published',
 		'design_edited',
 		'site_launched',
 	],
-	write: [
-		'setup_write',
-		'design_selected',
-		DOMAIN_UPSELL,
-		'first_post_published',
-		'site_launched',
-	],
+	write: [ 'setup_write', 'design_selected', 'first_post_published', 'site_launched' ],
 	videopress: [ 'videopress_setup', 'plan_selected', 'videopress_upload', 'videopress_launched' ],
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -1,6 +1,8 @@
 import { LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import { LaunchpadFlowTaskList, Task } from './types';
 
+export const DOMAIN_UPSELL = 'domain_upsell';
+
 export const tasks: Task[] = [
 	{
 		id: 'setup_newsletter',
@@ -88,7 +90,7 @@ export const tasks: Task[] = [
 		disabled: true,
 	},
 	{
-		id: 'domain_upsell',
+		id: DOMAIN_UPSELL,
 		completed: false,
 		disabled: false,
 	},
@@ -132,7 +134,7 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 	free: [
 		'setup_free',
 		'design_selected',
-		'domain_upsell',
+		DOMAIN_UPSELL,
 		'first_post_published',
 		'design_edited',
 		'site_launched',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -322,44 +322,6 @@ describe( 'Sidebar', () => {
 				expect( domainUpsellTaskFreeFlow ).toBeVisible();
 				expect( domainUpsellTaskBadgeFreeFlow ).toBeVisible();
 			} );
-
-			it( 'displays the upgrade plan badge on the "Choose a domain" task for write flow', () => {
-				const writeFlowProps = { ...props, flow: 'write' };
-
-				const siteDetails = buildSiteDetails( {
-					options: {
-						...defaultSiteDetails.options,
-					},
-					plan: {
-						is_free: true,
-					},
-				} );
-				renderSidebar( writeFlowProps, siteDetails );
-
-				const domainUpsellTaskFreeFlow = screen.queryByText( 'Choose a domain' );
-				const domainUpsellTaskBadgeFreeFlow = screen.queryByText( 'Upgrade plan' );
-				expect( domainUpsellTaskFreeFlow ).toBeVisible();
-				expect( domainUpsellTaskBadgeFreeFlow ).toBeVisible();
-			} );
-
-			it( 'displays the upgrade plan badge on the "Choose a domain" task for build flow', () => {
-				const buildFlowProps = { ...props, flow: 'build' };
-
-				const siteDetails = buildSiteDetails( {
-					options: {
-						...defaultSiteDetails.options,
-					},
-					plan: {
-						is_free: true,
-					},
-				} );
-				renderSidebar( buildFlowProps, siteDetails );
-
-				const domainUpsellTaskFreeFlow = screen.queryByText( 'Choose a domain' );
-				const domainUpsellTaskBadgeFreeFlow = screen.queryByText( 'Upgrade plan' );
-				expect( domainUpsellTaskFreeFlow ).toBeVisible();
-				expect( domainUpsellTaskBadgeFreeFlow ).toBeVisible();
-			} );
 		} );
 
 		describe( 'and the site is on a paid plan', () => {
@@ -374,42 +336,6 @@ describe( 'Sidebar', () => {
 					},
 				} );
 				renderSidebar( freeFlowProps, siteDetails );
-
-				const domainUpsellTask = screen.queryByText( 'Choose a domain' );
-				const domainUpsellTaskBadge = screen.queryByText( 'Upgrade plan' );
-				expect( domainUpsellTask ).toBeVisible();
-				expect( domainUpsellTaskBadge ).toBeNull();
-			} );
-
-			it( 'does not display the upgrade plan badge on the "Choose a domain" task for write flow', () => {
-				const writeFlowProps = { ...props, flow: 'write' };
-				const siteDetails = buildSiteDetails( {
-					options: {
-						...defaultSiteDetails.options,
-					},
-					plan: {
-						is_free: false,
-					},
-				} );
-				renderSidebar( writeFlowProps, siteDetails );
-
-				const domainUpsellTask = screen.queryByText( 'Choose a domain' );
-				const domainUpsellTaskBadge = screen.queryByText( 'Upgrade plan' );
-				expect( domainUpsellTask ).toBeVisible();
-				expect( domainUpsellTaskBadge ).toBeNull();
-			} );
-
-			it( 'does not display the upgrade plan badge on the "Choose a domain" task for build flow', () => {
-				const buildFlowProps = { ...props, flow: 'build' };
-				const siteDetails = buildSiteDetails( {
-					options: {
-						...defaultSiteDetails.options,
-					},
-					plan: {
-						is_free: false,
-					},
-				} );
-				renderSidebar( buildFlowProps, siteDetails );
 
 				const domainUpsellTask = screen.queryByText( 'Choose a domain' );
 				const domainUpsellTaskBadge = screen.queryByText( 'Upgrade plan' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -158,17 +158,17 @@ describe( 'Task Helpers', () => {
 			} );
 		} );
 		describe( 'when flow is write', () => {
-			it( 'does include upsell task', () => {
+			it( 'does not include upsell task', () => {
 				expect(
 					launchpadFlowTasks[ 'write' ].filter( ( task ) => task === 'domain_upsell' ).length
-				).toBe( 1 );
+				).toBe( 0 );
 			} );
 		} );
 		describe( 'when flow is build', () => {
-			it( 'does include upsell task', () => {
+			it( 'does not include upsell task', () => {
 				expect(
 					launchpadFlowTasks[ 'build' ].filter( ( task ) => task === 'domain_upsell' ).length
-				).toBe( 1 );
+				).toBe( 0 );
 			} );
 		} );
 		describe( 'when flow is free', () => {


### PR DESCRIPTION
### Time Estimate
Review: Short
Test: Short

### Summary
This PR removes the **Choose a domain** task for flows that already include a Domain Step. This means the only flow that will have that task is the **Free Flow**.

### Testing Instructions
1. Checkout this branch
2. Run `yarn` and `yarn start` if needed

#### Write Flow
1. Create a new site by going to http://calypso.localhost:3000/start
2. Once you arrive at the Goals page select **Write & Publish**
3. Once you arrive at Launchpad verify the **Choose a domain** task is not showing

#### Build Flow
1. Create a new site by going to http://calypso.localhost:3000/start
2. Once you arrive at the Goals page, don't select any goals
3. Once you arrive at Launchpad verify the **Choose a domain** task is not showing

#### Free Flow
1. Create a new site by going to http://calypso.localhost:3000/setup/free/intro
2. Once you arrive at Launchpad verify the **Choose a domain** task is enabled and clicking it leads you to the domain flow

#### Unit Tests
Run `yarn test-client launchpad` and ensure all tests are passing