### PR TITLE
Subscription management: Remove settings popover outline

### DIFF
--- a/client/landing/subscriptions/settings-popover/styles.scss
+++ b/client/landing/subscriptions/settings-popover/styles.scss
@@ -2,6 +2,7 @@
 
 .settings-popover {
 	width: 305px;
+	outline: none;
 
 	.popover__inner {
 		border: none;


### PR DESCRIPTION
Closes [#75447](https://github.com/Automattic/wp-calypso/issues/75447)

## Proposed Changes

This PR fixes the blue outline you get when opening a site's settings in the Subscription Management portal.

## Testing Instructions

I tried testing this locally, but it's a PITA. You'll need to setup a proxy (like Charles or Proxyman), and even with that all setup correctly, and with the subkey cookie set, Calypso kept redirecting me to WP.com. 

I think it's asier with Calypso Live. These instructions are for iPhone, but I think they're [about the same for Android](https://developer.chrome.com/docs/devtools/remote-debugging/).

- Navigate to https://container-xenodochial-merkle.calypso.live/ on your mobile device (I had to copy/paste this URL, scanning the QR code in the comment below kept redirecting me to WP.com for some reason).
- In the Safari Web Inspector, select your iPhone and open the debug tools:

<img width="300" alt="CleanShot 2023-04-10 at 10 34 09@2x" src="https://user-images.githubusercontent.com/528287/230865269-f9bd2e56-4c31-4385-b3fd-206251e8a23e.png">

- Go the cookies panel and add your subkey

<img src="https://user-images.githubusercontent.com/528287/230865427-446d012a-612b-4679-8625-cd179c087f40.png" width="300" />

- Navigate to  https://container-xenodochial-merkle.calypso.live/subscriptions/sites
- Click on Popover menu (the three dots) and you should see the popover without blue outline

<img src="https://user-images.githubusercontent.com/528287/230865615-a54b6618-d4a7-401e-b5d0-f2963e837974.png" width="300" />

(This is not a Simulator screenshot, I just have [this Shortcut](https://www.macstories.net/ios/apple-frames-3-0-completely-rewritten-support-for-iphone-14-pro-and-dynamic-island-new-devices-multiple-display-resolutions-and-more/) installed which automatically adds a device frame when I Airdrop a screenshot 🤪)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
