### PR TITLE
Jetpack Pro Dashboard: add tooltip & popover to the expandable block icons

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -156,6 +156,7 @@ export default function SiteCard( { rows, columns }: Props ) {
 														isSmallScreen
 														site={ rows.site.value }
 														columns={ [ column.key ] }
+														hasError={ site.error || ! isSiteConnected }
 													/>
 												) }
 											</>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -17,6 +17,7 @@ import type { Site, Backup } from '../types';
 interface Props {
 	site: Site;
 	trackEvent: ( eventName: string ) => void;
+	hasError: boolean;
 }
 
 const BACKUP_ERROR_STATUSES = [ 'rewind_backup_error', 'backup_only_error' ];
@@ -96,7 +97,7 @@ const BackupStorageContent = ( {
 	);
 };
 
-export default function BackupStorage( { site, trackEvent }: Props ) {
+export default function BackupStorage( { site, trackEvent, hasError }: Props ) {
 	const {
 		blog_id: siteId,
 		url: siteUrl,
@@ -181,6 +182,7 @@ export default function BackupStorage( { site, trackEvent }: Props ) {
 			// If the backup is not enabled, we want to allow the user to click on the card
 			onClick={ ! isBackupEnabled ? handleOnClick : undefined }
 			href={ link }
+			hasError={ hasError }
 		>
 			{ isBackupEnabled && (
 				<BackupStorageContent

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -15,6 +15,7 @@ interface Props {
 	siteId: number;
 	siteUrlWithScheme: string;
 	trackEvent: ( eventName: string ) => void;
+	hasError: boolean;
 }
 
 export default function BoostSitePerformance( {
@@ -23,6 +24,7 @@ export default function BoostSitePerformance( {
 	siteId,
 	siteUrlWithScheme,
 	trackEvent,
+	hasError,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -51,6 +53,7 @@ export default function BoostSitePerformance( {
 					components,
 				}
 			) }
+			hasError={ hasError }
 		>
 			<div className="site-expanded-content__card-content-container">
 				<div className="site-expanded-content__card-content">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/expanded-card.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/expanded-card.tsx
@@ -12,6 +12,7 @@ interface Props {
 	onClick?: () => void;
 	href?: string;
 	isLoading?: boolean;
+	hasError?: boolean;
 }
 
 export default function ExpandedCard( {
@@ -22,6 +23,7 @@ export default function ExpandedCard( {
 	onClick,
 	href,
 	isLoading,
+	hasError,
 }: Props ) {
 	// Trigger click event when pressing Enter or Space
 	const handleOnKeyDown = ( event: React.KeyboardEvent< HTMLDivElement > ) => {
@@ -30,7 +32,7 @@ export default function ExpandedCard( {
 		}
 	};
 
-	const isClickable = !! onClick && ! isLoading;
+	const isClickable = !! onClick && ! isLoading && ! hasError;
 
 	const props = {
 		href,
@@ -40,6 +42,7 @@ export default function ExpandedCard( {
 			'expanded-card__not-enabled': ! isEnabled,
 			'expanded-card__clickable': isClickable,
 			'expanded-card__loading': isLoading,
+			'expanded-card__error': ! isEnabled && hasError, // If the card is not enabled and has an error, show the error state
 		} ),
 		// Add click handlers if onClick is provided
 		...( isClickable && {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/index.tsx
@@ -13,6 +13,7 @@ interface Props {
 	site: Site;
 	columns?: AllowedTypes[];
 	isSmallScreen?: boolean;
+	hasError: boolean;
 }
 
 const defaultColumns: AllowedTypes[] = siteColumns.map( ( { key } ) => key );
@@ -21,6 +22,7 @@ export default function SiteExpandedContent( {
 	site,
 	columns = defaultColumns,
 	isSmallScreen = false,
+	hasError,
 }: Props ) {
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], ! isSmallScreen );
 
@@ -53,13 +55,19 @@ export default function SiteExpandedContent( {
 					siteUrlWithScheme={ siteUrlWithScheme }
 					hasBoost={ site.has_boost }
 					trackEvent={ trackEvent }
+					hasError={ hasError }
 				/>
 			) }
 			{ columns.includes( 'backup' ) && stats && (
-				<BackupStorage site={ site } trackEvent={ trackEvent } />
+				<BackupStorage site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			) }
 			{ columns.includes( 'monitor' ) && (
-				<MonitorActivity hasMonitor={ hasMonitor } site={ site } trackEvent={ trackEvent } />
+				<MonitorActivity
+					hasMonitor={ hasMonitor }
+					site={ site }
+					trackEvent={ trackEvent }
+					hasError={ hasError }
+				/>
 			) }
 		</div>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
@@ -15,6 +15,7 @@ interface Props {
 	hasMonitor: boolean;
 	site: Site;
 	trackEvent: ( eventName: string ) => void;
+	hasError: boolean;
 }
 
 const START_INDEX = 10;
@@ -82,7 +83,7 @@ const MonitorDataContent = ( { siteId }: { siteId: number } ) => {
 	);
 };
 
-export default function MonitorActivity( { hasMonitor, site, trackEvent }: Props ) {
+export default function MonitorActivity( { hasMonitor, site, trackEvent, hasError }: Props ) {
 	const translate = useTranslate();
 
 	const toggleActivateMonitor = useToggleActivateMonitor( [ site ] );
@@ -107,6 +108,7 @@ export default function MonitorActivity( { hasMonitor, site, trackEvent }: Props
 				}
 			) }
 			isLoading={ isLoading }
+			hasError={ hasError }
 			// Allow to click on the card only if the monitor is not active
 			onClick={ ! hasMonitor ? handleOnClick : undefined }
 		>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/style.scss
@@ -278,3 +278,8 @@ $color-yellow: var(--studio-yellow-50);
 .expanded-card__loading {
 	opacity: 0.5;
 }
+
+.expanded-card__error {
+	opacity: 0.5;
+	cursor: not-allowed;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/index.tsx
@@ -50,24 +50,22 @@ export default function SiteTableExpand( { index, setExpanded, isExpanded, siteI
 	};
 
 	return (
-		<>
-			<td
-				className={ classNames( 'site-table__actions site-table__expand-row', {
-					'site-table__td-without-border-bottom': isExpanded,
-				} ) }
-			>
-				<>
-					<Button { ...props }>
-						<Icon icon={ isExpanded ? chevronUp : chevronDown } />
-					</Button>
-					{ ! isExpanded && isPopoverDismissed && (
-						<SiteTableTooltip ref={ buttonRef } siteId={ siteId } showTooltip={ showTooltip } />
-					) }
-					{ ! isPopoverDismissed && (
-						<SiteTablePopover savePreferenceType={ savePreferenceType } ref={ buttonRef } />
-					) }
-				</>
-			</td>
-		</>
+		<td
+			className={ classNames( 'site-table__actions site-table__expand-row', {
+				'site-table__td-without-border-bottom': isExpanded,
+			} ) }
+		>
+			<>
+				<Button { ...props }>
+					<Icon icon={ isExpanded ? chevronUp : chevronDown } />
+				</Button>
+				{ ! isExpanded && isPopoverDismissed && (
+					<SiteTableTooltip ref={ buttonRef } siteId={ siteId } showTooltip={ showTooltip } />
+				) }
+				{ ! isPopoverDismissed && (
+					<SiteTablePopover savePreferenceType={ savePreferenceType } ref={ buttonRef } />
+				) }
+			</>
+		</td>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/index.tsx
@@ -1,0 +1,73 @@
+import { Button } from '@automattic/components';
+import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
+import classNames from 'classnames';
+import { useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { DASHBOARD_PREFERENCE_NAMES } from '../utils';
+import SiteTablePopover from './site-table-popover';
+import SiteTableTooltip from './site-table-tooltip';
+
+interface Props {
+	index: number;
+	setExpanded: () => void;
+	isExpanded: boolean;
+	siteId: number;
+}
+export default function SiteTableExpand( { index, setExpanded, isExpanded, siteId }: Props ) {
+	const dispatch = useDispatch();
+	const buttonRef = useRef< HTMLButtonElement | null >( null );
+	const [ showTooltip, setShowTooltip ] = useState( false );
+
+	const preference = useSelector( ( state ) =>
+		getPreference( state, DASHBOARD_PREFERENCE_NAMES.EXPANDABLE_BLOCK_POPOVER_MESSAGE )
+	);
+	const savePreferenceType = () => {
+		dispatch(
+			savePreference( DASHBOARD_PREFERENCE_NAMES.EXPANDABLE_BLOCK_POPOVER_MESSAGE, {
+				...preference,
+				dismiss: true,
+			} )
+		);
+	};
+	const isPopoverDismissed = index === 0 ? preference?.dismiss : true;
+
+	const props = {
+		className: 'site-table__expandable-button',
+		borderless: true,
+		onClick: setExpanded,
+		...( ! isExpanded &&
+			isPopoverDismissed && {
+				ref: buttonRef,
+				onMouseEnter: () => setShowTooltip( true ),
+				onMouseLeave: () => setShowTooltip( false ),
+				onMouseDown: () => setShowTooltip( false ),
+			} ),
+		...( ! isPopoverDismissed && {
+			ref: buttonRef,
+		} ),
+	};
+
+	return (
+		<>
+			<td
+				className={ classNames( 'site-table__actions site-table__expand-row', {
+					'site-table__td-without-border-bottom': isExpanded,
+				} ) }
+			>
+				<>
+					<Button { ...props }>
+						<Icon icon={ isExpanded ? chevronUp : chevronDown } />
+					</Button>
+					{ ! isExpanded && isPopoverDismissed && (
+						<SiteTableTooltip ref={ buttonRef } siteId={ siteId } showTooltip={ showTooltip } />
+					) }
+					{ ! isPopoverDismissed && (
+						<SiteTablePopover savePreferenceType={ savePreferenceType } ref={ buttonRef } />
+					) }
+				</>
+			</td>
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/site-table-popover.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/site-table-popover.tsx
@@ -1,0 +1,47 @@
+import { Button, Popover } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { forwardRef } from 'react';
+import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
+
+import './style.scss';
+
+const SiteTablePopover = (
+	{ savePreferenceType }: { savePreferenceType: () => void },
+	ref: any
+) => {
+	const translate = useTranslate();
+
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, true );
+
+	const handlePopoverDismiss = () => {
+		savePreferenceType();
+		recordEvent( 'expandable_block_popover_dismiss_click' );
+	};
+
+	const content = (
+		<div className="site-table__expand-popover-content">
+			<div className="site-table__expand-popover-header">{ translate( 'See more info' ) }</div>
+			<div className="site-table__expand-popover-body">
+				{ translate( 'Click here and access to more info about your site.' ) }
+			</div>
+			<div className="site-table__expand-popover-footer">
+				<Button onClick={ handlePopoverDismiss } compact>
+					{ translate( 'Got it' ) }
+				</Button>
+			</div>
+		</div>
+	);
+
+	return (
+		<Popover
+			id="site-table-expand-popover"
+			isVisible={ true }
+			position="bottom"
+			context={ ref.current }
+		>
+			{ content }
+		</Popover>
+	);
+};
+
+export default forwardRef( SiteTablePopover );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/site-table-popover.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/site-table-popover.tsx
@@ -5,6 +5,7 @@ import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
 
 import './style.scss';
 
+// @todo: We could make the component more generic by passing the header, body and footer as props.
 const SiteTablePopover = (
 	{ savePreferenceType }: { savePreferenceType: () => void },
 	ref: any
@@ -22,7 +23,7 @@ const SiteTablePopover = (
 		<div className="site-table__expand-popover-content">
 			<div className="site-table__expand-popover-header">{ translate( 'See more info' ) }</div>
 			<div className="site-table__expand-popover-body">
-				{ translate( 'Click here and access to more info about your site.' ) }
+				{ translate( 'Click here for more info about your site.' ) }
 			</div>
 			<div className="site-table__expand-popover-footer">
 				<Button onClick={ handlePopoverDismiss } compact>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/site-table-tooltip.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/site-table-tooltip.tsx
@@ -7,6 +7,7 @@ interface Props {
 	showTooltip: boolean;
 }
 
+// @todo: We could make the component more generic by passing the text as a prop.
 const SiteTableTooltip = ( { siteId, showTooltip }: Props, ref: any ) => {
 	const translate = useTranslate();
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/site-table-tooltip.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/site-table-tooltip.tsx
@@ -1,0 +1,28 @@
+import { useTranslate } from 'i18n-calypso';
+import { forwardRef } from 'react';
+import Tooltip from 'calypso/components/tooltip';
+
+interface Props {
+	siteId: number;
+	showTooltip: boolean;
+}
+
+const SiteTableTooltip = ( { siteId, showTooltip }: Props, ref: any ) => {
+	const translate = useTranslate();
+
+	const tooltipId = `site-table-expand-tooltip-${ siteId }`;
+
+	return (
+		<Tooltip
+			id={ tooltipId }
+			context={ ref.current }
+			isVisible={ showTooltip }
+			position="bottom left"
+			className="sites-overview__tooltip"
+		>
+			{ translate( 'Click here for more info' ) }
+		</Tooltip>
+	);
+};
+
+export default forwardRef( SiteTableTooltip );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/style.scss
@@ -1,0 +1,31 @@
+#site-table-expand-popover {
+	.popover__inner {
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 8px;
+	}
+
+	.site-table__expand-popover-content {
+		padding: 16px;
+		width: 250px;
+		text-align: left;
+
+		.site-table__expand-popover-header {
+			font-weight: 600;
+			font-size: 1rem;
+			line-height: 18px;
+			color: var(--studio-gray-100);
+		}
+
+		.site-table__expand-popover-body {
+			padding: 16px 0;
+			font-size: 0.875rem;
+			line-height: 16px;
+			letter-spacing: -0.24px;
+			color: var(--studio-gray-70);
+		}
+
+		.site-table__expand-popover-footer button {
+			color: var(--studio-black) !important;
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -118,12 +118,12 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 						'site-table__actions-button': isExpandedContentEnabled,
 					} ) }
 					// If there is an error, we need to span the whole row because we don't show the expand buttons.
-					colSpan={ hasSiteError && isExpandedContentEnabled ? 2 : 1 }
+					colSpan={ isExpandedContentEnabled ? 2 : 1 }
 				>
 					<SiteActions isLargeScreen site={ site } siteError={ siteError } />
 				</td>
-				{ /* Show expand buttons only when the feature is enabled and there is no site error. */ }
-				{ ! hasSiteError && isExpandedContentEnabled && (
+				{ /* Show expand buttons only when the feature is enabled */ }
+				{ isExpandedContentEnabled && (
 					<SiteTableExpand
 						index={ index }
 						isExpanded={ isExpanded }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -1,6 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Button } from '@automattic/components';
-import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import classNames from 'classnames';
 import { Fragment } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -16,18 +14,20 @@ import SiteErrorContent from '../site-error-content';
 import SiteExpandedContent from '../site-expanded-content';
 import SitePhpVersion from '../site-expanded-content/site-php-version';
 import SiteStatusContent from '../site-status-content';
+import SiteTableExpand from '../site-table-expand';
 import type { SiteData, SiteColumns } from '../types';
 
 import './style.scss';
 
 interface Props {
+	index: number;
 	columns: SiteColumns;
 	item: SiteData;
 	setExpanded: () => void;
 	isExpanded: boolean;
 }
 
-export default function SiteTableRow( { columns, item, setExpanded, isExpanded }: Props ) {
+export default function SiteTableRow( { index, columns, item, setExpanded, isExpanded }: Props ) {
 	const dispatch = useDispatch();
 
 	const site = item.site;
@@ -124,15 +124,12 @@ export default function SiteTableRow( { columns, item, setExpanded, isExpanded }
 				</td>
 				{ /* Show expand buttons only when the feature is enabled and there is no site error. */ }
 				{ ! hasSiteError && isExpandedContentEnabled && (
-					<td
-						className={ classNames( 'site-table__actions site-table__expand-row', {
-							'site-table__td-without-border-bottom': isExpanded,
-						} ) }
-					>
-						<Button className="site-table__expandable-button" borderless onClick={ setExpanded }>
-							<Icon icon={ isExpanded ? chevronUp : chevronDown } />
-						</Button>
-					</td>
+					<SiteTableExpand
+						index={ index }
+						isExpanded={ isExpanded }
+						setExpanded={ setExpanded }
+						siteId={ site.value.blog_id }
+					/>
 				) }
 			</tr>
 			{ /* Show expanded content when expandable block is enabled. */ }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -136,7 +136,7 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 			{ isExpanded && (
 				<tr className="site-table__table-row-expanded">
 					<td colSpan={ Object.keys( item ).length + 1 }>
-						<SiteExpandedContent site={ site.value } />
+						<SiteExpandedContent site={ site.value } hasError={ hasSiteError } />
 						<SitePhpVersion phpVersion={ site.value.php_version_num } />
 					</td>
 				</tr>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -85,11 +85,12 @@ const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableEle
 						</td>
 					</tr>
 				) : (
-					items.map( ( item ) => {
+					items.map( ( item, index ) => {
 						const blogId = item.site.value.blog_id;
 
 						return (
 							<SiteTableRow
+								index={ index }
 								item={ item }
 								columns={ columns }
 								key={ `table-row-${ blogId }` }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -63,7 +63,7 @@ const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableEle
 									</SiteSort>
 								</th>
 							) ) }
-							<th colSpan={ isExpandedBlockEnabled ? 2 : 1 }>
+							<th colSpan={ isExpandedBlockEnabled ? 3 : 1 }>
 								<div className="plugin-common-table__bulk-actions">
 									<EditButton isLargeScreen sites={ items } />
 								</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -644,3 +644,8 @@ export const getMonitorDowntimeText = ( downtime: number | undefined ) => {
 		comment: '%(time) is the downtime, e.g. "2d 5h 30m", "5h 30m", "55m"',
 	} );
 };
+
+export const DASHBOARD_PREFERENCE_NAMES = {
+	EXPANDABLE_BLOCK_POPOVER_MESSAGE:
+		'jetpack-cloud-agency-dashboard-expandable-block-popover-message',
+};


### PR DESCRIPTION
Related to 1203940061556608-as-1203942568423018

## Proposed Changes

This PR

- Adds a tooltip to the expandable block icons(dropdown) when hovered over.
- Adds a popover indicating that the user can now expand the table row.
- Allow expand table even where is a site connection error and disable clicking on the card.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/tooltip-for-expandable-block` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that you can see the popover as shown below. Clicking on the `Got it` button should dismiss the popover and never show again. Also, verify that the track event API call is made with the event name - `calypso_jetpack_agency_dashboard_expandable_block_popover_dismiss_click_large_screen`

<img width="926" alt="Screenshot 2023-04-11 at 3 22 51 PM" src="https://user-images.githubusercontent.com/10586875/231129460-adac87c4-56a4-494c-b039-3a8379483df7.png">


<img width="1347" alt="Screenshot 2023-04-11 at 3 14 53 PM" src="https://user-images.githubusercontent.com/10586875/231134687-ee518e68-2549-4f54-9195-21a7fa02fd09.png">

<img width="1370" alt="Screenshot 2023-04-11 at 3 21 42 PM" src="https://user-images.githubusercontent.com/10586875/231134692-82848fcd-f3d4-44d2-a2f6-ad6ae2c604e6.png">


4. Verify that hovering over the dropdown icons shows the tooltip as shown below

<img width="307" alt="Screenshot 2023-04-06 at 1 31 08 PM" src="https://user-images.githubusercontent.com/10586875/230369961-9071d697-efd1-4190-9fe8-f62cd6c8d6fe.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?