### PR TITLE
Stats: Polish subscribers heading behavior and styling

### DIFF
--- a/client/my-sites/stats/subscribers-section/index.tsx
+++ b/client/my-sites/stats/subscribers-section/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import UplotChart from '@automattic/components/src/chart-uplot';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
@@ -37,6 +38,7 @@ export default function SubscribersSection( {
 	siteId: string;
 	siteSlug: string;
 } ) {
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const period = 'month';
 	const quantity = 30;
 	const {
@@ -64,14 +66,16 @@ export default function SubscribersSection( {
 			<div className="subscribers-section-heading highlight-cards">
 				<h1 className="highlight-cards-heading">
 					{ translate( 'Subscribers' ) }{ ' ' }
-					<small>
-						<a
-							className="highlight-cards-heading-wrapper"
-							href={ '/people/subscribers/' + siteSlug }
-						>
-							{ translate( 'View all subscribers' ) }
-						</a>
-					</small>
+					{ isOdysseyStats ? null : (
+						<small>
+							<a
+								className="highlight-cards-heading-wrapper"
+								href={ '/people/subscribers/' + siteSlug }
+							>
+								{ translate( 'View all subscribers' ) }
+							</a>
+						</small>
+					) }
 				</h1>
 				<div className="subscribers-section-legend" ref={ legendRef }></div>
 			</div>

--- a/client/my-sites/stats/subscribers-section/style.scss
+++ b/client/my-sites/stats/subscribers-section/style.scss
@@ -17,6 +17,7 @@
 	display: flex;
 	justify-content: space-between;
 	margin-bottom: 16px;
+	box-shadow: none; // override .highlight-cards styling
 
 	> .highlight-cards-heading {
 		margin-bottom: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #75707

## Proposed Changes

Before|After|After (in Odyssey)
-|-|-
<img width="1258" alt="image" src="https://user-images.githubusercontent.com/4044428/231842305-b09fd4ae-075e-4a76-8dc7-d2d6ac646af9.png">|<img width="1261" alt="image" src="https://user-images.githubusercontent.com/4044428/231842624-8262b6ff-4eb5-4c6a-aa2f-a0451aa756f3.png">|<img width="1246" alt="image" src="https://user-images.githubusercontent.com/4044428/231844866-280d7402-944c-4248-9902-7bc8baf5aee3.png">


* Removes the unintended line created by a box-shadow on the headings element.
* Removes the link altogether if running inside Odyssey Stats.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live branch for this PR and navigate to the Stats page (`/stats/day/:siteSlug`).
* Enable the new subscriber stats section by appending this query string to the URL: `?flags=stats/subscribers-section`.
* Ensure that there's a new link next to the "Subscribers" chart heading.
* Ensure that there's only one "Subscribers" navigation item at the top of the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
