### PR TITLE
Feature flag: Add flag to display Thank You page for some Themes

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -186,6 +186,7 @@
 		"subscription-gifting": true,
 		"subscription-management": true,
 		"themes/atomic-homepage-replace": true,
+		"themes/display-thank-you-page": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": true,
 		"themes/theme-switch-persist-template": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -130,6 +130,7 @@
 		"subscription-gifting": true,
 		"subscription-management": true,
 		"themes/atomic-homepage-replace": true,
+		"themes/display-thank-you-page": false,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/production.json
+++ b/config/production.json
@@ -151,6 +151,7 @@
 		"subscription-gifting": true,
 		"subscription-management": true,
 		"themes/atomic-homepage-replace": true,
+		"themes/display-thank-you-page": false,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -147,6 +147,7 @@
 		"subscription-gifting": true,
 		"subscription-management": true,
 		"themes/atomic-homepage-replace": true,
+		"themes/display-thank-you-page": false,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -158,6 +158,7 @@
 		"subscription-gifting": true,
 		"subscription-management": true,
 		"themes/atomic-homepage-replace": true,
+		"themes/display-thank-you-page": false,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/73835, https://github.com/Automattic/wp-calypso/issues/73834, and https://github.com/Automattic/wp-calypso/issues/73836

## Proposed Changes

* Add a feature flag that will be used to display the Thank You page for certain theme types, like Premium or Free

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Inspect visually that the flag `themes/display-thank-you-page` is false for all the environments other than `development.json`
* Apply this branch, run calypso. Open Developer Tools and check the following returns true: `configData.features['themes/display-thank-you-page']`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
