### PR TITLE
VideoPress Onboarding: Do not play video if reduced motion setting is enabled

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/videopress-intro-background.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/videopress-intro-background.tsx
@@ -4,8 +4,12 @@ import * as VideoPressIframeApi from './videopress-iframe-api';
 const VideoPressIntroBackground = () => {
 	const iframeRef = createRef< HTMLIFrameElement >();
 	const divRef = createRef< HTMLDivElement >();
+	const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
 
 	useEffect( () => {
+		if ( prefersReducedMotion ) {
+			return;
+		}
 		const iframeApi = VideoPressIframeApi(
 			document.getElementById( 'videopress-intro-video-frame' ),
 			() => {
@@ -23,17 +27,19 @@ const VideoPressIntroBackground = () => {
 				);
 			}
 		);
-	}, [ divRef ] );
+	}, [ divRef, prefersReducedMotion ] );
 
 	return (
 		<>
-			<iframe
-				ref={ iframeRef }
-				id="videopress-intro-video-frame"
-				className="intro__video"
-				title="Video"
-				src="https://video.wordpress.com/v/l9GrBaPw?autoPlay=true&amp;controls=false&amp;muted=true&amp;loop=true&amp;cover=true&amp;playsinline=true"
-			></iframe>
+			{ prefersReducedMotion ? null : (
+				<iframe
+					ref={ iframeRef }
+					id="videopress-intro-video-frame"
+					className="intro__video"
+					title="Video"
+					src="https://video.wordpress.com/v/l9GrBaPw?autoPlay=true&amp;controls=false&amp;muted=true&amp;loop=true&amp;cover=true&amp;playsinline=true"
+				></iframe>
+			) }
 			<div ref={ divRef } className="intro__video loading-frame"></div>
 		</>
 	);


### PR DESCRIPTION
Fixes https://github.com/Automattic/greenhouse/issues/1590

## Proposed Changes

* Does not play the intro video background of the VideoPress onboarding flow if reduced motion is set.

## Testing Instructions

* On your OS, set reduced motion setting to on (On macOS it is in Accessibility)
* Visit `/setup/videopress`
* You should NOT see a background video, just the picture of the car mirror
* Turn the reduced motion setting back off.
* Reload the page, and the video should autoplay.
* Repeat the steps for multiple browsers 😉 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
