### PR TITLE
Hosting onboarding flow: use new plans grid

### DIFF
--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1041,3 +1041,11 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 .formatted-header {
 	margin-bottom: 0;
 }
+
+
+/* Hosting onboarding flow */
+.is-hosting div.plan-features-2023-grid__content {
+	max-width: 768px;
+	margin-left: auto !important;
+	margin-right: auto !important;
+}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -357,6 +357,7 @@ export class PlansFeaturesMain extends Component {
 			hidePersonalPlan,
 			hidePremiumPlan,
 			hideEcommercePlan,
+			hideEnterprisePlan = false,
 			sitePlanSlug,
 			showTreatmentPlansReorderTest,
 			flowName,
@@ -372,7 +373,7 @@ export class PlansFeaturesMain extends Component {
 			plans = plansFromProps;
 		} else {
 			const isBloggerPlanVisible = hideBloggerPlan === true ? false : true;
-			const isEnterprisePlanVisible = is2023PricingGridVisible;
+			const isEnterprisePlanVisible = is2023PricingGridVisible && hideEnterprisePlan !== false;
 			plans = [
 				findPlansKeys( { group: GROUP_WPCOM, type: TYPE_FREE } )[ 0 ],
 				isBloggerPlanVisible &&

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -238,6 +238,7 @@ export function generateSteps( {
 				hideFreePlan: true,
 				hidePremiumPlan: true,
 				hidePersonalPlan: true,
+				hideEnterprisePlan: true,
 				shouldHideNavButtons: true,
 			},
 		},

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -75,6 +75,11 @@ export const is2023PricingGridActivePage = (
 		return isPricingGridEnabled;
 	}
 
+	// Is this the hosting flow?
+	if ( currentRoutePath.startsWith( '/start/hosting' ) ) {
+		return isPricingGridEnabled;
+	}
+
 	// Is this the launch site flow?
 	if ( currentRoutePath.startsWith( '/start/launch-site/plans-launch' ) ) {
 		return isPricingGridEnabled;


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/2126.

## Proposed Changes

This PR enables the new plan grid for the `/start/hosting` flow. It narrows the grid a bit, because there are only two plans and it got too wide.

It also hides the "Enterprise" plan on demand. Do you think it's OK to do that? Should we present the Enterprise plan even though it bails the hosting flow? @vindl would like your input here.

@claudiucelfilip is there any better way of narrowing the grid?

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/26530524/231153058-c499341d-0df5-47e6-af46-55eb6079abba.png">

## Testing Instructions

1. Clone this branch;
2. Go to `/start/hosting`;
3. Verify that the new grid is displayed according to the screenshot;
4. Verify that the plan comparison still stretches to the full width of the page.