### PR TITLE
Revert "Hosting onboarding flow: use new plans grid"

### DIFF
--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1041,11 +1041,3 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 .formatted-header {
 	margin-bottom: 0;
 }
-
-
-/* Hosting onboarding flow */
-.is-hosting div.plan-features-2023-grid__content {
-	max-width: 768px;
-	margin-left: auto !important;
-	margin-right: auto !important;
-}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -357,7 +357,6 @@ export class PlansFeaturesMain extends Component {
 			hidePersonalPlan,
 			hidePremiumPlan,
 			hideEcommercePlan,
-			hideEnterprisePlan = false,
 			sitePlanSlug,
 			showTreatmentPlansReorderTest,
 			flowName,
@@ -373,7 +372,7 @@ export class PlansFeaturesMain extends Component {
 			plans = plansFromProps;
 		} else {
 			const isBloggerPlanVisible = hideBloggerPlan === true ? false : true;
-			const isEnterprisePlanVisible = is2023PricingGridVisible && hideEnterprisePlan !== false;
+			const isEnterprisePlanVisible = is2023PricingGridVisible;
 			plans = [
 				findPlansKeys( { group: GROUP_WPCOM, type: TYPE_FREE } )[ 0 ],
 				isBloggerPlanVisible &&

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -238,7 +238,6 @@ export function generateSteps( {
 				hideFreePlan: true,
 				hidePremiumPlan: true,
 				hidePersonalPlan: true,
-				hideEnterprisePlan: true,
 				shouldHideNavButtons: true,
 			},
 		},

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -75,11 +75,6 @@ export const is2023PricingGridActivePage = (
 		return isPricingGridEnabled;
 	}
 
-	// Is this the hosting flow?
-	if ( currentRoutePath.startsWith( '/start/hosting' ) ) {
-		return isPricingGridEnabled;
-	}
-
 	// Is this the launch site flow?
 	if ( currentRoutePath.startsWith( '/start/launch-site/plans-launch' ) ) {
 		return isPricingGridEnabled;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#75547

The Enterprise plan was removed from the plans grid in general, and not just from the Hosting onboarding flow.