### PR TITLE
Hosting onboarding: use passwordless mode on signup step

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { isNewsletterFlow } from '@automattic/onboarding';
+import { isHostingLPFlow, isNewsletterFlow } from '@automattic/onboarding';
 import { isMobile } from '@automattic/viewport';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -479,7 +479,7 @@ export class UserStep extends Component {
 					submitButtonText={ this.submitButtonText() }
 					suggestedUsername={ this.props.suggestedUsername }
 					handleSocialResponse={ this.handleSocialResponse }
-					isPasswordless={ isMobile() }
+					isPasswordless={ isMobile() || isHostingLPFlow( this.props.flowName ) }
 					queryArgs={ this.props.initialContext?.query || {} }
 					isSocialSignupEnabled={ isSocialSignupEnabled }
 					socialService={ socialService }


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/2123.

## Proposed Changes

Let's not ask for a password when creating an account exclusively on the hosting flow to improve conversions for that step. More info on [the issue](https://github.com/Automattic/dotcom-forge/issues/2123).

## Testing Instructions

- Check out this branch;
- Open `/start/hosting`;
- Check that the signup form includes only an e-mail input;
- Input an e-mail;
- Complete the purchase;
- Verify that you're authorized and the site has been created.

Also, try signing in with the same e-mail, and verify that the signup link arrives in your inbox, and the link successfully logs you in.

<img width="946" alt="image" src="https://user-images.githubusercontent.com/26530524/230378521-92524f23-adcd-4005-be3f-05e108b58bf6.png">
