### PR TITLE
Stepper Framework: Introduce the checkout modal instead of redirecting to the checkout page

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -3,16 +3,20 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useState, useCallback, Suspense, lazy } from 'react';
 import Modal from 'react-modal';
 import { Navigate, Route, Routes, generatePath, useNavigate, useLocation } from 'react-router-dom';
+
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
 import { recordFullStoryEvent } from 'calypso/lib/analytics/fullstory';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { recordSignupStart } from 'calypso/lib/analytics/signup';
+import AsyncCheckoutModal from 'calypso/my-sites/checkout/modal/async';
 import {
 	getSignupCompleteFlowNameAndClear,
 	getSignupCompleteStepNameAndClear,
 } from 'calypso/signup/storageUtils';
+import { useSite } from '../../hooks/use-site';
+import useSyncRoute from '../../hooks/use-sync-route';
 import { ONBOARD_STORE } from '../../stores';
 import kebabCase from '../../utils/kebabCase';
 import recordStepStart from './analytics/record-step-start';
@@ -47,6 +51,8 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
 		[]
 	);
+
+	const site = useSite();
 	const ref = useQuery().get( 'ref' ) || '';
 
 	const stepProgress = useSelect(
@@ -97,6 +103,8 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	);
 
 	flow.useSideEffect?.( currentStepRoute, _navigate );
+
+	useSyncRoute();
 
 	useEffect( () => {
 		window.scrollTo( 0, 0 );
@@ -199,6 +207,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 					}
 				/>
 			</Routes>
+			<AsyncCheckoutModal siteId={ site?.ID } />
 		</Suspense>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -3,7 +3,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useState, useCallback, Suspense, lazy } from 'react';
 import Modal from 'react-modal';
 import { Navigate, Route, Routes, generatePath, useNavigate, useLocation } from 'react-router-dom';
-
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -380,6 +380,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				destination: destString,
 				plan,
 			} );
+
+			setShowUpgradeModal( false );
 		}
 	}
 
@@ -436,6 +438,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 				destination: destString,
 				plan: 'premium',
 			} );
+
+			setShowPremiumGlobalStylesModal( false );
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
@@ -75,6 +75,8 @@ const useGlobalStylesUpgradeModal = ( {
 			destination: redirectUrl,
 			plan: 'premium',
 		} );
+
+		setIsOpen( false );
 	};
 
 	const upgradeLater = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -478,6 +478,10 @@ const PatternAssembler = ( {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_FONTS_DONE_CLICK );
 	};
 
+	if ( ! site?.ID || ! selectedDesign ) {
+		return null;
+	}
+
 	const stepContent = (
 		<NavigatorProvider
 			initialPath={ NAVIGATOR_PATHS.MAIN }
@@ -599,10 +603,6 @@ const PatternAssembler = ( {
 			<PremiumGlobalStylesUpgradeModal { ...globalStylesUpgradeModalProps } />
 		</NavigatorProvider>
 	);
-
-	if ( ! site?.ID || ! selectedDesign ) {
-		return null;
-	}
 
 	return (
 		<StepContainer

--- a/client/landing/stepper/hooks/use-checkout.ts
+++ b/client/landing/stepper/hooks/use-checkout.ts
@@ -40,7 +40,7 @@ const useCheckout = () => {
 			if ( plan ) {
 				checkoutUrl += `/${ plan }`;
 			}
-	
+
 			// The theme upsell link does not work with siteId and requires a siteSlug.
 			// See https://github.com/Automattic/wp-calypso/pull/64899
 			window.location.href = `${ checkoutUrl }?${ params }`;

--- a/client/landing/stepper/hooks/use-checkout.ts
+++ b/client/landing/stepper/hooks/use-checkout.ts
@@ -1,3 +1,4 @@
+import { openCheckoutModal } from 'calypso/my-sites/checkout/modal/utils';
 import {
 	setSignupCompleteSlug,
 	persistSignupDestination,
@@ -33,14 +34,19 @@ const useCheckout = () => {
 		setSignupCompleteFlowName( flowName );
 		setSignupCompleteStepName( stepName );
 
-		let checkoutUrl = `/checkout/${ encodeURIComponent( siteSlug ) }`;
-		if ( plan ) {
-			checkoutUrl += `/${ plan }`;
+		// If the plan is not provided, we might have added plan to the cart so we just go to the checkout page directly
+		if ( ! plan ) {
+			let checkoutUrl = `/checkout/${ encodeURIComponent( siteSlug ) }`;
+			if ( plan ) {
+				checkoutUrl += `/${ plan }`;
+			}
+	
+			// The theme upsell link does not work with siteId and requires a siteSlug.
+			// See https://github.com/Automattic/wp-calypso/pull/64899
+			window.location.href = `${ checkoutUrl }?${ params }`;
+		} else {
+			openCheckoutModal( [ plan ] );
 		}
-
-		// The theme upsell link does not work with siteId and requires a siteSlug.
-		// See https://github.com/Automattic/wp-calypso/pull/64899
-		window.location.href = `${ checkoutUrl }?${ params }`;
 	};
 
 	return { goToCheckout };

--- a/client/landing/stepper/hooks/use-checkout.ts
+++ b/client/landing/stepper/hooks/use-checkout.ts
@@ -36,14 +36,9 @@ const useCheckout = () => {
 
 		// If the plan is not provided, we might have added plan to the cart so we just go to the checkout page directly
 		if ( ! plan ) {
-			let checkoutUrl = `/checkout/${ encodeURIComponent( siteSlug ) }`;
-			if ( plan ) {
-				checkoutUrl += `/${ plan }`;
-			}
-
 			// The theme upsell link does not work with siteId and requires a siteSlug.
 			// See https://github.com/Automattic/wp-calypso/pull/64899
-			window.location.href = `${ checkoutUrl }?${ params }`;
+			window.location.href = `/checkout/${ encodeURIComponent( siteSlug ) }?${ params }`;
 		} else {
 			openCheckoutModal( [ plan ] );
 		}

--- a/client/landing/stepper/hooks/use-sync-route.ts
+++ b/client/landing/stepper/hooks/use-sync-route.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { setRoute } from 'calypso/state/route/actions';
+import 'calypso/state/route/init';
+
+const useSyncRoute = () => {
+	const { pathname, search } = window.location;
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		const searchParams = new URLSearchParams( search );
+		const query = Object.fromEntries( searchParams.entries() );
+		dispatch( setRoute( pathname, query ) );
+	}, [ pathname, search ] );
+};
+
+export default useSyncRoute;

--- a/client/lib/navigate/index.ts
+++ b/client/lib/navigate/index.ts
@@ -7,9 +7,21 @@ function isSameOrigin( path: string ): boolean {
 	return new URL( path, window.location.href ).origin === window.location.origin;
 }
 
+// Check whether the section is defined as a page.js routing path or not.
+// For example, the section "/setup" is registered by react-router-dom instead of page.js
+function isPageRegistered() {
+	return !! String( page.base() );
+}
+
 export function navigate( path: string ): void {
 	if ( isSameOrigin( path ) ) {
-		page.show( path );
+		if ( ! isPageRegistered() ) {
+			const state = { path };
+			window.history.pushState( state, '', path );
+			dispatchEvent( new PopStateEvent( 'popstate', { state } ) );
+		} else {
+			page.show( path );
+		}
 	} else {
 		window.location.href = logmeinUrl( path );
 	}

--- a/client/my-sites/checkout/modal/async.tsx
+++ b/client/my-sites/checkout/modal/async.tsx
@@ -1,11 +1,16 @@
-import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { KEY_PRODUCTS } from './constants';
 import type { Props } from '.';
 
 const useProducts = () => {
-	const { search } = window.location;
-	const products = useMemo( () => new URLSearchParams( search ).get( KEY_PRODUCTS ), [ search ] );
+	const { products } = useSelector( ( state ) => {
+		const query = getCurrentQueryArguments( state ) || {};
+		return {
+			products: query[ KEY_PRODUCTS ],
+		};
+	} );
 
 	return products;
 };

--- a/client/my-sites/checkout/modal/utils.ts
+++ b/client/my-sites/checkout/modal/utils.ts
@@ -1,12 +1,16 @@
-import page from 'page';
+import { navigate } from 'calypso/lib/navigate';
 import { addQueryArgs } from 'calypso/lib/url';
 import { KEY_PRODUCTS } from './constants';
 
-export const openCheckoutModal = ( products: string[] ) => {
-	page(
-		addQueryArgs(
-			{ [ KEY_PRODUCTS ]: products.join( ',' ) },
-			window.location.href.replace( window.location.origin, '' )
-		)
+export const openCheckoutModal = (
+	products: string[],
+	searchParams: Record< string, string > = {}
+) => {
+	const relativeCurrentPath = window.location.href.replace( window.location.origin, '' );
+	const path = addQueryArgs(
+		{ ...searchParams, [ KEY_PRODUCTS ]: products.join( ',' ), cancel_to: relativeCurrentPath },
+		relativeCurrentPath
 	);
+
+	navigate( path );
 };

--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -200,7 +200,7 @@ export default function DesignPickerStep( props ) {
 	}
 
 	function renderCheckoutModal() {
-		return <AsyncCheckoutModal />;
+		return <AsyncCheckoutModal siteId={ siteId } />;
 	}
 
 	function renderDesignPicker() {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Introduce the checkout modal into the stepper framework so we don't need to redirect to the checkout page and load lots of assets when going to checkout from a certain step of the onboarding flow

Any thoughts?

**Demo**

https://user-images.githubusercontent.com/13596067/231739460-3dd8061e-116b-450e-b600-41a1c68354dd.mov

<br />

**Comparison**

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/231932748-f5eaf30b-d036-40f9-bd46-7546c50d25b4.png) | ![image](https://user-images.githubusercontent.com/13596067/231931264-ef36bf5a-f6f4-492a-bf18-302cc9e14f56.png) |
| <video src="https://user-images.githubusercontent.com/13596067/232372969-b13c3bc6-1dc8-4f86-a14b-3226acfcfa86.mov" /> | <video src="https://user-images.githubusercontent.com/13596067/232372976-0ee2f664-b1c8-415c-b7f0-29623e9c38ce.mov" /> |

Both the number and size of total requests are reduced by ~50%. Also, the checkout form is loaded ~1.x s faster than before from the recorded video

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Pattern Assembler

* Go to /setup?siteSlug=<your_free_site>
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll to the bottom and select "Start designing"
* On the Pattern Assembler screen
  * Select `Colors` > Any color variation
  * Go back to the main screen
  * Click `Unlock this style`
  * Click `Upgrade plan` to open the checkout modal
  * When you're back to the Pattern Assembler screen via the following ways, ensure the checkout modal is close
    * Click `X` at the top-left corner to cancel the checkout
    * Click `Remove from cart` to empty your cart to cancel the checkout
  * When you complete the checkout and go back to the Pattern Assembler screen, ensure the `Unlock this style` text is replaced with `Continue`

### Design Picker

* Go to /setup?siteSlug=<your_free_site>
* Continue until you land on the Design Picker
* On the Design Picker screen
  * Go to the checkout page via the following ways
    * Select any premium design and click `Unlock theme` at the top-right corner
    * Select any design with style variation, select a premium style variation, and click `Unlock this style`
  * When you're back to the Design Picker screen via the following ways, ensure the checkout modal is close
    * Click `X` at the top-left corner to cancel the checkout
    * Click `Remove from cart` to empty your cart to cancel the checkout
  * When you complete the checkout and go back to the Design Picker screen, ensure either `Unlock theme` or `Unlock this style` text is replaced with `Continue`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
