### PR TITLE
Anchor: Remove My Home right sidebar promo link

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -214,7 +215,7 @@ export const QuickLinks = ( {
 					/>
 				</>
 			) }
-			{ canManageSite && ! isAtomic && (
+			{ ! isEnabled( 'anchor/sunset-integration' ) && canManageSite && ! isAtomic && (
 				<ActionBox
 					href="https://anchor.fm/wordpressdotcom"
 					onClick={ trackAnchorPodcastAction }

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -1,9 +1,7 @@
-import { isEnabled } from '@automattic/calypso-config';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { useDebouncedCallback } from 'use-debounce';
-import anchorLogoIcon from 'calypso/assets/images/customer-home/anchor-logo-grey.svg';
 import fiverrIcon from 'calypso/assets/images/customer-home/fiverr-logo-grey.svg';
 import blazeIcon from 'calypso/assets/images/icons/blaze-icon.svg';
 import FoldableCard from 'calypso/components/foldable-card';
@@ -42,7 +40,6 @@ export const QuickLinks = ( {
 	canManageSite,
 	canModerateComments,
 	customizeUrl,
-	isAtomic,
 	isWpcomStagingSite,
 	isStaticHomePage,
 	canAddEmail,
@@ -57,7 +54,6 @@ export const QuickLinks = ( {
 	trackCustomizeThemeAction,
 	trackChangeThemeAction,
 	trackDesignLogoAction,
-	trackAnchorPodcastAction,
 	trackAddEmailAction,
 	trackAddDomainAction,
 	trackExplorePluginsAction,
@@ -214,16 +210,6 @@ export const QuickLinks = ( {
 						iconSrc={ fiverrIcon }
 					/>
 				</>
-			) }
-			{ ! isEnabled( 'anchor/sunset-integration' ) && canManageSite && ! isAtomic && (
-				<ActionBox
-					href="https://anchor.fm/wordpressdotcom"
-					onClick={ trackAnchorPodcastAction }
-					target="_blank"
-					label={ translate( 'Create a podcast with Anchor' ) }
-					external
-					iconSrc={ anchorLogoIcon }
-				/>
 			) }
 		</div>
 	);


### PR DESCRIPTION
Closes #75404

## Proposed Changes

* The Anchor.fm promo link under `Quick links` on the My Home page should no longer be available to users

More details: p7fD6U-9EZ-p2

#### Before

![Screen Shot 2023-04-06 at 13 46 47](https://user-images.githubusercontent.com/1234758/230458637-944c1614-ec4e-4031-97b0-82a1f9bbdafa.png)

#### After

![Screen Shot 2023-04-06 at 15 04 33](https://user-images.githubusercontent.com/1234758/230459593-aab4befd-0539-4cbc-b5cd-c9ad60c63364.png)

## Testing Instructions

* Navigate to `/home/{YOUR-SITE}` on a `simple` site
* You should no longer see the Anchor.fm promo link under `Quick links`.