### PR TITLE
Billing History: Show Loading State

### DIFF
--- a/client/me/purchases/billing-history/billing-history-list.tsx
+++ b/client/me/purchases/billing-history/billing-history-list.tsx
@@ -271,12 +271,9 @@ export default connect(
 		const transactions = getPastBillingTransactions( state );
 		const filter = getBillingTransactionFilters( state, 'past' );
 		const pageSize = 5;
-		const filteredTransactions = filterTransactions( transactions, filter, siteId );
-		const paginatedTransactions = paginateTransactions(
-			filteredTransactions,
-			filter.page,
-			pageSize
-		);
+		const filteredTransactions = transactions && filterTransactions( transactions, filter, siteId );
+		const paginatedTransactions =
+			filteredTransactions && paginateTransactions( filteredTransactions, filter.page, pageSize );
 
 		return {
 			app: filter.app,
@@ -284,7 +281,7 @@ export default connect(
 			page: filter.page,
 			pageSize,
 			query: filter.query,
-			total: filteredTransactions.length,
+			total: filteredTransactions?.length ?? 0,
 			transactions: paginatedTransactions,
 			sendingBillingReceiptEmail: getIsSendingReceiptEmail( state ),
 		};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

When updating the [filtered transactions function](https://github.com/Automattic/wp-calypso/pull/74975/commits/89ead7aebc04605605628611ded7e3894a2a0611#diff-d4a9af5c7314b149cffd7b0cc6c1d2fdc538be3e9a6559aa422470fed78db261L68), a regression was introduced where the previous version would return a null value if passed a null value and the updated version will return an empty array. The billing history list has logic that [shows the loading state if the passed transactions property is null](https://github.com/Automattic/wp-calypso/blob/e5fbc3172d9c192f289b47cf1f59101b4c778a7b/client/me/purchases/billing-history/billing-history-list.tsx#L207-L209).

Fixes Automattic/payments-shilling#1516

## Proposed Changes

* Restores the behavior of passing a null value to the transactions property if it received a null value.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit [`/me/purchases/billing`](https://container-mystifying-lederberg.calypso.live/me/purchases/billing) (preferably with an account with a few purchases)
* Observe a loading state
	* <img width="967" alt="Billing history loading state" src="https://user-images.githubusercontent.com/38750/231804447-f6bb9eeb-3d4c-45ba-b112-24060e83d086.png">
* You may need to try again with an empty cache/incognito window/deleted Redux store