### PR TITLE
Payment Methods: Stop deleting similar payment methods

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
@@ -1,7 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
-import { isPaymentAgreement } from 'calypso/lib/checkout/payment-methods';
 import wp from 'calypso/lib/wp';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import type { ComponentType } from 'react';
@@ -118,37 +117,6 @@ export function useStoredPaymentMethods( {
 		[ mutation ]
 	);
 
-	const deletePaymentMethodAndSimilar = useCallback<
-		StoredPaymentMethodsState[ 'deletePaymentMethod' ]
-	>(
-		async ( id ) => {
-			const matchingPaymentMethod = data?.find( ( method ) => method.stored_details_id === id );
-			if ( ! matchingPaymentMethod ) {
-				return Promise.reject(
-					new Error(
-						translate( 'There was a problem deleting that payment method.', { textOnly: true } )
-					)
-				);
-			}
-
-			if ( isPaymentAgreement( matchingPaymentMethod ) ) {
-				const similarPaymentAgreements =
-					data?.filter(
-						( method ) =>
-							method.email === matchingPaymentMethod.email && isPaymentAgreement( method )
-					) ?? [];
-				return Promise.all(
-					similarPaymentAgreements.map( ( method ) =>
-						deletePaymentMethod( method.stored_details_id )
-					)
-				).then( () => Promise.resolve() );
-			}
-
-			return deletePaymentMethod( id );
-		},
-		[ translate, data, deletePaymentMethod ]
-	);
-
 	const errorMessage = ( () => {
 		if ( mutation.error ) {
 			return mutation.error.message;
@@ -169,6 +137,6 @@ export function useStoredPaymentMethods( {
 		isLoading: isLoggedOut ? false : isLoading,
 		isDeleting: mutation.isLoading,
 		error: errorMessage,
-		deletePaymentMethod: deletePaymentMethodAndSimilar,
+		deletePaymentMethod,
 	};
 }


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/74676 replaced the old way of dealing with stored payment methods with a new hook, `useStoredPaymentMethods`. In addition to querying the payment-methods endpoint, it also handles deleting stored payment methods. As part of the migration, it reimplements what the previous code did: for stored (PayPal) payment agreements it will request not only a deletion of one payment method, but also the deletion of all payment methods matching that method's email address.

In order to perform that logic, the hook must determine if the payment method is a payment agreement or not, but this requires that its current cache contains the payment method that the consumer wants deleted. There are cases where the hook's cache does not contain the requested payment method, which would cause the deletion to fail.

What's more, this is a silly problem to have because the client shouldn't be responsible for enforcing this logic. The server has access to all the information about the user's payment methods and could easily delete similar payment agreements without additional work on the client side. I've updated the server to have this functionality in D109007-code.

## Proposed Changes

In this PR we remove the logic to delete similar payment methods from the `deletePaymentMethod()` action in the `useStoredPaymentMethods()` hook.

## Testing Instructions

- Use a site which has a payment method.
- Visit `/me/purchases/payment-methods` and try to delete the payment method.
- Verify that the deletion was successful.