### PR TITLE
Staging Sites: Tweak links and button text in module

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -208,7 +208,11 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 					</SiteInfo>
 				</SiteRow>
 				<ActionButtons>
-					<Button primary href={ `/home/${ urlToSlug( stagingSite.url ) }` } disabled={ disabled }>
+					<Button
+						primary
+						href={ `/hosting-config/${ urlToSlug( stagingSite.url ) }` }
+						disabled={ disabled }
+					>
 						<span>{ translate( 'Manage staging site' ) }</span>
 					</Button>
 					<DeleteStagingSite

--- a/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
@@ -79,10 +79,10 @@ function StagingSiteProductionCard( { disabled, siteId }: CardProps ) {
 				<ActionButtons>
 					<Button
 						primary
-						href={ `/home/${ urlToSlug( productionSite.url ) }` }
+						href={ `/hosting-config/${ urlToSlug( productionSite.url ) }` }
 						disabled={ disabled }
 					>
-						<span>{ __( 'Manage production site' ) }</span>
+						<span>{ __( 'Go back to production' ) }</span>
 					</Button>
 				</ActionButtons>
 			</>


### PR DESCRIPTION
From https://github.com/Automattic/wp-calypso/pull/75515#pullrequestreview-1379440360

## Proposed Changes

On a staging site, changes button text to 'Go back to production' and changes the link to the Hosting Configuration page for the production site:

<img width="763" alt="image" src="https://user-images.githubusercontent.com/36432/231278449-457e22c4-e46e-4899-9fb5-96dd18b09236.png">

On a production site, changes the link to the Hosting Configuration page for a staging site:

<img width="787" alt="image" src="https://user-images.githubusercontent.com/36432/231278703-32ad35aa-e0f3-4a52-8c3c-ac513231b2f5.png">

## Testing Instructions

1. Play around with these buttons and see if it feels better.