### PR TITLE
Subscriptions Management: Add `subscription-management-comments-view` feature flag and locale check for the "Comments" tab

### DIFF
--- a/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
+++ b/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { SubscriptionManager } from '@automattic/data-stores';
+import { useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import Nav from 'calypso/components/section-nav';
@@ -18,6 +19,9 @@ const TabsSwitcher = () => {
 	const navigate = useNavigate();
 	const { pathname } = useLocation();
 	const { data: counts } = SubscriptionManager.useSubscriptionsCountQuery();
+	const locale = useLocale();
+	const shouldEnableCommentsTab =
+		config.isEnabled( 'subscription-management-comments-view' ) && locale === 'en';
 
 	return (
 		<>
@@ -33,7 +37,7 @@ const TabsSwitcher = () => {
 
 					<NavItem
 						onClick={ () => {
-							config.isEnabled( 'subscription-management-comments-view' )
+							shouldEnableCommentsTab
 								? navigate( commentsPath )
 								: window.location.replace(
 										'https://wordpress.com/email-subscriptions/?option=comments'

--- a/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
+++ b/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { SubscriptionManager } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
@@ -31,11 +32,13 @@ const TabsSwitcher = () => {
 					</NavItem>
 
 					<NavItem
-						onClick={ () =>
-							window.location.replace(
-								'https://wordpress.com/email-subscriptions/?option=comments'
-							)
-						}
+						onClick={ () => {
+							config.isEnabled( 'subscription-management-comments-view' )
+								? navigate( commentsPath )
+								: window.location.replace(
+										'https://wordpress.com/email-subscriptions/?option=comments'
+								  );
+						} }
 						count={ counts?.comments || undefined }
 						selected={ pathname.startsWith( commentsPath ) }
 					>

--- a/config/development.json
+++ b/config/development.json
@@ -185,6 +185,7 @@
 		"subscriber-importer": true,
 		"subscription-gifting": true,
 		"subscription-management": true,
+		"subscription-management-comments-view": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -129,6 +129,7 @@
 		"subscriber-importer": true,
 		"subscription-gifting": true,
 		"subscription-management": true,
+		"subscription-management-comments-view": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,

--- a/config/production.json
+++ b/config/production.json
@@ -150,6 +150,7 @@
 		"subscriber-importer": true,
 		"subscription-gifting": true,
 		"subscription-management": true,
+		"subscription-management-comments-view": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -146,6 +146,7 @@
 		"subscriber-importer": true,
 		"subscription-gifting": true,
 		"subscription-management": true,
+		"subscription-management-comments-view": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -157,6 +157,7 @@
 		"subscriber-importer": true,
 		"subscription-gifting": true,
 		"subscription-management": true,
+		"subscription-management-comments-view": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/75566.

## Proposed Changes

* add `subscription-management-comments-view` feature flag and enable it in the development environment only
* check for user's locale and adjust the "Comments" tab link as follows:
  * if the locale is EN and the above feature flag is enabled, the tab will point to http://calypso.localhost:3000/subscriptions/comments
  * otherwise, the tab will point to https://wordpress.com/email-subscriptions/?option=comments

![Markup on 2023-04-12 at 17:05:58](https://user-images.githubusercontent.com/25105483/231500388-cfdd42f7-adec-438f-ad52-6e2d705723ef.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Build this PR locally.
2. Navigate to http://calypso.localhost:3000/subscriptions/settings?flags=subscription-management-comments-view&locale=pt-br (or specify some other non-EN locale). → When you click on the "Comments" tab, you should be directed to https://wordpress.com/email-subscriptions/?option=comments.
3. Navigate to http://calypso.localhost:3000/subscriptions/settings?flags=subscription-management-comments-view&locale=en (English locale) → When you click on the "Comments" link now, you should end up on the new "Comments" view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
