### PR TITLE
VideoPress: restore progress bar style

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -81,8 +81,11 @@
 	.processing-step__content {
 		background-color: #fff3;
 		border-radius: 4px;
-		.loading-bar::before {
-			background-color: #ffe61c;
+		.loading-bar {
+			background-color: #fff3;
+			&::before {
+				background-color: #ffe61c;
+			}
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/style.scss
@@ -34,28 +34,6 @@
 	width: 100%;
 }
 
-.is-videopress-stepper.is-processing-step {
-	padding: 0;
-	color: #fff;
-
-	.processing-step__progress-bar {
-		background-color: #fff3;
-		border-radius: 4px;
-		&::before {
-			background-color: #ffe61c;
-		}
-	}
-
-	@include break-medium {
-		background-size: auto 50%, auto 50%;
-	}
-
-	@include break-large {
-		background-position-y: 50%, 100%;
-		background-position-x: 0, 100%;
-	}
-}
-
 .processing-step__subtitle {
 	font-size: 1rem;
 	line-height: 21px;
@@ -94,4 +72,26 @@
 		}
 	}
 
+}
+
+.is-videopress-stepper.is-processing-step {
+	padding: 0;
+	color: #fff;
+
+	.processing-step__content {
+		background-color: #fff3;
+		border-radius: 4px;
+		.loading-bar::before {
+			background-color: #ffe61c;
+		}
+	}
+
+	@include break-medium {
+		background-size: auto 50%, auto 50%;
+	}
+
+	@include break-large {
+		background-position-y: 50%, 100%;
+		background-position-x: 0, 100%;
+	}
 }


### PR DESCRIPTION
Related to 1662-gh-Automattic/greenhouse

## Proposed Changes

*

## Testing Instructions

* Apply PR
* Go to `client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx` and update `const progress = 0.5;`
* `yarn start`
* Go to `http://calypso.localhost:3000/setup/videopress/processing`
* ✅ Should look like this
![Capture d’écran 2023-04-11 à 12 10 44](https://user-images.githubusercontent.com/1420594/231129520-b6079cc9-4242-427b-8ef4-390ff46df132.png)

