### PR TITLE
Fix: iOS App link for the jetpack app

### DIFF
--- a/client/blocks/get-apps/apps-badge.jsx
+++ b/client/blocks/get-apps/apps-badge.jsx
@@ -18,7 +18,7 @@ const APP_STORE_BADGE_URLS = {
 		src: 'https://linkmaker.itunes.apple.com/assets/shared/badges/{localeSlug}/appstore-lrg.svg',
 		tracksEvent: 'calypso_app_download_ios_click',
 		getStoreLink: ( utm_source ) => {
-			return `https://apps.apple.com/app/apple-store/id$1565481562?pt=299112&ct=${ utm_source }&mt=8`;
+			return `https://apps.apple.com/app/apple-store/id1565481562?pt=299112&ct=${ utm_source }&mt=8`;
 		},
 		getTitleText: () => translate( 'Download the Jetpack iOS mobile app.' ),
 		getAltText: () => translate( 'Apple App Store download badge' ),


### PR DESCRIPTION
Related to #

## Proposed Changes

* This PR fixes the link to the jetpack app from calypso.

## Testing Instructions
1. Navigate to the dashboard using a /home/example.com with a iOS user agent.
2. Notice the link that appears in the carousel take you to the correct place in the dashboard.

<img width="1694" alt="Screenshot 2023-04-10 at 4 53 16 PM" src="https://user-images.githubusercontent.com/115071/231020905-ddddcf6b-31f2-475c-b6ae-33b8d2d29219.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
