### PR TITLE
Site Assembler - Use tooltip component for category description and pattern name

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.scss
@@ -4,7 +4,7 @@
 	.components-popover__content {
 		white-space: normal;
 		width: auto;
-		max-width: 280px;
+		max-width: 100%;
 		margin: 0 auto;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.scss
@@ -1,3 +1,11 @@
 .pattern-list-renderer__pattern-list-item {
 	padding: 0;
+
+	.components-popover__content {
+		white-space: normal;
+		width: auto;
+		max-width: 280px;
+		margin: 0 auto;
+	}
 }
+

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -1,5 +1,6 @@
 import { PatternRenderer } from '@automattic/block-renderer';
 import { Button } from '@automattic/components';
+import { Tooltip } from '@wordpress/components';
 import classnames from 'classnames';
 import { useEffect, useCallback, useRef } from 'react';
 import { useInView } from 'react-intersection-observer';
@@ -57,24 +58,21 @@ const PatternListItem = ( {
 	}, [ isShown, isFirst, ref, inViewOnce ] );
 
 	return (
-		<Button
-			className={ className }
-			title={ pattern.title }
-			ref={ setRefs }
-			onClick={ () => onSelect( pattern ) }
-		>
-			{ isShown && inViewOnce ? (
-				<PatternRenderer
-					key={ pattern.ID }
-					patternId={ encodePatternId( pattern.ID ) }
-					viewportWidth={ 1060 }
-					minHeight={ PLACEHOLDER_HEIGHT }
-					maxHeightFor100vh={ MAX_HEIGHT_FOR_100VH }
-				/>
-			) : (
-				<div key={ pattern.ID } style={ { height: PLACEHOLDER_HEIGHT } } />
-			) }
-		</Button>
+		<Tooltip text={ pattern.title }>
+			<Button className={ className } ref={ setRefs } onClick={ () => onSelect( pattern ) }>
+				{ isShown && inViewOnce ? (
+					<PatternRenderer
+						key={ pattern.ID }
+						patternId={ encodePatternId( pattern.ID ) }
+						viewportWidth={ 1060 }
+						minHeight={ PLACEHOLDER_HEIGHT }
+						maxHeightFor100vh={ MAX_HEIGHT_FOR_100VH }
+					/>
+				) : (
+					<div key={ pattern.ID } style={ { height: PLACEHOLDER_HEIGHT } } />
+				) }
+			</Button>
+		</Tooltip>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -90,7 +90,7 @@ const ScreenCategoryList = ( {
 				}
 			/>
 			<div className="screen-container__body screen-container__body--align-sides screen-category-list__body">
-				{ categoriesInOrder.map( ( { name, label, description } ) => {
+				{ categoriesInOrder.map( ( { name, label } ) => {
 					const isOpen = selectedCategory === name;
 					const hasPatterns = name && patternsMapByCategory[ name ]?.length;
 					const isHeaderCategory = name === 'header';
@@ -106,7 +106,6 @@ const ScreenCategoryList = ( {
 							className={ classNames( 'screen-category-list__category-button navigator-button', {
 								'screen-category-list__category-button--is-open': isOpen,
 							} ) }
-							title={ description }
 							onClick={ () => {
 								if ( isOpen ) {
 									setSelectedCategory( null );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -208,6 +208,7 @@ $font-family: "SF Pro Text", $sans;
 		}
 
 		.pattern-selector__body {
+			position: relative;
 			margin-bottom: 32px;
 			padding: 2px;
 			overflow-y: scroll;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -228,7 +228,6 @@ $font-family: "SF Pro Text", $sans;
 				border: 1px solid rgba(0, 0, 0, 5%);
 				border-radius: 4px;
 				width: 100%;
-				transform: translateZ(0);
 				overflow: hidden;
 				user-select: none;
 				cursor: pointer;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes to #75253

## Proposed Changes

* Show a tooltip with the pattern name as in the editor
* Remove the tooltip from the category name

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Click on the Calypso Live link in the first comment.
- Create a new site and `Continue` until landing on the Design Picker.
- Go to the site assembler by clicking `Start designing` from the bottom.
- Click `Header` and hover the patterns to verify that the tooltip is centered at the bottom of the patterns.
- Click `Footer` and hover the patterns too.
- Note that when the patterns is the last, the tooltip appears on the top rather than the bottom. 
- Click `Sections`, then `Add patterns` and hover the categories to verify that there is not tooltip
- Click on a category and hover over the first and last pattern to verify the pattern name is visible in a tooltip

|BEFORE|AFTER|
|---|---|
|<img width="332" alt="Screenshot 2566-04-10 at 22 08 58" src="https://user-images.githubusercontent.com/1881481/230917819-a90b5596-bc69-4e85-9e90-051cb2c837a8.png">|<img width="336" alt="Screenshot 2566-04-10 at 22 08 29" src="https://user-images.githubusercontent.com/1881481/230917841-6dc75b4d-4506-443f-beae-c73031a4a74e.png">|




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?