### PR TITLE
Remove 1USD intro override for JP Social Basic and Backup

### DIFF
--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -1,7 +1,6 @@
 import {
-	JETPACK_BACKUP_T1_PRODUCTS,
 	JETPACK_CRM_PRODUCTS,
-	JETPACK_SOCIAL_PRODUCTS,
+	JETPACK_SOCIAL_ADVANCED_PRODUCTS,
 	TERM_MONTHLY,
 } from '@automattic/calypso-products';
 import { useMemo } from 'react';
@@ -167,12 +166,10 @@ const useItemPrice = (
 				? getMonthlyPrice( introductoryOfferPrices.introOfferCost )
 				: undefined;
 
-			// Override Jetpack Social Basic, Jetpack Social Advanced and Jetpack Backup Tier 1 price by hard-coding it for now
+			// Override Jetpack Social Advanced price by hard-coding it for now
 			if (
-				[ ...JETPACK_SOCIAL_PRODUCTS, ...JETPACK_BACKUP_T1_PRODUCTS ].includes(
-					item?.productSlug as
-						| ( typeof JETPACK_SOCIAL_PRODUCTS )[ number ]
-						| ( typeof JETPACK_BACKUP_T1_PRODUCTS )[ number ]
+				JETPACK_SOCIAL_ADVANCED_PRODUCTS.includes(
+					item?.productSlug as ( typeof JETPACK_SOCIAL_ADVANCED_PRODUCTS )[ number ]
 				)
 			) {
 				discountedPrice = introductoryOfferPrices.introOfferCost || undefined;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #71923

## Proposed Changes

This PR removes hotfix for 1 USD intro pricing for Jetpack Social Basic and Jetpack VaultPress Backup products (as we don't need them anymore - we introduce first year -50% discounts instead)

Currently, the hotfix causes issues with displaying prices. E.g.:
<img width="605" alt="CleanShot 2023-04-06 at 19 16 41@2x" src="https://user-images.githubusercontent.com/8419292/230520975-cfe53baf-9690-4c5b-ba45-855ff5c16d32.png">


## Testing Instructions

* Build this PR `yarn start-jetpack-cloud-p`
* Enable store sandbox on your sandbox
* Go to http://jetpack.cloud.localhost:3001/pricing
* Jetpack VaultPress Backup price should be displayed properly
<img width="613" alt="CleanShot 2023-04-06 at 19 14 16@2x" src="https://user-images.githubusercontent.com/8419292/230520681-f1b4e82d-df80-4bc4-8617-d9b5cd6b56a2.png">

* Click "More about Social" hyperlink and select Social Basic plan
* Jetpack Social Basic plan should be displayed properly
<img width="406" alt="CleanShot 2023-04-06 at 19 15 17@2x" src="https://user-images.githubusercontent.com/8419292/230520746-35fe45d8-e3cf-4842-b5c0-91a2f97b14c0.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
