### PR TITLE
Staging Sites: Add explanatory tooltip to plan storage indicator

### DIFF
--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -109,7 +109,9 @@ export function PlanStorage( { children, className, siteId } ) {
 				title={ translate( 'Storage quota is shared between production and staging.' ) }
 				className="plan-storage__tooltip"
 			>
-				<div className={ classNames( className, 'plan-storage' ) }>{ planStorageComponents }</div>
+				<div className={ classNames( className, 'plan-storage plan-storage__shared_quota' ) }>
+					{ planStorageComponents }
+				</div>
 			</Tooltip>
 		);
 	}

--- a/client/blocks/plan-storage/test/plan-storage.jsx
+++ b/client/blocks/plan-storage/test/plan-storage.jsx
@@ -149,12 +149,58 @@ describe( 'PlanStorage basic tests', () => {
 						},
 						options: {
 							is_automated_transfer: true,
+							wpcom_staging_blog_ids: [],
 						},
 					},
 				},
 			},
 		} );
 		expect( container.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 1 );
+		expect( container.getElementsByClassName( 'plan-storage__shared_quota' ) ).toHaveLength( 0 );
+	} );
+
+	test( 'should render for an atomic site with a staging site', () => {
+		const { container } = renderComponent( <PlanStorage siteId={ siteId } />, {
+			sites: {
+				items: {
+					[ siteId ]: {
+						name: 'yourjetpack.blog',
+						jetpack: true,
+						plan: {
+							product_slug: PLAN_BUSINESS,
+						},
+						options: {
+							is_automated_transfer: true,
+							wpcom_staging_blog_ids: [ 456 ],
+						},
+					},
+				},
+			},
+		} );
+		expect( container.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 1 );
+		expect( container.getElementsByClassName( 'plan-storage__shared_quota' ) ).toHaveLength( 1 );
+	} );
+
+	test( 'should render for a staging site', () => {
+		const { container } = renderComponent( <PlanStorage siteId={ siteId } />, {
+			sites: {
+				items: {
+					[ siteId ]: {
+						name: 'staging-4e35-awesomesite.wpcomstaging.com',
+						is_wpcom_staging_site: true,
+						jetpack: true,
+						plan: {
+							product_slug: PLAN_BUSINESS,
+						},
+						options: {
+							is_automated_transfer: true,
+						},
+					},
+				},
+			},
+		} );
+		expect( container.getElementsByClassName( 'plan-storage' ) ).toHaveLength( 1 );
+		expect( container.getElementsByClassName( 'plan-storage__shared_quota' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should not render for jetpack sites', () => {

--- a/client/state/selectors/has-wpcom-staging-site.ts
+++ b/client/state/selectors/has-wpcom-staging-site.ts
@@ -13,5 +13,5 @@ export default function hasWpcomStagingSite( state: AppState, siteId: number | n
 		return false;
 	}
 	const site = getRawSite( state, siteId );
-	return site?.options?.wpcom_staging_blog_ids ?? false;
+	return site?.options?.wpcom_staging_blog_ids?.length ?? false;
 }

--- a/client/state/selectors/has-wpcom-staging-site.ts
+++ b/client/state/selectors/has-wpcom-staging-site.ts
@@ -1,0 +1,17 @@
+import { AppState } from 'calypso/types';
+import getRawSite from './get-raw-site';
+
+/**
+ * Returns true if the site has a staging site, false otherwise.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {number | null}   siteId Site ID
+ * @returns {boolean}        Whether site has a staging site or note
+ */
+export default function hasWpcomStagingSite( state: AppState, siteId: number | null ) {
+	if ( ! siteId ) {
+		return false;
+	}
+	const site = getRawSite( state, siteId );
+	return site?.options?.wpcom_staging_blog_ids ?? false;
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2044

## Proposed Changes

Updates the plan storage component to show a helpful tooltip on both staging and production sites:

<img width="405" alt="image" src="https://user-images.githubusercontent.com/36432/231290738-c5303d32-f253-4561-ab07-f2e26f815d54.png">

## Testing Instructions

1. Navigate to `/media/<domain>`.
2. On a staging site, the tooltip should appear on hover and the upgrade link should no longer appear.
3. On a Business site with a staging site, the tooltip should appear on hover.
4. On a Business site without a staging site, the tooltip should not appear on hover.
5. On a Personal site, an upgrade link should appear with an upgrade nag in the tooltip.