### PR TITLE
Blog onboarding: Redirect onboarding user after publishing a post

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/editor.js
+++ b/apps/wpcom-block-editor/src/wpcom/editor.js
@@ -9,6 +9,7 @@ import './features/use-classic-block-guide';
 import InserterMenuTrackingEvent from './features/tracking/wpcom-inserter-menu-search-term';
 import './features/site-editor-env-consistency';
 import './editor.scss';
+import './features/redirect-onboarding-user-after-publishing-post';
 
 registerPlugin( 'track-inserter-menu-events', {
 	render() {

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -2,30 +2,25 @@ import { select, subscribe } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
 import { getQueryArg } from '@wordpress/url';
 
-const siteOrigin = getQueryArg( window.location.search, 'origin' );
-const showLaunchpad = getQueryArg( window.location.search, 'showLaunchpad' );
+export function redirectOnboardingUserAfterPublishingPost() {
+	const showLaunchpad = getQueryArg( window.location.search, 'showLaunchpad' );
 
-export const postWasPublished = async () =>
-	new Promise( ( resolve ) => {
-		const unsubscribe = subscribe( () => {
-			const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
-			const getCurrentPostRevisionsCount = select( 'core/editor' ).getCurrentPostRevisionsCount();
-
-			if ( isCurrentPostPublished && getCurrentPostRevisionsCount === 1 ) {
-				unsubscribe();
-				resolve();
-			}
-		} );
-	} );
-
-function redirectOnboardingUserAfterPublishingPost() {
 	if ( 'true' !== showLaunchpad ) {
 		return false;
 	}
 
-	postWasPublished().then( () => {
-		const siteSlug = window.location.hostname;
-		window.location.href = siteOrigin + '/setup/write/launchpad?siteSlug=' + siteSlug;
+	const siteOrigin = getQueryArg( window.location.search, 'origin' );
+	const siteSlug = window.location.hostname;
+
+	const unsubscribe = subscribe( () => {
+		const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
+		const getCurrentPostRevisionsCount = select( 'core/editor' ).getCurrentPostRevisionsCount();
+
+		if ( isCurrentPostPublished && getCurrentPostRevisionsCount === 1 ) {
+			unsubscribe();
+
+			window.location.href = siteOrigin + '/setup/write/launchpad?siteSlug=' + siteSlug;
+		}
 	} );
 }
 

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -3,6 +3,7 @@ import domReady from '@wordpress/dom-ready';
 import { getQueryArg } from '@wordpress/url';
 
 const siteOrigin = getQueryArg( window.location.search, 'origin' );
+const showLaunchpad = getQueryArg( window.location.search, 'showLaunchpad' );
 
 export const postWasPublished = async () =>
 	new Promise( ( resolve ) => {
@@ -18,9 +19,7 @@ export const postWasPublished = async () =>
 	} );
 
 function redirectOnboardingUserAfterPublishingPost() {
-	const showLaunchpad = window.location.search.indexOf( 'showLaunchpad=true' ) !== -1;
-
-	if ( ! showLaunchpad ) {
+	if ( 'true' !== showLaunchpad ) {
 		return false;
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -1,16 +1,12 @@
 import { select, subscribe } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
+import { getQueryArg } from '@wordpress/url';
+
+const siteOrigin = getQueryArg( window.location.search, 'origin' );
 
 export const postWasPublished = async () =>
 	new Promise( ( resolve ) => {
 		const unsubscribe = subscribe( () => {
-			const onboardingFlag = true;
-
-			if ( false === onboardingFlag ) {
-				unsubscribe();
-				return false;
-			}
-
 			const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
 			const getCurrentPostRevisionsCount = select( 'core/editor' ).getCurrentPostRevisionsCount();
 
@@ -22,10 +18,15 @@ export const postWasPublished = async () =>
 	} );
 
 function redirectOnboardingUserAfterPublishingPost() {
-	postWasPublished().then( () => {
-		console.log( 'Redirecting...' );
+	const showLaunchpad = window.location.search.indexOf( 'showLaunchpad=true' ) !== -1;
 
-		window.location.href = '/setup/write/launchpad?siteSlug=paulopmt1test.wordpress.com';
+	if ( ! showLaunchpad ) {
+		return false;
+	}
+
+	postWasPublished().then( () => {
+		const siteSlug = window.location.hostname;
+		window.location.href = siteOrigin + '/setup/write/launchpad?siteSlug=' + siteSlug;
 	} );
 }
 

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -1,0 +1,32 @@
+import { select, subscribe } from '@wordpress/data';
+import domReady from '@wordpress/dom-ready';
+
+export const postWasPublished = async () =>
+	new Promise( ( resolve ) => {
+		const unsubscribe = subscribe( () => {
+			const onboardingFlag = true;
+
+			if ( false === onboardingFlag ) {
+				unsubscribe();
+				return false;
+			}
+
+			const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
+			const getCurrentPostRevisionsCount = select( 'core/editor' ).getCurrentPostRevisionsCount();
+
+			if ( isCurrentPostPublished && getCurrentPostRevisionsCount === 1 ) {
+				unsubscribe();
+				resolve();
+			}
+		} );
+	} );
+
+function redirectOnboardingUserAfterPublishingPost() {
+	postWasPublished().then( () => {
+		console.log( 'Redirecting...' );
+
+		window.location.href = '/setup/write/launchpad?siteSlug=paulopmt1test.wordpress.com';
+	} );
+}
+
+domReady( redirectOnboardingUserAfterPublishingPost );

--- a/apps/wpcom-block-editor/src/wpcom/features/test/redirect-onboarding-user-after-publishing-post.test.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/test/redirect-onboarding-user-after-publishing-post.test.js
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+import { redirectOnboardingUserAfterPublishingPost } from '../redirect-onboarding-user-after-publishing-post';
+
+beforeAll( () => {} );
+
+const mockUnSubscribe = jest.fn();
+let mockSubscribeFunction = null;
+
+jest.mock( '@wordpress/data', () => ( {
+	subscribe: ( userFunction ) => {
+		mockSubscribeFunction = userFunction;
+
+		return mockUnSubscribe;
+	},
+	select: ( item ) => {
+		if ( item === 'core/editor' ) {
+			return {
+				isCurrentPostPublished: () => true,
+				getCurrentPostRevisionsCount: () => 1,
+			};
+		}
+	},
+} ) );
+
+describe( 'redirectOnboardingUserAfterPublishingPost', () => {
+	it( 'should NOT redirect the user to the launchpad if showLaunchpad query parameter is NOT present', () => {
+		delete global.window;
+		global.window = {
+			location: {
+				search: 'origin=https://calypso.localhost:3000',
+				hostname: 'wordpress.com',
+			},
+		};
+
+		redirectOnboardingUserAfterPublishingPost();
+		expect( mockSubscribeFunction ).toBe( null );
+		expect( global.window.location.href ).toBe( undefined );
+	} );
+
+	it( 'should redirect the user to the launchpad when a post is published and the showLaunchpad query parameter is present', () => {
+		delete global.window;
+		global.window = {
+			location: {
+				search: '?showLaunchpad=true&origin=https://calypso.localhost:3000',
+				hostname: 'wordpress.com',
+			},
+		};
+
+		redirectOnboardingUserAfterPublishingPost();
+		expect( mockSubscribeFunction ).not.toBe( null );
+		mockSubscribeFunction();
+
+		expect( mockUnSubscribe ).toBeCalledTimes( 1 );
+		expect( global.window.location.href ).toBe(
+			'https://calypso.localhost:3000/setup/write/launchpad?siteSlug=wordpress.com'
+		);
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2158-gh-Automattic/dotcom-forge

## Proposed Changes

* While using the special flag `showLaunchpad=true` from a new post page (without iFrame), we get redirected to Launchpad.

https://user-images.githubusercontent.com/1044309/232502311-23b7643f-2467-483e-8592-9dec6aaca5e6.mp4


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Apply this branch on your local Calypso
* Make sure `widgets.wp.com` is sandboxed.
* [Comment this line on Launchpad](https://github.com/Automattic/wp-calypso/blob/update/redirect-onboarding-user-after-publishing-post/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx#L78) to avoid redirect
* Follow the [wpcom-block-editor sync flow](https://github.com/Automattic/wp-calypso/tree/trunk/apps/wpcom-block-editor#dev-workflow). In summary: 
  - cd apps/wpcom-block-editor/src 
  - yarn dev --sync

* Create a new post using the onboarding flag: http://calypso.localhost:3000/post/{domain}?showLaunchpad=true
* Inspect the page and open the iFrame URL in a new tab
* After publishing a post, you should get redirected to the Launchpad
* If you have any issues showing the launchpad locally, this might help: p1665762866952539/1665762375.564149-slack-CHN6J22MP
* Try to break the flow and make sure without the flag we won't be redirected
* Run test with this command: `yarn run jest apps/wpcom-block-editor/src/wpcom/features/test/redirect-onboarding-user-after-publishing-post.test.js`



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?