### PR TITLE
Update Jetpack Presales Chat API Key

### DIFF
--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -26,7 +26,7 @@
 		}
 	],
 	"oauth_client_id": 68663,
-	"zendesk_presales_chat_key": "d729d42c-b547-4750-a6f6-8b30534a5f12",
+	"zendesk_presales_chat_key": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"features": {
 		"activity-log/v2": true,
 		"always_use_logout_url": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -23,7 +23,7 @@
 			"content": "https://i1.wp.com/s0.wp.com/wp-content/themes/a8c/jetpackme-new/images-2019/jetpack-logo.png?ssl=1"
 		}
 	],
-	"zendesk_presales_chat_key": "d729d42c-b547-4750-a6f6-8b30534a5f12",
+	"zendesk_presales_chat_key": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"features": {
 		"activity-log/v2": true,
 		"always_use_logout_url": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -24,7 +24,7 @@
 		}
 	],
 	"oauth_client_id": 69041,
-	"zendesk_presales_chat_key": "d729d42c-b547-4750-a6f6-8b30534a5f12",
+	"zendesk_presales_chat_key": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"features": {
 		"activity-log/v2": true,
 		"ad-tracking": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -24,7 +24,7 @@
 		}
 	],
 	"oauth_client_id": 69040,
-	"zendesk_presales_chat_key": "d729d42c-b547-4750-a6f6-8b30534a5f12",
+	"zendesk_presales_chat_key": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"features": {
 		"activity-log/v2": true,
 		"ad-tracking": false,


### PR DESCRIPTION
Related to pbtFFM-2ui-p2

## Proposed Changes

* Update the API key in the environment files to use a new key requested by JPOP Happiness

## Testing Instructions

* The chat widget functionality should remain the same (it shows when you are logged out and agents are staffed)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?