### PR TITLE
Update links to point to new /built-by landing page

### DIFF
--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -12,17 +12,17 @@ class UpworkBanner extends PureComponent {
 	static propTypes = {
 		currentPlan: PropTypes.object,
 		location: PropTypes.string.isRequired,
-		utmCampaign: PropTypes.string.isRequired,
+		refURLParam: PropTypes.string.isRequired,
 		siteId: PropTypes.number,
 		translate: PropTypes.func.isRequired,
 	};
 
 	render() {
-		const { translate, location, utmCampaign, currentPlan } = this.props;
+		const { translate, location, refURLParam, currentPlan } = this.props;
 		const plan = currentPlan?.productSlug;
 		const builtByWpUrl = new URL( 'https://wordpress.com/built-by/' );
 		builtByWpUrl.search = new URLSearchParams( {
-			utm_campaign: utmCampaign,
+			ref: refURLParam,
 		} );
 
 		return (

--- a/client/blocks/upwork-banner/index.jsx
+++ b/client/blocks/upwork-banner/index.jsx
@@ -20,11 +20,9 @@ class UpworkBanner extends PureComponent {
 	render() {
 		const { translate, location, utmCampaign, currentPlan } = this.props;
 		const plan = currentPlan?.productSlug;
-		const builtByWpUrl = new URL( 'https://builtbywp.com/' );
+		const builtByWpUrl = new URL( 'https://wordpress.com/built-by/' );
 		builtByWpUrl.search = new URLSearchParams( {
 			utm_campaign: utmCampaign,
-			utm_medium: 'automattic_referred',
-			utm_source: 'WordPresscom',
 		} );
 
 		return (

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -114,8 +114,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 	const numberOfPluginsThemes = numberFormat( 50000, 0 );
 	const discountRate = '25%';
 	const couponCode = 'BIZWPC25';
-	const builtByURL =
-		'https://builtbywp.com/get-started/?utm_medium=automattic_referred&utm_source=WordPresscom&utm_campaign=cancel-flow';
+	const builtByURL = 'https://wordpress.com/built-by/?ref=wpcom-cancel-flow';
 	const { refundAmount } = props;
 
 	switch ( upsell ) {

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -271,9 +271,9 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 				site_plan: sitePlan,
 				search_term: searchTerm,
 			} );
-			window.location.replace( 'https://wordpress.com/do-it-for-me/' );
+			window.location.replace( 'https://wordpress.com/built-by/?ref=no-themes' );
 		},
-		url: 'https://wordpress.com/do-it-for-me/',
+		url: 'https://wordpress.com/built-by/?ref=no-themes',
 		buttonText: translate( 'Hire an expert' ),
 	} );
 

--- a/client/my-sites/customer-home/cards/tasks/use-built-by/index.js
+++ b/client/my-sites/customer-home/cards/tasks/use-built-by/index.js
@@ -8,7 +8,7 @@ const UseBuiltBy = () => {
 			title="Get expert help for your website"
 			description="Whether you want to create an online store, redesign your website, migrate your site or simply showcase your work — we are happy to help."
 			actionText="Get Started"
-			actionUrl="https://builtbywp.com/?utm_medium=automattic_referred&utm_source=WordPresscom&utm_campaign=bb-card-home"
+			actionUrl="https://wordpress.com/built-by/?ref=my-home-card"
 			illustration={ announcementImage }
 			taskId={ TASK_USE_BUILT_BY }
 		/>

--- a/client/my-sites/marketing/index.js
+++ b/client/my-sites/marketing/index.js
@@ -16,7 +16,7 @@ import {
 
 export default function () {
 	page( '/marketing/do-it-for-me*', function redirectToDIFMLandingPage() {
-		window.location.replace( 'https://wordpress.com/do-it-for-me/' );
+		window.location.replace( 'https://wordpress.com/built-by/' );
 	} );
 
 	page( '/marketing/ultimate-traffic-guide*', function redirectToWPCoursesPage() {

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -106,7 +106,7 @@ export const MarketingTools: FunctionComponent = () => {
 				>
 					<Button
 						onClick={ handleBuiltByWpClick }
-						href="https://builtbywp.com/?utm_medium=automattic_referred&utm_source=WordPresscom&utm_campaign=tools"
+						href="https://wordpress.com/built-by/?ref=tools-banner"
 						target="_blank"
 					>
 						{ translate( 'Get started' ) }

--- a/client/my-sites/plans-features-main/plansStepFaq.jsx
+++ b/client/my-sites/plans-features-main/plansStepFaq.jsx
@@ -188,7 +188,7 @@ const PlanFAQ = ( { titanMonthlyRenewalCost } ) => {
 							ExternalLinkWithTracking: (
 								<ExternalLinkWithTracking
 									icon={ true }
-									href="https://wordpress.com/do-it-for-me/"
+									href="https://wordpress.com/built-by/"
 									tracksEventName="calypso_signup_step_plans_faq_difm_lp"
 								/>
 							),

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -383,16 +383,16 @@ class ThemeShowcase extends Component {
 			// these are from the time we rely on the redirect.
 			// See p2-pau2Xa-4nq#comment-12480
 			let location = 'theme-banner';
-			let utmCampaign = 'built-by-wordpress-com-redirect';
+			let refURLParam = 'built-by-wordpress-com-redirect';
 
 			// See p2-pau2Xa-4nq#comment-12458 for the context regarding the utm campaign value.
 			switch ( tabKey ) {
 				case staticFilters.ALL.key:
 					location = 'all-theme-banner';
-					utmCampaign = 'theme-all';
+					refURLParam = 'themes';
 			}
 
-			return <UpworkBanner location={ location } utmCampaign={ utmCampaign } />;
+			return <UpworkBanner location={ location } refURLParam={ refURLParam } />;
 		}
 
 		return upsellBanner;

--- a/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
@@ -131,7 +131,7 @@ export const PureUniversalNavbarFooter = ( {
 								</li>
 								<li>
 									<a
-										href={ localizeUrl( 'https://wordpress.com/do-it-for-me/?ref=footer_pricing' ) }
+										href={ localizeUrl( 'https://wordpress.com/built-by/?ref=footer_pricing' ) }
 										title="WordPress Website Building Service"
 										target="_self"
 									>


### PR DESCRIPTION
## Proposed Changes

Update "Built By" links throughout Calypso to point to the new landing page.

P2: pau2Xa-4rO-p2

## Testing Instructions

* Marketing card in Calypso
	* Visit `http://calypso.localhost:3000/marketing/tools/[SITE]`
	* ![Aw3mCj.png](https://user-images.githubusercontent.com/690843/230681835-8395f38f-d0f3-4686-a3fd-9475b2eaed75.png)
	* Should go to https://wordpress.com/built-by/?ref=tools-banner
* Cancelation flow
	* Start plan cancellation, for the feedback select:
		* “Why would you like to cancel?” = **Couldn’t finish my site**
		* “Why is that?” = **Need professional help to build my site.**
	* Click “Get help building my site”
	* ![A77aki.png](https://user-images.githubusercontent.com/690843/230681837-71886a75-2a89-4186-b7c6-be470e3b0e0f.png)
	* Should go to https://wordpress.com/built-by/?ref=wpcom-cancel-flow
* My Home card
	* With a user with less than 8 total sites, choose a site and has been launched (public).
	* Visit `http://calypso.localhost:3000/home/[SITE]`
	* Scroll through the cards until you find the “Built By” card
	* ![XDYeAp.png](https://user-images.githubusercontent.com/690843/230681836-3da85d97-f229-440e-9542-e6f7a1aa96f6.png)
	* Click “Get Started
	* Should go to https://wordpress.com/built-by/?ref=my-home-card
* CTA on Themes page
	* Visit  `http://calypso.localhost:3000/themes/[SITE]`
	* Click the “Find your expert” button in the banner.
	* <img width="1424" alt="Screenshot 2023-04-07 at 2 41 20 PM" src="https://user-images.githubusercontent.com/690843/230682663-e26f3e70-2c91-483f-b978-d58408c5d18c.png">
	* Should go to https://wordpress.com/built-by/?ref=themes
* CTA on Themes page (No themes found)
	* Same page, but do a search that won’t return any results
	* Click the “Hire an expert” button
	* <img width="1424" alt="Screenshot 2023-04-07 at 2 09 46 PM" src="https://user-images.githubusercontent.com/690843/230682719-1bba3492-a52a-4c23-a493-a2af52d521d0.png">
	* Should go to https://wordpress.com/built-by/?ref=no-themes
* Try to visit `/marketing/do-it-for-me`
	* It should redirect you to https://wordpress.com/built-by/

I also made the change to two other locations, but I’m not sure how to test those or if they're still in use anywhere.
These are the changes in `plansStepFaq.jsx` and `universal-footer-navigation/index.tsx`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?