### PR TITLE
Subscriptions Management: Fix delivery frequency translation

### DIFF
--- a/client/landing/subscriptions/site-list/site-row.tsx
+++ b/client/landing/subscriptions/site-list/site-row.tsx
@@ -1,12 +1,28 @@
 import { Gridicon } from '@automattic/components';
 import { SubscriptionManager } from '@automattic/data-stores';
-import { useMemo } from '@wordpress/element';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { SiteSettings } from '../settings-popover';
 import type {
 	SiteSubscription,
 	SiteSubscriptionDeliveryFrequency,
 } from '@automattic/data-stores/src/reader/types';
+
+const useDeliveryFrequencyLabel = ( deliveryFrequencyValue: SiteSubscriptionDeliveryFrequency ) => {
+	const translate = useTranslate();
+
+	const deliveryFrequencyLabels = useMemo(
+		() => ( {
+			daily: translate( 'Daily' ),
+			weekly: translate( 'Weekly' ),
+			instantly: translate( 'Instantly' ),
+		} ),
+		[ translate ]
+	);
+
+	return deliveryFrequencyLabels[ deliveryFrequencyValue ];
+};
 
 export default function SiteRow( {
 	blog_ID,
@@ -21,8 +37,6 @@ export default function SiteRow( {
 		() => moment( date_subscribed ).format( 'LL' ),
 		[ date_subscribed, moment ]
 	);
-	const deliveryFrequency = delivery_methods?.email
-		?.post_delivery_frequency as SiteSubscriptionDeliveryFrequency;
 	const hostname = useMemo( () => new URL( url ).hostname, [ url ] );
 	const siteIcon = useMemo( () => {
 		if ( site_icon ) {
@@ -30,6 +44,12 @@ export default function SiteRow( {
 		}
 		return <Gridicon className="icon" icon="globe" size={ 48 } />;
 	}, [ site_icon, name ] );
+
+	const deliveryFrequencyValue = useMemo(
+		() => delivery_methods?.email?.post_delivery_frequency as SiteSubscriptionDeliveryFrequency,
+		[ delivery_methods?.email?.post_delivery_frequency ]
+	);
+	const deliveryFrequencyLabel = useDeliveryFrequencyLabel( deliveryFrequencyValue );
 
 	const { mutate: updateDeliveryFrequency, isLoading: updatingFrequency } =
 		SubscriptionManager.useSiteDeliveryFrequencyMutation();
@@ -51,11 +71,11 @@ export default function SiteRow( {
 				{ since }
 			</span>
 			<span className="email-frequency" role="cell">
-				{ deliveryFrequency }
+				{ deliveryFrequencyLabel }
 			</span>
 			<span className="actions" role="cell">
 				<SiteSettings
-					deliveryFrequency={ deliveryFrequency }
+					deliveryFrequency={ deliveryFrequencyValue }
 					onDeliveryFrequencyChange={ ( delivery_frequency ) =>
 						updateDeliveryFrequency( { blog_id: blog_ID, delivery_frequency } )
 					}


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/75406

## Proposed Changes

This PR fixes delivery frequency translation.

## Testing Instructions

* Run this PR on your local env
* Go to http://calypso.localhost:3000/subscriptions/sites
* Verify if the Delivery Frequency column is displayed as expected
  * The first letter should be capitalized
* Change the language by settings the locale: `?locale=pt-br`
  * Verify if the string is translated (check if the translation is available for that locale)

<img width="218" alt="image" src="https://user-images.githubusercontent.com/3113712/230449009-36640e66-1ab4-441e-bfbe-0c28e0ceafe4.png">

**Regression Test**
* Verify if the delivery frequency input is working as expected
  * Check if the changing the frequency updates the table row properly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
