### PR TITLE
Pattern Assembler: Replace `calypso/lib/use-in-view` with `react-intersection-observer`

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -1,8 +1,8 @@
 import { PatternRenderer } from '@automattic/block-renderer';
 import { Button } from '@automattic/components';
 import classnames from 'classnames';
-import { useEffect, useState } from 'react';
-import { useInView } from 'calypso/lib/use-in-view';
+import { useEffect, useCallback, useRef } from 'react';
+import { useInView } from 'react-intersection-observer';
 import EmptyPattern from './empty-pattern';
 import { encodePatternId } from './utils';
 import type { Pattern } from './types';
@@ -35,10 +35,20 @@ const PatternListItem = ( {
 	isShown,
 	onSelect,
 }: PatternListItemProps ) => {
-	const [ inViewOnce, setInViewOnce ] = useState( false );
-	const ref = useInView< HTMLButtonElement >( () => setInViewOnce( true ), {
-		threshold: [ 0 ],
+	const ref = useRef< HTMLButtonElement >();
+	const { ref: inViewRef, inView: inViewOnce } = useInView( {
+		triggerOnce: true,
 	} );
+
+	const setRefs = useCallback(
+		( node?: Element | null | undefined ) => {
+			if ( node ) {
+				ref.current;
+			}
+			inViewRef( node );
+		},
+		[ inViewRef ]
+	);
 
 	useEffect( () => {
 		if ( isShown && inViewOnce && isFirst && ref.current ) {
@@ -50,7 +60,7 @@ const PatternListItem = ( {
 		<Button
 			className={ className }
 			title={ pattern.title }
-			ref={ ref }
+			ref={ setRefs }
 			onClick={ () => onSelect( pattern ) }
 		>
 			{ isShown && inViewOnce ? (


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/issues/74022
Previously https://github.com/Automattic/wp-calypso/pull/75365

## Proposed Changes

Switches to `react-intersection-observer` in the Pattern Assembler because `calypso/lib/use-in-view` is buggy and it doesn't make sense to spend time reinventing the wheel.

## Testing Instructions

- Click on the Calypso Live link in the first comment.
- Create a new site and `Continue` until landing on the Design Picker.
- Go to the site assembler by clicking `Start designing` from the bottom.
- Click `Sections`, then `Add patterns` and explore patterns by clicking on the categories and scrolling the list of pattens
- Verify that patterns load properly when you scroll the list