### PR TITLE
Stepper Framework: Avoid the calypso_signup_step_start event fired after checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -10,8 +10,8 @@ import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { recordSignupStart } from 'calypso/lib/analytics/signup';
 import {
-	getSignupCompleteFlowName,
-	clearSignupCompleteFlowName,
+	getSignupCompleteFlowNameAndClear,
+	getSignupCompleteStepNameAndClear,
 } from 'calypso/signup/storageUtils';
 import { ONBOARD_STORE } from '../../stores';
 import kebabCase from '../../utils/kebabCase';
@@ -115,12 +115,12 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 			return;
 		}
 
-		const signupCompleteFlowName = getSignupCompleteFlowName();
-		const isReEnteringFlow = signupCompleteFlowName === flow.name;
-		if ( ! isReEnteringFlow ) {
+		const signupCompleteFlowName = getSignupCompleteFlowNameAndClear();
+		const signupCompleteStepName = getSignupCompleteStepNameAndClear();
+		const isReEnteringStep =
+			signupCompleteFlowName === flow.name && signupCompleteStepName === currentStepRoute;
+		if ( ! isReEnteringStep ) {
 			recordStepStart( flow.name, kebabCase( currentStepRoute ), { intent } );
-		} else {
-			clearSignupCompleteFlowName();
 		}
 
 		// Also record page view for data and analytics

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -29,6 +29,7 @@ import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-gl
 import { setActiveTheme } from 'calypso/state/themes/actions';
 import { getPurchasedThemes } from 'calypso/state/themes/selectors/get-purchased-themes';
 import { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
+import useCheckout from '../../../../hooks/use-checkout';
 import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundle-eligible';
 import { useQuery } from '../../../../hooks/use-query';
 import { useSite } from '../../../../hooks/use-site';
@@ -86,6 +87,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		[ site ]
 	);
 	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles();
+
+	const { goToCheckout } = useCheckout();
 
 	const isAtomic = useSelect(
 		( select ) => site && ( select( SITE_STORE ) as SiteSelect ).isSiteAtomic( site.ID ),
@@ -341,7 +344,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		setShowUpgradeModal( false );
 	}
 
-	function goToCheckout() {
+	function handleCheckout() {
 		recordTracksEvent( 'calypso_signup_design_upgrade_modal_checkout_button_click', {
 			theme: selectedDesign?.slug,
 		} );
@@ -358,8 +361,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		}
 
 		if ( siteSlugOrId ) {
-			const params = new URLSearchParams();
-
 			// When the user is done with checkout, send them back to the current url
 			const destUrl = new URL( window.location.href );
 			const destSearchP = destUrl.searchParams;
@@ -371,13 +372,13 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			}
 
 			const destString = destUrl.toString().replace( window.location.origin, '' );
-			params.append( 'redirect_to', destString );
 
-			// The theme upsell link does not work with siteId and requires a siteSlug.
-			// See https://github.com/Automattic/wp-calypso/pull/64899
-			window.location.href = `/checkout/${ encodeURIComponent(
-				siteSlug || urlToSlug( site?.URL || '' ) || ''
-			) }/${ plan }?${ params.toString() }`;
+			goToCheckout( {
+				flowName: flow,
+				siteSlug: siteSlug || urlToSlug( site?.URL || '' ) || '',
+				destination: destString,
+				plan,
+			} );
 		}
 	}
 
@@ -414,8 +415,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 				getEventPropsByDesign( selectedDesign, selectedStyleVariation )
 			);
 
-			const params = new URLSearchParams();
-
 			// When the user is done with checkout, send them back to the current url
 			const destUrl = new URL( window.location.href );
 			const destSearchP = destUrl.searchParams;
@@ -428,13 +427,13 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 			}
 
 			const destString = destUrl.toString().replace( window.location.origin, '' );
-			params.append( 'redirect_to', destString );
 
-			// The theme upsell link does not work with siteId and requires a siteSlug.
-			// See https://github.com/Automattic/wp-calypso/pull/64899
-			window.location.href = `/checkout/${ encodeURIComponent(
-				siteSlug || urlToSlug( site?.URL || '' ) || ''
-			) }/premium?${ params.toString() }`;
+			goToCheckout( {
+				flowName: flow,
+				siteSlug: siteSlug || urlToSlug( site?.URL || '' ) || '',
+				destination: destString,
+				plan: 'premium',
+			} );
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -59,7 +59,7 @@ import type { Design, StyleVariation } from '@automattic/design-picker';
 const SiteIntent = Onboard.SiteIntent;
 const SITE_ASSEMBLER_AVAILABLE_INTENTS: string[] = [ SiteIntent.Build, SiteIntent.Write ];
 
-const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
+const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const { goBack, submit, exitFlow } = navigation;
 
 	const reduxDispatch = useReduxDispatch();
@@ -375,6 +375,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 			goToCheckout( {
 				flowName: flow,
+				stepName,
 				siteSlug: siteSlug || urlToSlug( site?.URL || '' ) || '',
 				destination: destString,
 				plan,
@@ -407,7 +408,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 		}
 	}
 
-	function goToCheckoutForPremiumGlobalStyles() {
+	function handleCheckoutForPremiumGlobalStyles() {
 		// These conditions should be true at this point, but just in case...
 		if ( selectedDesign && selectedStyleVariation && siteSlugOrId ) {
 			recordTracksEvent(
@@ -430,6 +431,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 
 			goToCheckout( {
 				flowName: flow,
+				stepName,
 				siteSlug: siteSlug || urlToSlug( site?.URL || '' ) || '',
 				destination: destString,
 				plan: 'premium',
@@ -643,10 +645,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow } ) => {
 					slug={ selectedDesign.slug }
 					isOpen={ showUpgradeModal }
 					closeModal={ closeUpgradeModal }
-					checkout={ goToCheckout }
+					checkout={ handleCheckout }
 				/>
 				<PremiumGlobalStylesUpgradeModal
-					checkout={ goToCheckoutForPremiumGlobalStyles }
+					checkout={ handleCheckoutForPremiumGlobalStyles }
 					closeModal={ closePremiumGlobalStylesModal }
 					isOpen={ showPremiumGlobalStylesModal }
 					tryStyle={ tryPremiumGlobalStyles }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
@@ -2,12 +2,14 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { urlToSlug } from 'calypso/lib/url';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
+import useCheckout from '../../../../../hooks/use-checkout';
 import { useSite } from '../../../../../hooks/use-site';
 import { useSiteSlugParam } from '../../../../../hooks/use-site-slug-param';
 import { PATTERN_ASSEMBLER_EVENTS } from '../events';
 import type { PremiumGlobalStylesUpgradeModalProps } from 'calypso/components/premium-global-styles-upgrade-modal';
 
 interface Props {
+	flowName: string;
 	hasSelectedColorVariation?: boolean;
 	hasSelectedFontVariation?: boolean;
 	onCheckout?: () => void;
@@ -15,6 +17,7 @@ interface Props {
 }
 
 const useGlobalStylesUpgradeModal = ( {
+	flowName,
 	hasSelectedColorVariation = false,
 	hasSelectedFontVariation = false,
 	onCheckout,
@@ -27,6 +30,7 @@ const useGlobalStylesUpgradeModal = ( {
 	const siteUrl = siteSlug || urlToSlug( site?.URL || '' ) || '';
 	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 	const translate = useTranslate();
+	const { goToCheckout } = useCheckout();
 
 	const customizeDescription = ( description: JSX.Element ) => {
 		return (
@@ -60,15 +64,14 @@ const useGlobalStylesUpgradeModal = ( {
 		onCheckout?.();
 
 		// When the user is done with checkout, send them back to the current url
-		const destUrl = new URL( window.location.href );
-		const redirectUrl = destUrl.toString().replace( window.location.origin, '' );
-		const params = new URLSearchParams( {
-			redirect_to: redirectUrl,
-		} );
+		const redirectUrl = window.location.href.replace( window.location.origin, '' );
 
-		// The theme upsell link does not work with siteId and requires a siteSlug.
-		// See https://github.com/Automattic/wp-calypso/pull/64899
-		window.location.href = `/checkout/${ encodeURIComponent( siteUrl ) }/premium?${ params }`;
+		goToCheckout( {
+			flowName,
+			siteSlug: siteUrl,
+			destination: redirectUrl,
+			plan: 'premium',
+		} );
 	};
 
 	const upgradeLater = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
@@ -10,6 +10,7 @@ import type { PremiumGlobalStylesUpgradeModalProps } from 'calypso/components/pr
 
 interface Props {
 	flowName: string;
+	stepName: string;
 	hasSelectedColorVariation?: boolean;
 	hasSelectedFontVariation?: boolean;
 	onCheckout?: () => void;
@@ -18,6 +19,7 @@ interface Props {
 
 const useGlobalStylesUpgradeModal = ( {
 	flowName,
+	stepName,
 	hasSelectedColorVariation = false,
 	hasSelectedFontVariation = false,
 	onCheckout,
@@ -68,6 +70,7 @@ const useGlobalStylesUpgradeModal = ( {
 
 		goToCheckout( {
 			flowName,
+			stepName,
 			siteSlug: siteUrl,
 			destination: redirectUrl,
 			plan: 'premium',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -379,6 +379,7 @@ const PatternAssembler = ( {
 		openModal: openGlobalStylesUpgradeModal,
 		globalStylesUpgradeModalProps,
 	} = useGlobalStylesUpgradeModal( {
+		flowName: flow,
 		hasSelectedColorVariation: !! colorVariation,
 		hasSelectedFontVariation: !! fontVariation,
 		onCheckout: snapshotRecipe,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -380,6 +380,7 @@ const PatternAssembler = ( {
 		globalStylesUpgradeModalProps,
 	} = useGlobalStylesUpgradeModal( {
 		flowName: flow,
+		stepName,
 		hasSelectedColorVariation: !! colorVariation,
 		hasSelectedFontVariation: !! fontVariation,
 		onCheckout: snapshotRecipe,

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -114,7 +114,7 @@ export type Flow = {
 export type StepProps = {
 	navigation: NavigationControls;
 	stepName: string;
-	flow: string | null;
+	flow: string;
 	/**
 	 * If this is a step of a flow that extends another, pass the variantSlug of the variant flow, it can come handy.
 	 */

--- a/client/landing/stepper/hooks/use-checkout.ts
+++ b/client/landing/stepper/hooks/use-checkout.ts
@@ -1,0 +1,40 @@
+import {
+	setSignupCompleteSlug,
+	persistSignupDestination,
+	setSignupCompleteFlowName,
+} from 'calypso/signup/storageUtils';
+
+interface GoToCheckoutProps {
+	flowName: string;
+	siteSlug: string;
+	destination: string;
+	plan?: string;
+}
+
+const useCheckout = () => {
+	const goToCheckout = ( { flowName, siteSlug, destination, plan }: GoToCheckoutProps ) => {
+		const relativeCurrentPath = window.location.href.replace( window.location.origin, '' );
+		const params = new URLSearchParams( {
+			redirect_to: destination,
+			cancel_to: relativeCurrentPath,
+			signup: '1',
+		} );
+
+		persistSignupDestination( destination );
+		setSignupCompleteSlug( siteSlug );
+		setSignupCompleteFlowName( flowName );
+
+		let checkoutUrl = `/checkout/${ encodeURIComponent( siteSlug ) }`;
+		if ( plan ) {
+			checkoutUrl += `/${ plan }`;
+		}
+
+		// The theme upsell link does not work with siteId and requires a siteSlug.
+		// See https://github.com/Automattic/wp-calypso/pull/64899
+		window.location.href = `${ checkoutUrl }?${ params }`;
+	};
+
+	return { goToCheckout };
+};
+
+export default useCheckout;

--- a/client/landing/stepper/hooks/use-checkout.ts
+++ b/client/landing/stepper/hooks/use-checkout.ts
@@ -2,17 +2,25 @@ import {
 	setSignupCompleteSlug,
 	persistSignupDestination,
 	setSignupCompleteFlowName,
+	setSignupCompleteStepName,
 } from 'calypso/signup/storageUtils';
 
 interface GoToCheckoutProps {
 	flowName: string;
+	stepName: string;
 	siteSlug: string;
 	destination: string;
 	plan?: string;
 }
 
 const useCheckout = () => {
-	const goToCheckout = ( { flowName, siteSlug, destination, plan }: GoToCheckoutProps ) => {
+	const goToCheckout = ( {
+		flowName,
+		stepName,
+		siteSlug,
+		destination,
+		plan,
+	}: GoToCheckoutProps ) => {
 		const relativeCurrentPath = window.location.href.replace( window.location.origin, '' );
 		const params = new URLSearchParams( {
 			redirect_to: destination,
@@ -23,6 +31,7 @@ const useCheckout = () => {
 		persistSignupDestination( destination );
 		setSignupCompleteSlug( siteSlug );
 		setSignupCompleteFlowName( flowName );
+		setSignupCompleteStepName( stepName );
 
 		let checkoutUrl = `/checkout/${ encodeURIComponent( siteSlug ) }`;
 		if ( plan ) {

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -34,3 +34,19 @@ export const setSignupCompleteFlowName = ( value ) =>
 	sessionStorage?.setItem( 'wpcom_signup_complete_flow_name', value );
 export const clearSignupCompleteFlowName = () =>
 	sessionStorage?.removeItem( 'wpcom_signup_complete_flow_name' );
+export const getSignupCompleteFlowNameAndClear = () => {
+	const value = getSignupCompleteFlowName();
+	clearSignupCompleteFlowName();
+	return value;
+};
+export const getSignupCompleteStepName = () =>
+	sessionStorage?.getItem( 'wpcom_signup_complete_step_name' );
+export const setSignupCompleteStepName = ( value ) =>
+	sessionStorage?.setItem( 'wpcom_signup_complete_step_name', value );
+export const clearSignupCompleteStepName = () =>
+	sessionStorage?.removeItem( 'wpcom_signup_complete_step_name' );
+export const getSignupCompleteStepNameAndClear = () => {
+	const value = getSignupCompleteStepName();
+	clearSignupCompleteStepName();
+	return value;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2159

## Proposed Changes

* We want to avoid the `calypso_signup_step_start` event fired after checkout

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Pattern Assembler

* Go to /setup?siteSlug=<your_free_site>
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll to the bottom and select "Start designing"
* On the Pattern Assembler screen
  * Select `Colors` > Any color variation
  * Go back to the main screen
  * Click `Unlock this style`
  * Click `Upgrade plan` to checkout
  * When you're back to the Pattern Assembler screen via the following ways, ensure the `calypso_signup_step_start` event is not fired
    * Click `X` at the top-left corner to cancel the checkout
    * Click `Remove from cart` to empty your cart to cancel the checkout
    * Complete the checkout 
  * When you're back and forth to the Pattern Assembler screen, ensure the `calypso_signup_step_start` event  is still fired

### Design Picker

* Go to /setup?siteSlug=<your_free_site>
* Continue until you land on the Design Picker
* On the Design Picker screen
  * Go to the checkout page via the following ways
    * Select any premium design and click `Unlock theme` at the top-right corner
    * Select any design with style variation, select a premium style variation, and click `Unlock this style`
  * When you're back to the Design Picker screen via the following ways, ensure the `calypso_signup_step_start` event is not fired
    * Click `X` at the top-left corner to cancel the checkout
    * Click `Remove from cart` to empty your cart to cancel the checkout
    * Complete the checkout 
  * When you're back and forth to the Design Picker screen, ensure the `calypso_signup_step_start` event  is still fired

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
