### PR TITLE
Add E2E tests for the Site Assembler

### DIFF
--- a/test/e2e/specs/onboarding/setup__site-assembler.ts
+++ b/test/e2e/specs/onboarding/setup__site-assembler.ts
@@ -1,0 +1,89 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	SecretsManager,
+	TestAccount,
+	SiteAssemblerFlow,
+} from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Site Assembler' ), () => {
+	const credentials = SecretsManager.secrets.testAccounts.defaultUser;
+	const siteSlug = credentials.testSites?.primary?.url as string;
+
+	let page: Page;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+
+		const testAccount = new TestAccount( 'defaultUser' );
+		await testAccount.authenticate( page );
+	} );
+
+	describe( 'Create a site with the Site Assembler', function () {
+		let startSiteFlow: SiteAssemblerFlow;
+
+		beforeAll( async function () {
+			startSiteFlow = new SiteAssemblerFlow( page );
+		} );
+
+		it( 'Enter Onboarding flow', async function () {
+			await page.goto( DataHelper.getCalypsoURL( '/setup/site-setup', { siteSlug } ), {
+				timeout: 30 * 1000,
+			} );
+		} );
+
+		it( 'Select "Continue" until it lands on the Design Picker', async function () {
+			await startSiteFlow.clickButton( 'Continue' );
+			await startSiteFlow.clickButton( 'Continue' );
+		} );
+
+		it( 'Select "Start designing" and land on the Site Assembler', async function () {
+			await startSiteFlow.clickButton( 'Start designing' );
+			await page.waitForURL(
+				DataHelper.getCalypsoURL( `/setup/site-setup/patternAssembler?siteSlug=${ siteSlug }` ),
+				{
+					timeout: 30 * 1000,
+				}
+			);
+		} );
+
+		it( 'Select "Header"', async function () {
+			await startSiteFlow.selectHeader();
+			await startSiteFlow.clickButton( 'Save' );
+			await page
+				.locator( '.pattern-large-preview__patterns .block-renderer' )
+				.count()
+				.then( ( count ) => {
+					expect( count ).toBe( 1 );
+				} );
+		} );
+
+		it( 'Select "Footer"', async function () {
+			await startSiteFlow.selectFooter();
+			await startSiteFlow.clickButton( 'Save' );
+			await page
+				.locator( '.pattern-large-preview__patterns .block-renderer' )
+				.count()
+				.then( ( count ) => {
+					expect( count ).toBe( 2 );
+				} );
+		} );
+
+		it( 'Click "Continue" and land on the Site Editor', async function () {
+			await startSiteFlow.clickButton( 'Continue' );
+			await page.waitForURL( /.*\/site-editor\/.*/, {
+				timeout: 30 * 1000,
+			} );
+		} );
+	} );
+
+	describe( 'GET `/block-renderer/patterns/render` should response HTML and styles', function () {
+		// TODO:
+	} );
+} );

--- a/test/e2e/specs/onboarding/setup__site-assembler.ts
+++ b/test/e2e/specs/onboarding/setup__site-assembler.ts
@@ -82,8 +82,4 @@ describe( DataHelper.createSuiteTitle( 'Site Assembler' ), () => {
 			} );
 		} );
 	} );
-
-	describe( 'GET `/block-renderer/patterns/render` should response HTML and styles', function () {
-		// TODO:
-	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72408, https://github.com/Automattic/wp-calypso/pull/75525

## Proposed Changes

- Add E2E tests for the Site Assembler 

### Why E2E tests?

_As for why it's started, please see this post's `Background`._ pbxlJb-3Iv-p2

To begin with, I have been trying to figure out how the Site Assembler as a whole can be ensured to work. Here is what I thought;

1. Add (general) E2E tests (this PR)
2. Add unit tests for the API (D107622-code)

I believe that the most critical behavior can be ensured by `1`. (It should not cover all functions p6fDka-Ld-p2)
Also, I thought that by unit testing several patterns in `2`, we could reduce the possibility of regressions.
(Personally, I'd like to have the visual regression tests, but we can compromise for now)

There was an idea to run E2E tests only for the endpoints, but I decided not to do it for the following reasons;

- In this case, if the parameter (`site_id`) sent by the client is wrong, the bug will happen. It can only be verified when the client and the backend are connected.
- Could be tested to some extent with unit tests in WPCOM.
- API testing is not common in Calypso. pbxlJb-3Iv-p2#comment-2495

I'd be happy to hear any opinions 🙏 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* NODE_ENV=test yarn workspace wp-e2e-tests test -- test/e2e/specs/onboarding/setup__site-assembler.ts
* To run tests locally, you may need to setup environment.
	* https://wpcalypso.wordpress.com/devdocs/test/e2e/docs/setup.md
	* https://wpcalypso.wordpress.com/devdocs/test/e2e/docs/test_environment.md
	* https://wpcalypso.wordpress.com/devdocs/test/e2e/docs/tests_local.md

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?