### PR TITLE
Staging Sites: Disable ellipsis menu link for Pro sites

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_SFTP,
+	FEATURE_SITE_STAGING_SITES,
 	WPCOM_FEATURES_MANAGE_PLUGINS,
 	WPCOM_FEATURES_SITE_PREVIEW_LINKS,
 } from '@automattic/calypso-products';
@@ -264,6 +265,7 @@ function useSubmenuItems( site: SiteExcerptData ) {
 	const siteSlug = site.slug;
 	const isStagingSite = site.is_wpcom_staging_site;
 	const isStagingSiteEnabled = isEnabled( 'yolo/staging-sites-i1' );
+	const hasStagingSitesFeature = useSafeSiteHasFeature( site.ID, FEATURE_SITE_STAGING_SITES );
 
 	useQueryReaderTeams();
 	const isA12n = useSelector( ( state ) => isAutomatticTeamMember( getReaderTeams( state ) ) );
@@ -281,7 +283,7 @@ function useSubmenuItems( site: SiteExcerptData ) {
 				sectionName: 'database_access',
 			},
 			{
-				condition: ! isStagingSite && isStagingSiteEnabled,
+				condition: ! isStagingSite && isStagingSiteEnabled && hasStagingSitesFeature,
 				label: __( 'Staging site' ),
 				href: `/hosting-config/${ siteSlug }#staging-site`,
 				sectionName: 'staging_site',

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -311,7 +311,7 @@ function useSubmenuItems( site: SiteExcerptData ) {
 				sectionName: 'logs',
 			},
 		].filter( ( { condition } ) => condition ?? true );
-	}, [ __, isStagingSiteEnabled, siteSlug, isStagingSite, isA12n ] );
+	}, [ __, siteSlug, isStagingSite, isStagingSiteEnabled, hasStagingSitesFeature, isA12n ] );
 }
 
 function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2128

## Proposed Changes

Disables the 'Staging site' link for Pro sites:

<img width="818" alt="image" src="https://user-images.githubusercontent.com/36432/231283829-ed723eac-0a2c-4286-984b-b2de1c0bf50d.png">

The 'Staging site' link remains for Business sites:

<img width="780" alt="image" src="https://user-images.githubusercontent.com/36432/231283878-43dc445f-7ca7-423a-8cab-ab7644934f0f.png">

## Testing Instructions

1. Navigate to `/sites`.
2. Click on the ellipsis menu for a Pro site and verify the 'Staging site' link doesn't appear.
3. Click on the ellipsis menu for a Business site and verify the 'Staging site' link does appear.