### PR TITLE
Woo Express Trial: Hide renew link in sites grid

### DIFF
--- a/client/sites-dashboard/components/sites-grid-action-renew.tsx
+++ b/client/sites-dashboard/components/sites-grid-action-renew.tsx
@@ -12,6 +12,7 @@ import { PLAN_RENEW_NAG_EVENT_NAMES } from '../utils';
 
 interface SitesGridActionRenewProps {
 	site: SiteExcerptData;
+	hideRenewLink?: boolean;
 }
 
 const Container = styled.div( {
@@ -36,7 +37,7 @@ const RenewLink = styled.a( {
 	},
 } );
 
-export function SitesGridActionRenew( { site }: SitesGridActionRenewProps ) {
+export function SitesGridActionRenew( { site, hideRenewLink }: SitesGridActionRenewProps ) {
 	const { __ } = useI18n();
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 	const isSiteOwner = site.site_owner === userId;
@@ -63,7 +64,7 @@ export function SitesGridActionRenew( { site }: SitesGridActionRenewProps ) {
 						sprintf( __( '%s Plan expired.' ), site.plan?.product_name_short )
 					}
 				</span>
-				{ isSiteOwner && (
+				{ isSiteOwner && ! hideRenewLink && (
 					<RenewLink
 						href={ `/checkout/${ site.slug }/${ productSlug }` }
 						onClick={ () => {

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -1,3 +1,4 @@
+import { PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { useSiteLaunchStatusLabel, getSiteLaunchStatus } from '@automattic/sites';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
@@ -79,6 +80,7 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 	const isP2Site = site.options?.is_wpforteams_site;
 	const isStagingSite = site.is_wpcom_staging_site;
 	const translatedStatus = useSiteLaunchStatusLabel( site );
+	const isECommerceTrialSite = site.plan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 
 	const { ref, inView } = useInView( { triggerOnce: true } );
 
@@ -108,7 +110,9 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 							sizesAttr={ SIZES_ATTR }
 						/>
 					</ThumbnailLink>
-					{ site.plan?.expired && <SitesGridActionRenew site={ site } /> }
+					{ site.plan?.expired && (
+						<SitesGridActionRenew site={ site } hideRenewLink={ isECommerceTrialSite } />
+					) }
 				</>
 			}
 			primary={


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73893

## Proposed Changes

* We've hidden the link on sites for list view; this PR does the same for grid view.
Before
<img width="421" alt="Screen Shot 2023-04-12 at 1 52 11 PM" src="https://user-images.githubusercontent.com/2124984/231563271-a50b5008-1d8c-4fce-9b8d-a887c503d444.png">

After


<img width="417" alt="Screen Shot 2023-04-12 at 3 24 03 PM" src="https://user-images.githubusercontent.com/2124984/231563403-2086d025-5cbb-4d7d-aace-4968db17c45c.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Create a new trial site from `/setup/wooexpress` and set its expiration date to past in the SA
* Alternatively test with an existing expired trial site
* Visit `/sites`, switch to Grid mode
* You should see the expired plan notice on your trial site, but no "Renew" link

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
