### PR TITLE
@automattic/calypso-e2e: Add `RestAPIClient.getRenderedPatterns` method

### DIFF
--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-e2e",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Tools for e2e tests.",
 	"main": "dist/esm/src/index.js",
 	"types": "dist/types/src/index.d.ts",

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -10,6 +10,7 @@ import {
 	AllDomainsResponse,
 	DomainData,
 } from './types';
+import { RenderedPatternResponse } from './types/rest-api-client.types';
 import type { Roles } from './lib';
 import type {
 	AccountDetails,
@@ -1089,5 +1090,39 @@ export class RestAPIClient {
 		const widgets = await this.getAllWidgets( siteID );
 
 		widgets.map( async ( widget ) => await this.deleteWidget( siteID, widget.id ) );
+	}
+
+	/**
+	 * Gets the rendered patterns.
+	 *
+	 * @returns {Promise<RenderedPatternResponse>} An Array of posts.
+	 * @throws {Error} If API responded with an error.
+	 */
+	async getRenderedPatterns(
+		siteID: number,
+		urlParams?: { title?: string }
+	): Promise< ReaderResponse > {
+		const params: RequestParams = {
+			method: 'get',
+			headers: {
+				Authorization: await this.getAuthorizationHeader( 'bearer' ),
+				'Content-Type': this.getContentTypeHeader( 'json' ),
+			},
+		};
+		const urlParamsStr = urlParams ? `?${ new URLSearchParams( urlParams ) }` : '';
+		const url = this.getRequestURL(
+			'2',
+			`/sites/${ siteID }/block-renderer/patterns/render${ urlParamsStr }`,
+			'wpcom'
+		);
+		const response = await this.sendRequest( url, params );
+
+		if ( response.hasOwnProperty( 'error' ) ) {
+			throw new Error(
+				`${ ( response as ErrorResponse ).error }: ${ ( response as ErrorResponse ).message }`
+			);
+		}
+
+		return response;
 	}
 }

--- a/packages/calypso-e2e/src/test/rest-api-client.getRenderedPatterns.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.getRenderedPatterns.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test, jest } from '@jest/globals';
+import nock from 'nock';
+import { RestAPIClient, BEARER_TOKEN_URL } from '../rest-api-client';
+import { SecretsManager } from '../secrets';
+import type { Secrets } from '../secrets';
+
+const fakeSecrets = {
+	calypsoOauthApplication: {
+		client_id: 'some_value',
+		client_secret: 'some_value',
+	},
+	testAccounts: {
+		basicUser: {
+			username: 'wpcomuser2',
+			password: 'hunter2',
+			primarySite: 'wpcomuser.wordpress.com/',
+		},
+		noUrlUser: {
+			username: 'nourluser',
+			password: 'password1234',
+		},
+	},
+} as unknown as Secrets;
+
+jest.spyOn( SecretsManager, 'secrets', 'get' ).mockImplementation( () => fakeSecrets );
+
+// Persist and intercept all bearer token calls in these tests.
+nock( BEARER_TOKEN_URL )
+	.persist()
+	.post( /.*/ )
+	.reply( 200, {
+		success: true,
+		data: {
+			bearer_token: 'abcdefghijklmn',
+			token_links: [ 'link_1', 'link_2' ],
+		},
+	} );
+
+describe( 'RestAPIClient: getRenderedPatterns', function () {
+	const restAPIClient = new RestAPIClient( {
+		username: 'fake_user',
+		password: 'fake_password',
+	} );
+	const siteID = 2789;
+	const requestURL = restAPIClient.getRequestURL(
+		'2',
+		`/sites/${ siteID }/block-renderer/patterns/render`,
+		'wpcom'
+	);
+
+	test( 'should make a request', async function () {
+		const expected = {
+			12345: {
+				ID: 'ID',
+				html: 'html',
+				styles: [
+					{
+						css: 'css',
+						isGlobalStyles: false,
+					},
+				],
+			},
+		};
+		nock( requestURL.origin ).get( requestURL.pathname ).reply( 200, expected );
+		const response = await restAPIClient.getRenderedPatterns( siteID );
+		expect( response ).toEqual( expected );
+	} );
+} );

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -186,6 +186,17 @@ export interface PluginRemovalResponse {
 	log: string[];
 }
 
+export interface RenderedPatternResponse {
+	[ key: string ]: {
+		ID: string;
+		html: string;
+		styles: {
+			css: string;
+			isGlobalStyles: boolean;
+		}[];
+	};
+}
+
 /* Error Responses */
 
 export interface BearerTokenErrorResponse {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72408

## Proposed Changes

* Add `RestAPIClient.getRenderedPatterns` method to add e2e tests for the endpoint `/block-renderer/patterns/render`.
* We want to add simple tests to ensure the endpoint returns correct data. Please refer to this post pbxlJb-3Iv-p2 and the comment pbxlJb-3Iv-p2#comment-2489.

After this PR, I'm going to add e2e tests like below;

```.ts
    // pseudo code
	describe( 'GET `/block-renderer/patterns/render` should response HTML and styles', function () {
		await const res = restAPIClient.getRenderedPatterns()
		expect( res.status ).toBe( 200 );
		expect( res.body.html ).not.empty( 'html' );
		expect( res.body.styles ).not.empty( 'styles' );
	} );
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `NODE_ENV=test yarn test-packages packages/calypso-e2e`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?