### PR TITLE
Subscriptions Management: Add "Comments" table with mock data

### DIFF
--- a/client/landing/subscriptions/comment-list/comment-list.tsx
+++ b/client/landing/subscriptions/comment-list/comment-list.tsx
@@ -13,7 +13,7 @@ const CommentList = ( { posts }: CommentListProps ) => {
 	return (
 		<ul className="subscription-manager__comment-list" role="table">
 			<li className="row header" role="row">
-				<span className="site" role="columnheader">
+				<span className="post" role="columnheader">
 					{ translate( 'Subscribed post' ) }
 				</span>
 				<span className="title-box" role="columnheader">

--- a/client/landing/subscriptions/comment-list/comment-list.tsx
+++ b/client/landing/subscriptions/comment-list/comment-list.tsx
@@ -1,7 +1,13 @@
 import { useTranslate } from 'i18n-calypso';
+import CommentRow from './comment-row';
 import './styles.scss';
+import type { PostSubscription } from '@automattic/data-stores/src/reader/types';
 
-const CommentList = () => {
+type CommentListProps = {
+	posts?: PostSubscription[];
+};
+
+const CommentList = ( { posts }: CommentListProps ) => {
 	const translate = useTranslate();
 
 	return (
@@ -18,6 +24,10 @@ const CommentList = () => {
 				</span>
 				<span className="actions" role="columnheader" />
 			</li>
+			{ posts &&
+				posts.map( ( post ) => (
+					<CommentRow key={ `posts.commentrow.${ post.id }` } { ...post } />
+				) ) }
 		</ul>
 	);
 };

--- a/client/landing/subscriptions/comment-list/comment-list.tsx
+++ b/client/landing/subscriptions/comment-list/comment-list.tsx
@@ -1,0 +1,25 @@
+import { useTranslate } from 'i18n-calypso';
+import './styles.scss';
+
+const CommentList = () => {
+	const translate = useTranslate();
+
+	return (
+		<ul className="subscription-manager__comment-list" role="table">
+			<li className="row header" role="row">
+				<span className="site" role="columnheader">
+					{ translate( 'Subscribed post' ) }
+				</span>
+				<span className="title-box" role="columnheader">
+					{ translate( 'Site' ) }
+				</span>
+				<span className="date" role="columnheader">
+					{ translate( 'Since' ) }
+				</span>
+				<span className="actions" role="columnheader" />
+			</li>
+		</ul>
+	);
+};
+
+export default CommentList;

--- a/client/landing/subscriptions/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/comment-list/comment-row.tsx
@@ -1,0 +1,23 @@
+import type { PostSubscription } from '@automattic/data-stores/src/reader/types';
+
+const CommentRow = ( {
+	id,
+	title,
+	excerpt,
+	site_icon,
+	site_url,
+	date_subscribed,
+}: PostSubscription ) => {
+	return (
+		<li className="row" role="row">
+			{ id } <br />
+			{ title } <br />
+			{ excerpt } <br />
+			{ site_icon } <br />
+			{ site_url } <br />
+			{ date_subscribed } <br />
+		</li>
+	);
+};
+
+export default CommentRow;

--- a/client/landing/subscriptions/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/comment-list/comment-row.tsx
@@ -26,8 +26,8 @@ const CommentRow = ( {
 	return (
 		<li className="row" role="row">
 			<span className="post" role="cell">
-				<span className="title">{ title }</span>
-				<span className="excerpt">{ excerpt }</span>
+				<div className="title">{ title }</div>
+				<div className="excerpt">{ excerpt }</div>
 			</span>
 			<span className="title-box" role="cell">
 				{ siteIcon }
@@ -40,7 +40,7 @@ const CommentRow = ( {
 				{ since }
 			</span>
 			<span className="actions" role="cell">
-				actions
+				...
 			</span>
 		</li>
 	);

--- a/client/landing/subscriptions/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/comment-list/comment-row.tsx
@@ -1,21 +1,47 @@
+import { Gridicon } from '@automattic/components';
+import moment from 'moment';
+import { useMemo } from 'react';
 import type { PostSubscription } from '@automattic/data-stores/src/reader/types';
 
 const CommentRow = ( {
-	id,
 	title,
 	excerpt,
+	site_title,
 	site_icon,
 	site_url,
 	date_subscribed,
 }: PostSubscription ) => {
+	const since = useMemo(
+		() => moment( date_subscribed ).format( 'LL' ),
+		[ date_subscribed, moment ]
+	);
+	const hostname = useMemo( () => new URL( site_url ).hostname, [ site_url ] );
+	const siteIcon = useMemo( () => {
+		if ( site_icon ) {
+			return <img className="icon" src={ site_icon } alt={ site_title } />;
+		}
+		return <Gridicon className="icon" icon="globe" size={ 48 } />;
+	}, [ site_icon, site_title ] );
+
 	return (
 		<li className="row" role="row">
-			{ id } <br />
-			{ title } <br />
-			{ excerpt } <br />
-			{ site_icon } <br />
-			{ site_url } <br />
-			{ date_subscribed } <br />
+			<span className="post" role="cell">
+				<span className="title">{ title }</span>
+				<span className="excerpt">{ excerpt }</span>
+			</span>
+			<span className="title-box" role="cell">
+				{ siteIcon }
+				<span className="title-column">
+					<span className="name">{ site_title }</span>
+					<span className="url">{ hostname }</span>
+				</span>
+			</span>
+			<span className="date" role="cell">
+				{ since }
+			</span>
+			<span className="actions" role="cell">
+				actions
+			</span>
 		</li>
 	);
 };

--- a/client/landing/subscriptions/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/comment-list/comment-row.tsx
@@ -35,7 +35,7 @@ const CommentRow = ( {
 				</span>
 			</a>
 			<span className="date" role="cell">
-				<TimeSince date={ date_subscribed.toISOString() } />
+				<TimeSince date={ date_subscribed.toISOString?.() ?? date_subscribed } />
 			</span>
 			<span className="actions" role="cell">
 				...

--- a/client/landing/subscriptions/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/comment-list/comment-row.tsx
@@ -1,6 +1,6 @@
 import { Gridicon } from '@automattic/components';
-import moment from 'moment';
 import { useMemo } from 'react';
+import TimeSince from 'calypso/components/time-since';
 import type { PostSubscription } from '@automattic/data-stores/src/reader/types';
 
 const CommentRow = ( {
@@ -11,10 +11,6 @@ const CommentRow = ( {
 	site_url,
 	date_subscribed,
 }: PostSubscription ) => {
-	const since = useMemo(
-		() => moment( date_subscribed ).format( 'LL' ),
-		[ date_subscribed, moment ]
-	);
 	const hostname = useMemo( () => new URL( site_url ).hostname, [ site_url ] );
 	const siteIcon = useMemo( () => {
 		if ( site_icon ) {
@@ -39,7 +35,7 @@ const CommentRow = ( {
 				</span>
 			</a>
 			<span className="date" role="cell">
-				{ since }
+				<TimeSince date={ date_subscribed.toISOString() } />
 			</span>
 			<span className="actions" role="cell">
 				...

--- a/client/landing/subscriptions/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/comment-list/comment-row.tsx
@@ -29,13 +29,15 @@ const CommentRow = ( {
 				<div className="title">{ title }</div>
 				<div className="excerpt">{ excerpt }</div>
 			</span>
-			<span className="title-box" role="cell">
-				{ siteIcon }
-				<span className="title-column">
-					<span className="name">{ site_title }</span>
-					<span className="url">{ hostname }</span>
+			<a href={ site_url } rel="noreferrer noopener" className="title-box" target="_blank">
+				<span className="title-box" role="cell">
+					{ siteIcon }
+					<span className="title-column">
+						<span className="name">{ site_title }</span>
+						<span className="url">{ hostname }</span>
+					</span>
 				</span>
-			</span>
+			</a>
 			<span className="date" role="cell">
 				{ since }
 			</span>

--- a/client/landing/subscriptions/comment-list/styles.scss
+++ b/client/landing/subscriptions/comment-list/styles.scss
@@ -82,6 +82,10 @@ $max-list-width: 1300px;
 					letter-spacing: -0.24px;
 					padding-right: 10px;
 					@extend %ellipsis;
+
+					&:hover {
+						text-decoration: underline;
+					}
 				}
 
 				.url {
@@ -90,6 +94,10 @@ $max-list-width: 1300px;
 					line-height: 18px;
 					color: $studio-gray-40;
 					@extend %ellipsis;
+
+					&:hover {
+						text-decoration: underline;
+					}
 				}
 			}
 		}

--- a/client/landing/subscriptions/comment-list/styles.scss
+++ b/client/landing/subscriptions/comment-list/styles.scss
@@ -4,6 +4,12 @@
 
 $max-list-width: 1300px;
 
+%ellipsis {
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
+}
+
 .subscription-manager__comment-list {
 	max-width: $max-list-width;
 
@@ -24,10 +30,29 @@ $max-list-width: 1300px;
 			padding-top: 0;
 		}
 
+		.post {
+			display: flex;
+			flex-direction: column;
+			max-width: 403px;
+			font-size: $font-body-small;
+			line-height: 20px;
+
+			.title {
+				font-weight: 500;
+				@extend %ellipsis;
+			}
+
+			.excerpt {
+				max-width: 350px;
+				font-weight: 400;
+				color: $studio-gray-60;
+				@extend %ellipsis;
+			}
+		}
+
 		.title-box {
 			display: flex;
 			align-items: center;
-			flex: 1.83;
 			min-width: 0;
 
 			.icon {
@@ -50,14 +75,8 @@ $max-list-width: 1300px;
 					line-height: 22px;
 					color: $studio-gray-100;
 					letter-spacing: -0.24px;
-					text-overflow: ellipsis;
-					white-space: nowrap;
-					overflow: hidden;
 					padding-right: 10px;
-
-					&:hover {
-						text-decoration: underline;
-					}
+					@extend %ellipsis;
 				}
 
 				.url {
@@ -65,13 +84,7 @@ $max-list-width: 1300px;
 					font-size: $font-body-extra-small;
 					line-height: 18px;
 					color: $studio-gray-40;
-					text-overflow: ellipsis;
-					white-space: nowrap;
-					overflow: hidden;
-
-					&:hover {
-						text-decoration: underline;
-					}
+					@extend %ellipsis;
 				}
 			}
 		}

--- a/client/landing/subscriptions/comment-list/styles.scss
+++ b/client/landing/subscriptions/comment-list/styles.scss
@@ -1,0 +1,102 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+
+$max-list-width: 1300px;
+
+.subscription-manager__comment-list {
+	max-width: $max-list-width;
+
+	.row {
+		border-bottom: 1px solid var(--color-border-subtle);
+		display: flex;
+		align-items: center;
+		flex-direction: row;
+		padding-top: 20px;
+		padding-bottom: 20px;
+
+		* {
+			flex: 1;
+		}
+
+		&.header {
+			padding-bottom: $font-code;
+			padding-top: 0;
+		}
+
+		.title-box {
+			display: flex;
+			align-items: center;
+			flex: 1.83;
+			min-width: 0;
+
+			.icon {
+				fill: var(--color-text-subtle);
+				width: 40px;
+				height: 40px;
+				flex: none;
+				border-radius: 50%;
+			}
+
+			.title-column {
+				display: flex;
+				flex-direction: column;
+				min-width: 0;
+				padding-left: 12px;
+
+				.name {
+					font-weight: 600;
+					font-size: $font-code;
+					line-height: 22px;
+					color: $studio-gray-100;
+					letter-spacing: -0.24px;
+					text-overflow: ellipsis;
+					white-space: nowrap;
+					overflow: hidden;
+					padding-right: 10px;
+
+					&:hover {
+						text-decoration: underline;
+					}
+				}
+
+				.url {
+					font-weight: 400;
+					font-size: $font-body-extra-small;
+					line-height: 18px;
+					color: $studio-gray-40;
+					text-overflow: ellipsis;
+					white-space: nowrap;
+					overflow: hidden;
+
+					&:hover {
+						text-decoration: underline;
+					}
+				}
+			}
+		}
+
+		.title-box,
+		.site,
+		.date {
+			font-weight: 400;
+			font-size: $font-body-small;
+			line-height: 20px;
+			letter-spacing: -0.15px;
+			color: $studio-gray-60;
+		}
+
+		.actions {
+			flex-basis: 36px;
+			flex-grow: initial;
+
+			.gridicon {
+				fill: $studio-gray-50;
+			}
+		}
+
+		&:last-child {
+			border-bottom: none;
+		}
+	}
+}

--- a/client/landing/subscriptions/comment-list/styles.scss
+++ b/client/landing/subscriptions/comment-list/styles.scss
@@ -31,9 +31,8 @@ $max-list-width: 1300px;
 		}
 
 		.post {
-			display: flex;
-			flex-direction: column;
 			max-width: 403px;
+			min-width: 350px;
 			font-size: $font-body-small;
 			line-height: 20px;
 
@@ -47,6 +46,12 @@ $max-list-width: 1300px;
 				font-weight: 400;
 				color: $studio-gray-60;
 				@extend %ellipsis;
+			}
+		}
+
+		@media (max-width: $break-small) {
+			.post {
+				min-width: 0;
 			}
 		}
 
@@ -89,14 +94,25 @@ $max-list-width: 1300px;
 			}
 		}
 
+		@media (max-width: $break-small) {
+			.title-box {
+				display: none;
+			}
+		}
+
 		.title-box,
-		.site,
 		.date {
 			font-weight: 400;
 			font-size: $font-body-small;
 			line-height: 20px;
 			letter-spacing: -0.15px;
 			color: $studio-gray-60;
+		}
+
+		@media (max-width: $break-medium) {
+			.date {
+				display: none;
+			}
 		}
 
 		.actions {

--- a/client/landing/subscriptions/site-list/site-row.tsx
+++ b/client/landing/subscriptions/site-list/site-row.tsx
@@ -63,7 +63,7 @@ export default function SiteRow( {
 				</span>
 			</a>
 			<span className="date" role="cell">
-				<TimeSince date={ date_subscribed.toDateString?.() ?? date_subscribed } />
+				<TimeSince date={ date_subscribed.toISOString?.() ?? date_subscribed } />
 			</span>
 			<span className="email-frequency" role="cell">
 				{ deliveryFrequencyLabel }

--- a/client/landing/subscriptions/tab-views/comments.tsx
+++ b/client/landing/subscriptions/tab-views/comments.tsx
@@ -1,8 +1,9 @@
+import CommentList from '../comment-list/comment-list';
 import TabView from './tab-view';
 
 const Comments = () => (
 	<TabView errorMessage="" isLoading={ false }>
-		<>Comments Tab</>
+		<CommentList />
 	</TabView>
 );
 

--- a/client/landing/subscriptions/tab-views/comments.tsx
+++ b/client/landing/subscriptions/tab-views/comments.tsx
@@ -1,9 +1,29 @@
 import CommentList from '../comment-list/comment-list';
 import TabView from './tab-view';
+import type { PostSubscription } from '@automattic/data-stores/src/reader/types';
+
+const posts: PostSubscription[] = [
+	{
+		id: '1',
+		title: 'Post Title 1',
+		excerpt: 'Post excerpt 1',
+		site_icon: 'https://www.gravatar.com/avatar/',
+		site_url: 'https://testsite2022.wordpress.com',
+		date_subscribed: '2022-03-29T14:55:53+00:00',
+	},
+	{
+		id: '2',
+		title: 'April Post',
+		excerpt: 'This post was written on the April 1st, 2023.',
+		site_icon: 'https://www.gravatar.com/avatar/',
+		site_url: 'https://testsite2023.wordpress.com',
+		date_subscribed: '2023-01-04T17:55:53+00:00',
+	},
+];
 
 const Comments = () => (
 	<TabView errorMessage="" isLoading={ false }>
-		<CommentList />
+		<CommentList posts={ posts } />
 	</TabView>
 );
 

--- a/client/landing/subscriptions/tab-views/comments.tsx
+++ b/client/landing/subscriptions/tab-views/comments.tsx
@@ -11,7 +11,7 @@ const posts: PostSubscription[] = [
 		site_title: 'Test Site 2022',
 		site_icon: 'https://www.gravatar.com/avatar/',
 		site_url: 'https://testsite2022.wordpress.com',
-		date_subscribed: '2022-03-29T14:55:53+00:00',
+		date_subscribed: new Date( '2022-03-29T14:55:53+00:00' ),
 	},
 	{
 		id: '2',
@@ -21,7 +21,7 @@ const posts: PostSubscription[] = [
 		site_icon: 'https://www.gravatar.com/avatar/',
 		site_title: 'April Site',
 		site_url: 'https://testsite2023.wordpress.com',
-		date_subscribed: '2023-01-04T17:55:53+00:00',
+		date_subscribed: new Date( '2023-01-04T17:55:53+00:00' ),
 	},
 ];
 

--- a/client/landing/subscriptions/tab-views/comments.tsx
+++ b/client/landing/subscriptions/tab-views/comments.tsx
@@ -5,17 +5,21 @@ import type { PostSubscription } from '@automattic/data-stores/src/reader/types'
 const posts: PostSubscription[] = [
 	{
 		id: '1',
-		title: 'Post Title 1',
-		excerpt: 'Post excerpt 1',
+		title: 'Alone at the Edge of the World',
+		excerpt:
+			'Susie Goodall wanted to circumnavigate the globe in a sailboat. She did it, but not without a few hiccups along the way.',
+		site_title: 'Test Site 2022',
 		site_icon: 'https://www.gravatar.com/avatar/',
 		site_url: 'https://testsite2022.wordpress.com',
 		date_subscribed: '2022-03-29T14:55:53+00:00',
 	},
 	{
 		id: '2',
-		title: 'April Post',
-		excerpt: 'This post was written on the April 1st, 2023.',
+		title: '50 Years Ago, Stevie Wonder Heard the Future',
+		excerpt:
+			'On the anniversary of the landmark 1972 album “Talking Book,” the singer-songwriter reflects on the making of his masterpiece.',
 		site_icon: 'https://www.gravatar.com/avatar/',
+		site_title: 'April Site',
 		site_url: 'https://testsite2023.wordpress.com',
 		date_subscribed: '2023-01-04T17:55:53+00:00',
 	},

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -61,3 +61,12 @@ export type SiteSubscription = {
 };
 
 export type SiteSubscriptionDeliveryFrequency = 'instantly' | 'daily' | 'weekly';
+
+export type PostSubscription = {
+	id: string;
+	title: string;
+	excerpt: string;
+	site_icon: string;
+	site_url: string;
+	date_subscribed: string;
+};

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -66,6 +66,7 @@ export type PostSubscription = {
 	id: string;
 	title: string;
 	excerpt: string;
+	site_title: string;
 	site_icon: string;
 	site_url: string;
 	date_subscribed: string;

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -69,5 +69,5 @@ export type PostSubscription = {
 	site_title: string;
 	site_icon: string;
 	site_url: string;
-	date_subscribed: string;
+	date_subscribed: Date;
 };


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/75374.

The proposed changes add the list of comment subscriptions:

![Markup on 2023-04-11 at 14:00:54](https://user-images.githubusercontent.com/25105483/231156529-57b821a0-8f8c-4571-aca6-4dc040563fc7.png)


## Proposed Changes

* add `CommentList` and `CommentRow` components that build the list of comment subscriptions on the Comments tab
* change `date_subscribed.toDateString?.()` to `date_subscribed.toISOString?.()` to fix the date format warning (context: p1681200787867589/1681200123.398929-slack-C02TCEHP3HA)

## Testing Instructions

1. Check out and build the PR locally.
2. Apply the correct `subkey` value to your `calypso.localhost:3000` host.
3. Make sure the related user has existing comment subscriptions.
4. Navigate to http://calypso.localhost:3000/subscriptions/comments and review the page.
  - The design should match to what we have in Figma: inDLaEQV8jJ21O4WXawIsJ-fi-712-25346
  - Site icon, Site title and Site address should open in a new tab
5. Navigate to http://calypso.localhost:3000/subscriptions/sites. The values in the "Since" column should render correctly and there should be no warning in the browser console.

ℹ️ It is not yet clear if we want to link post title to the related post → I asked for clarification in Figma.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?