### PR TITLE
Help Center: Update Launchpad icon to use real data

### DIFF
--- a/packages/help-center/src/components/help-center-launchpad.tsx
+++ b/packages/help-center/src/components/help-center-launchpad.tsx
@@ -44,7 +44,7 @@ export const HelpCenterLaunchpad = () => {
 		siteSlug = window?.location?.host;
 	}
 
-	const { data } = useLaunchpadChecklist( siteSlug );
+	const { data } = useLaunchpadChecklist( siteSlug, siteIntent || '' );
 	const totalLaunchpadSteps = data?.checklist?.length || 4;
 	const completeLaunchpadSteps =
 		data?.checklist?.filter( ( checklistItem ) => checklistItem.completed ).length || 1;

--- a/packages/help-center/src/components/help-center-launchpad.tsx
+++ b/packages/help-center/src/components/help-center-launchpad.tsx
@@ -8,6 +8,7 @@ import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { useLaunchpadChecklist } from '../hooks/use-launchpad';
 import { SITE_STORE } from '../stores';
 import type { SiteSelect } from '@automattic/data-stores';
 
@@ -43,6 +44,11 @@ export const HelpCenterLaunchpad = () => {
 		siteSlug = window?.location?.host;
 	}
 
+	const { data } = useLaunchpadChecklist( siteSlug );
+	const totalLaunchpadSteps = data?.checklist?.length || 4;
+	const completeLaunchpadSteps =
+		data?.checklist?.filter( ( checklistItem ) => checklistItem.completed ).length || 1;
+
 	const launchpadURL = `${ getEnvironmentHostname() }/setup/${ siteIntent }/launchpad?siteSlug=${ siteSlug }`;
 	const sectionName = useSelector( ( state ) => getSectionName( state ) );
 	const handleLaunchpadHelpLinkClick = () => {
@@ -69,7 +75,11 @@ export const HelpCenterLaunchpad = () => {
 					handleLaunchpadHelpLinkClick();
 				} }
 			>
-				<CircularProgressBar size={ 32 } currentStep={ 1 } numberOfSteps={ 4 } />
+				<CircularProgressBar
+					size={ 32 }
+					currentStep={ completeLaunchpadSteps }
+					numberOfSteps={ totalLaunchpadSteps }
+				/>
 				<span className="inline-help-launchpad-link-text">
 					{ __( 'Continue setting up your site with these next steps.' ) }
 				</span>

--- a/packages/help-center/src/hooks/use-launchpad.tsx
+++ b/packages/help-center/src/hooks/use-launchpad.tsx
@@ -23,24 +23,27 @@ interface LaunchpadTasks {
 	checklist: LaunchpadTask[];
 }
 
-export const fetchLaunchpadChecklist = ( siteSlug: string | null ): Promise< LaunchpadTasks > => {
+export const fetchLaunchpadChecklist = (
+	siteSlug: string | null,
+	siteIntent: string
+): Promise< LaunchpadTasks > => {
 	const slug = encodeURIComponent( siteSlug as string );
 
 	return canAccessWpcomApis()
 		? wpcomRequest( {
-				path: `sites/${ slug }/launchpad/checklist?checklist_slug=newsletter`,
+				path: `sites/${ slug }/launchpad/checklist?checklist_slug=${ siteIntent }`,
 				apiNamespace: 'wpcom/v2/',
 				apiVersion: '2',
 		  } )
 		: apiFetch( {
 				global: true,
-				path: `sites/${ slug }/launchpad/checklist?checklist_slug=newsletter`,
+				path: `sites/${ slug }/launchpad/checklist?checklist_slug=${ siteIntent }`,
 		  } as APIFetchOptions );
 };
 
-export const useLaunchpadChecklist = ( siteSlug: string | null ) => {
+export const useLaunchpadChecklist = ( siteSlug: string | null, siteIntent: string ) => {
 	const key = [ 'launchpad', siteSlug ];
-	return useQuery( key, () => fetchLaunchpadChecklist( siteSlug ), {
+	return useQuery( key, () => fetchLaunchpadChecklist( siteSlug, siteIntent ), {
 		retry: 3,
 		initialData: {
 			checklist: [],

--- a/packages/help-center/src/hooks/use-launchpad.tsx
+++ b/packages/help-center/src/hooks/use-launchpad.tsx
@@ -1,0 +1,49 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useQuery } from 'react-query';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+
+interface APIFetchOptions {
+	global: boolean;
+	path: string;
+}
+
+interface LaunchpadTask {
+	id?: string;
+	completed?: boolean;
+	disabled?: boolean;
+	title?: string;
+	subtitle?: string;
+	badgeText?: string;
+	actionDispatch?: () => void;
+	isLaunchTask?: boolean;
+	warning?: boolean;
+}
+
+interface LaunchpadTasks {
+	checklist: LaunchpadTask[];
+}
+
+export const fetchLaunchpadChecklist = ( siteSlug: string | null ): Promise< LaunchpadTasks > => {
+	const slug = encodeURIComponent( siteSlug as string );
+
+	return canAccessWpcomApis()
+		? wpcomRequest( {
+				path: `sites/${ slug }/launchpad/checklist?checklist_slug=newsletter`,
+				apiNamespace: 'wpcom/v2/',
+				apiVersion: '2',
+		  } )
+		: apiFetch( {
+				global: true,
+				path: `sites/${ slug }/launchpad/checklist?checklist_slug=newsletter`,
+		  } as APIFetchOptions );
+};
+
+export const useLaunchpadChecklist = ( siteSlug: string | null ) => {
+	const key = [ 'launchpad', siteSlug ];
+	return useQuery( key, () => fetchLaunchpadChecklist( siteSlug ), {
+		retry: 3,
+		initialData: {
+			checklist: [],
+		},
+	} );
+};


### PR DESCRIPTION
### Proposed Changes

**This PR is a draft. It depends on the backend Jetpack PR below, which is still in development. Because the backend endpoint is in development and may return incomplete or unpredictable data, this PR may not render the launchpad icon with the correct progress level for a given site. It simply uses whatever data is returned from the endpoint.**

Related Issue: https://github.com/Automattic/wp-calypso/issues/75504
Requires Backend Jetpack PR: https://github.com/Automattic/jetpack/pull/30023

Before this PR the Launchpad icon in the help center was using hard coded placeholder numbers to determine how much of the progress bar was completed (1 out of 4 steps or 25%). This PR use our new /launchpad/checklist endpoint to fetch the site checklist render the launchpad icon based on actual completed / total steps. 

<img width="879" alt="launchpad icon" src="https://user-images.githubusercontent.com/21228350/231255601-1c3d772d-0229-4c5d-8d01-5141ff54a932.png">

### Testing Instructions

1. You'll need to set up the required backend diff. You can do that by running `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/launchpad-checklist-refactor-scaffolding` on your sandbox. Also sandbox the _url of the test site_ you'll be working with
2. Checkout this branch and run yarn and yarn start. This should build the help center package fresh for testing in addition to starting your local dev environment. Note that the relevant changes here are in a package. I sometimes needed to run `yarn build-packages` to force the help center package to rebuild with latest changes. 
3. You will need to create or test with a Launchpad enabled site. 
4. Go to http://calypso.localhost:3000/post/YOURSITESLUG
4. TEST: Click on the help / question mark icon in the upper right icon. You should see the Launchpad icon. Historically, this has always rendered with the progress bar at 25% complete. It should now be dynamically based on the total and completed site steps. See screenshot above. 