### PR TITLE
Launchpad: remove "Edit Site" overlay for Newsletter flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -1,6 +1,12 @@
 import { FEATURE_VIDEO_UPLOADS, planHasFeature } from '@automattic/calypso-products';
 import { DEVICE_TYPES } from '@automattic/components';
-import { FREE_FLOW, NEWSLETTER_FLOW, BUILD_FLOW, WRITE_FLOW } from '@automattic/onboarding';
+import {
+	FREE_FLOW,
+	NEWSLETTER_FLOW,
+	BUILD_FLOW,
+	WRITE_FLOW,
+	isNewsletterFlow,
+} from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import WebPreview from 'calypso/components/web-preview/component';
@@ -22,6 +28,7 @@ const LaunchpadSitePreview = ( {
 	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 	const site = useSite();
 	const isInVideoPressFlow = isVideoPressFlow( flow );
+	const enableEditOverlay = ! isNewsletterFlow( flow );
 
 	let previewUrl = siteSlug ? 'https://' + siteSlug : null;
 	const devicesToShow: Device[] = [ DEVICE_TYPES.COMPUTER, DEVICE_TYPES.PHONE ];
@@ -106,7 +113,7 @@ const LaunchpadSitePreview = ( {
 				defaultViewportDevice={ defaultDevice }
 				devicesToShow={ devicesToShow }
 				showSiteAddressBar={ false }
-				enableEditOverlay
+				enableEditOverlay={ enableEditOverlay }
 			/>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -141,7 +141,6 @@ describe( 'StepContent', () => {
 			renderStepContent( false, NEWSLETTER_FLOW );
 
 			expect( screen.getByTitle( 'Preview' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Edit design' ) ).toBeInTheDocument();
 		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #75624

## Proposed Changes

* Remove the "Edit Site" overlay on a Newsletter site's preview

## Testing Instructions

* If you don't have a newsletter site lying around, create one at `/setup/newsletter`
* In Launchpad for your Newsletter site, you should not see the "Edit Site" overlay when you hover over the preview
* The preview should still not allow interactions


<img width="1280" alt="Screenshot 2023-04-12 at 14 44 37" src="https://user-images.githubusercontent.com/195089/231567901-20ce0a0c-5605-444e-9daf-1452c9547026.png">
^ Before

<img width="1278" alt="Screenshot 2023-04-12 at 14 45 15" src="https://user-images.githubusercontent.com/195089/231568028-b7c409a2-60bc-4c6d-874c-7d98510b7323.png">
^ After


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
