### PR TITLE
Flag clean-up: themes/showcase-i4/details-and-preview

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -37,7 +37,6 @@ import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import StickyPanel from 'calypso/components/sticky-panel';
-import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
@@ -525,14 +524,8 @@ class ThemeSheet extends Component {
 		);
 	};
 
-	renderSectionContent = ( section ) => {
-		const isNewDetailsAndPreview = config.isEnabled( 'themes/showcase-i4/details-and-preview' );
+	renderSectionContent = () => {
 		const { isPremium, isWpcomTheme, supportDocumentation } = this.props;
-		const activeSection = {
-			'': this.renderOverviewTab(),
-			setup: this.renderSetupTab(),
-			support: this.renderSupportTab(),
-		}[ section ];
 
 		return (
 			<div className="theme__sheet-content">
@@ -543,27 +536,13 @@ class ThemeSheet extends Component {
 						messagePath="calypso:theme:admin_notices"
 					/>
 				) }
-				{ ! isNewDetailsAndPreview ? (
+				{ this.isLoaded() && (
 					<>
-						{ this.renderSectionNav( section ) }
-						{ activeSection }
+						{ this.renderOverviewTab() }
+						{ ! isPremium && supportDocumentation && this.renderSetupTab() }
+						{ this.renderSupportTab() }
+						{ isWpcomTheme && this.renderNextTheme() }
 					</>
-				) : (
-					<>
-						{ this.isLoaded() && (
-							<>
-								{ this.renderOverviewTab() }
-								{ ! isPremium && supportDocumentation && this.renderSetupTab() }
-								{ this.renderSupportTab() }
-								{ isNewDetailsAndPreview && isWpcomTheme && this.renderNextTheme() }
-							</>
-						) }
-					</>
-				) }
-				{ ! isNewDetailsAndPreview && (
-					<div className="theme__sheet-footer-line">
-						<Gridicon icon="my-sites" />
-					</div>
 				) }
 			</div>
 		);
@@ -654,7 +633,6 @@ class ThemeSheet extends Component {
 	};
 
 	renderOverviewTab = () => {
-		const isNewDetailsAndPreview = config.isEnabled( 'themes/showcase-i4/details-and-preview' );
 		const { download, isWpcomTheme, siteSlug, taxonomies, isPremium } = this.props;
 
 		return (
@@ -669,7 +647,6 @@ class ThemeSheet extends Component {
 					/>
 				</div>
 				{ download && ! isPremium && <ThemeDownloadCard href={ download } /> }
-				{ ! isNewDetailsAndPreview && isWpcomTheme && this.renderNextTheme() }
 			</div>
 		);
 	};
@@ -1135,7 +1112,6 @@ class ThemeSheet extends Component {
 			isBundledSoftwareSet,
 			isSiteBundleEligible,
 			translate,
-			isWPForTeamsSite,
 			isLoggedIn,
 			isExternallyManagedTheme,
 			isSiteEligibleForManagedExternalThemes,
@@ -1279,7 +1255,6 @@ class ThemeSheet extends Component {
 			} );
 		}
 
-		const isNewDetailsAndPreview = config.isEnabled( 'themes/showcase-i4/details-and-preview' );
 		const isRemoved = this.isRemoved();
 
 		const className = classNames( 'theme__sheet', { 'is-with-upsell-banner': hasUpsellBanner } );
@@ -1289,9 +1264,6 @@ class ThemeSheet extends Component {
 
 		return (
 			<Main className={ className }>
-				<BodySectionCssClass
-					bodyClass={ [ ...( isNewDetailsAndPreview ? [ 'is-section-theme-i4' ] : [] ) ] }
-				/>
 				<QueryCanonicalTheme themeId={ this.props.themeId } siteId={ siteId } />
 				<QueryProductsList />
 				<QueryUserPurchases />
@@ -1308,43 +1280,29 @@ class ThemeSheet extends Component {
 					properties={ { is_logged_in: isLoggedIn } }
 				/>
 				<AsyncLoad require="calypso/components/global-notices" placeholder={ null } id="notices" />
-				{ ! isNewDetailsAndPreview && this.renderBar() }
 				<QueryActiveTheme siteId={ siteId } />
 				<ThanksModal source="details" themeId={ this.props.themeId } />
 				<AutoLoadingHomepageModal source="details" />
-				{ ! isNewDetailsAndPreview && pageUpsellBanner }
 				<div className="theme__sheet-action-bar-container">
 					<HeaderCake
 						className="theme__sheet-action-bar"
-						backText={
-							isNewDetailsAndPreview ? translate( 'Back to themes' ) : translate( 'All Themes' )
-						}
+						backText={ translate( 'Back to themes' ) }
 						onClick={ this.goBack }
-						alwaysShowBackText={ isNewDetailsAndPreview }
-					>
-						{ ! isNewDetailsAndPreview &&
-							! retired &&
-							! hasWpOrgThemeUpsellBanner &&
-							! isWPForTeamsSite &&
-							this.renderButton() }
-					</HeaderCake>
+						alwaysShowBackText
+					/>
 				</div>
 				<div className={ columnsClassName }>
-					{ isNewDetailsAndPreview && (
-						<div className="theme__sheet-column-header">
-							{ pageUpsellBanner }
-							{ this.renderHeader() }
-						</div>
-					) }
+					<div className="theme__sheet-column-header">
+						{ pageUpsellBanner }
+						{ this.renderHeader() }
+					</div>
 					<div className="theme__sheet-column-left">
 						{ ! retired && this.renderSectionContent( section ) }
 						{ retired && this.renderRetired() }
 					</div>
 					{ ! isRemoved && (
 						<div className="theme__sheet-column-right">
-							{ isNewDetailsAndPreview && styleVariations.length
-								? this.renderWebPreview()
-								: this.renderScreenshot() }
+							{ styleVariations.length ? this.renderWebPreview() : this.renderScreenshot() }
 						</div>
 					) }
 				</div>

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -2,7 +2,7 @@
 
 $theme-sheet-content-max-width: 1462px;
 
-body.is-section-theme-i4 {
+.is-section-theme {
 	&.theme-default.color-scheme {
 		--color-surface-backdrop: var(--studio-white);
 	}
@@ -22,203 +22,6 @@ body.is-section-theme-i4 {
 		}
 	}
 
-	.theme__sheet-action-bar-container {
-		box-shadow: 0 1px var(--color-border-subtle);
-	}
-
-	.theme__sheet-action-bar {
-		box-shadow: none;
-		box-sizing: content-box;
-		margin: 0 auto;
-		max-width: $theme-sheet-content-max-width;
-		min-height: 70px;
-		padding: 0 20px;
-		position: relative;
-
-		@include breakpoint-deprecated( "<960px" ) {
-			margin: 0 0 32px 0;
-		}
-
-		@include breakpoint-deprecated( "<960px" ) {
-			min-height: 60px;
-		}
-	}
-
-	.theme__sheet-columns {
-		display: grid;
-		gap: 0 32px;
-		grid-template-areas:
-			"header preview"
-			"content preview";
-		grid-template-columns: 1fr 1fr;
-		grid-template-rows: auto 1fr;
-		max-width: $theme-sheet-content-max-width;
-		padding: 48px 20px;
-
-		h2,
-		.theme__sheet-features .section-header__label {
-			border: 0;
-			color: var(--color-neutral-100);
-			font-size: $font-body;
-			font-weight: 500;
-			line-height: 24px;
-			margin: 40px 0 12px 0;
-			padding: 0;
-
-			&::before {
-				content: none;
-			}
-		}
-
-		.theme__sheet-column-header {
-			grid-area: header;
-
-			h2 {
-				margin: 0;
-			}
-		}
-
-		.theme__sheet-column-left {
-			grid-area: content;
-		}
-
-		.theme__sheet-column-right {
-			grid-area: preview;
-
-			.sticky-panel {
-				width: 100%;
-
-				&.is-sticky .sticky-panel__content {
-					margin-top: 16px;
-
-					@include breakpoint-deprecated( "<960px" ) {
-						margin-top: 0;
-						position: relative;
-						top: auto !important;
-					}
-				}
-
-				.sticky-panel__content {
-					transition: all 200ms ease-in-out;
-				}
-
-				.sticky-panel__spacer {
-					@include breakpoint-deprecated( "<960px" ) {
-						display: none;
-					}
-				}
-			}
-		}
-
-		.theme__sheet-column-left,
-		.theme__sheet-column-right {
-			align-items: flex-start;
-			box-sizing: border-box;
-			width: 100%;
-		}
-
-		@include breakpoint-deprecated( "<960px" ) {
-			display: flex;
-			gap: 16px;
-			flex-direction: column;
-			padding: 0;
-
-			.theme__sheet-column-left {
-				padding: 0 24px;
-				order: 2;
-			}
-
-			.theme__sheet-column-right {
-				order: 1;
-			}
-		}
-	}
-
-	.theme__sheet-content {
-		box-shadow: none;
-		font-size: 1rem;
-		min-height: auto;
-		padding: 0;
-
-		h2 {
-			font-size: 1.25rem;
-		}
-
-		video {
-			height: auto;
-			max-width: 100%;
-		}
-
-		.notes {
-			background: transparent;
-			border: 0;
-			margin: 0;
-			padding: 0;
-		}
-	}
-
-	.theme__page-upsell-banner {
-		background-color: #f0f7fc;
-		border: 0;
-		border-radius: 4px;
-		box-shadow: none;
-		margin-bottom: 24px;
-		padding: 24px 30px;
-		width: 100%;
-
-		.banner__icon-circle {
-			background-color: var(--studio-blue-50);
-		}
-	}
-
-	.theme__sheet-web-preview,
-	.theme__sheet-screenshot {
-		border-radius: 8px; /* stylelint-disable-line scales/radii */
-		box-shadow:
-			0 6px 10px rgba(0, 0, 0, 0.14),
-			0 1px 18px rgba(0, 0, 0, 0.12),
-			0 3px 5px rgba(0, 0, 0, 0.2);
-		margin-top: 0;
-		overflow: hidden;
-
-		@include breakpoint-deprecated( "<960px" ) {
-			border-radius: 0;
-			box-shadow: none;
-		}
-	}
-
-	.theme__sheet-features {
-		margin-bottom: 24px;
-
-		.card {
-			box-shadow: none;
-			padding: 0;
-		}
-
-		.theme__sheet-features-list {
-			display: flex;
-			flex-wrap: wrap;
-			gap: 8px;
-			margin: 0;
-			text-align: left;
-
-			a,
-			span {
-				background-color: var(--color-neutral-5);
-				border-radius: 4px;
-				color: var(--color-neutral-80);
-				margin: 0;
-				padding: 2px 10px;
-
-				&::after {
-					content: none;
-				}
-			}
-		}
-	}
-}
-
-.is-section-theme {
 	.empty-content {
 		margin-bottom: 20px;
 	}
@@ -306,13 +109,31 @@ body.is-section-theme-i4 {
 }
 
 .theme__sheet-columns {
-	display: flex;
-	flex-direction: row;
-	max-width: 1500px;
+	display: grid;
+	gap: 0 32px;
+	grid-template-areas:
+		"header preview"
+		"content preview";
+	grid-template-columns: 1fr 1fr;
+	grid-template-rows: auto 1fr;
 	margin: 0 auto;
+	max-width: $theme-sheet-content-max-width;
+	padding: 48px 20px;
 
 	@include breakpoint-deprecated( "<960px" ) {
-		flex-direction: column-reverse;
+		display: flex;
+		gap: 16px;
+		flex-direction: column;
+		padding: 0;
+
+		.theme__sheet-column-left {
+			padding: 0 24px;
+			order: 2;
+		}
+
+		.theme__sheet-column-right {
+			order: 1;
+		}
 	}
 }
 
@@ -321,10 +142,18 @@ body.is-section-theme-i4 {
 }
 
 .theme__sheet-column-header {
+	grid-area: header;
 	margin-bottom: 24px;
 
 	@include breakpoint-deprecated( "<960px" ) {
 		margin-bottom: 0;
+	}
+
+	h2 {
+		font-size: $font-body;
+		font-weight: 500;
+		line-height: 24px;
+		margin: 0;
 	}
 
 	.theme__sheet-header {
@@ -395,22 +224,65 @@ body.is-section-theme-i4 {
 
 .theme__sheet-column-left,
 .theme__sheet-column-right {
+	align-items: flex-start;
+	box-sizing: border-box;
 	display: flex;
-	width: 50%;
 	flex-direction: column;
+	width: 100%;
 
 	@include breakpoint-deprecated( "<960px" ) {
 		width: 100%;
 	}
 }
 
-.theme__sheet-action-bar {
-	height: 50px;
+.theme__sheet-column-left {
+	grid-area: content;
+}
+
+.theme__sheet-column-right {
+	grid-area: preview;
+
+	.sticky-panel {
+		width: 100%;
+
+		&.is-sticky .sticky-panel__content {
+			margin-top: 16px;
+
+			@include breakpoint-deprecated( "<960px" ) {
+				margin-top: 0;
+				position: relative;
+				top: auto !important;
+			}
+		}
+
+		.sticky-panel__content {
+			transition: all 200ms ease-in-out;
+		}
+
+		.sticky-panel__spacer {
+			@include breakpoint-deprecated( "<960px" ) {
+				display: none;
+			}
+		}
+	}
+}
+
+.theme__sheet-action-bar-container {
+	box-shadow: 0 1px var(--color-border-subtle);
+}
+
+.theme__sheet-action-bar.card {
+	box-shadow: none;
+	box-sizing: content-box;
+	margin: 0 auto;
+	max-width: $theme-sheet-content-max-width;
+	min-height: 70px;
+	padding: 0 20px;
+	position: relative;
 
 	@include breakpoint-deprecated( "<960px" ) {
-		&.card {
-			margin: 0 0 1px;
-		}
+		margin: 0 0 32px 0;
+		min-height: 60px;
 	}
 }
 
@@ -484,28 +356,32 @@ body.is-section-theme-i4 {
 
 .theme__sheet-web-preview,
 .theme__sheet-screenshot {
+	background-color: transparentize(rgb(255, 255, 255), 0.5);
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+	box-shadow:
+		0 6px 10px rgba(0, 0, 0, 0.14),
+		0 1px 18px rgba(0, 0, 0, 0.12),
+		0 3px 5px rgba(0, 0, 0, 0.2);
 	display: block;
-	margin-top: -156px;
+	margin-top: 0;
+	overflow: hidden;
+	transition: all 200ms ease-in-out;
 	width: 98%;
 	z-index: 1;
-	box-shadow:
-		0 0 0 1px rgba(var(--color-neutral-dark-rgb), 0),
-		0 2px 8px 0 rgba(var(--color-neutral-dark-rgb), 0.5);
-	background-color: transparentize(rgb(255, 255, 255), 0.5);
-	transition: all 200ms ease-in-out;
 
 	// with width: 98%, gives 4:3 ratio before the image loads
 	// also x-browser issues, so it's smaller than 4:3 proper
 	min-height: 36.15vw; // 36.75vw would be correct, but Safari is slightly off
 
 	@include breakpoint-deprecated( "<960px" ) {
+		border-radius: 0;
+		box-shadow: none;
 		position: relative;
+		height: 100vw; // force proportions
+		overflow: hidden;
 		margin-top: 0;
 		top: 0;
 		width: 100%;
-		height: 100vw; // force proportions
-		overflow: hidden;
-		box-shadow: none;
 
 		&::before {
 			content: "";
@@ -589,14 +465,15 @@ body.is-section-theme-i4 {
 }
 
 .theme__sheet-content {
-	padding: 20px;
-	font-size: $font-body-small;
-
-	min-height: 400px; // whilst loading
+	box-shadow: none;
+	font-size: 1rem;
+	min-height: auto;
+	padding: 0;
 
 	div {
 		width: auto !important; // override inline style in content markup
 	}
+
 	.banner__icon-circle {
 		width: 24px !important;
 	}
@@ -642,31 +519,19 @@ body.is-section-theme-i4 {
 		padding: 3px 8px 6px;
 	}
 
+	h2,
+	.theme__sheet-features .section-header__label {
+		border: 0;
+		color: var(--color-neutral-100);
+		font-size: $font-body;
+		font-weight: 500;
+		line-height: 24px;
+		margin: 40px 0 12px 0;
+		padding: 0;
+	}
+
 	h2 {
-		color: var(--color-neutral-light);
-		font-size: $font-body-small;
-		font-weight: 400;
-
-		margin: -20px -20px 20px;
-		padding: 15px 20px;
-		border-bottom: 1px solid #dce5eb;
-
-		&:nth-child(n + 2) {
-			// Everything except the first
-			border-top: 1px solid #dce5eb;
-			margin: 20px -20px;
-			padding: 15px 20px;
-
-			&::before {
-				// The "fake" Card separation
-				content: "";
-				display: block;
-				height: 15px;
-				margin: -15px -21px 15px;
-				border-bottom: 1px solid #dce5eb;
-				background: #f3f6f8;
-			}
-		}
+		font-size: 1.25rem;
 	}
 
 	h3 {
@@ -713,12 +578,18 @@ body.is-section-theme-i4 {
 		border-left: 2px solid var(--color-neutral-light);
 	}
 
+	video {
+		height: auto;
+		max-width: 100%;
+	}
+
 	.notes {
-		background: var(--color-neutral-0);
-		margin: 40px -20px;
+		background: transparent;
+		border: 0;
+		margin: 0;
 		border-top: 1px solid #e9eff3;
 		border-bottom: 1px solid #e9eff3;
-		padding: 20px;
+		padding: 0;
 
 		font-size: $font-body-small;
 		line-height: 21px;
@@ -757,37 +628,33 @@ body.is-section-theme-i4 {
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
+.theme__sheet-features {
+	margin-bottom: 24px;
+
+	.card {
+		box-shadow: none;
+		padding: 0;
+	}
+}
+
 .theme__sheet-features-list {
-	text-align: center;
-	margin: -10px;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin: 0;
 	padding: 0;
+	text-align: left;
 
 	a,
 	span {
 		display: inline-block;
 		position: relative;
-		background: var(--color-neutral-0);
-		color: var(--color-neutral-70);
-		margin: 4px;
-		padding: 2px 12px;
-		border-radius: 2px;
+		background-color: var(--color-neutral-5);
+		border-radius: 4px;
+		color: var(--color-neutral-80);
+		margin: 0;
+		padding: 2px 10px;
 		transition: all 100ms ease-in;
-
-		&::after {
-			content: "";
-			pointer-events: none;
-			position: absolute;
-			width: 100%;
-			height: 100%;
-			border-radius: 2px;
-			background: var(--color-primary-dark);
-			top: 0;
-			left: 0;
-			padding: 0;
-			z-index: -1;
-			transform: scale(0.9, 0.9);
-			transition: transform 300ms, opacity 400ms;
-		}
 
 		&:hover {
 			color: var(--color-text-inverted);
@@ -904,11 +771,16 @@ body.is-section-theme-i4 {
 }
 
 .banner.theme__page-upsell-banner {
-	width: 50%;
-	margin: 0 0 10px;
+	background-color: #f0f7fc;
+	border: 0;
+	border-radius: 4px;
+	box-shadow: none;
+	margin-bottom: 24px;
+	padding: 24px 30px;
+	width: 100%;
 
-	@include breakpoint-deprecated( "<960px" ) {
-		width: 100%;
+	.banner__icon-circle {
+		background-color: var(--studio-blue-50);
 	}
 }
 

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -1,6 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
 import Main from 'calypso/components/main';
-import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
 
@@ -8,13 +6,6 @@ const ConnectedThemeShowcase = connectOptions( ThemeShowcase );
 
 export default ( props ) => (
 	<Main fullWidthLayout isLoggedOut className="themes">
-		<BodySectionCssClass
-			bodyClass={ [
-				...( isEnabled( 'themes/showcase-i4/details-and-preview' )
-					? [ 'is-section-themes-i4-2' ]
-					: [] ),
-			] }
-		/>
 		<ConnectedThemeShowcase
 			{ ...props }
 			origin="wpcom"

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_UPLOAD_THEMES,
 	PLAN_BUSINESS,
@@ -12,7 +11,6 @@ import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import Main from 'calypso/components/main';
 import { useRequestSiteChecklistTaskUpdate } from 'calypso/data/site-checklist';
-import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getCurrentPlan, isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
@@ -54,7 +52,6 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 		requestingSitePlans,
 	} = props;
 
-	const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
 	const isWooExpressTrial = PLAN_ECOMMERCE_TRIAL_MONTHLY === currentPlan?.productSlug;
 
 	const upsellBanner = () => {
@@ -103,9 +100,6 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 
 	return (
 		<Main fullWidthLayout className="themes">
-			<BodySectionCssClass
-				bodyClass={ [ ...( isNewDetailsAndPreview ? [ 'is-section-themes-i4-2' ] : [] ) ] }
-			/>
 			<QueryActiveTheme siteId={ siteId } />
 			{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
 

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -15,7 +15,6 @@ import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import Main from 'calypso/components/main';
 import { useRequestSiteChecklistTaskUpdate } from 'calypso/data/site-checklist';
-import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { getCurrentPlan, isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
@@ -28,7 +27,6 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 	const { currentPlan, currentThemeId, isVip, requestingSitePlans, siteId, siteSlug, translate } =
 		props;
 
-	const isNewDetailsAndPreview = isEnabled( 'themes/showcase-i4/details-and-preview' );
 	const displayUpsellBanner = ! requestingSitePlans && currentPlan && ! isVip;
 	const upsellUrl = `/plans/${ siteSlug }`;
 	const isEnglishLocale = useIsEnglishLocale();
@@ -86,9 +84,6 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 
 	return (
 		<Main fullWidthLayout className="themes">
-			<BodySectionCssClass
-				bodyClass={ [ ...( isNewDetailsAndPreview ? [ 'is-section-themes-i4-2' ] : [] ) ] }
-			/>
 			<QueryActiveTheme siteId={ siteId } />
 			{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
 

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { mapValues, pickBy, flowRight as compose } from 'lodash';
 import { connect } from 'react-redux';
@@ -22,7 +21,6 @@ import {
 	getTheme,
 	getThemeDemoUrl,
 	getThemeDetailsUrl,
-	getThemeHelpUrl,
 	getThemePurchaseUrl,
 	getThemeSignupUrl,
 	isPremiumThemeAvailable,
@@ -255,11 +253,6 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 		getUrl: getThemeDetailsUrl,
 	};
 
-	const help = {
-		label: translate( 'Support' ),
-		getUrl: getThemeHelpUrl,
-	};
-
 	return {
 		customize,
 		preview,
@@ -274,7 +267,6 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 		signup,
 		separator,
 		info,
-		...( ! isEnabled( 'themes/showcase-i4/details-and-preview' ) && { help } ),
 	};
 }
 

--- a/config/development.json
+++ b/config/development.json
@@ -186,7 +186,6 @@
 		"subscription-management": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
-		"themes/showcase-i4/details-and-preview": true,
 		"themes/subscription-purchases": true,
 		"themes/theme-switch-persist-template": false,
 		"titan/iframe-control-panel": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -130,7 +130,6 @@
 		"subscription-management": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
-		"themes/showcase-i4/details-and-preview": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
 		"unified-pages/virtual-home-page": true,

--- a/config/production.json
+++ b/config/production.json
@@ -151,7 +151,6 @@
 		"subscription-management": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
-		"themes/showcase-i4/details-and-preview": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
 		"unified-pages/virtual-home-page": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -147,7 +147,6 @@
 		"subscription-management": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
-		"themes/showcase-i4/details-and-preview": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
 		"unified-pages/virtual-home-page": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -158,7 +158,6 @@
 		"subscription-management": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
-		"themes/showcase-i4/details-and-preview": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,
 		"unified-pages/virtual-home-page": true,


### PR DESCRIPTION
## Proposed Changes

Since the flag `themes/showcase-i4/details-and-preview` has been enabled in all environments since March 23rd, 2023 via https://github.com/Automattic/wp-calypso/pull/74810, we can now remove the flag to avoid clutter.

![Screenshot 2023-04-10 at 6 21 59 PM](https://user-images.githubusercontent.com/797888/230883862-2c4a3d19-3c9a-4699-ad99-4bf28050e0e9.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Select any theme.
* Ensure that the UI is the same as the one in production.
* Please check the following theme types:
  *  With style variation.
  *  Without style variation.
  *  Third-party themes.
* Also, please check the logged-out Theme Showcase.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
