### PR TITLE
Marketplace: Update Marketplace Installation route for plugins and its usage

### DIFF
--- a/client/my-sites/marketplace/index.js
+++ b/client/my-sites/marketplace/index.js
@@ -29,7 +29,7 @@ export default function () {
 	}
 
 	page(
-		'/marketplace/:productSlug?/install/:site?',
+		'/marketplace/plugin/:productSlug?/install/:site?',
 		siteSelection,
 		renderPluginsInstallPage,
 		makeLayout,

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -361,7 +361,7 @@ const MarketplacePluginInstall = ( {
 						"Your current plan doesn't allow plugin installation. Please upgrade to Business plan first."
 					) }
 					action={ translate( 'Upgrade to Business Plan' ) }
-					actionURL={ `/checkout/${ selectedSite?.slug }/business?redirect_to=/marketplace/${ productSlug }/install/${ selectedSite?.slug }#step2` }
+					actionURL={ `/checkout/${ selectedSite?.slug }/business?redirect_to=/marketplace/plugin/${ productSlug }/install/${ selectedSite?.slug }#step2` }
 				/>
 			);
 		}

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -285,12 +285,12 @@ function onClickInstallPlugin( {
 
 	if ( isPreinstalledPremiumPlugin ) {
 		const checkoutUrl = `/checkout/${ selectedSite.slug }/${ preinstalledPremiumPluginProduct }`;
-		const installUrl = `/marketplace/${ plugin.slug }/install/${ selectedSite.slug }`;
+		const installUrl = `/marketplace/plugin/${ plugin.slug }/install/${ selectedSite.slug }`;
 		return page( `${ checkoutUrl }?redirect_to=${ installUrl }#step2` );
 	}
 
 	// After buying a plan we need to redirect to the plugin install page.
-	const installPluginURL = `/marketplace/${ plugin.slug }/install/${ selectedSite.slug }`;
+	const installPluginURL = `/marketplace/plugin/${ plugin.slug }/install/${ selectedSite.slug }`;
 	if ( upgradeAndInstall ) {
 		// We also need to add a business plan to the cart.
 		return page(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #75501

## Proposed Changes

* Update the Marketplace installation route for plugins from `/marketplace/:productSlug?/install/:site` to `/marketplace/plugin/:productSlug?/install/:site`
* Update the URLs to the new route

## Testing Instructions
* From a business site, go to a free plugin details route. Ex: `/plugins/contact-form-7/:site`
* Click on `Install and activate`
* Check if it will redirect you to the new route (with `plugin`)
* Verify the installation will be completed as usual

--- 

* From a lower-than-business site, go to a free plugin details route. Ex: `/plugins/contact-form-7/:site`
* Click on `Upgrade and activate`
* Proceed on the modal check 
* On the cart, check if the `redirect_to` parameter has the new route
* Complete the purchase and verify if the installation is completed successfully 

---

* From a lower-than-business site, go to a free plugin installation route. Ex: `/marketplace/plugin/wordpress-seo/install/:site`
* Click on `Upgrade to Business Plan` and check the same conditions as above


![CleanShot 2023-04-10 at 15 25 34@2x](https://user-images.githubusercontent.com/5039531/230967449-4189a5bf-94db-409e-a778-f7bc69c42718.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
