### PR TITLE
Remove feature flags from config

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -141,8 +141,6 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
-		"plans/wooexpress-medium": true,
-		"plans/wooexpress-small": true,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -91,8 +91,6 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
-		"plans/wooexpress-medium": true,
-		"plans/wooexpress-small": true,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,

--- a/config/production.json
+++ b/config/production.json
@@ -106,8 +106,6 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
-		"plans/wooexpress-medium": true,
-		"plans/wooexpress-small": true,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -104,8 +104,6 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
-		"plans/wooexpress-medium": true,
-		"plans/wooexpress-small": true,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,

--- a/config/test.json
+++ b/config/test.json
@@ -77,8 +77,6 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
-		"plans/wooexpress-medium": true,
-		"plans/wooexpress-small": true,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -115,8 +115,6 @@
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,
 		"plans/starter-plan": false,
-		"plans/wooexpress-medium": true,
-		"plans/wooexpress-small": true,
 		"plugins/ssr-categories": true,
 		"plugins/ssr-details": true,
 		"plugins/ssr-landing": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75560

## Proposed Changes

* Remove now-unused feature flags from environment config files.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, make sure Calypso still loads, esp. the Plans pages for Woo Express sites
* Run `yarn run feature-search plans/wooexpress-medium` and `yarn run feature-search plans/wooexpress-small`; you should see no feature found: 

<img width="649" alt="Screen Shot 2023-04-13 at 1 15 43 PM" src="https://user-images.githubusercontent.com/2124984/231841667-00d5e777-ea27-4017-b439-69f17fbe8217.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
