### PR TITLE
LeanDomainSearch: customize domain step

### DIFF
--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -38,18 +38,19 @@ class SiteOrDomain extends Component {
 
 	isLeanDomainSearch() {
 		const { signupDependencies } = this.props;
-		return (
-			'leandomainsearch' === signupDependencies?.refParameter
-		);
+		return 'leandomainsearch' === signupDependencies?.refParameter;
 	}
 
 	getChoices() {
 		const { translate, isReskinned, isLoggedIn, siteCount } = this.props;
 
 		const domainName = this.getDomainName();
-		const buyADomainTitle = this.isLeanDomainSearch()
-			? translate( 'Just buy %s', { args: [ domainName ] } )
-			: translate( 'Just buy a domain' );
+		let buyADomainTitle = translate( 'Just buy a domain' );
+
+		if ( this.isLeanDomainSearch() && domainName ) {
+			// translators: %s is a domain name
+			buyADomainTitle = translate( 'Just buy %s', { args: [ domainName ] } );
+		}
 
 		const choices = [];
 
@@ -228,8 +229,9 @@ class SiteOrDomain extends Component {
 
 	render() {
 		const { translate, productsLoaded, isReskinned } = this.props;
+		const domainName = this.getDomainName();
 
-		if ( productsLoaded && ! this.getDomainName() ) {
+		if ( productsLoaded && ! domainName ) {
 			const headerText = translate( 'Unsupported domain.' );
 			const subHeaderText = translate(
 				'Please visit {{a}}wordpress.com/domains{{/a}} to search for a domain.',
@@ -262,7 +264,10 @@ class SiteOrDomain extends Component {
 
 		if ( this.isLeanDomainSearch() ) {
 			additionalProps.className = 'lean-domain-search';
-			headerText = translate( 'Choose how to use %s', { args: [ this.getDomainName() ] } );
+			if ( domainName ) {
+				// translators: %s is a domain name
+				headerText = translate( 'Choose how to use %s', { args: [ domainName ] } );
+			}
 		}
 
 		return (

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -39,9 +39,7 @@ class SiteOrDomain extends Component {
 	isLeanDomainSearch() {
 		const { signupDependencies } = this.props;
 		return (
-			!! signupDependencies &&
-			!! signupDependencies.refParameter &&
-			'leandomainsearch' === signupDependencies.refParameter
+			'leandomainsearch' === signupDependencies?.refParameter
 		);
 	}
 

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -36,15 +36,29 @@ class SiteOrDomain extends Component {
 		return isValidDomain && domain;
 	}
 
+	isLeanDomainSearch() {
+		const { signupDependencies } = this.props;
+		return (
+			!! signupDependencies &&
+			!! signupDependencies.refParameter &&
+			'leandomainsearch' === signupDependencies.refParameter
+		);
+	}
+
 	getChoices() {
 		const { translate, isReskinned, isLoggedIn, siteCount } = this.props;
+
+		const domainName = this.getDomainName();
+		const buyADomainTitle = this.isLeanDomainSearch()
+			? translate( 'Just buy %s', { args: [ domainName ] } )
+			: translate( 'Just buy a domain' );
 
 		const choices = [];
 
 		if ( isReskinned ) {
 			choices.push( {
 				key: 'domain',
-				title: translate( 'Just buy a domain' ),
+				title: buyADomainTitle,
 				description: translate( 'Show a "coming soon" notice on your domain. Add a site later.' ),
 				icon: globe,
 				value: 'domain',
@@ -105,7 +119,7 @@ class SiteOrDomain extends Component {
 			}
 			choices.push( {
 				type: 'domain',
-				label: translate( 'Just buy a domain' ),
+				label: buyADomainTitle,
 				image: <DomainImage />,
 				description: translate( 'Show a "coming soon" notice on your domain. Add a site later.' ),
 			} );
@@ -240,6 +254,7 @@ class SiteOrDomain extends Component {
 		}
 
 		const additionalProps = {};
+		let headerText = this.props.headerText;
 
 		if ( isReskinned ) {
 			additionalProps.isHorizontalLayout = true;
@@ -247,14 +262,19 @@ class SiteOrDomain extends Component {
 			additionalProps.headerImageUrl = HeaderImage;
 		}
 
+		if ( this.isLeanDomainSearch() ) {
+			additionalProps.className = 'lean-domain-search';
+			headerText = translate( 'Choose how to use %s', { args: [ this.getDomainName() ] } );
+		}
+
 		return (
 			<StepWrapper
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				positionInFlow={ this.props.positionInFlow }
-				headerText={ this.props.headerText }
+				headerText={ headerText }
 				subHeaderText={ this.props.subHeaderText }
-				fallbackHeaderText={ this.props.headerText }
+				fallbackHeaderText={ headerText }
 				fallbackSubHeaderText={ this.props.subHeaderText }
 				stepContent={ this.renderScreen() }
 				{ ...additionalProps }

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -116,3 +116,34 @@ body.is-white-signup {
 		}
 	}
 }
+
+.signup .lean-domain-search {
+
+	.step-wrapper__header {
+		max-width: 50%;
+	}
+
+	.step-wrapper__content {
+		max-width: 50%;
+	}
+
+	.formatted-header__title {
+		max-width: 100%;
+		word-wrap: break-word;
+	}
+
+	.select-items__item-title {
+		max-width: 300px;
+		text-overflow: ellipsis;
+		overflow: hidden;
+	}
+
+	@media (max-width: 600px) {
+		.step-wrapper__header {
+			max-width: 100%;
+		}
+		.step-wrapper__content {
+			max-width: 100%;
+		}
+	}
+}


### PR DESCRIPTION
Related to #

## Proposed Changes

This PR adds customizations to the domain step, displaying the selected domain, for LeanDomainSearch landing.
* 1663-gh-Automattic/greenhouse

## Testing Instructions
* Apply PR
* `yarn start`
* Go to `/start/domain/domain-only?ref=leandomainsearch&new=PierreSiteRandom.com`
* ✅ You should see the domain in the domain step
