### PR TITLE
Updates theme detection of full site editing to use block-template-parts

### DIFF
--- a/client/data/themes/with-is-fse-active.js
+++ b/client/data/themes/with-is-fse-active.js
@@ -9,7 +9,7 @@ const withIsFSEActive = createHigherOrderComponent(
 		const siteId = useSelector( getSelectedSiteId );
 		const userLoggedIn = useSelector( isUserLoggedIn );
 		const { data, isLoading } = useActiveThemeQuery( siteId, userLoggedIn );
-		const isFSEActive = data?.[ 0 ]?.theme_supports?.[ 'block-templates' ] ?? false;
+		const isFSEActive = data?.[ 0 ]?.theme_supports?.[ 'block-template-parts' ] ?? false;
 
 		return <Wrapped { ...props } isFSEActiveLoading={ isLoading } isFSEActive={ isFSEActive } />;
 	},

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -92,7 +92,7 @@ export const ThankYouThemeSection = ( { theme }: { theme: any } ) => {
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const isActive = useSelector( ( state ) => isThemeActive( state, theme.id, siteId ) );
 	const { data: activeThemeData, isLoading } = useActiveThemeQuery( siteId, true );
-	const isFSEActive = activeThemeData?.[ 0 ]?.theme_supports[ 'block-templates' ] ?? false;
+	const isFSEActive = activeThemeData?.[ 0 ]?.theme_supports[ 'block-template-parts' ] ?? false;
 	const hasActivated = useSelector( ( state ) => hasActivatedTheme( state, siteId ) );
 	const isActivating = useSelector( ( state ) => isActivatingTheme( state, siteId ) );
 	const customizeUrl = useSelector( ( state ) =>


### PR DESCRIPTION
## Proposed Changes

WordPress 6.1 (https://github.com/WordPress/wordpress-develop/commit/98cfa29f8d312e1aa8f3979387c75e26b5bf1734) introduced the `block-template-parts` theme support and uses that to determine support for the Site editor.

This change updates Calypso logic to do the same.

## Testing Instructions

- The easiest way to make sure this works correctly is to enable a block based theme, and then a classic theme.
- Check that the link at the top of the Quick links section of My Home says either "Edit site" (for themes that support the Site editor) or "Write blog post" (classic themes)

| **Classic** | **Block** |
| - | - |
| <img width="299" alt="image" src="https://user-images.githubusercontent.com/1699996/231528003-c0b00d11-6b58-4513-87a2-faef34668b54.png"> | <img width="299" alt="image" src="https://user-images.githubusercontent.com/1699996/231528029-83969bdc-7e35-45b2-9324-89d7b4cf2d64.png"> |


