### PR TITLE
Site Assembler: Fix wrong pattern_category in track events

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -193,7 +193,7 @@ const PatternAssembler = ( {
 			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_FINAL_SELECT, {
 				pattern_id: ID,
 				pattern_name: name,
-				pattern_category: category?.slug,
+				pattern_category: category?.name,
 			} );
 		} );
 	};
@@ -314,16 +314,16 @@ const PatternAssembler = ( {
 		if ( selectedPattern ) {
 			// Inject the selected pattern category or the first category
 			// because it's used in tracks and as pattern name in the list
-			const [ firstCategory ] = Object.values( selectedPattern.categories );
+			const [ firstCategory ] = Object.keys( selectedPattern.categories );
 			selectedPattern.category = categories.find(
-				( { name } ) => name === ( selectedCategory || firstCategory?.slug )
+				( { name } ) => name === ( selectedCategory || firstCategory )
 			);
 
 			trackEventPatternSelect( {
 				patternType: type,
 				patternId: selectedPattern.ID,
 				patternName: selectedPattern.name,
-				patternCategory: selectedPattern.category?.slug,
+				patternCategory: selectedPattern.category?.name,
 			} );
 
 			if ( 'section' === type ) {
@@ -397,7 +397,7 @@ const PatternAssembler = ( {
 			pattern_type: type,
 			pattern_ids: patterns.map( ( { ID } ) => ID ).join( ',' ),
 			pattern_names: patterns.map( ( { name } ) => name ).join( ',' ),
-			pattern_categories: patterns.map( ( { category } ) => category?.slug ).join( ',' ),
+			pattern_categories: patterns.map( ( { category } ) => category?.name ).join( ',' ),
 		} );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1681200629471349-slack-CRWCHQGUB, https://github.com/Automattic/wp-calypso/pull/75320

## Proposed Changes

Since we're pulling categories and patterns from our endpoints, there are some structural changes on both `categories` and `pattern.categories`.

Here are the screenshots of the categories

| categories | pattern.categories |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/231108982-d3bb3d5b-f96c-4144-bf5e-79a036462a01.png) | ![image](https://user-images.githubusercontent.com/13596067/231108903-2185e09e-ec13-4183-a72a-985c4cc4f224.png) |

We have to use the unique slug for the category (without translation), so I made changes to use the `name` from `categories` and the `key` of `pattern.categories`

Here are the screenshots of the events

| calypso_signup_pattern_assembler_pattern_select_click | calypso_signup_pattern_assembler_pattern_select_done_click | calypso_signup_pattern_assembler_pattern_final_select | calypso_signup_pattern_assembler_continue_click |
| - | - | - | - |
| ![image](https://user-images.githubusercontent.com/13596067/231109334-5812f450-704c-485b-bcc1-62949a478488.png) | ![image](https://user-images.githubusercontent.com/13596067/231109396-590058c7-0c1c-4125-899e-21c476a1a0f4.png) | ![image](https://user-images.githubusercontent.com/13596067/231109931-36bd9950-d178-4ca2-987c-d4f426afed12.png) | ![image](https://user-images.githubusercontent.com/13596067/231109762-f3c30fcc-a600-414a-9905-194edaafde59.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_site>
  * Note that the site should be the site with a free plan
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll to the bottom and select "Start designing"
* On the Pattern Assembler screen
  * Select any patterns and ensure the `calypso_signup_pattern_assembler_pattern_select_click ` event is fired with the correct `pattern_category`
  * Click `Save` and ensure the `calypso_signup_pattern_assembler_pattern_select_done_click ` event is fired with the correct `pattern_categories`
  * Continue to the site editor, and ensure
    * the `calypso_signup_pattern_assembler_pattern_final_select` event is fired with the correct `pattern_category`
    * the `calypso_signup_pattern_assembler_continue_click` event is fired with the correct `pattern_categories`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?