### PR TITLE
Add extended header section to logged out tags page.

### DIFF
--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -150,7 +150,7 @@ class MasterbarLoggedOut extends Component {
 
 		return (
 			<Masterbar>
-				<Item className="masterbar__item-logo">
+				<Item className="masterbar__item-logo masterbar__item--always-show-content">
 					<WordPressLogo className="masterbar__wpcom-logo" />
 					<WordPressWordmark className="masterbar__wpcom-wordmark" />
 				</Item>

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -1,3 +1,4 @@
+import { translate } from 'i18n-calypso';
 import { trim } from 'lodash';
 import AsyncLoad from 'calypso/components/async-load';
 import {
@@ -8,8 +9,21 @@ import {
 } from 'calypso/reader/controller-helper';
 import { TAG_PAGE } from 'calypso/reader/follow-sources';
 import { recordTrack } from 'calypso/reader/stats';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const analyticsPageTitle = 'Reader';
+
+const renderHeaderSection = () => (
+	<div className="tag-stream__page-header">
+		<h2>
+			{
+				// translators: The title of the reader tag page
+				translate( 'WordPress Reader' )
+			}
+		</h2>
+		<h1>{ translate( 'Enjoy millions of blogs at your fingertips.' ) }</h1>
+	</div>
+);
 
 export const tagListing = ( context, next ) => {
 	const basePath = '/tag/:slug';
@@ -28,6 +42,9 @@ export const tagListing = ( context, next ) => {
 		tag: tagSlug,
 	} );
 
+	if ( ! isUserLoggedIn( context.store.getState() ) ) {
+		context.headerSection = renderHeaderSection();
+	}
 	context.primary = (
 		<AsyncLoad
 			require="calypso/reader/tag-stream/main"

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -43,3 +43,19 @@
 .is-reader-page .tag-stream__main.main {
 	max-width: 800px;
 }
+
+// specific rule to override existing rules
+.layout.has-header-section.is-section-reader .layout__header-section-content .tag-stream__page-header {
+	text-align: center;
+
+	h2 {
+		font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-weight: 500;
+		margin-bottom: 10px;
+	}
+
+	h1 {
+		font-size: 40px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-weight: 500;
+	}
+}


### PR DESCRIPTION
Part of pe7F0s-IS-p2

Adds the header section for logged out users. Header section for logged in users will stay the same for now as per pe7F0s-IS-p2#comment-799

Before:
<img width="687" alt="Screen Shot 2023-04-12 at 3 02 44 pm" src="https://user-images.githubusercontent.com/22446385/231361648-20c62390-5695-457a-8b00-28dc4caeedd4.png">
After:
<img width="671" alt="Screen Shot 2023-04-12 at 3 02 12 pm" src="https://user-images.githubusercontent.com/22446385/231361894-760c2916-3fff-47af-98dc-389aaa453b07.png">

This also enables the wordpress logo on mobile for anywhere logged out masterbar is used.
I couldn't find examples of where the logged out masterbar is used except for when it flashes on screen before the normal logged out header loads, for example: previously the wordpress logo in the black masterbar would not be shown on mobile.

https://user-images.githubusercontent.com/22446385/231354561-a92d513d-f797-4e58-8559-37ddce04b021.mov

