### PR TITLE
@automattic/calypso-e2e: Add `SiteAssemblerFlow`

### DIFF
--- a/packages/calypso-e2e/package.json
+++ b/packages/calypso-e2e/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-e2e",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Tools for e2e tests.",
 	"main": "dist/esm/src/index.js",
 	"types": "dist/types/src/index.d.ts",

--- a/packages/calypso-e2e/src/lib/flows/index.ts
+++ b/packages/calypso-e2e/src/lib/flows/index.ts
@@ -1,5 +1,6 @@
 export * from './new-post-flow';
 export * from './close-account-flow';
+export * from './site-assembler-flow';
 export * from './start-import-flow';
 export * from './start-site-flow';
 export * from './change-ui-language-flow';

--- a/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
@@ -1,0 +1,49 @@
+import { Page } from 'playwright';
+
+const selectors = {
+	button: ( text: string ) => `button:text("${ text }")`,
+	blockRenderer: '.block-renderer',
+};
+
+/**
+ * Class encapsulating the Site Assembler flow
+ */
+export class SiteAssemblerFlow {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the flow.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Given text, clicks on the first instance of the button with the text.
+	 *
+	 * @param {string} text User-visible text on the button.
+	 */
+	async clickButton( text: string ): Promise< void > {
+		await this.page.click( selectors.button( text ) );
+	}
+
+	/**
+	 * Select Header
+	 */
+	async selectHeader(): Promise< void > {
+		await this.page.getByText( 'Header' ).click();
+		const header = this.page.locator( selectors.blockRenderer ).nth( 0 );
+		await header.click();
+	}
+
+	/**
+	 * Select Footer
+	 */
+	async selectFooter(): Promise< void > {
+		await this.page.getByText( 'Footer' ).click();
+		const footer = this.page.locator( selectors.blockRenderer ).nth( 0 );
+		await footer.click();
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72408

## Proposed Changes

* Add the new `SiteAssemblerFlow` class for the [Site Assembler](pekYwv-gV-p2)'s e2e test.
* It'd be good to have general e2e tests for the Site Assembler Flow. pbxlJb-3Iv-p2#comment-2490
* After this PR, I'm going to add e2e tests that go through the basic flow (Land on the Site Assembler, select Header and Footer, and land on the Site Editor).

<!--
In addition to the endpoint tests https://github.com/Automattic/wp-calypso/pull/75524, 
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensured it was working locally.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?