### PR TITLE
Jetpack Pro Dashboard: Fix issue with assigning incompatible license key to multisite.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -9,7 +9,7 @@ import SearchCard from 'calypso/components/search-card';
 import { SITE_CARDS_PER_PAGE } from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-form/constants';
 import { useAssignMultipleLicenses } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import { addQueryArgs } from 'calypso/lib/url';
-import { areLicenseKeysMultisiteCompatible } from '../utils';
+import { areLicenseKeysAssignableToMultisite } from '../utils';
 import './style.scss';
 
 function setPage( pageNumber: number ): void {
@@ -53,7 +53,8 @@ export default function AssignLicenseForm( {
 	};
 	const [ assignLicenses, isLoading ] = useAssignMultipleLicenses( licenseKeysArray, selectedSite );
 
-	let results = areLicenseKeysMultisiteCompatible( licenseKeysArray )
+	// We need to filter out multisites if the licenses are not assignable to a multisite.
+	let results = areLicenseKeysAssignableToMultisite( licenseKeysArray )
 		? sites
 		: sites.filter( ( site: any ) => ! site.is_multisite );
 

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -9,7 +9,7 @@ import SearchCard from 'calypso/components/search-card';
 import { SITE_CARDS_PER_PAGE } from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-form/constants';
 import { useAssignMultipleLicenses } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import { addQueryArgs } from 'calypso/lib/url';
-import { isMultisiteCompatibleLicenseKeys } from '../utils';
+import { areLicenseKeysMultisiteCompatible } from '../utils';
 import './style.scss';
 
 function setPage( pageNumber: number ): void {
@@ -53,7 +53,7 @@ export default function AssignLicenseForm( {
 	};
 	const [ assignLicenses, isLoading ] = useAssignMultipleLicenses( licenseKeysArray, selectedSite );
 
-	let results = isMultisiteCompatibleLicenseKeys( licenseKeysArray )
+	let results = areLicenseKeysMultisiteCompatible( licenseKeysArray )
 		? sites
 		: sites.filter( ( site: any ) => ! site.is_multisite );
 

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-form/index.tsx
@@ -9,6 +9,7 @@ import SearchCard from 'calypso/components/search-card';
 import { SITE_CARDS_PER_PAGE } from 'calypso/jetpack-cloud/sections/partner-portal/assign-license-form/constants';
 import { useAssignMultipleLicenses } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import { addQueryArgs } from 'calypso/lib/url';
+import { isMultisiteCompatibleLicenseKeys } from '../utils';
 import './style.scss';
 
 function setPage( pageNumber: number ): void {
@@ -52,7 +53,9 @@ export default function AssignLicenseForm( {
 	};
 	const [ assignLicenses, isLoading ] = useAssignMultipleLicenses( licenseKeysArray, selectedSite );
 
-	let results = sites;
+	let results = isMultisiteCompatibleLicenseKeys( licenseKeysArray )
+		? sites
+		: sites.filter( ( site: any ) => ! site.is_multisite );
 
 	if ( search ) {
 		results = results.filter( ( site: any ) => site.domain.search( search ) !== -1 );

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -203,12 +203,13 @@ export function isJetpackBundle( product: APIProductFamilyProduct | string ) {
 }
 
 /**
- * Whether the license keys are compatible with WP Multisite.
+ * Whether the licenses are assignable to WP multisite. This function uses key prefix to determine
+ * if the license is compatible with multisite.
  *
  * @param {Array<string>} licenseKeys
- * @returns {boolean} indicating if the license keys are compatible with multisite
+ * @returns {boolean} indicating if the license keys are assignable to multisite
  */
-export function areLicenseKeysMultisiteCompatible( licenseKeys: Array< string > ): boolean {
-	// Jetpack Backup and Scan are not compatible with WP Multisite.
-	return licenseKeys.every( ( key ) => ! /^jetpack-(backup|scan)/.test( key ) );
+export function areLicenseKeysAssignableToMultisite( licenseKeys: Array< string > ): boolean {
+	// If any license keys are not Jetpack Backup or Scan, they can be assigned to multisite.
+	return licenseKeys.some( ( key ) => ! /^jetpack-(backup|scan)/.test( key ) );
 }

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -201,3 +201,18 @@ export function isJetpackBundle( product: APIProductFamilyProduct | string ) {
 	}
 	return product.family_slug === 'jetpack-packs';
 }
+
+/**
+ *	Checks if the license keys are compatible with multisite.
+ *
+ * @param licenseKeys
+ * @returns boolean indicating if the license keys are compatible with multisite
+ */
+export function isMultisiteCompatibleLicenseKeys( licenseKeys: string[] ): boolean {
+	const INCOMPATIBLE_LICENSE_KEY_PREFIXES = [ 'jetpack-backup', 'jetpack-scan' ];
+
+	const isIncompatibleLicenseKey = ( licenseKey: string ) =>
+		!! INCOMPATIBLE_LICENSE_KEY_PREFIXES.find( ( prefix ) => licenseKey?.startsWith( prefix ) );
+
+	return ! licenseKeys.find( ( licenseKey ) => isIncompatibleLicenseKey( licenseKey ) );
+}

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -203,16 +203,11 @@ export function isJetpackBundle( product: APIProductFamilyProduct | string ) {
 }
 
 /**
- *	Checks if the license keys are compatible with multisite.
+ * Whether the license keys are compatible with WP Multisite.
  *
- * @param licenseKeys
- * @returns boolean indicating if the license keys are compatible with multisite
+ * @param {Array<string>} licenseKeys
+ * @returns {boolean} indicating if the license keys are compatible with multisite
  */
-export function isMultisiteCompatibleLicenseKeys( licenseKeys: string[] ): boolean {
-	const INCOMPATIBLE_LICENSE_KEY_PREFIXES = [ 'jetpack-backup', 'jetpack-scan' ];
-
-	const isIncompatibleLicenseKey = ( licenseKey: string ) =>
-		!! INCOMPATIBLE_LICENSE_KEY_PREFIXES.find( ( prefix ) => licenseKey?.startsWith( prefix ) );
-
-	return ! licenseKeys.find( ( licenseKey ) => isIncompatibleLicenseKey( licenseKey ) );
+export function areLicenseKeysMultisiteCompatible( licenseKeys: Array< string > ): boolean {
+	return licenseKeys.every( ( key ) => ! /^jetpack-(backup|scan)/.test( key ) );
 }

--- a/client/jetpack-cloud/sections/partner-portal/utils.ts
+++ b/client/jetpack-cloud/sections/partner-portal/utils.ts
@@ -209,5 +209,6 @@ export function isJetpackBundle( product: APIProductFamilyProduct | string ) {
  * @returns {boolean} indicating if the license keys are compatible with multisite
  */
 export function areLicenseKeysMultisiteCompatible( licenseKeys: Array< string > ): boolean {
+	// Jetpack Backup and Scan are not compatible with WP Multisite.
 	return licenseKeys.every( ( key ) => ! /^jetpack-(backup|scan)/.test( key ) );
 }


### PR DESCRIPTION
The assign license page in the Jetpack Cloud shouldn't allow users to select a multisite when assigning a Backup or Scan license since they are not supported. This PR fixes this issue by ensuring multisites are non-selectable when these licenses are selected.
<img width="1132" alt="226523218-7b62f664-effd-47e8-b88b-37659cb6c2a2" src="https://user-images.githubusercontent.com/56598660/231699092-ea0d7508-490e-4401-8fb6-3f043dbddcaf.png">

Related to #74689

## Proposed Changes

* Update the assigned License page to check first if the currently selected licenses are compatible with Multisites. If not, the page will filter all Multisites from the selectable sites.

## Testing Instructions

* Spin up a JN multisite and connect it with your agency account.
* Use the Jetpack cloud live link and go to `/partner-portal/licenses`
* Issue a Backup or Scan license and click **Assign license**
* In the Assign License page, make sure there are no multisites in the list.
<img width="1723" alt="Screen Shot 2023-04-13 at 4 26 36 PM" src="https://user-images.githubusercontent.com/56598660/231700877-5eca9f15-af49-4f76-ad0e-0286dfac96e5.png">

* Go back to `/partner-portal/licenses` and issue another license. (This time it should not be **Backup** or **Scan**)
* In the Assign License page, make sure all sites are listed including multisites.
<img width="1723" alt="Screen Shot 2023-04-13 at 4 29 23 PM" src="https://user-images.githubusercontent.com/56598660/231701638-d746d924-ab5c-49e1-960b-61c6f2f2500b.png">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
