### PR TITLE
Fix untranslated text on /stats/ads/ admin page

### DIFF
--- a/client/blocks/stats-navigation/constants.js
+++ b/client/blocks/stats-navigation/constants.js
@@ -37,7 +37,7 @@ const store = {
 	showIntervals: true,
 };
 const wordads = {
-	label: 'Ads',
+	label: translate( 'Ads' ),
 	path: '/stats/ads',
 	showIntervals: true,
 };
@@ -77,7 +77,7 @@ Object.defineProperty( year, 'label', { get: () => translate( 'Years' ) } );
 Object.defineProperty( traffic, 'label', { get: () => translate( 'Traffic' ) } );
 Object.defineProperty( insights, 'label', { get: () => translate( 'Insights' ) } );
 Object.defineProperty( store, 'label', { get: () => translate( 'Store' ) } );
-Object.defineProperty( wordads, 'label', { get: () => 'Ads' } );
+Object.defineProperty( wordads, 'label', { get: () => translate( 'Ads' ) } );
 Object.defineProperty( googleMyBusiness, 'label', {
 	get: () => translate( 'Google My Business' ),
 } );

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import illustration404 from 'calypso/assets/images/illustrations/illustration-404.svg';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
+import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
@@ -62,6 +63,24 @@ const CHARTS = [
 		format: formatCurrency,
 	},
 ];
+
+/**
+ * Define chart properties with translatable string getters
+ * so that they can be translated on the fly. Without this,
+ * you'd have to reload the page in certain instances
+ * to see the translated strings.
+ */
+Object.defineProperty( CHARTS[ 0 ], 'label', {
+	get: () => translate( 'Ads Served' ),
+} );
+
+Object.defineProperty( CHARTS[ 1 ], 'label', {
+	get: () => translate( 'Average CPM' ),
+} );
+
+Object.defineProperty( CHARTS[ 2 ], 'label', {
+	get: () => translate( 'Revenue' ),
+} );
 
 const getActiveTab = ( chartTab ) => find( CHARTS, { attr: chartTab } ) || CHARTS[ 0 ];
 
@@ -135,12 +154,7 @@ class WordAds extends Component {
 			date: endOf.format( 'YYYY-MM-DD' ),
 		};
 
-		// For period option links
-		const wordads = {
-			label: 'Ads',
-			path: '/stats/ads',
-		};
-
+		const wordads = navItems.wordads;
 		const slugPath = slug ? `/${ slug }` : '';
 		const pathTemplate = `${ wordads.path }/{{ interval }}${ slugPath }`;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 539-gh-Automattic/i18n-issues


## Proposed Changes

This is a combination of two problems:
- The 'Ads' navigational item always appeared in English
- Ad chart tabs containing text like 'Ads Served' and 'Average CPM' can appear untranslated.

The first issue was fixed by wrapping the text, and getters with `translate()` calls.

The second issue is more benign. Although the strings are wrapped in `translate()` calls, they can appear untranslated and require page reloading to fix. Using Javascript getters allow the text to appear translated at the time the label is queried by the UI.

## Testing Instructions

1.  Change your user settings to one of the 16 supported languages in the user interface.
2. Navigate to wordpress.com/stats/ads on a Business Account.
3. Verify that the 'Ads' navigational menu item, along with the Chart buttons ('Ads Served', 'Average CPM', etc.) are translated.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
**Before**
![Before](https://user-images.githubusercontent.com/31164683/230220087-f72dfd57-1c29-4c5e-b86f-f00327e318bf.png)
Multiple reloads later
![After multiple page reloads](https://user-images.githubusercontent.com/31164683/230220459-71706242-0cdb-4259-bb88-edef000694ee.png)

**After**

![After implementing the fix](https://user-images.githubusercontent.com/31164683/230221186-e0144944-e6f7-4466-a2ec-71e55b4f77d1.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
