### PR TITLE
AT E2E: fix the `Likes: Comments` spec to wait for the comment to be fully present on the page prior to interaction.

### DIFF
--- a/test/e2e/specs/published-content/likes__comment.ts
+++ b/test/e2e/specs/published-content/likes__comment.ts
@@ -12,6 +12,7 @@ import {
 	RestAPIClient,
 	NewCommentResponse,
 	PostResponse,
+	ElementHelper,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
@@ -76,7 +77,11 @@ describe( 'Likes: Comment', function () {
 				newComment.ID
 			);
 
-			await page.reload( { waitUntil: 'networkidle' } );
+			async function closure( page: Page ) {
+				await page.getByText( 'Loading...' ).last().waitFor( { state: 'hidden' } );
+			}
+			// await page.reload( { waitUntil: 'networkidle' } );
+			await ElementHelper.reloadAndRetry( page, closure );
 		} );
 
 		it( 'Like the comment', async function () {
@@ -96,7 +101,11 @@ describe( 'Likes: Comment', function () {
 				newComment.ID
 			);
 
-			await page.reload( { waitUntil: 'networkidle' } );
+			async function closure( page: Page ) {
+				await page.getByText( 'Loading...' ).last().waitFor( { state: 'hidden' } );
+			}
+			// await page.reload( { waitUntil: 'networkidle' } );
+			await ElementHelper.reloadAndRetry( page, closure );
 		} );
 
 		it( 'Unlike the comment', async function () {

--- a/test/e2e/specs/published-content/likes__comment.ts
+++ b/test/e2e/specs/published-content/likes__comment.ts
@@ -80,7 +80,6 @@ describe( 'Likes: Comment', function () {
 			async function closure( page: Page ) {
 				await page.getByText( 'Loading...' ).last().waitFor( { state: 'hidden' } );
 			}
-			// await page.reload( { waitUntil: 'networkidle' } );
 			await ElementHelper.reloadAndRetry( page, closure );
 		} );
 
@@ -104,7 +103,6 @@ describe( 'Likes: Comment', function () {
 			async function closure( page: Page ) {
 				await page.getByText( 'Loading...' ).last().waitFor( { state: 'hidden' } );
 			}
-			// await page.reload( { waitUntil: 'networkidle' } );
 			await ElementHelper.reloadAndRetry( page, closure );
 		} );
 

--- a/test/e2e/specs/published-content/likes__comment.ts
+++ b/test/e2e/specs/published-content/likes__comment.ts
@@ -76,7 +76,7 @@ describe( 'Likes: Comment', function () {
 				newComment.ID
 			);
 
-			await page.reload();
+			await page.reload( { waitUntil: 'networkidle' } );
 		} );
 
 		it( 'Like the comment', async function () {
@@ -96,7 +96,7 @@ describe( 'Likes: Comment', function () {
 				newComment.ID
 			);
 
-			await page.reload();
+			await page.reload( { waitUntil: 'networkidle' } );
 		} );
 
 		it( 'Unlike the comment', async function () {


### PR DESCRIPTION
Related to #

## Proposed Changes

This PR adds some guards to the `Likes: Comments` spec to prevent a race condition.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E (desktop)
  - [x] Gutenberg E2E (mobile)
  - [x] Gutenberg E2E AT (desktop)
  - [x] Gutenberg E2E AT (mobile)

Gutenberg Simple desktop
![image](https://user-images.githubusercontent.com/6549265/230831245-1d525e0d-94e4-4bec-9ed8-b08bf29b85ef.png)


Gutenberg Atomic desktop
![image](https://user-images.githubusercontent.com/6549265/230831259-e0f22336-e9b3-4aeb-8a36-98f485f627aa.png)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
