### PR TITLE
Sites Page: Switch a few nags to use 'react-intersection-observer'

### DIFF
--- a/client/sites-dashboard/components/sites-grid-action-renew.tsx
+++ b/client/sites-dashboard/components/sites-grid-action-renew.tsx
@@ -3,10 +3,10 @@ import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
+import { useInView } from 'react-intersection-observer';
 import { useSelector } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
-import { useInView } from 'calypso/lib/use-in-view';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { PLAN_RENEW_NAG_EVENT_NAMES } from '../utils';
 
@@ -50,7 +50,9 @@ export function SitesGridActionRenew( { site }: SitesGridActionRenewProps ) {
 		} );
 	}, [ isSiteOwner, productSlug ] );
 
-	const ref = useInView< HTMLSpanElement >( trackCallback );
+	const { ref } = useInView( {
+		onChange: ( inView ) => inView && trackCallback(),
+	} );
 
 	return (
 		<Container>

--- a/client/sites-dashboard/components/sites-plan-renew-nag.tsx
+++ b/client/sites-dashboard/components/sites-plan-renew-nag.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
-import { useInView } from 'calypso/lib/use-in-view';
+import { useInView } from 'react-intersection-observer';
 import { PLAN_RENEW_NAG_EVENT_NAMES } from '../utils';
 
 interface PlanRenewProps {
@@ -66,7 +66,9 @@ export const PlanRenewNag = ( {
 			} ),
 		[ isSiteOwner, plan.product_slug ]
 	);
-	const ref = useInView< HTMLDivElement >( trackCallback );
+	const { ref } = useInView( {
+		onChange: ( inView ) => inView && trackCallback(),
+	} );
 
 	const renewText = __( 'Renew plan' );
 	return (

--- a/client/sites-dashboard/components/sites-site-launch-nag.tsx
+++ b/client/sites-dashboard/components/sites-site-launch-nag.tsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
-import { useInView } from 'calypso/lib/use-in-view';
+import { useInView } from 'react-intersection-observer';
 import { getDashboardUrl, getLaunchpadUrl } from '../utils';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
@@ -85,7 +85,9 @@ const recordNagView = () => {
 
 export const SiteLaunchNag = ( { site }: SiteLaunchNagProps ) => {
 	const { __ } = useI18n();
-	const ref = useInView< HTMLAnchorElement >( recordNagView );
+	const { ref } = useInView( {
+		onChange: ( inView ) => inView && recordNagView(),
+	} );
 
 	// Don't show nag to all Coming Soon sites, only those that are "unlaunched"
 	// That's because sites that have been previously launched before going back to


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/issues/74022

## Proposed Changes

Switches a few nags on the Sites page to use `react-intersection-observer`.

### Launch Nag

<img width="1712" alt="image" src="https://user-images.githubusercontent.com/36432/231306200-130b4470-8c66-4ad1-a985-3136ecb4554f.png">

### Grid Renew Nag

<img width="1712" alt="image" src="https://user-images.githubusercontent.com/36432/231306055-c7474afa-fa7e-4f69-bad4-b97886636c02.png">

### List Renew Nag

<img width="1712" alt="image" src="https://user-images.githubusercontent.com/36432/231306129-8c77e4e0-809b-459f-b392-3cabc172680b.png">

## Testing Instructions

1. Navigate to `/sites` and verify the Tracks events fire when the nag is in view.