### PR TITLE
Fix the redirect to primary slug if there is a hashstring

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -583,7 +583,8 @@ export function siteSelection( context, next ) {
 					const unmappedSlug = withoutHttp( getSiteOption( getState(), site.ID, 'unmapped_url' ) );
 
 					if ( unmappedSlug !== siteSlug && unmappedSlug === siteFragment ) {
-						return page.redirect( context.path.replace( siteFragment, siteSlug ) );
+						const hash = context.hashstring ? `#${ context.hashstring }` : '';
+						return page.redirect( context.path.replace( siteFragment, siteSlug ) + hash );
 					}
 				}
 


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/Automattic/wp-calypso/pull/62964

- If calypso is using a hashstring for navigation
- And the URL to calypso is not using a primary domain
- 
Then the hash string is lost in the redirect.

## Proposed Changes

* Preserve hash string upon redirect

## Testing Instructions
* Pick a **wordpress.com simple** site with a primary domain
* Find a URL to any section, and use the *.wordpress.com site slug
* Add some hash to the query string, like https://calypso.localhost:3000/posts/site-with-custom-domain.wordpress.com#test
* Load the URL 
* Observe the URL changing to https://calypso.localhost:3000/posts/custom-domain.com#test - previously it would lose the `#test`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
