### PR TITLE
BlazePress Widget: Update the strings for translation

### DIFF
--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -52,6 +52,12 @@ const BlazePressStrings = () => {
 	translate(
 		'Cannot create subscription. Please {{supportLink}}contact support{{/supportLink}} or try again later.'
 	);
+	translate(
+		'There was an error with the address. Please, verify that all the required data is valid'
+	);
+	translate(
+		'There was an error with the address. The province, state or region should be filled'
+	);
 	translate( 'State field is required' );
 	translate( 'Use saved card' );
 	translate( 'First Name' );
@@ -84,6 +90,14 @@ const BlazePressStrings = () => {
 	translate( 'Audience & Budget' );
 	translate( 'Save and Submit' );
 	translate( 'Next' );
+	translate( 'Close' );
+	translate( 'Make the most of your Blaze campaign' );
+	translate( 'Choose an eye-catching image for your ad' );
+	translate( 'Adjust your title to make it more engaging' );
+	translate( 'Pick the right audience, budget and duration' );
+	translate( 'Get started' );
+	translate( 'Learn more' );
+	translate( "Don't show me this step again." );
 	translate( 'Drop image here' );
 	translate( 'Click or Drag an image here' );
 	translate( 'All fields marked as required' );
@@ -91,13 +105,6 @@ const BlazePressStrings = () => {
 	translate( 'All' );
 	translate( 'Mobile devices' );
 	translate( 'Desktop devices' );
-	translate( 'Close' );
-	translate( 'Learn more' );
-	translate( 'Get started' );
-	translate( 'Pick the right audience, budget and duration' );
-	translate( 'Adjust your title to make it more engaging' );
-	translate( 'Make the most of your Blaze campaign' );
-	translate( 'Choose an eye-catching image for your ad' );
 };
 
 if ( window.BlazePress ) {


### PR DESCRIPTION
Related to a8c-dsp#38

## Proposed Changes

* Update promote-post/string.ts with the latest strings

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
