### PR TITLE
Media Library: Show Video Upload Progress

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -222,6 +222,7 @@ $z-layers: (
 		".media-library__list-item.is-transient .media-library__list-item-figure::after": 10,
 		".media-library__list-item-selected-icon .gridicon": 20,
 		".media-library__list-item-spinner": 20,
+		".media-library__list-item-progress": 20,
 	),
 	".dialog__backdrop": (
 		".editor-media-modal .section-nav": 10,

--- a/client/my-sites/media-library/list-item.scss
+++ b/client/my-sites/media-library/list-item.scss
@@ -98,6 +98,20 @@
 	fill: transparent;
 }
 
+.media-library__list-item-progress {
+	position: inherit;
+	z-index: z-index(".media-library__list-item", ".media-library__list-item-progress");
+
+	.progress-bar {
+		display: block;
+		border-radius: 0;
+
+		.progress-bar__progress {
+			border-radius: 0;
+		}
+	}
+}
+
 .media-library__list-item-centered {
 	position: absolute;
 	top: 50%;

--- a/client/my-sites/media-library/list-item.scss
+++ b/client/my-sites/media-library/list-item.scss
@@ -108,6 +108,7 @@
 
 		.progress-bar__progress {
 			border-radius: 0;
+			background-color: var(--color-accent);
 		}
 	}
 }

--- a/client/my-sites/media-library/list-item.tsx
+++ b/client/my-sites/media-library/list-item.tsx
@@ -108,6 +108,7 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 	}
 
 	render() {
+		let dataAttributes = null;
 		let title;
 		let selectedNumber;
 
@@ -123,9 +124,6 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 		} = this.props;
 
 		const { uploadProgress } = this.state;
-
-		let dataAttributes = null;
-
 		const isTransient = media && ( media as MediaObject ).transient;
 
 		const classes = classNames( 'media-library__list-item', {
@@ -159,7 +157,7 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 				</span>
 				<figure className="media-library__list-item-figure" title={ title }>
 					{ this.renderItem() }
-					{ media && ( media as MediaObject ).transient && (
+					{ isTransient && (
 						<>
 							{ uploadProgress > 0 ? (
 								<div className="media-library__list-item-progress">

--- a/packages/wpcom.js/src/lib/tus-uploader.js
+++ b/packages/wpcom.js/src/lib/tus-uploader.js
@@ -36,7 +36,16 @@ export default class TusUploader {
 						.then( ( res ) => resolve( { media: [ res ] } ) )
 						.catch( ( err ) => reject( err ) );
 				},
-				onProgress: (/*bytesUploaded, bytesTotal*/) => {},
+				onProgress: ( bytesUploaded, bytesTotal ) => {
+					const uploadEvent = new CustomEvent( 'tus-upload-progress', {
+						detail: {
+							fileName: file.name,
+							progress: ( bytesUploaded / bytesTotal ) * 100,
+						},
+					} );
+
+					document.dispatchEvent( uploadEvent );
+				},
 			} );
 
 			return this.createGetJwtRequest().then( ( jwtData ) => uploader( file, jwtData ) );


### PR DESCRIPTION
Adds an event emitter from the Tus upload script that the media library item listens to to show upload progress.

![video-upload-progress-calypso](https://user-images.githubusercontent.com/789137/230224737-2fb0b49f-e828-4ef2-8b25-4ed8bd429c7f.gif)

**To Test**
* Upload a video to the media library, you should see upload progress.
* Other media upload types should behave as before with the indeterminate spinner.