### PR TITLE
Focus on the first pattern in the pattern panel

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -1,7 +1,7 @@
 import { PatternRenderer } from '@automattic/block-renderer';
 import { Button } from '@automattic/components';
 import classnames from 'classnames';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useInView } from 'calypso/lib/use-in-view';
 import EmptyPattern from './empty-pattern';
 import { encodePatternId } from './utils';
@@ -11,6 +11,7 @@ import './pattern-list-renderer.scss';
 interface PatternListItemProps {
 	pattern: Pattern;
 	className: string;
+	isFirst: boolean;
 	isShown: boolean;
 	onSelect: ( selectedPattern: Pattern | null ) => void;
 }
@@ -27,11 +28,23 @@ interface PatternListRendererProps {
 const PLACEHOLDER_HEIGHT = 100;
 const MAX_HEIGHT_FOR_100VH = 500;
 
-const PatternListItem = ( { pattern, className, isShown, onSelect }: PatternListItemProps ) => {
+const PatternListItem = ( {
+	pattern,
+	className,
+	isFirst,
+	isShown,
+	onSelect,
+}: PatternListItemProps ) => {
 	const [ inViewOnce, setInViewOnce ] = useState( false );
 	const ref = useInView< HTMLButtonElement >( () => setInViewOnce( true ), {
 		threshold: [ 0 ],
 	} );
+
+	useEffect( () => {
+		if ( isShown && inViewOnce && isFirst && ref.current ) {
+			ref.current.focus();
+		}
+	}, [ isShown, isFirst, ref, inViewOnce ] );
 
 	return (
 		<Button
@@ -81,6 +94,7 @@ const PatternListRenderer = ( {
 					className={ classnames( 'pattern-list-renderer__pattern-list-item', {
 						[ activeClassName ]: pattern.ID === selectedPattern?.ID,
 					} ) }
+					isFirst={ index === 0 }
 					isShown={ shownPatterns.includes( pattern ) }
 					onSelect={ onSelect }
 				/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74829

## Proposed Changes

* Focus on the first pattern when we open the pattern panel.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a new site and `Continue` until landing on the Design Picker.
- Go to the site assembler by clicking `Start designing` from the bottom.
- Click `Sections` and open the pattern panel, see it focuses on the first element.

https://user-images.githubusercontent.com/5287479/230270462-623bc13f-2da4-43e6-a646-ceced845e0f1.mov

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
