### PR TITLE
Jetpack Backup: Add selector to get backups_stopped flag

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/size/from-api.ts
+++ b/client/state/data-layer/wpcom/sites/rewind/size/from-api.ts
@@ -9,6 +9,7 @@ type ApiResponse = {
 	days_of_backups_allowed: number;
 	retention_days: number;
 	last_backup_size: number;
+	backups_stopped: boolean;
 };
 
 const fromApi = ( {
@@ -18,6 +19,7 @@ const fromApi = ( {
 	days_of_backups_saved,
 	retention_days,
 	last_backup_size,
+	backups_stopped,
 }: ApiResponse ): RewindSizeInfo => ( {
 	bytesUsed: size,
 	minDaysOfBackupsAllowed: min_days_of_backups_allowed,
@@ -25,6 +27,7 @@ const fromApi = ( {
 	daysOfBackupsSaved: days_of_backups_saved,
 	retentionDays: retention_days,
 	lastBackupSize: last_backup_size,
+	backupsStopped: backups_stopped,
 } );
 
 export default fromApi;

--- a/client/state/rewind/selectors/get-backup-stopped-flag.ts
+++ b/client/state/rewind/selectors/get-backup-stopped-flag.ts
@@ -7,7 +7,7 @@ import type { AppState } from 'calypso/types';
  * @param siteId The site ID for which to backup status.
  * @returns true if backups are stopped false otherwise.
  */
-const getBackupStoppedFlag = ( state: AppState, siteId: number ): bool =>
+const getBackupStoppedFlag = ( state: AppState, siteId: number ): boolean =>
 	state.rewind[ siteId ]?.size?.backupsStopped ?? false;
 
 export default getBackupStoppedFlag;

--- a/client/state/rewind/selectors/get-backup-stopped-flag.ts
+++ b/client/state/rewind/selectors/get-backup-stopped-flag.ts
@@ -1,0 +1,13 @@
+import type { AppState } from 'calypso/types';
+
+/**
+ * Indicates if the backups are stopped for the site.
+ *
+ * @param state The application state.
+ * @param siteId The site ID for which to backup status.
+ * @returns true if backups are stopped false otherwise.
+ */
+const getBackupStoppedFlag = ( state: AppState, siteId: number ): bool =>
+	state.rewind[ siteId ]?.size?.backupsStopped ?? false;
+
+export default getBackupStoppedFlag;

--- a/client/state/rewind/selectors/index.ts
+++ b/client/state/rewind/selectors/index.ts
@@ -14,3 +14,4 @@ export { default as getRewindStorageUsageLevel } from './get-rewind-storage-usag
 export { default as getBackupRetentionDays } from './get-backup-retention-days';
 export { default as getBackupCurrentSiteSize } from './get-backup-current-site-size';
 export { default as getBackupRetentionUpdateRequestStatus } from './get-backup-retention-update-status';
+export { default as getBackupStoppedFlag } from './get-backup-stopped-flag';

--- a/client/state/rewind/size/reducer.ts
+++ b/client/state/rewind/size/reducer.ts
@@ -88,6 +88,17 @@ const lastBackupSize = (
 	return size.lastBackupSize ?? null;
 };
 
+const backupsStopped = (
+	state: AppState = null,
+	{ type, size }: AnyAction
+): AppState | boolean | null => {
+	if ( type !== REWIND_SIZE_SET ) {
+		return state;
+	}
+
+	return size.backupsStopped ?? false;
+};
+
 export default combineReducers( {
 	requestStatus,
 	bytesUsed,
@@ -96,4 +107,5 @@ export default combineReducers( {
 	daysOfBackupsSaved,
 	retentionDays,
 	lastBackupSize,
+	backupsStopped,
 } );

--- a/client/state/rewind/size/test/reducer.js
+++ b/client/state/rewind/size/test/reducer.js
@@ -1,8 +1,4 @@
-import {
-	JETPACK_BACKUP_RETENTION_SET,
-	REWIND_SIZE_GET,
-	REWIND_SIZE_SET,
-} from 'calypso/state/action-types';
+import { JETPACK_BACKUP_RETENTION_SET, REWIND_SIZE_SET } from 'calypso/state/action-types';
 import sizeReducer from '../reducer';
 
 // @TODO: Add tests for the other reducers
@@ -11,17 +7,7 @@ describe( 'rewind.size reducers', () => {
 		it.each( [
 			{
 				state: undefined,
-				action: {},
-				expected: null,
-			},
-			{
-				state: undefined,
-				action: { type: REWIND_SIZE_GET },
-				expected: null,
-			},
-			{
-				state: { lastBackupSize: 100 },
-				action: { type: REWIND_SIZE_GET },
+				action: { type: REWIND_SIZE_SET, size: { lastBackupSize: 100 } },
 				expected: 100,
 			},
 			{
@@ -41,18 +27,8 @@ describe( 'rewind.size reducers', () => {
 		it.each( [
 			{
 				state: undefined,
-				action: {},
-				expected: null,
-			},
-			{
-				state: undefined,
-				action: { type: REWIND_SIZE_GET },
-				expected: null,
-			},
-			{
-				state: { retentionDays: 30 },
-				action: { type: REWIND_SIZE_GET },
-				expected: 30,
+				action: { type: REWIND_SIZE_SET, size: { retentionDays: 7 } },
+				expected: 7,
 			},
 			{
 				state: { retentionDays: 30 },
@@ -82,12 +58,8 @@ describe( 'rewind.size reducers', () => {
 			).toEqual( 7 );
 		} );
 	} );
+
 	describe( 'backupsStopped', () => {
-		it( 'should return false when there is nothing in the state', () => {
-			expect(
-				sizeReducer( undefined, { type: REWIND_SIZE_SET, size: {} } ).backupsStopped
-			).toEqual( false );
-		} );
 		it( 'should return the value when the action is REWIND_SIZE_SET', () => {
 			expect(
 				sizeReducer( undefined, { type: REWIND_SIZE_SET, size: { backupsStopped: true } } )
@@ -102,7 +74,7 @@ describe( 'rewind.size reducers', () => {
 				).backupsStopped
 			).toEqual( false );
 		} );
-		it( 'should return null when the action is not REWIND_SIZE_SET', () => {
+		it( 'should return null when the action is not REWIND_SIZE_SET and the state is undefined', () => {
 			expect(
 				sizeReducer( undefined, { type: JETPACK_BACKUP_RETENTION_SET } ).backupsStopped
 			).toEqual( null );

--- a/client/state/rewind/size/test/reducer.js
+++ b/client/state/rewind/size/test/reducer.js
@@ -82,4 +82,30 @@ describe( 'rewind.size reducers', () => {
 			).toEqual( 7 );
 		} );
 	} );
+	describe( 'backupsStopped', () => {
+		it( 'should return false when there is nothing in the state', () => {
+			expect(
+				sizeReducer( undefined, { type: REWIND_SIZE_SET, size: {} } ).backupsStopped
+			).toEqual( false );
+		} );
+		it( 'should return the value when the action is REWIND_SIZE_SET', () => {
+			expect(
+				sizeReducer( undefined, { type: REWIND_SIZE_SET, size: { backupsStopped: true } } )
+					.backupsStopped
+			).toEqual( true );
+		} );
+		it( 'should return new the value when it is updated and the action is REWIND_SIZE_SET', () => {
+			expect(
+				sizeReducer(
+					{ backupsStopped: true },
+					{ type: REWIND_SIZE_SET, size: { backupsStopped: false } }
+				).backupsStopped
+			).toEqual( false );
+		} );
+		it( 'should return null when the action is not REWIND_SIZE_SET', () => {
+			expect(
+				sizeReducer( undefined, { type: JETPACK_BACKUP_RETENTION_SET } ).backupsStopped
+			).toEqual( null );
+		} );
+	} );
 } );

--- a/client/state/rewind/size/types.ts
+++ b/client/state/rewind/size/types.ts
@@ -5,4 +5,5 @@ export type RewindSizeInfo = {
 	daysOfBackupsSaved: number;
 	lastBackupSize: number;
 	retentionDays: number;
+	backupsStopped: boolean;
 };

--- a/client/state/rewind/test/selectors.js
+++ b/client/state/rewind/test/selectors.js
@@ -4,6 +4,7 @@ import {
 	getBackupCurrentSiteSize,
 	getBackupRetentionDays,
 	getBackupRetentionUpdateRequestStatus,
+	getBackupStoppedFlag,
 } from '../selectors';
 import { StorageUsageLevels } from '../storage/types';
 
@@ -143,5 +144,28 @@ describe( 'getBackupRetentionUpdateRequestStatus()', () => {
 		expect( getBackupRetentionUpdateRequestStatus( state, TEST_SITE_ID ) ).toEqual(
 			BACKUP_RETENTION_UPDATE_REQUEST.PENDING
 		);
+	} );
+} );
+describe( 'getBackupStoppedFlag()', () => {
+	const TEST_SITE_ID = 123;
+
+	test( 'should default to false when the state does not contain the flag.', () => {
+		const state = {
+			rewind: {
+				[ TEST_SITE_ID ]: {},
+			},
+		};
+		expect( getBackupStoppedFlag( state, TEST_SITE_ID ) ).toEqual( false );
+	} );
+
+	test( 'should return the value as is when the state contains the value for flag.', () => {
+		const state = {
+			rewind: {
+				[ TEST_SITE_ID ]: {
+					size: { backupsStopped: true },
+				},
+			},
+		};
+		expect( getBackupStoppedFlag( state, TEST_SITE_ID ) ).toEqual( true );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

PT: peaFOp-1b9-p2

## Proposed Changes

As a part of As a part of the [Project - Backup retention option on cancelation flow](1204174192068668-as-1204101785545874), we need to show this 2-day retention option to customers only who have reached their storage limit. To determine if the customer have reached the storage limit, we have added a `backups_stopped` flag to the WPCOM API and it will be used in the PR https://github.com/Automattic/wp-calypso/pull/75400 to show/hide the option

## Testing Instructions

Unit tests only:

```
➜  $ yarn test-client client/state/rewind/test/selectors.js                 
 PASS  client/state/rewind/test/selectors.js

Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        0.894 s, estimated 1 s
Ran all test suites matching /client\/state\/rewind\/test\/selectors.js/i.
```

```
➜  $ yarn test-client client/state/rewind/size/test        
 PASS  client/state/rewind/size/test/reducer.js

Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
Snapshots:   0 total
Time:        0.578 s, estimated 1 s
Ran all test suites matching /client\/state\/rewind\/size\/test/i.
```
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?