### PR TITLE
Plans: Removes custom domain from conditional features

### DIFF
--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1278,7 +1278,6 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_SEO_JP,
 	],
 	get2023PlanComparisonConditionalFeatures: () => [
-		FEATURE_CUSTOM_DOMAIN,
 		FEATURE_SELL_SHIP,
 		FEATURE_CUSTOM_STORE,
 		FEATURE_INVENTORY,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2126#issuecomment-1502147181

## Proposed Changes

* Removes the `FEATURE_CUSTOM_DOMAIN` feature from the `get2023PlanComparisonConditionalFeatures` array of the Business plan. This was mistakenly added via https://github.com/Automattic/wp-calypso/pull/74875/files#diff-8f9fb14a44111dd55e67d9462573bf9233849ac1d9a77bf65b56e1f6ce22d384R501 and caused the check icon for the free domain feature to be hidden in the comparison grid:
<img width="1686" alt="image" src="https://user-images.githubusercontent.com/5436027/231115760-958d796d-90ba-4387-9485-e20f89ac25ad.png">

* After the fix:
<img width="1763" alt="image" src="https://user-images.githubusercontent.com/5436027/231115942-21361cd2-603f-45f0-80b2-580683f0e65a.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start` and choose any domain.
* On the plans step, open the plan comparison grid.
* Confirm that the check icon is present for the Business plan for the "Free domain for one year" feature.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
