### PR TITLE
Hosting onboarding: only reuse is-user class name when visiting the user-hosting step on signup

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -73,7 +73,7 @@ import {
 } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import flows from './config/flows';
-import { getStepComponent, getStepModuleName } from './config/step-components';
+import { getStepComponent } from './config/step-components';
 import steps from './config/steps';
 import { addP2SignupClassName } from './controller';
 import {
@@ -816,12 +816,11 @@ class Signup extends Component {
 			};
 		}
 
-		let stepName = getStepModuleName( this.props.stepName );
-		stepName = stepName === 'user' ? 'user' : stepName;
+		const stepClassName = this.props.stepName === 'user-hosting' ? 'user' : this.props.stepName;
 
 		return (
 			<div className="signup__step" key={ stepKey }>
-				<div className={ `signup__step is-${ stepName }` }>
+				<div className={ `signup__step is-${ stepClassName }` }>
 					{ shouldRenderLocaleSuggestions && (
 						<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
 					) }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/74911

## Proposed Changes

Fixes a regression introduced in https://github.com/Automattic/wp-calypso/pull/74911 where other flows were affected by the step name to component name mapping. We're only treating `user-hosting` (and renaming it as `user`) moving forward.

## Testing Instructions

1. Checkout this branch;
2. Visit `/start/hosting` and check that the passwordless flow is styled just like `trunk`;
3. Visit `/start/do-it-for-me-store` and check that the last step is styled just like the "after" column in [this comment](https://github.com/Automattic/wp-calypso/pull/74911#discussion_r1163643335).
