### PR TITLE
Stats: Address feedback on Subscribers page

### DIFF
--- a/client/my-sites/stats/stats-subscribers-page/index.jsx
+++ b/client/my-sites/stats/stats-subscribers-page/index.jsx
@@ -1,9 +1,7 @@
 import config from '@automattic/calypso-config';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
-import { flowRight } from 'lodash';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import DomainTip from 'calypso/blocks/domain-tip';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -12,17 +10,22 @@ import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { isJetpackSite, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import AnnualHighlightsSection from '../annual-highlights-section';
 import Followers from '../stats-followers';
 import StatsModuleEmails from '../stats-module-emails';
 import Reach from '../stats-reach';
 import SubscribersSection from '../subscribers-section';
 
-const StatsSubscribersPage = ( props ) => {
-	const { siteId, siteSlug, translate, isOdysseyStats, isJetpack } = props;
-
+const StatsSubscribersPage = () => {
+	const translate = useTranslate();
+	// Use hooks for Redux pulls.
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	// Run-time configuration.
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const showEmailSection = config.isEnabled( 'newsletter/stats' ) && ! isOdysseyStats;
 
 	const statsModuleListClass = classNames(
@@ -75,19 +78,4 @@ const StatsSubscribersPage = ( props ) => {
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
-StatsSubscribersPage.propTypes = {
-	translate: PropTypes.func,
-};
-
-const connectComponent = connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
-	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-	return {
-		siteId,
-		siteSlug: getSelectedSiteSlug( state, siteId ),
-		isOdysseyStats,
-		isJetpack: isJetpackSite( state, siteId ),
-	};
-} );
-
-export default flowRight( connectComponent, localize )( StatsSubscribersPage );
+export default StatsSubscribersPage;

--- a/client/my-sites/stats/stats-subscribers-page/index.jsx
+++ b/client/my-sites/stats/stats-subscribers-page/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import DomainTip from 'calypso/blocks/domain-tip';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
-import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
@@ -19,6 +18,7 @@ import AnnualHighlightsSection from '../annual-highlights-section';
 import Followers from '../stats-followers';
 import StatsModuleEmails from '../stats-module-emails';
 import Reach from '../stats-reach';
+import SubscribersSection from '../subscribers-section';
 
 const StatsSubscribersPage = ( props ) => {
 	const { siteId, siteSlug, translate, isOdysseyStats, isJetpack } = props;
@@ -66,7 +66,7 @@ const StatsSubscribersPage = ( props ) => {
 							/>
 						) }
 						{ config.isEnabled( 'stats/subscribers-section' ) && (
-							<AsyncLoad require="calypso/my-sites/stats/subscribers-section" siteId={ siteId } />
+							<SubscribersSection siteId={ siteId } />
 						) }
 						<div className={ statsModuleListClass }>
 							<Followers path="followers" />

--- a/client/my-sites/stats/stats-subscribers-page/index.jsx
+++ b/client/my-sites/stats/stats-subscribers-page/index.jsx
@@ -65,9 +65,7 @@ const StatsSubscribersPage = ( props ) => {
 								vendor={ getSuggestionsVendor() }
 							/>
 						) }
-						{ config.isEnabled( 'stats/subscribers-section' ) && (
-							<SubscribersSection siteId={ siteId } />
-						) }
+						{ isSubscribersPageEnabled && <SubscribersSection siteId={ siteId } /> }
 						<div className={ statsModuleListClass }>
 							<Followers path="followers" />
 							<Reach />

--- a/client/my-sites/stats/stats-subscribers-page/index.jsx
+++ b/client/my-sites/stats/stats-subscribers-page/index.jsx
@@ -23,7 +23,6 @@ import SubscribersSection from '../subscribers-section';
 const StatsSubscribersPage = ( props ) => {
 	const { siteId, siteSlug, translate, isOdysseyStats, isJetpack } = props;
 
-	const isSubscribersPageEnabled = config.isEnabled( 'stats/subscribers-section' );
 	const showEmailSection = config.isEnabled( 'newsletter/stats' ) && ! isOdysseyStats;
 
 	const statsModuleListClass = classNames(
@@ -54,25 +53,21 @@ const StatsSubscribersPage = ( props ) => {
 					align="left"
 				/>
 				<StatsNavigation selectedItem="subscribers" siteId={ siteId } slug={ siteSlug } />
-				{ isSubscribersPageEnabled && (
-					<>
-						{ /* TODO: replace annual highlight */ }
-						<AnnualHighlightsSection siteId={ siteId } />
-						{ siteId && (
-							<DomainTip
-								siteId={ siteId }
-								event="stats_subscribers_domain"
-								vendor={ getSuggestionsVendor() }
-							/>
-						) }
-						{ isSubscribersPageEnabled && <SubscribersSection siteId={ siteId } /> }
-						<div className={ statsModuleListClass }>
-							<Followers path="followers" />
-							<Reach />
-							{ showEmailSection && <StatsModuleEmails /> }
-						</div>
-					</>
+				{ /* TODO: replace annual highlight */ }
+				<AnnualHighlightsSection siteId={ siteId } />
+				{ siteId && (
+					<DomainTip
+						siteId={ siteId }
+						event="stats_subscribers_domain"
+						vendor={ getSuggestionsVendor() }
+					/>
 				) }
+				<SubscribersSection siteId={ siteId } />
+				<div className={ statsModuleListClass }>
+					<Followers path="followers" />
+					<Reach />
+					{ showEmailSection && <StatsModuleEmails /> }
+				</div>
 				<JetpackColophon />
 			</div>
 		</Main>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75378

## Proposed Changes

* Removes `connect` wrapper in favour of `useTranslate` and `useSelector` hooks.
* Removes feature flags for the Subscribers chart. Gating is around page availability now (as opposed to the SubscribersSection component).
* Removes usage of AsyncLoad that were necessary to keep the Traffic page loading quickly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Launch the Calypso Live link and visit Stats → Traffic.
2. Add `?flags=stats/subscribers-section` to the URL and refresh.
3. Click the new Subscribers link in the navigation header.
4. Confirm the page loads correctly and includes both the Subscribers section and the Emails module.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
