### PR TITLE
Update Gravatar log-in page

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -16,7 +16,6 @@ import {
 	isCrowdsignalOAuth2Client,
 	isJetpackCloudOAuth2Client,
 	isWooOAuth2Client,
-	isGravatarOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import { isWebAuthnSupported } from 'calypso/lib/webauthn';
@@ -260,6 +259,7 @@ class Login extends Component {
 			isWhiteLogin,
 			isJetpackWooCommerceFlow,
 			isP2Login,
+			isGravatarLogin,
 			wccomFrom,
 			isManualRenewalImmediateLoginAttempt,
 			linkingSocialService,
@@ -463,7 +463,7 @@ class Login extends Component {
 		}
 
 		if ( isWhiteLogin ) {
-			preHeader = isGravatarOAuth2Client( oauth2Client ) ? (
+			preHeader = isGravatarLogin ? (
 				<div className="login__form-gravatar-logo">
 					<img src={ oauth2Client.icon } alt={ oauth2Client.title } />
 				</div>

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -16,6 +16,7 @@ import {
 	isCrowdsignalOAuth2Client,
 	isJetpackCloudOAuth2Client,
 	isWooOAuth2Client,
+	isGravatarOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import { isWebAuthnSupported } from 'calypso/lib/webauthn';
@@ -462,7 +463,11 @@ class Login extends Component {
 		}
 
 		if ( isWhiteLogin ) {
-			preHeader = (
+			preHeader = isGravatarOAuth2Client( oauth2Client ) ? (
+				<div className="login__form-gravatar-logo">
+					<img src={ oauth2Client.icon } alt={ oauth2Client.name } />
+				</div>
+			) : (
 				<div className="login__form-gutenboarding-wordpress-logo">
 					<svg
 						aria-hidden="true"

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -465,7 +465,7 @@ class Login extends Component {
 		if ( isWhiteLogin ) {
 			preHeader = isGravatarOAuth2Client( oauth2Client ) ? (
 				<div className="login__form-gravatar-logo">
-					<img src={ oauth2Client.icon } alt={ oauth2Client.name } />
+					<img src={ oauth2Client.icon } alt={ oauth2Client.title } />
 				</div>
 			) : (
 				<div className="login__form-gutenboarding-wordpress-logo">

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -22,7 +22,11 @@ import {
 	pathWithLeadingSlash,
 	isReactLostPasswordScreenEnabled,
 } from 'calypso/lib/login';
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import {
+	isCrowdsignalOAuth2Client,
+	isWooOAuth2Client,
+	isGravatarOAuth2Client,
+} from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -562,7 +566,7 @@ export class LoginForm extends Component {
 			isWoo,
 			isPartnerSignup,
 		} = this.props;
-		const isOauthLogin = !! oauth2Client;
+		const showSignupUrl = !! oauth2Client && ! isGravatarOAuth2Client( oauth2Client );
 		const isPasswordHidden = this.isUsernameOrEmailView();
 
 		const signupUrl = this.props.signupUrl
@@ -737,7 +741,7 @@ export class LoginForm extends Component {
 						</FormsButton>
 					</div>
 
-					{ isOauthLogin && (
+					{ showSignupUrl && (
 						<div className={ classNames( 'login__form-signup-link' ) }>
 							{ this.props.translate(
 								'Not on WordPress.com? {{signupLink}}Create an Account{{/signupLink}}.',

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -22,11 +22,7 @@ import {
 	pathWithLeadingSlash,
 	isReactLostPasswordScreenEnabled,
 } from 'calypso/lib/login';
-import {
-	isCrowdsignalOAuth2Client,
-	isWooOAuth2Client,
-	isGravatarOAuth2Client,
-} from 'calypso/lib/oauth2-clients';
+import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -566,7 +562,7 @@ export class LoginForm extends Component {
 			isWoo,
 			isPartnerSignup,
 		} = this.props;
-		const showSignupUrl = !! oauth2Client && ! isGravatarOAuth2Client( oauth2Client );
+		const isOauthLogin = !! oauth2Client;
 		const isPasswordHidden = this.isUsernameOrEmailView();
 
 		const signupUrl = this.props.signupUrl
@@ -741,7 +737,7 @@ export class LoginForm extends Component {
 						</FormsButton>
 					</div>
 
-					{ showSignupUrl && (
+					{ isOauthLogin && (
 						<div className={ classNames( 'login__form-signup-link' ) }>
 							{ this.props.translate(
 								'Not on WordPress.com? {{signupLink}}Create an Account{{/signupLink}}.',

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -247,6 +247,7 @@
 	}
 }
 
+.login__form-gravatar-logo,
 .login__form-gutenboarding-wordpress-logo {
 	height: 64px;
 	position: absolute;

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -41,6 +41,7 @@ const LayoutLoggedOut = ( {
 	isJetpackWooCommerceFlow,
 	isJetpackWooDnaFlow,
 	isP2Login,
+	isGravatarLogin,
 	wccomFrom,
 	masterbarIsHidden,
 	oauth2Client,
@@ -90,6 +91,7 @@ const LayoutLoggedOut = ( {
 		'is-jetpack-woo-dna-flow': isJetpackWooDnaFlow,
 		'is-wccom-oauth-flow': isWooOAuth2Client( oauth2Client ) && wccomFrom,
 		'is-p2-login': isP2Login,
+		'is-gravatar-login': isGravatarLogin,
 	};
 
 	let masterbar = null;
@@ -104,18 +106,15 @@ const LayoutLoggedOut = ( {
 		} else if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
 			masterbar = null;
 		} else {
-			classes.dops = true;
-			classes[ oauth2Client.name ] = true;
+			if ( ! isGravatarLogin ) {
+				classes.dops = true;
+				// Using .is-gravatar-login instead of .gravatar to avoid style conflicts with the Gravatar component
+				classes[ oauth2Client.name ] = true;
+			}
 
 			// Force masterbar for all Crowdsignal OAuth pages
 			if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
 				classes[ 'has-no-masterbar' ] = false;
-			}
-
-			// Using more specific class name insteadly to avoid style conflicts with the Gravatar component
-			if ( isGravatarOAuth2Client( oauth2Client ) ) {
-				classes[ oauth2Client.name ] = false;
-				classes[ 'is-gravatar' ] = true;
 			}
 
 			masterbar = <OauthClientMasterbar oauth2Client={ oauth2Client } />;
@@ -224,16 +223,15 @@ export default withCurrentRoute(
 		const isPartnerSignupStart = currentRoute.startsWith( '/start/wpcc' );
 		const isJetpackWooDnaFlow = wooDnaConfig( getInitialQueryArguments( state ) ).isWooDnaFlow();
 		const isP2Login = 'login' === sectionName && 'p2' === currentQuery?.from;
+		const oauth2Client = getCurrentOAuth2Client( state );
+		const isGravatarLogin = isGravatarOAuth2Client( oauth2Client );
 		const isReskinLoginRoute =
 			currentRoute.startsWith( '/log-in' ) &&
 			! isJetpackLogin &&
 			! isP2Login &&
 			Boolean( currentQuery?.client_id ) === false;
-		const oauth2Client = getCurrentOAuth2Client( state );
 		const isWhiteLogin =
-			isReskinLoginRoute ||
-			( isPartnerSignup && ! isPartnerSignupStart ) ||
-			isGravatarOAuth2Client( oauth2Client );
+			isReskinLoginRoute || ( isPartnerSignup && ! isPartnerSignupStart ) || isGravatarLogin;
 		const noMasterbarForRoute =
 			isJetpackLogin || ( isWhiteLogin && ! isPartnerSignup ) || isJetpackWooDnaFlow || isP2Login;
 		const isPopup = '1' === currentQuery?.is_popup;
@@ -252,6 +250,7 @@ export default withCurrentRoute(
 			isJetpackWooCommerceFlow,
 			isJetpackWooDnaFlow,
 			isP2Login,
+			isGravatarLogin,
 			wccomFrom,
 			masterbarIsHidden,
 			sectionGroup,

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -16,7 +16,11 @@ import OauthClientMasterbar from 'calypso/layout/masterbar/oauth-client';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { navigate } from 'calypso/lib/navigate';
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import {
+	isCrowdsignalOAuth2Client,
+	isWooOAuth2Client,
+	isGravatarOAuth2Client,
+} from 'calypso/lib/oauth2-clients';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isPartnerSignupQuery } from 'calypso/state/login/utils';
 import {
@@ -106,6 +110,12 @@ const LayoutLoggedOut = ( {
 			// Force masterbar for all Crowdsignal OAuth pages
 			if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
 				classes[ 'has-no-masterbar' ] = false;
+			}
+
+			// Using more specific class name insteadly to avoid style conflicts with the Gravatar component
+			if ( isGravatarOAuth2Client( oauth2Client ) ) {
+				classes[ oauth2Client.name ] = false;
+				classes[ 'is-gravatar' ] = true;
 			}
 
 			masterbar = <OauthClientMasterbar oauth2Client={ oauth2Client } />;
@@ -219,11 +229,14 @@ export default withCurrentRoute(
 			! isJetpackLogin &&
 			! isP2Login &&
 			Boolean( currentQuery?.client_id ) === false;
-		const isWhiteLogin = isReskinLoginRoute || ( isPartnerSignup && ! isPartnerSignupStart );
+		const oauth2Client = getCurrentOAuth2Client( state );
+		const isWhiteLogin =
+			isReskinLoginRoute ||
+			( isPartnerSignup && ! isPartnerSignupStart ) ||
+			isGravatarOAuth2Client( oauth2Client );
 		const noMasterbarForRoute =
 			isJetpackLogin || ( isWhiteLogin && ! isPartnerSignup ) || isJetpackWooDnaFlow || isP2Login;
 		const isPopup = '1' === currentQuery?.is_popup;
-		const oauth2Client = getCurrentOAuth2Client( state );
 		const noMasterbarForSection =
 			! isWooOAuth2Client( oauth2Client ) &&
 			[ 'signup', 'jetpack-connect' ].includes( sectionName );

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -50,13 +50,13 @@ const enhanceContextWithLogin = ( context ) => {
 	const isP2Login = query && query.from === 'p2';
 	const clientId = query?.client_id;
 	const oauth2ClientId = query?.oauth2_client_id;
-	const oauth2Client = { id: Number( clientId || oauth2ClientId ) };
+	const isGravatarLogin = isGravatarOAuth2Client( { id: Number( clientId || oauth2ClientId ) } );
 	const isWhiteLogin =
 		( ! isJetpackLogin &&
 			! isP2Login &&
 			Boolean( clientId ) === false &&
 			Boolean( oauth2ClientId ) === false ) ||
-		isGravatarOAuth2Client( oauth2Client );
+		isGravatarLogin;
 
 	context.primary = (
 		<WPLogin
@@ -64,6 +64,7 @@ const enhanceContextWithLogin = ( context ) => {
 			isJetpack={ isJetpackLogin }
 			isWhiteLogin={ isWhiteLogin }
 			isP2Login={ isP2Login }
+			isGravatarLogin={ isGravatarLogin }
 			path={ path }
 			twoFactorAuthType={ twoFactorAuthType }
 			socialService={ socialService }

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import page from 'page';
+import { isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { SOCIAL_HANDOFF_CONNECT_ACCOUNT } from 'calypso/state/action-types';
 import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
@@ -47,11 +48,15 @@ const enhanceContextWithLogin = ( context ) => {
 		: null;
 	const isJetpackLogin = isJetpack === 'jetpack';
 	const isP2Login = query && query.from === 'p2';
+	const clientId = query?.client_id;
+	const oauth2ClientId = query?.oauth2_client_id;
+	const oauth2Client = { id: Number( clientId || oauth2ClientId ) };
 	const isWhiteLogin =
-		! isJetpackLogin &&
-		! isP2Login &&
-		Boolean( query?.client_id ) === false &&
-		Boolean( query?.oauth2_client_id ) === false;
+		( ! isJetpackLogin &&
+			! isP2Login &&
+			Boolean( clientId ) === false &&
+			Boolean( oauth2ClientId ) === false ) ||
+		isGravatarOAuth2Client( oauth2Client );
 
 	context.primary = (
 		<WPLogin

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -223,6 +223,7 @@ export class Login extends Component {
 			isJetpack,
 			isWhiteLogin,
 			isP2Login,
+			isGravatarLogin,
 			oauth2Client,
 			privateSite,
 			socialConnect,
@@ -259,6 +260,7 @@ export class Login extends Component {
 						twoFactorAuthType={ twoFactorAuthType }
 						isWhiteLogin={ isWhiteLogin }
 						isP2Login={ isP2Login }
+						isGravatarLogin={ isGravatarLogin }
 						signupUrl={ signupUrl }
 						usernameOrEmail={ this.state.usernameOrEmail }
 						oauth2ClientId={ this.props.oauth2Client?.id }
@@ -278,6 +280,7 @@ export class Login extends Component {
 				isJetpack={ isJetpack }
 				isWhiteLogin={ isWhiteLogin }
 				isP2Login={ isP2Login }
+				isGravatarLogin={ isGravatarLogin }
 				oauth2Client={ oauth2Client }
 				socialService={ socialService }
 				socialServiceResponse={ socialServiceResponse }

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -328,7 +328,10 @@ export class LoginLinks extends Component {
 			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
 			: getSignupUrl( query, currentRoute, oauth2Client, locale, pathname );
 
-		if ( isJetpackCloudOAuth2Client( oauth2Client ) && '/log-in/authenticator' !== currentRoute ) {
+		if (
+			( isJetpackCloudOAuth2Client( oauth2Client ) && '/log-in/authenticator' !== currentRoute ) ||
+			isGravatarOAuth2Client( oauth2Client )
+		) {
 			return null;
 		}
 

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -14,7 +14,6 @@ import {
 	isCrowdsignalOAuth2Client,
 	isJetpackCloudOAuth2Client,
 	isWooOAuth2Client,
-	isGravatarOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -126,7 +125,7 @@ export class LoginLinks extends Component {
 		if (
 			isCrowdsignalOAuth2Client( this.props.oauth2Client ) ||
 			isJetpackCloudOAuth2Client( this.props.oauth2Client ) ||
-			( this.props.isWhiteLogin && ! isGravatarOAuth2Client( this.props.oauth2Client ) ) ||
+			( this.props.isWhiteLogin && ! this.props.isGravatarLogin ) ||
 			this.props.isP2Login ||
 			this.props.isPartnerSignup
 		) {
@@ -315,6 +314,7 @@ export class LoginLinks extends Component {
 		const {
 			currentRoute,
 			isP2Login,
+			isGravatarLogin,
 			locale,
 			oauth2Client,
 			pathname,
@@ -323,15 +323,16 @@ export class LoginLinks extends Component {
 			usernameOrEmail,
 		} = this.props;
 
+		if ( isGravatarLogin ) {
+			return null;
+		}
+
 		// use '?signup_url' if explicitly passed as URL query param
 		const signupUrl = this.props.signupUrl
 			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
 			: getSignupUrl( query, currentRoute, oauth2Client, locale, pathname );
 
-		if (
-			( isJetpackCloudOAuth2Client( oauth2Client ) && '/log-in/authenticator' !== currentRoute ) ||
-			isGravatarOAuth2Client( oauth2Client )
-		) {
+		if ( isJetpackCloudOAuth2Client( oauth2Client ) && '/log-in/authenticator' !== currentRoute ) {
 			return null;
 		}
 

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -14,6 +14,7 @@ import {
 	isCrowdsignalOAuth2Client,
 	isJetpackCloudOAuth2Client,
 	isWooOAuth2Client,
+	isGravatarOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -125,7 +126,7 @@ export class LoginLinks extends Component {
 		if (
 			isCrowdsignalOAuth2Client( this.props.oauth2Client ) ||
 			isJetpackCloudOAuth2Client( this.props.oauth2Client ) ||
-			this.props.isWhiteLogin ||
+			( this.props.isWhiteLogin && ! isGravatarOAuth2Client( this.props.oauth2Client ) ) ||
 			this.props.isP2Login ||
 			this.props.isPartnerSignup
 		) {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -542,6 +542,12 @@ $image-height: 47px;
 	}
 }
 
+.layout.is-gravatar {
+	.wp-login__main {
+		max-width: 640px;
+	}
+}
+
 .wp-login__p2-logo {
 	position: absolute;
 	top: 24px;

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -542,7 +542,7 @@ $image-height: 47px;
 	}
 }
 
-.layout.is-gravatar {
+.layout.is-gravatar-login {
 	.wp-login__main {
 		max-width: 640px;
 	}

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -554,6 +554,12 @@ $image-height: 47px;
 		box-shadow: none;
 		border-radius: 0;
 		color: var(--color-neutral-50);
+
+		&:hover,
+		&:focus {
+			border-color: var(--color-neutral-10);
+			color: #00a0d2;
+		}
 	}
 }
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -546,6 +546,15 @@ $image-height: 47px;
 	.wp-login__main {
 		max-width: 640px;
 	}
+
+	.wp-login__links > a:first-of-type {
+		border-top: none;
+		border-left: none;
+		border-right: none;
+		box-shadow: none;
+		border-radius: 0;
+		color: var(--color-neutral-50);
+	}
 }
 
 .wp-login__p2-logo {

--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -26,7 +26,7 @@ export const initialClientsData = {
 		id: 1854,
 		name: 'gravatar',
 		title: 'Gravatar',
-		icon: 'https://gravatar.com/images/grav-logo-2x.png',
+		icon: 'https://gravatar.com/images/grav-logo-blue.svg',
 	},
 	2665: {
 		id: 2665,


### PR DESCRIPTION
> # This PR has been moved here: https://github.com/Automattic/wp-calypso/pull/75746

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p9lV3a-5P8-p2

## Proposed Changes

This PR is to re-use the [design of the WP's login page](https://wordpress.com/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2F) for the [Gravatar's login page](https://wordpress.com/log-in?client_id=1854&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3Dad4b462bedc61ff0ee2b72b16252632bcf4f4ec2e9aaab25a169e49d565e87bf%26redirect_uri%3Dhttps%253A%252F%252Fen.gravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1). The changes are as follows:

* To use the "white login" styles for the Gravatar's login page
* To use a `.is-gravatar` class name instead of the `.gravatar` for style customization purpose and avoiding style conflicts (as below)
<img width="1279" alt="截圖 2023-04-12 下午5 08 18" src="https://user-images.githubusercontent.com/21308003/231410305-83088854-69da-41ad-85b7-3d9349191443.png">

* To remove the "Create a new account" button
* To show the "Back to gravatar" link
* To use Gravatar logo

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to the branch and run it locally
* Log out your WP account
* Go to the login page by [this URL](http://calypso.localhost:3000/log-in?client_id=1854&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3Dad4b462bedc61ff0ee2b72b16252632bcf4f4ec2e9aaab25a169e49d565e87bf%26redirect_uri%3Dhttps%253A%252F%252Fen.gravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1) (you might need to modify your origin), and you will see the new Gravatar's login page as below:

| Old | New |
| - | - |
| <img width="2560" alt="old_login_page" src="https://user-images.githubusercontent.com/21308003/231380809-2402e385-8468-41c0-bbf6-f5f58c3cef08.png"> |  <img width="1713" alt="截圖 2023-04-12 下午8 16 47" src="https://user-images.githubusercontent.com/21308003/231455276-77c20ca4-2a62-4801-8067-33a3b41a27c4.png"> |

* Try to login your WP account, and you will be re-directed to your Gravatar manage page
* This changes doesn't influence the login page of other services (please run Calypso locally for dev):
  * WordPress:
    * [Production](https://wordpress.com/log-in/)
    * [Development](http://calypso.localhost:3000/log-in)
  * WooCommerce:
    * [Production](https://wordpress.com/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D89c377eff8f6cc5e58dbfdd2138e883f2f75933aa7d5876347291891955cdcae%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1)
    * [Development](http://calypso.localhost:3000/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D89c377eff8f6cc5e58dbfdd2138e883f2f75933aa7d5876347291891955cdcae%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1)
  * Jetpack:
    * [Production](https://wordpress.com/log-in?client_id=69040&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud.jetpack.com%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252Fpricing%26scope%3Dglobal%26blog_id%3D0%26from-calypso%3D1)
    * [Development](http://calypso.localhost:3000/log-in?client_id=69040&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud.jetpack.com%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252Fpricing%26scope%3Dglobal%26blog_id%3D0%26from-calypso%3D1)
  * Akismet:
    * [Production](https://wordpress.com/log-in?client_id=973&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D973%26response_type%3Dcode%26blog_id%3D0%26state%3D202e9384cd96c958a22d138bf35bf102662bd4dee8357efe8d2207f7450e3d80%26redirect_uri%3Dhttps%253A%252F%252Fakismet.com%252Faccount%252F%253Faction%253Drequest_access_token%26implicit%3Dtrue%26new-user%3D0%26from-calypso%3D1)
    * [Development](https://wordpress.com/log-in?client_id=973&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D973%26response_type%3Dcode%26blog_id%3D0%26state%3D202e9384cd96c958a22d138bf35bf102662bd4dee8357efe8d2207f7450e3d80%26redirect_uri%3Dhttps%253A%252F%252Fakismet.com%252Faccount%252F%253Faction%253Drequest_access_token%26implicit%3Dtrue%26new-user%3D0%26from-calypso%3D1)
  * Crowdsignal:
    * [Production](https://wordpress.com/log-in?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D710b3271d959aaa6a02c3be9e799038443511289283f9608b77d35ea5a5b3659%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1%26from-calypso%3D1)
    * [Development](http://calypso.localhost:3000/log-in?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D710b3271d959aaa6a02c3be9e799038443511289283f9608b77d35ea5a5b3659%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1%26from-calypso%3D1)
  * P2
    * [Production](https://wordpress.com/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2Fstart%2Fp2%2Fp2-confirm-email%3Fref%3Dp2-lp&from=p2&signup_url=%2Fstart%2Fp2%2Fuser%3Fref%3Dp2-lp)
    * [Development](http://calypso.localhost:3000/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2Fstart%2Fp2%2Fp2-confirm-email%3Fref%3Dp2-lp&from=p2&signup_url=%2Fstart%2Fp2%2Fuser%3Fref%3Dp2-lp)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
