### PR TITLE
Jetpack Pro Dashboard: code cleanup for the expandable block feature flag

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Card, Gridicon, Button } from '@automattic/components';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import classNames from 'classnames';
@@ -89,8 +88,6 @@ export default function SiteCard( { rows, columns }: Props ) {
 	const shouldDisableLicenseSelection =
 		selectedLicenses?.length && ! currentSiteHasSelectedLicenses;
 
-	const isExpandableBlockEnabled = isEnabled( 'jetpack/pro-dashboard-expandable-block' );
-
 	return (
 		<Card
 			className={ classNames( 'site-card__card', {
@@ -129,54 +126,43 @@ export default function SiteCard( { rows, columns }: Props ) {
 										) }
 										key={ index }
 									>
-										{ isExpandableBlockEnabled ? (
-											<>
-												<div className="site-card__expanded-content-header">
-													<span className="site-card__expanded-content-key">{ column.title }</span>
-													<span className="site-card__expanded-content-value">
-														<span className="site-card__expanded-content-status">
-															<SiteStatusContent rows={ rows } type={ row.type } />
-														</span>
-														<span className="site-card__expanded-column">
-															{ column.isExpandable && (
-																<Button
-																	borderless
-																	onClick={ () => handleSetExpandedColumn( column.key ) }
-																>
-																	<Icon
-																		icon={ expandedColumn === column.key ? chevronUp : chevronDown }
-																	/>
-																</Button>
-															) }
-														</span>
-													</span>
-												</div>
-												{ expandedColumn === column.key && (
-													<SiteExpandedContent
-														isSmallScreen
-														site={ rows.site.value }
-														columns={ [ column.key ] }
-														hasError={ site.error || ! isSiteConnected }
-													/>
-												) }
-											</>
-										) : (
-											<>
+										<>
+											<div className="site-card__expanded-content-header">
 												<span className="site-card__expanded-content-key">{ column.title }</span>
 												<span className="site-card__expanded-content-value">
-													<SiteStatusContent rows={ rows } type={ row.type } />
+													<span className="site-card__expanded-content-status">
+														<SiteStatusContent rows={ rows } type={ row.type } />
+													</span>
+													<span className="site-card__expanded-column">
+														{ column.isExpandable && (
+															<Button
+																borderless
+																onClick={ () => handleSetExpandedColumn( column.key ) }
+															>
+																<Icon
+																	icon={ expandedColumn === column.key ? chevronUp : chevronDown }
+																/>
+															</Button>
+														) }
+													</span>
 												</span>
-											</>
-										) }
+											</div>
+											{ expandedColumn === column.key && (
+												<SiteExpandedContent
+													isSmallScreen
+													site={ rows.site.value }
+													columns={ [ column.key ] }
+													hasError={ site.error || ! isSiteConnected }
+												/>
+											) }
+										</>
 									</div>
 								);
 							}
 						} ) }
-					{ isExpandableBlockEnabled && (
-						<div className="site-card__expanded-content-list site-card__content-list-no-error">
-							<SitePhpVersion phpVersion={ rows.site.value.php_version_num } />
-						</div>
-					) }
+					<div className="site-card__expanded-content-list site-card__content-list-no-error">
+						<SitePhpVersion phpVersion={ rows.site.value.php_version_num } />
+					</div>
 				</div>
 			) }
 		</Card>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
@@ -54,6 +54,22 @@ describe( '<SiteCard>', () => {
 				type: 'site',
 				status: '',
 			},
+			stats: {
+				type: 'stats',
+				status: 'active',
+				value: {
+					views: {
+						total: 0,
+						trend: 'up',
+						trend_change: 0,
+					},
+					visitors: {
+						total: 0,
+						trend: 'up',
+						trend_change: 0,
+					},
+				},
+			},
 			backup: {
 				type: 'backup',
 				status: '',

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/backup-storage.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/backup-storage.test.tsx
@@ -53,13 +53,17 @@ describe( 'BackupStorage component', () => {
 	);
 
 	it( 'renders empty content when backup is not supported on multisite', () => {
-		render( <BackupStorage site={ site } trackEvent={ mockTrackEvent } />, { wrapper: Wrapper } );
+		render( <BackupStorage site={ site } trackEvent={ mockTrackEvent } hasError={ false } />, {
+			wrapper: Wrapper,
+		} );
 		expect( screen.getByText( /backup not supported on multisite/i ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders empty content when backup is not enabled', () => {
 		initialState.sites.items[ site.blog_id ].is_multisite = false;
-		render( <BackupStorage site={ site } trackEvent={ mockTrackEvent } />, { wrapper: Wrapper } );
+		render( <BackupStorage site={ site } trackEvent={ mockTrackEvent } hasError={ false } />, {
+			wrapper: Wrapper,
+		} );
 		expect( screen.getByText( /see your backup/i ) ).toBeInTheDocument();
 		fireEvent.click( screen.getByRole( 'button', { name: /add backup/i } ) );
 		expect( mockTrackEvent ).toHaveBeenCalledWith( 'expandable_block_backup_add_click' );
@@ -67,7 +71,9 @@ describe( 'BackupStorage component', () => {
 
 	it( 'renders BackupStorageContent when backup is enabled', async () => {
 		site.has_backup = true;
-		render( <BackupStorage site={ site } trackEvent={ mockTrackEvent } />, { wrapper: Wrapper } );
+		render( <BackupStorage site={ site } trackEvent={ mockTrackEvent } hasError={ false } />, {
+			wrapper: Wrapper,
+		} );
 		expect( screen.getByText( /latest backup/i ) ).toBeInTheDocument();
 		expect( screen.getByText( /activity log/i ) ).toHaveAttribute(
 			'href',
@@ -81,7 +87,9 @@ describe( 'BackupStorage component', () => {
 	it( 'renders empty content when backup has error', async () => {
 		site.has_backup = true;
 		site.latest_backup_status = 'backup_only_error';
-		render( <BackupStorage site={ site } trackEvent={ mockTrackEvent } />, { wrapper: Wrapper } );
+		render( <BackupStorage site={ site } trackEvent={ mockTrackEvent } hasError={ false } />, {
+			wrapper: Wrapper,
+		} );
 		expect( screen.getByText( /see your backup storage/i ) ).toBeInTheDocument();
 		const button = screen.getByRole( 'button', { name: /fix backup/i } );
 		fireEvent.click( button );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
@@ -26,6 +26,7 @@ describe( 'BoostSitePerformance', () => {
 				siteId={ siteId }
 				siteUrlWithScheme={ siteUrlWithScheme }
 				trackEvent={ trackEventMock }
+				hasError={ false }
 			/>
 		);
 
@@ -48,6 +49,7 @@ describe( 'BoostSitePerformance', () => {
 				siteId={ siteId }
 				siteUrlWithScheme={ siteUrlWithScheme }
 				trackEvent={ trackEventMock }
+				hasError={ false }
 			/>
 		);
 
@@ -67,6 +69,7 @@ describe( 'BoostSitePerformance', () => {
 				siteId={ siteId }
 				siteUrlWithScheme={ siteUrlWithScheme }
 				trackEvent={ trackEventMock }
+				hasError={ false }
 			/>
 		);
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/monitor-activity.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/monitor-activity.test.tsx
@@ -46,9 +46,17 @@ describe( 'MonitorActivity component', () => {
 	const hasMonitor = true;
 
 	test( 'renders the header and content', async () => {
-		render( <MonitorActivity site={ site } trackEvent={ trackEvent } hasMonitor={ hasMonitor } />, {
-			wrapper: Wrapper,
-		} );
+		render(
+			<MonitorActivity
+				site={ site }
+				trackEvent={ trackEvent }
+				hasMonitor={ hasMonitor }
+				hasError={ false }
+			/>,
+			{
+				wrapper: Wrapper,
+			}
+		);
 		expect( screen.getByText( /monitor activity/i ) ).toBeInTheDocument();
 		expect( screen.getByText( /20d ago/i ) ).toBeInTheDocument();
 		expect( screen.getByText( /today/i ) ).toBeInTheDocument();
@@ -58,9 +66,17 @@ describe( 'MonitorActivity component', () => {
 
 	test( 'calls the trackEvent function and toggleActivateMonitor when clicked', () => {
 		const hasMonitor = false;
-		render( <MonitorActivity site={ site } trackEvent={ trackEvent } hasMonitor={ hasMonitor } />, {
-			wrapper: Wrapper,
-		} );
+		render(
+			<MonitorActivity
+				site={ site }
+				trackEvent={ trackEvent }
+				hasMonitor={ hasMonitor }
+				hasError={ false }
+			/>,
+			{
+				wrapper: Wrapper,
+			}
+		);
 		const card = screen.getByRole( 'button', {
 			name: /activate monitor to see your uptime records/i,
 		} );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon, ShortenedNumber } from '@automattic/components';
 import { Icon, arrowUp, arrowDown } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
@@ -7,7 +6,6 @@ import { translate } from 'i18n-calypso';
 import page from 'page';
 import { useRef, useState, useMemo, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import Badge from 'calypso/components/badge';
 import Tooltip from 'calypso/components/tooltip';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectLicense, unselectLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
@@ -54,7 +52,6 @@ export default function SiteStatusContent( {
 	let { tooltip } = metadataRest;
 
 	const { isBulkManagementActive } = useContext( SitesOverviewContext );
-	const isExpandedBlockEnabled = isEnabled( 'jetpack/pro-dashboard-expandable-block' );
 
 	const siteId = rows.site.value.blog_id;
 	const siteUrl = rows.site.value.url;
@@ -260,23 +257,11 @@ export default function SiteStatusContent( {
 				break;
 			}
 			case 'failed': {
-				content = isExpandedBlockEnabled ? (
-					<div className="sites-overview__failed">{ value }</div>
-				) : (
-					<Badge className="sites-overview__badge" type="error">
-						{ value }
-					</Badge>
-				);
+				content = <div className="sites-overview__failed">{ value }</div>;
 				break;
 			}
 			case 'warning': {
-				content = isExpandedBlockEnabled ? (
-					<div className="sites-overview__warning">{ value }</div>
-				) : (
-					<Badge className="sites-overview__badge" type="warning">
-						{ value }
-					</Badge>
-				);
+				content = <div className="sites-overview__warning">{ value }</div>;
 				break;
 			}
 			case 'success': {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import classNames from 'classnames';
 import { Fragment } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -53,8 +52,6 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 
 	const hasSiteError = site.error || ! isSiteConnected;
 
-	const isExpandedContentEnabled = isEnabled( 'jetpack/pro-dashboard-expandable-block' );
-
 	return (
 		<Fragment>
 			<tr
@@ -102,9 +99,8 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 				{ /* Show error content when there is a site error */ }
 				{ hasSiteError && (
 					<td
-						className={ classNames( 'site-table__error', {
+						className={ classNames( 'site-table__error padding-0', {
 							'site-table__td-without-border-bottom': isExpanded,
-							'padding-0': isExpandedContentEnabled,
 						} ) }
 						// If there is an error, we need to span the whole row because we don't show any column.
 						colSpan={ columns.length - 1 }
@@ -113,22 +109,18 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 					</td>
 				) }
 				<td
-					className={ classNames( 'site-table__actions', {
+					className={ classNames( 'site-table__actions site-table__actions-button', {
 						'site-table__td-without-border-bottom': isExpanded,
-						'site-table__actions-button': isExpandedContentEnabled,
 					} ) }
 				>
 					<SiteActions isLargeScreen site={ site } siteError={ siteError } />
 				</td>
-				{ /* Show expand buttons only when the feature is enabled */ }
-				{ isExpandedContentEnabled && (
-					<SiteTableExpand
-						index={ index }
-						isExpanded={ isExpanded }
-						setExpanded={ setExpanded }
-						siteId={ site.value.blog_id }
-					/>
-				) }
+				<SiteTableExpand
+					index={ index }
+					isExpanded={ isExpanded }
+					setExpanded={ setExpanded }
+					siteId={ site.value.blog_id }
+				/>
 			</tr>
 			{ /* Show expanded content when expandable block is enabled. */ }
 			{ isExpanded && (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
@@ -56,10 +56,26 @@ describe( '<SiteTableRow>', () => {
 			type: 'site',
 			status: '',
 		},
+		stats: {
+			type: 'stats',
+			status: 'active',
+			value: {
+				views: {
+					total: 0,
+					trend: 'up',
+					trend_change: 0,
+				},
+				visitors: {
+					total: 0,
+					trend: 'up',
+					trend_change: 0,
+				},
+			},
+		},
 		backup: {
 			type: 'backup',
 			value: translate( 'Failed' ),
-			status: 'failed',
+			status: 'critical',
 		},
 		monitor: {
 			error: false,
@@ -96,6 +112,7 @@ describe( '<SiteTableRow>', () => {
 			throw new Error( 'Function not implemented.' );
 		},
 		isExpanded: false,
+		index: 0,
 	};
 	const initialState = {
 		partnerPortal: {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Icon, starFilled } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useContext, useState, forwardRef, Ref } from 'react';
@@ -33,15 +32,8 @@ const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableEle
 		setExpandedRow( expandedRow === blogId ? null : blogId );
 	};
 
-	const isExpandedBlockEnabled = isEnabled( 'jetpack/pro-dashboard-expandable-block' );
-
 	return (
-		<table
-			ref={ ref }
-			className={ classNames( 'site-table__table', {
-				'site-table__table-v2': isExpandedBlockEnabled,
-			} ) }
-		>
+		<table ref={ ref } className="site-table__table">
 			<thead>
 				<tr>
 					{ isBulkManagementActive ? (
@@ -63,7 +55,7 @@ const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableEle
 									</SiteSort>
 								</th>
 							) ) }
-							<th colSpan={ isExpandedBlockEnabled ? 3 : 1 }>
+							<th colSpan={ 3 }>
 								<div className="plugin-common-table__bulk-actions">
 									<EditButton isLargeScreen sites={ items } />
 								</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/style.scss
@@ -1,12 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.site-table__table-v2 {
-	td,
-	th {
-		border: 1px solid rgba(220, 220, 222, 0.5);
-	}
-}
 
 .site-table__table {
 	border: 1px solid var(--studio-gray-5);
@@ -62,7 +56,7 @@
 
 	td,
 	th {
-		border-bottom: 1px solid var(--studio-gray-5);
+		border: 1px solid rgba(220, 220, 222, 0.5);
 		text-align: left;
 		border-collapse: collapse;
 		vertical-align: middle;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -58,10 +58,26 @@ describe( '<SiteTable>', () => {
 				type: 'site',
 				status: '',
 			},
+			stats: {
+				type: 'stats',
+				status: 'active',
+				value: {
+					views: {
+						total: 0,
+						trend: 'up',
+						trend_change: 0,
+					},
+					visitors: {
+						total: 0,
+						trend: 'up',
+						trend_change: 0,
+					},
+				},
+			},
 			backup: {
 				type: 'backup',
 				value: translate( 'Failed' ),
-				status: 'failed',
+				status: 'critical',
 			},
 			monitor: {
 				error: false,
@@ -114,7 +130,7 @@ describe( '<SiteTable>', () => {
 	const queryClient = new QueryClient();
 
 	test( 'should render correctly and have href and status for each row', () => {
-		const { getByTestId } = render(
+		const { getByTestId, getByText } = render(
 			<Provider store={ store }>
 				<QueryClientProvider client={ queryClient }>
 					<SiteTable { ...props } />
@@ -124,22 +140,16 @@ describe( '<SiteTable>', () => {
 
 		const backupEle = getByTestId( `row-${ blogId }-backup` );
 		expect( backupEle.getAttribute( 'href' ) ).toEqual( `/backup/${ siteUrl }` );
-		expect( backupEle.getElementsByClassName( 'sites-overview__badge' )[ 0 ].textContent ).toEqual(
-			'Failed'
-		);
+		expect( getByText( /failed/i ) ).toBeInTheDocument();
 
 		const scanEle = getByTestId( `row-${ blogId }-scan` );
 		expect( scanEle.getAttribute( 'href' ) ).toEqual( `/scan/${ siteUrl }` );
-		expect( scanEle.getElementsByClassName( 'sites-overview__badge' )[ 0 ].textContent ).toEqual(
-			`${ scanThreats } Threats`
-		);
+		expect( getByText( `${ scanThreats } Threats` ) ).toBeInTheDocument();
 
 		const pluginEle = getByTestId( `row-${ blogId }-plugin` );
 		expect( pluginEle.getAttribute( 'href' ) ).toEqual(
 			`https://wordpress.com/plugins/updates/${ siteUrl }`
 		);
-		expect( pluginEle.getElementsByClassName( 'sites-overview__badge' )[ 0 ].textContent ).toEqual(
-			`${ pluginUpdates.length } Available`
-		);
+		expect( getByText( `${ pluginUpdates.length } Available` ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/utils.ts
@@ -38,7 +38,7 @@ describe( 'utils', () => {
 			backup: {
 				type: 'backup',
 				value: translate( 'Failed' ),
-				status: 'failed',
+				status: 'critical',
 			},
 			monitor: {
 				error: false,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -23,7 +23,6 @@ import type {
 
 const INITIAL_UNIX_EPOCH = '1970-01-01 00:00:00';
 
-const isExpandedBlockEnabled = config.isEnabled( 'jetpack/pro-dashboard-expandable-block' );
 const isBoostEnabled = config.isEnabled( 'jetpack/pro-dashboard-jetpack-boost' );
 
 // Mapping the columns to the site data keys
@@ -42,30 +41,24 @@ const boostColumn: SiteColumns = isBoostEnabled
 	  ]
 	: [];
 
-const statsColumns: SiteColumns = isExpandedBlockEnabled
-	? [
-			{
-				key: 'stats',
-				title: translate( 'Stats' ),
-				className: 'width-fit-content',
-				isExpandable: true,
-			},
-	  ]
-	: [];
-
 export const siteColumns: SiteColumns = [
 	{
 		key: 'site',
 		title: translate( 'Site' ),
 		isSortable: true,
 	},
-	...statsColumns,
+	{
+		key: 'stats',
+		title: translate( 'Stats' ),
+		className: 'width-fit-content',
+		isExpandable: true,
+	},
 	...boostColumn,
 	{
 		key: 'backup',
 		title: translate( 'Backup' ),
 		className: 'width-fit-content',
-		isExpandable: isExpandedBlockEnabled,
+		isExpandable: true,
 	},
 	{
 		key: 'scan',
@@ -76,7 +69,7 @@ export const siteColumns: SiteColumns = [
 		key: 'monitor',
 		title: translate( 'Monitor' ),
 		className: 'min-width-100px',
-		isExpandable: isExpandedBlockEnabled,
+		isExpandable: true,
 	},
 	{
 		key: 'plugin',
@@ -120,10 +113,6 @@ const backupEventNames: StatusEventNames = {
 	progress: {
 		small_screen: 'calypso_jetpack_agency_dashboard_backup_progress_click_small_screen',
 		large_screen: 'calypso_jetpack_agency_dashboard_backup_progress_click_large_screen',
-	},
-	failed: {
-		small_screen: 'calypso_jetpack_agency_dashboard_backup_failed_click_small_screen',
-		large_screen: 'calypso_jetpack_agency_dashboard_backup_failed_click_large_screen',
 	},
 	critical: {
 		small_screen: 'calypso_jetpack_agency_dashboard_backup_failed_click_small_screen',
@@ -212,7 +201,6 @@ const getRowEventName = (
 
 const backupTooltips: StatusTooltip = {
 	critical: translate( 'Latest backup failed' ),
-	failed: translate( 'Latest backup failed' ),
 	warning: translate( 'Latest backup completed with warnings' ),
 	inactive: translate( 'Add Jetpack VaultPress Backup to this site' ),
 	progress: translate( 'Backup in progress' ),
@@ -378,7 +366,7 @@ const formatBackupData = ( site: Site ) => {
 			break;
 		case 'rewind_backup_error':
 		case 'backup_only_error':
-			backup.status = isExpandedBlockEnabled ? 'critical' : 'failed';
+			backup.status = 'critical';
 			backup.value = translate( 'Failed' );
 			break;
 		case 'rewind_backup_complete_warning':

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -49,7 +49,6 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
-		"jetpack/pro-dashboard-expandable-block": true,
 		"jetpack/pro-dashboard-jetpack-boost": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -43,7 +43,6 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
-		"jetpack/pro-dashboard-expandable-block": true,
 		"jetpack/pro-dashboard-jetpack-boost": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -46,7 +46,6 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
-		"jetpack/pro-dashboard-expandable-block": true,
 		"jetpack/pro-dashboard-jetpack-boost": false,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -46,7 +46,6 @@
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
-		"jetpack/pro-dashboard-expandable-block": true,
 		"jetpack/pro-dashboard-jetpack-boost": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,


### PR DESCRIPTION
Related to 1203940061556608-as-1204200406864526

## Proposed Changes

This PR removes the feature flag and logic behind the usage of the feature flag used for the expandable block in the Jetpack Pro Dashboard.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout remove/expandable-block-feature-flag-code-cleanup` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify all the code changes make sense and look as shown below.
4. Verify all the tests are passing and that the code changes look good.

<img width="1582" alt="Screenshot 2023-04-13 at 11 58 21 AM" src="https://user-images.githubusercontent.com/10586875/231673483-256be72e-1763-4f2a-b877-16367b07df95.png">

<img width="1582" alt="Screenshot 2023-04-13 at 11 58 31 AM" src="https://user-images.githubusercontent.com/10586875/231673504-98f024af-6987-4a3c-a17b-855efcf1befc.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?