### PR TITLE
Fix plugin upload redirect

### DIFF
--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -55,7 +55,7 @@ class PluginUpload extends Component {
 		if ( nextProps.inProgress ) {
 			this.props.productToBeInstalled( nextProps.pluginId, nextProps.siteSlug );
 
-			page( `/marketplace/install/${ nextProps.siteSlug }` );
+			page( `/marketplace/plugin/install/${ nextProps.siteSlug }` );
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #75680
Conversation: p1681371986133899-slack-C02FMH4G8

## Proposed Changes

* Fix the redirection from the plugin uploads page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- with a business or ecom site, visit `/plugins/upload`
- upload a plugin
- verify that the site redirects to the `/marketplace/plugin/install` and the progressbar is shown
- after the installation, you should be redirected to the thank you page

Before:
https://user-images.githubusercontent.com/11555574/231698835-9e6d19f3-9273-4200-b339-651c6e95b1bd.mp4

After:
https://user-images.githubusercontent.com/11555574/231697747-87599164-508d-4ebc-abea-6bc4fdb81774.mp4

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?