### PR TITLE
Plans 2023 : Plan purchase credits messaging tweak

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -22,9 +22,9 @@ interface Props {
 	isMonthlyPlan: boolean;
 }
 
-const StrikethroughText = styled.span`
-	color: 'var(--studio-gray-20)';
-	text-decoration: 'line-through';
+export const StrikethroughText = styled.span`
+	color: var( --studio-gray-20 );
+	text-decoration: line-through;
 `;
 
 function usePerMonthDescription( {

--- a/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx
@@ -8,6 +8,7 @@ import {
 	TERM_ANNUALLY,
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
+import styled from '@emotion/styled';
 import { localize, TranslateResult, useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
@@ -20,6 +21,11 @@ interface Props {
 	billingPeriod: number | null | undefined;
 	isMonthlyPlan: boolean;
 }
+
+const StrikethroughText = styled.span`
+	color: 'var(--studio-gray-20)';
+	text-decoration: 'line-through';
+`;
 
 function usePerMonthDescription( {
 	isMonthlyPlan,
@@ -63,23 +69,51 @@ function usePerMonthDescription( {
 	}
 
 	if ( ! isMonthlyPlan ) {
-		const maybeDiscountedPrice =
-			planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice || planPrices.rawPrice;
-		const fullTermPriceText =
-			currencyCode && maybeDiscountedPrice
-				? formatCurrency( maybeDiscountedPrice, currencyCode, { stripZeros: true } )
+		const discountedPrice = planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice;
+		const fullTermDiscountedPriceText =
+			currencyCode && discountedPrice
+				? formatCurrency( discountedPrice, currencyCode, { stripZeros: true } )
 				: null;
-
-		if ( fullTermPriceText ) {
+		const rawPrice =
+			currencyCode && planPrices.rawPrice
+				? formatCurrency( planPrices.rawPrice, currencyCode, { stripZeros: true } )
+				: null;
+		if ( fullTermDiscountedPriceText ) {
 			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-				return translate( 'per month, %(fullTermPriceText)s billed annually', {
-					args: { fullTermPriceText },
+				//per month, $96 billed annually $84 for the first year
+
+				return translate(
+					'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year',
+					{
+						args: { fullTermDiscountedPriceText, rawPrice },
+						components: {
+							discount: <StrikethroughText />,
+						},
+					}
+				);
+			}
+
+			if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
+				return translate(
+					'per month, {{discount}} %(rawPrice)s billed annually{{/discount}} %(fullTermDiscountedPriceText)s for the first year',
+					{
+						args: { fullTermDiscountedPriceText, rawPrice },
+						components: {
+							discount: <StrikethroughText />,
+						},
+					}
+				);
+			}
+		} else if ( rawPrice ) {
+			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
+				return translate( 'per month, %(rawPrice)s billed annually', {
+					args: { rawPrice },
 				} );
 			}
 
 			if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
-				return translate( 'per month, %(fullTermPriceText)s billed every two years', {
-					args: { fullTermPriceText },
+				return translate( 'per month, %(rawPrice)s billed every two years.', {
+					args: { rawPrice },
 				} );
 			}
 		}
@@ -97,7 +131,7 @@ const PlanFeatures2023GridBillingTimeframe: FunctionComponent< Props > = ( props
 	if ( isWpcomEnterpriseGridPlan( planName ) ) {
 		return (
 			<div className="plan-features-2023-grid__vip-price">
-				{ translate( 'Starts at {{b}}%(price)s{{/b}} yearly.', {
+				{ translate( 'Starts at {{b}}%(price)s{{/b}} yearly', {
 					args: { price },
 					components: { b: <b /> },
 					comment: 'Translators: the price is in US dollars for all users (US$25,000)',

--- a/client/my-sites/plan-features-2023-grid/components/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/header-price.tsx
@@ -1,5 +1,6 @@
 import { isWpcomEnterpriseGridPlan, PlanSlug } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import PlanPrice from 'calypso/my-sites/plan-price';
 import usePlanPrices from 'calypso/my-sites/plans/hooks/use-plan-prices';
@@ -10,6 +11,7 @@ interface PlanFeatures2023GridHeaderPriceProps {
 	planProperties: PlanProperties;
 	is2023OnboardingPricingGrid: boolean;
 	isLargeCurrency: boolean;
+	isPlanUpgradeCreditEligible: boolean;
 }
 
 const PricesGroup = styled.div< { isLargeCurrency: boolean } >`
@@ -18,6 +20,21 @@ const PricesGroup = styled.div< { isLargeCurrency: boolean } >`
 	flex-direction: ${ ( props ) => ( props.isLargeCurrency ? 'column' : 'row-reverse' ) };
 	align-items: ${ ( props ) => ( props.isLargeCurrency ? 'flex-start' : 'flex-end' ) };
 	gap: 4px;
+`;
+
+const Badge = styled.div`
+	text-align: center;
+	white-space: nowrap;
+	font-size: 0.75rem;
+	font-weight: 500;
+	letter-spacing: 0.2px;
+	line-height: 1.25rem;
+	padding: 0 12px;
+	border-radius: 4px;
+	height: 21px;
+	background-color: var( --studio-green-0 );
+	display: inline-block;
+	color: var( --studio-green-40 );
 `;
 
 const HeaderPriceContainer = styled.div`
@@ -100,13 +117,18 @@ const HeaderPriceContainer = styled.div`
 			}
 		}
 	}
+	.plan-features-2023-grid__badge {
+		margin-bottom: 10px;
+	}
 `;
 
 const PlanFeatures2023GridHeaderPrice = ( {
 	planProperties,
 	is2023OnboardingPricingGrid,
 	isLargeCurrency,
+	isPlanUpgradeCreditEligible,
 }: PlanFeatures2023GridHeaderPriceProps ) => {
+	const translate = useTranslate();
 	const { planName, showMonthlyPrice } = planProperties;
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const planPrices = usePlanPrices( {
@@ -124,24 +146,31 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	return (
 		<HeaderPriceContainer>
 			{ shouldShowDiscountedPrice && (
-				<PricesGroup isLargeCurrency={ isLargeCurrency }>
-					<PlanPrice
-						currencyCode={ currencyCode }
-						rawPrice={ planPrices.rawPrice }
-						displayPerMonthNotation={ false }
-						is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
-						isLargeCurrency={ isLargeCurrency }
-						original
-					/>
-					<PlanPrice
-						currencyCode={ currencyCode }
-						rawPrice={ planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice }
-						displayPerMonthNotation={ false }
-						is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
-						isLargeCurrency={ isLargeCurrency }
-						discounted
-					/>
-				</PricesGroup>
+				<>
+					<Badge className="plan-features-2023-grid__badge">
+						{ isPlanUpgradeCreditEligible
+							? translate( 'Credit applied' )
+							: translate( 'One time discount' ) }
+					</Badge>
+					<PricesGroup isLargeCurrency={ isLargeCurrency }>
+						<PlanPrice
+							currencyCode={ currencyCode }
+							rawPrice={ planPrices.rawPrice }
+							displayPerMonthNotation={ false }
+							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+							isLargeCurrency={ isLargeCurrency }
+							original
+						/>
+						<PlanPrice
+							currencyCode={ currencyCode }
+							rawPrice={ planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice }
+							displayPerMonthNotation={ false }
+							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
+							isLargeCurrency={ isLargeCurrency }
+							discounted
+						/>
+					</PricesGroup>
+				</>
 			) }
 			{ ! shouldShowDiscountedPrice && (
 				<PlanPrice

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -22,6 +22,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback, useEffect, ChangeEvent } from 'react';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import { FeatureObject, getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
+import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible';
 import { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import TermExperimentPlanTypeSelector from 'calypso/my-sites/plans-features-main/components/term-experiment-plan-type-selector';
 import useHighlightAdjacencyMatrix from '../hooks/use-highlight-adjacency-matrix';
@@ -332,6 +333,7 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 		allVisible: boolean;
 		isLastInRow: boolean;
 		isLargeCurrency: boolean;
+		isPlanUpgradeCreditEligible: boolean;
 	}
 > = ( {
 	planProperties,
@@ -351,6 +353,7 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 	isLargeCurrency,
 	onUpgradeClick,
 	planActionOverrides,
+	isPlanUpgradeCreditEligible,
 } ) => {
 	const { planName, planConstantObj, availableForPurchase, current, ...planPropertiesObj } =
 		planProperties;
@@ -413,6 +416,7 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 				</h4>
 			</PlanSelector>
 			<PlanFeatures2023GridHeaderPrice
+				isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
 				planProperties={ planProperties }
 				is2023OnboardingPricingGrid={ true }
 				isLargeCurrency={ isLargeCurrency }
@@ -470,7 +474,10 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 		planSlugs: displayedPlansProperties.map( ( properties ) => properties.planName as PlanSlug ),
 		siteId,
 	} );
-
+	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible(
+		siteId ?? 0,
+		displayedPlansProperties.map( ( { planName } ) => planName )
+	);
 	return (
 		<PlanRow>
 			<RowTitleCell
@@ -479,6 +486,7 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 			/>
 			{ visiblePlansProperties.map( ( planProperties, index ) => (
 				<PlanComparisonGridHeaderCell
+					isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
 					key={ planProperties.planName }
 					planProperties={ planProperties }
 					isLastInRow={ index === visiblePlansProperties.length - 1 }
@@ -890,6 +898,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 			/>
 			<Grid isInSignup={ isInSignup }>
 				<PlanComparisonGridHeader
+					siteId={ siteId }
 					displayedPlansProperties={ displayedPlansProperties }
 					visiblePlansProperties={ visiblePlansProperties }
 					isInSignup={ isInSignup }
@@ -901,7 +910,6 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 					canUserPurchasePlan={ canUserPurchasePlan }
 					selectedSiteSlug={ selectedSiteSlug }
 					onUpgradeClick={ onUpgradeClick }
-					siteId={ siteId }
 					planActionOverrides={ planActionOverrides }
 				/>
 				{ Object.values( featureGroupMap ).map( ( featureGroup: FeatureGroup ) => {

--- a/client/my-sites/plan-features-2023-grid/components/test/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/test/billing-timeframe.tsx
@@ -96,18 +96,17 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 			/>
 		);
 
-		const discountedPrice = formatCurrency(
-			planPrices.planDiscountedRawPrice,
-			getCurrentUserCurrencyCode(),
-			{ stripZeros: true }
-		);
-		const rawPrice = formatCurrency( planPrices.rawPrice, getCurrentUserCurrencyCode(), {
+		const discountedPrice = formatCurrency( planPrices.planDiscountedRawPrice, 'INR', {
+			stripZeros: true,
+		} );
+		const rawPrice = formatCurrency( planPrices.rawPrice, 'INR', {
 			stripZeros: true,
 		} );
 
-		expect( container ).toContainHTML(
-			`per month, <span style="text-decoration: line-through;"> ${ rawPrice } billed annually</span> ${ discountedPrice } for the first year`
+		expect( container ).toHaveTextContent(
+			`per month, ${ rawPrice } billed annually ${ discountedPrice } for the first year`
 		);
+		expect( container ).toContainHTML( `StrikethroughText` );
 	} );
 
 	test( 'should show full-term discounted price when plan is 2-yearly', () => {
@@ -127,16 +126,15 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 				billingPeriod={ PLAN_BIENNIAL_PERIOD }
 			/>
 		);
-		const discountedPrice = formatCurrency(
-			planPrices.planDiscountedRawPrice,
-			getCurrentUserCurrencyCode(),
-			{ stripZeros: true }
-		);
-		const rawPrice = formatCurrency( planPrices.rawPrice, getCurrentUserCurrencyCode(), {
+		const discountedPrice = formatCurrency( planPrices.planDiscountedRawPrice, 'INR', {
 			stripZeros: true,
 		} );
-		expect( container ).toContainHTML(
-			`per month, <span style="text-decoration: line-through;"> ${ rawPrice } billed annually</span> ${ discountedPrice } for the first year`
+		const rawPrice = formatCurrency( planPrices.rawPrice, 'INR', {
+			stripZeros: true,
+		} );
+		expect( container ).toHaveTextContent(
+			`per month, ${ rawPrice } billed annually ${ discountedPrice } for the first year`
 		);
+		expect( container ).toContainHTML( `StrikethroughText` );
 	} );
 } );

--- a/client/my-sites/plan-features-2023-grid/components/test/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/test/billing-timeframe.tsx
@@ -96,12 +96,17 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 			/>
 		);
 
-		expect( container ).toHaveTextContent(
-			`per month, ${ formatCurrency(
-				planPrices.planDiscountedRawPrice,
-				getCurrentUserCurrencyCode(),
-				{ stripZeros: true }
-			) } billed annually`
+		const discountedPrice = formatCurrency(
+			planPrices.planDiscountedRawPrice,
+			getCurrentUserCurrencyCode(),
+			{ stripZeros: true }
+		);
+		const rawPrice = formatCurrency( planPrices.rawPrice, getCurrentUserCurrencyCode(), {
+			stripZeros: true,
+		} );
+
+		expect( container ).toContainHTML(
+			`per month, <span style="text-decoration: line-through;"> ${ rawPrice } billed annually</span> ${ discountedPrice } for the first year`
 		);
 	} );
 
@@ -122,13 +127,16 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 				billingPeriod={ PLAN_BIENNIAL_PERIOD }
 			/>
 		);
-
-		expect( container ).toHaveTextContent(
-			`per month, ${ formatCurrency(
-				planPrices.planDiscountedRawPrice,
-				getCurrentUserCurrencyCode(),
-				{ stripZeros: true }
-			) } billed every two years`
+		const discountedPrice = formatCurrency(
+			planPrices.planDiscountedRawPrice,
+			getCurrentUserCurrencyCode(),
+			{ stripZeros: true }
+		);
+		const rawPrice = formatCurrency( planPrices.rawPrice, getCurrentUserCurrencyCode(), {
+			stripZeros: true,
+		} );
+		expect( container ).toContainHTML(
+			`per month, <span style="text-decoration: line-through;"> ${ rawPrice } billed annually</span> ${ discountedPrice } for the first year`
 		);
 	} );
 } );

--- a/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-upgrade-credits-display.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-upgrade-credits-display.tsx
@@ -21,9 +21,12 @@ jest.mock( 'calypso/state/sites/selectors', () => ( {
 jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
 	getSitePlanSlug: jest.fn(),
 } ) );
-jest.mock( 'calypso/my-sites/plan-features-2023-grid/hooks/use-plan-upgrade-credits', () => ( {
-	useCalculateMaxPlanUpgradeCredit: jest.fn(),
-} ) );
+jest.mock(
+	'calypso/my-sites/plan-features-2023-grid/hooks/use-calculate-max-plan-upgrade-credit',
+	() => ( {
+		useCalculateMaxPlanUpgradeCredit: jest.fn(),
+	} )
+);
 jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {
 	__esModule: true,
 	default: jest.fn(),

--- a/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-upgrade-credits-display.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-upgrade-credits-display.tsx
@@ -7,8 +7,8 @@ import {
 	PLAN_FREE,
 	PlanSlug,
 } from '@automattic/calypso-products';
-import { usePlanUpgradeCredits } from 'calypso/my-sites/plans-features-main/hooks/use-plan-upgrade-credits';
-import { usePlanUpgradeCreditsDisplay } from 'calypso/my-sites/plans-features-main/hooks/use-plan-upgrade-credits-display';
+import { useCalculateMaxPlanUpgradeCredit } from 'calypso/my-sites/plan-features-2023-grid/hooks/use-calculate-max-plan-upgrade-credit';
+import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible';
 import isAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
 import { isCurrentPlanPaid, isJetpackSite } from 'calypso/state/sites/selectors';
@@ -21,8 +21,8 @@ jest.mock( 'calypso/state/sites/selectors', () => ( {
 jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
 	getSitePlanSlug: jest.fn(),
 } ) );
-jest.mock( 'calypso/my-sites/plans-features-main/hooks/use-plan-upgrade-credits', () => ( {
-	usePlanUpgradeCredits: jest.fn(),
+jest.mock( 'calypso/my-sites/plan-features-2023-grid/hooks/use-plan-upgrade-credits', () => ( {
+	useCalculateMaxPlanUpgradeCredit: jest.fn(),
 } ) );
 jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {
 	__esModule: true,
@@ -30,8 +30,8 @@ jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {
 } ) );
 
 // Mocked types
-const mUsePlanUpgradeCredits = usePlanUpgradeCredits as jest.MockedFunction<
-	typeof usePlanUpgradeCredits
+const mUsePlanUpgradeCredits = useCalculateMaxPlanUpgradeCredit as jest.MockedFunction<
+	typeof useCalculateMaxPlanUpgradeCredit
 >;
 const mIsAutomatedTransfer = isAutomatedTransfer as jest.MockedFunction<
 	typeof isAutomatedTransfer
@@ -49,7 +49,7 @@ const plansList: PlanSlug[] = [
 	PLAN_ECOMMERCE,
 	PLAN_ENTERPRISE_GRID_WPCOM,
 ];
-describe( 'usePlanUpgradeCreditsDisplay hook', () => {
+describe( 'useIsPlanUpgradeCreditVisible hook', () => {
 	beforeEach( () => {
 		jest.resetAllMocks();
 
@@ -62,17 +62,17 @@ describe( 'usePlanUpgradeCreditsDisplay hook', () => {
 
 	test( 'Show a plans upgrade credit when the necessary conditions are met above', () => {
 		const { result } = renderHookWithProvider( () =>
-			usePlanUpgradeCreditsDisplay( siteId, plansList )
+			useIsPlanUpgradeCreditVisible( siteId, plansList )
 		);
-		expect( result.current ).toEqual( { creditsValue: 100, isPlanUpgradeCreditEligible: true } );
+		expect( result.current ).toEqual( true );
 	} );
 
 	test( 'Plan upgrade credits should not be shown when a site is on the highest purchasable plan', () => {
 		mGetSitePlanSlug.mockImplementation( () => PLAN_ECOMMERCE );
 		const { result } = renderHookWithProvider( () =>
-			usePlanUpgradeCreditsDisplay( siteId, plansList )
+			useIsPlanUpgradeCreditVisible( siteId, plansList )
 		);
-		expect( result.current ).toEqual( { creditsValue: 100, isPlanUpgradeCreditEligible: false } );
+		expect( result.current ).toEqual( false );
 	} );
 
 	test( 'A non atomic jetpack site is not shown the plan upgrade credit', () => {
@@ -80,26 +80,26 @@ describe( 'usePlanUpgradeCreditsDisplay hook', () => {
 		mIsJetpackSite.mockImplementation( () => true );
 
 		const { result } = renderHookWithProvider( () =>
-			usePlanUpgradeCreditsDisplay( siteId, plansList )
+			useIsPlanUpgradeCreditVisible( siteId, plansList )
 		);
-		expect( result.current ).toEqual( { creditsValue: 100, isPlanUpgradeCreditEligible: false } );
+		expect( result.current ).toEqual( false );
 	} );
 
 	test( 'Plan upgrade credit should NOT be shown if there are no discounts provided by the pricing API', () => {
 		mUsePlanUpgradeCredits.mockImplementation( () => 0 );
 
 		const { result } = renderHookWithProvider( () =>
-			usePlanUpgradeCreditsDisplay( siteId, plansList )
+			useIsPlanUpgradeCreditVisible( siteId, plansList )
 		);
-		expect( result.current ).toEqual( { creditsValue: 0, isPlanUpgradeCreditEligible: false } );
+		expect( result.current ).toEqual( false );
 	} );
 
 	test( 'Site on a free plan should not show the plan upgrade credit', () => {
 		mIsCurrentPlanPaid.mockImplementation( () => false );
 
 		const { result } = renderHookWithProvider( () =>
-			usePlanUpgradeCreditsDisplay( siteId, plansList )
+			useIsPlanUpgradeCreditVisible( siteId, plansList )
 		);
-		expect( result.current ).toEqual( { creditsValue: 100, isPlanUpgradeCreditEligible: false } );
+		expect( result.current ).toEqual( false );
 	} );
 } );

--- a/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-upgrade-credits.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-upgrade-credits.tsx
@@ -9,7 +9,7 @@ import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
 import { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors/get-site-plan-raw-price';
 import isPlanAvailableForPurchase from 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
-import { usePlanUpgradeCredits } from '../use-plan-upgrade-credits';
+import { useCalculateMaxPlanUpgradeCredit } from '../use-plan-upgrade-credits';
 import type { PlanSlug } from '@automattic/calypso-products';
 
 jest.mock( 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase', () => ( {
@@ -43,7 +43,7 @@ const plansList: PlanSlug[] = [
 	PLAN_ECOMMERCE,
 ];
 
-describe( 'usePlanUpgradeCredits hook', () => {
+describe( 'useCalculateMaxPlanUpgradeCredit hook', () => {
 	beforeEach( () => {
 		jest.resetAllMocks();
 		mGetSitePlanRawPrice.mockImplementation( ( _state, _siteId, planSlug ) => {
@@ -83,7 +83,9 @@ describe( 'usePlanUpgradeCredits hook', () => {
 	} );
 
 	test( 'Return the correct amount of credits given a plan list', () => {
-		const { result } = renderHookWithProvider( () => usePlanUpgradeCredits( siteId, plansList ) );
+		const { result } = renderHookWithProvider( () =>
+			useCalculateMaxPlanUpgradeCredit( siteId, plansList )
+		);
 		expect( result.current ).toEqual( 1000 );
 	} );
 
@@ -92,7 +94,9 @@ describe( 'usePlanUpgradeCredits hook', () => {
 			( _state, _siteId, planName ) => ! ( planName === PLAN_ECOMMERCE )
 		);
 
-		const { result } = renderHookWithProvider( () => usePlanUpgradeCredits( siteId, plansList ) );
+		const { result } = renderHookWithProvider( () =>
+			useCalculateMaxPlanUpgradeCredit( siteId, plansList )
+		);
 		expect( result.current ).toEqual( 800 );
 	} );
 } );

--- a/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-upgrade-credits.tsx
+++ b/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-upgrade-credits.tsx
@@ -9,7 +9,7 @@ import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
 import { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors/get-site-plan-raw-price';
 import isPlanAvailableForPurchase from 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
-import { useCalculateMaxPlanUpgradeCredit } from '../use-plan-upgrade-credits';
+import { useCalculateMaxPlanUpgradeCredit } from '../use-calculate-max-plan-upgrade-credit';
 import type { PlanSlug } from '@automattic/calypso-products';
 
 jest.mock( 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase', () => ( {

--- a/client/my-sites/plan-features-2023-grid/hooks/use-calculate-max-plan-upgrade-credit.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-calculate-max-plan-upgrade-credit.ts
@@ -12,7 +12,10 @@ import type { PlanSlug } from '@automattic/calypso-products';
  * @param {PlanSlug[]}  plans Plans that are considered for the given calculation
  * @returns {number} The maximum amount of credits possible for a given set of plans
  */
-export function usePlanUpgradeCredits( siteId: number | undefined, plans: PlanSlug[] ): number {
+export function useCalculateMaxPlanUpgradeCredit(
+	siteId: number | undefined,
+	plans: PlanSlug[]
+): number {
 	const plansDetails = useSelector( ( state ) =>
 		plans.map( ( planName ) => ( {
 			isPlanAvailableForPurchase: isPlanAvailableForPurchase( state, siteId ?? 0, planName ),

--- a/client/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible.ts
@@ -1,20 +1,24 @@
 import { PlanSlug, PLAN_ENTERPRISE_GRID_WPCOM } from '@automattic/calypso-products';
 import { useSelector } from 'react-redux';
-import { usePlanUpgradeCredits } from 'calypso/my-sites/plans-features-main/hooks/use-plan-upgrade-credits';
+import { useCalculateMaxPlanUpgradeCredit } from 'calypso/my-sites/plan-features-2023-grid/hooks/use-calculate-max-plan-upgrade-credit';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
 import { isCurrentPlanPaid, isJetpackSite } from 'calypso/state/sites/selectors';
 
-export function usePlanUpgradeCreditsDisplay(
+/**
+ * This hook determines if the plan upgrade credit should be visible in the current plans display context
+ *
+ * @param siteId Considered site id
+ * @param visiblePlans Plans that are visible to the user
+ * @returns If the credit should be displayed to the user
+ */
+export function useIsPlanUpgradeCreditVisible(
 	siteId: number,
 	visiblePlans: PlanSlug[] = []
-): {
-	creditsValue: number;
-	isPlanUpgradeCreditEligible: boolean;
-} {
+): boolean {
 	const isSiteOnPaidPlan = !! useSelector( ( state ) => isCurrentPlanPaid( state, siteId ) );
 	const currentSitePlanSlug = useSelector( ( state ) => getSitePlanSlug( state, siteId ) );
-	const creditsValue = usePlanUpgradeCredits( siteId, visiblePlans );
+	const creditsValue = useCalculateMaxPlanUpgradeCredit( siteId, visiblePlans );
 	const isJetpackNotAtomic = useSelector(
 		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
 	);
@@ -29,8 +33,5 @@ export function usePlanUpgradeCreditsDisplay(
 	// !isJetpackNotAtomic means --> A non atomic jetpack site is not upgradeable (!isJetpackSite || isAtomicSite)
 	const isUpgradeEligibleSite = isSiteOnPaidPlan && ! isJetpackNotAtomic && isHigherPlanAvailable();
 
-	return {
-		creditsValue,
-		isPlanUpgradeCreditEligible: isUpgradeEligibleSite && creditsValue > 0,
-	};
+	return isUpgradeEligibleSite && creditsValue > 0;
 }

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -334,7 +334,6 @@ export class PlanFeatures2023Grid extends Component<
 						className="plan-features-2023-grid__plan-comparison-grid-container"
 					>
 						<PlanComparisonGrid
-							siteId={ siteId }
 							planTypeSelectorProps={ planTypeSelectorProps }
 							planProperties={ planProperties }
 							intervalType={ intervalType }

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -1,4 +1,4 @@
-import { applyTestFiltersToPlansList } from '@automattic/calypso-products';
+import { applyTestFiltersToPlansList, PlanSlug } from '@automattic/calypso-products';
 import { FeatureObject } from 'calypso/lib/plans/features-list';
 import type { PricedAPIPlan } from '@automattic/data-stores';
 
@@ -19,7 +19,7 @@ export type PlanProperties = {
 	isPlaceholder?: boolean;
 	isVisible: boolean;
 	planConstantObj: ReturnType< typeof applyTestFiltersToPlansList >;
-	planName: string;
+	planName: PlanSlug;
 	planObject: PricedAPIPlan | undefined;
 	product_name_short: string;
 	hideMonthly?: boolean;

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -895,8 +895,8 @@ export const isPrimaryUpgradeByPlanDelta = ( currentPlan, plan ) =>
 		planMatches( plan, { type: TYPE_P2_PLUS, group: GROUP_WPCOM } ) );
 
 /**
- * @deprecated Use the {@link usePlanUpgradeCredits} hook instead, to be cleaned up with Plan
- * @module calypso/my-sites/plans-features-main/hooks/usePlanUpgradeCredits
+ * @deprecated Use the {@link useCalculateMaxPlanUpgradeCredit} hook instead, to be cleaned up with Plan
+ * @module calypso/my-sites/plan-features-2023-grid/hooks/useCalculateMaxPlanUpgradeCredit
  */
 export const calculatePlanCredits = ( state, siteId, planProperties ) =>
 	planProperties

--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -1,12 +1,14 @@
 import { PlanSlug } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import MarketingMessage from 'calypso/components/marketing-message';
 import Notice from 'calypso/components/notice';
 import { getDiscountByName } from 'calypso/lib/discounts';
-import { usePlanUpgradeCreditsDisplay } from 'calypso/my-sites/plans-features-main/hooks/use-plan-upgrade-credits-display';
+import { useCalculateMaxPlanUpgradeCredit } from 'calypso/my-sites/plan-features-2023-grid/hooks/use-calculate-max-plan-upgrade-credit';
+import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plan-features-2023-grid/hooks/use-is-plan-upgrade-credit-visible';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import { isCurrentPlanPaid } from 'calypso/state/sites/selectors';
@@ -33,10 +35,8 @@ export default function PlanNotice( {
 			! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
 	);
 	const activeDiscount = getDiscountByName( withDiscount, discountEndDate );
-	const { creditsValue, isPlanUpgradeCreditEligible } = usePlanUpgradeCreditsDisplay(
-		siteId,
-		visiblePlans
-	);
+	const creditsValue = useCalculateMaxPlanUpgradeCredit( siteId, visiblePlans );
+	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible( siteId, visiblePlans );
 
 	const handleDismissNotice = () => setIsNoticeDismissed( true );
 
@@ -83,14 +83,21 @@ export default function PlanNotice( {
 				status="is-success"
 			>
 				{ translate(
-					'You have {{b}}%(amountInCurrency)s{{/b}} of pro-rated credits available from your current plan. ' +
-						'Apply those credits towards an upgrade before they expire!',
+					'We’ve applied the {{b}}%(amountInCurrency)s{{/b}} {{a}}upgrade credit{{/a}} from your current plan as a deduction to your new plan, below. This remaining credit will be applied at checkout if you upgrade today!',
 					{
 						args: {
 							amountInCurrency: formatCurrency( creditsValue, currencyCode ?? '' ),
 						},
 						components: {
 							b: <strong />,
+							a: (
+								<a
+									href={ localizeUrl(
+										'https://wordpress.com/support/manage-purchases/#pro-rated-credits'
+									) }
+									className="get-apps__desktop-link"
+								/>
+							),
 						},
 					}
 				) }


### PR DESCRIPTION
~Blocked by #76100~
Related to pdgrnI-2iW-p2
### Proposed Changes and test cases

* Fixes following use case bugs which were discussed @ pdgrnI-2iW-p2

The notice has been updated to following and this update is not reflected in the table below.
<img width="1281" alt="image" src="https://user-images.githubusercontent.com/3422709/235569370-cb2e22e7-3031-4ef5-8f3a-29148b6433aa.png">

### Use Cases


| # | Use Case      | Existing  | New  |
| -- | ----------- | -----------  | -----------  | 
| 1 | Purchase any monthly plan other than Woocommerce  and look at yearly plans   |  <img alt="image" src="https://user-images.githubusercontent.com/3422709/232101897-340970a8-46be-4382-a0e9-fd90c0ca4289.png">   |   <img alt="image" src="https://user-images.githubusercontent.com/3422709/233128254-515c9de8-b1f3-45f4-a2b5-bc1aaa01b0b3.png">   |
| 2 | Purchase any monthly plan other than Woocommerce  and look at monthly plans   |  ![image](https://user-images.githubusercontent.com/3422709/232100912-4c4959cc-8b2e-4c11-8a48-900b0a0abb3d.png)    | <img width="1276" alt="image" src="https://user-images.githubusercontent.com/3422709/233128648-bcbdeb78-c49a-46e7-b3d3-163136f628b3.png"> |
| 3 | On a free plan change the currency to INR and look at the yearly plans. This has a flat discount for the first year for select currencies.   |  ![image](https://user-images.githubusercontent.com/3422709/232100912-4c4959cc-8b2e-4c11-8a48-900b0a0abb3d.png)    | <img width="1473" alt="image" src="https://user-images.githubusercontent.com/3422709/233130267-00a44a13-62e8-400c-88c3-c726b83b1d35.png"> | 
| 4 | In the [biennial experiment variation](https://github.com/Automattic/wp-calypso/blob/c0aba3a809b43ecce0d6ec109397e2a591cb0ed4/client/my-sites/plans-features-main/term-experiment-plan-type-selector.tsx#L27-L28) purchase a non WooCommerce monthly plan and look at yearly plans   |  <img width="1272" alt="image" src="https://user-images.githubusercontent.com/3422709/232138280-13900da2-5cc7-4876-bb03-02d89b50f392.png">  | <img width="1574" alt="image" src="https://user-images.githubusercontent.com/3422709/233133514-a99edaaf-2a2c-40d1-b7a0-ef1fa34f712f.png"> |
| 5 | In the [biennial experiment variation](https://github.com/Automattic/wp-calypso/blob/c0aba3a809b43ecce0d6ec109397e2a591cb0ed4/client/my-sites/plans-features-main/term-experiment-plan-type-selector.tsx#L27-L28) purchase a non WooCommerce monthly plan and look at biennial plans   |  <img width="1302" alt="image" src="https://user-images.githubusercontent.com/3422709/232138158-62412d79-826b-4265-a10d-0e6dbbb61440.png">    | <img width="1567" alt="image" src="https://user-images.githubusercontent.com/3422709/233133653-348a538b-afd3-4c94-b2e8-570cfa9be7c8.png"> |
| 6 | On the signup flow |  <img width="1581" alt="image" src="https://user-images.githubusercontent.com/3422709/232927461-49afbf08-3935-4620-b6c9-2f9de293a1a1.png"> | <img width="1568" alt="image" src="https://user-images.githubusercontent.com/3422709/233130625-8480edf6-5394-4807-9ad0-a61cb20e850c.png"> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

Fixes Automattic/martech#1678