### PR TITLE
Fix: update styles for push notification screen

### DIFF
--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -72,7 +72,7 @@ class TwoFactorActions extends Component {
 				{ this.props.isWoo && ! this.props.isPartnerSignup && (
 					<Divider>{ this.props.translate( 'or' ) }</Divider>
 				) }
-				<Card className="two-factor-authentication__actions">
+				<Card className="two-factor-authentication__actions wp-login__links">
 					{ isSecurityKeyAvailable && (
 						<Button data-e2e-link="2fa-security-key-link" onClick={ this.recordSecurityKey }>
 							{ translate( 'Continue with your security\u00A0key' ) }

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.scss
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.scss
@@ -1,12 +1,8 @@
 .two-factor-authentication__actions.card {
 	margin-bottom: 0;
+	padding: 24px 0;
 
-	.button {
-		height: auto;
-		width: 100%;
-
-		&:not(:first-child) {
-			margin-top: 20px;
-		}
+	.button:not(:first-child) {
+		margin-top: 20px;
 	}
 }

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.scss
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.scss
@@ -1,6 +1,6 @@
 .two-factor-authentication__actions.card {
 	margin-bottom: 0;
-	padding: 24px 0;
+	padding: 0 0 24px;
 
 	.button:not(:first-child) {
 		margin-top: 20px;

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Gridicon } from '@automattic/components';
+import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -357,7 +358,11 @@ export class LoginLinks extends Component {
 
 	render() {
 		return (
-			<div className="wp-login__links">
+			<div
+				className={ classnames( 'wp-login__links', {
+					'has-2fa-links': this.props.twoFactorAuthType,
+				} ) }
+			>
 				{ this.renderSignUpLink() }
 				{ this.renderLostPhoneLink() }
 				{ this.renderHelpLink() }

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -386,7 +386,7 @@ $image-height: 47px;
 			}
 		}
 	}
-
+	.wp-login__links > .button:first-of-type,
 	.wp-login__links > a:first-of-type {
 		/* Note: Matches secondary button used in /start (signup). Should probably turn this into a button. */
 		background: transparent;
@@ -416,7 +416,7 @@ $image-height: 47px;
 		}
 	}
 
-
+	.wp-login__links > button,
 	.wp-login__links > a {
 		display: flex;
 		align-items: center;

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -387,7 +387,7 @@ $image-height: 47px;
 		}
 	}
 	.wp-login__links > .button:first-of-type,
-	.wp-login__links > a:first-of-type {
+	.wp-login__links:not(.has-2fa-links) > a:first-of-type {
 		/* Note: Matches secondary button used in /start (signup). Should probably turn this into a button. */
 		background: transparent;
 		margin: 0;


### PR DESCRIPTION
Fixes the styling of wordpress.com/login/push page to make the button align better with the rest of the page. 

## Proposed Changes

Before:
<img width="300" alt="Screenshot 2023-04-06 at 1 59 48 PM" src="https://user-images.githubusercontent.com/115071/230493181-677528c8-6df9-4b8d-94f6-5dd3b178813a.png">


After:
<img width="300" alt="Screenshot 2023-04-12 at 5 25 29 PM" src="https://user-images.githubusercontent.com/115071/231614689-98a5d9e9-6805-4ade-98ab-4d615bba98ac.png">



## Testing Instructions

In a incognito or logged out state open the calypso live link.
1. Try login in with an account that has 2FA enabled. 
2. Notice the App Notification screen button looks more align then before.



## Pre-merge Checklist


- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
