### PR TITLE
Jetpack Cloud:  fix issue w/ sidebar displaying 'Loading My Sites' when user has no site.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/style.scss
@@ -10,11 +10,8 @@
 	box-shadow: none;
 	background: transparent;
 
-	&.is-loading {
-		.site-icon {
-			animation: pulse-light 0.8s ease-in-out infinite;
-		}
-
+	&.is-loading,
+	&.is-no-sites {
 		.site__title {
 			color: var(--color-neutral-50);
 			line-height: 35px;
@@ -27,6 +24,10 @@
 				visibility: hidden;
 			}
 		}
+	}
+
+	&.is-loading .site-icon {
+		animation: pulse-light 0.8s ease-in-out infinite;
 	}
 }
 

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button, Card } from '@automattic/components';
+import classnames from 'classnames';
 import { localize, withRtl } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -41,14 +42,22 @@ class CurrentSite extends Component {
 		const { selectedSite, translate, anySiteSelected } = this.props;
 
 		if ( ! anySiteSelected.length || ( ! selectedSite && ! this.props.hasAllSitesList ) ) {
+			const hasNoSites = this.props.hasAllSitesList && ! anySiteSelected.length;
 			/* eslint-disable wpcalypso/jsx-classname-namespace, jsx-a11y/anchor-is-valid */
 			return (
-				<Card className="current-site is-loading">
+				<Card
+					className={ classnames( 'current-site', {
+						'is-no-sites': hasNoSites,
+						'is-loading': ! this.props.hasAllSitesList,
+					} ) }
+				>
 					<div className="site">
 						<a className="site__content">
 							<div className="site-icon" />
 							<div className="site__info">
-								<span className="site__title">{ translate( 'Loading My Sites…' ) }</span>
+								<span className="site__title">
+									{ hasNoSites ? translate( 'No Sites' ) : translate( 'Loading My Sites…' ) }
+								</span>
 							</div>
 						</a>
 					</div>

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -10,11 +10,8 @@
 	box-shadow: none;
 	background: transparent;
 
-	&.is-loading {
-		.site-icon {
-			animation: pulse-light 0.8s ease-in-out infinite;
-		}
-
+	&.is-loading,
+	&.is-no-sites {
 		.site__title {
 			color: var(--color-neutral-50);
 			line-height: 35px;
@@ -27,6 +24,10 @@
 				visibility: hidden;
 			}
 		}
+	}
+
+	&.is-loading .site-icon {
+		animation: pulse-light 0.8s ease-in-out infinite;
 	}
 }
 


### PR DESCRIPTION
In Jetpack cloud, when an agency user tries to access the dashboard without a JP site, the sidebar keeps displaying the **Loading My Sites** text even though it has already finished fetching the data, which makes it confusing.

<img width="1719" alt="Screen Shot 2023-04-11 at 11 44 23 PM" src="https://user-images.githubusercontent.com/56598660/231217032-0c83945d-e6f6-442d-bc75-6eaeef26da52.png">


 Upon checking, the `CurrentSite` component does not assume the possibility of an empty selection. While this scenario is not possible on the WPCOM My Site page, the JP cloud dashboard renders this component while having no selectable site.
 
Related to #74693

## Proposed Changes

* This PR updates the `CurrentSite` component so it renders the **No Site** text when there is no selected data. These changes should not affect the sidebar in WPCOM.

## Testing Instructions

* Create a new WPCOM account and signup for Agency program in https://cloud.jetpack.com/agency/signup. (Make sure you do not have a JP site connected with this account)
* Visit the Jetpack Cloud live link which should ask you to sign in using WPCOM account.
* Once you sign in, visit the JP cloud dashboard page `/dashboard`
* Confirm that the **No Site** text is displayed.
<img width="1726" alt="Screen Shot 2023-04-11 at 11 59 13 PM" src="https://user-images.githubusercontent.com/56598660/231221102-4994901a-b8b0-49b3-83e9-28530bc40e05.png">
* Please also test with a JP site connected and confirm it is working as expected.
<img width="1728" alt="Screen Shot 2023-04-12 at 12 02 21 AM" src="https://user-images.githubusercontent.com/56598660/231221928-b1888cc1-213f-4495-b1fe-f9322d6b1f04.png">

* Please also confirm that the WPCOM sidebar is not affected by this change.
<img width="1724" alt="Screen Shot 2023-04-12 at 12 01 14 AM" src="https://user-images.githubusercontent.com/56598660/231221684-be43dc84-e0e8-401e-b560-c9a18c0fdff2.png">

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
