### PR TITLE
VideoPress: add plan price on intro page

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -10,6 +10,7 @@ import { useSelect } from '@wordpress/data';
 import { createInterpolateElement, useMemo } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import { ReactElement } from 'react';
 import { PlansSelect } from 'calypso/../packages/data-stores/src';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
 import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
@@ -29,7 +30,10 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 		( select ) => ( select( PLANS_STORE ) as PlansSelect ).getPlanProduct,
 		[]
 	);
-	let videoPressGetStartedText = __( 'A home for all your videos.<br />Play. Roll. Share.' );
+	// VideoPress: we should always send a non-empty string so the spacing stays the same on the intro page
+	let videoPressGetStartedText: string | ReactElement = createInterpolateElement( '<nbsp />', {
+		nbsp: <>&nbsp;</>,
+	} );
 
 	if ( VIDEOPRESS_FLOW === flowName ) {
 		let defaultSupportedPlan = supportedPlans.find( ( plan ) => {
@@ -51,9 +55,7 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 				// eslint-disable-next-line @wordpress/valid-sprintf
 				videoPressGetStartedText = sprintf(
 					/* translators: Price displayed on VideoPress intro page. First %s is monthly price, second is annual price */
-					__(
-						'A home for all your videos.<br />Play. Roll. Share.<div>Starts at %s per month<br /><span>%s billed annually</span></div>'
-					),
+					__( 'Starts at %s per month, %s billed annually' ),
 					planProductObject.price,
 					planProductObject.annualPrice
 				);
@@ -93,11 +95,11 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 
 		if ( flowName === VIDEOPRESS_FLOW ) {
 			return {
-				title: createInterpolateElement( videoPressGetStartedText, {
-					br: <br />,
-					div: <div className="videopress-intro-pricing" />,
-					span: <span className="small" />,
-				} ),
+				title: createInterpolateElement(
+					__( 'A home for all your videos.<br />Play. Roll. Share.' ),
+					{ br: <br /> }
+				),
+				secondaryText: videoPressGetStartedText,
 				buttonText: __( 'Get started' ),
 				modal: {
 					buttonText: __( 'Learn more' ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -50,7 +50,7 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 			if ( planProductObject ) {
 				// eslint-disable-next-line @wordpress/valid-sprintf
 				videoPressGetStartedText = sprintf(
-					/* translators: Price displayed on VideoPress intro page "Get started" button. First %s is monthly price, second is annual price */
+					/* translators: Price displayed on VideoPress intro page. First %s is monthly price, second is annual price */
 					__(
 						'A home for all your videos.<br />Play. Roll. Share.<div>Get started for %s (%s billed annually).</div>'
 					),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -52,7 +52,7 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 				videoPressGetStartedText = sprintf(
 					/* translators: Price displayed on VideoPress intro page. First %s is monthly price, second is annual price */
 					__(
-						'A home for all your videos.<br />Play. Roll. Share.<div>Get started from %s per month (%s billed annually).</div>'
+						'A home for all your videos.<br />Play. Roll. Share.<div>Starts at %s per month<br /><span>%s billed annually</span></div>'
 					),
 					planProductObject.price,
 					planProductObject.annualPrice
@@ -96,6 +96,7 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 				title: createInterpolateElement( videoPressGetStartedText, {
 					br: <br />,
 					div: <div className="videopress-intro-pricing" />,
+					span: <span className="small" />,
 				} ),
 				buttonText: __( 'Get started' ),
 				modal: {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -52,7 +52,7 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 				videoPressGetStartedText = sprintf(
 					/* translators: Price displayed on VideoPress intro page. First %s is monthly price, second is annual price */
 					__(
-						'A home for all your videos.<br />Play. Roll. Share.<div>Get started for %s (%s billed annually).</div>'
+						'A home for all your videos.<br />Play. Roll. Share.<div>Get started for %s per month (%s billed annually).</div>'
 					),
 					planProductObject.price,
 					planProductObject.annualPrice

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -52,7 +52,7 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 				videoPressGetStartedText = sprintf(
 					/* translators: Price displayed on VideoPress intro page. First %s is monthly price, second is annual price */
 					__(
-						'A home for all your videos.<br />Play. Roll. Share.<div>Get started for %s per month (%s billed annually).</div>'
+						'A home for all your videos.<br />Play. Roll. Share.<div>Get started from %s per month (%s billed annually).</div>'
 					),
 					planProductObject.price,
 					planProductObject.annualPrice

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -1,3 +1,4 @@
+import { useLocale } from '@automattic/i18n-utils';
 import {
 	NEWSLETTER_FLOW,
 	ECOMMERCE_FLOW,
@@ -5,9 +6,14 @@ import {
 	FREE_FLOW,
 	isLinkInBioFlow,
 } from '@automattic/onboarding';
+import { useSelect } from '@wordpress/data';
 import { createInterpolateElement, useMemo } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import { PlansSelect } from 'calypso/../packages/data-stores/src';
 import { StepContainer } from 'calypso/../packages/onboarding/src';
+import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
+import { PLANS_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import IntroStep, { IntroContent } from './intro';
 import VideoPressIntroModalContent from './videopress-intro-modal-content';
@@ -17,6 +23,43 @@ import './styles.scss';
 
 const useIntroContent = ( flowName: string | null ): IntroContent => {
 	const { __ } = useI18n();
+	const locale = useLocale();
+	const { supportedPlans } = useSupportedPlans( locale, 'ANNUALLY' );
+	const getPlanProduct = useSelect(
+		( select ) => ( select( PLANS_STORE ) as PlansSelect ).getPlanProduct,
+		[]
+	);
+	let videoPressGetStartedText = __( 'A home for all your videos.<br />Play. Roll. Share.' );
+
+	if ( VIDEOPRESS_FLOW === flowName ) {
+		let defaultSupportedPlan = supportedPlans.find( ( plan ) => {
+			return plan.periodAgnosticSlug === 'premium';
+		} );
+		if ( ! defaultSupportedPlan ) {
+			defaultSupportedPlan = supportedPlans.find( ( plan ) => {
+				return plan.periodAgnosticSlug === 'business';
+			} );
+		}
+
+		if ( defaultSupportedPlan ) {
+			const planProductObject = getPlanProduct(
+				defaultSupportedPlan.periodAgnosticSlug,
+				'ANNUALLY'
+			);
+
+			if ( planProductObject ) {
+				// eslint-disable-next-line @wordpress/valid-sprintf
+				videoPressGetStartedText = sprintf(
+					/* translators: Price displayed on VideoPress intro page "Get started" button. First %s is monthly price, second is annual price */
+					__(
+						'A home for all your videos.<br />Play. Roll. Share.<div>Get started for %s (%s billed annually).</div>'
+					),
+					planProductObject.price,
+					planProductObject.annualPrice
+				);
+			}
+		}
+	}
 
 	return useMemo( () => {
 		if ( isLinkInBioFlow( flowName ) ) {
@@ -50,10 +93,10 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 
 		if ( flowName === VIDEOPRESS_FLOW ) {
 			return {
-				title: createInterpolateElement(
-					__( 'A home for all your videos.<br />Play. Roll. Share.' ),
-					{ br: <br /> }
-				),
+				title: createInterpolateElement( videoPressGetStartedText, {
+					br: <br />,
+					div: <div className="videopress-intro-pricing" />,
+				} ),
 				buttonText: __( 'Get started' ),
 				modal: {
 					buttonText: __( 'Learn more' ),
@@ -80,7 +123,7 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 			),
 			buttonText: __( 'Get started' ),
 		};
-	}, [ flowName, __ ] );
+	}, [ flowName, __, videoPressGetStartedText ] );
 };
 
 const Intro: Step = function Intro( { navigation, flow } ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/intro.tsx
@@ -12,6 +12,7 @@ interface Props {
 export interface IntroContent {
 	title: WPElement | string;
 	text?: WPElement | string;
+	secondaryText?: WPElement | string;
 	buttonText: string;
 	modal?: IntroModal;
 }
@@ -28,7 +29,7 @@ export interface IntroModal {
 
 const Intro: React.FC< Props > = ( { onSubmit, introContent } ) => {
 	const [ showModal, setShowModal ] = useState( false );
-	const { title, text, buttonText, modal } = introContent;
+	const { title, text, buttonText, modal, secondaryText } = introContent;
 
 	const modalClasses = classNames( 'intro__more-modal', {
 		show: showModal,
@@ -62,6 +63,7 @@ const Intro: React.FC< Props > = ( { onSubmit, introContent } ) => {
 						</Button>
 					) }
 				</div>
+				{ secondaryText && <div className="intro__secondary-text">{ secondaryText }</div> }
 			</div>
 			{ modal && (
 				<div className={ modalClasses }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -125,6 +125,11 @@
 			margin-top: 20px;
 			font-weight: bold;
 			font-size: 25px;
+			line-height: 25px;
+			.small {
+				font-size: 18px;
+				font-weight: normal;
+			}
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -121,15 +121,9 @@
 			}
 		}
 
-		.videopress-intro-pricing {
-			margin-top: 20px;
-			font-weight: bold;
-			font-size: 25px;
-			line-height: 25px;
-			.small {
-				font-size: 18px;
-				font-weight: normal;
-			}
+		.intro__secondary-text {
+			margin-top: 32px;
+			font-size: 1.25rem;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -120,6 +120,12 @@
 				border-color: #fff;
 			}
 		}
+
+		.videopress-intro-pricing {
+			margin-top: 20px;
+			font-weight: bold;
+			font-size: 25px;
+		}
 	}
 
 	min-height: 100%;


### PR DESCRIPTION
Related to 1668-gh-Automattic/greenhouse

## Proposed Changes

This PR pulls the premium or business plan pricing on the VideoPress onboarding intro page.

## Testing Instructions

* Apply pr
* `yarn start`
* Go to `/setup/videopress/intro`
* ✅ You should see a text "Starts at \<price\>" appearing
* ✅ The price should make sense in your locale

![Capture d’écran 2023-04-12 à 10 40 39](https://user-images.githubusercontent.com/1420594/231402404-e2422197-2eda-4f54-98d7-f0189eebcd18.png)

