### PR TITLE
Stats: Update grid on the Subscribers page (take 2)

### DIFF
--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -29,6 +29,38 @@ $grid-vertical-gutters: 32px;
 	}
 }
 
+.stats__module-list.stats__module--unified.subscribers-page {
+
+	@include stats-desktop-grid(
+		"followers followers followers followers followers followers publicize publicize publicize publicize publicize publicize",
+		1
+	);
+
+	@include stats-tablet-grid(
+		"followers followers followers followers publicize publicize publicize publicize",
+		1
+	);
+
+	@include stats-mobile-grid(
+		"followers followers followers followers"
+		"publicize publicize publicize publicize",
+		2
+	);
+
+	@media (max-width: 660px) {
+		padding: 0 16px;
+	}
+
+	.stats__module-wrapper--followers,
+	.list-followers {
+		grid-area: followers;
+	}
+
+	.stats__module-wrapper--publicize,
+	.list-publicize {
+		grid-area: publicize;
+	}
+}
 
 .stats__module-list.stats__module--unified.is-insights-page-enabled {
 
@@ -145,7 +177,6 @@ $grid-vertical-gutters: 32px;
 		grid-area: publicize;
 	}
 }
-
 
 .is-section-stats .stats__module-list--traffic {
 	@include stats-desktop-grid(

--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -32,19 +32,22 @@ $grid-vertical-gutters: 32px;
 .stats__module-list.stats__module--unified.subscribers-page {
 
 	@include stats-desktop-grid(
-		"followers followers followers followers followers followers publicize publicize publicize publicize publicize publicize",
-		1
+		"followers followers followers followers followers followers publicize publicize publicize publicize publicize publicize"
+		"emails emails emails emails emails emails emails emails emails emails emails emails",
+		2
 	);
 
 	@include stats-tablet-grid(
-		"followers followers followers followers publicize publicize publicize publicize",
-		1
+		"followers followers followers followers publicize publicize publicize publicize"
+		"emails emails emails emails emails emails emails emails",
+		2
 	);
 
 	@include stats-mobile-grid(
 		"followers followers followers followers"
-		"publicize publicize publicize publicize",
-		2
+		"publicize publicize publicize publicize"
+		"emails emails emails emails",
+		3
 	);
 
 	@media (max-width: 660px) {
@@ -59,6 +62,11 @@ $grid-vertical-gutters: 32px;
 	.stats__module-wrapper--publicize,
 	.list-publicize {
 		grid-area: publicize;
+	}
+
+	.stats__module-wrapper--emails,
+	.list-emails {
+		grid-area: emails;
 	}
 }
 

--- a/client/my-sites/stats/stats-subscribers-page/index.jsx
+++ b/client/my-sites/stats/stats-subscribers-page/index.jsx
@@ -25,6 +25,7 @@ const StatsSubscribersPage = ( props ) => {
 	const { siteId, siteSlug, translate, isOdysseyStats, isJetpack } = props;
 
 	const isSubscribersPageEnabled = config.isEnabled( 'stats/subscribers-section' );
+	const showEmailSection = config.isEnabled( 'newsletter/stats' ) && ! isOdysseyStats;
 
 	const statsModuleListClass = classNames(
 		'stats__module-list stats__module--unified',
@@ -73,28 +74,30 @@ const StatsSubscribersPage = ( props ) => {
 						<div className={ statsModuleListClass }>
 							<Followers path="followers" />
 							<Reach />
-							<StatsModule
-								additionalColumns={ {
-									header: (
-										<>
-											<span>{ translate( 'Opens' ) }</span>
-										</>
-									),
-									body: ( item ) => (
-										<>
-											<span>{ item.opens }</span>
-										</>
-									),
-								} }
-								path="emails"
-								moduleStrings={ moduleStrings.emails }
-								// period={ this.props.period }
-								// query={ query }
-								statType="statsEmailsSummary"
-								mainItemLabel={ translate( 'Latest Emails' ) }
-								metricLabel={ translate( 'Clicks' ) }
-								showSummaryLink
-							/>
+							{ showEmailSection && (
+								<StatsModule
+									additionalColumns={ {
+										header: (
+											<>
+												<span>{ translate( 'Opens' ) }</span>
+											</>
+										),
+										body: ( item ) => (
+											<>
+												<span>{ item.opens }</span>
+											</>
+										),
+									} }
+									path="emails"
+									moduleStrings={ moduleStrings.emails }
+									// period={ this.props.period }
+									// query={ query }
+									statType="statsEmailsSummary"
+									mainItemLabel={ translate( 'Latest Emails' ) }
+									metricLabel={ translate( 'Clicks' ) }
+									showSummaryLink
+								/>
+							) }
 						</div>
 					</>
 				) }

--- a/client/my-sites/stats/stats-subscribers-page/index.jsx
+++ b/client/my-sites/stats/stats-subscribers-page/index.jsx
@@ -17,7 +17,9 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import AnnualHighlightsSection from '../annual-highlights-section';
 import Followers from '../stats-followers';
+import StatsModule from '../stats-module';
 import Reach from '../stats-reach';
+import statsStrings from '../stats-strings';
 
 const StatsSubscribersPage = ( props ) => {
 	const { siteId, siteSlug, translate, isOdysseyStats, isJetpack } = props;
@@ -32,6 +34,8 @@ const StatsSubscribersPage = ( props ) => {
 		},
 		'subscribers-page'
 	);
+
+	const moduleStrings = statsStrings();
 
 	// Track the last viewed tab.
 	// Necessary to properly configure the fixed navigation headers.
@@ -69,6 +73,28 @@ const StatsSubscribersPage = ( props ) => {
 						<div className={ statsModuleListClass }>
 							<Followers path="followers" />
 							<Reach />
+							<StatsModule
+								additionalColumns={ {
+									header: (
+										<>
+											<span>{ translate( 'Opens' ) }</span>
+										</>
+									),
+									body: ( item ) => (
+										<>
+											<span>{ item.opens }</span>
+										</>
+									),
+								} }
+								path="emails"
+								moduleStrings={ moduleStrings.emails }
+								// period={ this.props.period }
+								// query={ query }
+								statType="statsEmailsSummary"
+								mainItemLabel={ translate( 'Latest Emails' ) }
+								metricLabel={ translate( 'Clicks' ) }
+								showSummaryLink
+							/>
 						</div>
 					</>
 				) }

--- a/client/my-sites/stats/stats-subscribers-page/index.jsx
+++ b/client/my-sites/stats/stats-subscribers-page/index.jsx
@@ -30,7 +30,7 @@ const StatsSubscribersPage = ( props ) => {
 			'is-odyssey-stats': isOdysseyStats,
 			'is-jetpack': isJetpack,
 		},
-		'is-insights-page-enabled'
+		'subscribers-page'
 	);
 
 	// Track the last viewed tab.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75316.

## Proposed Changes

1. Updates grid for Subscribers page.
2. Brings Emails module over from Traffic page (still present there too).

With changes it should look like this:
<img width="785" alt="SCR-20230406-pfgs" src="https://user-images.githubusercontent.com/40267301/230333501-294eeea7-8138-45d1-b996-570c5fedd7f6.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Calypso Live link.
* Visit Jetpack → Stats → Traffic.
* Confirm the Subscribers page isn't listed in the navigation.
* Add `?flags=stats/subscribers-section` to the URL.
* Confirm the Subscribers page is now visible in the navigation.
* Click over to the Subscribers page and confirm the layout matches the screenshot above.
* Test with both Atomic & self-hosted.
* Test with different screen sizes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
