### PR TITLE
Jetpack Pro Dashboard: update issue license button text

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -146,6 +146,8 @@ export default function IssueMultipleLicensesForm( {
 
 	const selectedSiteDomain = selectedSite?.domain;
 
+	const selectedLicenseCount = selectedProductSlugs.length;
+
 	return (
 		<div className="issue-multiple-licenses-form">
 			{ isLoadingProducts && <div className="issue-multiple-licenses-form__placeholder" /> }
@@ -168,15 +170,22 @@ export default function IssueMultipleLicensesForm( {
 						</p>
 						<div className="issue-multiple-licenses-form__controls">
 							<TotalCost />
-							<Button
-								primary
-								className="issue-multiple-licenses-form__select-license"
-								disabled={ ! selectedProductSlugs.length }
-								busy={ isLoading }
-								onClick={ issueLicenses }
-							>
-								{ translate( 'Select License' ) }
-							</Button>
+							{ selectedLicenseCount > 0 && (
+								<Button
+									primary
+									className="issue-multiple-licenses-form__select-license"
+									busy={ isLoading }
+									onClick={ issueLicenses }
+								>
+									{ translate( 'Issue %(numLicenses)d license', 'Issue %(numLicenses)d licenses', {
+										context: 'button label',
+										count: selectedLicenseCount,
+										args: {
+											numLicenses: selectedLicenseCount,
+										},
+									} ) }
+								</Button>
+							) }
 						</div>
 					</div>
 					<div className="issue-multiple-licenses-form__bottom">


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/74791

## Proposed Changes

This PR updates the issue license button text based on the no of licenses selected.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/issue-license-button-text` and `yarn start-jetpack-cloud`
2. Visit http://jetpack.cloud.localhost:3001/partner-portal/issue-license
3. Verify the below scenarios work as expected.

**Before any license is selected**

<img width="1096" alt="Screenshot 2023-04-13 at 3 06 34 PM" src="https://user-images.githubusercontent.com/10586875/231721575-5c9aa889-01b0-4814-b35c-058f2433cbc4.png">

**When one license is selected**

<img width="1096" alt="Screenshot 2023-04-13 at 3 06 38 PM" src="https://user-images.githubusercontent.com/10586875/231721615-dd7a76b3-ebfe-415e-85fc-5a12499fed9d.png">

**When more than one license is selected**

<img width="1096" alt="Screenshot 2023-04-13 at 3 06 41 PM" src="https://user-images.githubusercontent.com/10586875/231721626-d6c95fa7-0e2e-48b4-82b4-a98bfd37942c.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
