### PR TITLE
Jetpack Pro Dashboard: add UI test cases to the newly added components for the expandable block

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/expanded-card.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/expanded-card.tsx
@@ -54,7 +54,7 @@ export default function ExpandedCard( {
 	};
 
 	return (
-		<Card { ...props }>
+		<Card data-testid="expanded-card" { ...props }>
 			{ isEnabled ? (
 				<>
 					<div className="expanded-card__header">{ header }</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/site-php-version.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/site-php-version.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 export default function SitePhpVersion( {
 	phpVersion,
 }: {
-	phpVersion: number;
+	phpVersion: number | null;
 } ): JSX.Element | null {
 	const translate = useTranslate();
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/backup-storage.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/backup-storage.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { urlToSlug } from 'calypso/lib/url';
+import { site } from '../../test/test-utils/constants';
+import BackupStorage from '../backup-storage';
+
+jest.mock( 'calypso/data/activity-log/use-rewindable-activity-log-query', () => {
+	return jest.fn().mockReturnValue( {
+		isLoading: false,
+		data: [
+			{
+				activityTs: new Date(),
+				activityName: 'backup',
+				activityDescription: [
+					{ children: [ { text: '5 plugins, 3 themes, 0 uploads, 1 post, 1 page' } ] },
+				],
+			},
+		],
+	} );
+} );
+
+describe( 'BackupStorage component', () => {
+	const initialState = {
+		sites: {
+			items: {
+				[ site.blog_id ]: {
+					blog_id: site.blog_id,
+					is_multisite: true,
+					jetpack: true,
+				},
+			},
+		},
+		siteSettings: { items: {} },
+	};
+
+	const mockTrackEvent = jest.fn();
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	it( 'renders empty content when backup is not supported on multisite', () => {
+		render( <BackupStorage site={ site } trackEvent={ mockTrackEvent } />, { wrapper: Wrapper } );
+		expect( screen.getByText( /backup not supported on multisite/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders empty content when backup is not enabled', () => {
+		initialState.sites.items[ site.blog_id ].is_multisite = false;
+		render( <BackupStorage site={ site } trackEvent={ mockTrackEvent } />, { wrapper: Wrapper } );
+		expect( screen.getByText( /see your backup/i ) ).toBeInTheDocument();
+		fireEvent.click( screen.getByRole( 'button', { name: /add backup/i } ) );
+		expect( mockTrackEvent ).toHaveBeenCalledWith( 'expandable_block_backup_add_click' );
+	} );
+
+	it( 'renders BackupStorageContent when backup is enabled', async () => {
+		site.has_backup = true;
+		render( <BackupStorage site={ site } trackEvent={ mockTrackEvent } />, { wrapper: Wrapper } );
+		expect( screen.getByText( /latest backup/i ) ).toBeInTheDocument();
+		expect( screen.getByText( /activity log/i ) ).toHaveAttribute(
+			'href',
+			`/activity-log/${ site.url }`
+		);
+		expect( screen.getByText( '1 post, 1 page' ) ).toBeInTheDocument();
+		const promise = Promise.resolve();
+		await act( () => promise );
+	} );
+
+	it( 'renders empty content when backup has error', async () => {
+		site.has_backup = true;
+		site.latest_backup_status = 'backup_only_error';
+		render( <BackupStorage site={ site } trackEvent={ mockTrackEvent } />, { wrapper: Wrapper } );
+		expect( screen.getByText( /see your backup storage/i ) ).toBeInTheDocument();
+		const button = screen.getByRole( 'button', { name: /fix backup/i } );
+		fireEvent.click( button );
+		const siteUrlWithMultiSiteSupport = urlToSlug( site.url );
+		expect( button ).toHaveAttribute( 'href', `/backup/${ siteUrlWithMultiSiteSupport }` );
+		expect( mockTrackEvent ).toHaveBeenCalledWith( 'expandable_block_backup_error_click' );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import BoostSitePerformance from '../boost-site-performance';
+
+describe( 'BoostSitePerformance', () => {
+	const boostData = {
+		overall: 80,
+		mobile: 75,
+		desktop: 85,
+	};
+	const siteId = 123;
+	const siteUrlWithScheme = 'https://example.com';
+	const trackEventMock = jest.fn();
+
+	test( 'renders the overall score and tooltip', () => {
+		const hasBoost = true;
+
+		render(
+			<BoostSitePerformance
+				boostData={ boostData }
+				hasBoost={ hasBoost }
+				siteId={ siteId }
+				siteUrlWithScheme={ siteUrlWithScheme }
+				trackEvent={ trackEventMock }
+			/>
+		);
+
+		const overallRating = screen.getByText( 'B' );
+		expect( overallRating ).toBeInTheDocument();
+
+		const mobileScore = screen.getByText( /75/i );
+		expect( mobileScore ).toBeInTheDocument();
+
+		const desktopScore = screen.getByText( /85/i );
+		expect( desktopScore ).toBeInTheDocument();
+	} );
+
+	test( 'renders the empty content when hasBoost is false', () => {
+		const hasBoost = false;
+		render(
+			<BoostSitePerformance
+				boostData={ boostData }
+				hasBoost={ hasBoost }
+				siteId={ siteId }
+				siteUrlWithScheme={ siteUrlWithScheme }
+				trackEvent={ trackEventMock }
+			/>
+		);
+
+		const emptyContent = screen.getByText( /see your site performance scores/i );
+		expect( emptyContent ).toBeInTheDocument();
+		const strongTag = screen.getByText( /Boost/i );
+		expect( strongTag ).toHaveStyle( 'font-weight: bold' );
+	} );
+
+	test( 'calls trackEvent when button is clicked and checks if the button has href', () => {
+		const hasBoost = true;
+
+		render(
+			<BoostSitePerformance
+				boostData={ boostData }
+				hasBoost={ hasBoost }
+				siteId={ siteId }
+				siteUrlWithScheme={ siteUrlWithScheme }
+				trackEvent={ trackEventMock }
+			/>
+		);
+
+		const button = screen.getByRole( 'link', { name: /optimize css/i } );
+		expect( button ).toBeInTheDocument();
+		expect( button ).toHaveAttribute(
+			'href',
+			`${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`
+		);
+
+		fireEvent.click( button );
+		expect( trackEventMock ).toHaveBeenCalledWith( 'expandable_block_optimize_css_click' );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/expanded-card.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/expanded-card.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import ExpandedCard from '../expanded-card';
+
+describe( 'ExpandedCard', () => {
+	const header = 'Test Header';
+	const children = <div>Test Children</div>;
+	const emptyContent = 'Test Empty Content';
+	const onClick = jest.fn();
+	const href = 'https://example.com';
+
+	test( 'should render header and children when enabled', () => {
+		render(
+			<ExpandedCard header={ header } isEnabled={ true }>
+				{ children }
+			</ExpandedCard>
+		);
+		expect( screen.getByText( header ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Test Children' ) ).toBeInTheDocument();
+	} );
+
+	test( 'should render empty content when not enabled', () => {
+		render( <ExpandedCard emptyContent={ emptyContent } isEnabled={ false } /> );
+		expect( screen.getByText( 'Test Empty Content' ) ).toBeInTheDocument();
+	} );
+
+	test( 'should not be clickable when onClick is not provided', () => {
+		render( <ExpandedCard /> );
+		expect( screen.getByTestId( 'expanded-card' ) ).not.toHaveAttribute( 'tabIndex' );
+		expect( screen.getByTestId( 'expanded-card' ) ).not.toHaveAttribute( 'onClick' );
+	} );
+
+	test( 'should be clickable when onClick is provided and not loading', () => {
+		render( <ExpandedCard onClick={ onClick } /> );
+		expect( screen.getByRole( 'button' ) ).toHaveAttribute( 'tabIndex', '0' );
+		fireEvent.click( screen.getByRole( 'button' ) );
+		expect( onClick ).toHaveBeenCalled();
+	} );
+
+	test( 'should not be clickable when isLoading is true', () => {
+		render( <ExpandedCard onClick={ onClick } isLoading={ true } /> );
+		expect( screen.getByTestId( 'expanded-card' ) ).not.toHaveAttribute( 'tabIndex' );
+		expect( screen.getByTestId( 'expanded-card' ) ).not.toHaveAttribute( 'onClick' );
+	} );
+
+	test( 'should have href when provided', () => {
+		render( <ExpandedCard href={ href } /> );
+		expect( screen.getByRole( 'link' ) ).toHaveAttribute( 'href', 'https://example.com' );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/insight-stats.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/insight-stats.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { site } from '../../test/test-utils/constants';
+import InsightsStats from '../insights-stats';
+
+describe( 'InsightsStats', () => {
+	const stats = site.site_stats;
+	const trackEventMock = jest.fn();
+
+	beforeEach( () => {
+		render(
+			<InsightsStats
+				stats={ stats }
+				siteUrlWithScheme={ site.url_with_scheme }
+				trackEvent={ trackEventMock }
+			/>
+		);
+	} );
+
+	test( 'renders the Visitors stats with the up trend', () => {
+		const visitorsTitle = screen.getByText( /Visitors/i );
+		const visitorsTotal = screen.getByText( /1k/i );
+		const visitorsTrend = screen.getByText( /50/i );
+
+		expect( visitorsTitle ).toBeInTheDocument();
+		expect( visitorsTotal ).toBeInTheDocument();
+		expect( visitorsTrend ).toBeInTheDocument();
+		expect( visitorsTrend.parentElement ).toHaveClass( 'is-up' );
+	} );
+
+	test( 'renders the Views stats with the down trend', () => {
+		const viewsTitle = screen.getByText( /Views/i );
+		const viewsTotal = screen.getByText( /5k/i );
+		const viewsTrend = screen.getByText( /100/i );
+
+		expect( viewsTitle ).toBeInTheDocument();
+		expect( viewsTotal ).toBeInTheDocument();
+		expect( viewsTrend ).toBeInTheDocument();
+		expect( viewsTrend.parentElement ).toHaveClass( 'is-down' );
+	} );
+
+	test( 'clicking on the See all stats button triggers the trackEvent callback', () => {
+		const seeAllStatsButton = screen.getByRole( 'link', { name: /See all stats/i } );
+
+		fireEvent.click( seeAllStatsButton );
+
+		expect( trackEventMock ).toHaveBeenCalledWith( 'expandable_block_see_all_stats_click' );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/monitor-activity.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/monitor-activity.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { site } from '../../test/test-utils/constants';
+import MonitorActivity from '../monitor-activity';
+
+jest.mock( 'calypso/data/agency-dashboard/use-fetch-monitor-data', () => {
+	return jest.fn().mockReturnValue( {
+		data: [
+			{
+				date: '2023-04-07',
+				status: 'up',
+			},
+		],
+	} );
+} );
+
+describe( 'MonitorActivity component', () => {
+	const initialState = {
+		sites: {
+			items: {
+				[ site.blog_id ]: {
+					blog_id: site.blog_id,
+				},
+			},
+		},
+	};
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+
+	const queryClient = new QueryClient();
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
+	const trackEvent = jest.fn();
+	const hasMonitor = true;
+
+	test( 'renders the header and content', async () => {
+		render( <MonitorActivity site={ site } trackEvent={ trackEvent } hasMonitor={ hasMonitor } />, {
+			wrapper: Wrapper,
+		} );
+		expect( screen.getByText( /monitor activity/i ) ).toBeInTheDocument();
+		expect( screen.getByText( /20d ago/i ) ).toBeInTheDocument();
+		expect( screen.getByText( /today/i ) ).toBeInTheDocument();
+		const promise = Promise.resolve();
+		await act( () => promise );
+	} );
+
+	test( 'calls the trackEvent function and toggleActivateMonitor when clicked', () => {
+		const hasMonitor = false;
+		render( <MonitorActivity site={ site } trackEvent={ trackEvent } hasMonitor={ hasMonitor } />, {
+			wrapper: Wrapper,
+		} );
+		const card = screen.getByRole( 'button', {
+			name: /activate monitor to see your uptime records/i,
+		} );
+		fireEvent.click( card );
+		expect( trackEvent ).toHaveBeenCalledWith( 'expandable_block_activate_monitor_click' );
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/site-php-version.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/site-php-version.test.tsx
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import SitePhpVersion from '../site-php-version';
+
+describe( 'SitePhpVersion', () => {
+	it( 'renders the PHP version', () => {
+		const { getByText } = render( <SitePhpVersion phpVersion={ 7.4 } /> );
+		expect( getByText( /php version/i ) ).toBeInTheDocument();
+		expect( getByText( /7.4/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'returns null when the PHP version is missing', () => {
+		const { container } = render( <SitePhpVersion phpVersion={ null } /> );
+		expect( container.firstChild ).toBeNull();
+	} );
+} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/test-utils/constants.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/test-utils/constants.ts
@@ -1,0 +1,50 @@
+import type { Site } from '../../types';
+
+const siteId = 12345678;
+
+const site: Site = {
+	blog_id: siteId,
+	url: 'test.wordpress.com',
+	url_with_scheme: 'https://test.wordpress.com',
+	monitor_active: true,
+	monitor_site_status: true,
+	has_scan: true,
+	has_backup: false,
+	has_boost: true,
+	latest_scan_threats_found: [],
+	latest_backup_status: '',
+	is_connection_healthy: true,
+	awaiting_plugin_updates: [ 'plugin1', 'plugin2' ],
+	is_favorite: true,
+	monitor_settings: {
+		monitor_active: true,
+		monitor_site_status: true,
+		last_down_time: '2021-01-01T00:00:00+00:00',
+		monitor_deferment_time: 5,
+		monitor_user_emails: [ 'test.com' ],
+		monitor_user_email_notifications: true,
+		monitor_user_wp_note_notifications: true,
+	},
+	monitor_last_status_change: '2021-01-01T00:00:00+00:00',
+	isSelected: true,
+	site_stats: {
+		visitors: {
+			total: 1000,
+			trend_change: 50,
+			trend: 'up',
+		},
+		views: {
+			total: 5000,
+			trend_change: 100,
+			trend: 'down',
+		},
+	},
+	jetpack_boost_scores: {
+		overall: 10,
+		mobile: 10,
+		desktop: 10,
+	},
+	php_version_num: 7.4,
+};
+
+export { site };


### PR DESCRIPTION
Related to 1203940061556608-as-1203943609783467

#### Proposed Changes

This PR adds test cases to components that were added as a part of the expandable block project

#### Testing Instructions

- Run `git checkout add/test-cases-expandable-block-components && git pull`
- Run `yarn run test-client client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test` to run the tests.
- Verify the tests are passing and code changes make sense

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?