### PR TITLE
Fix: Filtered plans comparison grid features 

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -134,7 +134,6 @@ type PlanFeatures2023GridProps = {
 	withDiscount: boolean;
 	discountEndDate: Date;
 	hidePlansFeatureComparison: boolean;
-	hideFreePlan: boolean;
 };
 
 type PlanFeatures2023GridConnectedProps = {
@@ -1012,8 +1011,7 @@ export class PlanFeatures2023Grid extends Component<
 /* eslint-disable wpcalypso/redux-no-bound-selectors */
 const ConnectedPlanFeatures2023Grid = connect(
 	( state: IAppState, ownProps: PlanFeatures2023GridProps ) => {
-		const { placeholder, plans, isLandingPage, visiblePlans, isInSignup, siteId, hideFreePlan } =
-			ownProps;
+		const { placeholder, plans, isLandingPage, visiblePlans, isInSignup, siteId } = ownProps;
 		const canUserPurchasePlan =
 			! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId );
 		const purchaseId = getCurrentPlanPurchaseId( state, siteId );
@@ -1128,11 +1126,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 
 			const availableForPurchase = isInSignup || isPlanAvailableForPurchase( state, siteId, plan );
 			const isCurrentPlan = isCurrentSitePlan( state, siteId, planProductId ) ?? false;
-			let isVisible = visiblePlans.indexOf( plan ) !== -1;
-
-			if ( hideFreePlan && plan === PLAN_FREE ) {
-				isVisible = false;
-			}
+			const isVisible = visiblePlans.indexOf( plan ) !== -1;
 
 			return {
 				availableForPurchase,

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -13,12 +13,6 @@ import {
 	isMonthly,
 	TERM_MONTHLY,
 	isBusinessPlan,
-	TYPE_FREE,
-	TYPE_PERSONAL,
-	TYPE_PREMIUM,
-	TYPE_BUSINESS,
-	TYPE_ECOMMERCE,
-	TYPE_ENTERPRISE_GRID_WPCOM,
 	getPlanPath,
 	PLAN_FREE,
 	PLAN_ENTERPRISE_GRID_WPCOM,
@@ -394,24 +388,17 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderTabletView() {
-		const { planProperties, hideFreePlan } = this.props;
-		const plansToShow = hideFreePlan
-			? [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE, TYPE_ENTERPRISE_GRID_WPCOM ]
-			: [
-					TYPE_FREE,
-					TYPE_PERSONAL,
-					TYPE_PREMIUM,
-					TYPE_BUSINESS,
-					TYPE_ECOMMERCE,
-					TYPE_ENTERPRISE_GRID_WPCOM,
-			  ];
+		const { planProperties } = this.props;
+		const plansToShow = planProperties
+			.filter( ( { isVisible } ) => isVisible )
+			.map( ( properties ) => properties.planName );
 		const topRowPlans = plansToShow.slice( 0, 3 );
 		const bottomRowPlans = plansToShow.slice( 3, 6 );
 		const planPropertiesForTopRow = planProperties.filter( ( properties: PlanProperties ) =>
-			topRowPlans.includes( properties.planConstantObj.type )
+			topRowPlans.includes( properties.planName )
 		);
 		const planPropertiesForBottomRow = planProperties.filter( ( properties: PlanProperties ) =>
-			bottomRowPlans.includes( properties.planConstantObj.type )
+			bottomRowPlans.includes( properties.planName )
 		);
 
 		return (
@@ -442,37 +429,39 @@ export class PlanFeatures2023Grid extends Component<
 		};
 		let previousProductNameShort: string;
 
-		return planProperties.map( ( properties: PlanProperties, index: number ) => {
-			const planCardClasses = classNames(
-				'plan-features-2023-grid__mobile-plan-card',
-				getPlanClass( properties.planName )
-			);
-			const planCardJsx = (
-				<div className={ planCardClasses } key={ `${ properties.planName }-${ index }` }>
-					{ this.renderPlanLogos( [ properties ], { isMobile: true } ) }
-					{ this.renderPlanHeaders( [ properties ], { isMobile: true } ) }
-					{ this.renderPlanTagline( [ properties ], { isMobile: true } ) }
-					{ this.renderPlanPrice( [ properties ], { isMobile: true } ) }
-					{ this.renderBillingTimeframe( [ properties ], { isMobile: true } ) }
-					{ this.renderMobileFreeDomain( properties.planName, properties.isMonthlyPlan ) }
-					{ this.renderTopButtons( [ properties ], { isMobile: true } ) }
-					<CardContainer
-						header={ translate( 'Show all features' ) }
-						planName={ properties.planName }
-						key={ `${ properties.planName }-${ index }` }
-					>
-						{ this.renderPreviousFeaturesIncludedTitle( [ properties ], {
-							isMobile: true,
-							previousProductNameShort,
-						} ) }
-						{ this.renderPlanFeaturesList( [ properties ], { isMobile: true } ) }
-						{ this.renderPlanStorageOptions( [ properties ], { isMobile: true } ) }
-					</CardContainer>
-				</div>
-			);
-			previousProductNameShort = properties.product_name_short;
-			return planCardJsx;
-		} );
+		return planProperties
+			.filter( ( { isVisible } ) => isVisible )
+			.map( ( properties: PlanProperties, index: number ) => {
+				const planCardClasses = classNames(
+					'plan-features-2023-grid__mobile-plan-card',
+					getPlanClass( properties.planName )
+				);
+				const planCardJsx = (
+					<div className={ planCardClasses } key={ `${ properties.planName }-${ index }` }>
+						{ this.renderPlanLogos( [ properties ], { isMobile: true } ) }
+						{ this.renderPlanHeaders( [ properties ], { isMobile: true } ) }
+						{ this.renderPlanTagline( [ properties ], { isMobile: true } ) }
+						{ this.renderPlanPrice( [ properties ], { isMobile: true } ) }
+						{ this.renderBillingTimeframe( [ properties ], { isMobile: true } ) }
+						{ this.renderMobileFreeDomain( properties.planName, properties.isMonthlyPlan ) }
+						{ this.renderTopButtons( [ properties ], { isMobile: true } ) }
+						<CardContainer
+							header={ translate( 'Show all features' ) }
+							planName={ properties.planName }
+							key={ `${ properties.planName }-${ index }` }
+						>
+							{ this.renderPreviousFeaturesIncludedTitle( [ properties ], {
+								isMobile: true,
+								previousProductNameShort,
+							} ) }
+							{ this.renderPlanFeaturesList( [ properties ], { isMobile: true } ) }
+							{ this.renderPlanStorageOptions( [ properties ], { isMobile: true } ) }
+						</CardContainer>
+					</div>
+				);
+				previousProductNameShort = properties.product_name_short;
+				return planCardJsx;
+			} );
 	}
 
 	renderMobileFreeDomain( planName: string, isMonthlyPlan: boolean ) {
@@ -507,120 +496,130 @@ export class PlanFeatures2023Grid extends Component<
 			( properties ) => properties?.rawPrice && properties?.rawPrice > 99000
 		);
 
-		return planPropertiesObj.map( ( properties ) => {
-			const { planName, rawPrice } = properties;
-			const classes = classNames( 'plan-features-2023-grid__table-item', 'is-bottom-aligned', {
-				'has-border-top': ! isReskinned,
-			} );
-			const hasNoPrice = rawPrice === undefined || rawPrice === null;
+		return planPropertiesObj
+			.filter( ( { isVisible } ) => isVisible )
+			.map( ( properties ) => {
+				const { planName, rawPrice } = properties;
+				const classes = classNames( 'plan-features-2023-grid__table-item', 'is-bottom-aligned', {
+					'has-border-top': ! isReskinned,
+				} );
+				const hasNoPrice = rawPrice === undefined || rawPrice === null;
 
-			return (
-				<Container
-					scope="col"
-					key={ planName }
-					className={ classes }
-					isMobile={ options?.isMobile }
-				>
-					{ ! hasNoPrice && (
-						<PlanFeatures2023GridHeaderPrice
-							planProperties={ properties }
-							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
-							isLargeCurrency={ isLargeCurrency }
-						/>
-					) }
-				</Container>
-			);
-		} );
+				return (
+					<Container
+						scope="col"
+						key={ planName }
+						className={ classes }
+						isMobile={ options?.isMobile }
+					>
+						{ ! hasNoPrice && (
+							<PlanFeatures2023GridHeaderPrice
+								planProperties={ properties }
+								is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+								isLargeCurrency={ isLargeCurrency }
+							/>
+						) }
+					</Container>
+				);
+			} );
 	}
 
 	renderBillingTimeframe( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
-		return planPropertiesObj.map( ( properties ) => {
-			const {
-				planConstantObj,
-				planName,
-				rawPrice,
-				maybeDiscountedFullTermPrice,
-				annualPricePerMonth,
-				isMonthlyPlan,
-				billingPeriod,
-			} = properties;
+		return planPropertiesObj
+			.filter( ( { isVisible } ) => isVisible )
+			.map( ( properties ) => {
+				const {
+					planConstantObj,
+					planName,
+					rawPrice,
+					maybeDiscountedFullTermPrice,
+					annualPricePerMonth,
+					isMonthlyPlan,
+					billingPeriod,
+				} = properties;
 
-			const classes = classNames(
-				'plan-features-2023-grid__table-item',
-				'plan-features-2023-grid__header-billing-info'
-			);
+				const classes = classNames(
+					'plan-features-2023-grid__table-item',
+					'plan-features-2023-grid__header-billing-info'
+				);
 
-			return (
-				<Container className={ classes } isMobile={ options?.isMobile } key={ planName }>
-					<PlanFeatures2023GridBillingTimeframe
-						rawPrice={ rawPrice }
-						maybeDiscountedFullTermPrice={ maybeDiscountedFullTermPrice }
-						annualPricePerMonth={ annualPricePerMonth }
-						isMonthlyPlan={ isMonthlyPlan }
-						planName={ planName }
-						billingTimeframe={ planConstantObj.getBillingTimeFrame() }
-						billingPeriod={ billingPeriod }
-					/>
-				</Container>
-			);
-		} );
+				return (
+					<Container className={ classes } isMobile={ options?.isMobile } key={ planName }>
+						<PlanFeatures2023GridBillingTimeframe
+							rawPrice={ rawPrice }
+							maybeDiscountedFullTermPrice={ maybeDiscountedFullTermPrice }
+							annualPricePerMonth={ annualPricePerMonth }
+							isMonthlyPlan={ isMonthlyPlan }
+							planName={ planName }
+							billingTimeframe={ planConstantObj.getBillingTimeFrame() }
+							billingPeriod={ billingPeriod }
+						/>
+					</Container>
+				);
+			} );
 	}
 
 	renderPlanLogos( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
 		const { isInSignup } = this.props;
 
-		return planPropertiesObj.map( ( properties, index ) => {
-			return (
-				<PlanLogo
-					key={ properties.planName }
-					planIndex={ index }
-					planPropertiesObj={ planPropertiesObj }
-					planProperties={ properties }
-					isMobile={ options?.isMobile }
-					isInSignup={ isInSignup }
-				/>
-			);
-		} );
+		return planPropertiesObj
+			.filter( ( { isVisible } ) => isVisible )
+			.map( ( properties, index ) => {
+				return (
+					<PlanLogo
+						key={ properties.planName }
+						planIndex={ index }
+						planPropertiesObj={ planPropertiesObj }
+						planProperties={ properties }
+						isMobile={ options?.isMobile }
+						isInSignup={ isInSignup }
+					/>
+				);
+			} );
 	}
 
 	renderPlanHeaders( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
-		return planPropertiesObj.map( ( properties: PlanProperties ) => {
-			const { planName, planConstantObj } = properties;
-			const headerClasses = classNames(
-				'plan-features-2023-grid__header',
-				getPlanClass( planName )
-			);
+		return planPropertiesObj
+			.filter( ( { isVisible } ) => isVisible )
+			.map( ( properties: PlanProperties ) => {
+				const { planName, planConstantObj } = properties;
+				const headerClasses = classNames(
+					'plan-features-2023-grid__header',
+					getPlanClass( planName )
+				);
 
-			return (
-				<Container
-					key={ planName }
-					className="plan-features-2023-grid__table-item"
-					isMobile={ options?.isMobile }
-				>
-					<header className={ headerClasses }>
-						<h4 className="plan-features-2023-grid__header-title">
-							{ planConstantObj.getTitle() }
-						</h4>
-					</header>
-				</Container>
-			);
-		} );
+				return (
+					<Container
+						key={ planName }
+						className="plan-features-2023-grid__table-item"
+						isMobile={ options?.isMobile }
+					>
+						<header className={ headerClasses }>
+							<h4 className="plan-features-2023-grid__header-title">
+								{ planConstantObj.getTitle() }
+							</h4>
+						</header>
+					</Container>
+				);
+			} );
 	}
 
 	renderPlanTagline( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
-		return planPropertiesObj.map( ( properties ) => {
-			const { planName, tagline } = properties;
+		return planPropertiesObj
+			.filter( ( { isVisible } ) => isVisible )
+			.map( ( properties ) => {
+				const { planName, tagline } = properties;
 
-			return (
-				<Container
-					key={ planName }
-					className="plan-features-2023-grid__table-item"
-					isMobile={ options?.isMobile }
-				>
-					<div className="plan-features-2023-grid__header-tagline">{ tagline }</div>
-				</Container>
-			);
-		} );
+				return (
+					<Container
+						key={ planName }
+						className="plan-features-2023-grid__table-item"
+						isMobile={ options?.isMobile }
+					>
+						<div className="plan-features-2023-grid__header-tagline">{ tagline }</div>
+					</Container>
+				);
+			} );
 	}
 
 	handleUpgradeClick = ( singlePlanProperties: PlanProperties ) => {
@@ -654,50 +653,55 @@ export class PlanFeatures2023Grid extends Component<
 			translate,
 		} = this.props;
 
-		return planPropertiesObj.map( ( properties: PlanProperties ) => {
-			const { planName, isPlaceholder, planConstantObj, current } = properties;
-			const classes = classNames(
-				'plan-features-2023-grid__table-item',
-				'is-top-buttons',
-				'is-bottom-aligned'
-			);
+		return planPropertiesObj
+			.filter( ( { isVisible } ) => isVisible )
+			.map( ( properties: PlanProperties ) => {
+				const { planName, isPlaceholder, planConstantObj, current } = properties;
+				const classes = classNames(
+					'plan-features-2023-grid__table-item',
+					'is-top-buttons',
+					'is-bottom-aligned'
+				);
 
-			// Leaving it `undefined` makes it use the default label
-			let buttonText;
+				// Leaving it `undefined` makes it use the default label
+				let buttonText;
 
-			if ( isWooExpressMediumPlan( planName ) && ! isWooExpressMediumPlan( currentSitePlanSlug ) ) {
-				buttonText = translate( 'Get Performance', { textOnly: true } );
-			} else if (
-				isWooExpressSmallPlan( planName ) &&
-				! isWooExpressSmallPlan( currentSitePlanSlug )
-			) {
-				buttonText = translate( 'Get Essential', { textOnly: true } );
-			}
+				if (
+					isWooExpressMediumPlan( planName ) &&
+					! isWooExpressMediumPlan( currentSitePlanSlug )
+				) {
+					buttonText = translate( 'Get Performance', { textOnly: true } );
+				} else if (
+					isWooExpressSmallPlan( planName ) &&
+					! isWooExpressSmallPlan( currentSitePlanSlug )
+				) {
+					buttonText = translate( 'Get Essential', { textOnly: true } );
+				}
 
-			return (
-				<Container key={ planName } className={ classes } isMobile={ options?.isMobile }>
-					<PlanFeatures2023GridActions
-						manageHref={ manageHref }
-						canUserPurchasePlan={ canUserPurchasePlan }
-						availableForPurchase={ properties.availableForPurchase }
-						className={ getPlanClass( planName ) }
-						freePlan={ isFreePlan( planName ) }
-						isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planName ) }
-						isPlaceholder={ isPlaceholder ?? false }
-						isInSignup={ isInSignup }
-						isLaunchPage={ isLaunchPage }
-						onUpgradeClick={ () => this.handleUpgradeClick( properties ) }
-						planName={ planConstantObj.getTitle() }
-						planType={ planName }
-						flowName={ flowName }
-						current={ current ?? false }
-						currentSitePlanSlug={ currentSitePlanSlug }
-						selectedSiteSlug={ selectedSiteSlug }
-						buttonText={ buttonText }
-					/>
-				</Container>
-			);
-		} );
+				return (
+					<Container key={ planName } className={ classes } isMobile={ options?.isMobile }>
+						<PlanFeatures2023GridActions
+							manageHref={ manageHref }
+							canUserPurchasePlan={ canUserPurchasePlan }
+							availableForPurchase={ properties.availableForPurchase }
+							className={ getPlanClass( planName ) }
+							freePlan={ isFreePlan( planName ) }
+							isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planName ) }
+							isPlaceholder={ isPlaceholder ?? false }
+							isInSignup={ isInSignup }
+							isLaunchPage={ isLaunchPage }
+							onUpgradeClick={ () => this.handleUpgradeClick( properties ) }
+							planName={ planConstantObj.getTitle() }
+							planType={ planName }
+							flowName={ flowName }
+							current={ current ?? false }
+							currentSitePlanSlug={ currentSitePlanSlug }
+							selectedSiteSlug={ selectedSiteSlug }
+							buttonText={ buttonText }
+						/>
+					</Container>
+				);
+			} );
 	}
 
 	renderEnterpriseClientLogos() {
@@ -722,36 +726,38 @@ export class PlanFeatures2023Grid extends Component<
 		const { translate } = this.props;
 		let previousPlanShortNameFromProperties: string;
 
-		return planPropertiesObj.map( ( properties: PlanProperties ) => {
-			const { planName, product_name_short } = properties;
-			const shouldShowFeatureTitle =
-				! isWpComFreePlan( planName ) && ! isWpcomEnterpriseGridPlan( planName );
-			const planShortName =
-				options?.previousProductNameShort || previousPlanShortNameFromProperties;
-			previousPlanShortNameFromProperties = product_name_short;
-			const title =
-				planShortName &&
-				translate( 'Everything in %(planShortName)s, plus:', {
-					args: { planShortName },
-				} );
-			const classes = classNames(
-				'plan-features-2023-grid__common-title',
-				getPlanClass( planName )
-			);
-			const rowspanProp =
-				! options?.isMobile && isWpcomEnterpriseGridPlan( planName ) ? { rowSpan: '2' } : {};
-			return (
-				<Container
-					key={ planName }
-					isMobile={ options?.isMobile }
-					className="plan-features-2023-grid__table-item"
-					{ ...rowspanProp }
-				>
-					{ shouldShowFeatureTitle && <div className={ classes }>{ title }</div> }
-					{ isWpcomEnterpriseGridPlan( planName ) && this.renderEnterpriseClientLogos() }
-				</Container>
-			);
-		} );
+		return planPropertiesObj
+			.filter( ( { isVisible } ) => isVisible )
+			.map( ( properties: PlanProperties ) => {
+				const { planName, product_name_short } = properties;
+				const shouldShowFeatureTitle =
+					! isWpComFreePlan( planName ) && ! isWpcomEnterpriseGridPlan( planName );
+				const planShortName =
+					options?.previousProductNameShort || previousPlanShortNameFromProperties;
+				previousPlanShortNameFromProperties = product_name_short;
+				const title =
+					planShortName &&
+					translate( 'Everything in %(planShortName)s, plus:', {
+						args: { planShortName },
+					} );
+				const classes = classNames(
+					'plan-features-2023-grid__common-title',
+					getPlanClass( planName )
+				);
+				const rowspanProp =
+					! options?.isMobile && isWpcomEnterpriseGridPlan( planName ) ? { rowSpan: '2' } : {};
+				return (
+					<Container
+						key={ planName }
+						isMobile={ options?.isMobile }
+						className="plan-features-2023-grid__table-item"
+						{ ...rowspanProp }
+					>
+						{ shouldShowFeatureTitle && <div className={ classes }>{ title }</div> }
+						{ isWpcomEnterpriseGridPlan( planName ) && this.renderEnterpriseClientLogos() }
+					</Container>
+				);
+			} );
 	}
 
 	renderPlanFeaturesList( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
@@ -760,72 +766,78 @@ export class PlanFeatures2023Grid extends Component<
 			( properties ) => ! isWpcomEnterpriseGridPlan( properties.planName )
 		);
 
-		return planProperties.map( ( properties, mapIndex ) => {
-			const { planName, features, jpFeatures } = properties;
-			return (
-				<Container
-					key={ `${ planName }-${ mapIndex }` }
-					isMobile={ options?.isMobile }
-					className="plan-features-2023-grid__table-item"
-				>
-					<PlanFeatures2023GridFeatures
-						features={ features }
-						planName={ planName }
-						domainName={ domainName }
-					/>
-					{ jpFeatures.length !== 0 && (
-						<div className="plan-features-2023-grid__jp-logo" key="jp-logo">
-							<Plans2023Tooltip
-								text={ translate(
-									'Security, performance and growth tools made by the WordPress experts.'
-								) }
-							>
-								<JetpackLogo size={ 16 } />
-							</Plans2023Tooltip>
-						</div>
-					) }
-					<PlanFeatures2023GridFeatures
-						features={ jpFeatures }
-						planName={ planName }
-						domainName={ domainName }
-					/>
-				</Container>
-			);
-		} );
+		return planProperties
+			.filter( ( { isVisible } ) => isVisible )
+			.map( ( properties, mapIndex ) => {
+				const { planName, features, jpFeatures } = properties;
+				return (
+					<Container
+						key={ `${ planName }-${ mapIndex }` }
+						isMobile={ options?.isMobile }
+						className="plan-features-2023-grid__table-item"
+					>
+						<PlanFeatures2023GridFeatures
+							features={ features }
+							planName={ planName }
+							domainName={ domainName }
+						/>
+						{ jpFeatures.length !== 0 && (
+							<div className="plan-features-2023-grid__jp-logo" key="jp-logo">
+								<Plans2023Tooltip
+									text={ translate(
+										'Security, performance and growth tools made by the WordPress experts.'
+									) }
+								>
+									<JetpackLogo size={ 16 } />
+								</Plans2023Tooltip>
+							</div>
+						) }
+						<PlanFeatures2023GridFeatures
+							features={ jpFeatures }
+							planName={ planName }
+							domainName={ domainName }
+						/>
+					</Container>
+				);
+			} );
 	}
 
 	renderPlanStorageOptions( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
 		const { translate } = this.props;
-		return planPropertiesObj.map( ( properties ) => {
-			if ( options?.isMobile && isWpcomEnterpriseGridPlan( properties.planName ) ) {
-				return null;
-			}
-
-			const { planName, storageOptions } = properties;
-			const storageJSX = storageOptions.map( ( storageFeature: string ) => {
-				if ( storageFeature.length <= 0 ) {
-					return;
+		return planPropertiesObj
+			.filter( ( { isVisible } ) => isVisible )
+			.map( ( properties ) => {
+				if ( options?.isMobile && isWpcomEnterpriseGridPlan( properties.planName ) ) {
+					return null;
 				}
+
+				const { planName, storageOptions } = properties;
+				const storageJSX = storageOptions.map( ( storageFeature: string ) => {
+					if ( storageFeature.length <= 0 ) {
+						return;
+					}
+					return (
+						<div className="plan-features-2023-grid__storage-buttons" key={ planName }>
+							{ getStorageStringFromFeature( storageFeature ) }
+						</div>
+					);
+				} );
+
 				return (
-					<div className="plan-features-2023-grid__storage-buttons" key={ planName }>
-						{ getStorageStringFromFeature( storageFeature ) }
-					</div>
+					<Container
+						key={ planName }
+						className="plan-features-2023-grid__table-item plan-features-2023-grid__storage"
+						isMobile={ options?.isMobile }
+					>
+						{ storageOptions.length ? (
+							<div className="plan-features-2023-grid__storage-title">
+								{ translate( 'Storage' ) }
+							</div>
+						) : null }
+						{ storageJSX }
+					</Container>
 				);
 			} );
-
-			return (
-				<Container
-					key={ planName }
-					className="plan-features-2023-grid__table-item plan-features-2023-grid__storage"
-					isMobile={ options?.isMobile }
-				>
-					{ storageOptions.length ? (
-						<div className="plan-features-2023-grid__storage-title">{ translate( 'Storage' ) }</div>
-					) : null }
-					{ storageJSX }
-				</Container>
-			);
-		} );
 	}
 
 	getBannerContainer() {
@@ -1000,7 +1012,8 @@ export class PlanFeatures2023Grid extends Component<
 /* eslint-disable wpcalypso/redux-no-bound-selectors */
 const ConnectedPlanFeatures2023Grid = connect(
 	( state: IAppState, ownProps: PlanFeatures2023GridProps ) => {
-		const { placeholder, plans, isLandingPage, visiblePlans, isInSignup, siteId } = ownProps;
+		const { placeholder, plans, isLandingPage, visiblePlans, isInSignup, siteId, hideFreePlan } =
+			ownProps;
 		const canUserPurchasePlan =
 			! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId );
 		const purchaseId = getCurrentPlanPurchaseId( state, siteId );
@@ -1011,7 +1024,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 		const isJetpack = siteId ? isJetpackSite( state, siteId ) : false;
 		const isSiteAT = siteId ? isSiteAutomatedTransfer( state, siteId ) : false;
 
-		let planProperties: PlanProperties[] = plans.map( ( plan: string ) => {
+		const planProperties: PlanProperties[] = plans.map( ( plan: string ) => {
 			let isPlaceholder = false;
 			const planConstantObj = applyTestFiltersToPlansList( plan, undefined );
 			const planProductId = planConstantObj.getProductId();
@@ -1115,6 +1128,11 @@ const ConnectedPlanFeatures2023Grid = connect(
 
 			const availableForPurchase = isInSignup || isPlanAvailableForPurchase( state, siteId, plan );
 			const isCurrentPlan = isCurrentSitePlan( state, siteId, planProductId ) ?? false;
+			let isVisible = visiblePlans.indexOf( plan ) !== -1;
+
+			if ( hideFreePlan && plan === PLAN_FREE ) {
+				isVisible = false;
+			}
 
 			return {
 				availableForPurchase,
@@ -1125,6 +1143,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 				jpFeatures: jetpackFeaturesTransformed,
 				isLandingPage,
 				isPlaceholder,
+				isVisible,
 				planConstantObj,
 				planName: plan,
 				planObject: planObject,
@@ -1142,12 +1161,6 @@ const ConnectedPlanFeatures2023Grid = connect(
 				showMonthlyPrice,
 			};
 		} );
-
-		if ( Array.isArray( visiblePlans ) ) {
-			planProperties = planProperties.filter(
-				( p: PlanProperties ) => visiblePlans.indexOf( p?.planName ) !== -1
-			);
-		}
 
 		const manageHref =
 			purchaseId && selectedSiteSlug

--- a/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/plan-comparison-grid.tsx
@@ -610,7 +610,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 	const displayedPlansProperties = useMemo(
 		() =>
 			( planProperties ?? [] ).filter(
-				( { planName } ) => ! ( planName === PLAN_ENTERPRISE_GRID_WPCOM )
+				( { planName, isVisible } ) => isVisible && ! ( planName === PLAN_ENTERPRISE_GRID_WPCOM )
 			),
 		[ planProperties ]
 	);

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -17,6 +17,7 @@ export type PlanProperties = {
 	jpFeatures: TransformedFeatureObject[];
 	isLandingPage?: boolean;
 	isPlaceholder?: boolean;
+	isVisible: boolean;
 	planConstantObj: ReturnType< typeof applyTestFiltersToPlansList >;
 	planName: string;
 	planObject: PricedAPIPlan | undefined;

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -388,6 +388,14 @@ export class PlansFeaturesMain extends Component {
 			].filter( ( el ) => el );
 		}
 
+		if ( is2023PricingGridVisible ) {
+			/*
+			 * We need to pass all the plans in order to show the correct features in the plan comparison table.
+			 * Pleas use the getVisiblePlansForPlanFeatures selector to filter out the plans that should not be visible.
+			 */
+			return plans;
+		}
+
 		if ( hideFreePlan ) {
 			plans = plans.filter( ( planSlug ) => ! isFreePlan( planSlug ) );
 		}
@@ -450,12 +458,16 @@ export class PlansFeaturesMain extends Component {
 			isInMarketplace,
 			sitePlanSlug,
 			is2023PricingGridVisible,
+			hideFreePlan,
+			hidePersonalPlan,
+			hidePremiumPlan,
+			hideEcommercePlan,
 		} = this.props;
 
 		const isPlanOneOfType = ( plan, types ) =>
 			types.filter( ( type ) => planMatches( plan, { type } ) ).length > 0;
 
-		const plans = this.isDisplayingPlansNeededForFeature()
+		let plans = this.isDisplayingPlansNeededForFeature()
 			? availablePlans.filter( ( plan ) => {
 					if ( isEcommercePlan( selectedPlan ) ) {
 						return isEcommercePlan( plan );
@@ -470,7 +482,7 @@ export class PlansFeaturesMain extends Component {
 			: availablePlans;
 
 		if ( is2023PricingGridVisible ) {
-			return plans.filter( ( plan ) =>
+			plans = plans.filter( ( plan ) =>
 				isPlanOneOfType( plan, [
 					TYPE_FREE,
 					TYPE_PERSONAL,
@@ -480,6 +492,24 @@ export class PlansFeaturesMain extends Component {
 					TYPE_ENTERPRISE_GRID_WPCOM,
 				] )
 			);
+
+			if ( hideFreePlan ) {
+				plans = plans.filter( ( planSlug ) => ! isFreePlan( planSlug ) );
+			}
+
+			if ( hidePersonalPlan ) {
+				plans = plans.filter( ( planSlug ) => ! isPersonalPlan( planSlug ) );
+			}
+
+			if ( hidePremiumPlan ) {
+				plans = plans.filter( ( planSlug ) => ! isPremiumPlan( planSlug ) );
+			}
+
+			if ( hideEcommercePlan ) {
+				plans = plans.filter( ( planSlug ) => ! isEcommercePlan( planSlug ) );
+			}
+
+			return plans;
 		}
 
 		if ( plansWithScroll ) {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -128,7 +128,6 @@ export class PlansFeaturesMain extends Component {
 			planTypeSelectorProps,
 			busyOnUpgradeClick,
 			hidePlansFeatureComparison,
-			hideFreePlan,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -162,7 +161,6 @@ export class PlansFeaturesMain extends Component {
 				isPlansInsideStepper,
 				intervalType,
 				hidePlansFeatureComparison,
-				hideFreePlan,
 			};
 			const asyncPlanFeatures2023Grid = (
 				<AsyncLoad

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -85,5 +85,5 @@ export const is2023PricingGridActivePage = (
 		return isPricingGridEnabled;
 	}
 
-	return false;
+	return true;
 };

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -85,5 +85,5 @@ export const is2023PricingGridActivePage = (
 		return isPricingGridEnabled;
 	}
 
-	return true;
+	return false;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#1464](https://github.com/Automattic/martech/issues/1464)

## Proposed Changes

The features for each plan in the Comparison grid found in the Onboarding Flows and the Plans pages are constructed by appending to the previous plan features. If a lower-tier plan is filtered-out, then its features never get inherited by the other plans.

<img width="320" alt="Screenshot 2023-04-07 at 13 32 33" src="https://user-images.githubusercontent.com/2749938/230595291-dcf1b8f1-9a94-41e2-a98a-79d179e78927.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout and run this branch locally
* Go to `/start/plans` and `/plans/{SITE_ID}`
* Try out multiple screen widths
* The plans grid and comparison table below should be unchanged

* Go to this line and manipulate the `visiblePlans` array to show fewer plans (ex. `visiblePlans.splice( 0, 1 )` )
* The plans grid and comparison table below should only show the remaining plans
* Make sure the correct features are shown in the comparison table

<img width="320" alt="Screenshot 2023-04-07 at 13 53 40" src="https://user-images.githubusercontent.com/2749938/230597098-4660c194-b1d0-413b-a568-dae1c20d37fe.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
