### PR TITLE
Update multiple site discount amount on the pricing page

### DIFF
--- a/client/my-sites/plans/jetpack-plans/faq/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/faq/index.tsx
@@ -146,7 +146,7 @@ const JetpackFAQ: FC = () => {
 							className="jetpack-faq__section"
 						>
 							{ translate(
-								'Anyone with at least five websites can join our licensing platform and enjoy a 25% discount across all Jetpack products! You can learn more about our {{agenciesLink}}licensing platform and agency program here{{/agenciesLink}}.',
+								'Anyone with at least five websites can join our licensing platform and enjoy up to 60% discount across all Jetpack products! You can learn more about our {{agenciesLink}}licensing platform and agency program here{{/agenciesLink}}.',
 								{
 									components: { agenciesLink: getAgenciesLink() },
 								}


### PR DESCRIPTION
This is a quick patch to correct the multiple-site discount amount on the pricing page FAQ. I think ideally we should retrieve that amount dynamically from somewhere; however, it is out of the scope of this pull request. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1681086009129379-slack-C01264051NE 


## Testing Instructions
- ssh your sandbox
- kick off the calypso environment 
- change the string
- Go to http://jetpack.cloud.localhost:3000/pricing or http://jetpack.cloud.localhost:3001/pricing to check if the string is shown correctly. 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before 
<img width="1086" alt="Screen Shot 2023-04-10 at 11 41 11" src="https://user-images.githubusercontent.com/82706809/230867490-ed05a0eb-d4fb-416e-96e7-cd2565567ae1.png">


After
<img width="882" alt="Screen Shot 2023-04-10 at 11 41 31" src="https://user-images.githubusercontent.com/82706809/230867537-e174f7f2-85f1-4f29-92b6-789d409616d8.png">



*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?