### PR TITLE
Initial scaffolding for blazepress redesign

### DIFF
--- a/client/my-sites/promote-post-i2/index.js
+++ b/client/my-sites/promote-post-i2/index.js
@@ -1,0 +1,18 @@
+import page from 'page';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { navigation, sites, siteSelection } from 'calypso/my-sites/controller';
+import { promotedPosts, redirectToPrimarySite } from './controller';
+
+export default () => {
+	page( '/advertising/', redirectToPrimarySite, sites, makeLayout, clientRender );
+
+	page(
+		'/advertising/:site?/:tab?',
+		redirectToPrimarySite,
+		siteSelection,
+		navigation,
+		promotedPosts,
+		makeLayout,
+		clientRender
+	);
+};

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -1,0 +1,309 @@
+import './style.scss';
+import { useTranslate } from 'i18n-calypso';
+import { debounce } from 'lodash';
+import moment from 'moment';
+import { useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import DocumentHead from 'calypso/components/data/document-head';
+import QueryPosts from 'calypso/components/data/query-posts';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
+import QueryStatsRecentPostViews from 'calypso/components/data/query-stats-recent-post-views';
+import EmptyContent from 'calypso/components/empty-content';
+import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import Main from 'calypso/components/main';
+import useCampaignsQuery from 'calypso/data/promote-post/use-promote-post-campaigns-query';
+import useCampaignsStatsQuery from 'calypso/data/promote-post/use-promote-post-campaigns-stats-query';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import memoizeLast from 'calypso/lib/memoize-last';
+import { isWpMobileApp } from 'calypso/lib/mobile-app';
+import CampaignsList from 'calypso/my-sites/promote-post/components/campaigns-list';
+import PostsList from 'calypso/my-sites/promote-post/components/posts-list';
+import PostsListBanner from 'calypso/my-sites/promote-post/components/posts-list-banner';
+import PromotePostTabBar from 'calypso/my-sites/promote-post/components/promoted-post-filter';
+import {
+	getSitePost,
+	getPostsForQuery,
+	isRequestingPostsForQuery,
+} from 'calypso/state/posts/selectors';
+import {
+	getTopPostAndPages,
+	hasSiteStatsForQueryFinished,
+} from 'calypso/state/stats/lists/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { PostType } from 'calypso/types';
+import { unifyCampaigns } from './utils';
+
+export type TabType = 'posts' | 'campaigns';
+export type TabOption = {
+	id: TabType;
+	name: string;
+};
+
+interface Props {
+	tab?: TabType;
+}
+
+const queryProducts = {
+	number: 20, // max supported by /me/posts endpoint for all-sites mode
+	status: 'publish', // do not allow private or unpublished posts
+	type: 'product',
+};
+
+const queryPageAndPostsByComments = {
+	...queryProducts,
+	type: 'any',
+	order_by: 'comment_count',
+};
+
+const queryPageAndPostsByIDs = {
+	...queryProducts,
+	type: 'any',
+	order_by: 'id',
+	number: 5,
+};
+
+export type DSPMessage = {
+	errorCode?: string;
+};
+
+const ERROR_NO_LOCAL_USER = 'no_local_user';
+
+const memoizedQuery = memoizeLast( ( period, unit, quantity, endOf, num ) => ( {
+	period,
+	unit: unit,
+	quantity: quantity,
+	date: endOf,
+	num: num,
+	max: 20,
+} ) );
+const today = moment().locale( 'en' );
+const period = 'year';
+const topPostsQuery = memoizedQuery( period, 'month', 20, today.format( 'YYYY-MM-DD' ), -1 );
+
+export default function PromotedPosts( { tab }: Props ) {
+	const selectedTab = tab === 'campaigns' ? 'campaigns' : 'posts';
+	const selectedSite = useSelector( getSelectedSite );
+	const [ expandedCampaigns, setExpandedCampaigns ] = useState< number[] >( [] );
+	const [ alreadyScrolled, setAlreadyScrolled ] = useState< boolean >( false );
+	const selectedSiteId = selectedSite?.ID || 0;
+
+	const products = useSelector( ( state ) => {
+		const products = getPostsForQuery( state, selectedSiteId, queryProducts );
+		return products?.filter( ( product: any ) => ! product.password );
+	} );
+
+	const postAndPagesByComments = useSelector( ( state ) => {
+		const postsAndPages = getPostsForQuery( state, selectedSiteId, queryPageAndPostsByComments );
+		return postsAndPages?.filter( ( product: any ) => ! product.password );
+	} );
+
+	const postAndPagesByIDs = useSelector( ( state ) => {
+		const postsAndPages = getPostsForQuery( state, selectedSiteId, queryPageAndPostsByIDs );
+		return postsAndPages?.filter( ( product: any ) => ! product.password );
+	} );
+
+	const isLoadingProducts = useSelector( ( state ) =>
+		isRequestingPostsForQuery( state, selectedSiteId, queryProducts )
+	);
+
+	const topViewedPostAndPages = useSelector( ( state ) =>
+		getTopPostAndPages( state, selectedSiteId, topPostsQuery )
+	);
+
+	const mostPopularPostAndPages = useSelector( ( state ) => {
+		const topPostsAndPages: any[ PostType ] = [];
+
+		topViewedPostAndPages?.forEach( ( post: any ) => {
+			const item = getSitePost( state, selectedSiteId, post.id );
+			item && topPostsAndPages.push( { ...item, views: post.views } );
+		} );
+
+		return topPostsAndPages;
+	} );
+
+	const campaigns = useCampaignsQuery( selectedSiteId ?? 0 );
+	const campaignsStats = useCampaignsStatsQuery( selectedSiteId ?? 0 );
+
+	const { isLoading: campaignsIsLoading, isError, error: campaignError } = campaigns;
+	const { data: campaignsData } = campaigns;
+	const { data: campaignsStatsData } = campaignsStats;
+
+	const campaignsFull = useMemo(
+		() => unifyCampaigns( campaignsData || [], campaignsStatsData || [] ),
+		[ campaignsData, campaignsStatsData ]
+	);
+
+	const hasLocalUser = ( campaignError as DSPMessage )?.errorCode !== ERROR_NO_LOCAL_USER;
+
+	const translate = useTranslate();
+
+	const tabs: TabOption[] = [
+		{ id: 'posts', name: translate( 'Ready to Blaze' ) },
+		{ id: 'campaigns', name: translate( 'Campaigns' ) },
+	];
+
+	const topViewedPostAndPagesIds = topViewedPostAndPages?.map( ( post: any ) => post.id );
+	const topViewedMemoizedQuery = useMemo(
+		() => ( { include: topViewedPostAndPagesIds } ),
+		[ JSON.stringify( topViewedPostAndPagesIds ) ]
+	);
+
+	const hasTopPostsFinished = useSelector( ( state ) =>
+		hasSiteStatsForQueryFinished( state, selectedSiteId, 'statsTopPosts', topPostsQuery )
+	);
+
+	const isLoadingMemoizedQuery = useSelector( ( state ) =>
+		isRequestingPostsForQuery( state, selectedSiteId, topViewedMemoizedQuery )
+	);
+
+	const isLoadingByIDsQuery = useSelector( ( state ) =>
+		isRequestingPostsForQuery( state, selectedSiteId, queryPageAndPostsByIDs )
+	);
+
+	const isLoadingByCommentsQuery = useSelector( ( state ) =>
+		isRequestingPostsForQuery( state, selectedSiteId, queryPageAndPostsByComments )
+	);
+
+	const subtitle = translate(
+		'Reach new readers and customers with WordPress Blaze. Promote a post or a page on our network of millions blogs and web sites. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',
+		{
+			components: {
+				learnMoreLink: <InlineSupportLink supportContext="advertising" showIcon={ false } />,
+			},
+		}
+	);
+
+	const debouncedScrollToCampaign = debounce( ( campaignId ) => {
+		const element = document.querySelector( `.promote-post__campaigns_id_${ campaignId }` );
+		if ( element instanceof Element ) {
+			const margin = 50; // Some margin so it keeps below the header in mobile/desktop
+			const dims = element.getBoundingClientRect();
+			window.scrollTo( {
+				top: dims.top - margin,
+				behavior: 'smooth',
+			} );
+		}
+	}, 100 );
+
+	useEffect( () => {
+		if ( ! alreadyScrolled && campaignsFull.length ) {
+			const windowUrl = window.location.search;
+			const params = new URLSearchParams( windowUrl );
+			const campaignId = Number( params?.get( 'campaign_id' ) || 0 );
+			if ( campaignId ) {
+				setExpandedCampaigns( [ ...expandedCampaigns, campaignId ] );
+				debouncedScrollToCampaign( campaignId );
+				setAlreadyScrolled( true );
+			}
+		}
+	}, [ campaignsFull, alreadyScrolled ] );
+
+	if ( selectedSite?.is_coming_soon || selectedSite?.is_private ) {
+		return (
+			<EmptyContent
+				className="campaigns-empty"
+				title={
+					selectedSite?.is_coming_soon
+						? translate( 'Site is not published' )
+						: translate( 'Site is private' )
+				}
+				line={ translate(
+					'To start using Blaze, you must make your site public. You can do that from {{sitePrivacySettingsLink}}here{{/sitePrivacySettingsLink}}.',
+					{
+						components: {
+							sitePrivacySettingsLink: (
+								<a
+									href={ `https://wordpress.com/settings/general/${ selectedSite.domain }#site-privacy-settings` }
+									rel="noreferrer"
+								/>
+							),
+						},
+					}
+				) }
+				illustration={ null }
+			/>
+		);
+	}
+
+	const content = [
+		...( postAndPagesByIDs || [] ),
+		...( mostPopularPostAndPages || [] ),
+		...( postAndPagesByComments || [] ),
+		...( products || [] ),
+	];
+
+	/**
+	 * Some of the posts/pages may be duplicated as we load them by popularity and sometimes by comments.
+	 */
+	const contentWithoutDuplicatedIds = content.filter(
+		( obj, index ) => content.findIndex( ( item ) => item.ID === obj.ID ) === index
+	);
+
+	const isLoading =
+		isLoadingByCommentsQuery ||
+		isLoadingByIDsQuery ||
+		isLoadingMemoizedQuery ||
+		! hasTopPostsFinished ||
+		( ! isWpMobileApp() && isLoadingProducts );
+
+	return (
+		<Main wideLayout className="promote-post">
+			<DocumentHead title={ translate( 'Advertising - Redesign page!' ) } />
+
+			<FormattedHeader
+				brandFont
+				className="advertising__page-header"
+				headerText={ `${ translate( 'Advertising' ) } - Redesign page` }
+				subHeaderText={ campaignsData?.length ? subtitle : '' }
+				align="left"
+			/>
+
+			{ ! campaignsIsLoading && ! campaignsData?.length && <PostsListBanner /> }
+
+			<PromotePostTabBar tabs={ tabs } selectedTab={ selectedTab } />
+			{ selectedTab === 'campaigns' ? (
+				<>
+					<PageViewTracker path="/advertising/:site/campaigns" title="Advertising > Campaigns" />
+					<CampaignsList
+						hasLocalUser={ hasLocalUser }
+						isError={ isError }
+						isLoading={ campaignsIsLoading }
+						campaigns={ campaignsFull || [] }
+						expandedCampaigns={ expandedCampaigns }
+						setExpandedCampaigns={ setExpandedCampaigns }
+					/>
+				</>
+			) : (
+				<PageViewTracker path="/advertising/:site/posts" title="Advertising > Ready to Blaze" />
+			) }
+
+			<QuerySiteStats siteId={ selectedSiteId } statType="statsTopPosts" query={ topPostsQuery } />
+
+			{ ! isLoading && content?.length > 0 && (
+				<QueryStatsRecentPostViews
+					siteId={ selectedSiteId }
+					postIds={ content?.map( ( post: any ) => post.ID ) }
+					num={ 30 }
+				/>
+			) }
+			{ topViewedPostAndPages && (
+				<QueryPosts siteId={ selectedSiteId } query={ topViewedMemoizedQuery } postId={ null } />
+			) }
+			<QueryPosts siteId={ selectedSiteId } query={ queryPageAndPostsByIDs } postId={ null } />
+			{ hasTopPostsFinished && ( ! topViewedPostAndPages || topViewedPostAndPages.length < 10 ) && (
+				<QueryPosts
+					siteId={ selectedSiteId }
+					query={ queryPageAndPostsByComments }
+					postId={ null }
+				/>
+			) }
+			{ selectedTab === 'posts' && (
+				<PostsList content={ contentWithoutDuplicatedIds } isLoading={ isLoading } />
+			) }
+			{ ! isWpMobileApp() && (
+				<QueryPosts siteId={ selectedSiteId } query={ queryProducts } postId={ null } />
+			) }
+		</Main>
+	);
+}

--- a/client/my-sites/promote-post-i2/style.scss
+++ b/client/my-sites/promote-post-i2/style.scss
@@ -1,0 +1,51 @@
+.promote-post__loading-container {
+	text-align: center;
+}
+
+.promote-post__header-container {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+
+	.promote-post__heading {
+		flex: 1;
+	}
+}
+
+.promote-post__footer {
+	text-align: center;
+	margin: 24px 0;
+
+	a {
+		color: var(--studio-gray-60);
+		text-decoration: underline;
+	}
+}
+
+.promote-post__empty-content {
+	.empty-content__title {
+		font-size: $font-body-large;
+		font-weight: bold;
+	}
+
+	.empty-content__line {
+		font-weight: normal;
+		font-size: $font-body;
+	}
+}
+
+.is-mobile-app-view {
+	.advertising__page-header,
+	.promote-post .posts-list-banner__container,
+	.promote-post .section-nav,
+	.promote-post .post-item__link {
+		display: none;
+	}
+	.layout.has-no-masterbar.is-group-sites.is-section-promote-post .layout__content {
+		padding-top: 0;
+	}
+
+	.layout__primary .main {
+		padding-bottom: 0;
+	}
+}

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -1,0 +1,222 @@
+import { __, sprintf } from '@wordpress/i18n';
+import moment from 'moment';
+import {
+	Campaign,
+	CampaignStats,
+} from 'calypso/data/promote-post/use-promote-post-campaigns-query';
+
+export const campaignStatus = {
+	SCHEDULED: 'scheduled',
+	CREATED: 'created',
+	REJECTED: 'rejected',
+	APPROVED: 'approved',
+	ACTIVE: 'active',
+	CANCELED: 'canceled',
+	FINISHED: 'finished',
+};
+
+export const getPostType = ( type: string ) => {
+	switch ( type ) {
+		case 'post': {
+			return __( 'Post' );
+		}
+		case 'page': {
+			return __( 'Page' );
+		}
+		case 'product': {
+			return __( 'Product' );
+		}
+		default:
+			return type;
+	}
+};
+
+export const getCampaignStatusBadgeColor = ( status: string ) => {
+	switch ( status ) {
+		case campaignStatus.SCHEDULED: {
+			return 'info-blue';
+		}
+		case campaignStatus.CREATED: {
+			return 'info-blue';
+		}
+		case campaignStatus.REJECTED: {
+			return 'error';
+		}
+		case campaignStatus.APPROVED: {
+			return 'info-blue';
+		}
+		case campaignStatus.ACTIVE: {
+			return 'info-green';
+		}
+		case campaignStatus.CANCELED: {
+			return 'error';
+		}
+		case campaignStatus.FINISHED: {
+			return 'info-purple';
+		}
+		default:
+			return 'warning';
+	}
+};
+
+export const getCampaignStatus = ( status: string ) => {
+	switch ( status ) {
+		case campaignStatus.SCHEDULED: {
+			return __( 'Scheduled' );
+		}
+		case campaignStatus.CREATED: {
+			return __( 'Pending review' );
+		}
+		case campaignStatus.REJECTED: {
+			return __( 'Rejected' );
+		}
+		case campaignStatus.APPROVED: {
+			return __( 'Approved' );
+		}
+		case campaignStatus.ACTIVE: {
+			return __( 'Active' );
+		}
+		case campaignStatus.CANCELED: {
+			return __( 'Canceled' );
+		}
+		case campaignStatus.FINISHED: {
+			return __( 'Finished' );
+		}
+		default:
+			return status;
+	}
+};
+
+export const normalizeCampaignStatus = ( campaign: Campaign ): string => {
+	// This is a transactional status, so we just alter this in calypso
+	if (
+		campaign.status === campaignStatus.ACTIVE &&
+		moment().isBefore( campaign.start_date, 'day' )
+	) {
+		return campaignStatus.SCHEDULED;
+	}
+
+	return campaign.status;
+};
+
+export const getCampaignDurationDays = ( start_date: string, end_date: string ) => {
+	const dateStart = new Date( start_date );
+	const dateEnd = new Date( end_date );
+	const diffTime = Math.abs( dateEnd.getTime() - dateStart.getTime() );
+	return Math.round( diffTime / ( 1000 * 60 * 60 * 24 ) );
+};
+
+export const getCampaignOverallSpending = (
+	spent_budget_cents: number,
+	budget_cents: number,
+	start_date: string,
+	end_date: string
+) => {
+	if ( ! spent_budget_cents ) {
+		return '-';
+	}
+	const campaignDays = getCampaignDurationDays( start_date, end_date );
+	const spentBudgetCents =
+		spent_budget_cents > budget_cents * campaignDays
+			? budget_cents * campaignDays
+			: spent_budget_cents;
+
+	const totalBudgetUsed = ( spentBudgetCents / 100 ).toFixed( 2 );
+	let daysRun = moment().diff( moment( start_date ), 'days' );
+	daysRun = daysRun > campaignDays ? campaignDays : daysRun;
+
+	const daysText = daysRun === 1 ? 'day' : 'days';
+
+	if ( daysRun > 0 ) {
+		/* translators: %1$s: Amount, %2$s: Days. Singular or plural: Day(s) eg: $3 over 2 days */
+		return sprintf( __( '$%1$s over %2$s %3$s' ), totalBudgetUsed, daysRun, daysText );
+	}
+
+	/* translators: %1$s: Amount, eg: $3 today */
+	return sprintf( __( '$%1$s today' ), totalBudgetUsed );
+};
+
+export const getCampaignClickthroughRate = ( clicks_total: number, impressions_total: number ) => {
+	const clickthroughRate = ( clicks_total * 100 ) / impressions_total || 0;
+	return clickthroughRate.toLocaleString( undefined, {
+		useGrouping: true,
+		minimumFractionDigits: 0,
+		maximumFractionDigits: 2,
+	} );
+};
+
+export const getCampaignDurationFormatted = ( start_date: string, end_date: string ) => {
+	const campaignDays = getCampaignDurationDays( start_date, end_date );
+
+	let durationFormatted;
+	if ( campaignDays === 0 ) {
+		durationFormatted = '-';
+	} else {
+		const dateStartFormatted = moment.utc( start_date ).format( 'MMM D' );
+		const dateEndFormatted = moment.utc( end_date ).format( 'MMM D' );
+		durationFormatted = `${ dateStartFormatted } - ${ dateEndFormatted } (${ campaignDays } ${ __(
+			'days'
+		) })`;
+	}
+
+	return durationFormatted;
+};
+
+export const getCampaignBudgetData = (
+	budget_cents: number,
+	start_date: string,
+	end_date: string,
+	spent_budget_cents: number
+) => {
+	const campaignDays = getCampaignDurationDays( start_date, end_date );
+
+	const spentBudgetCents =
+		spent_budget_cents > budget_cents * campaignDays
+			? budget_cents * campaignDays
+			: spent_budget_cents;
+
+	const totalBudget = ( budget_cents * campaignDays ) / 100;
+	const totalBudgetUsed = spentBudgetCents / 100;
+	const totalBudgetLeft = totalBudget - totalBudgetUsed;
+	return {
+		totalBudget,
+		totalBudgetUsed,
+		totalBudgetLeft,
+		campaignDays,
+	};
+};
+
+export const formatCents = ( amount: number ) => {
+	return amount.toLocaleString( undefined, {
+		useGrouping: true,
+		minimumFractionDigits: amount % 1 !== 0 ? 2 : 0,
+		maximumFractionDigits: 2,
+	} );
+};
+
+export const getCampaignEstimatedImpressions = ( displayDeliveryEstimate: string ) => {
+	if ( ! displayDeliveryEstimate ) {
+		return '-';
+	}
+	const [ minEstimate, maxEstimate ] = displayDeliveryEstimate.split( ':' );
+	return `${ ( +minEstimate ).toLocaleString() } - ${ ( +maxEstimate ).toLocaleString() }`;
+};
+
+export const canCancelCampaign = ( status: string ) => {
+	return [ campaignStatus.SCHEDULED, campaignStatus.CREATED, campaignStatus.ACTIVE ].includes(
+		status
+	);
+};
+
+export const unifyCampaigns = ( campaigns: Campaign[], campaignsStats: CampaignStats[] ) => {
+	return campaigns.map( ( campaign ) => {
+		const campaignStats = campaignsStats.find(
+			( cs: CampaignStats ) => cs.campaign_id === campaign.campaign_id
+		);
+		return {
+			...campaign,
+			campaign_stats_loading: ! campaignsStats.length,
+			...( campaignStats ? campaignStats : {} ),
+		};
+	} );
+};

--- a/client/my-sites/promote-post/controller.js
+++ b/client/my-sites/promote-post/controller.js
@@ -1,12 +1,19 @@
+import config from '@automattic/calypso-config';
 import page from 'page';
 import { getSiteFragment } from 'calypso/lib/route';
 import { siteSelection } from 'calypso/my-sites/controller';
 import PromotedPosts from 'calypso/my-sites/promote-post/main';
+import PromotedPostsRedesignI2 from 'calypso/my-sites/promote-post-i2/main';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
 
 export const promotedPosts = ( context, next ) => {
 	const { tab } = context.params;
-	context.primary = <PromotedPosts tab={ tab } />;
+	// PromotedPostsRedesignI2
+	context.primary = config.isEnabled( 'promote-post/redesign-i2' ) ? (
+		<PromotedPostsRedesignI2 tab={ tab } />
+	) : (
+		<PromotedPosts tab={ tab } />
+	);
 	next();
 };
 

--- a/config/development.json
+++ b/config/development.json
@@ -150,6 +150,7 @@
 		"post-list/qr-code-link": true,
 		"pre-cancellation-modal": false,
 		"press-this": true,
+		"promote-post/redesign-i2": true,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -100,6 +100,7 @@
 		"post-list/qr-code-link": false,
 		"pre-cancellation-modal": false,
 		"press-this": true,
+		"promote-post/redesign-i2": false,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,

--- a/config/production.json
+++ b/config/production.json
@@ -115,6 +115,7 @@
 		"post-list/qr-code-link": false,
 		"pre-cancellation-modal": false,
 		"press-this": true,
+		"promote-post/redesign-i2": false,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -112,6 +112,7 @@
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": true,
 		"press-this": true,
+		"promote-post/redesign-i2": false,
 		"pre-cancellation-modal": false,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,

--- a/config/test.json
+++ b/config/test.json
@@ -84,6 +84,7 @@
 		"plugins/ssr-landing": true,
 		"post-list/qr-code-link": false,
 		"press-this": true,
+		"promote-post/redesign-i2": false,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -123,6 +123,7 @@
 		"post-editor/checkout-overlay": true,
 		"post-list/qr-code-link": true,
 		"press-this": true,
+		"promote-post/redesign-i2": false,
 		"pre-cancellation-modal": false,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,


### PR DESCRIPTION
Related to #

## Proposed Changes

* Initial scaffolding for BlazePress redesign. This is just a copy of the previous page and a new feature flag `promote-post/redesign-i2` to render the new page in development

## Testing Instructions
- Open calypso in development mode
- Go to /advertising page. You should see this header:

![image](https://user-images.githubusercontent.com/43957544/231440948-1cf96175-d1ee-4c76-afac-2d8503f223c8.png)


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
