### PR TITLE
Site Editor: un-iframe in all environments

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -291,16 +291,9 @@ export const exitPost = ( context, next ) => {
  * Redirects to the un-iframed Site Editor if the config is enabled.
  *
  * @param {Object} context Shared context in the route.
- * @param {Function} next  Next registered callback for the route.
  * @returns {*}            Whatever the next callback returns.
  */
-export const redirectSiteEditor = async ( context, next ) => {
-	// bail unless the config is enabled
-	if ( ! isEnabled( 'block-editor/un-iframed-site-editor' ) ) {
-		return next();
-	}
-
-	// Let's ditch that iframe!
+export const redirectSiteEditor = async ( context ) => {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 
@@ -323,5 +316,6 @@ export const redirectSiteEditor = async ( context, next ) => {
 	// We aren't using `getSiteEditorUrl` because it still thinks we should gutenframe the Site Editor.
 	const siteAdminUrl = getSiteAdminUrl( state, siteId );
 	const siteEditorUrl = addQueryArgs( queryArgs, `${ siteAdminUrl }site-editor.php` );
-	return location.assign( siteEditorUrl );
+	// Calling replace to avoid adding an entry to the browser history.
+	return location.replace( siteEditorUrl );
 };

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -261,23 +261,6 @@ export const post = ( context, next ) => {
 	return next();
 };
 
-export const siteEditor = ( context, next ) => {
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
-
-	context.primary = (
-		<CalypsoifyIframe
-			// This key is added as a precaution due to it's oberserved necessity in the above post editor.
-			// It will force the component to remount completely when the Id changes.
-			key={ siteId }
-			editorType="site"
-			completedFlow={ getSessionStorageOneTimeValue( 'wpcom_signup_completed_flow' ) }
-		/>
-	);
-
-	return next();
-};
-
 export const exitPost = ( context, next ) => {
 	const postId = getPostID( context );
 	const siteId = getSelectedSiteId( context.store.getState() );

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -1,26 +1,10 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { siteSelection, sites } from 'calypso/my-sites/controller';
-import {
-	authenticate,
-	post,
-	redirect,
-	siteEditor,
-	exitPost,
-	redirectSiteEditor,
-} from './controller';
+import { authenticate, post, redirect, exitPost, redirectSiteEditor } from './controller';
 
 export default function () {
-	page(
-		'/site-editor/:site?',
-		siteSelection,
-		redirectSiteEditor,
-		redirect,
-		authenticate,
-		siteEditor,
-		makeLayout,
-		clientRender
-	);
+	page( '/site-editor/:site?', siteSelection, redirectSiteEditor );
 
 	page( '/post', siteSelection, sites, makeLayout, clientRender );
 	page( '/post/new', '/post' ); // redirect from beep-beep-boop

--- a/config/development.json
+++ b/config/development.json
@@ -29,7 +29,6 @@
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
 		"anchor/sunset-integration": true,
-		"block-editor/un-iframed-site-editor": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -17,7 +17,6 @@
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
 		"anchor/sunset-integration": false,
-		"block-editor/un-iframed-site-editor": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -24,10 +24,7 @@ import {
 import { getIdFromBlock } from '../../element-helper';
 import envVariables from '../../env-variables';
 
-const wpAdminPath = 'wp-admin/site-editor.php';
-
 const selectors = {
-	editorIframe: `iframe.is-loaded[src*="${ wpAdminPath }"]`,
 	editorRoot: 'body.block-editor-page',
 	editorCanvasIframe: 'iframe[name="editor-canvas"]',
 	editorCanvasRoot: 'body.block-editor-iframe__body',

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -21,7 +21,6 @@ import {
 	DimensionsSettings,
 	CookieBannerComponent,
 } from '..';
-import { getCalypsoURL } from '../../data-helper';
 import { getIdFromBlock } from '../../element-helper';
 import envVariables from '../../env-variables';
 
@@ -75,11 +74,7 @@ export class FullSiteEditorPage {
 	constructor( page: Page ) {
 		this.page = page;
 
-		if ( this.shouldUseIframe() ) {
-			this.editor = page.frameLocator( selectors.editorIframe ).locator( selectors.editorRoot );
-		} else {
-			this.editor = page.locator( selectors.editorRoot );
-		}
+		this.editor = page.locator( selectors.editorRoot );
 
 		this.editorCanvas = this.editor
 			.frameLocator( selectors.editorCanvasIframe )
@@ -128,16 +123,10 @@ export class FullSiteEditorPage {
 			);
 		}
 
-		let targetHref: string;
-		if ( this.shouldUseIframe() ) {
-			targetHref = getCalypsoURL( `/site-editor/${ parsedUrl.host }` );
-		} else {
-			parsedUrl.pathname = '/wp-admin/site-editor.php';
-			parsedUrl.searchParams.set( 'calypso_origin', envVariables.CALYPSO_BASE_URL );
-			targetHref = parsedUrl.href;
-		}
+		parsedUrl.pathname = '/wp-admin/site-editor.php';
+		parsedUrl.searchParams.set( 'calypso_origin', envVariables.CALYPSO_BASE_URL );
 
-		await this.page.goto( targetHref, { timeout: 60 * 1000 } );
+		await this.page.goto( parsedUrl.href, { timeout: 60 * 1000 } );
 	}
 
 	/**
@@ -657,16 +646,6 @@ export class FullSiteEditorPage {
 		if ( ( await toastLocator.count() ) > 0 ) {
 			await toastLocator.click();
 		}
-	}
-
-	/**
-	 * TODO: Temp check -- we will delete when we un-iframe everywhere
-	 */
-	private shouldUseIframe(): boolean {
-		// The only place we are preserving the Site Editor iFrame is Simple sites on staging/production.
-		return (
-			! envVariables.TEST_ON_ATOMIC && envVariables.CALYPSO_BASE_URL === 'https://wordpress.com'
-		);
 	}
 
 	//#endregion


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75183 and #74413

## Proposed Changes

* Disables the iframe in all environments

## Testing Instructions

Try to enter the Site Editor. You should only end up in a URL that includes `wp-admin/site-editor.php`, both Simple and Atomic.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
