### PR TITLE
Stepper: Generalise removal of grey progress bar

### DIFF
--- a/client/signup/signup-header/index.tsx
+++ b/client/signup/signup-header/index.tsx
@@ -46,13 +46,16 @@ const SignupHeader = ( {
 
 	return (
 		<div className="signup-header" role="banner" aria-label="banner">
-			{ flowProgress && ! shouldShowLoadingScreen && showProgressBar && (
-				<ProgressBar
-					className={ variationName ? variationName : progressBar.flowName }
-					value={ flowProgress.progress }
-					total={ flowProgress.count }
-				/>
-			) }
+			{ flowProgress &&
+				! shouldShowLoadingScreen &&
+				showProgressBar &&
+				flowProgress?.progress > 0 && (
+					<ProgressBar
+						className={ variationName ? variationName : progressBar.flowName }
+						value={ flowProgress.progress }
+						total={ flowProgress.count }
+					/>
+				) }
 			{ ! showWooLogo && <WordPressLogo size={ 120 } className={ logoClasses } /> }
 			{ showWooLogo && (
 				<WooCommerceWooLogo width={ 120 } height={ 120 } className={ logoClasses } />

--- a/client/signup/signup-header/style.scss
+++ b/client/signup/signup-header/style.scss
@@ -19,19 +19,6 @@
 		pointer-events: none;
 	}
 
-	.newsletter.progress-bar,
-	.link-in-bio.progress-bar,
-	.link-in-bio-tld.progress-bar,
-	.import.progress-bar,
-	.free.progress-bar {
-		position: absolute;
-		top: -8px;
-		background-color: #fff;
-
-		.progress-bar__progress {
-			border-radius: 0;
-		}
-	}
 
 	.wordpress-logo {
 		height: 180px;


### PR DESCRIPTION
## What
We have CSS that removes the grey progress bar on the signup step while on some of the flows in Stepper. This needs to be generalised to not happen again

## Testing
1. Checkout branch or Live Link
2. Try the LiB (/setup/link-in-bio) or Newsletter flows (/setup/newsletter) while on incognito
3. Check that the grey progress bar on the signup step is gone

Fixes https://github.com/Automattic/wp-calypso/issues/75375