### PR TITLE
Subscriptions Management: Fix the Comments view display

### DIFF
--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -12,6 +12,7 @@ type CommentRowProps = PostSubscription & {
 const CommentRow = ( {
 	title,
 	excerpt,
+	url,
 	site_title,
 	site_icon,
 	site_url,
@@ -30,7 +31,11 @@ const CommentRow = ( {
 		<div style={ style } ref={ forwardedRef } className="row-wrapper">
 			<div className="row" role="row">
 				<span className="post" role="cell">
-					<div className="title">{ title }</div>
+					<div className="title">
+						<a href={ url } target="_blank" rel="noreferrer noopener">
+							{ title }
+						</a>
+					</div>
 					<div className="excerpt">{ excerpt }</div>
 				</span>
 				<a href={ site_url } rel="noreferrer noopener" className="title-box" target="_blank">

--- a/client/landing/subscriptions/components/comment-list/styles.scss
+++ b/client/landing/subscriptions/components/comment-list/styles.scss
@@ -34,8 +34,7 @@ $max-list-width: 1300px;
 		}
 
 		.post {
-			max-width: 403px;
-			min-width: 350px;
+			flex: 0 0 403px;
 			font-size: $font-body-small;
 			line-height: 20px;
 
@@ -60,7 +59,12 @@ $max-list-width: 1300px;
 
 		@media (max-width: $break-small) {
 			.post {
+				flex: 1 1 302px;
 				min-width: 0;
+
+				.excerpt {
+					max-width: 302px;
+				}
 			}
 		}
 

--- a/client/landing/subscriptions/components/comment-list/styles.scss
+++ b/client/landing/subscriptions/components/comment-list/styles.scss
@@ -53,6 +53,7 @@ $max-list-width: 1300px;
 				max-width: 350px;
 				font-weight: 400;
 				color: $studio-gray-60;
+				margin-top: 4px;
 				@extend %ellipsis;
 			}
 		}

--- a/client/landing/subscriptions/components/comment-list/styles.scss
+++ b/client/landing/subscriptions/components/comment-list/styles.scss
@@ -39,9 +39,14 @@ $max-list-width: 1300px;
 			font-size: $font-body-small;
 			line-height: 20px;
 
-			.title {
+			.title a {
 				font-weight: 500;
+				color: $studio-gray-100;
 				@extend %ellipsis;
+
+				&:hover {
+					text-decoration: underline;
+				}
 			}
 
 			.excerpt {

--- a/client/landing/subscriptions/components/comment-list/styles.scss
+++ b/client/landing/subscriptions/components/comment-list/styles.scss
@@ -12,6 +12,7 @@ $max-list-width: 1300px;
 
 .subscription-manager__comment-list {
 	max-width: $max-list-width;
+	min-width: 300px;
 
 	.row-wrapper {
 		border-bottom: 1px solid var(--color-border-subtle);
@@ -23,6 +24,7 @@ $max-list-width: 1300px;
 		flex-direction: row;
 		margin-top: 20px;
 		margin-bottom: 20px;
+		justify-content: space-between;
 
 		* {
 			flex: 1;
@@ -38,13 +40,16 @@ $max-list-width: 1300px;
 			font-size: $font-body-small;
 			line-height: 20px;
 
-			.title a {
-				font-weight: 500;
-				color: $studio-gray-100;
+			.title {
 				@extend %ellipsis;
 
-				&:hover {
-					text-decoration: underline;
+				a {
+					font-weight: 500;
+					color: $studio-gray-100;
+
+					&:hover {
+						text-decoration: underline;
+					}
 				}
 			}
 
@@ -59,12 +64,8 @@ $max-list-width: 1300px;
 
 		@media (max-width: $break-small) {
 			.post {
-				flex: 1 1 302px;
-				min-width: 0;
-
-				.excerpt {
-					max-width: 302px;
-				}
+				flex: 1 1;
+				max-width: calc(100% - 54px);
 			}
 		}
 

--- a/client/landing/subscriptions/components/tab-views/comments/comments.tsx
+++ b/client/landing/subscriptions/components/tab-views/comments/comments.tsx
@@ -8,6 +8,7 @@ const posts: PostSubscription[] = [
 		title: 'Alone at the Edge of the World',
 		excerpt:
 			'Susie Goodall wanted to circumnavigate the globe in a sailboat. She did it, but not without a few hiccups along the way.',
+		url: 'https://testsite2022.wordpress.com/2021/03/29/alone-at-the-edge-of-the-world/',
 		site_title: 'Test Site 2022',
 		site_icon: 'https://www.gravatar.com/avatar/',
 		site_url: 'https://testsite2022.wordpress.com',
@@ -18,6 +19,7 @@ const posts: PostSubscription[] = [
 		title: '50 Years Ago, Stevie Wonder Heard the Future',
 		excerpt:
 			'On the anniversary of the landmark 1972 album “Talking Book,” the singer-songwriter reflects on the making of his masterpiece.',
+		url: 'https://testsite2023.wordpress.com/2021/03/29/50-years-ago-stevie-wonder-heard-the-future/',
 		site_icon: 'https://www.gravatar.com/avatar/',
 		site_title: 'April Site',
 		site_url: 'https://testsite2023.wordpress.com',

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -66,6 +66,7 @@ export type PostSubscription = {
 	id: string;
 	title: string;
 	excerpt: string;
+	url: string;
 	site_title: string;
 	site_icon: string;
 	site_url: string;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/75561.

## Proposed Changes

* add link to the Post title that opens in a new tab
* fix width of the "Subscribed post" column and space between the Post title and Post Excerpt (context: https://github.com/Automattic/wp-calypso/pull/75376#issuecomment-1502972488)

![Markup on 2023-04-11 at 14:00:05](https://user-images.githubusercontent.com/25105483/231188836-e5fa639a-0eb6-4b32-98d0-daaa7f331d42.png)

## Testing Instructions

1. Check out and build the PR locally.
2. Apply the correct `subkey` value to your `calypso.localhost:3000` host.
3. Make sure the related user has existing comment subscriptions.
4. Navigate to http://calypso.localhost:3000/subscriptions/comments and review the page.
  - The design should match Figma: inDLaEQV8jJ21O4WXawIsJ-fi-712-25346
    -  the distance between Post title and Post excerpt should be 4 px
    - the width of the "Subscribed post" column should be 403 px on desktop and 302 px on mobile
  - Post title should be clickable, open in a new tab and underline on hover.
5. Please review the Comments list on mobile generally as well. It should render correctly and match the mobile design in Figma as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
