### PR TITLE
Remove "Start Writing" step from newsletter launchpad flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -116,7 +116,6 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 		'subscribers_added',
 		'verify_email',
 		'first_post_published_newsletter',
-		'first_post_published',
 	],
 	[ LINK_IN_BIO_FLOW ]: linkInBioTaskList,
 	[ LINK_IN_BIO_TLD_FLOW ]: linkInBioTaskList,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

We have two call to action for "Start writing" for the newsletter flow. This PR removes the "Start Writing" from the list of Launchpad tasks.

| Before  | After |
| ------------- | ------------- |
|<img width="1722" alt="Screenshot 2023-04-10 at 2 57 41 PM" src="https://user-images.githubusercontent.com/7076981/230986598-9b987e11-35aa-49d6-9e94-4ce6a0b5e8b9.png"> | <img width="1728" alt="Screenshot 2023-04-10 at 2 57 57 PM" src="https://user-images.githubusercontent.com/7076981/230986601-b06f41e5-5423-4a49-853d-4592c7da1e88.png">  |



## Testing Instructions
1. Checkout this branch
1. Start a new newsletter site from - http://calypso.localhost:3000/setup/newsletter/intro
1. Sign up for a free plan
1. Verify that the launchpad steps do not include the "Start Writing" launchpad step and the the CTA button to "Write your first post"

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist


<!--


Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?