### PR TITLE
Tags page: Add tracking and fix alphabetic listing on tablet

### DIFF
--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import titlecase from 'to-title-case';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { AlphabeticTagsResult, Tag } from './controller';
 
@@ -20,9 +21,19 @@ interface TagsTableProps {
 	tags: Tag[][];
 }
 
+const trackTagClick = ( slug: string ) => {
+	recordTracksEvent( 'calypso_tags_page_tag_clicked', {
+		type: 'alphabetic',
+		tag: slug,
+	} );
+};
+
 const TagsColumn = ( props: TagsColProps ) => (
 	<div key={ props.slug }>
-		<a href={ `/tag/${ encodeURIComponent( props.slug ) }` }>
+		<a
+			href={ `/tag/${ encodeURIComponent( props.slug ) }` }
+			onClick={ trackTagClick.bind( null, props.slug ) }
+		>
 			<span className="alphabetic-tags__title">{ titlecase( props.title ) }</span>
 		</a>
 	</div>

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -119,7 +119,9 @@
 			text-decoration: none;
 			font-weight: 500;
 			flex-grow: 1;
-
+			&:last-child {
+				flex-grow: 0;
+			}
 			&:focus {
 				border-radius: 0;
 				box-shadow: none;
@@ -131,6 +133,7 @@
 		}
 	}
 }
+
 .alphabetic-tags__table {
 	padding-bottom: 26px;
 	border-bottom: 1px solid var(--studio-gray-5);

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -87,9 +87,11 @@
 	margin-bottom: 26px;
 	padding-left: 10px;
 	@include break-small {
+		padding-left: 0;
+	}
+	@include break-large {
 		display: flex;
 		flex-direction: row;
-		padding-left: 0;
 	}
 
 	h2 {
@@ -98,7 +100,7 @@
 		font-weight: 500;
 		width: 100%;
 		margin-bottom: 20px;
-		@include break-small {
+		@include break-large {
 			width: 50%;
 			margin-bottom: 0;
 		}
@@ -108,7 +110,7 @@
 		flex-direction: row;
 		justify-content: space-between;
 		width: 100%;
-		@include break-small {
+		@include break-large {
 			width: 50%;
 		}
 		button {
@@ -117,7 +119,6 @@
 			text-decoration: none;
 			font-weight: 500;
 			flex-grow: 1;
-			padding-left: 6px;
 
 			&:focus {
 				border-radius: 0;

--- a/client/reader/tags/trending-tags.tsx
+++ b/client/reader/tags/trending-tags.tsx
@@ -1,4 +1,5 @@
 import titlecase from 'to-title-case';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import formatNumberCompact from 'calypso/lib/format-number-compact';
 import { TagResult } from './controller';
 
@@ -12,9 +13,19 @@ interface TagRowProps {
 	count: number;
 }
 
+const trackTagClick = ( slug: string ) => {
+	recordTracksEvent( 'calypso_tags_page_tag_clicked', {
+		type: 'trending',
+		tag: slug,
+	} );
+};
+
 const TagRow = ( props: TagRowProps ) => (
 	<div className="trending-tags__column" key={ props.slug }>
-		<a href={ `/tag/${ encodeURIComponent( props.slug ) }` }>
+		<a
+			href={ `/tag/${ encodeURIComponent( props.slug ) }` }
+			onClick={ trackTagClick.bind( null, props.slug ) }
+		>
 			<span className="trending-tags__title">{ titlecase( props.title ) }</span>
 			<span className="trending-tags__count">{ formatNumberCompact( props.count ) }</span>
 		</a>


### PR DESCRIPTION
Fix two things: 
1) Add tracking to clicking the trending and alphabetic tag links. Event props are as follows:
`calypso_tags_page_tag_clicked { tag: tag_slug}, type: 'trending' | 'alphabetic' }`

2) Fixes alphabetic index on tablet view

**Before**
<img width="833" alt="Screen Shot 2023-04-06 at 11 20 23 am" src="https://user-images.githubusercontent.com/22446385/230249158-e0e97c97-a237-4f9f-92bd-3301abb4940c.png">

**After**
<img width="834" alt="Screen Shot 2023-04-06 at 11 20 01 am" src="https://user-images.githubusercontent.com/22446385/230249189-3f4ae3fe-fa66-412c-b4b2-03201393a63d.png">

### Test instruction.

Tracks events can be tested with the dev tools by filtering for "t.gif" in the network tab
<img width="895" alt="Screen Shot 2023-04-06 at 11 25 14 am" src="https://user-images.githubusercontent.com/22446385/230249452-d6ff9c72-acbe-417d-a27c-3476b1ed55f4.png">


