### PR TITLE
Domains: Enable the new .uk contact verification card for all users

### DIFF
--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
@@ -394,11 +393,6 @@ const Settings = ( {
 	};
 
 	const renderContactVerificationSection = () => {
-		// TODO: Remove this when we implement the contact verification domain flag
-		if ( ! config.isEnabled( 'contact-verification-feature' ) ) {
-			return null;
-		}
-
 		if ( ! domain || ! domain.currentUserCanManage ) {
 			return null;
 		}


### PR DESCRIPTION
## Proposed Changes

This PR enables the new contact verification card in the domain management page for all users. That card was added in #75096 but was gated by a feature flag. More context at pcYYhz-17s-p2.

Note: We should deploy this on Friday 2023-04-07, which is when Validation.com will stop working.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Build this branch locally or open the live Calypso link
- Navigate to the domain management page of a .uk domain for which contact verification was requested
- Ensure you see the new "Contact verification" card at the bottom

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
