### PR TITLE
Staging Sites: Place staging sites below production site

### DIFF
--- a/packages/sites/src/site-type.ts
+++ b/packages/sites/src/site-type.ts
@@ -1,4 +1,5 @@
 export interface MinimumSite {
+	ID: number;
 	URL: string;
 	name: string | undefined;
 	slug: string;
@@ -8,7 +9,10 @@ export interface MinimumSite {
 	is_private?: boolean;
 	launch_status?: string;
 	user_interactions?: string[];
+	is_wpcom_staging_site?: boolean;
 	options?: {
+		wpcom_production_blog_id?: number;
+		wpcom_staging_blog_ids?: number[];
 		is_redirect?: boolean;
 		updated_at?: string;
 	};

--- a/packages/sites/src/use-sites-list-sorting.tsx
+++ b/packages/sites/src/use-sites-list-sorting.tsx
@@ -20,8 +20,8 @@ export type SiteDetailsForSorting =
 const validSortKeys = [ 'lastInteractedWith', 'updatedAt', 'alphabetically' ] as const;
 const validSortOrders = [ 'asc', 'desc' ] as const;
 
-export type SitesSortKey = typeof validSortKeys[ number ];
-export type SitesSortOrder = typeof validSortOrders[ number ];
+export type SitesSortKey = ( typeof validSortKeys )[ number ];
+export type SitesSortOrder = ( typeof validSortOrders )[ number ];
 
 export const isValidSorting = ( input: {
 	sortKey: string;

--- a/packages/sites/src/use-sites-list-sorting.tsx
+++ b/packages/sites/src/use-sites-list-sorting.tsx
@@ -175,12 +175,12 @@ export function sortSitesByStaging< T extends SiteDetailsForSorting >( sites: T[
 
 	const visited = {} as Record< number, boolean >;
 	const sortedItems = sites.reduce< T[] >( ( acc, site ) => {
-		// We have already visit this site, so we dont need to procceed further.
+		// We have already visited this site, therefore, there is no need to proceed any further.
 		if ( visited[ site.ID ] ) {
 			return acc;
 		}
 		// Site is staging but we haven't visit its production site yet...
-		// the production site exists in the site map
+		// The production site exists in the site map, and
 		// that means that we are going to visit it later on.
 		// Don't add it to the list yet.
 		if (
@@ -192,19 +192,19 @@ export function sortSitesByStaging< T extends SiteDetailsForSorting >( sites: T[
 			return acc;
 		}
 
-		// Otherwise, add it to the list, as the production site that
-		// is associated to this staging site is filtered out, or we have a production site.
+		// If the production site associated with this staging site is filtered out,
+		// or if we have a production site, add it to the list.
 		acc.push( site );
 		visited[ site.ID ] = true;
 
-		// The sorting is useful in case we have more than one staging sites.
-		// All the sites are already sorted (by sortSitesByLastInteractedWith ),
-		// so we want to keep that order.
+		// Sorting is useful when dealing with multiple staging sites.
+		// The sites are already sorted by 'sortSitesByLastInteractedWith',
+		// we want to maintain that order."
 		site.options?.wpcom_staging_blog_ids
 			?.sort( ( a, b ) => {
-				// One of the two staging sites is filtered out.
-				// Retain the order of the other sites by moving it down
-				// to the list.
+				// If one of the two staging sites is filtered out, we should
+				// maintain the order of the remaining sites by moving it down
+				// in the list
 				if ( ! sitesById[ a ] ) {
 					return -1;
 				}

--- a/packages/sites/src/use-sites-list-sorting.tsx
+++ b/packages/sites/src/use-sites-list-sorting.tsx
@@ -199,7 +199,8 @@ export function sortSitesByStaging< T extends SiteDetailsForSorting >( sites: T[
 
 		// Sorting is useful when dealing with multiple staging sites.
 		// The sites are already sorted by 'sortSitesByLastInteractedWith',
-		// we want to maintain that order."
+		// we want to maintain that order in case some of the staging sites are
+		// filtered out.
 		site.options?.wpcom_staging_blog_ids
 			?.sort( ( a, b ) => {
 				// If one of the two staging sites is filtered out, we should

--- a/packages/sites/tests/use-sites-list-sorting.test.ts
+++ b/packages/sites/tests/use-sites-list-sorting.test.ts
@@ -58,6 +58,140 @@ describe( 'useSitesSorting', () => {
 		},
 	];
 
+	const frequentSitesWithStaging = [
+		{
+			ID: 1,
+			title: 'B',
+			options: {
+				updated_at: '2022-05-27T07:19:20+00:00',
+			},
+			user_interactions: [ '2022-09-25' ],
+		},
+		{
+			ID: 2,
+			title: 'A',
+			options: {
+				updated_at: '2022-07-13T17:17:12+00:00',
+				wpcom_staging_blog_ids: [ 3 ],
+			},
+			user_interactions: [ '2022-09-19' ],
+		},
+		{
+			ID: 3,
+			title: 'C',
+			is_wpcom_staging_site: true,
+			options: {
+				updated_at: '2022-06-14T13:32:34+00:00',
+				wpcom_production_blog_id: 2,
+			},
+			user_interactions: [ '2022-09-21', '2022-09-16', '2022-09-13', '2022-09-09' ],
+		},
+		{
+			ID: 4,
+			title: 'E',
+			options: {
+				updated_at: '2022-06-14T13:32:34+00:00',
+			},
+			user_interactions: [ '2022-09-16', '2022-09-13', '2022-09-09' ],
+		},
+	];
+
+	const frequentSitesWithStagingMissingProduction = [
+		{
+			ID: 1,
+			title: 'B',
+			options: {
+				updated_at: '2022-05-27T07:19:20+00:00',
+			},
+			user_interactions: [ '2022-09-25' ],
+		},
+		{
+			ID: 2,
+			title: 'A',
+			options: {
+				updated_at: '2022-07-13T17:17:12+00:00',
+				wpcom_staging_blog_ids: [ 3 ],
+			},
+			user_interactions: [ '2022-09-19' ],
+		},
+		{
+			ID: 3,
+			title: 'C',
+			is_wpcom_staging_site: true,
+			options: {
+				updated_at: '2022-06-14T13:32:34+00:00',
+				wpcom_production_blog_id: 2,
+			},
+			user_interactions: [ '2022-09-21', '2022-09-16', '2022-09-13', '2022-09-09' ],
+		},
+		{
+			ID: 4,
+			title: 'E',
+			options: {
+				updated_at: '2022-06-14T13:32:34+00:00',
+			},
+			user_interactions: [ '2022-09-16', '2022-09-13', '2022-09-09' ],
+		},
+		{
+			ID: 5,
+			title: 'F',
+			is_wpcom_staging_site: true,
+			options: {
+				wpcom_production_blog_id: 10,
+				updated_at: '2022-06-14T13:32:34+00:00',
+			},
+			user_interactions: [ '2022-09-16', '2022-09-13', '2022-09-09' ],
+		},
+	];
+
+	const frequentSitesWithStagingMissing = [
+		{
+			ID: 1,
+			title: 'B',
+			options: {
+				updated_at: '2022-05-27T07:19:20+00:00',
+			},
+			user_interactions: [ '2022-09-25' ],
+		},
+		{
+			ID: 2,
+			title: 'A',
+			options: {
+				updated_at: '2022-07-13T17:17:12+00:00',
+				wpcom_staging_blog_ids: [ 3, 11, 5 ],
+			},
+			user_interactions: [ '2022-09-19' ],
+		},
+		{
+			ID: 3,
+			title: 'C',
+			is_wpcom_staging_site: true,
+			options: {
+				updated_at: '2022-06-14T13:32:34+00:00',
+				wpcom_production_blog_id: 2,
+			},
+			user_interactions: [ '2022-09-21', '2022-09-16', '2022-09-13', '2022-09-09' ],
+		},
+		{
+			ID: 4,
+			title: 'E',
+			options: {
+				updated_at: '2022-06-14T13:32:34+00:00',
+			},
+			user_interactions: [ '2022-09-16', '2022-09-13', '2022-09-09' ],
+		},
+		{
+			ID: 5,
+			title: 'F',
+			is_wpcom_staging_site: true,
+			options: {
+				updated_at: '2022-06-14T13:32:34+00:00',
+				wpcom_production_blog_id: 2,
+			},
+			user_interactions: [ '2022-09-16', '2022-09-13', '2022-09-09' ],
+		},
+	];
+
 	test( 'should not sort sites if unsupported sortKey is provided', () => {
 		const { result } = renderHook( () =>
 			useSitesListSorting( filteredSites, {
@@ -139,6 +273,53 @@ describe( 'useSitesSorting', () => {
 		expect( result.current[ 0 ].title ).toBe( 'A' );
 		expect( result.current[ 1 ].title ).toBe( 'B' );
 		expect( result.current[ 2 ].title ).toBe( 'C' );
+	} );
+
+	test( 'should keep the staging sites under their production sites, retaining the order for other sites', () => {
+		const { result } = renderHook( () =>
+			useSitesListSorting( frequentSitesWithStaging, {
+				sortKey: 'lastInteractedWith',
+				sortOrder: 'asc',
+			} )
+		);
+		// After sortSitesByLastInteractedWith: A -> B -> E -> C
+		expect( result.current.length ).toBe( 4 );
+		expect( result.current[ 0 ].title ).toBe( 'A' );
+		expect( result.current[ 1 ].title ).toBe( 'C' );
+		expect( result.current[ 2 ].title ).toBe( 'B' );
+		expect( result.current[ 3 ].title ).toBe( 'E' );
+	} );
+
+	test( 'should not change an order of a staging site if its associated producion site is filtered out', () => {
+		const { result } = renderHook( () =>
+			useSitesListSorting( frequentSitesWithStagingMissingProduction, {
+				sortKey: 'lastInteractedWith',
+				sortOrder: 'asc',
+			} )
+		);
+		// After sortSitesByLastInteractedWith: A -> B -> F -> E -> C
+		expect( result.current.length ).toBe( 5 );
+		expect( result.current[ 0 ].title ).toBe( 'A' );
+		expect( result.current[ 1 ].title ).toBe( 'C' );
+		expect( result.current[ 2 ].title ).toBe( 'B' );
+		expect( result.current[ 3 ].title ).toBe( 'F' );
+		expect( result.current[ 4 ].title ).toBe( 'E' );
+	} );
+
+	test( 'should move missing staging sites down to the production site list', () => {
+		const { result } = renderHook( () =>
+			useSitesListSorting( frequentSitesWithStagingMissing, {
+				sortKey: 'lastInteractedWith',
+				sortOrder: 'asc',
+			} )
+		);
+		// After sortSitesByLastInteractedWith: A -> B -> F -> E -> C
+		expect( result.current.length ).toBe( 5 );
+		expect( result.current[ 0 ].title ).toBe( 'A' );
+		expect( result.current[ 1 ].title ).toBe( 'F' );
+		expect( result.current[ 2 ].title ).toBe( 'C' );
+		expect( result.current[ 3 ].title ).toBe( 'B' );
+		expect( result.current[ 4 ].title ).toBe( 'E' );
 	} );
 
 	test( 'should pick the site more frequently interacted with descending', () => {

--- a/packages/sites/tests/use-sites-list-sorting.test.ts
+++ b/packages/sites/tests/use-sites-list-sorting.test.ts
@@ -290,7 +290,7 @@ describe( 'useSitesSorting', () => {
 		expect( result.current[ 3 ].title ).toBe( 'E' );
 	} );
 
-	test( 'should not change an order of a staging site if its associated producion site is filtered out', () => {
+	test( 'should not change the order of a staging site if its associated producion site is filtered out', () => {
 		const { result } = renderHook( () =>
 			useSitesListSorting( frequentSitesWithStagingMissingProduction, {
 				sortKey: 'lastInteractedWith',
@@ -306,7 +306,7 @@ describe( 'useSitesSorting', () => {
 		expect( result.current[ 4 ].title ).toBe( 'E' );
 	} );
 
-	test( 'should move missing staging sites down to the production site list', () => {
+	test( 'should staging sites that missing, down to the production site list', () => {
 		const { result } = renderHook( () =>
 			useSitesListSorting( frequentSitesWithStagingMissing, {
 				sortKey: 'lastInteractedWith',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2106

## Proposed Changes

This pr recommends positioning the staging site directly beneath the production site when using the Magic sort algorithm.

| **Before** | **After** |
| :---:         |    :---:       |
|![magic_sort_staging_before](https://user-images.githubusercontent.com/497103/230390343-837c469a-bd76-48d3-bf4d-16b4d1afe64b.png)|![magic_sort_staging_after](https://user-images.githubusercontent.com/497103/230390378-92e8348e-09d7-453d-8e2b-bf0711503831.png)|

## Testing Instructions

### Test 1

1. Navigate to `/sites`
2. Select magic sort, as the sort method
3. Ensure that every staging site is listed below its production site.

### Test 2

1. Navigate to `/sites`
2. Select magic sort, as the sort method
3. Ensure that you have a production site that is `Public` with a staging site that is `Comming soon`
4. Select `Public` as a filter
5. Ensure that every staging is listed below its production site.
6. Ensure that this production site is in between the list items that were before

For example, let `B` be the site we are interested in, `BSPx` be the public staging sites of this site, and `BSCx` be the staging sites that are `coming soon`.

**NOTE**: The following examples are taking multiple staging sites into consideration. However, we are not supporting multiple staging sites at the current moment. The code ensures that the sorting will work for any use case.

**BEFORE FILTER**
- A
- B
- BP1
- BS1
- BP2
- C

**AFTER FILTER**
- A
- B
- BP1
- BP2
- C

Another example:

**BEFORE FILTER**
- A
- B
- BS1
- BS2
- C

**AFTER FILTER**
- A
- B
- C

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be beneficial when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
