### PR TITLE
Woo Express: Fix fatal error on the plans page.

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -1126,7 +1126,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 
 			const availableForPurchase = isInSignup || isPlanAvailableForPurchase( state, siteId, plan );
 			const isCurrentPlan = isCurrentSitePlan( state, siteId, planProductId ) ?? false;
-			const isVisible = visiblePlans.indexOf( plan ) !== -1;
+			const isVisible = visiblePlans?.indexOf( plan ) !== -1;
 
 			return {
 				availableForPurchase,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #75497

## Proposed Changes

In 51cdc22, we added a new `isVisible` prop which checked `visiblePlans` for the current plan.

The issue with Woo Express plans is that `visiblePlans` is undefined at this point which caused a fatal error. Now we check for undefined `visiblePlans`.


## Testing Instructions

1. Don't apply the patch yet and create a new trial site by visiting `/setup/wooexpress`.
1. Once the trial site has been created, visit `/plans/:siteSlug` and verify that you get a fatal TS error and the plans page is not displayed.
1. Now apply the patch and visit `/plans/:siteSlug` again. You should see the normal trial plans page:
![image](https://user-images.githubusercontent.com/917632/230954984-2c7a7b34-72cb-4033-9db0-127c1b829913.png)

1. Now upgrade the trial site to the Essential plan and visit `/plans/:siteSlug`. You should see the Woo Express plans page:
![image](https://user-images.githubusercontent.com/917632/230955103-2bc62a9d-c614-4a2c-8cc2-f88ca1e3f48b.png)

1. Lastly, verify the non-Woo Express plans page is working by visiting `/plans/:siteSlug` for a site with any non-Woo Express plan (a Free site works fine). You should see the non-Woo Express plans page:
![image](https://user-images.githubusercontent.com/917632/230955422-f8c1a3e5-5d02-4556-a6e9-3fcb20ec0458.png)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
