### PR TITLE
Plan Price: set is2023OnboardingPricingGrid to true

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -499,7 +499,7 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderPlanPrice( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
-		const { isReskinned, is2023OnboardingPricingGrid, isLargeCurrency } = this.props;
+		const { isReskinned, isLargeCurrency } = this.props;
 
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
@@ -520,7 +520,7 @@ export class PlanFeatures2023Grid extends Component<
 						{ ! hasNoPrice && (
 							<PlanFeatures2023GridHeaderPrice
 								planProperties={ properties }
-								is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+								is2023OnboardingPricingGrid={ true }
 								isLargeCurrency={ isLargeCurrency }
 							/>
 						) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Currently, the `is2023OnboardingPricingGrid` is passed as undefined, causing the decimal part of the price to be rendered as a superscript. By setting the value of this prop to `true`, it correctly displays the price in the same line.

Before:
<img width="1401" alt="image" src="https://user-images.githubusercontent.com/5436027/231391164-fd506826-2d89-4022-8804-9236085ffe4f.png">

After
<img width="1519" alt="image" src="https://user-images.githubusercontent.com/5436027/231403962-bf6e65fa-5daa-4d22-8100-c4cbb0c68007.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/yearly/<site slug>` for a site on any plan, and try a few different currencies till a decimal value is shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
