### PR TITLE
Theme Showcase: Label dotorg themes with the Community badge

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -27,6 +27,7 @@ import {
 	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
 	isThemePremium as getIsThemePremium,
 	isThemePurchased,
+	isWporgTheme as getIsWporgTheme,
 } from 'calypso/state/themes/selectors';
 import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
 import ThemeMoreButton from './more-button';
@@ -302,6 +303,7 @@ export class Theme extends Component {
 			isSiteEligibleForBundledSoftware,
 			isExternallyManagedTheme,
 			isSiteEligibleForManagedExternalThemes,
+			isWporgTheme,
 			themeSubscriptionPrices,
 		} = this.props;
 
@@ -372,6 +374,15 @@ export class Theme extends Component {
 					Link: <LinkButton isLink onClick={ () => this.goToCheckout( 'business' ) } />,
 				}
 			);
+		} else if ( isWporgTheme ) {
+			return createInterpolateElement(
+				translate(
+					'This community theme can only be installed if you have the <Link>Business plan</Link> on your site.'
+				),
+				{
+					Link: <LinkButton isLink onClick={ () => this.goToCheckout( 'business' ) } />,
+				}
+			);
 		}
 
 		return createInterpolateElement(
@@ -391,7 +402,15 @@ export class Theme extends Component {
 	};
 
 	getUpsellHeader = () => {
-		const { doesThemeBundleSoftwareSet, isExternallyManagedTheme, translate } = this.props;
+		const { doesThemeBundleSoftwareSet, isExternallyManagedTheme, isWporgTheme, translate } =
+			this.props;
+
+		if ( isWporgTheme ) {
+			return translate( 'Community theme', {
+				context: 'This theme is developed and supported by a community',
+				textOnly: true,
+			} );
+		}
 
 		if ( isExternallyManagedTheme ) {
 			return translate( 'Paid theme' );
@@ -424,7 +443,8 @@ export class Theme extends Component {
 	};
 
 	getPremiumThemeBadge = () => {
-		const { doesThemeBundleSoftwareSet, isExternallyManagedTheme, translate } = this.props;
+		const { doesThemeBundleSoftwareSet, isExternallyManagedTheme, isWporgTheme, translate } =
+			this.props;
 
 		const commonProps = {
 			className: 'theme__upsell-popover',
@@ -432,6 +452,19 @@ export class Theme extends Component {
 			tooltipContent: this.getUpsellPopoverContent(),
 			tooltipPosition: 'top',
 		};
+
+		if ( isWporgTheme ) {
+			return (
+				<PremiumBadge
+					{ ...commonProps }
+					className={ classNames( commonProps.className, 'theme__community-theme' ) }
+					labelText={ translate( 'Community', {
+						context: 'This theme is developed and supported by a community',
+						textOnly: true,
+					} ) }
+				/>
+			);
+		}
 
 		if ( isExternallyManagedTheme ) {
 			return (
@@ -468,12 +501,13 @@ export class Theme extends Component {
 	};
 
 	renderPricingBadge = () => {
-		const { active, isExternallyManagedTheme, isPremiumTheme, translate } = this.props;
+		const { active, isExternallyManagedTheme, isPremiumTheme, isWporgTheme, translate } =
+			this.props;
 		if ( active ) {
 			return null;
 		}
 
-		if ( isExternallyManagedTheme || isPremiumTheme ) {
+		if ( isExternallyManagedTheme || isPremiumTheme || isWporgTheme ) {
 			return this.renderUpsell();
 		}
 
@@ -552,6 +586,7 @@ export default connect(
 			isUpdating: themesUpdating && themesUpdating.indexOf( theme.id ) > -1,
 			isUpdated: themesUpdated && themesUpdated.indexOf( theme.id ) > -1,
 			isPremiumTheme: getIsThemePremium( state, theme.id ),
+			isWporgTheme: getIsWporgTheme( state, theme.id ),
 			hasPremiumThemesFeature:
 				hasPremiumThemesFeature?.() ||
 				siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -377,7 +377,7 @@ export class Theme extends Component {
 		} else if ( isWporgTheme ) {
 			return createInterpolateElement(
 				translate(
-					'This community theme can only be installed if you have the <Link>Business plan</Link> on your site.'
+					'This community theme can only be installed if you have the <Link>Business plan</Link> or higher on your site.'
 				),
 				{
 					Link: <LinkButton isLink onClick={ () => this.goToCheckout( 'business' ) } />,

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -53,7 +53,8 @@ $theme-info-height: 54px;
 		fill: #fff;
 	}
 
-	&.premium-badge.theme__marketplace-theme {
+	&.premium-badge.theme__marketplace-theme,
+	&.premium-badge.theme__community-theme {
 		background: var(--color-primary);
 	}
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes an issue in the Theme Showcase where dotorg themes were incorrectly labeled as "Free". This PR adds the badge "Community" for dotorg themes.

![Screenshot 2023-04-12 at 6 06 52 PM](https://user-images.githubusercontent.com/797888/231426223-baaf2822-5862-4580-88b0-e36abdf74e70.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Search for a dotorg theme, such as Astra.
* Ensure that the theme has the badge "Community", and that the tooltip is displayed as shown in the screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
