### PR TITLE
Site Assembler - Focus first pattern in a category (fix for scroll)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -41,10 +41,10 @@ const PatternListItem = ( {
 	} );
 
 	useEffect( () => {
-		if ( isShown && inViewOnce && isFirst && ref.current ) {
+		if ( isShown && isFirst && ref.current ) {
 			ref.current.focus();
 		}
-	}, [ isShown, isFirst, ref, inViewOnce ] );
+	}, [ isShown, isFirst, ref ] );
 
 	return (
 		<Button


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75365
Closes #75423

## Proposed Changes

* Focus on the first pattern in a category when the patterns panel opens

While #75365 addressed the same issue, it didn't work when the patterns list is scrolled. The version in this PR always focuses on the first pattern in the list when exploring patterns in categories because it resets the previous scroll position.

https://user-images.githubusercontent.com/1881481/230820302-471c7e83-21bf-4afe-b9cf-6c22582bdb7a.mov


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Click on the Calypso Live link in the first comment.
- Create a new site and `Continue` until landing on the Design Picker.
- Go to the site assembler by clicking `Start designing` from the bottom.
- Click `Sections`, then `Add patterns` and click on `Posts` category and scroll to the bottom of the list, then click `Call to action` and verify that the first pattern is focused.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
