### PR TITLE
Hide subheadings when no colors/fonts

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	__experimentalHStack as HStack,
 	__experimentalItemGroup as ItemGroup,
@@ -10,12 +11,14 @@ type Props = {
 };
 
 export const NavigatorItemGroup = ( { children, title }: Props ) => {
-	return (
+	return isEnabled( 'pattern-assembler/color-and-fonts' ) ? (
 		<section>
 			<HStack direction="column" alignment="top" spacing="0">
 				<h3 className="pattern-layout__navigator-item-group">{ title }</h3>
 				<ItemGroup>{ children }</ItemGroup>
 			</HStack>
 		</section>
+	) : (
+		<ItemGroup>{ children }</ItemGroup>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	__experimentalHStack as HStack,
 	__experimentalItemGroup as ItemGroup,
@@ -11,14 +10,12 @@ type Props = {
 };
 
 export const NavigatorItemGroup = ( { children, title }: Props ) => {
-	return isEnabled( 'pattern-assembler/color-and-fonts' ) ? (
-		<section>
+	return (
+		<section className="navigator-item-group">
 			<HStack direction="column" alignment="top" spacing="0">
-				<h3 className="pattern-layout__navigator-item-group">{ title }</h3>
+				<h3 className="navigator-item-group__title">{ title }</h3>
 				<ItemGroup>{ children }</ItemGroup>
 			</HStack>
 		</section>
-	) : (
-		<ItemGroup>{ children }</ItemGroup>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/navigator-item-group/style.scss
@@ -1,12 +1,19 @@
 @import "@automattic/typography/styles/fonts";
 
 .pattern-assembler {
-	.pattern-layout__navigator-item-group {
+	.navigator-item-group:only-child {
+		.navigator-item-group__title {
+			display: none;
+		}
+	}
+
+	.navigator-item-group__title {
 		color: var(--color-neutral-100);
 		font-size: $font-body-small;
 		font-weight: 500;
 		letter-spacing: -0.15px;
 		line-height: 1.4;
-		padding: 0 10px;
+		padding: 0 2px;
+		margin-bottom: 4px;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74945

## Proposed Changes

- Hide subheadings when no colors/fonts
- With https://github.com/Automattic/wp-calypso/pull/75321, subheadings are added, but it should be shown only when colors/fonts are enabled.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- (Tested locally) Set `pattern-assembler/color-and-fonts` false in `config/development.json`
- Create a new site and `Continue` until landing on the Design Picker.
- Go to the site assembler by clicking `Start designing` from the bottom.
- See `Layout` is hidden

| before | after |
|--------|--------|
|<img width="312" alt="Screen Shot 2023-04-12 at 16 52 53" src="https://user-images.githubusercontent.com/13596067/231395873-39935296-86e0-4325-bed4-71f7e43949bf.png"> | <img width="307" alt="Screen Shot 2023-04-12 at 16 52 57" src="https://user-images.githubusercontent.com/5287479/231390376-4f74b089-0156-40cc-a3ef-00b71742ef13.png"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
