### PR TITLE
Subscription management: Fix delivery frequency overflow

### DIFF
--- a/client/landing/subscriptions/settings-popover/styles.scss
+++ b/client/landing/subscriptions/settings-popover/styles.scss
@@ -1,7 +1,7 @@
 @import "@automattic/color-studio/dist/color-variables";
 
 .settings-popover {
-	width: 305px;
+	min-width: 305px;
 
 	.popover__inner {
 		border: none;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/75463

## Proposed Changes

| Before | After |
|-------|------|
| <img src="https://user-images.githubusercontent.com/528287/230853141-2c90434b-52e5-4186-a7c4-e4bd11317aae.png" /> | <img width="449" alt="CleanShot 2023-04-10 at 13 00 30@2x" src="https://user-images.githubusercontent.com/528287/230890349-e9202ff2-224e-43b3-91f2-12f63f407d7a.png"> |

It changes `width: 305px;` to `min-width: 305px;`. I tested with `pt-BR` on an emulated iPhone XR, and the content still fits well within the viewport. 

We'll have to keep an eye on other translations.

## Testing Instructions

1. Apply this PR
2. Go to http://calypso.localhost:3000/subscriptions/sites?locale=pt-br
3. Click the three dots to get the Popover, the content should not overflow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
