### PR TITLE
Remove reader tag image from header

### DIFF
--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -1,24 +1,11 @@
-import { Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FollowButton from 'calypso/blocks/follow-button/button';
-import QueryReaderTagImages from 'calypso/components/data/query-reader-tag-images';
-import cssSafeUrl from 'calypso/lib/css-safe-url';
-import { decodeEntities } from 'calypso/lib/formatting';
-import resizeImageUrl from 'calypso/lib/resize-image-url';
 import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-icon';
 import ReaderFollowingFeedIcon from 'calypso/reader/components/icons/following-feed-icon';
-import { getTagImages } from 'calypso/state/reader/tags/images/selectors';
-
-const TAG_HEADER_WIDTH = 800;
-const TAG_HEADER_HEIGHT = 140;
-
-function sample( array ) {
-	return array[ Math.floor( Math.random() * array.length ) ];
-}
 
 class TagStreamHeader extends Component {
 	static propTypes = {
@@ -26,73 +13,21 @@ class TagStreamHeader extends Component {
 		showFollow: PropTypes.bool,
 		following: PropTypes.bool,
 		onFollowToggle: PropTypes.func,
-		tagImages: PropTypes.array,
 		showBack: PropTypes.bool,
 	};
 
-	static defaultProps = {
-		tagImages: [],
-	};
-
-	state = {
-		tagImages: this.props.tagImages,
-		chosenTagImage: sample( this.props.tagImages ),
-	};
-
-	static getDerivedStateFromProps( nextProps, prevState ) {
-		if ( nextProps.tagImages === prevState.tagImages ) {
-			return null;
-		}
-
-		return {
-			tagImages: nextProps.tagImages,
-			chosenTagImage: sample( nextProps.tagImages ),
-		};
-	}
-
 	render() {
-		const {
-			title,
-			isPlaceholder,
-			showFollow,
-			following,
-			onFollowToggle,
-			translate,
-			showBack,
-			imageSearchString,
-		} = this.props;
+		const { title, isPlaceholder, showFollow, following, onFollowToggle, translate, showBack } =
+			this.props;
 		const classes = classnames( {
 			'tag-stream__header': true,
 			'is-placeholder': isPlaceholder,
 			'has-back-button': showBack,
 		} );
-		const imageStyle = {};
-		const tagImage = this.state.chosenTagImage;
-
-		let sourceWrapper;
-		let authorLink;
-		if ( tagImage ) {
-			const imageUrl = resizeImageUrl( 'https://' + tagImage.url, {
-				resize: `${ TAG_HEADER_WIDTH },${ TAG_HEADER_HEIGHT }`,
-			} );
-			const safeCssUrl = cssSafeUrl( imageUrl );
-			imageStyle.backgroundImage = 'url(' + safeCssUrl + ')';
-
-			sourceWrapper = <span className="tag-stream__header-image-byline-label" />;
-			authorLink = (
-				<a
-					href={ `/read/blogs/${ tagImage.blog_id }/posts/${ tagImage.post_id }` }
-					className="tag-stream__header-image-byline-link"
-					rel="author"
-				>
-					{ decodeEntities( tagImage.author ) }
-				</a>
-			);
-		}
 
 		return (
 			<div className={ classes }>
-				<QueryReaderTagImages tag={ imageSearchString } />
+				<h1 className="tag-stream__header-title">{ title }</h1>
 				<div className="tag-stream__header-follow">
 					{ showFollow && (
 						<FollowButton
@@ -106,29 +41,9 @@ class TagStreamHeader extends Component {
 						/>
 					) }
 				</div>
-				<div className="tag-stream__header-image" style={ imageStyle }>
-					<h1 className="tag-stream__header-image-title">
-						<Gridicon icon="tag" size={ 24 } />
-						{ title }
-					</h1>
-					{ tagImage && (
-						<div className="tag-stream__header-image-byline">
-							{ translate( '{{sourceWrapper}}Photo from{{/sourceWrapper}} {{authorLink/}}', {
-								components: {
-									sourceWrapper,
-									authorLink,
-								},
-							} ) }
-						</div>
-					) }
-				</div>
 			</div>
 		);
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	return {
-		tagImages: getTagImages( state, ownProps.imageSearchString ),
-	};
-} )( localize( TagStreamHeader ) );
+export default connect( null, null )( localize( TagStreamHeader ) );

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -1,96 +1,15 @@
 .tag-stream__header {
 	display: flex;
-	flex-direction: column;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: baseline;
+	margin-bottom: 10px;
 }
 
-.tag-stream__header-follow {
-	display: flex;
-	justify-content: flex-end;
-	min-height: 20px;
-}
-
-.tag-stream__header .follow-button {
-	z-index: z-index(".tag-stream__header-follow", ".follow-button");
-
-	@include breakpoint-deprecated( "<660px" ) {
-		margin: 12px 20px 0 15px;
-	}
-}
-
-.tag-stream__header .follow-button__label {
-
-	@include breakpoint-deprecated( "<660px" ) {
-		display: inline;
-	}
-}
-
-.tag-stream__header-image {
-	background: var(--color-neutral-0);
-	background-size: cover;
-	background-repeat: no-repeat;
-	background-position: right center;
-	box-sizing: content-box;
-	display: flex;
-	flex-direction: column;
-	min-height: 120px;
-	margin-top: 15px;
-	padding: 10px;
-	position: relative;
-	z-index: 0;
-
-	&::before {
-		content: "";
-		background: rgba(0, 0, 0, 0.3);
-		height: 100%;
-		position: absolute;
-		bottom: 0;
-		left: 0;
-		width: 100%;
-		z-index: 1;
-	}
-}
-
-.tag-stream__header-image .gridicon.gridicons-tag {
-	fill: var(--color-text-inverted);
-	position: relative;
-	right: 6px;
-	top: 3px;
-	z-index: 2;
-}
-
-.tag-stream__header-image-title {
-	color: var(--color-text-inverted);
-	font-size: $font-title-large;
-	line-height: 1.3;
-	margin-top: 42px;
-	text-align: center;
-	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
-	z-index: 2;
-}
-
-.tag-stream__header-image-byline {
-	color: var(--color-text-inverted);
-	font-size: $font-body-extra-small;
+.tag-stream__header-title {
+	font-size: 2rem;
+	text-transform: capitalize;
 	font-weight: 600;
-	padding-top: 24px;
-	text-align: right;
-	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
-	z-index: 2;
-	-webkit-font-smoothing: antialiased;
-}
-
-.tag-stream__header-image-byline-label {
-	opacity: 0.7;
-}
-
-.tag-stream__header-image-byline-link,
-.tag-stream__header-image-byline-link:visited {
-	color: var(--color-text-inverted);
-	opacity: 0.9;
-}
-
-.tag-stream__header-image-byline-link:hover {
-	color: var(--color-text-inverted);
 }
 
 // Back button in Tag streams


### PR DESCRIPTION
We are restyling the tag pages.

As part of this we are removing the tag image from the header for a simpler layout.

This PR removes the image from the tag header and adds the h1 tag for the title and a follow button.

**Before:**
<img width="805" alt="Screenshot 2023-04-11 at 15 10 51" src="https://user-images.githubusercontent.com/5560595/231190135-22d3b0d5-b096-46fe-882a-de8e4f142278.png">

**After:**
<img width="804" alt="Screenshot 2023-04-11 at 15 08 47" src="https://user-images.githubusercontent.com/5560595/231189535-cb38717e-b133-4ac7-a817-1a13046f2610.png">
