### PR TITLE
Subscription management: Add TimeSince component

### DIFF
--- a/client/landing/subscriptions/site-list/site-row.tsx
+++ b/client/landing/subscriptions/site-list/site-row.tsx
@@ -2,7 +2,7 @@ import { Gridicon } from '@automattic/components';
 import { SubscriptionManager } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import TimeSince from 'calypso/components/time-since';
 import { SiteSettings } from '../settings-popover';
 import type {
 	SiteSubscription,
@@ -32,11 +32,6 @@ export default function SiteRow( {
 	date_subscribed,
 	delivery_methods,
 }: SiteSubscription ) {
-	const moment = useLocalizedMoment();
-	const since = useMemo(
-		() => moment( date_subscribed ).format( 'LL' ),
-		[ date_subscribed, moment ]
-	);
 	const hostname = useMemo( () => new URL( url ).hostname, [ url ] );
 	const siteIcon = useMemo( () => {
 		if ( site_icon ) {
@@ -68,7 +63,7 @@ export default function SiteRow( {
 				</span>
 			</a>
 			<span className="date" role="cell">
-				{ since }
+				<TimeSince date={ date_subscribed.toDateString() } />
 			</span>
 			<span className="email-frequency" role="cell">
 				{ deliveryFrequencyLabel }

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -29,7 +29,13 @@ const callFollowingEndPoint = async (
 	} );
 
 	if ( incoming && incoming.subscriptions ) {
-		data.push( ...incoming.subscriptions );
+		data.push(
+			...incoming.subscriptions.map( ( subscription ) => ( {
+				...subscription,
+				last_updated: new Date( subscription.last_updated ),
+				date_subscribed: new Date( subscription.date_subscribed ),
+			} ) )
+		);
 	}
 
 	if ( incoming.page * number < incoming.total_subscriptions ) {


### PR DESCRIPTION
Closes [#75135](https://github.com/Automattic/wp-calypso/issues/75135)

## Proposed Changes

* This adds the `<TimeSince />` component to the Subscription management site's list

<img width="1379" alt="CleanShot 2023-04-10 at 14 11 03@2x" src="https://user-images.githubusercontent.com/528287/230899246-2e0f87ba-b754-4e86-a3fc-1e38ab91aae0.png">

It also fixes an error between the API data rerturned and the TypeScript type. The type for SiteSubscription states that the `date_subscribed` & `last_updated` fields are Dates., but in fact they were returned as strings.

```ts
export type SiteSubscription = {
	ID: string;
	blog_ID: string;
	feed_ID: string;
	URL: string;
	date_subscribed: Date;
	delivery_methods: SiteSubscriptionDeliveryMethods;
	name: string;
	organization_id: number;
	unseen_count: number;
	last_updated: Date;
	site_icon: string;
	is_owner: boolean;
	meta: SiteSubscriptionMeta;
};
```

This is now fixed by converting the value returned by the API to real JS Dates:

```js
		data.push(
			...incoming.subscriptions.map( ( subscription ) => ( {
				...subscription,
				last_updated: new Date( subscription.last_updated ),
				date_subscribed: new Date( subscription.date_subscribed ),
			} ) )
		);
```

## Testing Instructions

- Apply this PR & make sure you have a correct subkey set
- Visit http://calypso.localhost:3000/subscriptions/settings
- The Since column should be localized & display friendly values

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
