### PR TITLE
DotOrg Theme: Activate theme on the Marketplace Installation page for themes

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -1,10 +1,11 @@
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { useQueryThemes } from 'calypso/components/data/query-theme';
 import { ThankYouData, ThankYouSectionProps } from 'calypso/components/thank-you/types';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { clearActivated } from 'calypso/state/themes/actions';
 import { getThemes } from 'calypso/state/themes/selectors';
 import { hasExternallyManagedThemes as getHasExternallyManagedThemes } from 'calypso/state/themes/selectors/is-externally-managed-theme';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -13,6 +14,7 @@ import MasterbarStyled from './masterbar-styled';
 
 export function useThemesThankYouData( themeSlugs: string[] ): ThankYouData {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
@@ -34,6 +36,13 @@ export function useThemesThankYouData( themeSlugs: string[] ): ThankYouData {
 
 	useQueryThemes( 'wpcom', themeSlugs );
 	useQueryThemes( 'wporg', themeSlugs );
+
+	// Clear completed activated them request state to avoid displaying the Thanks modal
+	useEffect( () => {
+		return () => {
+			dispatch( clearActivated( siteId || 0 ) );
+		};
+	}, [ dispatch, siteId ] );
 
 	const themesSection: ThankYouSectionProps = {
 		sectionKey: 'theme_information',

--- a/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-plugin-install/index.tsx
@@ -42,8 +42,8 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import {
-	activateTheme,
 	initiateThemeTransfer as initiateTransfer,
+	installAndActivateTheme,
 	requestActiveTheme,
 } from 'calypso/state/themes/actions';
 import { getTheme, isThemeActive as getThemeActive } from 'calypso/state/themes/selectors';
@@ -203,7 +203,7 @@ const MarketplacePluginInstall = ( {
 			if ( selectedSite.jetpack ) {
 				if ( wpOrgTheme ) {
 					// initilize theme activating
-					dispatch( activateTheme( wpOrgTheme.id, siteId ) );
+					dispatch( installAndActivateTheme( wpOrgTheme.id, siteId ) );
 				} else {
 					// initialize plugin installing
 					dispatch( installPlugin( siteId, wporgPlugin, false ) );

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -64,17 +64,6 @@ class ThanksModal extends Component {
 	}
 
 	static getDerivedStateFromProps( nextProps, prevState ) {
-		/**
-		 * Clear activation status and don't show the modal if the theme is not a WPCOM theme.
-		 */
-		if ( ! nextProps.isThemeWpcom && nextProps.siteId ) {
-			nextProps.clearActivated( nextProps.siteId );
-			return {
-				isVisible: false,
-				wasInstalling: nextProps.isInstalling,
-			};
-		}
-
 		if ( nextProps.isInstalling || nextProps.isActivating || nextProps.hasActivated ) {
 			return {
 				isVisible: true,

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -64,6 +64,17 @@ class ThanksModal extends Component {
 	}
 
 	static getDerivedStateFromProps( nextProps, prevState ) {
+		/**
+		 * Clear activation status and don't show the modal if the theme is not a WPCOM theme.
+		 */
+		if ( ! nextProps.isThemeWpcom && nextProps.siteId ) {
+			nextProps.clearActivated( nextProps.siteId );
+			return {
+				isVisible: false,
+				wasInstalling: nextProps.isInstalling,
+			};
+		}
+
 		if ( nextProps.isInstalling || nextProps.isActivating || nextProps.hasActivated ) {
 			return {
 				isVisible: true,

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -1,6 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
+import page from 'page';
+import { productToBeInstalled } from 'calypso/state/marketplace/purchase-flow/actions';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import { activateTheme } from 'calypso/state/themes/actions/activate-theme';
 import { installAndActivateTheme } from 'calypso/state/themes/actions/install-and-activate-theme';
 import { showAutoLoadingHomepageWarning } from 'calypso/state/themes/actions/show-auto-loading-homepage-warning';
@@ -54,6 +56,15 @@ export function activate(
 			! hasAutoLoadingHomepageModalAccepted( getState(), themeId )
 		) {
 			return dispatch( showAutoLoadingHomepageWarning( themeId ) );
+		}
+
+		// Check if the theme is a .org Theme and redirect it to the Marketplace theme installation page
+		const isDotOrgTheme = !! getTheme( getState(), 'wporg', themeId );
+		if ( isDotOrgTheme ) {
+			const siteSlug = getSiteSlug( getState(), siteId );
+
+			dispatch( productToBeInstalled( themeId, siteSlug ) );
+			return page( `/marketplace/theme/${ themeId }/install/${ siteSlug }` );
 		}
 
 		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -58,9 +58,13 @@ export function activate(
 			return dispatch( showAutoLoadingHomepageWarning( themeId ) );
 		}
 
-		// Check if the theme is a .org Theme and redirect it to the Marketplace theme installation page
+		/**
+		 * Check if the theme is a .org Theme and not provided by .com as well (as Premium themes)
+		 * and redirect it to the Marketplace theme installation page
+		 */
 		const isDotOrgTheme = !! getTheme( getState(), 'wporg', themeId );
-		if ( isDotOrgTheme ) {
+		const isDotComTheme = !! getTheme( getState(), 'wpcom', themeId );
+		if ( isDotOrgTheme && ! isDotComTheme ) {
 			const siteSlug = getSiteSlug( getState(), siteId );
 
 			dispatch( productToBeInstalled( themeId, siteSlug ) );


### PR DESCRIPTION
Related to #75314

The mentioned PR was reverted and it's being reapplied with fixes now.  The fix commit is https://github.com/Automattic/wp-calypso/commit/35a7f68a2d05cd4453c8287804163cce429ec64d.

## Proposed Changes

*  Redirect .org themes to the Marketplace Installation page
* Add intention to install a theme to be read on the Installation page
* Stop showing thanks modal for .org themes
* Update dotorg check to remove themes also provided by dotcom (Premium)


## Testing Instructions

* Follow the same testing instructions as #75314
* Test Premium plugins as `karuna` are still able to be installed on Premium plans

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
