### PR TITLE
Happy Blocks: fix learn url in global header

### DIFF
--- a/apps/happy-blocks/block-library/universal-header/index.php
+++ b/apps/happy-blocks/block-library/universal-header/index.php
@@ -16,7 +16,7 @@ $happy_blocks_current_tab = $args['active_tab'];
 $happy_blocks_tabs = array(
 	'learn'   => array(
 		'title' => __( 'Learn', 'happy-blocks' ),
-		'url'   => localized_wpcom_url( 'https://wordpress.com/learn' ),
+		'url'   => 'https://wordpress.com/learn',
 	),
 	'support' => array(
 		'title' => __( 'Support', 'happy-blocks' ),


### PR DESCRIPTION
This de-localizes learn URL in the new Global Header. 

#### Testing
1. cd into `apps/happy-blocks`.
2. run `yarn dev --sync`.
3. sandbox wordpress.com and es.support.wordpress.com.
4. Visit https://wordpress.com/es/support/.
5. Click on "Learn", you should land in English Learn.