### PR TITLE
Anchor: Disable the Anchor.fm onboarding flow

### DIFF
--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -1,15 +1,8 @@
-import { useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
-import { useSiteSlugParam } from '../hooks/use-site-slug-param';
-import { recordSubmitStep } from './internals/analytics/record-submit-step';
-import DesignSetup from './internals/steps-repository/design-setup';
 import ErrorStep from './internals/steps-repository/error-step';
-import { redirect } from './internals/steps-repository/import/util';
-import LoginStep from './internals/steps-repository/login';
-import PodcastTitleStep from './internals/steps-repository/podcast-title';
-import ProcessingStep from './internals/steps-repository/processing-step';
-import type { Flow, ProvidedDependencies } from './internals/types';
-import type { SiteSelect } from '@automattic/data-stores';
+import { AssertConditionState, type AssertConditionResult, type Flow } from './internals/types';
 
 export function isAnchorFmFlow() {
 	const sanitizePodcast = ( id: string ) => id.replace( /[^a-zA-Z0-9]/g, '' );
@@ -22,67 +15,21 @@ const anchorFmFlow: Flow = {
 	name: 'anchor-fm',
 
 	useSteps() {
-		return [
-			{ slug: 'login', component: LoginStep },
-			{ slug: 'podcastTitle', component: PodcastTitleStep },
-			{ slug: 'designSetup', component: DesignSetup },
-			{ slug: 'processing', component: ProcessingStep },
-			{ slug: 'error', component: ErrorStep },
-		];
+		return [ { slug: 'error', component: ErrorStep } ];
 	},
 
-	useStepNavigation( currentStep, navigate ) {
-		const flowName = this.name;
-		const { getNewSite } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
-		const siteSlugParam = useSiteSlugParam();
+	useAssertConditions(): AssertConditionResult {
+		const { setSiteSetupError } = useDispatch( SITE_STORE );
+		const { __ } = useI18n();
 
-		function submit( providedDependencies: ProvidedDependencies = {} ) {
-			recordSubmitStep( providedDependencies, 'anchor-fm', flowName, currentStep );
-			const siteSlug = siteSlugParam || getNewSite()?.site_slug;
+		const error = __( '[Notice title]' );
+		const message = __( '[Notice message]' );
+		setSiteSetupError( error, message );
+		return { state: AssertConditionState.SUCCESS };
+	},
 
-			switch ( currentStep ) {
-				case 'login':
-					return navigate( 'podcastTitle' );
-				case 'podcastTitle':
-					return navigate( 'designSetup' );
-				case 'designSetup':
-					return navigate( 'processing' );
-				case 'processing':
-					return redirect( `/page/${ siteSlug }/home` );
-			}
-		}
-
-		const goBack = () => {
-			switch ( currentStep ) {
-				case 'designSetup':
-					return navigate( 'podcastTitle' );
-				default:
-					return navigate( 'podcastTitle' );
-			}
-		};
-
-		const goNext = () => {
-			const siteSlug = siteSlugParam || getNewSite()?.site_slug;
-
-			switch ( currentStep ) {
-				case 'login':
-					return navigate( 'podcastTitle' );
-				case 'podcastTitle':
-					return navigate( 'designSetup' );
-				case 'designSetup':
-					return navigate( 'processing' );
-				case 'processing':
-					return redirect( `/page/${ siteSlug }/home` );
-				default:
-					return navigate( 'podcastTitle' );
-			}
-		};
-
-		const goToStep = ( step: string ) => {
-			navigate( step );
-		};
-
-		return { goNext, goBack, goToStep, submit };
+	useStepNavigation() {
+		return {};
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -48,6 +48,7 @@ const anchorFmFlow: Flow = {
 		if ( isEnabled( 'anchor/sunset-integration' ) ) {
 			/**
 			 * TODO: Replace the title and the message with the content of the link in the PR description.
+			 * p2: p7fD6U-9EZ-p2
 			 */
 			const error = __( '[Notice title]' );
 			const message = __( '[Notice message]' );

--- a/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
+++ b/client/landing/stepper/declarative-flow/anchor-fm-flow.ts
@@ -46,12 +46,10 @@ const anchorFmFlow: Flow = {
 		const { __ } = useI18n();
 
 		if ( isEnabled( 'anchor/sunset-integration' ) ) {
-			/**
-			 * TODO: Replace the title and the message with the content of the link in the PR description.
-			 * p2: p7fD6U-9EZ-p2
-			 */
-			const error = __( '[Notice title]' );
-			const message = __( '[Notice message]' );
+			const error = __( 'Anchor.fm Discontinuation Notice' );
+			const message = __(
+				"We're sorry to inform you that the Anchor.fm integration with WordPress.com is being discontinued. As a result, you may have encountered an error while setting up your site. We apologize for any inconvenience. Please contact our support team for assistance or return to Anchor.fm to continue managing your podcast."
+			);
 			setSiteSetupError( error, message );
 		}
 		return { state: AssertConditionState.SUCCESS };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -41,21 +41,21 @@ const ErrorStep: Step = function ErrorStep( { navigation, flow } ) {
 
 	const getContent = () => {
 		if ( flow === 'anchor-fm' ) {
+			const secondaryAction = isEnabled( 'anchor/sunset-integration' ) ? (
+				<Button className="error-step__link" borderless href="/help/contact">
+					{ __( 'Contact support' ) }
+				</Button>
+			) : (
+				<Button className="error-step__link" borderless href="https://anchor.fm">
+					{ __( 'Back to Anchor.fm' ) }
+				</Button>
+			);
 			return (
 				<WarningsOrHoldsSection>
 					<Button className="error-step__button" href="/start" primary>
 						{ __( 'Continue' ) }
 					</Button>
-					{ ! isEnabled( 'anchor/sunset-integration' ) && (
-						<Button className="error-step__link" borderless href="https://anchor.fm">
-							{ __( 'Back to Anchor.fm' ) }
-						</Button>
-					) }
-					{ isEnabled( 'anchor/sunset-integration' ) && (
-						<Button className="error-step__link" borderless href="/help/contact">
-							{ __( 'Contact support' ) }
-						</Button>
-					) }
+					{ secondaryAction }
 				</WarningsOrHoldsSection>
 			);
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
 import styled from '@emotion/styled';
@@ -48,6 +49,15 @@ const ErrorStep: Step = function ErrorStep( { navigation, flow } ) {
 					<Button className="error-step__link" borderless href="https://anchor.fm">
 						{ __( 'Back to Anchor.fm' ) }
 					</Button>
+					{ isEnabled( 'anchor/sunset-integration' ) && (
+						<Button
+							className="error-step__link error-step__contact-suport"
+							borderless
+							href="https://anchor.fm"
+						>
+							{ __( 'Contact support' ) }
+						</Button>
+					) }
 				</WarningsOrHoldsSection>
 			);
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -46,15 +46,13 @@ const ErrorStep: Step = function ErrorStep( { navigation, flow } ) {
 					<Button className="error-step__button" href="/start" primary>
 						{ __( 'Continue' ) }
 					</Button>
-					<Button className="error-step__link" borderless href="https://anchor.fm">
-						{ __( 'Back to Anchor.fm' ) }
-					</Button>
+					{ ! isEnabled( 'anchor/sunset-integration' ) && (
+						<Button className="error-step__link" borderless href="https://anchor.fm">
+							{ __( 'Back to Anchor.fm' ) }
+						</Button>
+					) }
 					{ isEnabled( 'anchor/sunset-integration' ) && (
-						<Button
-							className="error-step__link error-step__contact-suport"
-							borderless
-							href="https://anchor.fm"
-						>
+						<Button className="error-step__link" borderless href="/help/contact">
 							{ __( 'Contact support' ) }
 						</Button>
 					) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/style.scss
@@ -39,4 +39,7 @@ $design-button-primary-hover-color: var(--color-primary-60);
 	&.components-button.is-link:active:not(:disabled) {
 		color: var(--studio-gray-60);
 	}
+	&.error-step__contact-suport {
+		float: right;
+	}
 }


### PR DESCRIPTION
## Proposed Changes

* This PR disables the integration with Anchor.fm from our platform's onboarding flow. The changes will not remove all references to Anchor.fm from the onboarding flow but ensure that users can not go through the Anchor.fm onboarding flow.
* Redirects the users to the communication notice.

![Screen Shot 2023-04-12 at 15 49 35](https://user-images.githubusercontent.com/1234758/231556075-d10d2bb1-8f18-45e6-bacd-d6a8b15b0a68.png)

More details about the decision: p7fD6U-9EZ-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

When users attempt to navigate to the Anchor.fm flow, they will be redirected to the default error page with the discontinuation notice.

* Navigate `/setup/anchor-fm/?anchor_podcast=22b6608` 
* You should be redirected to `/setup/anchor-fm/error?anchor_podcast=22b6608`, and a discontinuation message should be presented.