### PR TITLE
Site Assembler: Fix the category of the selected pattern after checkout might be wrong

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-recipe.ts
@@ -89,8 +89,8 @@ const useRecipe = ( siteId = 0, patterns: Pattern[], categories: Category[] ) =>
 				.map( ( patternId: string | number ) => patternsById[ decodePatternId( patternId ) ] )
 				.filter( Boolean )
 				.map( ( pattern: Pattern ) => {
-					const [ firstCategory ] = Object.values( pattern.categories ) as Category[];
-					const category = firstCategory?.slug ? categoriesByName[ firstCategory.slug ] : undefined;
+					const [ firstCategory ] = Object.keys( pattern.categories );
+					const category = categoriesByName[ firstCategory ];
 					return {
 						...pattern,
 						key: generateKey( pattern ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/75533

## Proposed Changes

* Continue on https://github.com/Automattic/wp-calypso/pull/75533 since I forgot to push the latest change before merging... we might not be able to resolve the selected category due to the translation.

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/231119642-6d6a57ae-87ac-4124-827b-926a327a2c61.png) | ![image](https://user-images.githubusercontent.com/13596067/231119702-39ff09bc-fbde-4e8a-8ab6-5c581115ee0a.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch the language of your account to non-English, e.g. `es`
* Go to /setup?siteSlug=<your_free_site>
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll to the bottom and select "Start designing"
* On the Pattern Assembler screen
  * Select `Sections > Add patterns > Imágenes`
  * Select any color or font
  * Click `Continue`
  * Select `Upgrade plan`
  * Click browser back
  * Select `Sections` again and ensure the category of the pattern displays correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
