### PR TITLE
Hosting onboarding: reword supporting copies for agencies at the domains step

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1293,11 +1293,11 @@ class RegisterDomainStep extends Component {
 	};
 
 	renderBestNamesPrompt() {
-		const { translate } = this.props;
+		const { translate, promptText } = this.props;
 		return (
 			<div className="register-domain-step__example-prompt">
 				<Icon icon={ tip } size={ 20 } />
-				{ translate( 'The best names are short and memorable' ) }
+				{ promptText ?? translate( 'The best names are short and memorable' ) }
 			</div>
 		);
 	}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -573,6 +573,11 @@ class DomainsStep extends Component {
 					isReskinned={ this.props.isReskinned }
 					reskinSideContent={ this.getSideContent() }
 					isInLaunchFlow={ 'launch-site' === this.props.flowName }
+					promptText={
+						this.isHostingFlow()
+							? this.props.translate( 'Stand out with a short and memorable domain' )
+							: undefined
+					}
 				/>
 			</CalypsoShoppingCartProvider>
 		);
@@ -627,6 +632,8 @@ class DomainsStep extends Component {
 		);
 	};
 
+	isHostingFlow = () => isHostingFlow( this.props.flowName );
+
 	getSubHeaderText() {
 		const { flowName, isAllDomains, siteType, stepSectionName, isReskinned, translate } =
 			this.props;
@@ -653,7 +660,7 @@ class DomainsStep extends Component {
 			);
 		}
 
-		if ( isHostingFlow( flowName ) ) {
+		if ( this.isHostingFlow() ) {
 			const components = {
 				span: (
 					<button
@@ -665,7 +672,7 @@ class DomainsStep extends Component {
 			};
 
 			return translate(
-				'Enter some descriptive keywords to get started. Not sure yet? {{span}}Decide later{{/span}}.',
+				'Find the perfect domain for your exciting new project or {{span}}decide later{{/span}}.',
 				{ components }
 			);
 		}


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/2124.

## Proposed Changes

This PR rewords some of the supporting texts in the domains step **exclusively on the hosting onboarding flow**. It aims to 

<img width="757" alt="image" src="https://user-images.githubusercontent.com/26530524/231851805-06d40475-133a-4488-9449-4c8b6f9ac7f1.png">

## Testing Instructions

1. Checkout this branch;
2. Verify that `/start/domains` has the old copy;
3. Verify that `/start/hosting/domains` has the new copies, from the screenshot.
