### PR TITLE
Staging Sites: Use 'Production' instead of 'Live' on the My Home card

### DIFF
--- a/client/my-sites/customer-home/cards/notices/staging-site/index.js
+++ b/client/my-sites/customer-home/cards/notices/staging-site/index.js
@@ -7,7 +7,7 @@ const StagingSiteNotice = () => {
 	return (
 		<CelebrateNotice
 			description={ __(
-				'This is a staging site that you can use to try out new plugins and themes, debug and troubleshoot changes, and fine-tune every aspect of your website without worrying about breaking your live site.'
+				'This is a staging site that you can use to try out new plugins and themes, debug and troubleshoot changes, and fine-tune every aspect of your website without worrying about breaking your production site.'
 			) }
 			noticeId={ NOTICE_STAGING_SITE }
 			title={ __( 'Staging site' ) }


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/2152

## Proposed Changes

Switches to 'Production' instead of 'Live' on the My Home card:

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/36432/231134135-b914ecec-2ada-40ff-8d56-17e933b0aa14.png">

## Testing Instructions

1. Navigate to 'My Home' for a staging site.
2. Verify the text appears as expected.