### PR TITLE
Update Reader tag header to use MasterbarLoggedOut header when logged…

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -68,6 +68,9 @@ const LayoutLoggedOut = ( {
 		sectionName === 'checkout' &&
 		window.location.pathname.startsWith( '/checkout/jetpack/thank-you' );
 
+	const isReaderTagPage =
+		sectionName === 'reader' && window.location.pathname.startsWith( '/tag/' );
+
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,
 		[ 'is-section-' + sectionName ]: sectionName,
@@ -110,7 +113,8 @@ const LayoutLoggedOut = ( {
 	} else if ( config.isEnabled( 'jetpack-cloud' ) || isWpMobileApp() || isJetpackThankYou ) {
 		masterbar = null;
 	} else if (
-		[ 'plugins', 'themes', 'theme', 'reader', 'subscriptions' ].includes( sectionName )
+		[ 'plugins', 'themes', 'theme', 'reader', 'subscriptions' ].includes( sectionName ) &&
+		! isReaderTagPage
 	) {
 		masterbar = (
 			<UniversalNavbarHeader


### PR DESCRIPTION
As part of the Public tags pages, we want to use the `MasterbarLoggedOut` header component when viewing a public tag page while logged out.

At the moment we are showing the blue `UniversalNavbarHeader` header component.

This PR checks to see if we are viewing a tag page and renders the `MasterbarLoggedOut` header component instead.

**Before:**
<img width="801" alt="Screenshot 2023-04-11 at 14 20 45" src="https://user-images.githubusercontent.com/5560595/231175847-7efcec2f-2e23-4910-9443-45e914698f28.png">

**After:**
<img width="734" alt="Screenshot 2023-04-11 at 14 19 45" src="https://user-images.githubusercontent.com/5560595/231176012-d8be118a-8a98-44af-a1e0-aa1ee26ca72d.png">

Ref: pe7F0s-IS-p2