### PR TITLE
Global Styles: Disable moving focus to the writing flow wrapper

### DIFF
--- a/packages/global-styles/src/components/global-styles-variation-container/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variation-container/index.tsx
@@ -2,6 +2,7 @@ import {
 	__unstableIframe as Iframe,
 	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
+import { useRefEffect } from '@wordpress/compose';
 import { useGlobalStylesOutput } from '@wordpress/edit-site/build-module/components/global-styles/use-global-styles-output';
 import { useMemo } from 'react';
 import './style.scss';
@@ -56,6 +57,15 @@ const GlobalStylesVariationContainer = ( {
 				visibility: width ? 'visible' : 'hidden',
 			} }
 			tabIndex={ -1 }
+			contentRef={ useRefEffect( ( bodyElement ) => {
+				// Disable moving focus to the writing flow wrapper if the focus disappears
+				// See https://github.com/WordPress/gutenberg/blob/aa8e1c52c7cb497e224a479673e584baaca97113/packages/block-editor/src/components/writing-flow/use-tab-nav.js#L136
+				const onFocusOut = ( event: Event ) => event.stopImmediatePropagation();
+				bodyElement.addEventListener( 'focusout', onFocusOut );
+				return () => {
+					bodyElement.removeEventListener( 'focusout', onFocusOut );
+				};
+			}, [] ) }
 			scrolling="no"
 			{ ...props }
 		>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-1mb-p2#comment-2484

## Proposed Changes

The `Iframe` from Gutenberg has [writingFlowRef](https://github.com/WordPress/gutenberg/blob/aa8e1c52c7cb497e224a479673e584baaca97113/packages/block-editor/src/components/iframe/index.js#L216) which will move focus to the writing flow wrapper when the focus disappears due to there being no blocks. However, when we bring up the `Iframe` to the calypso, the number of inserted blocks is always 0 and it results in the iframe of each variation preview might re-focus immediately after losing the focus. So, this PR is proposing to attaching the `focusout` event to the body of the iframe to disable this feature

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/site-setup?siteSlug=<your_site>
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Select `Fonts` 
  * Scroll to the bottom to select the last one
  * Scroll to the top to select the first one
  * Ensure the scrollbar won't jump to the bottom accidentally

Note that this happens also when you preview the design with several style variations

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?