### PR TITLE
Fix: Add the inline styles back to the inline-help-search-results

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -24,6 +24,8 @@ import {
 } from './constants';
 import PlaceholderLines from './placeholder-lines';
 
+import './style.scss';
+
 const noop = () => {};
 
 function debounceSpeak( { message = '', priority = 'polite', timeout = 800 } ) {


### PR DESCRIPTION
This PR fixes the styles of the Help section on the dashboard by adding the styles back on that page.

## Proposed Changes

Before:
<img width="717" alt="Screenshot 2023-04-05 at 5 21 40 PM" src="https://user-images.githubusercontent.com/115071/230242486-ad12881a-a080-4c05-a903-ae6c946e2171.png">

After:
<img width="699" alt="Screenshot 2023-04-05 at 5 21 46 PM" src="https://user-images.githubusercontent.com/115071/230242471-c6f44342-be1b-4ca9-b6da-b57bad1aa081.png">


## Testing Instructions
* Navigate to /home/example.com 
Notice the dashboard links look as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
