### PR TITLE
Fix encoding issue in from site

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -18,7 +18,7 @@ export function getFinalImporterUrl(
 	framework: 'signup' | 'stepper' = 'signup'
 ) {
 	let importerUrl;
-
+	const encodedFromSite = encodeURIComponent( fromSite );
 	// Escape WordPress, has two sub-flows "Import everything" and "Content only"
 	// firstly show import type chooser screen and then decide about importer url
 	if ( isAtomicSite && platform !== 'wordpress' ) {
@@ -30,7 +30,7 @@ export function getFinalImporterUrl(
 			);
 		} )
 	) {
-		importerUrl = getWpComOnboardingUrl( targetSlug, platform, fromSite, framework );
+		importerUrl = getWpComOnboardingUrl( targetSlug, platform, encodedFromSite, framework );
 
 		if ( platform === 'wordpress' && ! fromSite && isAtomicSite ) {
 			importerUrl = getWpOrgImporterUrl( targetSlug, platform );
@@ -40,7 +40,7 @@ export function getFinalImporterUrl(
 			} );
 		}
 	} else {
-		importerUrl = getImporterUrl( targetSlug, platform, fromSite );
+		importerUrl = getImporterUrl( targetSlug, platform, encodedFromSite );
 	}
 
 	return importerUrl;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75522 

## Proposed Changes

* In this PR, we encoded the `from` site query string before sending it down to the `generatePath` function so it won't get confused later

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a JN site, connect to your WordPress.com with user approval. 
* Navigate to `http://calypso.localhost:3000/setup/import-focused/import?siteSlug=${site_slug}`.
* Fill in the site address and go through the flow.
* If you link your JN site correctly it should allow you to click on the import everything continue button
* Open your inspector and make sure there's no error like `Uncaught (in promise) BadRequestError: Site url is not valid.` when you land on the content chooser screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
