### PR TITLE
devdocs: Restore `react-intersection-observer` usage

### DIFF
--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -1,11 +1,11 @@
 import { map, chunk } from 'lodash';
-import { useState, Children } from 'react';
+import { Children } from 'react';
+import { useInView } from 'react-intersection-observer';
 import ReadmeViewer from 'calypso/components/readme-viewer';
 import ComponentPlayground from 'calypso/devdocs/design/component-playground';
 import Placeholder from 'calypso/devdocs/devdocs-async-load/placeholder';
 import { camelCaseToSlug, getComponentName } from 'calypso/devdocs/docs-example/util';
 import DocsExampleWrapper from 'calypso/devdocs/docs-example/wrapper';
-import { useInView } from 'calypso/lib/use-in-view';
 import { getExampleCodeFromComponent } from './playground-utils';
 
 const shouldShowInstance = ( example, filter, component ) => {
@@ -139,8 +139,9 @@ const Collection = ( {
 };
 
 function LazyExampleGroup( { exampleGroup, examplesToMount } ) {
-	const [ inView, setInView ] = useState( false );
-	const ref = useInView( () => setInView( true ) );
+	const { ref, inView } = useInView( {
+		triggerOnce: true,
+	} );
 	return (
 		<div ref={ ref }>{ inView ? exampleGroup : <Placeholder count={ examplesToMount } /> }</div>
 	);


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/issues/74022
Previously https://github.com/Automattic/wp-calypso/pull/69469

## Proposed Changes

Restores use of `react-intersection-observer` in devdocs because `calypso/lib/use-in-view` is buggy and it doesn't make sense to spend time reinventing the wheel.

## Testing Instructions

* Test the component galleries at `/devdocs/blocks` and `/devdocs/design`
* Notice how the scroll bar shrinks as you scroll down the page, that's because components are rendering as you scroll
* You should still be able to find any component/block by searching
* Confirm that there are no changes in behaviour between this branch and production https://wpcalypso.wordpress.com/devdocs/design