### PR TITLE
Site Assembler: Prevent the Continue button mis-clicking

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
@@ -7,6 +7,7 @@ export const PATTERN_ASSEMBLER_EVENTS = {
 	 */
 	MAIN_ITEM_SELECT: 'calypso_signup_pattern_assembler_main_item_select',
 	CONTINUE_CLICK: 'calypso_signup_pattern_assembler_continue_click',
+	CONTINUE_MISCLICK: 'calypso_signup_pattern_assembler_continue_misclick',
 	BACK_CLICK: 'calypso_signup_pattern_assembler_back_click',
 	PATTERN_FINAL_SELECT: 'calypso_signup_pattern_assembler_pattern_final_select',
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -495,6 +495,7 @@ const PatternAssembler = ( {
 						isDismissedGlobalStylesUpgradeModal={ isDismissedGlobalStylesUpgradeModal }
 						onSelect={ onMainItemSelect }
 						onContinueClick={ onContinueClick }
+						recordTracksEvent={ recordTracksEvent }
 					/>
 				</NavigatorScreen>
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -4,6 +4,7 @@ import { __experimentalHStack as HStack } from '@wordpress/components';
 import { header, footer, layout, color, typography } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
+import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import { NavigationButtonAsItem } from './navigator-buttons';
 import NavigatorHeader from './navigator-header';
 import { NavigatorItemGroup } from './navigator-item-group';
@@ -14,6 +15,7 @@ interface Props {
 	isDismissedGlobalStylesUpgradeModal?: boolean;
 	onSelect: ( name: string ) => void;
 	onContinueClick: () => void;
+	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 }
 
 const ScreenMain = ( {
@@ -21,6 +23,7 @@ const ScreenMain = ( {
 	isDismissedGlobalStylesUpgradeModal,
 	onSelect,
 	onContinueClick,
+	recordTracksEvent,
 }: Props ) => {
 	const translate = useTranslate();
 	const [ disabled, setDisabled ] = useState( true );
@@ -42,6 +45,7 @@ const ScreenMain = ( {
 	const handleMouseDown = ( event: MouseEvent< HTMLButtonElement > ) => {
 		if ( disabled ) {
 			event.preventDefault();
+			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.CONTINUE_MISCLICK );
 			return;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -3,9 +3,11 @@ import { Button } from '@automattic/components';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { header, footer, layout, color, typography } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useState, useEffect } from 'react';
 import { NavigationButtonAsItem } from './navigator-buttons';
 import NavigatorHeader from './navigator-header';
 import { NavigatorItemGroup } from './navigator-item-group';
+import type { MouseEvent } from 'react';
 
 interface Props {
 	shouldUnlockGlobalStyles: boolean;
@@ -21,6 +23,7 @@ const ScreenMain = ( {
 	onContinueClick,
 }: Props ) => {
 	const translate = useTranslate();
+	const [ disabled, setDisabled ] = useState( true );
 	const getDescription = () => {
 		if ( ! shouldUnlockGlobalStyles ) {
 			return translate( 'Ready? Go to the Site Editor to edit your content.' );
@@ -34,6 +37,24 @@ const ScreenMain = ( {
 
 		return translate( "You've selected a premium color or font for your site." );
 	};
+
+	// Use the mousedown event to prevent either the button focusing or text selection
+	const handleMouseDown = ( event: MouseEvent< HTMLButtonElement > ) => {
+		if ( disabled ) {
+			event.preventDefault();
+			return;
+		}
+
+		onContinueClick();
+	};
+
+	// Set a delay to enable the Continue button since the user might mis-click easily when they go back from another screen
+	useEffect( () => {
+		const timeoutId = window.setTimeout( () => setDisabled( false ), 300 );
+		return () => {
+			window.clearTimeout( timeoutId );
+		};
+	}, [] );
 
 	return (
 		<>
@@ -98,7 +119,7 @@ const ScreenMain = ( {
 			</div>
 			<div className="screen-container__footer">
 				<span className="screen-container__description">{ getDescription() }</span>
-				<Button className="pattern-assembler__button" onClick={ onContinueClick } primary>
+				<Button className="pattern-assembler__button" primary onMouseDown={ handleMouseDown }>
 					{ shouldUnlockGlobalStyles && ! isDismissedGlobalStylesUpgradeModal
 						? translate( 'Unlock this style' )
 						: translate( 'Continue' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1681263218769429-slack-CRWCHQGUB

## Proposed Changes

* The user easily misclicks the Continue button to proceed to the next step when they come back to the sub-screen. So, this PR is proposing to delay the Continue button being clickable by about 300ms to reduce this kind of accident.
* Also, adding a new event to track mis-clicking
  ![image](https://user-images.githubusercontent.com/13596067/231400876-8b1d6a47-1183-4b33-a22a-cec8726b9678.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_free_site>
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll to the bottom and select "Start designing"
* On the Pattern Assembler screen
  * Go to any sub-screen
  * Double click the `Save` button
  * When you're back to the main screen, ensure you're not proceeding to the next step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?