### PR TITLE
Analytics: Improve Facebook tracking pixel with more meta data

### DIFF
--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -288,11 +288,23 @@ function recordOrderInFacebook( cart, orderId, wpcomJetpackCartInfo ) {
 	// WPCom
 	if ( wpcomJetpackCartInfo.containsWpcomProducts ) {
 		if ( null !== wpcomJetpackCartInfo.wpcomCostUSD && wpcomJetpackCartInfo.wpcomCostUSD > 0 ) {
+			const cartItemsArray = wpcomJetpackCartInfo.wpcomProducts.map( ( product ) => {
+				return {
+					product_slug: product.product_slug ?? '',
+					product_name: product.product_name ?? '',
+					bill_period: product.bill_period ?? 0,
+					is_sale_coupon_applied: product.is_sale_coupon_applied ?? false,
+					is_bundled: product.is_bundled ?? false,
+					is_domain_registration: product.is_domain_registration ?? false,
+					value: product.cost ?? 0,
+				};
+			} );
 			const params = [
-				'trackSingle',
+				'trackSingle', // Allows sending to a single pixel when multiple are loaded on the page.
 				TRACKING_IDS.facebookInit,
 				'Purchase',
 				{
+					contents: cartItemsArray.length > 0 ? cartItemsArray : [],
 					product_slug: wpcomJetpackCartInfo.wpcomProducts
 						.map( ( product ) => product.product_slug )
 						.join( ', ' ),

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -1,4 +1,5 @@
 import { getCurrentUser } from '@automattic/calypso-analytics';
+import { isPlan } from '@automattic/calypso-products';
 import { costToUSD, refreshCountryCodeCookieGdpr } from 'calypso/lib/analytics/utils';
 import { mayWeTrackByTracker } from '../tracker-buckets';
 import { cartToGaPurchase } from '../utils/cart-to-ga-purchase';
@@ -291,12 +292,15 @@ function recordOrderInFacebook( cart, orderId, wpcomJetpackCartInfo ) {
 			const cartItemsArray = wpcomJetpackCartInfo.wpcomProducts.map( ( product ) => {
 				return {
 					product_slug: product.product_slug ?? '',
+					id: product.product_id ?? '',
 					product_name: product.product_name ?? '',
 					bill_period: product.bill_period ?? 0,
 					is_sale_coupon_applied: product.is_sale_coupon_applied ?? false,
 					is_bundled: product.is_bundled ?? false,
 					is_domain_registration: product.is_domain_registration ?? false,
-					value: product.cost ?? 0,
+					is_plan: isPlan( product ) ?? false,
+					value: costToUSD( product.cost, product.currency ) ?? 0,
+					quantity: product.volume ?? 1,
 				};
 			} );
 			const params = [
@@ -305,6 +309,7 @@ function recordOrderInFacebook( cart, orderId, wpcomJetpackCartInfo ) {
 				'Purchase',
 				{
 					contents: cartItemsArray.length > 0 ? cartItemsArray : [],
+					content_type: 'product',
 					product_slug: wpcomJetpackCartInfo.wpcomProducts
 						.map( ( product ) => product.product_slug )
 						.join( ', ' ),


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes Automattic/Martech#1681

## Proposed Changes

* We'd like to add more information to the Facebook/Meta tracking pixel, e.g. bill period.
* Removes the joined string of product_slugs, and instead adds them in an array. This makes it easier to "pick up" product slugs and other info in the Meta Ads Manager (hopefully).

## Testing Instructions
* Sandbox store
* Allow ad-tracking and allow advertising via the cookie banner (if you're in GDPR). E.g. by changing the config/development.json file, or adding `?flags=ad-tracking` to the URL.
* You can add a `debugger` statement inside the `containsWpcomProducts` conditonal in `recordOrderInFacebook`, and verify that the array get's populated, or just monitor in the network console. Once the payment is complete, you should see this data being sent to Facebook
* (We need to verify that the Facebook analytics panel is picking up this meta data). 

Expected data for a Business plan with a bundled domain:
![Screenshot 2023-04-14 at 02 32 50](https://user-images.githubusercontent.com/52675688/231914533-fb8f6ec9-d243-4818-876d-bea5f09ba402.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
