### PR TITLE
Shopping Cart: Make the cart blog_id always a number and always exist

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
@@ -41,7 +41,9 @@ export async function createWpcomAccountBeforeTransaction(
 		siteId: transactionOptions.siteId,
 		recaptchaClientId: transactionOptions.recaptchaClientId,
 	} ).then( ( response ) => {
-		const siteIdFromResponse = response?.blog_details?.blogid;
+		const siteIdFromResponse: number | undefined = parseInt(
+			String( response?.blog_details?.blogid ?? 0 )
+		);
 
 		// We need to store the created site ID so that if the transaction fails,
 		// we can retry safely. createUserAndSiteBeforeTransaction will still be
@@ -55,10 +57,10 @@ export async function createWpcomAccountBeforeTransaction(
 		// If the account is already created (as happens when we are reprocessing
 		// after a transaction error), then the create account response will not
 		// have a site ID, so we fetch from state.
-		const siteId = siteIdFromResponse || transactionOptions.siteId;
+		const siteId: number | undefined = siteIdFromResponse || transactionOptions.siteId || 0;
 		return {
 			...transactionCart,
-			blog_id: siteId ? String( siteId ) : '0',
+			blog_id: siteId,
 			cart_key: ( siteId ? siteId : 'no-site' ) as CartKey,
 		};
 	} );

--- a/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/create-wpcom-account-before-transaction.ts
@@ -42,7 +42,7 @@ export async function createWpcomAccountBeforeTransaction(
 		recaptchaClientId: transactionOptions.recaptchaClientId,
 	} ).then( ( response ) => {
 		const siteIdFromResponse: number | undefined = parseInt(
-			String( response?.blog_details?.blogid ?? 0 )
+			response?.blog_details?.blogid ?? '0'
 		);
 
 		// We need to store the created site ID so that if the transaction fails,

--- a/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/existing-card-processor.ts
@@ -69,13 +69,12 @@ export default async function existingCardProcessor(
 	const formattedTransactionData = createTransactionEndpointRequestPayload( {
 		...transactionData,
 		name: transactionData.name ?? '',
-		siteId: dataForProcessor.siteId ? String( dataForProcessor.siteId ) : undefined,
 		country: contactDetails?.countryCode?.value ?? '',
 		postalCode: getPostalCode( contactDetails ),
 		subdivisionCode: contactDetails?.state?.value,
 		domainDetails,
 		cart: createTransactionEndpointCartFromResponseCart( {
-			siteId: dataForProcessor.siteId ? String( dataForProcessor.siteId ) : undefined,
+			siteId: dataForProcessor.siteId,
 			contactDetails: domainDetails ?? null,
 			responseCart,
 		} ),

--- a/client/my-sites/checkout/composite-checkout/lib/free-purchase-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/free-purchase-processor.ts
@@ -25,7 +25,6 @@ export default async function freePurchaseProcessor(
 	transactionOptions: PaymentProcessorOptions
 ): Promise< PaymentProcessorResponse > {
 	const {
-		siteId,
 		responseCart,
 		includeDomainDetails,
 		includeGSuiteDetails,
@@ -52,7 +51,6 @@ export default async function freePurchaseProcessor(
 		{
 			name: '',
 			couponId: responseCart.coupon,
-			siteId: siteId ? String( siteId ) : '',
 			domainDetails: getDomainDetails( contactDetails, {
 				includeDomainDetails,
 				includeGSuiteDetails,
@@ -75,7 +73,7 @@ function prepareFreePurchaseTransaction(
 	const formattedTransactionData = createTransactionEndpointRequestPayload( {
 		...transactionData,
 		cart: createTransactionEndpointCartFromResponseCart( {
-			siteId: transactionOptions.siteId ? String( transactionOptions.siteId ) : undefined,
+			siteId: transactionOptions.siteId,
 			contactDetails: transactionData.domainDetails ?? null,
 			responseCart: doesPurchaseHaveFullCredits( transactionOptions.responseCart )
 				? transactionOptions.responseCart

--- a/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/generic-redirect-processor.ts
@@ -25,7 +25,6 @@ export default async function genericRedirectProcessor(
 	const {
 		getThankYouUrl,
 		siteSlug,
-		siteId,
 		includeDomainDetails,
 		includeGSuiteDetails,
 		reduxDispatch,
@@ -65,7 +64,6 @@ export default async function genericRedirectProcessor(
 			country: contactDetails?.countryCode?.value ?? '',
 			postalCode: getPostalCode( contactDetails ),
 			subdivisionCode: contactDetails?.state?.value,
-			siteId: siteId ? String( siteId ) : '',
 			domainDetails: getDomainDetails( contactDetails, {
 				includeDomainDetails,
 				includeGSuiteDetails,

--- a/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/multi-partner-card-processor.ts
@@ -120,7 +120,7 @@ async function stripeCardProcessor(
 		} ),
 		paymentMethodToken,
 		cart: createTransactionEndpointCartFromResponseCart( {
-			siteId: siteId ? String( siteId ) : undefined,
+			siteId,
 			contactDetails:
 				getDomainDetails( contactDetails, { includeDomainDetails, includeGSuiteDetails } ) ?? null,
 			responseCart: responseCart,
@@ -174,7 +174,6 @@ async function ebanxCardProcessor(
 		includeDomainDetails,
 		includeGSuiteDetails,
 		responseCart,
-		siteId,
 		contactDetails,
 		reduxDispatch,
 	} = transactionOptions;
@@ -201,7 +200,6 @@ async function ebanxCardProcessor(
 		...submitData,
 		couponId: responseCart.coupon,
 		country: submitData.countryCode,
-		siteId: siteId ? String( siteId ) : undefined,
 		deviceId: paymentMethodToken?.deviceId,
 		domainDetails: getDomainDetails( contactDetails, {
 			includeDomainDetails,
@@ -209,7 +207,7 @@ async function ebanxCardProcessor(
 		} ),
 		paymentMethodToken: paymentMethodToken.token,
 		cart: createTransactionEndpointCartFromResponseCart( {
-			siteId: transactionOptions.siteId ? String( transactionOptions.siteId ) : undefined,
+			siteId: transactionOptions.siteId,
 			contactDetails:
 				getDomainDetails( contactDetails, { includeDomainDetails, includeGSuiteDetails } ) ?? null,
 			responseCart: transactionOptions.responseCart,

--- a/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/paypal-express-processor.ts
@@ -116,7 +116,7 @@ function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 }: {
 	successUrl: string;
 	cancelUrl: string;
-	siteId: string | number | undefined;
+	siteId: number | undefined;
 	domainDetails: DomainContactDetails | null;
 	responseCart: ResponseCart;
 } ): PayPalExpressEndpointRequestPayload {
@@ -126,7 +126,7 @@ function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		successUrl,
 		cancelUrl,
 		cart: createTransactionEndpointCartFromResponseCart( {
-			siteId: siteId ? String( siteId ) : undefined,
+			siteId,
 			contactDetails: domainDetails,
 			responseCart,
 		} ),

--- a/client/my-sites/checkout/composite-checkout/lib/prepare-redirect-transaction.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/prepare-redirect-transaction.ts
@@ -29,7 +29,7 @@ export default function prepareRedirectTransaction(
 	const formattedTransactionData = createTransactionEndpointRequestPayload( {
 		...transactionData,
 		cart: createTransactionEndpointCartFromResponseCart( {
-			siteId: transactionOptions.siteId ? String( transactionOptions.siteId ) : undefined,
+			siteId: transactionOptions.siteId,
 			contactDetails: transactionData.domainDetails ?? null,
 			responseCart: transactionOptions.responseCart,
 		} ),

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -74,7 +74,7 @@ export function createTransactionEndpointCartFromResponseCart( {
 		// Once the WP.com account is created, the cart key is replaced with the blog ID and sent to the
 		// /transactions endpoint. If there is no blog ID, a temporary blog is created on the backend side.
 		return {
-			blog_id: responseCart.blog_id.toString(),
+			blog_id: responseCart.blog_id,
 			cart_key: cartKey as CartKey,
 			coupon: responseCart.coupon || '',
 			temporary: false,
@@ -86,7 +86,7 @@ export function createTransactionEndpointCartFromResponseCart( {
 	}
 
 	return {
-		blog_id: siteId || '0',
+		blog_id: siteId ? parseInt( siteId ) : 0,
 		cart_key: ( siteId || 'no-site' ) as CartKey,
 		coupon: responseCart.coupon || '',
 		temporary: false,

--- a/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/translate-cart.ts
@@ -55,7 +55,7 @@ export function createTransactionEndpointCartFromResponseCart( {
 	contactDetails,
 	responseCart,
 }: {
-	siteId: string | undefined;
+	siteId: number | undefined;
 	contactDetails: DomainContactDetails | null;
 	responseCart: ResponseCart;
 } ): RequestCart {
@@ -86,7 +86,7 @@ export function createTransactionEndpointCartFromResponseCart( {
 	}
 
 	return {
-		blog_id: siteId ? parseInt( siteId ) : 0,
+		blog_id: siteId ? siteId : 0,
 		cart_key: ( siteId || 'no-site' ) as CartKey,
 		coupon: responseCart.coupon || '',
 		temporary: false,

--- a/client/my-sites/checkout/composite-checkout/lib/web-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/web-pay-processor.ts
@@ -41,7 +41,6 @@ export default async function webPayProcessor(
 	const formattedTransactionData = createTransactionEndpointRequestPayload( {
 		...submitData,
 		name: submitData.name || '',
-		siteId: siteId ? String( siteId ) : undefined,
 		country: contactDetails?.countryCode?.value ?? '',
 		postalCode: getPostalCode( contactDetails ),
 		domainDetails: getDomainDetails( contactDetails, {
@@ -49,7 +48,7 @@ export default async function webPayProcessor(
 			includeGSuiteDetails,
 		} ),
 		cart: createTransactionEndpointCartFromResponseCart( {
-			siteId: siteId ? String( siteId ) : undefined,
+			siteId,
 			contactDetails:
 				getDomainDetails( contactDetails, { includeDomainDetails, includeGSuiteDetails } ) ?? null,
 			responseCart: responseCart,

--- a/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/existing-card-processor.ts
@@ -34,7 +34,7 @@ describe( 'existingCardProcessor', () => {
 
 	const basicExpectedStripeRequest = {
 		cart: {
-			blog_id: '0',
+			blog_id: 0,
 			cart_key: 'no-site',
 			coupon: '',
 			products: [ product ],
@@ -186,8 +186,8 @@ describe( 'existingCardProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 			},
 		} );
@@ -227,8 +227,8 @@ describe( 'existingCardProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 				tax: { location: { postal_code: 'pr267ry', country_code: 'GB' } },
 			},
@@ -258,8 +258,8 @@ describe( 'existingCardProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 				products: [ domainProduct ],
 			},

--- a/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/free-purchase-processor.ts
@@ -40,7 +40,7 @@ describe( 'freePurchaseProcessor', () => {
 
 	const basicExpectedStripeRequest = {
 		cart: {
-			blog_id: '0',
+			blog_id: 0,
 			cart_key: 'no-site',
 			coupon: '',
 			products: [ product ],
@@ -117,8 +117,8 @@ describe( 'freePurchaseProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 			},
 		} );
@@ -152,8 +152,8 @@ describe( 'freePurchaseProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 			},
 		} );
@@ -191,8 +191,8 @@ describe( 'freePurchaseProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 				products: [ domainProduct ],
 				tax: { location: { postal_code: 'pr267ry', country_code: 'GB' } },
@@ -224,8 +224,8 @@ describe( 'freePurchaseProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 				products: [ domainProduct ],
 			},

--- a/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/generic-redirect-processor.ts
@@ -25,7 +25,7 @@ describe( 'genericRedirectProcessor', () => {
 
 	const basicExpectedStripeRequest = {
 		cart: {
-			blog_id: '0',
+			blog_id: 0,
 			cart_key: 'no-site',
 			coupon: '',
 			products: [ product ],
@@ -143,8 +143,8 @@ describe( 'genericRedirectProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 			},
 			payment: {
@@ -179,8 +179,8 @@ describe( 'genericRedirectProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 			},
 			payment: {
@@ -217,8 +217,8 @@ describe( 'genericRedirectProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 			},
 			payment: {
@@ -263,8 +263,8 @@ describe( 'genericRedirectProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 				tax: { location: { postal_code: 'pr267ry', country_code: 'GB' } },
 			},
@@ -297,8 +297,8 @@ describe( 'genericRedirectProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 				products: [ domainProduct ],
 			},

--- a/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/multi-partner-card-processor.tsx
@@ -117,7 +117,7 @@ describe( 'multiPartnerCardProcessor', () => {
 
 	const basicExpectedStripeRequest = {
 		cart: {
-			blog_id: '0',
+			blog_id: 0,
 			cart_key: 'no-site',
 			coupon: '',
 			products: [ product ],
@@ -331,7 +331,7 @@ describe( 'multiPartnerCardProcessor', () => {
 				...basicExpectedStripeRequest,
 				cart: {
 					...basicExpectedStripeRequest.cart,
-					blog_id: '1234567',
+					blog_id: 1234567,
 					cart_key: 1234567,
 					coupon: '',
 				},
@@ -399,7 +399,7 @@ describe( 'multiPartnerCardProcessor', () => {
 				...basicExpectedStripeRequest,
 				cart: {
 					...basicExpectedStripeRequest.cart,
-					blog_id: '1234567',
+					blog_id: 1234567,
 					cart_key: 1234567,
 					coupon: '',
 				},
@@ -458,8 +458,8 @@ describe( 'multiPartnerCardProcessor', () => {
 				...basicExpectedStripeRequest,
 				cart: {
 					...basicExpectedStripeRequest.cart,
-					blog_id: '1234567',
-					cart_key: '1234567',
+					blog_id: 1234567,
+					cart_key: 1234567,
 					coupon: '',
 				},
 			} );
@@ -500,8 +500,8 @@ describe( 'multiPartnerCardProcessor', () => {
 				...basicExpectedStripeRequest,
 				cart: {
 					...basicExpectedStripeRequest.cart,
-					blog_id: '1234567',
-					cart_key: '1234567',
+					blog_id: 1234567,
+					cart_key: 1234567,
 					coupon: '',
 					tax: { location: { postal_code: 'pr267ry', country_code: 'GB' } },
 				},
@@ -532,8 +532,8 @@ describe( 'multiPartnerCardProcessor', () => {
 				...basicExpectedStripeRequest,
 				cart: {
 					...basicExpectedStripeRequest.cart,
-					blog_id: '1234567',
-					cart_key: '1234567',
+					blog_id: 1234567,
+					cart_key: 1234567,
 					coupon: '',
 					products: [ domainProduct ],
 				},
@@ -672,8 +672,8 @@ describe( 'multiPartnerCardProcessor', () => {
 				...basicExpectedEbanxRequest,
 				cart: {
 					...basicExpectedStripeRequest.cart,
-					blog_id: '1234567',
-					cart_key: '1234567',
+					blog_id: 1234567,
+					cart_key: 1234567,
 					coupon: '',
 					products: [ product ],
 				},
@@ -701,8 +701,8 @@ describe( 'multiPartnerCardProcessor', () => {
 				...basicExpectedEbanxRequest,
 				cart: {
 					...basicExpectedStripeRequest.cart,
-					blog_id: '1234567',
-					cart_key: '1234567',
+					blog_id: 1234567,
+					cart_key: 1234567,
 					coupon: '',
 					products: [ domainProduct ],
 				},

--- a/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/paypal-express-processor.ts
@@ -36,7 +36,7 @@ describe( 'payPalExpressProcessor', () => {
 	const basicExpectedRequest = {
 		cancel_url: 'https://example.com/',
 		cart: {
-			blog_id: '0',
+			blog_id: 0,
 			cart_key: 'no-site',
 			coupon: '',
 			products: [ product ],
@@ -116,8 +116,8 @@ describe( 'payPalExpressProcessor', () => {
 				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
 			cart: {
 				...basicExpectedRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 			},
 		} );
@@ -153,8 +153,8 @@ describe( 'payPalExpressProcessor', () => {
 				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
 			cart: {
 				...basicExpectedRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 				tax: { location: { postal_code: 'pr267ry', country_code: 'GB' } },
 			},
@@ -182,8 +182,8 @@ describe( 'payPalExpressProcessor', () => {
 				'https://example.com/checkout/thank-you/example.wordpress.com/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
 			cart: {
 				...basicExpectedRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 				products: [ domainProduct ],
 			},
@@ -212,7 +212,7 @@ describe( 'payPalExpressProcessor', () => {
 			cancel_url: 'https://example.com/?cart=no-user',
 			cart: {
 				...basicExpectedRequest.cart,
-				blog_id: '1234567',
+				blog_id: 1234567,
 				cart_key: 1234567,
 				coupon: '',
 			},
@@ -242,7 +242,7 @@ describe( 'payPalExpressProcessor', () => {
 			cancel_url: 'https://example.com/?cart=no-user',
 			cart: {
 				...basicExpectedRequest.cart,
-				blog_id: '0',
+				blog_id: 0,
 				cart_key: 'no-site',
 				coupon: '',
 			},
@@ -270,7 +270,7 @@ describe( 'payPalExpressProcessor', () => {
 				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
 			cart: {
 				...basicExpectedRequest.cart,
-				blog_id: '0',
+				blog_id: 0,
 				cart_key: 'no-site',
 				coupon: '',
 			},
@@ -303,7 +303,7 @@ describe( 'payPalExpressProcessor', () => {
 				'https://wordpress.com/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fthank-you&receiptId=%3AreceiptId',
 			cart: {
 				...basicExpectedRequest.cart,
-				blog_id: '0',
+				blog_id: 0,
 				cart_key: 'no-site',
 				coupon: '',
 			},
@@ -342,7 +342,7 @@ describe( 'payPalExpressProcessor', () => {
 			cancel_url: 'https://example.com/?cart=no-user',
 			cart: {
 				...basicExpectedRequest.cart,
-				blog_id: '1234567',
+				blog_id: 1234567,
 				cart_key: 1234567,
 				coupon: '',
 			},

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -384,7 +384,7 @@ export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
 
 		return {
 			allowed_payment_methods: [ 'WPCOM_Billing_PayPal_Express' ],
-			blog_id: '1234',
+			blog_id: 1234,
 			cart_generated_at_timestamp: 12345,
 			cart_key: 1234,
 			coupon: requestCoupon,

--- a/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/we-chat-processor.ts
@@ -29,7 +29,7 @@ describe( 'weChatProcessor', () => {
 
 	const basicExpectedStripeRequest = {
 		cart: {
-			blog_id: '0',
+			blog_id: 0,
 			cart_key: 'no-site',
 			coupon: '',
 			products: [ product ],
@@ -121,8 +121,8 @@ describe( 'weChatProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 			},
 			payment: {
@@ -164,8 +164,8 @@ describe( 'weChatProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 				tax: { location: { postal_code: 'pr267ry', country_code: 'GB' } },
 			},
@@ -197,8 +197,8 @@ describe( 'weChatProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 				products: [ domainProduct ],
 			},

--- a/client/my-sites/checkout/composite-checkout/test/web-pay-processor.ts
+++ b/client/my-sites/checkout/composite-checkout/test/web-pay-processor.ts
@@ -28,7 +28,7 @@ describe( 'webPayProcessor', () => {
 
 	const basicExpectedStripeRequest = {
 		cart: {
-			blog_id: '0',
+			blog_id: 0,
 			cart_key: 'no-site',
 			coupon: '',
 			products: [ product ],
@@ -139,8 +139,8 @@ describe( 'webPayProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 			},
 		} );
@@ -180,8 +180,8 @@ describe( 'webPayProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 				tax: { location: { postal_code: 'pr267ry', country_code: 'GB' } },
 			},
@@ -211,8 +211,8 @@ describe( 'webPayProcessor', () => {
 			...basicExpectedStripeRequest,
 			cart: {
 				...basicExpectedStripeRequest.cart,
-				blog_id: '1234567',
-				cart_key: '1234567',
+				blog_id: 1234567,
+				cart_key: 1234567,
 				coupon: '',
 				products: [ domainProduct ],
 			},

--- a/packages/shopping-cart/src/cart-functions.ts
+++ b/packages/shopping-cart/src/cart-functions.ts
@@ -33,6 +33,7 @@ export function convertResponseCartToRequestCart( {
 	products,
 	coupon,
 	tax,
+	blog_id,
 }: TempResponseCart ): RequestCart {
 	let requestCartTax = null;
 	if (
@@ -57,6 +58,7 @@ export function convertResponseCartToRequestCart( {
 		};
 	}
 	return {
+		blog_id,
 		products: products.map( convertResponseCartProductToRequestCartProduct ),
 		coupon,
 		temporary: false,

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -2,7 +2,7 @@ import type { ResponseCart, ResponseCartProduct } from './types';
 
 export function getEmptyResponseCart(): ResponseCart {
 	return {
-		blog_id: '',
+		blog_id: 0,
 		cart_generated_at_timestamp: 0,
 		cart_key: 'no-site',
 		products: [],

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -190,7 +190,7 @@ export interface CartSyncManager {
 }
 
 export interface RequestCart {
-	blog_id?: number | string;
+	blog_id: number;
 	cart_key?: CartKey;
 	products: RequestCartProduct[];
 	tax: RequestCartTaxData;
@@ -223,7 +223,7 @@ export type MinimalRequestCartProduct = Partial< RequestCartProduct > &
 	Pick< RequestCartProduct, 'product_slug' >;
 
 export interface ResponseCart< P = ResponseCartProduct > {
-	blog_id: number | string;
+	blog_id: number;
 	cart_key: CartKey;
 	products: P[];
 


### PR DESCRIPTION
## Proposed Changes

This PR modifies the shopping cart to specify that the cart's `blog_id`, both in a cart request and a cart response, must always be a number and must always exist (although it can be 0). Previously the types allowed for a `blog_id` which was a string (I don't think that ever happens in a cart response and shouldn't be necessary for a cart request) and sometimes did not exist on the request (this is risky because it would make the cart's `blog_id` default to the current blog ID during the API request, which might not belong to the cart's owner and also probably never happened if TypeScript can be believed since we did not have to change anything other than casting by making it required).

This PR should not actually change any behavior other than to submit `blog_id` to the cart and transactions endpoints as a number rather than a string. Since the shopping cart on the backend always expects `blog_id` to be a number (or null), this should just prevent casting the value inside the endpoint. By requiring a number we will also protect against the possibility of using an arbitrary string somehow which could cause undefined behavior when submitted.

## Testing Instructions

If the tests pass, the main things to try here are:

1. A regular purchase for an existing site. Verify that the purchase succeeds and that a receipt appears under `/me/purchases` with the correct data for the upgrade.
2. A domain-only purchase. You can visit `/start/domain/domain-only` to begin this flow. Verify that the purchase succeeds and that a receipt appears under `/me/purchases` with the correct data for the upgrade.