### PR TITLE
Fix Happy Chat targeting notice

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -488,6 +488,19 @@ export class HelpContactForm extends PureComponent {
 			<div className="help-contact-form">
 				{ formDescription && <p>{ formDescription }</p> }
 
+				{ showChatStagingNotice && (
+					<Notice
+						className="help-contact-form__site-notice"
+						status="is-warning"
+						showDismiss={ false }
+						text="Targeting HappyChat staging"
+					>
+						<NoticeAction href="https://wp.me/PCYsg-Q7X" external>
+							Learn More
+						</NoticeAction>
+					</Notice>
+				) }
+
 				{ showSiteField && (
 					<div className="help-contact-form__site-selection">
 						{ ! hasNoSites && (
@@ -562,18 +575,6 @@ export class HelpContactForm extends PureComponent {
 								{ actionMessage }
 							</NoticeAction>
 						) }
-					</Notice>
-				) }
-				{ showChatStagingNotice && (
-					<Notice
-						className="help-contact-form__site-notice"
-						status="is-warning"
-						showDismiss={ false }
-						text="Targeting HappyChat staging"
-					>
-						<NoticeAction href="https://hud-staging.happychat.io/" external>
-							HUD
-						</NoticeAction>
 					</Notice>
 				) }
 

--- a/client/me/help/help-contact-form/style.scss
+++ b/client/me/help/help-contact-form/style.scss
@@ -78,7 +78,7 @@
 }
 
 .help-contact-form__site-notice {
-	margin: 8px auto 0;
+	margin: 8px auto 8px;
 }
 
 .help-contact-form__site-alternatives {

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -130,6 +130,17 @@ export const HelpCenterContactPage: FC = () => {
 					reopensAt="2023-04-10 07:00Z"
 					enabled={ hasAccessToLivechat }
 				/>
+				{ renderChat.env === 'staging' && (
+					<Notice
+						status="warning"
+						actions={ [ { label: 'Learn more', url: 'https://wp.me/PCYsg-Q7X' } ] }
+						className="help-center-contact-page__staging-notice"
+						isDismissible={ false }
+					>
+						Targeting HappyChat staging
+					</Notice>
+				) }
+
 				<div className={ classnames( 'help-center-contact-page__boxes' ) }>
 					<Link to="/contact-form?mode=FORUM">
 						<div
@@ -173,16 +184,6 @@ export const HelpCenterContactPage: FC = () => {
 									</div>
 								</div>
 							</ConditionalLink>
-							{ renderChat.env === 'staging' && (
-								<Notice
-									status="warning"
-									actions={ [ { label: 'Learn more', url: 'https://wp.me/PCYsg-Q7X' } ] }
-									className="help-center-contact-page__staging-notice"
-									isDismissible={ false }
-								>
-									Using HappyChat staging
-								</Notice>
-							) }
 						</div>
 					) }
 

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -176,7 +176,7 @@ export const HelpCenterContactPage: FC = () => {
 							{ renderChat.env === 'staging' && (
 								<Notice
 									status="warning"
-									actions={ [ { label: 'HUD', url: 'https://hud-staging.happychat.io/' } ] }
+									actions={ [ { label: 'Learn more', url: 'https://wp.me/PCYsg-Q7X' } ] }
 									className="help-center-contact-page__staging-notice"
 									isDismissible={ false }
 								>

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -296,7 +296,7 @@ $head-foot-height: 50px;
 	}
 
 	.help-center-contact-page__staging-notice {
-		margin: 2px 0;
+		margin: 5px 0;
 		.components-notice__content {
 			display: flex;
 			justify-content: space-between;


### PR DESCRIPTION
Our HEs are often confused as to why Happychat availability is zero when they try to test. Not knowing that they're targeting staging Happy Chat.

This links them to a Field Guide entry explaining all the details. 