### PR TITLE
Change initialization param of twitter tracker for Jetpack

### DIFF
--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -122,12 +122,11 @@ function initLoadedTrackingScripts() {
 
 	// init Twitter
 	if ( mayWeTrackByTracker( 'twitter' ) ) {
-		window.twq(
-			'init',
-			isJetpackCloud() || isJetpackCheckout()
-				? TRACKING_IDS.jetpackTwitterPixelId
-				: TRACKING_IDS.twitterPixelId
-		);
+		if ( isJetpackCloud() || isJetpackCheckout() ) {
+			window.twq( 'config', TRACKING_IDS.jetpackTwitterPixelId );
+		} else {
+			window.twq( 'init', TRACKING_IDS.twitterPixelId );
+		}
 	}
 
 	// init Quora


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72877

## Proposed Changes

Our marketing agency reported Twitter tracker doesn't work on the Pricing and Checkout (calypso) pages. It might be cause we're using the old initialization param (`init`) instead of one that is recommended in implementation snippets currently (`config`). This PR should fix the Twitter tracker issue.

## Testing Instructions

It's not really necessary to go through testing instructions as the change is not testable from console (it will be checked my our marketing agency once live). However, practically steps are the same as for the initial implementation PR:

* Checkout the PR, and run `yarn start`
* Go to `http://calypso.localhost:3000/checkout/jetpack/jetpack_boost_monthly?flags=ad-tracking,cookie-banner`
* Ensure that you allow for advertising trackers (`sensitive_pixel_options=%7B%22ok%22%3Atrue%2C%22buckets%22%3A%7B%22essential%22%3Atrue%2C%22analytics%22%3Atrue%2C%22advertising%22%3Atrue%7D%7D`)
* See that `window.twq` is defined
* Start `yarn start-jetpack-cloud`
* Go to `http://jetpack.cloud.localhost:3000/pricing?flags=ad-tracking,cookie-banner`
* Ensure that you allow for advertising trackers (`sensitive_pixel_options=%7B%22ok%22%3Atrue%2C%22buckets%22%3A%7B%22essential%22%3Atrue%2C%22analytics%22%3Atrue%2C%22advertising%22%3Atrue%7D%7D`)
* See that `window.twq` is defined

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
