### PR TITLE
ExPlat: stop logging `dangerouslyGetExperimentAssignment-error`

### DIFF
--- a/packages/explat-client/src/create-explat-client.ts
+++ b/packages/explat-client/src/create-explat-client.ts
@@ -206,11 +206,13 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 
 				return storedExperimentAssignment;
 			} catch ( error ) {
-				safeLogError( {
-					message: ( error as Error ).message,
-					experimentName,
-					source: 'dangerouslyGetExperimentAssignment-error',
-				} );
+				if ( config.isDevelopmentMode ) {
+					safeLogError( {
+						message: ( error as Error ).message,
+						experimentName,
+						source: 'dangerouslyGetExperimentAssignment-error',
+					} );
+				}
 				return createFallbackExperimentAssignment( experimentName );
 			}
 		},

--- a/packages/explat-client/src/test/create-explat-client.ts
+++ b/packages/explat-client/src/test/create-explat-client.ts
@@ -476,7 +476,7 @@ describe( 'ExPlatClient.loadExperimentAssignment multiple-use', () => {
 
 describe( 'ExPlatClient.dangerouslyGetExperimentAssignment', () => {
 	it( 'should log and return fallback when given an invalid name', () => {
-		const mockedConfig = createMockedConfig();
+		const mockedConfig = createMockedConfig( { isDevelopmentMode: true } );
 		const client = createExPlatClient( mockedConfig );
 		const firstNow = Date.now();
 		spiedMonotonicNow.mockImplementationOnce( () => firstNow );
@@ -501,7 +501,7 @@ describe( 'ExPlatClient.dangerouslyGetExperimentAssignment', () => {
 	} );
 
 	it( `should log and return fallback when the matching experiment hasn't loaded yet`, () => {
-		const mockedConfig = createMockedConfig();
+		const mockedConfig = createMockedConfig( { isDevelopmentMode: true } );
 		const client = createExPlatClient( mockedConfig );
 		const firstNow = Date.now();
 		spiedMonotonicNow.mockImplementationOnce( () => firstNow );
@@ -527,7 +527,7 @@ describe( 'ExPlatClient.dangerouslyGetExperimentAssignment', () => {
 
 	it( `should log and return fallback when the matching experiment hasn't loaded yet but is currently loading`, async () => {
 		jest.useFakeTimers();
-		const mockedConfig = createMockedConfig();
+		const mockedConfig = createMockedConfig( { isDevelopmentMode: true } );
 		const client = createExPlatClient( mockedConfig );
 		const firstNow = Date.now();
 		spiedMonotonicNow.mockImplementationOnce( () => firstNow );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/75063#pullrequestreview-1376581806

## Proposed Changes

* By design, in https://github.com/Automattic/wp-calypso/pull/75063 we're expecting `dangerouslyGetExperimentAssignment` function calls to fail when a user lands on checkout without being assigned first to the 21115-explat-experiment.
* This change will temporarily mute this error in production as we are purposefully ignoring it at the moment. See the discussion in p1680892941597569-slack-C02DQP0FP

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Error `Trying to dangerously get an ExperimentAssignment that hasn't loaded` shouldn't be logged anymore in production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?