### PR TITLE
Billing History: Fix broken pagination

### DIFF
--- a/client/me/purchases/billing-history/billing-history-list.tsx
+++ b/client/me/purchases/billing-history/billing-history-list.tsx
@@ -18,7 +18,7 @@ import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-tr
 import getPastBillingTransactions from 'calypso/state/selectors/get-past-billing-transactions';
 import isSendingBillingReceiptEmail from 'calypso/state/selectors/is-sending-billing-receipt-email';
 import { IAppState } from 'calypso/state/types';
-import { filterTransactions } from './filter-transactions';
+import { filterTransactions, paginateTransactions } from './filter-transactions';
 import {
 	getTransactionTermLabel,
 	groupDomainProducts,
@@ -271,7 +271,12 @@ export default connect(
 		const transactions = getPastBillingTransactions( state );
 		const filter = getBillingTransactionFilters( state, 'past' );
 		const pageSize = 5;
-		const filteredTransactions = filterTransactions( transactions, filter, siteId, pageSize );
+		const filteredTransactions = filterTransactions( transactions, filter, siteId );
+		const paginatedTransactions = paginateTransactions(
+			filteredTransactions,
+			filter.page,
+			pageSize
+		);
 
 		return {
 			app: filter.app,
@@ -280,7 +285,7 @@ export default connect(
 			pageSize,
 			query: filter.query,
 			total: filteredTransactions.length,
-			transactions: filteredTransactions,
+			transactions: paginatedTransactions,
 			sendingBillingReceiptEmail: getIsSendingReceiptEmail( state ),
 		};
 	},

--- a/client/me/purchases/billing-history/filter-transactions.ts
+++ b/client/me/purchases/billing-history/filter-transactions.ts
@@ -49,10 +49,9 @@ function searchTransactions(
 export function filterTransactions(
 	transactions: BillingTransaction[] | null | undefined,
 	filter: BillingTransactionUiState,
-	siteId: number | string | null | undefined,
-	pageSize: number
+	siteId: number | string | null | undefined
 ): BillingTransaction[] {
-	const { app, date, page, query } = filter;
+	const { app, date, query } = filter;
 	let results = query ? searchTransactions( transactions ?? [], query ) : transactions ?? [];
 
 	if ( date && date.month && date.operator ) {
@@ -79,6 +78,14 @@ export function filterTransactions(
 		} );
 	}
 
+	return results;
+}
+
+export function paginateTransactions(
+	transactions: BillingTransaction[],
+	page: number | null | undefined,
+	pageSize: number
+): BillingTransaction[] {
 	const pageIndex = ( page ?? 1 ) - 1;
-	return results.slice( pageIndex * pageSize, pageIndex * pageSize + pageSize );
+	return transactions.slice( pageIndex * pageSize, pageIndex * pageSize + pageSize );
 }

--- a/client/me/purchases/billing-history/test/filter-transactions.ts
+++ b/client/me/purchases/billing-history/test/filter-transactions.ts
@@ -6,8 +6,6 @@ import {
 import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-transaction-filters';
 import { filterTransactions } from '../filter-transactions';
 
-const PAGE_SIZE = 5;
-
 const mockTransaction: BillingTransaction = {
 	currency: 'USD',
 	address: '',
@@ -244,19 +242,14 @@ const state = {
 
 describe( 'filterTransactions()', () => {
 	describe( 'date filter', () => {
-		test( 'returns a page from all transactions when filtering by newest', () => {
+		test( 'returns all transactions when filtering by newest', () => {
 			const testState = cloneDeep( state );
 			testState.billingTransactions.ui.past = {
 				date: { month: null, operator: null },
 			};
 			const filter = getBillingTransactionFilters( testState as any, 'past' );
-			const result = filterTransactions(
-				testState.billingTransactions.items.past,
-				filter,
-				null,
-				PAGE_SIZE
-			);
-			expect( result ).toEqual( state.billingTransactions.items.past.slice( 0, PAGE_SIZE ) );
+			const result = filterTransactions( testState.billingTransactions.items.past, filter, null );
+			expect( result ).toEqual( state.billingTransactions.items.past );
 		} );
 
 		test( 'returns transactions filtered by month', () => {
@@ -265,12 +258,7 @@ describe( 'filterTransactions()', () => {
 				date: { month: '2018-03', operator: 'equal' },
 			};
 			const filter = getBillingTransactionFilters( testState as any, 'past' );
-			const result = filterTransactions(
-				testState.billingTransactions.items.past,
-				filter,
-				null,
-				PAGE_SIZE
-			);
+			const result = filterTransactions( testState.billingTransactions.items.past, filter, null );
 			expect( result ).toHaveLength( 3 );
 			expect( new Date( result[ 0 ].date ).getMonth() ).toBe( 2 );
 			expect( new Date( result[ 1 ].date ).getMonth() ).toBe( 2 );
@@ -283,27 +271,17 @@ describe( 'filterTransactions()', () => {
 				date: { month: '2017-12', operator: 'before' },
 			};
 			const filter = getBillingTransactionFilters( testState as any, 'past' );
-			const result = filterTransactions(
-				testState.billingTransactions.items.past,
-				filter,
-				null,
-				PAGE_SIZE
-			);
+			const result = filterTransactions( testState.billingTransactions.items.past, filter, null );
 			expect( new Date( result[ 0 ].date ).getMonth() ).toBe( 10 );
 			expect( new Date( result[ 1 ].date ).getMonth() ).toBe( 0 );
 		} );
 	} );
 
 	describe( 'app filter', () => {
-		test( 'returns the first page of all transactions when the filter is empty', () => {
+		test( 'returns all transactions when the filter is empty', () => {
 			const filter = getBillingTransactionFilters( state as any, 'past' );
-			const result = filterTransactions(
-				state.billingTransactions.items.past,
-				filter,
-				null,
-				PAGE_SIZE
-			);
-			expect( result ).toEqual( state.billingTransactions.items.past.slice( 0, PAGE_SIZE ) );
+			const result = filterTransactions( state.billingTransactions.items.past, filter, null );
+			expect( result ).toEqual( state.billingTransactions.items.past );
 		} );
 
 		test( 'returns transactions filtered by app name', () => {
@@ -312,12 +290,7 @@ describe( 'filterTransactions()', () => {
 				app: 'Store Services',
 			};
 			const filter = getBillingTransactionFilters( testState as any, 'past' );
-			const result = filterTransactions(
-				testState.billingTransactions.items.past,
-				filter,
-				null,
-				PAGE_SIZE
-			);
+			const result = filterTransactions( testState.billingTransactions.items.past, filter, null );
 			result.forEach( ( transaction ) => {
 				expect( transaction.service ).toEqual( 'Store Services' );
 			} );
@@ -325,29 +298,13 @@ describe( 'filterTransactions()', () => {
 	} );
 
 	describe( 'search query', () => {
-		test( 'returns all transactions when the filter is empty', () => {
-			const filter = getBillingTransactionFilters( state as any, 'past' );
-			const result = filterTransactions(
-				state.billingTransactions.items.past,
-				filter,
-				null,
-				PAGE_SIZE
-			);
-			expect( result ).toEqual( state.billingTransactions.items.past.slice( 0, PAGE_SIZE ) );
-		} );
-
 		test( 'query matches a field in the root transaction object', () => {
 			const testState = cloneDeep( state );
 			testState.billingTransactions.ui.past = {
 				query: 'mastercard',
 			};
 			const filter = getBillingTransactionFilters( testState as any, 'past' );
-			const result = filterTransactions(
-				state.billingTransactions.items.past,
-				filter,
-				null,
-				PAGE_SIZE
-			);
+			const result = filterTransactions( state.billingTransactions.items.past, filter, null );
 			result.forEach( ( transaction ) => {
 				expect( transaction.cc_type ).toEqual( 'mastercard' );
 			} );
@@ -359,12 +316,7 @@ describe( 'filterTransactions()', () => {
 				query: 'may 1',
 			};
 			const filter = getBillingTransactionFilters( testState as any, 'past' );
-			const result = filterTransactions(
-				testState.billingTransactions.items.past,
-				filter,
-				null,
-				PAGE_SIZE
-			);
+			const result = filterTransactions( testState.billingTransactions.items.past, filter, null );
 			result.forEach( ( transaction ) => {
 				expect( transaction.date ).toBe( '2018-05-01T12:00:00' );
 			} );
@@ -376,12 +328,7 @@ describe( 'filterTransactions()', () => {
 				query: '$3.50',
 			};
 			const filter = getBillingTransactionFilters( testState as any, 'past' );
-			const result = filterTransactions(
-				testState.billingTransactions.items.past,
-				filter,
-				null,
-				PAGE_SIZE
-			);
+			const result = filterTransactions( testState.billingTransactions.items.past, filter, null );
 			expect( result[ 0 ].items ).toMatchObject( [ { amount: '$3.50' } ] );
 			expect( result[ 1 ].items ).toMatchObject( [ { amount: '$3.50' }, { amount: '$5.00' } ] );
 			expect( result[ 2 ].items ).toMatchObject( [ { amount: '$3.50' } ] );
@@ -396,12 +343,7 @@ describe( 'filterTransactions()', () => {
 				app: 'Store Services',
 			};
 			const filter = getBillingTransactionFilters( testState as any, 'past' );
-			const result = filterTransactions(
-				testState.billingTransactions.items.past,
-				filter,
-				null,
-				PAGE_SIZE
-			);
+			const result = filterTransactions( testState.billingTransactions.items.past, filter, null );
 			expect( new Date( result[ 0 ].date ).getMonth() ).toBe( 2 );
 			expect( result[ 0 ].service ).toEqual( 'Store Services' );
 			expect( new Date( result[ 1 ].date ).getMonth() ).toBe( 2 );
@@ -415,12 +357,7 @@ describe( 'filterTransactions()', () => {
 				query: '$3.50',
 			};
 			const filter = getBillingTransactionFilters( testState as any, 'past' );
-			const result = filterTransactions(
-				testState.billingTransactions.items.past,
-				filter,
-				null,
-				PAGE_SIZE
-			);
+			const result = filterTransactions( testState.billingTransactions.items.past, filter, null );
 			expect( result[ 0 ].items ).toMatchObject( [ { amount: '$3.50' }, { amount: '$5.00' } ] );
 			expect( result[ 0 ].service ).toEqual( 'Store Services' );
 		} );
@@ -432,12 +369,7 @@ describe( 'filterTransactions()', () => {
 				query: '$3.50',
 			};
 			const filter = getBillingTransactionFilters( testState as any, 'past' );
-			const result = filterTransactions(
-				testState.billingTransactions.items.past,
-				filter,
-				null,
-				PAGE_SIZE
-			);
+			const result = filterTransactions( testState.billingTransactions.items.past, filter, null );
 			expect( result[ 0 ].items ).toMatchObject( [ { amount: '$3.50' } ] );
 			expect( new Date( result[ 0 ].date ).getMonth() ).toBe( 4 );
 		} );
@@ -450,12 +382,7 @@ describe( 'filterTransactions()', () => {
 				app: 'WordPress.com',
 			};
 			const filter = getBillingTransactionFilters( testState as any, 'past' );
-			const result = filterTransactions(
-				testState.billingTransactions.items.past,
-				filter,
-				null,
-				PAGE_SIZE
-			);
+			const result = filterTransactions( testState.billingTransactions.items.past, filter, null );
 			expect( result[ 0 ].cc_type ).toEqual( 'visa' );
 			expect( new Date( result[ 0 ].date ).getMonth() ).toBe( 2 );
 			expect( result[ 0 ].service ).toEqual( 'WordPress.com' );
@@ -469,12 +396,7 @@ describe( 'filterTransactions()', () => {
 				date: { month: '2019-01', operator: 'equal' },
 			};
 			const filter = getBillingTransactionFilters( testState as any, 'past' );
-			const result = filterTransactions(
-				testState.billingTransactions.items.past,
-				filter,
-				null,
-				PAGE_SIZE
-			);
+			const result = filterTransactions( testState.billingTransactions.items.past, filter, null );
 			expect( result ).toEqual( [] );
 		} );
 	} );

--- a/client/me/purchases/billing-history/test/paginate-transactions.ts
+++ b/client/me/purchases/billing-history/test/paginate-transactions.ts
@@ -272,9 +272,9 @@ describe( 'paginateTransactions()', () => {
 		const result = paginateTransactions( testState.billingTransactions.items.past, 2, 3 );
 		expect( result.length ).toEqual( 3 );
 		expect( result ).toEqual( state.billingTransactions.items.past.slice( 3, 6 ) );
-		expect( result[ 0 ].items ).toMatchObject( [ { date: '2018-03-15T10:39:27' } ] );
-		expect( result[ 1 ].items ).toMatchObject( [ { date: '2018-03-13T16:10:45' } ] );
-		expect( result[ 2 ].items ).toMatchObject( [ { date: '2018-01-10T14:24:38' } ] );
+		expect( result[ 0 ].date ).toEqual( '2018-03-15T10:39:27' );
+		expect( result[ 1 ].date ).toEqual( '2018-03-13T16:10:45' );
+		expect( result[ 2 ].date ).toEqual( '2018-01-10T14:24:38' );
 	} );
 
 	test( 'returns an abbreviated last page of transactions when the last page is specified', () => {
@@ -282,6 +282,6 @@ describe( 'paginateTransactions()', () => {
 		const result = paginateTransactions( testState.billingTransactions.items.past, 4, 3 );
 		expect( result.length ).toEqual( 1 );
 		expect( result ).toEqual( state.billingTransactions.items.past.slice( 9, 10 ) );
-		expect( result[ 0 ].items ).toMatchObject( [ { date: '2017-01-01T00:00:00' } ] );
+		expect( result[ 0 ].date ).toEqual( '2017-01-01T00:00:00' );
 	} );
 } );

--- a/client/me/purchases/billing-history/test/paginate-transactions.ts
+++ b/client/me/purchases/billing-history/test/paginate-transactions.ts
@@ -1,0 +1,287 @@
+import { cloneDeep } from 'lodash';
+import {
+	BillingTransaction,
+	BillingTransactionItem,
+} from 'calypso/state/billing-transactions/types';
+import { paginateTransactions } from '../filter-transactions';
+
+const mockTransaction: BillingTransaction = {
+	currency: 'USD',
+	address: '',
+	amount: '',
+	amount_integer: 0,
+	tax_country_code: '',
+	cc_email: '',
+	cc_name: '',
+	cc_num: '',
+	cc_type: '',
+	credit: '',
+	date: '',
+	desc: '',
+	icon: '',
+	id: '',
+	items: [],
+	org: '',
+	pay_part: '',
+	pay_ref: '',
+	service: '',
+	subtotal: '',
+	subtotal_integer: 0,
+	support: '',
+	tax: '',
+	tax_integer: 0,
+	url: '',
+};
+
+const mockItem: BillingTransactionItem = {
+	id: '',
+	type: '',
+	type_localized: '',
+	domain: '',
+	site_id: '',
+	subtotal: '',
+	subtotal_integer: 0,
+	tax_integer: 0,
+	amount_integer: 0,
+	tax: '',
+	amount: '',
+	raw_subtotal: 0,
+	raw_tax: 0,
+	raw_amount: 0,
+	currency: '',
+	licensed_quantity: null,
+	new_quantity: null,
+	product: '',
+	product_slug: '',
+	variation: '',
+	variation_slug: '',
+	months_per_renewal_interval: 0,
+	wpcom_product_slug: '',
+};
+
+const past: BillingTransaction[] = [
+	{
+		...mockTransaction,
+		date: '2018-05-01T12:00:00',
+		service: 'WordPress.com',
+		cc_name: 'name1 surname1',
+		cc_type: 'mastercard',
+		items: [
+			{
+				...mockItem,
+				amount: '$3.50',
+				type: 'new purchase',
+				variation: 'Variation1',
+			},
+		],
+	},
+	{
+		...mockTransaction,
+		date: '2018-04-11T13:11:27',
+		service: 'WordPress.com',
+		cc_name: 'name2',
+		cc_type: 'visa',
+		items: [
+			{
+				...mockItem,
+				amount: '$5.75',
+				type: 'new purchase',
+				variation: 'Variation2',
+			},
+			{
+				...mockItem,
+				amount: '$8.00',
+				type: 'new purchase',
+				variation: 'Variation2',
+			},
+		],
+	},
+	{
+		...mockTransaction,
+		date: '2018-03-11T21:00:00',
+		service: 'Store Services',
+		cc_name: 'name1 surname1',
+		cc_type: 'visa',
+		items: [
+			{
+				...mockItem,
+				amount: '$3.50',
+				type: 'new purchase',
+				variation: 'Variation2',
+			},
+			{
+				...mockItem,
+				amount: '$5.00',
+				type: 'new purchase',
+				variation: 'Variation2',
+			},
+		],
+	},
+	{
+		...mockTransaction,
+		date: '2018-03-15T10:39:27',
+		service: 'Store Services',
+		cc_name: 'name2',
+		cc_type: 'mastercard',
+		items: [
+			{
+				...mockItem,
+				amount: '$4.86',
+				type: 'new purchase',
+				variation: 'Variation1',
+			},
+			{
+				...mockItem,
+				amount: '$1.23',
+				type: 'new purchase',
+				variation: 'Variation1',
+			},
+		],
+	},
+	{
+		...mockTransaction,
+		date: '2018-03-13T16:10:45',
+		service: 'WordPress.com',
+		cc_name: 'name1 surname1',
+		cc_type: 'visa',
+		items: [
+			{
+				...mockItem,
+				amount: '$3.50',
+				type: 'new purchase',
+				variation: 'Variation1',
+			},
+		],
+	},
+	{
+		...mockTransaction,
+		date: '2018-01-10T14:24:38',
+		service: 'WordPress.com',
+		cc_name: 'name2',
+		cc_type: 'mastercard',
+		items: [
+			{
+				...mockItem,
+				amount: '$4.20',
+				type: 'new purchase',
+				variation: 'Variation2',
+			},
+		],
+	},
+	{
+		...mockTransaction,
+		date: '2017-12-10T10:30:38',
+		service: 'Store Services',
+		cc_name: 'name1 surname1',
+		cc_type: 'visa',
+		items: [
+			{
+				...mockItem,
+				amount: '$3.75',
+				type: 'new purchase',
+				variation: 'Variation1',
+			},
+		],
+	},
+	{
+		...mockTransaction,
+		date: '2017-12-01T07:20:00',
+		service: 'Store Services',
+		cc_name: 'name1 surname1',
+		cc_type: 'visa',
+		items: [
+			{
+				...mockItem,
+				amount: '$9.50',
+				type: 'new purchase',
+				variation: 'Variation1',
+			},
+		],
+	},
+	{
+		...mockTransaction,
+		date: '2017-11-24T05:13:00',
+		service: 'WordPress.com',
+		cc_name: 'name1 surname1',
+		cc_type: 'visa',
+		items: [
+			{
+				...mockItem,
+				amount: '$8.40',
+				type: 'new purchase',
+				variation: 'Variation2',
+			},
+		],
+	},
+	{
+		...mockTransaction,
+		date: '2017-01-01T00:00:00',
+		service: 'Store Services',
+		cc_name: 'name2',
+		cc_type: 'mastercard',
+		items: [
+			{
+				...mockItem,
+				amount: '$2.40',
+				type: 'new purchase',
+				variation: 'Variation1',
+			},
+		],
+	},
+];
+
+const state = {
+	billingTransactions: {
+		items: {
+			past,
+		},
+	},
+};
+
+describe( 'paginateTransactions()', () => {
+	test( 'returns all transactions when there are fewer than the page limit', () => {
+		const testState = cloneDeep( state );
+		const pageSize = testState.billingTransactions.items.past.length + 1;
+		const result = paginateTransactions( testState.billingTransactions.items.past, 1, pageSize );
+		expect( result ).toEqual( state.billingTransactions.items.past );
+	} );
+
+	test( 'returns all transactions when there are the same number as the page limit', () => {
+		const testState = cloneDeep( state );
+		const pageSize = testState.billingTransactions.items.past.length;
+		const result = paginateTransactions( testState.billingTransactions.items.past, 1, pageSize );
+		expect( result ).toEqual( state.billingTransactions.items.past );
+	} );
+
+	test( 'returns a page from all transactions when there are more than the page limit', () => {
+		const testState = cloneDeep( state );
+		const pageSize = testState.billingTransactions.items.past.length - 1;
+		const result = paginateTransactions( testState.billingTransactions.items.past, 1, pageSize );
+		expect( result ).toEqual( state.billingTransactions.items.past.slice( 0, pageSize ) );
+	} );
+
+	test( 'returns the first page of transactions when no page is specified', () => {
+		const testState = cloneDeep( state );
+		const pageSize = testState.billingTransactions.items.past.length - 1;
+		const result = paginateTransactions( testState.billingTransactions.items.past, null, pageSize );
+		expect( result ).toEqual( state.billingTransactions.items.past.slice( 0, pageSize ) );
+	} );
+
+	test( 'returns the second page of transactions when the second page is specified', () => {
+		const testState = cloneDeep( state );
+		const result = paginateTransactions( testState.billingTransactions.items.past, 2, 3 );
+		expect( result.length ).toEqual( 3 );
+		expect( result ).toEqual( state.billingTransactions.items.past.slice( 3, 6 ) );
+		expect( result[ 0 ].items ).toMatchObject( [ { date: '2018-03-15T10:39:27' } ] );
+		expect( result[ 1 ].items ).toMatchObject( [ { date: '2018-03-13T16:10:45' } ] );
+		expect( result[ 2 ].items ).toMatchObject( [ { date: '2018-01-10T14:24:38' } ] );
+	} );
+
+	test( 'returns an abbreviated last page of transactions when the last page is specified', () => {
+		const testState = cloneDeep( state );
+		const result = paginateTransactions( testState.billingTransactions.items.past, 4, 3 );
+		expect( result.length ).toEqual( 1 );
+		expect( result ).toEqual( state.billingTransactions.items.past.slice( 9, 10 ) );
+		expect( result[ 0 ].items ).toMatchObject( [ { date: '2017-01-01T00:00:00' } ] );
+	} );
+} );


### PR DESCRIPTION
This pull request fixes the recently-introduced broken pagination on the billing history page.

It was broken by https://github.com/Automattic/wp-calypso/pull/74975 because that pull request made it so the total number of receipts to display was equal to the length of the **already-paginated** list (which meant that the length would never be more than one page).

The fix is to break up the receipt filtering and receipt pagination code into two functions, so the total can be taken from the length of the filtered-but-not-yet-paginated list.

Fixes https://github.com/Automattic/wp-calypso/issues/75619

## Testing Instructions

* Visit `/me/purchases/billing` on a user account that has more than 5 receipts.
* Make sure the pagination element is shown under the list of receipts and works correctly.
* Make sure all the filtering options on the page work correctly also.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
