### PR TITLE
Update onboarding design picker to use ThemeCard

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -528,6 +528,7 @@ export class Theme extends Component {
 				onClick={ this.setBookmark }
 				onImageClick={ this.onScreenshotClick }
 				onStyleVariationClick={ this.onStyleVariationClick }
+				onStyleVariationMoreClick={ this.onStyleVariationClick }
 			/>
 		);
 	}

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -8,20 +8,21 @@ exports[`Theme rendering with default display buttonContents should match snapsh
   <div
     class="theme-card__content"
   >
-    <a
-      aria-label="Twenty Seventeen"
-      class="theme-card__image"
-      href="javascript:;"
+    <div
+      class="theme-card__image-container"
     >
-      <div
-        class="theme-card__image-label"
-      />
-      <img
-        class="theme__img"
-        src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360"
-        srcset="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360&zoom=2 2x"
-      />
-    </a>
+      <a
+        aria-label="Twenty Seventeen"
+        class="theme-card__image"
+        href="#"
+      >
+	    <img
+          class="theme__img"
+          src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360"
+          srcset="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360&zoom=2 2x"
+        />
+      </a>
+    </div>
     <div
       class="theme-card__info"
     >

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -16,7 +16,12 @@ exports[`Theme rendering with default display buttonContents should match snapsh
         class="theme-card__image"
         href="#"
       >
-	    <img
+        <div
+          class="theme-card__image-label"
+        >
+          Info
+        </div>
+        <img
           class="theme__img"
           src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360"
           srcset="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360&zoom=2 2x"

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -17,6 +17,7 @@ describe( 'Theme', () => {
 			screenshot:
 				'https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?ssl=1',
 		},
+		actionLabel: 'Info',
 		buttonContents: { dummyAction: { label: 'Dummy action', action: jest.fn() } }, // TODO: test if called when clicked
 		translate: ( string ) => string,
 		setThemesBookmark: () => {},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -744,7 +744,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			onPreview={ previewDesign }
 			onChangeVariation={ onChangeVariation }
 			onViewAllDesigns={ trackAllDesignsView }
-			onCheckout={ goToCheckout }
 			heading={ heading }
 			categorization={ categorization }
 			isPremiumThemeAvailable={ isPremiumThemeAvailable }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -740,7 +740,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			staticDesigns={ staticDesigns }
 			verticalId={ siteVerticalId }
 			locale={ locale }
-			onSelect={ pickDesign }
 			onSelectBlankCanvas={ pickBlankCanvasDesign }
 			onPreview={ previewDesign }
 			onChangeVariation={ onChangeVariation }

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -269,6 +269,7 @@
 	.design-picker__option-name {
 		color: var(--studio-white);
 	}
+
 	.design-picker__design-option {
 		.design-picker__design-option-header svg {
 			fill: var(--studio-gray-40);
@@ -296,7 +297,21 @@
 		}
 	}
 
-	.design-button-container .design-picker__design-option .design-picker__image-frame:hover::after {
+	.theme-card {
+		&:hover,
+		&:focus-within {
+			.theme-card__image-container {
+				border-color: var(--studio-white);
+			}
+		}
+
+		.theme-card__image-container {
+			border-color: var(--studio-gray-40);
+		}
+	}
+
+	.design-button-container .design-picker__design-option .design-picker__image-frame:hover::after,
+	.theme-card .theme-card__image:hover::after {
 		background-color: rgba(255, 255, 255, 0.42);
 	}
 }
@@ -333,7 +348,21 @@
 		}
 	}
 
-	.design-button-container .design-picker__design-option .design-picker__image-frame:hover::after {
+	.theme-card {
+		&:hover,
+		&:focus-within {
+			.theme-card__image-container {
+				border-color: #a7aaad;
+			}
+		}
+
+		.theme-card__image-container {
+			border-color: rgba(0, 0, 0, 0.12);
+		}
+	}
+
+	.design-button-container .design-picker__design-option .design-picker__image-frame:hover::after,
+	.theme-card .theme-card__image:hover::after {
 		background-color: rgba(255, 255, 255, 0.72);
 	}
 }
@@ -446,6 +475,32 @@
 		font-weight: 600;
 		margin-top: 40px;
 		margin-bottom: 5px;
+	}
+
+	.theme-card {
+		margin: 0;
+
+		.mshots-image__loader,
+		.theme-card__image-container {
+			padding-top: 65%;
+		}
+
+		.mshots-image__loader {
+			animation: loading-fade 1.6s ease-in-out infinite;
+			background-color: var(--studio-gray-10);
+		}
+
+		.theme-card__image::after {
+			content: "";
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
+			box-sizing: border-box;
+			background-color: transparent;
+			transition: border-color 0.15s ease-in-out, background-color 0.15s ease-in-out;
+		}
 	}
 
 	.design-picker__design-option > button {

--- a/packages/design-picker/src/components/theme-card/index.tsx
+++ b/packages/design-picker/src/components/theme-card/index.tsx
@@ -16,6 +16,7 @@ interface ThemeCardProps {
 	banner?: React.ReactNode;
 	badge?: React.ReactNode;
 	styleVariations: StyleVariation[];
+	selectedStyleVariation: StyleVariation;
 	optionsMenu?: React.ReactNode;
 	isActive?: boolean;
 	isInstalling?: boolean;
@@ -24,6 +25,7 @@ interface ThemeCardProps {
 	onClick?: () => void;
 	onImageClick?: () => void;
 	onStyleVariationClick?: () => void;
+	onStyleVariationMoreClick?: () => void;
 }
 
 const ThemeCard = forwardRef(
@@ -37,6 +39,7 @@ const ThemeCard = forwardRef(
 			banner,
 			badge,
 			styleVariations = [],
+			selectedStyleVariation,
 			optionsMenu,
 			isActive,
 			isInstalling,
@@ -45,6 +48,7 @@ const ThemeCard = forwardRef(
 			onClick,
 			onImageClick,
 			onStyleVariationClick,
+			onStyleVariationMoreClick,
 		}: ThemeCardProps,
 		forwardedRef: Ref< any > // eslint-disable-line @typescript-eslint/no-explicit-any
 	) => {
@@ -65,18 +69,28 @@ const ThemeCard = forwardRef(
 			<Card className={ themeClasses } onClick={ onClick } data-e2e-theme={ e2eName }>
 				<div ref={ forwardedRef } className="theme-card__content">
 					{ banner && <div className="theme-card__banner">{ banner }</div> }
-					<a
-						ref={ imageRef }
-						className="theme-card__image"
-						href={ imageClickUrl || 'javascript:;' /* fallback for a11y */ }
-						aria-label={ name }
-						onClick={ onImageClick }
-						onMouseEnter={ () => setIsShowTooltip( true ) }
-						onMouseLeave={ () => setIsShowTooltip( false ) }
-					>
-						{ isActionable && <div className="theme-card__image-label">{ imageActionLabel }</div> }
-						{ image }
-					</a>
+					<div className="theme-card__image-container">
+						<a
+							ref={ imageRef }
+							className="theme-card__image"
+							href={ imageClickUrl || '#' }
+							aria-label={ name }
+							onClick={ ( e ) => {
+								if ( ! imageClickUrl ) {
+									e.preventDefault();
+								}
+
+								onImageClick?.();
+							} }
+							onMouseEnter={ () => setIsShowTooltip( true ) }
+							onMouseLeave={ () => setIsShowTooltip( false ) }
+						>
+							{ isActionable && imageActionLabel && (
+								<div className="theme-card__image-label">{ imageActionLabel }</div>
+							) }
+							{ image }
+						</a>
+					</div>
 					{ isInstalling && (
 						<div className="theme-card__installing">
 							<div className="theme-card__installing-dot" />
@@ -112,7 +126,8 @@ const ThemeCard = forwardRef(
 							<div className="theme-card__info-style-variations">
 								<StyleVariationBadges
 									variations={ styleVariations }
-									onMoreClick={ onStyleVariationClick }
+									selectedVariation={ selectedStyleVariation }
+									onMoreClick={ onStyleVariationMoreClick || onStyleVariationClick }
 									onClick={ onStyleVariationClick }
 								/>
 							</div>

--- a/packages/design-picker/src/components/theme-card/index.tsx
+++ b/packages/design-picker/src/components/theme-card/index.tsx
@@ -16,7 +16,7 @@ interface ThemeCardProps {
 	banner?: React.ReactNode;
 	badge?: React.ReactNode;
 	styleVariations: StyleVariation[];
-	selectedStyleVariation: StyleVariation;
+	selectedStyleVariation?: StyleVariation;
 	optionsMenu?: React.ReactNode;
 	isActive?: boolean;
 	isInstalling?: boolean;
@@ -24,7 +24,7 @@ interface ThemeCardProps {
 	isSoftLaunched?: boolean;
 	onClick?: () => void;
 	onImageClick?: () => void;
-	onStyleVariationClick?: () => void;
+	onStyleVariationClick?: ( styleVariation: StyleVariation ) => void;
 	onStyleVariationMoreClick?: () => void;
 }
 
@@ -127,7 +127,7 @@ const ThemeCard = forwardRef(
 								<StyleVariationBadges
 									variations={ styleVariations }
 									selectedVariation={ selectedStyleVariation }
-									onMoreClick={ onStyleVariationMoreClick || onStyleVariationClick }
+									onMoreClick={ onStyleVariationMoreClick }
 									onClick={ onStyleVariationClick }
 								/>
 							</div>

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -13,6 +13,10 @@ $theme-card-info-margin-top: 16px;
 	transition: all 100ms ease-in-out;
 
 	&--is-active {
+		.theme-card__image-container {
+			border: 0;
+		}
+
 		.theme-card__info {
 			align-items: center;
 			background: var(--color-primary);
@@ -52,10 +56,23 @@ $theme-card-info-margin-top: 16px;
 	position: relative;
 }
 
+.theme-card__image-container {
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	filter: drop-shadow(0 15px 25px rgba(0, 0, 0, 0.05));
+	overflow: hidden;
+	padding-top: 74%;
+	position: relative;
+}
+
 .theme-card__image {
 	cursor: default;
+	height: 100%;
+	left: 0;
 	opacity: 1;
+	position: absolute;
+	top: 0;
 	transition: all 200ms ease-in-out;
+	width: 100%;
 
 	&:hover,
 	&:focus {
@@ -85,19 +102,20 @@ $theme-card-info-margin-top: 16px;
 		pointer-events: none;
 		position: absolute;
 		text-transform: uppercase;
-		top: 36%;
+		top: 45%;
 		transform: translate(-50%, 0);
 		z-index: 1;
 	}
 
 	img {
-		aspect-ratio: 4/3;
-		border: 1px solid rgba(0, 0, 0, 0.1);
 		box-sizing: border-box;
 		display: block;
-		filter: drop-shadow(0 15px 25px rgba(0, 0, 0, 0.05));
+		height: auto;
+		left: 0;
 		padding: 0;
-		position: relative;
+		position: absolute;
+		right: 0;
+		top: 0;
 		width: 100%;
 	}
 }
@@ -263,6 +281,7 @@ $theme-card-info-margin-top: 16px;
 	display: flex;
 	flex-basis: 100%;
 	font-size: 0;
+	gap: 10px;
 	line-height: 20px;
 	padding: 0;
 
@@ -276,13 +295,16 @@ $theme-card-info-margin-top: 16px;
 	.woocommerce-bundled-badge {
 		margin: 0;
 		vertical-align: middle;
+
+		svg {
+			height: auto;
+			padding: 0;
+			width: auto;
+		}
 	}
 
 	.premium-badge svg {
-		height: auto;
-		padding: 0;
 		transform: none;
-		width: auto;
 	}
 }
 

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -451,7 +451,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 export interface UnifiedDesignPickerProps {
 	locale: string;
 	verticalId?: string;
-	onSelect: ( design: Design ) => void;
 	onSelectBlankCanvas: ( design: Design, shouldGoToAssemblerStep: boolean ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -148,7 +148,7 @@ interface DesignCardProps {
 	design: Design;
 	locale: string;
 	category?: string | null;
-	verticalId?: string | null;
+	verticalId?: string;
 	currentPlanFeatures?: string[];
 	hasPurchasedTheme?: boolean;
 	isPremiumThemeAvailable?: boolean;
@@ -251,7 +251,7 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 	);
 };
 
-interface DesignButtonContainerProps extends DesignButtonProps {
+interface DesignButtonContainerProps extends DesignCardProps {
 	category?: string | null;
 	onSelectBlankCanvas: ( design: Design, shouldGoToAssemblerStep: boolean ) => void;
 }
@@ -371,7 +371,6 @@ const wasThemePurchased = ( purchasedThemes: string[] | undefined, design: Desig
 interface DesignPickerProps {
 	locale: string;
 	verticalId?: string;
-	onSelect: ( design: Design ) => void;
 	onSelectBlankCanvas: ( design: Design, shouldGoToAssemblerStep: boolean ) => void;
 	onPreview: ( design: Design, variation?: StyleVariation ) => void;
 	onChangeVariation: ( design: Design, variation?: StyleVariation ) => void;
@@ -379,7 +378,6 @@ interface DesignPickerProps {
 	generatedDesigns: Design[];
 	categorization?: Categorization;
 	isPremiumThemeAvailable?: boolean;
-	onCheckout?: any;
 	purchasedThemes?: string[];
 	currentPlanFeatures?: string[];
 	shouldLimitGlobalStyles?: boolean;
@@ -387,7 +385,6 @@ interface DesignPickerProps {
 
 const DesignPicker: React.FC< DesignPickerProps > = ( {
 	locale,
-	onSelect,
 	onSelectBlankCanvas,
 	onPreview,
 	onChangeVariation,
@@ -395,7 +392,6 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	generatedDesigns,
 	categorization,
 	isPremiumThemeAvailable,
-	onCheckout,
 	verticalId,
 	purchasedThemes,
 	currentPlanFeatures,
@@ -426,12 +422,10 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						key={ index }
 						design={ design }
 						locale={ locale }
-						onSelect={ onSelect }
 						onSelectBlankCanvas={ onSelectBlankCanvas }
 						onPreview={ onPreview }
 						onChangeVariation={ onChangeVariation }
 						isPremiumThemeAvailable={ isPremiumThemeAvailable }
-						onCheckout={ onCheckout }
 						verticalId={ verticalId }
 						hasPurchasedTheme={ wasThemePurchased( purchasedThemes, design ) }
 						currentPlanFeatures={ currentPlanFeatures }
@@ -467,7 +461,6 @@ export interface UnifiedDesignPickerProps {
 	categorization?: Categorization;
 	heading?: React.ReactNode;
 	isPremiumThemeAvailable?: boolean;
-	onCheckout?: any;
 	purchasedThemes?: string[];
 	currentPlanFeatures?: string[];
 	shouldLimitGlobalStyles?: boolean;
@@ -475,7 +468,6 @@ export interface UnifiedDesignPickerProps {
 
 const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	locale,
-	onSelect,
 	onSelectBlankCanvas,
 	onPreview,
 	onChangeVariation,
@@ -486,7 +478,6 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	heading,
 	categorization,
 	isPremiumThemeAvailable,
-	onCheckout,
 	purchasedThemes,
 	currentPlanFeatures,
 	shouldLimitGlobalStyles,
@@ -515,7 +506,6 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 			<div className="unified-design-picker__designs">
 				<DesignPicker
 					locale={ locale }
-					onSelect={ onSelect }
 					onSelectBlankCanvas={ onSelectBlankCanvas }
 					onPreview={ onPreview }
 					onChangeVariation={ onChangeVariation }
@@ -524,7 +514,6 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 					categorization={ categorization }
 					verticalId={ verticalId }
 					isPremiumThemeAvailable={ isPremiumThemeAvailable }
-					onCheckout={ onCheckout }
 					purchasedThemes={ purchasedThemes }
 					currentPlanFeatures={ currentPlanFeatures }
 					shouldLimitGlobalStyles={ shouldLimitGlobalStyles }

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -85,6 +85,7 @@
 		h1 {
 			color: var(--studio-gray-100);
 			font-family: $brand-serif;
+			font-size: 2rem;
 			font-weight: 400;
 			letter-spacing: -0.4px;
 			line-height: 32px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75457

## Proposed Changes

As a follow-up to #75422, this PR updates the onboarding design picker to also use the component `<ThemeCard />` from `@automattic/design-picker` to render design grid. A follow-up PR will be created to remove unused code caused by this refactor.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the onboarding design picker `/setup/site-setup/designSetup?siteSlug=${site_slug}`.
* Ensure that the card UI and functionality is "roughly" the same as the one in production.
* Also check that the card UI and functionality in the Theme Showcase is "roughly" the same as the one in production.

NOTE: I use the term "roughly" as the card UI might not have the exactly same height, in favor of keeping both implementations consistent. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
