### PR TITLE
Make Jest teardown safer for e2e tests

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -143,49 +143,68 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 	 * The browser is then shut down at the end regardless of failure status.
 	 */
 	async teardown(): Promise< void > {
-		if ( ! this.global.browser ) {
-			throw new Error( 'Browser instance unavailable' );
-		}
-		const contexts = this.global.browser.contexts();
-		if ( this.failure ) {
-			let contextIndex = 1;
+		try {
+			if ( ! this.global.browser ) {
+				throw new Error( 'Browser instance unavailable' );
+			}
+			const contexts = this.global.browser.contexts();
+			if ( this.failure ) {
+				let contextIndex = 1;
 
-			const artifactFilename = `${ this.testFilename }__${ sanitizeString( this.failure.name ) }`;
+				const artifactFilename = `${ this.testFilename }__${ sanitizeString( this.failure.name ) }`;
 
-			for await ( const context of contexts ) {
-				let pageIndex = 1;
-				const traceFilePath = path.join(
-					this.testArtifactsPath,
-					`${ artifactFilename }__${ contextIndex }.zip`
-				);
-
-				// Traces are saved per context.
-				await context.tracing.stop( { path: traceFilePath } );
-
-				for await ( const page of context.pages() ) {
-					// Define artifact filename.
-					const mediaFilePath = path.join(
+				for await ( const context of contexts ) {
+					let pageIndex = 1;
+					const traceFilePath = path.join(
 						this.testArtifactsPath,
-						`${ artifactFilename }__${ contextIndex }-${ pageIndex }`
+						`${ artifactFilename }__${ contextIndex }.zip`
 					);
 
-					// Screenshots and video are saved per page, where numerous
-					// pages may exist within a context.
-					await page.screenshot( { path: `${ mediaFilePath }.png`, timeout: env.TIMEOUT } );
+					// Traces are saved per context.
+					await context.tracing.stop( { path: traceFilePath } );
 
-					// Close the now unnecessary page which also triggers saving
-					// of video to the disk.
-					await page.close();
-					await page.video()?.saveAs( `${ mediaFilePath }.webm` );
-					pageIndex++;
+					for await ( const page of context.pages() ) {
+						const pageName = `${ artifactFilename }__${ contextIndex }-${ pageIndex }`;
+						// Define artifact filename.
+						const mediaFilePath = path.join( this.testArtifactsPath, pageName );
+
+						// Screenshots and video are saved per page, where numerous
+						// pages may exist within a context.
+						try {
+							await page.screenshot( { path: `${ mediaFilePath }.png`, timeout: env.TIMEOUT } );
+						} catch ( error ) {
+							console.error(
+								`Error while capturing page (${ pageName }) screenshot. ` +
+									'This may mean the page already crashed during test execution. Error: ',
+								error
+							);
+						}
+
+						try {
+							// Close the now unnecessary page which also triggers saving
+							// of video to the disk.
+							await page.close();
+							await page.video()?.saveAs( `${ mediaFilePath }.webm` );
+						} catch ( error ) {
+							console.error(
+								`Error while closing page (${ pageName }) and saving video. ` +
+									'This may mean the page already crashed during test execution. Error: ',
+								error
+							);
+						}
+
+						pageIndex++;
+					}
+					contextIndex++;
 				}
-				contextIndex++;
+				// Print paths to captured artifacts for faster triaging.
+				console.error( `Artifacts for ${ this.testFilename }: ${ this.testArtifactsPath }` );
 			}
-			// Print paths to captured artifacts for faster triaging.
-			console.error( `Artifacts for ${ this.testFilename }: ${ this.testArtifactsPath }` );
+			// Regardless of pass/fail status, close the browser instance.
+			await this.global.browser.close();
+		} catch ( error ) {
+			console.error( 'Unexepected error during Jest teardown: ', error );
 		}
-		// Regardless of pass/fail status, close the browser instance.
-		await this.global.browser.close();
 
 		await super.teardown();
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This is a follow-up to our ongoing investigation of #70674

We often get tests that fail with `Jest failed to execute suite`, and logs like this:
```
page.screenshot: Target crashed
      =========================== logs ===========================
      taking page screenshot
      ============================================================
 page.screenshot: Target crashed
      =========================== logs ===========================
      taking page screenshot
      ============================================================
          at JestEnvironmentPlaywright.teardown (/home/teamcity-2/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/jest-playwright-config/environment.ts:165:22)
          at runTestInternal (/home/teamcity-2/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-runner/build/runTest.js:461:5)
          at runTest (/home/teamcity-2/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-runner/build/runTest.js:475:34)
          at Object.worker (/home/teamcity-2/buildAgent/work/c4a9d5b38c1dacde/node_modules/jest-runner/build/testWorker.js:133:12)
```
In most cases, the real problem is some kind of crash that occurs during the test execution (often on navigation). This leaves the page in a broken state, so it throws an error when we try to screenshot. Because this is in a jest circus even handler, this breaks the whole Jest suite execution and masks the true error.

This makes our Jest teardown code now safer. We do this in two ways...
1. We add specific try/catch blocks to the most likely places to throw, which is when interacting with individual pages
2. We add a high level try/catch to the whole function. Again, we really shouldn't be letting errors bubble up here, because they will mask the underlying test failures!


## Testing Instructions

E2E tests should continue to pass or bubble up artifacts as before!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
