### PR TITLE
Odyssey: more robust locale files loading

### DIFF
--- a/apps/odyssey-stats/src/lib/set-locale.js
+++ b/apps/odyssey-stats/src/lib/set-locale.js
@@ -8,7 +8,7 @@ const DEFAULT_LANGUAGE = 'en';
 const DEFAULT_MOMENT_LOCALE = 'en';
 const ALWAYS_LOAD_WITH_LOCALE = [ 'zh' ];
 
-const getLanguageWithoutRegionCode = ( localeSlug ) => {
+const getLanguageCodeFromLocale = ( localeSlug ) => {
 	if ( localeSlug.indexOf( '-' ) > -1 ) {
 		return localeSlug.split( '-' )[ 0 ];
 	}
@@ -58,7 +58,7 @@ const loadLanguageFile = ( languageFileName ) => {
 };
 
 export default ( localeSlug ) => {
-	const languageCode = getLanguageWithoutRegionCode( localeSlug );
+	const languageCode = getLanguageCodeFromLocale( localeSlug );
 
 	// Load tranlation file if it's not English.
 	if ( languageCode !== DEFAULT_LANGUAGE ) {

--- a/apps/odyssey-stats/src/lib/set-locale.js
+++ b/apps/odyssey-stats/src/lib/set-locale.js
@@ -4,40 +4,79 @@ import moment from 'moment';
 
 const debug = debugFactory( 'apps:odyssey' );
 
-const DEFAULT_LOCALE = 'en';
+const DEFAULT_LANGUAGE = 'en';
 
-const loadMomentLocale = ( localeSlug ) => {
-	return import(
-		/* webpackChunkName: "moment-locale-[request]", webpackInclude: /\.js$/ */ `moment/locale/${ localeSlug }`
-	).then( () => moment.locale( localeSlug ) );
+const getLanguageWithoutRegionCode = ( localeSlug ) => {
+	if ( localeSlug.indexOf( '-' ) > -1 ) {
+		return localeSlug.split( '-' )[ 0 ];
+	}
+	return localeSlug;
 };
 
-const loadLanguageFile = ( localeSlug ) => {
+const loadMomentLocale = ( localeSlug, languageCode ) => {
+	return import( `moment/locale/${ localeSlug }` )
+		.catch( ( error ) => {
+			debug(
+				`Encountered an error loading moment locale file for ${ localeSlug }. Falling back to language datetime format.`,
+				error
+			);
+			// Fallback to the language code.
+			localeSlug = languageCode;
+			return import( `moment/locale/${ localeSlug }` );
+		} )
+		.catch( ( error ) => {
+			debug(
+				`Encountered an error loading moment locale file for ${ localeSlug }. Falling back to US datetime format.`,
+				error
+			);
+			// Fallback to US date time format.
+			localeSlug = DEFAULT_LANGUAGE;
+		} )
+		.then( () => moment.locale( localeSlug ) );
+};
+
+const loadLanguageFile = ( localeSlug, languageCode ) => {
 	const url = `https://widgets.wp.com/odyssey-stats/v1/languages/${ localeSlug }-v1.1.json`;
 
-	return globalThis.fetch( url ).then( ( response ) => {
-		if ( response.ok ) {
-			return response.json().then( ( body ) => {
-				if ( body ) {
-					i18n.setLocale( body );
-				}
-			} );
-		}
-		return Promise.reject( response );
-	} );
+	return globalThis
+		.fetch( url )
+		.then( ( response ) => {
+			if ( response.ok ) {
+				return response.json().then( ( body ) => {
+					if ( body ) {
+						i18n.setLocale( body );
+					}
+				} );
+			}
+			return Promise.reject( response );
+		} )
+		.catch( ( response ) => {
+			// Try to load the language file without the region code.
+			if ( localeSlug !== languageCode ) {
+				return loadLanguageFile( languageCode, languageCode );
+			}
+			// If we can't load the language file, throw the error.
+			return Promise.reject( response );
+		} );
 };
 
 export default ( localeSlug ) => {
-	if ( localeSlug === DEFAULT_LOCALE ) {
-		return Promise.resolve();
+	const languageCode = getLanguageWithoutRegionCode( localeSlug );
+	// Load language file when the language is not English.
+	// All English is default to American English exepct for `en-gb` which is the only other English locale we support.
+	if ( languageCode !== DEFAULT_LANGUAGE || localeSlug === 'en-gb' ) {
+		// We don't have to wait for the language file to load before rendering the page, because i18n is using hooks to update translations.
+		loadLanguageFile( localeSlug, languageCode )
+			.then( () => debug( `Loaded locale files for ${ localeSlug } successfully.` ) )
+			.catch( ( error ) =>
+				debug(
+					`Encountered an error loading locale file for ${ localeSlug }. Falling back to English.`,
+					error
+				)
+			);
 	}
 
-	return Promise.all( loadLanguageFile( localeSlug ), loadMomentLocale( localeSlug ) )
-		.then( () => debug( `Loaded locale file for ${ localeSlug } successfully.` ) )
-		.catch( ( error ) =>
-			debug(
-				`Encountered an error loading locale file for ${ localeSlug }. Falling back to English.`,
-				error
-			)
-		);
+	// We have to wait for moment locale to load before rendering the page, because otherwise the rendered date time wouldn't get re-rendered.
+	// This could be improved in the future with hooks.
+	return loadMomentLocale( localeSlug, languageCode );
 };

--- a/apps/odyssey-stats/src/lib/set-locale.js
+++ b/apps/odyssey-stats/src/lib/set-locale.js
@@ -23,8 +23,12 @@ const loadMomentLocale = ( localeSlug, languageCode ) => {
 				error
 			);
 			// Fallback 1 to the language code.
-			localeSlug = languageCode;
-			return import( `moment/locale/${ localeSlug }` );
+			if ( localeSlug !== languageCode ) {
+				localeSlug = languageCode;
+				return import( `moment/locale/${ localeSlug }` );
+			}
+			// Pass it to the next catch block if the language code is the same as the locale slug.
+			return Promise.reject( error );
 		} )
 		.catch( ( error ) => {
 			debug(

--- a/apps/odyssey-stats/src/page-middleware/layout.jsx
+++ b/apps/odyssey-stats/src/page-middleware/layout.jsx
@@ -1,7 +1,6 @@
 import { QueryClientProvider } from 'react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
-import MomentProvider from 'calypso/components/localized-moment/provider';
 import { RouteProvider } from 'calypso/components/route';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import Layout from '../components/layout';
@@ -27,15 +26,13 @@ export const ProviderWrappedLayout = ( {
 			>
 				<QueryClientProvider client={ queryClient }>
 					<ReduxProvider store={ store }>
-						<MomentProvider>
-							<Layout
-								primary={ primary }
-								secondary={ secondary }
-								redirectUri={ redirectUri }
-								sectionName="stats"
-								groupName="sites"
-							/>
-						</MomentProvider>
+						<Layout
+							primary={ primary }
+							secondary={ secondary }
+							redirectUri={ redirectUri }
+							sectionName="stats"
+							groupName="sites"
+						/>
 					</ReduxProvider>
 					<CalypsoReactQueryDevtools />
 				</QueryClientProvider>


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/75190#discussion_r1159025078

## Proposed Changes

The PR changes the translation and moment locale loading with a full locale string, e.g. `zh-tw`, `es-ar` or just a language code e.g. `en`, `es`.

- If language is `en`, then we do not load any translations
- If language is `zh`, always load with locale e.g. `zh-tw`
- Load moment locale with locale, e.g. `zh-cn`
  - Fallback 1 to only language code e.g. `zh`
  - Fallback 2 to US format as last resort 

## Testing Instructions

- Please follow instructions in https://github.com/Automattic/jetpack/pull/29958
- Use Option 2 to test with the current release of Jetpack
- Ensure Odyssey Stats/Widget works well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
