### PR TITLE
Add Assets support to Happy Blocks

### DIFF
--- a/apps/happy-blocks/webpack.config.js
+++ b/apps/happy-blocks/webpack.config.js
@@ -46,6 +46,10 @@ function getWebpackConfig( env = { block: '' }, argv ) {
 			new CopyPlugin( {
 				patterns: [
 					ifExists( {
+						from: path.resolve( blockPath, 'assets' ),
+						to: path.resolve( blockPath, 'build', '[name][ext]' ),
+					} ),
+					ifExists( {
 						from: path.resolve( blockPath, 'index.php' ),
 						to: path.resolve( blockPath, 'build', '[name][ext]' ),
 						transform( content ) {


### PR DESCRIPTION
This adds the ability to have an `assets` folder in Happy Blocks. 

Note that you have to restart the build after adding the folder the first time. Once it's there, it you can add and remove files from it without restarting the build.