### PR TITLE
Convert useGeolocationQuery to TypeScript

### DIFF
--- a/client/data/geo/use-geolocation-query.js
+++ b/client/data/geo/use-geolocation-query.js
@@ -1,8 +1,0 @@
-import { useQuery } from 'react-query';
-
-export const useGeoLocationQuery = () =>
-	useQuery( 'geo', () =>
-		globalThis
-			.fetch( 'https://public-api.wordpress.com/geo/' )
-			.then( ( response ) => response.json() )
-	);

--- a/client/data/geo/use-geolocation-query.ts
+++ b/client/data/geo/use-geolocation-query.ts
@@ -1,0 +1,17 @@
+import { useQuery } from 'react-query';
+
+export interface GeoLocationData {
+	city: string;
+	country_long: string;
+	country_short: string;
+	latitude: string;
+	longitude: string;
+	region: string;
+}
+
+export const useGeoLocationQuery = () =>
+	useQuery< GeoLocationData >( 'geo', () =>
+		globalThis
+			.fetch( 'https://public-api.wordpress.com/geo/' )
+			.then( ( response ) => response.json() )
+	);

--- a/client/data/geo/use-geolocation-query.ts
+++ b/client/data/geo/use-geolocation-query.ts
@@ -10,7 +10,7 @@ export interface GeoLocationData {
 }
 
 export const useGeoLocationQuery = () =>
-	useQuery< GeoLocationData >( 'geo', () =>
+	useQuery< GeoLocationData >( [ 'geo' ], () =>
 		globalThis
 			.fetch( 'https://public-api.wordpress.com/geo/' )
 			.then( ( response ) => response.json() )


### PR DESCRIPTION
## Proposed Changes

This PR converts `useGeolocationQuery` to TypeScript and adds a type for its return data. Extracted from https://github.com/Automattic/wp-calypso/pull/75044.

This also changes the hook's `useQuery` to use an array for the key, taking care of https://github.com/Automattic/wp-calypso/pull/74720 for this hook.

## Testing Instructions

Make sure tests pass. You can see that this works by testing https://github.com/Automattic/wp-calypso/pull/75044.