### PR TITLE
Marketplace: avoid plugin overflows in thank you page if descriptions is big.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-plugin-section.tsx
@@ -21,7 +21,6 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 const PluginSectionContainer = styled.div`
 	display: flex;
 	flex-direction: row;
-	flex-wrap: wrap;
 	width: 720px;
 	box-sizing: border-box;
 	align-items: center;
@@ -67,6 +66,7 @@ const PluginSectionExpirationDate = styled.div`
 
 const PluginSectionButtons = styled.div`
 	display: flex;
+	flex-shrink: 0;
 	gap: 16px;
 	min-width: auto;
 `;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #75381 

## Proposed Changes

* avoid plugin overflow in thank you page if descriptions is big.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install visual composer (free plugin) and woocommerce 
* Visit `marketplace/thank-you/cpapecom.wpcomstaging.com?plugins=visualcomposer,woocommerce`

|Before | After|
|-------|------|
|![CleanShot 2023-04-06 at 14 38 30@2x](https://user-images.githubusercontent.com/12430020/230365917-ff896328-69bf-4433-899c-26272d1cfcf4.jpg)|![CleanShot 2023-04-06 at 14 38 19@2x](https://user-images.githubusercontent.com/12430020/230365871-978d2999-b10e-4102-b326-56a69c529a48.jpg)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
