### PR TITLE
Revert "DotOrg Theme: Active theme on the Marketplace Theme Installation page (#75314)"

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -64,17 +64,6 @@ class ThanksModal extends Component {
 	}
 
 	static getDerivedStateFromProps( nextProps, prevState ) {
-		/**
-		 * Clear activation status and don't show the modal if the theme is not a WPCOM theme.
-		 */
-		if ( ! nextProps.isThemeWpcom && nextProps.siteId ) {
-			nextProps.clearActivated( nextProps.siteId );
-			return {
-				isVisible: false,
-				wasInstalling: nextProps.isInstalling,
-			};
-		}
-
 		if ( nextProps.isInstalling || nextProps.isActivating || nextProps.hasActivated ) {
 			return {
 				isVisible: true,

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -1,8 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
-import page from 'page';
-import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { isJetpackSite, getSiteSlug } from 'calypso/state/sites/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { activateTheme } from 'calypso/state/themes/actions/activate-theme';
 import { installAndActivateTheme } from 'calypso/state/themes/actions/install-and-activate-theme';
 import { showAutoLoadingHomepageWarning } from 'calypso/state/themes/actions/show-auto-loading-homepage-warning';
@@ -56,15 +54,6 @@ export function activate(
 			! hasAutoLoadingHomepageModalAccepted( getState(), themeId )
 		) {
 			return dispatch( showAutoLoadingHomepageWarning( themeId ) );
-		}
-
-		// Check if the theme is a .org Theme and redirect it to the Marketplace theme installation page
-		const isDotOrgTheme = !! getTheme( getState(), 'wporg', themeId );
-		if ( isDotOrgTheme ) {
-			const siteSlug = getSiteSlug( getState(), siteId );
-
-			dispatch( productToBeInstalled( themeId, siteSlug ) );
-			return page( `/marketplace/theme/${ themeId }/install/${ siteSlug }` );
 		}
 
 		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {


### PR DESCRIPTION
Per p1681144016627269-slack-C02FMH4G8

This reverts commit 61b828036c6b4cdbad9aea41506dbcc135b7a6d2.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?