### PR TITLE
Hosting onboarding: enable money back guarantee copy below CTA at checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -18,6 +18,7 @@ import {
 	CheckoutFormSubmit,
 	PaymentMethodStep,
 } from '@automattic/composite-checkout';
+import { HOSTING_LP_FLOW } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled } from '@automattic/wpcom-checkout';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -41,6 +42,7 @@ import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/composite-checkou
 import { leaveCheckout } from 'calypso/my-sites/checkout/composite-checkout/lib/leave-checkout';
 import { prepareDomainContactValidationRequest } from 'calypso/my-sites/checkout/composite-checkout/types/wpcom-store-state';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { saveContactDetailsCache } from 'calypso/state/domains/management/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
@@ -618,7 +620,9 @@ const SubmitButtonFooter = () => {
 		isJetpackPurchasableItem( product.product_slug )
 	);
 
-	if ( ! hasCartJetpackProductsOnly ) {
+	const signupFlowName = getSignupCompleteFlowName();
+
+	if ( ! hasCartJetpackProductsOnly && HOSTING_LP_FLOW !== signupFlowName ) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -18,7 +18,7 @@ import {
 	CheckoutFormSubmit,
 	PaymentMethodStep,
 } from '@automattic/composite-checkout';
-import { HOSTING_LP_FLOW } from '@automattic/onboarding';
+import { isHostingFlow } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled } from '@automattic/wpcom-checkout';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -622,7 +622,7 @@ const SubmitButtonFooter = () => {
 
 	const signupFlowName = getSignupCompleteFlowName();
 
-	if ( ! hasCartJetpackProductsOnly && HOSTING_LP_FLOW !== signupFlowName ) {
+	if ( ! hasCartJetpackProductsOnly && ! isHostingFlow( signupFlowName ) ) {
 		return null;
 	}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,4 +1,4 @@
-import { VIDEOPRESS_FLOW, isWithThemeFlow, HOSTING_LP_FLOW } from '@automattic/onboarding';
+import { VIDEOPRESS_FLOW, isWithThemeFlow, isHostingFlow } from '@automattic/onboarding';
 import { isTailoredSignupFlow } from '@automattic/onboarding/src';
 import { localize } from 'i18n-calypso';
 import { defer, get, isEmpty } from 'lodash';
@@ -653,7 +653,7 @@ class DomainsStep extends Component {
 			);
 		}
 
-		if ( HOSTING_LP_FLOW === flowName ) {
+		if ( isHostingFlow( flowName ) ) {
 			const components = {
 				span: (
 					<button

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -62,6 +62,10 @@ export const isTailoredSignupFlow = ( flowName: string | null ) => {
 	);
 };
 
+export const isHostingFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && HOSTING_LP_FLOW === flowName );
+};
+
 export const isMigrationFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ MIGRATION_FLOW ].includes( flowName ) );
 };


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2121.

## Proposed Changes

The checkout step for folks from the `/start/hosting` flow should display the money-back guarantee copy below the CTA.

It should consider the frequency (monthly, yearly) of the plan that was chosen.

<img width="596" alt="image" src="https://user-images.githubusercontent.com/26530524/231132654-3ddab000-b2ef-4b93-814c-7a2161b70b82.png">

## Testing Instructions

1. Checkout this branch;
2. Start the flow at `/start/user` and chose a paid plan;
3. Check that the copy does not show up below the CTA;
4. Close the checkout (empty cart) and start the hosting flow at `/start/hosting`;
5. Chose a paid plan and proceed to checkout;
6. Verify that the copy DOES show up below the CTA.