### PR TITLE
Flaky E2E: When naving directly to plugins page, add safer waiting

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -78,10 +78,12 @@ export class PluginsPage {
 	 * @param {string} site Optional site URL.
 	 */
 	async visit( site = '' ): Promise< void > {
-		await this.page.goto( getCalypsoURL( `plugins/${ site }` ) );
-		// This is one of the last, reliable web requests to finish on this page
-		// and is a pretty good indicator the async loading is done.
-		await this.page.waitForResponse( /\/sites\/\d+\/plugins/, { timeout: 15 * 1000 } );
+		await Promise.all( [
+			this.page.waitForResponse( /\/sites\/\d+\/plugins/, { timeout: 20 * 1000 } ),
+			// This is one of the last, reliable web requests to finish on this page
+			// and is a pretty good indicator the async loading is done.
+			this.page.goto( getCalypsoURL( `plugins/${ site }` ) ),
+		] );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -79,6 +79,9 @@ export class PluginsPage {
 	 */
 	async visit( site = '' ): Promise< void > {
 		await this.page.goto( getCalypsoURL( `plugins/${ site }` ) );
+		// This is one of the last, reliable web requests to finish on this page
+		// and is a pretty good indicator the async loading is done.
+		await this.page.waitForResponse( /\/sites\/\d+\/plugins/, { timeout: 15 * 1000 } );
 	}
 
 	/**

--- a/test/e2e/specs/plugins/plugins__browse.ts
+++ b/test/e2e/specs/plugins/plugins__browse.ts
@@ -22,7 +22,13 @@ describe( DataHelper.createSuiteTitle( 'Plugins: Browse' ), function () {
 
 	beforeAll( async () => {
 		page = await browser.newPage();
-		const testUser = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+		const testUser = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+			{
+				gutenberg: 'stable',
+				siteType: 'simple',
+				accountName: 'defaultUser',
+			},
+		] );
 		const testAccount = new TestAccount( testUser );
 		await testAccount.authenticate( page );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

### The Flaky Failures

We've seen a lot of failures in `plugins__browse.ts` script that look like this...

```
page.waitForSelector: Timeout 10000ms exceeded.
=========================== logs ===========================
waiting for locator('.plugins-results-header__title:text("Our developers’ favorites")') to be visible
  locator resolved to visible <div class="plugins-results-header__title">Our developers’ favorites</div>
============================================================
at PluginsPage.validateHasSection (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/pages/plugins-page.ts:101:19)
    at /home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/plugins/plugins__browse.ts:48:21
    at Object.<anonymous> (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-each/build/bind.js:79:13)
    at Promise.then.completed (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/utils.js:391:28)
    at callAsyncCircusFn (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/utils.js:316:10)
    at _callCircusTest (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:218:40)
    at _runTest (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:155:3)
    at _runTestsForDescribeBlock (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:66:9)
    at _runTestsForDescribeBlock (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:60:9)
    at run (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/run.js:25:3)
    at runAndTransformResultsToJestFormat (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:170:21)
    at jestAdapter (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:82:19)
    at runTestInternal (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-runner/build/runTest.js:389:16)
    at runTest (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-runner/build/runTest.js:475:34)
    at Object.worker (/home/teamcity-1/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-runner/build/testWorker.js:133:12)
```

When you watch all of these, they happen under conditions where resources seem constrained -- everything is loading very slowly (likely network??). The tricky thing too is that the "load" event fires really early on these pages -- in true React fashion, most everything is being rendered and fetched after the fact.

So, the 10 second wait for the first section is really eaten up predominantly by waiting for the page to render!

At first, I was really thrown off by these two lines...
```
waiting for locator('.plugins-results-header__title:text("Our developers’ favorites")') to be visible
  locator resolved to visible <div class="plugins-results-header__title">Our developers’ favorites</div>
```
❓ ❓ 🤷 

Someone asked about it [here](https://github.com/microsoft/playwright/issues/20772), and they basically were just like "use our assertion library" lol... But the question asker said they had been having performance issues, and I think that's the core issue here. I did some digging around, and the locator resolving and the waitForSelector command finishing are in fact distinct, and especially under constrained resources, the timeout could interrupt the two. 

### The Fix

In this case, I think our best bet forward is to make sure we're actually ready to interact with the plugins page after a direct navigation. After sniffing the page load traffic, the `/plugins` request seems like a good, reliable, safe indicator to try out first.

As a bonus, I also fixed the user handling so this uses the `defaultUser` during PR runs. That should save us the extra time from having to log in. 

## Testing Instructions

- [ ] PR e2e tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
