### PR TITLE
require email for Akismet purchases

### DIFF
--- a/client/my-sites/checkout/composite-checkout/lib/get-contact-details-type.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-contact-details-type.ts
@@ -1,4 +1,5 @@
 import {
+	isAkismetProduct,
 	isGoogleWorkspaceExtraLicence,
 	isGoogleWorkspaceProductSlug,
 	isGSuiteProductSlug,
@@ -39,8 +40,12 @@ export default function getContactDetailsType( responseCart: ResponseCart ): Con
 
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
 	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
+	const isAkismetPurchase = responseCart.products.some( ( product ) => {
+		return isAkismetProduct( product );
+	} );
 
-	if ( isPurchaseFree && ! isFullCredits ) {
+	// Akismet free purchases still need contact information if logged out
+	if ( isPurchaseFree && ! isAkismetPurchase && ! isFullCredits ) {
 		return 'none';
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Requires contact information for Akismet free purchases so an account can be created for logged-out purchases. Without this, the purchase does not work and cannot be managed in the future.

## Testing Instructions

* Apply this patch to your local Calypso environment
* While logged out, navigate to http://calypso.localhost:3000/checkout/akismet/ak_free_yearly
* Confirm that you must enter basic billing info before completing the purchase

![Screenshot 2023-04-10 at 5 54 51 PM](https://user-images.githubusercontent.com/18016357/231006390-1dee6db6-bf44-452f-a6bd-9dd133bf3a30.png)

* You should receive a receipt and a new account creation email after completing the purchase
* Confirm that you can log into the new account and see the purchase

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
