### PR TITLE
Payment Methods: Allow deleting expired payment methods

### DIFF
--- a/client/me/purchases/payment-methods/payment-method-delete.tsx
+++ b/client/me/purchases/payment-methods/payment-method-delete.tsx
@@ -16,7 +16,10 @@ interface Props {
 
 const PaymentMethodDelete: FunctionComponent< Props > = ( { card } ) => {
 	const translate = useTranslate();
-	const { isDeleting, deletePaymentMethod } = useStoredPaymentMethods();
+	const { isDeleting, deletePaymentMethod } = useStoredPaymentMethods( {
+		type: 'all',
+		expired: true,
+	} );
 	const reduxDispatch = useDispatch< CalypsoDispatch >();
 	const [ isDialogVisible, setIsDialogVisible ] = useState( false );
 	const closeDialog = useCallback( () => setIsDialogVisible( false ), [] );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
@@ -111,7 +111,7 @@ export function useStoredPaymentMethods( {
 			return new Promise( ( resolve, reject ) => {
 				mutation.mutate( id, {
 					onSuccess: () => resolve(),
-					onError: ( error ) => reject( error.message ),
+					onError: ( error ) => reject( error ),
 				} );
 			} );
 		},
@@ -125,7 +125,9 @@ export function useStoredPaymentMethods( {
 			const matchingPaymentMethod = data?.find( ( method ) => method.stored_details_id === id );
 			if ( ! matchingPaymentMethod ) {
 				return Promise.reject(
-					translate( 'There was a problem deleting that payment method.', { textOnly: true } )
+					new Error(
+						translate( 'There was a problem deleting that payment method.', { textOnly: true } )
+					)
 				);
 			}
 


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/74676 replaced the old way of dealing with stored payment methods with a new hook, `useStoredPaymentMethods`. In addition to querying the payment-methods endpoint, it also handles deleting stored payment methods. As part of the migration, it reimplements what the previous code did: for stored (PayPal) payment agreements it will request not only a deletion of one payment method, but also the deletion of all payment methods matching that method's email address.

In order to perform that logic, the hook must determine if the payment method is a payment agreement or not, but this requires that its current cache contains the payment method that the consumer wants deleted. The hook call that lists the payment methods may include expired payment methods (the `expired: true` flag), but the hook call that's used to delete payment methods does not include that flag, risking the case that the deletion will not be able to find the payment method in its cache.

## Proposed Changes

In this PR we modify the deletion hook call to include the `expired` flag so that it should have access to all payment methods.

Fixes https://github.com/Automattic/payments-shilling/issues/1535

## Testing Instructions

- Use a site which has an expired payment method.
- Visit `/me/purchases/payment-methods` and try to delete the expired payment method.
- Verify that the deletion was successful.