### PR TITLE
Site Assembler: Avoid the content and scrollbar of the sidebar overlapping

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-buttons/style.scss
@@ -3,7 +3,8 @@
 .pattern-assembler {
 	.navigator-button {
 		height: 44px;
-		padding: 10px 8px;
+		padding: 0 8px;
+		margin: 0 -8px;
 		font-size: $font-body-small;
 		font-weight: 400;
 		letter-spacing: -0.15px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -263,7 +263,9 @@ $font-family: "SF Pro Text", $sans;
 	.screen-container__body {
 		display: flex;
 		flex-direction: column;
-		padding: 2px;
+		padding: 2px 16px;
+		// Use negative margin to avoid the content and scrollbar overlapping
+		margin: 0 -16px 32px;
 		margin-bottom: 32px;
 		overflow-y: auto;
 		flex-grow: 1;
@@ -276,10 +278,6 @@ $font-family: "SF Pro Text", $sans;
 	}
 
 	.screen-container__body--align-sides {
-		// Align the content of .navigator-button with the container sides
-		margin-left: -10px;
-		margin-right: -10px;
-
 		// Reduce the padding bottom of .navigator-header__description
 		margin-top: -8px;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-1mb-p2#comment-2476

## Proposed Changes

* Avoid the content and scrollbar of the sidebar overlapping by a negative margin

| Before | After |
| - | - |
| <img src="https://user-images.githubusercontent.com/13596067/230281717-84e43b15-26b4-4bfb-a41d-3afc0c746087.png" width="300" /> | <img src="https://user-images.githubusercontent.com/13596067/230281925-48f63d71-4650-4c49-b494-b52a476c0abc.png" width="300" /> |
| <img src="https://user-images.githubusercontent.com/13596067/230281695-62d2c0ff-9508-440a-9dc3-70526ee720b4.png" width="300" /> | <img src="https://user-images.githubusercontent.com/13596067/230281989-8c05740b-c5ea-4041-84e4-9b887bc7064e.png" width="300" /> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/site-setup?siteSlug=<your_site>
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Select `Colors`, and ensure the content and scrollbar don't overlap
  * Select `Fonts`, and ensure the content and scrollbar don't overlap

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?