### PR TITLE
2023 feature comparison: restore included domain indication in business plan

### DIFF
--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1278,7 +1278,6 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_SEO_JP,
 	],
 	get2023PlanComparisonConditionalFeatures: () => [
-		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_SELL_SHIP,
 		FEATURE_CUSTOM_STORE,
 		FEATURE_INVENTORY,


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2126

## Proposed Changes

| Before | After |
| ------  | ----- |
| ![image](https://user-images.githubusercontent.com/26530524/231115831-c565040b-af4f-44a0-8597-9cb3f00d9475.png) | ![image](https://user-images.githubusercontent.com/26530524/231115879-36ce43a9-43da-47ae-9f4e-a54d6974d252.png) |

## Testing Instructions

1. Open the plans page in some onboarding flow
2. Open the plan feature comparison grid
3. Verify that the checkmark for the "Free domain for one year" row shows up for the Business plan
