### PR TITLE
`/subscriptions/pending`: Scaffold pending page.

### DIFF
--- a/client/landing/subscriptions/components/tab-views/index.ts
+++ b/client/landing/subscriptions/components/tab-views/index.ts
@@ -1,3 +1,4 @@
-export { Comments } from './comments';
-export { Settings } from './settings';
 export { Sites } from './sites';
+export { Comments } from './comments';
+export { Pending } from './pending';
+export { Settings } from './settings';

--- a/client/landing/subscriptions/components/tab-views/pending/index.tsx
+++ b/client/landing/subscriptions/components/tab-views/pending/index.tsx
@@ -1,0 +1,1 @@
+export { default as Pending } from './pending';

--- a/client/landing/subscriptions/components/tab-views/pending/pending.tsx
+++ b/client/landing/subscriptions/components/tab-views/pending/pending.tsx
@@ -1,0 +1,11 @@
+import TabView from '../tab-view';
+
+const Pending = () => {
+	return (
+		<TabView errorMessage="" isLoading={ false }>
+			<p>Hello world!</p>
+		</TabView>
+	);
+};
+
+export default Pending;

--- a/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
+++ b/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
@@ -6,13 +6,21 @@ import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-
 import Nav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
-import { Comments, Settings, Sites } from 'calypso/landing/subscriptions/components/tab-views';
+import {
+	Comments,
+	Settings,
+	Sites,
+	Pending,
+} from 'calypso/landing/subscriptions/components/tab-views';
 import './styles.scss';
 
 const getFullPath = ( subpath: string ) => `/subscriptions/${ subpath }`;
-const [ sitesPath, commentsPath, settingsPath ] = [ 'sites', 'comments', 'settings' ].map(
-	getFullPath
-);
+const [ sitesPath, commentsPath, pendingPath, settingsPath ] = [
+	'sites',
+	'comments',
+	'pending',
+	'settings',
+].map( getFullPath );
 
 const TabsSwitcher = () => {
 	const translate = useTranslate();
@@ -22,6 +30,8 @@ const TabsSwitcher = () => {
 	const locale = useLocale();
 	const shouldEnableCommentsTab =
 		config.isEnabled( 'subscription-management-comments-view' ) && locale === 'en';
+	const shouldEnablePendingTab =
+		config.isEnabled( 'subscription-management-pending-view' ) && locale === 'en';
 
 	return (
 		<>
@@ -49,6 +59,24 @@ const TabsSwitcher = () => {
 						{ translate( 'Comments' ) }
 					</NavItem>
 
+					{ shouldEnablePendingTab && counts?.pending ? (
+						<NavItem
+							onClick={ () => {
+								shouldEnablePendingTab
+									? navigate( pendingPath )
+									: window.location.replace(
+											'https://wordpress.com/email-subscriptions/?option=pending'
+									  );
+							} }
+							count={ counts?.pending || undefined }
+							selected={ pathname.startsWith( pendingPath ) }
+						>
+							{ translate( 'Pending' ) }
+						</NavItem>
+					) : (
+						''
+					) }
+
 					<NavItem
 						onClick={ () => navigate( settingsPath ) }
 						selected={ pathname.startsWith( settingsPath ) }
@@ -62,6 +90,7 @@ const TabsSwitcher = () => {
 				<Route index element={ <Navigate to="sites" /> } />
 				<Route path="sites*" element={ <Sites /> } />
 				<Route path="comments*" element={ <Comments /> } />
+				<Route path="pending*" element={ <Pending /> } />
 				<Route path="settings" element={ <Settings /> } />
 			</Routes>
 		</>

--- a/config/development.json
+++ b/config/development.json
@@ -186,6 +186,7 @@
 		"subscription-gifting": true,
 		"subscription-management": true,
 		"subscription-management-comments-view": true,
+		"subscription-management-pending-view": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/display-thank-you-page": true,
 		"themes/premium": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #75711

## Proposed Changes

* Scaffold for pending page.
* It has Pending tab with actual pending count.
* Introduces the feature flag `subscription-management-pending-view`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Inject subkey cookie into `calypso.localhost:3000`.
* Ensure you have unconfirmed subscriptions, this is only possible as external email addresses (non-WP).
  * You can subscribe to`yasseralkabir.wordpress.com` & `jensendegroot.wordpress.com` just to quickly build data.
* Go to `calypso.localhost:3000/subscriptions/pending` or `/subscriptions/pending?flags=subscription-management-pending-view`.
* You should see the Pending tab with the right count, and a "Hello World!" content on it.

![2023-04-13_17-11-15](https://user-images.githubusercontent.com/1287077/231787526-9ff4f23c-79fc-4d9b-bc83-1858c4f3bf3c.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
