### PR TITLE
Subscription Management: Create email notification toggle

### DIFF
--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -39,13 +39,7 @@ const CommentRow = ( {
 				<TimeSince date={ date_subscribed.toISOString?.() ?? date_subscribed } />
 			</span>
 			<span className="actions" role="cell">
-				<CommentSettings
-					onChangeSendByEmail={ () => undefined }
-					onUnfollow={ () => undefined }
-					shouldSendByEmail={ true }
-					unfollowing={ false }
-					updatingSendByEmail={ false }
-				/>
+				<CommentSettings onUnfollow={ () => undefined } unfollowing={ false } />
 			</span>
 		</li>
 	);

--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -40,14 +40,11 @@ const CommentRow = ( {
 			</span>
 			<span className="actions" role="cell">
 				<CommentSettings
-					onChangeSendCommentsByEmail={ () => undefined }
-					onChangeSendCommentsByNotification={ () => undefined }
+					onChangeSendByEmail={ () => undefined }
 					onUnfollow={ () => undefined }
-					sendCommentsByEmail={ true }
-					sendCommentsByNotification={ false }
+					shouldSendByEmail={ true }
 					unfollowing={ false }
-					updatingSendCommentsByEmail={ false }
-					updatingSendCommentsByNotification={ true }
+					updatingSendByEmail={ false }
 				/>
 			</span>
 		</li>

--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -1,6 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { useMemo } from 'react';
 import TimeSince from 'calypso/components/time-since';
+import { CommentSettings } from '../settings-popover';
 import type { PostSubscription } from '@automattic/data-stores/src/reader/types';
 
 const CommentRow = ( {
@@ -38,7 +39,16 @@ const CommentRow = ( {
 				<TimeSince date={ date_subscribed.toISOString?.() ?? date_subscribed } />
 			</span>
 			<span className="actions" role="cell">
-				...
+				<CommentSettings
+					onChangeSendCommentsByEmail={ () => undefined }
+					onChangeSendCommentsByNotification={ () => undefined }
+					onUnfollow={ () => undefined }
+					sendCommentsByEmail={ true }
+					sendCommentsByNotification={ false }
+					unfollowing={ false }
+					updatingSendCommentsByEmail={ false }
+					updatingSendCommentsByNotification={ true }
+				/>
 			</span>
 		</li>
 	);

--- a/client/landing/subscriptions/components/settings-popover/comment-settings/comment-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/comment-settings/comment-settings.tsx
@@ -1,15 +1,51 @@
+import { useTranslate } from 'i18n-calypso';
+import Separator from 'calypso/components/popover-menu/separator';
 import SettingsPopover from '../settings-popover';
+import { ToggleInput } from '../toggle-input';
 import UnfollowCommentsButton from './unfollow-comments-button';
 
 type CommentSettingsProps = {
+	onChangeSendCommentsByEmail: ( sendCommentsByEmail: boolean ) => void;
+	onChangeSendCommentsByNotification: ( sendCommentsByNotification: boolean ) => void;
 	onUnfollow: () => void;
+	sendCommentsByEmail: boolean;
+	sendCommentsByNotification: boolean;
 	unfollowing: boolean;
+	updatingSendCommentsByEmail: boolean;
+	updatingSendCommentsByNotification: boolean;
 };
 
-const CommentSettings = ( { onUnfollow, unfollowing }: CommentSettingsProps ) => (
-	<SettingsPopover>
-		<UnfollowCommentsButton unfollowing={ unfollowing } onUnfollow={ onUnfollow } />
-	</SettingsPopover>
-);
+const CommentSettings = ( {
+	onChangeSendCommentsByEmail,
+	onChangeSendCommentsByNotification,
+	onUnfollow,
+	sendCommentsByEmail,
+	sendCommentsByNotification,
+	unfollowing,
+	updatingSendCommentsByEmail,
+	updatingSendCommentsByNotification,
+}: CommentSettingsProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<SettingsPopover>
+			<ToggleInput
+				checked={ sendCommentsByNotification }
+				onChange={ onChangeSendCommentsByNotification }
+				label={ translate( 'Notify me of new comments' ) }
+				hint={ translate( 'Receive web and mobile notifications for new posts from this site.' ) }
+				loading={ updatingSendCommentsByNotification }
+			/>
+			<ToggleInput
+				checked={ sendCommentsByEmail }
+				onChange={ onChangeSendCommentsByEmail }
+				label={ translate( 'Email me new comments' ) }
+				loading={ updatingSendCommentsByEmail }
+			/>
+			<Separator />
+			<UnfollowCommentsButton unfollowing={ unfollowing } onUnfollow={ onUnfollow } />
+		</SettingsPopover>
+	);
+};
 
 export default CommentSettings;

--- a/client/landing/subscriptions/components/settings-popover/comment-settings/comment-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/comment-settings/comment-settings.tsx
@@ -5,42 +5,29 @@ import { ToggleInput } from '../toggle-input';
 import UnfollowCommentsButton from './unfollow-comments-button';
 
 type CommentSettingsProps = {
-	onChangeSendCommentsByEmail: ( sendCommentsByEmail: boolean ) => void;
-	onChangeSendCommentsByNotification: ( sendCommentsByNotification: boolean ) => void;
+	onChangeSendByEmail: ( sendByEmail: boolean ) => void;
 	onUnfollow: () => void;
-	sendCommentsByEmail: boolean;
-	sendCommentsByNotification: boolean;
+	shouldSendByEmail: boolean;
 	unfollowing: boolean;
-	updatingSendCommentsByEmail: boolean;
-	updatingSendCommentsByNotification: boolean;
+	updatingSendByEmail: boolean;
 };
 
 const CommentSettings = ( {
-	onChangeSendCommentsByEmail,
-	onChangeSendCommentsByNotification,
+	onChangeSendByEmail,
 	onUnfollow,
-	sendCommentsByEmail,
-	sendCommentsByNotification,
+	shouldSendByEmail,
 	unfollowing,
-	updatingSendCommentsByEmail,
-	updatingSendCommentsByNotification,
+	updatingSendByEmail,
 }: CommentSettingsProps ) => {
 	const translate = useTranslate();
 
 	return (
 		<SettingsPopover>
 			<ToggleInput
-				checked={ sendCommentsByNotification }
-				onChange={ onChangeSendCommentsByNotification }
-				label={ translate( 'Notify me of new comments' ) }
-				hint={ translate( 'Receive web and mobile notifications for new posts from this site.' ) }
-				loading={ updatingSendCommentsByNotification }
-			/>
-			<ToggleInput
-				checked={ sendCommentsByEmail }
-				onChange={ onChangeSendCommentsByEmail }
+				checked={ shouldSendByEmail }
+				onChange={ onChangeSendByEmail }
 				label={ translate( 'Email me new comments' ) }
-				loading={ updatingSendCommentsByEmail }
+				loading={ updatingSendByEmail }
 			/>
 			<Separator />
 			<UnfollowCommentsButton unfollowing={ unfollowing } onUnfollow={ onUnfollow } />

--- a/client/landing/subscriptions/components/settings-popover/comment-settings/comment-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/comment-settings/comment-settings.tsx
@@ -1,38 +1,15 @@
-import { useTranslate } from 'i18n-calypso';
-import Separator from 'calypso/components/popover-menu/separator';
 import SettingsPopover from '../settings-popover';
-import { ToggleInput } from '../toggle-input';
 import UnfollowCommentsButton from './unfollow-comments-button';
 
 type CommentSettingsProps = {
-	onChangeSendByEmail: ( sendByEmail: boolean ) => void;
 	onUnfollow: () => void;
-	shouldSendByEmail: boolean;
 	unfollowing: boolean;
-	updatingSendByEmail: boolean;
 };
 
-const CommentSettings = ( {
-	onChangeSendByEmail,
-	onUnfollow,
-	shouldSendByEmail,
-	unfollowing,
-	updatingSendByEmail,
-}: CommentSettingsProps ) => {
-	const translate = useTranslate();
-
-	return (
-		<SettingsPopover>
-			<ToggleInput
-				checked={ shouldSendByEmail }
-				onChange={ onChangeSendByEmail }
-				label={ translate( 'Email me new comments' ) }
-				loading={ updatingSendByEmail }
-			/>
-			<Separator />
-			<UnfollowCommentsButton unfollowing={ unfollowing } onUnfollow={ onUnfollow } />
-		</SettingsPopover>
-	);
-};
+const CommentSettings = ( { onUnfollow, unfollowing }: CommentSettingsProps ) => (
+	<SettingsPopover>
+		<UnfollowCommentsButton unfollowing={ unfollowing } onUnfollow={ onUnfollow } />
+	</SettingsPopover>
+);
 
 export default CommentSettings;

--- a/client/landing/subscriptions/components/settings-popover/toggle-input/index.ts
+++ b/client/landing/subscriptions/components/settings-popover/toggle-input/index.ts
@@ -1,0 +1,1 @@
+export { default as ToggleInput } from './toggle-input';

--- a/client/landing/subscriptions/components/settings-popover/toggle-input/styles.scss
+++ b/client/landing/subscriptions/components/settings-popover/toggle-input/styles.scss
@@ -1,0 +1,44 @@
+@import "@automattic/color-studio/dist/color-variables";
+
+.toggle-input {
+	.toggle-input__control {
+		padding: 16px 21px;
+		margin-bottom: 0;
+
+		.components-form-toggle__input,
+		.components-toggle-control__label {
+			cursor: pointer;
+		}
+
+		&.is-loading {
+			cursor: default;
+			opacity: 0.5;
+			pointer-events: none;
+		}
+
+		.is-checked .components-form-toggle__track {
+			background-color: $studio-black;
+		}
+
+		.components-toggle-control__label {
+			font-size: $font-body-small;
+			line-height: $font-title-small;
+		}
+	}
+
+	&:first-child .toggle-input__control {
+		padding-top: 21px;
+	}
+
+	&:last-child .toggle-input__control {
+		padding-bottom: 21px;
+	}
+
+	.toggle-input__hint {
+		width: 212px;
+		padding: 0 21px;
+		text-align: left;
+		line-height: $font-body;
+		color: $studio-gray-50;
+	}
+}

--- a/client/landing/subscriptions/components/settings-popover/toggle-input/toggle-input.tsx
+++ b/client/landing/subscriptions/components/settings-popover/toggle-input/toggle-input.tsx
@@ -1,0 +1,27 @@
+import { ToggleControl } from '@wordpress/components';
+import classNames from 'classnames';
+import './styles.scss';
+
+type ToggleInputProps = {
+	checked: boolean;
+	onChange: ( checked: boolean ) => void;
+	label: string;
+	hint?: string;
+	loading?: boolean;
+};
+
+const ToggleInput = ( { checked, onChange, label, hint, loading }: ToggleInputProps ) => {
+	return (
+		<div className="toggle-input">
+			<ToggleControl
+				className={ classNames( 'toggle-input__control', { 'is-loading': loading } ) }
+				onChange={ onChange }
+				checked={ checked }
+				label={ label }
+			/>
+			{ hint && <p className="toggle-input__hint">{ hint }</p> }
+		</div>
+	);
+};
+
+export default ToggleInput;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/75583

## Proposed Changes

- Creates `ToggleInput` component
  - Includes `hint` prop, which will be used by the web/mobile notification toggle
- Updates `CommentSettings` component to include the email notification toggle
- Add the `CommentSettings` to the `CommentRow` component

## Testing Instructions

- Run this PR on your local env
- Go to http://calypso.localhost:3000/subscriptions/comments
- Click on ellipsis icon to open the CommentSettings popover
- Verify if it's rendered as expected
- You can test different scenarios by changing some props
  - Add `hint` value to the `ToggleInput` on `CommentSettings`
  - Set `updatingSendByEmail` to true on `CommentRow` component
  - Set `shouldSendByEmail` to false on `CommentRow` component to change the initial state
  - Add `console.log` to `onChangeSendByEmail` on `CommentRow` component to validate onChange calls


<img width="324" alt="image" src="https://user-images.githubusercontent.com/3113712/231291434-59897a08-275c-4f06-aa5e-019a6c3c5112.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
