### PR TITLE
Jetpack Pro Dashboard: fix the alignment issues in the pro dashboard table columns.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -117,8 +117,6 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 						'site-table__td-without-border-bottom': isExpanded,
 						'site-table__actions-button': isExpandedContentEnabled,
 					} ) }
-					// If there is an error, we need to span the whole row because we don't show the expand buttons.
-					colSpan={ isExpandedContentEnabled ? 2 : 1 }
 				>
 					<SiteActions isLargeScreen site={ site } siteError={ siteError } />
 				</td>


### PR DESCRIPTION
Related to 1203940061556608-as-1204378418814423

## Proposed Changes

This PR fixes the alignment issues in the pro dashboard table columns

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/table-alignment-issues-in-pro-dashboard` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify that the `Edit All` button is alignment with the table row actions.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="233" alt="Screenshot 2023-04-12 at 11 19 50 AM" src="https://user-images.githubusercontent.com/10586875/231364944-e322a7fa-118c-44b6-b6ad-bbb400cb3de4.png">
</td>
<td>
<img width="246" alt="Screenshot 2023-04-12 at 11 28 06 AM" src="https://user-images.githubusercontent.com/10586875/231365177-522c6264-cc47-497a-866e-c90219840632.png">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?