### PR TITLE
i18n: Support links in the cancellation flow aren't localized

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/educational-content-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/educational-content-step.tsx
@@ -1,3 +1,4 @@
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -72,6 +73,7 @@ type StepProps = {
 export default function EducationalCotnentStep( { type, site, ...props }: StepProps ) {
 	const translate = useTranslate();
 	const happyChat = useHappyChat();
+	const localizeUrl = useLocalizeUrl();
 
 	switch ( type ) {
 		case 'education:loading-time':
@@ -126,7 +128,12 @@ export default function EducationalCotnentStep( { type, site, ...props }: StepPr
 									'Read more about how to improve your site’s speed and performance {{link}}here{{/link}}.',
 									{
 										components: {
-											link: <Button href="https://wordpress.com/support/site-speed/" isLink />,
+											link: (
+												<Button
+													href={ localizeUrl( 'https://wordpress.com/support/site-speed/' ) }
+													isLink
+												/>
+											),
 										},
 									}
 								) }
@@ -180,7 +187,12 @@ export default function EducationalCotnentStep( { type, site, ...props }: StepPr
 							{ translate( 'Read more about domains {{link}}here{{/link}}.', {
 								components: {
 									link: (
-										<Button href="https://wordpress.com/support/domains/register-domain/" isLink />
+										<Button
+											href={ localizeUrl(
+												'https://wordpress.com/support/domains/register-domain/'
+											) }
+											isLink
+										/>
 									),
 								},
 							} ) }
@@ -202,7 +214,9 @@ export default function EducationalCotnentStep( { type, site, ...props }: StepPr
 								components: {
 									link: (
 										<Button
-											href="https://wordpress.com/support/domains/connect-existing-domain/#steps-to-connect-a-domain"
+											href={ localizeUrl(
+												'https://wordpress.com/support/domains/connect-existing-domain/#steps-to-connect-a-domain'
+											) }
 											isLink
 										/>
 									),
@@ -228,7 +242,9 @@ export default function EducationalCotnentStep( { type, site, ...props }: StepPr
 									components: {
 										link: (
 											<Button
-												href="https://wordpress.com/support/domains/connect-existing-domain/"
+												href={ localizeUrl(
+													'https://wordpress.com/support/domains/connect-existing-domain/'
+												) }
 												isLink
 											/>
 										),
@@ -315,10 +331,17 @@ export default function EducationalCotnentStep( { type, site, ...props }: StepPr
 									'Find other tips to optimize your site for search engines {{link}}here{{/link}}. If you’re looking for a full introduction to Search Engine Optimization, you can join our {{seo}}free SEO course{{/seo}}.',
 									{
 										components: {
-											link: <Button href="https://wordpress.com/support/seo/" isLink />,
+											link: (
+												<Button
+													href={ localizeUrl( 'https://wordpress.com/support/seo/' ) }
+													isLink
+												/>
+											),
 											seo: (
 												<Button
-													href="https://wpcourses.com/course/intro-to-search-engine-optimization-seo/"
+													href={ localizeUrl(
+														'https://wpcourses.com/course/intro-to-search-engine-optimization-seo/'
+													) }
 													isLink
 												/>
 											),

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/educational-content-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/educational-content-step.tsx
@@ -339,9 +339,7 @@ export default function EducationalCotnentStep( { type, site, ...props }: StepPr
 											),
 											seo: (
 												<Button
-													href={ localizeUrl(
-														'https://wpcourses.com/course/intro-to-search-engine-optimization-seo/'
-													) }
+													href="https://wpcourses.com/course/intro-to-search-engine-optimization-seo/"
 													isLink
 												/>
 											),


### PR DESCRIPTION
When cancelling and refunding a plan, there are a few educational cards that are shown in the cancellation survey. There are links that point to the support site that aren't localized.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Relates to https://github.com/Automattic/i18n-issues/issues/576

## Proposed Changes

* Update all raw URL references in `educational-content-step.tsx` to use `localizeUrl()`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that your user language settings are non-English.
* Create a website using the instructions of pavWQK-1AQ-p2
* Upgrade the plan (e.g. from Premium to Business, or from Business to eCommerce) 
* Proceed to cancel the upgrade using the cancelation instructions on pavWQK-1AQ-p2.
* When completing the survey, choose reasons that relate to `Loading times`, `Connecting a domain`, or `SEO`.
* Verify that the links are localized.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?