### PR TITLE
Woo Express: Update post-purchase payments link to point to payments page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-tasks.ts
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-tasks.ts
@@ -1,13 +1,17 @@
 import { translate as i18nTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import customDomain from 'calypso/assets/images/plans/wpcom/custom-domain.png';
 import customize from 'calypso/assets/images/plans/wpcom/customize.png';
 import launch from 'calypso/assets/images/plans/wpcom/launch-store.png';
 import manageWooCommerce from 'calypso/assets/images/plans/wpcom/manage-woocommerce.png';
 import promote from 'calypso/assets/images/plans/wpcom/promote.png';
 import wayToPay from 'calypso/assets/images/plans/wpcom/way-to-pay.png';
+import isPluginActive from 'calypso/state/selectors/is-plugin-active';
+import { getSiteId } from 'calypso/state/sites/selectors';
 
 type ConfirmationTasksProps = {
 	translate: typeof i18nTranslate;
+	siteSlug?: string | number;
 };
 
 export interface GetActionUrlProps {
@@ -17,7 +21,12 @@ export interface GetActionUrlProps {
 	wpAdminUrl: string;
 }
 
-export const getConfirmationTasks = ( { translate }: ConfirmationTasksProps ) => {
+export const GetConfirmationTasks = ( { translate, siteSlug }: ConfirmationTasksProps ) => {
+	const siteId = useSelector( ( state ) => siteSlug && getSiteId( state, siteSlug ) );
+	const hasWCPay = useSelector(
+		( state ) => siteId && isPluginActive( state, siteId, 'woocommerce-payments' )
+	);
+
 	return [
 		{
 			id: 'launch-store',
@@ -41,7 +50,7 @@ export const getConfirmationTasks = ( { translate }: ConfirmationTasksProps ) =>
 				'Set up one or more payment methods to make it easy for your customers to pay.'
 			),
 			getActionUrl: ( { wooAdminUrl }: GetActionUrlProps ) =>
-				`${ wooAdminUrl }&path=${ encodeURIComponent( '/payments/connect' ) }`,
+				`${ wooAdminUrl }${ hasWCPay ? '&path=' + encodeURIComponent( '/payments/connect' ) : '' }`,
 		},
 		{
 			id: 'custom-domain',

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-tasks.ts
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-tasks.ts
@@ -41,7 +41,7 @@ export const getConfirmationTasks = ( { translate }: ConfirmationTasksProps ) =>
 				'Set up one or more payment methods to make it easy for your customers to pay.'
 			),
 			getActionUrl: ( { wooAdminUrl }: GetActionUrlProps ) =>
-				`${ wooAdminUrl }&path=%2Fpayments%2Fconnect`,
+				`${ wooAdminUrl }&path=${ encodeURIComponent( '/payments/connect' ) }`,
 		},
 		{
 			id: 'custom-domain',

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-tasks.ts
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-tasks.ts
@@ -1,17 +1,14 @@
 import { translate as i18nTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
 import customDomain from 'calypso/assets/images/plans/wpcom/custom-domain.png';
 import customize from 'calypso/assets/images/plans/wpcom/customize.png';
 import launch from 'calypso/assets/images/plans/wpcom/launch-store.png';
 import manageWooCommerce from 'calypso/assets/images/plans/wpcom/manage-woocommerce.png';
 import promote from 'calypso/assets/images/plans/wpcom/promote.png';
 import wayToPay from 'calypso/assets/images/plans/wpcom/way-to-pay.png';
-import isPluginActive from 'calypso/state/selectors/is-plugin-active';
-import { getSiteId } from 'calypso/state/sites/selectors';
 
 type ConfirmationTasksProps = {
 	translate: typeof i18nTranslate;
-	siteSlug?: string | number;
+	hasWCPay?: boolean;
 };
 
 export interface GetActionUrlProps {
@@ -21,12 +18,7 @@ export interface GetActionUrlProps {
 	wpAdminUrl: string;
 }
 
-export const GetConfirmationTasks = ( { translate, siteSlug }: ConfirmationTasksProps ) => {
-	const siteId = useSelector( ( state ) => siteSlug && getSiteId( state, siteSlug ) );
-	const hasWCPay = useSelector(
-		( state ) => siteId && isPluginActive( state, siteId, 'woocommerce-payments' )
-	);
-
+export const getConfirmationTasks = ( { translate, hasWCPay }: ConfirmationTasksProps ) => {
 	return [
 		{
 			id: 'launch-store',
@@ -49,8 +41,12 @@ export const GetConfirmationTasks = ( { translate, siteSlug }: ConfirmationTasks
 			subtitle: translate(
 				'Set up one or more payment methods to make it easy for your customers to pay.'
 			),
-			getActionUrl: ( { wooAdminUrl }: GetActionUrlProps ) =>
-				`${ wooAdminUrl }${ hasWCPay ? '&path=' + encodeURIComponent( '/payments/connect' ) : '' }`,
+			getActionUrl: ( { wooAdminUrl }: GetActionUrlProps ) => {
+				if ( hasWCPay ) {
+					return `${ wooAdminUrl }&path=${ encodeURIComponent( '/payments/connect' ) }`;
+				}
+				return `${ wooAdminUrl }&task=payments`;
+			},
 		},
 		{
 			id: 'custom-domain',

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-tasks.ts
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-tasks.ts
@@ -40,7 +40,8 @@ export const getConfirmationTasks = ( { translate }: ConfirmationTasksProps ) =>
 			subtitle: translate(
 				'Set up one or more payment methods to make it easy for your customers to pay.'
 			),
-			getActionUrl: ( { wooAdminUrl }: GetActionUrlProps ) => `${ wooAdminUrl }&task=payments`,
+			getActionUrl: ( { wooAdminUrl }: GetActionUrlProps ) =>
+				`${ wooAdminUrl }&path=%2Fpayments%2Fconnect`,
 		},
 		{
 			id: 'custom-domain',

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -5,10 +5,11 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import isPluginActive from 'calypso/state/selectors/is-plugin-active';
 import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConfirmationTask from './confirmation-task';
-import { GetConfirmationTasks } from './confirmation-tasks';
+import { getConfirmationTasks } from './confirmation-tasks';
 import type { AppState } from 'calypso/types';
 
 import './style.scss';
@@ -16,8 +17,11 @@ import './style.scss';
 const TrialUpgradeConfirmation = () => {
 	const selectedSite = useSelector( getSelectedSite );
 	const translate = useTranslate();
-	const siteSlug = selectedSite?.slug;
-	const tasks = GetConfirmationTasks( { translate, siteSlug } );
+	const siteId = selectedSite?.ID;
+	const hasWCPay = useSelector(
+		( state ) => siteId && isPluginActive( state, siteId, 'woocommerce-payments' )
+	) as boolean;
+	const tasks = getConfirmationTasks( { translate, hasWCPay } );
 
 	const taskActionUrlProps = {
 		siteName: selectedSite?.name ?? '',

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -7,16 +7,17 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConfirmationTask from './confirmation-task';
-import { getConfirmationTasks } from './confirmation-tasks';
+import { GetConfirmationTasks } from './confirmation-tasks';
 import type { AppState } from 'calypso/types';
 
 import './style.scss';
+import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 
 const TrialUpgradeConfirmation = () => {
 	const selectedSite = useSelector( getSelectedSite );
 	const translate = useTranslate();
-
-	const tasks = getConfirmationTasks( { translate } );
+	const siteSlug = selectedSite?.slug;
+	const tasks = GetConfirmationTasks( { translate, siteSlug } );
 
 	const taskActionUrlProps = {
 		siteName: selectedSite?.name ?? '',
@@ -38,6 +39,7 @@ const TrialUpgradeConfirmation = () => {
 		<>
 			<BodySectionCssClass bodyClass={ [ 'ecommerce-trial-upgraded' ] } />
 			<QuerySitePlans siteId={ selectedSite?.ID ?? 0 } />
+			<QueryJetpackPlugins siteIds={ [ selectedSite?.ID ?? 0 ] } />
 			<Main wideLayout>
 				<PageViewTracker
 					path="/plans/my-plan/trial-upgraded/:site"

--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
@@ -11,7 +12,6 @@ import { GetConfirmationTasks } from './confirmation-tasks';
 import type { AppState } from 'calypso/types';
 
 import './style.scss';
-import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 
 const TrialUpgradeConfirmation = () => {
 	const selectedSite = useSelector( getSelectedSite );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75172

## Proposed Changes

* Rather than pointing to a non-existent task, check to see if the user has WC Payments installed before pointing to the WC Payments page; otherwise, go to the Home screen.

## Testing Instructions

* Switch to this PR
* Create a new test site from `/setup/wooexpress`
* Upgrade the site to Essential or Performance
* After checkout, click on the "Provide a way to pay" box

<img width="347" alt="Screen Shot 2023-04-12 at 12 49 20 PM" src="https://user-images.githubusercontent.com/2124984/231529238-322ea33e-c53f-4bcc-9d50-010ac430cc45.png">

* If in a country that supports WC Payments, you should be brought to the Payments screen:

<img width="1665" alt="Screen Shot 2023-04-12 at 12 48 17 PM" src="https://user-images.githubusercontent.com/2124984/231529377-07857870-7f90-4076-a572-2f32916c1dad.png">

* If in a country that does not support WC Payments, you'll be brought to the home screen:

<img width="1665" alt="Screen Shot 2023-04-25 at 12 07 26 PM" src="https://user-images.githubusercontent.com/2124984/234337173-4e7a9123-d91d-4a88-88fd-32962f66f612.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
