### PR TITLE
Redirect to `/sites` after deleting site, depending on user prefs

### DIFF
--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -21,6 +21,7 @@ import hasCancelableSitePurchases from 'calypso/state/selectors/has-cancelable-s
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { deleteSite } from 'calypso/state/sites/actions';
 import { getSite, getSiteDomain } from 'calypso/state/sites/selectors';
+import { hasSitesAsLandingPage } from 'calypso/state/sites/selectors/has-sites-as-landing-page';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -93,11 +94,15 @@ class DeleteSite extends Component {
 	};
 
 	componentDidUpdate( prevProps ) {
-		const { siteId, siteExists } = this.props;
+		const { siteId, siteExists, useSitesAsLandingPage } = this.props;
 
 		if ( siteId && prevProps.siteExists && ! siteExists ) {
 			this.props.setSelectedSiteId( null );
-			page.redirect( '/stats' );
+			if ( useSitesAsLandingPage ) {
+				page.redirect( '/sites' );
+			} else {
+				page.redirect( '/stats' );
+			}
 		}
 	}
 
@@ -364,6 +369,7 @@ export default connect(
 			siteSlug,
 			siteExists: !! getSite( state, siteId ),
 			hasCancelablePurchases: hasCancelableSitePurchases( state, siteId ),
+			useSitesAsLandingPage: hasSitesAsLandingPage( state ),
 		};
 	},
 	{


### PR DESCRIPTION
## Proposed Changes

Just a papercut I felt while testing.

After deleting a site in Calypso the current site selection is cleared and you're taken to `/stats/day`. But that doesn't seem like the natural place to go for someone who's accustomed to using the `/sites` page.

The "Admin home" preference in `/me/account` is used to determine what view the user wants to see by default after logging in.


<img src="https://user-images.githubusercontent.com/1500769/231603574-db70fd1e-4375-449f-aa50-b2b0e1409457.png" alt="CleanShot 2023-04-13 at 10 53 17@2x" style="max-width: 100%;" width="50%">


We can use this same preference as a hint for what view the user would expect to see after deleting a site.

Another way of thinking about it is after deleting a site I expect to be taken to the top of the IA, and for users with the "Admin home" preference set, the top of the IA is `/sites`.

One could make a case that after deleting a site we should _always_ go to `/sites`, but I only thought of it because I have the setting enabled, and it's easier to justify making the change if we depend on the setting I think.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure `/sites` _isn't_ the home page and delete a site. The behaviour should be the same as before—you are taken to an all-sites stats view.
* Set `/sites` as the home page and delete a site. After successfully deleting the site you should be taken to `/sites`
* Create a brand new user with only one site. Set `/sites` as the home page. Delete your one and only site. You should be taken to `/sites` and see the "create your first site" experience. IMO this feels like the right experience for someone who has deleted all of their sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
