### PR TITLE
Revert "Launchpad :: add newsletter steps (stripe/paid subscriptions)…

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -43,12 +43,6 @@ export function getEnhancedTasks(
 
 	const videoPressUploadCompleted = checklistStatuses?.video_uploaded || false;
 
-	const stripeAccountConnected =
-		site?.options?.launchpad_checklist_tasks_statuses?.stripe_connected || false;
-
-	const newsletterPlanCreated =
-		site?.options?.launchpad_checklist_tasks_statuses?.newsletter_plan_created || false;
-
 	const allowUpdateDesign =
 		flow && ( isFreeFlow( flow ) || isBuildFlow( flow ) || isWriteFlow( flow ) );
 
@@ -356,31 +350,6 @@ export function getEnhancedTasks(
 					taskData = {
 						completed: isEmailVerified,
 						title: translate( 'Confirm Email (Check Your Inbox)' ),
-					};
-					break;
-				case 'stripe_account_connected':
-					taskData = {
-						title: translate( 'Connect Stripe Account' ),
-						completed: stripeAccountConnected,
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.assign( `/earn/payments/${ siteSlug }#launchpad` );
-						},
-					};
-					break;
-				case 'newsletter_plan_created':
-					taskData = {
-						title: translate( 'Create a Paid Newsletter' ),
-						completed: newsletterPlanCreated,
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							if ( newsletterPlanCreated ) {
-								return;
-							}
-							window.location.assign(
-								`/earn/payments-plans/${ siteSlug }?launchpad=add-product#add-newsletter-payment-plan`
-							);
-						},
 					};
 					break;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -99,16 +99,6 @@ export const tasks: Task[] = [
 		completed: false,
 		disabled: true,
 	},
-	{
-		id: 'stripe_account_connected',
-		completed: false,
-		disabled: false,
-	},
-	{
-		id: 'newsletter_plan_created',
-		completed: false,
-		disabled: false,
-	},
 ];
 
 const linkInBioTaskList = [
@@ -125,9 +115,8 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 		'plan_selected',
 		'subscribers_added',
 		'verify_email',
-		'stripe_account_connected',
-		'newsletter_plan_created',
 		'first_post_published_newsletter',
+		'first_post_published',
 	],
 	[ LINK_IN_BIO_FLOW ]: linkInBioTaskList,
 	[ LINK_IN_BIO_TLD_FLOW ]: linkInBioTaskList,

--- a/client/my-sites/earn/memberships/constants.js
+++ b/client/my-sites/earn/memberships/constants.js
@@ -1,3 +1,2 @@
 export const ADD_NEW_PAYMENT_PLAN_HASH = '#add-new-payment-plan';
 export const ADD_NEWSLETTER_PAYMENT_PLAN_HASH = '#add-newsletter-payment-plan';
-export const LAUNCHPAD_HASH = '#launchpad';

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -53,7 +53,7 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-import { ADD_NEWSLETTER_PAYMENT_PLAN_HASH, LAUNCHPAD_HASH } from './constants';
+import { ADD_NEWSLETTER_PAYMENT_PLAN_HASH } from './constants';
 
 import './style.scss';
 
@@ -67,24 +67,14 @@ class MembershipsSection extends Component {
 		disconnectedConnectedAccountId: null,
 	};
 	componentDidMount() {
-		this.navigateToLaunchpad();
 		this.fetchNextSubscriberPage( false, true );
 	}
 	componentDidUpdate( prevProps ) {
-		this.navigateToLaunchpad();
 		if ( prevProps.siteId !== this.props.siteId ) {
 			// Site Id changed
 			this.fetchNextSubscriberPage( false, true );
 		}
 	}
-
-	navigateToLaunchpad() {
-		const shouldGoToLaunchpad = this.props?.query?.stripe_connect_success === 'launchpad';
-		if ( shouldGoToLaunchpad ) {
-			window.location.assign( `/setup/newsletter/launchpad?siteSlug=${ this.props.siteSlug }` );
-		}
-	}
-
 	renderEarnings() {
 		const { commission, currency, forecast, lastMonth, siteId, total, translate } = this.props;
 		return (
@@ -715,25 +705,10 @@ class MembershipsSection extends Component {
 	}
 }
 
-/**
- * Source is used to add data to the Stripe Connect URL. On a successful
- * connection, this source is used to redirect the user the appropriate place.
- */
-const getSource = () => {
-	if ( window.location.hash === ADD_NEWSLETTER_PAYMENT_PLAN_HASH ) {
-		return 'earn-newsletter';
-	}
-	if ( window.location.hash === LAUNCHPAD_HASH ) {
-		return 'launchpad';
-	}
-	return 'calypso';
-};
-
 const mapStateToProps = ( state ) => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
 	const earnings = getEarningsWithDefaultsForSiteId( state, siteId );
-	const source = getSource();
 
 	return {
 		site,
@@ -754,7 +729,8 @@ const mapStateToProps = ( state ) => {
 			siteHasFeature( state, siteId, FEATURE_DONATIONS ) ||
 			siteHasFeature( state, siteId, FEATURE_RECURRING_PAYMENTS ),
 		isJetpack: isJetpackSite( state, siteId ),
-		source,
+		source:
+			window.location.hash === ADD_NEWSLETTER_PAYMENT_PLAN_HASH ? 'earn-newsletter' : 'calypso',
 	};
 };
 

--- a/client/state/memberships/product-list/actions.js
+++ b/client/state/memberships/product-list/actions.js
@@ -55,16 +55,6 @@ export const requestAddProduct = ( siteId, product, noticeText ) => {
 				if ( newProduct.error ) {
 					throw new Error( newProduct.error );
 				}
-				// This is an override for the launchpad flow. If the user is in
-				// the launchpad flow, we want to redirect them to the launchpad
-				// flow after creating a product.  The launchpad flow adds the
-				// `launchpad` param to the URL only when the task has not been completed.
-				const url = new URL( window.location.href );
-				if ( url.searchParams.has( 'launchpad' ) ) {
-					const siteSlug = url.pathname.split( '/' ).pop();
-					window.location.assign( `/setup/newsletter/launchpad?siteSlug=${ siteSlug }` );
-				}
-
 				const membershipProduct = membershipProductFromApi( newProduct.product );
 				dispatch( receiveUpdateProduct( siteId, membershipProduct ) );
 				dispatch(

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -461,8 +461,6 @@ export interface GlobalStyles {
 }
 
 export interface LaunchPadCheckListTasksStatuses {
-	newsletter_plan_created: boolean;
-	stripe_connected?: boolean;
 	first_post_published?: boolean;
 	links_edited?: boolean;
 	site_launched?: boolean;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Relates to https://github.com/Automattic/wp-calypso/pull/73787. 

## Proposed Changes

This reverts commit 1bcff5897a2fbc7abeef53210bbb22f93338d120.


## Testing Instructions
1. Checkout this branch
2. Sandbox `public-api.wordpress.com` & store: PCYsg-IA-p2.
3. Start a new newsletter site from - http://calypso.localhost:3000/setup/newsletter/intro
4. Checkout
5. Verify that the launchpad steps do not include connecting a stripe account and creating a paid plan.
6. Following those steps should mark off the corresponding options to verify the flow works as expected

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?