### PR TITLE
CI: capture both full-screen and viewport sized screenshots when a spec fails.

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -171,7 +171,11 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 						// Screenshots and video are saved per page, where numerous
 						// pages may exist within a context.
 						try {
-							await page.screenshot( { path: `${ mediaFilePath }.png`, timeout: env.TIMEOUT } );
+							await page.screenshot( {
+								path: `${ mediaFilePath }.png`,
+								timeout: env.TIMEOUT,
+								fullPage: true,
+							} );
 						} catch ( error ) {
 							console.error(
 								`Error while capturing page (${ pageName }) screenshot. ` +

--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -172,9 +172,13 @@ class JestEnvironmentPlaywright extends NodeEnvironment {
 						// pages may exist within a context.
 						try {
 							await page.screenshot( {
-								path: `${ mediaFilePath }.png`,
+								path: `${ mediaFilePath }-fullpage.png`,
 								timeout: env.TIMEOUT,
 								fullPage: true,
+							} );
+							await page.screenshot( {
+								path: `${ mediaFilePath }.png`,
+								timeout: env.TIMEOUT,
 							} );
 						} catch ( error ) {
 							console.error(


### PR DESCRIPTION
Context: p1681179002366539-slack-C1A1EKDGQ

## Proposed Changes

This PR makes the change to capture both full-screen and viewport-sized screenshots when a spec fails.

## Testing Instructions

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?