### PR TITLE
Jetpack Pro Dashboard: pre-select a 10GB backup license instead of 1TB when issuing a license from the Dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -487,7 +487,7 @@ export const formatSites = ( sites: Array< Site > = [] ): Array< SiteData > | []
  */
 export const getProductSlugFromProductType = ( type: string ): string | undefined => {
 	const slugs: Record< string, string > = {
-		backup: 'jetpack-backup-t2',
+		backup: 'jetpack-backup-t1',
 		scan: 'jetpack-scan',
 	};
 


### PR DESCRIPTION
Related to 1202619025189113-as-1204372933037896

## Proposed Changes

This PR pre-selects a 10GB backup license instead of 1TB when issuing a license from the Dashboard.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/pre-select-backup-t1-in-pro-dashboard` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click `Add +` on the backup column and `Add +` on the scan column -> Click on `Issues 2 licenses` button. Verify that a 10GB backup license is pre-selected along with Scan Daily
4. Go back to Dashboard -> Click on `Add +` on the backup column when there is only one license available to be attached to a site, i.e when a site already has scan -> Verify that 10 GB backup plan is pre-selected

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1092" alt="Screenshot 2023-04-12 at 10 39 52 AM" src="https://user-images.githubusercontent.com/10586875/231356427-26a0d2bf-e595-4650-a6e9-a794fc18208a.png">
</td>
<td>
<img width="1092" alt="Screenshot 2023-04-12 at 10 39 40 AM" src="https://user-images.githubusercontent.com/10586875/231356410-83de4863-777b-43e9-98b7-083cd8a59b80.png"></td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?