### PR TITLE
Launchpad: Track Celebrate Launch Modal View

### DIFF
--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -33,6 +33,12 @@ function CelebrateLaunchModal( { setModalIsOpen, site, allDomains } ) {
 			'',
 			omitUrlParams( window.location.href, 'celebrateLaunch' )
 		);
+
+		dispatch(
+			recordTracksEvent( `calypso_launchpad_celebration_modal_view`, {
+				product_slug: site?.plan?.product_slug,
+			} )
+		);
 	}, [] );
 
 	function renderUpsellContent() {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/75506

### Time Estimate
• Review: Short
• Test: Short

### Proposed Changes
This PR adds a tracks event when the celebrate launch modal is displayed. Added a new event: `calypso_launchpad_celebration_modal_view`

### Testing
1. Checkout this branch
2. Make sure you have [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) setup
2. Go through a Launchpad flow and launch your site
3. Once you get redirected to My Home, you should see the Celebrate Launch modal appear
4. Confirm you see the following event in Tracks Vigilante with the `product_slug` set accordingly depending on the site's plan:
![image](https://user-images.githubusercontent.com/20927667/231004195-eadfbfd3-4a95-4083-9cec-fc46399adc1f.png)

