### PR TITLE
Hide missing domain connect support link until

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-support-info-link.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-support-info-link.jsx
@@ -20,6 +20,10 @@ export default function ConnectDomainStepSupportInfoLink( { baseClassName, mode 
 		[ modeType.DONE ]: MAP_DOMAIN_CHANGE_NAME_SERVERS,
 	};
 
+	if ( ! supportLink[ mode ] ) {
+		return null;
+	}
+
 	const classes = classNames(
 		baseClassName + '__support-documentation',
 		baseClassName + '__info-links'


### PR DESCRIPTION
We have not yet created the support page for the new Domain Connect mode.  This PR just prevents showing an empty link until we get the page created.

## Testing Instructions

- Connect a domain that supports Domain Connect.
- Visit the connection setup page at: `/domains/mapping/[site name]/setup/[domain name]?firstVisit=true`
- Make sure that the support link is not shown at the bottom of the page.
<img width="713" alt="Connect_a_Domain_Setup_‹_A8C_Test_Site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/230722961-f1404773-5c07-4e60-8df3-d6d371ff9781.png">
- Make sure that the support link _is_ shown at the bottom of the pages for manual or advanced setup.
<img width="729" alt="Connect_a_Domain_Setup_‹_A8C_Test_Site_—_WordPress_com" src="https://user-images.githubusercontent.com/1379730/230722939-2539ad07-c80c-4b25-9b2d-0b76e143672c.png">
