### PR TITLE
[PoC] Theme Showcase: Theme detail page hero

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -216,6 +216,52 @@ body.is-section-theme-i4 {
 			}
 		}
 	}
+
+	.theme__sheet-hero {
+		display: flex;
+		transition: background-color 0.2s ease-in;
+
+		@include breakpoint-deprecated( "<960px" ) {
+			padding: 20px;
+		}
+
+		.theme__sheet-columns {
+			align-items: center;
+			display: flex;
+			width: 100%;
+
+			.theme__sheet-main {
+				flex-basis: 33%;
+				padding: 0;
+
+				.theme__sheet-main-actions {
+					flex-direction: column;
+					width: 100%;
+				}
+			}
+
+			.theme__sheet-preview {
+				border-radius: 8px; /* stylelint-disable-line scales/radii */
+				flex-grow: 1;
+				max-height: 50vh;
+				overflow: scroll;
+				width: 100%;
+
+				.theme__sheet-web-preview {
+					box-shadow: none;
+					width: 100%;
+				}
+			}
+		}
+	}
+
+	.theme__sheet-sections {
+		display: flex;
+		gap: 0 32px;
+		margin: 0 auto;
+		max-width: $theme-sheet-content-max-width;
+		padding: 48px 20px;
+	}
 }
 
 .is-section-theme {
@@ -305,6 +351,75 @@ body.is-section-theme-i4 {
 	}
 }
 
+.theme__sheet-main {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+	justify-content: space-between;
+
+	@include breakpoint-deprecated( "<960px" ) {
+		align-items: flex-start;
+		flex-direction: column;
+		padding: 0 24px;
+	}
+
+	&-actions {
+		display: flex;
+		gap: 10px;
+
+		@include breakpoint-deprecated( "<960px" ) {
+			flex-direction: column;
+			width: 100%;
+		}
+
+		button {
+			border-radius: 4px;
+
+			@include breakpoint-deprecated( "<960px" ) {
+				width: 100%;
+			}
+		}
+
+		.theme__sheet-primary-button {
+			position: relative;
+			right: auto;
+			top: auto;
+			margin-right: 0 !important;
+		}
+	}
+
+	&-info-title {
+		@include onboarding-font-recoleta;
+		align-items: center;
+		display: flex;
+		font-size: $font-title-large;
+		line-height: 1;
+	}
+
+	&-info-tag,
+	&-info-description {
+		color: var(--color-neutral-60);
+		font-size: $font-body;
+		font-weight: 400;
+		letter-spacing: -0.32px;
+		line-height: 24px;
+	}
+
+	&-info-style-variations {
+		align-items: center;
+		display: flex;
+		font-size: 0;
+		gap: 4px;
+	}
+
+	&-info-tag,
+	&-info-description,
+	&-info-style-variations {
+		margin-bottom: 32px;
+	}
+}
+
 .theme__sheet-columns {
 	display: flex;
 	flex-direction: row;
@@ -337,60 +452,6 @@ body.is-section-theme-i4 {
 		}
 	}
 
-	.theme__sheet-main {
-		align-items: center;
-		display: flex;
-		flex-wrap: wrap;
-		gap: 16px;
-		justify-content: space-between;
-
-		@include breakpoint-deprecated( "<960px" ) {
-			align-items: flex-start;
-			flex-direction: column;
-			padding: 0 24px;
-		}
-	}
-
-	.theme__sheet-main-actions {
-		display: flex;
-		gap: 10px;
-
-		@include breakpoint-deprecated( "<960px" ) {
-			flex-direction: column;
-			width: 100%;
-		}
-
-		button {
-			border-radius: 4px;
-
-			@include breakpoint-deprecated( "<960px" ) {
-				width: 100%;
-			}
-		}
-
-		.theme__sheet-primary-button {
-			position: relative;
-			right: auto;
-			top: auto;
-			margin-right: 0 !important;
-		}
-	}
-
-	.theme__sheet-main-info-title {
-		@include onboarding-font-recoleta;
-		align-items: center;
-		display: flex;
-		font-size: $font-title-large;
-		line-height: 1;
-	}
-
-	.theme__sheet-main-info-tag {
-		color: var(--color-neutral-60);
-		font-size: $font-body;
-		font-weight: 400;
-		letter-spacing: -0.32px;
-		line-height: 24px;
-	}
 }
 
 .theme__sheet-column-left,

--- a/config/development.json
+++ b/config/development.json
@@ -184,6 +184,7 @@
 		"subscription-gifting": true,
 		"subscription-management": true,
 		"themes/atomic-homepage-replace": true,
+		"themes/detail-i5": true,
 		"themes/premium": true,
 		"themes/showcase-i4/details-and-preview": true,
 		"themes/subscription-purchases": true,

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -7,6 +7,7 @@ export { default as ThemePreview } from './components/theme-preview';
 export { default as UnifiedDesignPicker } from './components/unified-design-picker';
 export { default as WooCommerceBundledBadge } from './components/woocommerce-bundled-badge';
 export { default as PatternAssemblerCta } from './components/pattern-assembler-cta';
+export { getStylesColorFromVariation } from './components/style-variation-badges/utils';
 export {
 	availableDesignsConfig,
 	getAvailableDesigns,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
