### PR TITLE
Update font sizes on mobile for my plan page

### DIFF
--- a/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
@@ -1,4 +1,5 @@
 @import "@wordpress/base-styles/breakpoints";
+@import "@automattic/typography/styles/woo-commerce";
 
 body.is-section-plans.is-ecommerce-trial-plan {
 
@@ -77,7 +78,7 @@ body.is-section-plans.is-ecommerce-trial-plan {
 
 			@media (max-width: $break-mobile) {
 				text-align: left;
-				font-size: $font-body-extra-small;
+				font-size: $woo-font-body-extra-small;
 				padding: 0 20px;
 			}
 		}
@@ -94,12 +95,16 @@ body.is-section-plans.is-ecommerce-trial-plan {
 
 				.e-commerce-trial-current-plan__included-view-all {
 					color: var(--color-accent);
-					font-size: $font-body-extra-small;
+					font-size: $woo-font-body-extra-small;
 					border: 0;
 					padding: 0;
 					text-align: center;
 					width: 100%;
 					margin-top: 20px;
+				}
+
+				.feature-included-card__text {
+					font-size: $woo-font-body-extra-small;
 				}
 			}
 		}
@@ -110,6 +115,12 @@ body.is-section-plans.is-ecommerce-trial-plan {
 			list-style: none;
 			padding: 20px;
 			margin-top: 30px;
+
+			@media (max-width: $break-mobile) {
+				.feature-not-included-card__text {
+					font-size: $woo-font-body-extra-small;
+				}
+			}
 		}
 
 		.e-commerce-trial-current-plan__cta-wrapper {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/73321

## Proposed Changes

On My Plan page (mobile view),

- Change the action links in the What's included section to be 13px
- Change body copy for the grid items in the What's included section to be 13px
- Change the "Upgrade your free trial…" text to be 13px
- Change inner items in the "selling list" to be 13px

figma: lD0gTB4IqGsmSmsnjZNaP6-fi-470_15301


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a free trial site
* Go to `/plans/my-plan/{site-slug}`
* Use mobile view
* Confirm the font sizes are 13px for various components as follows:

<img width="375" alt="Plans _ Free trial - Mobile (1)" src="https://user-images.githubusercontent.com/4344253/231349665-735df131-f20c-4936-9ae7-ec0360e310ce.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?