### PR TITLE
i18n: Percent discount not localized in upsell during cancel flow

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -112,7 +112,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 	const currencyCode = useSelector( getCurrentUserCurrencyCode ) || 'USD';
 	const happyChat = useHappyChat();
 	const numberOfPluginsThemes = numberFormat( 50000, 0 );
-	const discountRate = '25%';
+	const discountRate = 25;
 	const couponCode = 'BIZWPC25';
 	const builtByURL = 'https://wordpress.com/built-by/?ref=wpcom-cancel-flow';
 	const { refundAmount } = props;
@@ -187,15 +187,18 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 					onDecline={ props.onDeclineUpsell }
 					image={ imgBusinessPlan }
 				>
-					{ translate(
-						'Did you know that you can now use over %(numberOfPluginsThemes)s third-party plugins and themes on the WordPress.com Business plan? ' +
-							'Whatever feature or design you want to add to your site, you’ll find a plugin or theme to get you there. ' +
-							'Claim a %(discountRate)s discount when you renew your Business plan today – {{b}}just enter the code %(couponCode)s at checkout.{{/b}}',
-						{
-							args: { numberOfPluginsThemes, discountRate, couponCode },
-							components: { b: <strong /> },
-						}
-					) }
+					{
+						/* Translators: %(discountRate)d%% is a discount percentage like 20% or 25%, followed by an escaped percentage sign %% */
+						translate(
+							'Did you know that you can now use over %(numberOfPluginsThemes)s third-party plugins and themes on the WordPress.com Business plan? ' +
+								'Whatever feature or design you want to add to your site, you’ll find a plugin or theme to get you there. ' +
+								'Claim a %(discountRate)d%% discount when you renew your Business plan today – {{b}}just enter the code %(couponCode)s at checkout.{{/b}}',
+							{
+								args: { numberOfPluginsThemes, discountRate, couponCode },
+								components: { b: <strong /> },
+							}
+						)
+					}
 				</Upsell>
 			);
 		case 'downgrade-monthly':

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -188,7 +188,7 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 					image={ imgBusinessPlan }
 				>
 					{
-						/* Translators: %(discountRate)d%% is a discount percentage like 20% or 25%, followed by an escaped percentage sign %% */
+						/* translators: %(discountRate)d%% is a discount percentage like 20% or 25%, followed by an escaped percentage sign %% */
 						translate(
 							'Did you know that you can now use over %(numberOfPluginsThemes)s third-party plugins and themes on the WordPress.com Business plan? ' +
 								'Whatever feature or design you want to add to your site, you’ll find a plugin or theme to get you there. ' +


### PR DESCRIPTION
In the cancel flow, the plan upsell screen contains a discount, but the percent sign and the discount amount are hard coded and not localizable. In some languages, there needs to be a space between the amount and the percent sign. And in some languages, the percent sign should be in front of the amount.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/i18n-issues/issues/578

## Proposed Changes

* Separate the percent sign from discount amount
* Provide a translator note so that they can place the percent sign in the correct location

## Screenshot
![image](https://user-images.githubusercontent.com/31164683/231472232-a87d3eb9-334b-4e16-a5d6-1e2ba531fa56.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Ensure that your user language settings are non-English.
2. Create a website using the instructions of pavWQK-1AQ-p2
3. Upgrade the plan (e.g. from Free to Premium)
4. Proceed to cancel the upgrade using the cancelation instructions on pavWQK-1AQ-p2.
5. When completing the survey, choose reasons that relate to `Couldn’t finish my site`, `Can’t use a plugin`.
6. Verify that the percentage discount is formatted correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?