### PR TITLE
Goals Screen: update premium badge styling & BBE copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -41,7 +41,7 @@ const useBBEGoal = () => {
 	//
 	// ************************************************************************
 
-	return translate( 'Get a website quickly' );
+	return translate( 'Get a website built quickly' );
 };
 
 export const useGoals = (): Goal[] => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/select-goals.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import { Onboard } from '@automattic/data-stores';
+import { PremiumBadge } from '@automattic/design-picker';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useGoals } from './goals';
@@ -95,9 +96,7 @@ export const SelectGoals = ( { onChange, onSubmit, selectedGoals }: SelectGoalsP
 								value={ key }
 							>
 								<span className="select-goals__goal-title">{ title }</span>
-								{ isPremium && (
-									<span className="select-goals__premium-badge">{ translate( 'Premium' ) }</span>
-								) }
+								{ isPremium && <PremiumBadge shouldHideTooltip={ true } /> }
 							</SelectCard>
 					  ) ) }
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/style.scss
@@ -64,18 +64,7 @@
 		grid-template-columns: repeat(1, 1fr);
 
 		.select-goals__goal-title {
-			margin-right: 14px;
-		}
-
-		.select-goals__premium-badge {
-			display: inline-block;
-			background: #101517;
-			color: #fff;
-			border-radius: 4px;
-			font-weight: 500;
-			font-size: 0.75rem;
-			line-height: 20px;
-			padding: 0 10px;
+			margin-inline-end: 4px;
 		}
 
 		@include break-small {
@@ -119,6 +108,8 @@
 	.select-card__label {
 		pointer-events: none;
 		user-select: none;
+		display: flex;
+		align-items: center;
 	}
 
 	&.selected {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdh1Xd-21T-p2

## Proposed Changes

* Updates the premium badge on the goals screen so that it is consistent with the style used elsewhere.
* Updates the copy of the goals screen text to `Get a website built quickly`.

<img width="1554" alt="image" src="https://user-images.githubusercontent.com/5436027/230842331-6577f44b-d20f-43d7-82f4-5504a9c7ae59.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/site-setup/goals?siteSlug=<site slug>`.
* Confirm that the Premium badge styling matches the screenshot.
* Confirm that the copy for the BBE goal has been updated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?