### PR TITLE
Stats: Add a "View all subscribers" subheading link

### DIFF
--- a/client/blocks/stats-navigation/constants.js
+++ b/client/blocks/stats-navigation/constants.js
@@ -26,6 +26,8 @@ const insights = {
 	path: '/stats/insights',
 	showIntervals: false,
 };
+// TODO: Consider adding subscriber counts into this nav item in the future.
+// See client/blocks/subscribers-count/index.jsx.
 const subscribers = {
 	label: translate( 'Subscribers' ),
 	path: '/stats/subscribers',

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -87,7 +87,7 @@ class StatsNavigation extends Component {
 					{ isLegacy && showIntervals && (
 						<Intervals selected={ interval } pathTemplate={ pathTemplate } />
 					) }
-					<SubscribersCount />
+					{ ! config.isEnabled( 'stats/subscribers-section' ) && <SubscribersCount /> }
 				</SectionNav>
 				{ isLegacy && showIntervals && (
 					<Intervals selected={ interval } pathTemplate={ pathTemplate } standalone />

--- a/client/my-sites/stats/stats-subscribers-page/index.jsx
+++ b/client/my-sites/stats/stats-subscribers-page/index.jsx
@@ -65,7 +65,7 @@ const StatsSubscribersPage = () => {
 						vendor={ getSuggestionsVendor() }
 					/>
 				) }
-				<SubscribersSection siteId={ siteId } />
+				<SubscribersSection siteId={ siteId } siteSlug={ siteSlug } />
 				<div className={ statsModuleListClass }>
 					<Followers path="followers" />
 					<Reach />

--- a/client/my-sites/stats/subscribers-section/index.tsx
+++ b/client/my-sites/stats/subscribers-section/index.tsx
@@ -1,4 +1,5 @@
 import UplotChart from '@automattic/components/src/chart-uplot';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import { UseQueryResult } from 'react-query';
 import useSubscribersQuery from 'calypso/my-sites/stats/hooks/use-subscribers-query';
@@ -29,7 +30,13 @@ function transformData( data: SubscribersData[] ): uPlot.AlignedData {
 	return [ x, y ];
 }
 
-export default function SubscribersSection( { siteId }: { siteId: string } ) {
+export default function SubscribersSection( {
+	siteId,
+	siteSlug,
+}: {
+	siteId: string;
+	siteSlug: string;
+} ) {
 	const period = 'month';
 	const quantity = 30;
 	const {
@@ -41,6 +48,7 @@ export default function SubscribersSection( { siteId }: { siteId: string } ) {
 	}: UseQueryResult< SubscribersDataResult > = useSubscribersQuery( siteId, period, quantity );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 	const legendRef = useRef< HTMLDivElement >( null );
+	const translate = useTranslate();
 
 	useEffect( () => {
 		if ( isError ) {
@@ -53,12 +61,24 @@ export default function SubscribersSection( { siteId }: { siteId: string } ) {
 	return (
 		<div className="subscribers-section">
 			<div className="subscribers-section-heading">
-				<h1 className="highlight-cards-heading">Subscribers</h1>
+				<h1 className="highlight-cards-heading">
+					{ translate( 'Subscribers' ) }{ ' ' }
+					<small>
+						<a
+							className="highlight-cards-heading-wrapper"
+							href={ '/people/subscribers/' + siteSlug }
+						>
+							{ translate( 'View all subscribers' ) }
+						</a>
+					</small>
+				</h1>
 				<div className="subscribers-section-legend" ref={ legendRef }></div>
 			</div>
 			{ isLoading && <StatsModulePlaceholder className="is-chart" isLoading /> }
 			{ ! isLoading && chartData.length === 0 && (
-				<p className="subscribers-section__no-data">No data availble for the specified period.</p>
+				<p className="subscribers-section__no-data">
+					{ translate( 'No data availble for the specified period.' ) }
+				</p>
 			) }
 			{ errorMessage && <div>Error: { errorMessage }</div> }
 			{ ! isLoading && chartData.length !== 0 && (

--- a/client/my-sites/stats/subscribers-section/index.tsx
+++ b/client/my-sites/stats/subscribers-section/index.tsx
@@ -60,7 +60,8 @@ export default function SubscribersSection( {
 
 	return (
 		<div className="subscribers-section">
-			<div className="subscribers-section-heading">
+			{ /* TODO: Remove highlight-cards class and use a highlight cards heading component instead. */ }
+			<div className="subscribers-section-heading highlight-cards">
 				<h1 className="highlight-cards-heading">
 					{ translate( 'Subscribers' ) }{ ' ' }
 					<small>


### PR DESCRIPTION
Fixes #75651.

## Proposed Changes

<img width="1263" alt="image" src="https://user-images.githubusercontent.com/4044428/231594508-3695f01d-44c5-4072-9672-0196b6c3f477.png">

* Adds a link to `/people/subscribers/:siteSlug` next to the "Subscribers" chart heading.

Before|After
-|-
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/4044428/231594866-3c7b7259-f5f3-4e06-b9fc-7eed83f7ff6d.png">|<img width="1271" alt="image" src="https://user-images.githubusercontent.com/4044428/231594808-b6e90224-85af-4125-b093-942e745d559d.png">

* When the new subscriber stats section is enabled, hide the duplicate "Subscribers" navitem.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live branch for this PR and navigate to the Stats page (`/stats/day/:siteSlug`).
* Enable the new subscriber stats section by appending this query string to the URL: `?flags=stats/subscribers-section`.
* Ensure that there's a new link next to the "Subscribers" chart heading.
* Ensure that there's only one "Subscribers" navigation item at the top of the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
