### PR TITLE
Stats: Improve accessibility for traffic page

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -64,7 +64,7 @@ class StatsNavigation extends Component {
 		return (
 			<div className={ wrapperClass }>
 				<SectionNav selectedText={ label }>
-					<NavTabs label="Stats" selectedText={ label }>
+					<NavTabs selectedText={ label }>
 						{ Object.keys( navItems )
 							.filter( this.isValidItem )
 							.map( ( item ) => {

--- a/client/blocks/subscribers-count/index.jsx
+++ b/client/blocks/subscribers-count/index.jsx
@@ -22,7 +22,8 @@ class SubscribersCount extends Component {
 						href={ '/people/subscribers/' + slug }
 						title={ translate( 'Total of WordPress and Email Subscribers' ) }
 					>
-						{ translate( 'Subscribers' ) } <Count count={ subscribers } />
+						{ translate( 'Subscribers' ) }
+						<span className="screen-reader-text">:</span> <Count count={ subscribers } />
 					</Button>
 				) }
 			</div>

--- a/client/components/main/index.tsx
+++ b/client/components/main/index.tsx
@@ -2,6 +2,16 @@ import classNames from 'classnames';
 
 import './style.scss';
 
+interface MainProps {
+	ariaLabel?: string;
+	children: React.ReactNode;
+	className?: string;
+	fullWidthLayout?: boolean;
+	id?: string;
+	isLoggedOut?: boolean;
+	wideLayout?: boolean;
+}
+
 export default function Main( {
 	className = '',
 	id = '',
@@ -9,7 +19,8 @@ export default function Main( {
 	wideLayout = false,
 	fullWidthLayout = false,
 	isLoggedOut = false,
-} ) {
+	ariaLabel,
+}: MainProps ) {
 	const classes = classNames( className, 'main', {
 		'is-wide-layout': wideLayout,
 		'is-full-width-layout': fullWidthLayout,
@@ -17,7 +28,7 @@ export default function Main( {
 	} );
 
 	return (
-		<main className={ classes } id={ id || null } role="main">
+		<main className={ classes } id={ id || undefined } role="main" aria-label={ ariaLabel }>
 			{ children }
 		</main>
 	);

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -347,7 +347,7 @@ class StatsSite extends Component {
 		sessionStorage.setItem( 'jp-stats-last-tab', 'traffic' );
 
 		return (
-			<Main fullWidthLayout>
+			<Main fullWidthLayout ariaLabel={ translate( 'Jetpack Stats' ) }>
 				{ /* Odyssey: Google My Business pages are currently unsupported. */ }
 				{ ! isOdysseyStats && (
 					<>

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -82,7 +82,16 @@ const StatsCard = ( {
 				</div>
 			</div>
 			{ footerAction && (
-				<a className={ `${ BASE_CLASS_NAME }--footer` } href={ footerAction?.url }>
+				<a
+					className={ `${ BASE_CLASS_NAME }--footer` }
+					href={ footerAction?.url }
+					aria-label={
+						translate( 'View all %(title)s', {
+							args: { title: title.toLocaleLowerCase() },
+							comment: '"View all posts & pages", "View all referrers", etc.',
+						} ) as string
+					}
+				>
 					{ footerAction.label || translate( 'View all' ) }
 				</a>
 			) }

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -136,7 +136,15 @@ export default function JetpackUpsellCard( {
 							</span>
 							<Gridicon icon="external" size={ 16 } />
 						</a>
-						<Button href={ upgradeUrls[ slug ] } className="jetpack-upsell-card__product-button">
+						<Button
+							href={ upgradeUrls[ slug ] }
+							className="jetpack-upsell-card__product-button"
+							aria-label={
+								translate( 'Upgrade to Jetpack %(productName)s', {
+									args: { productName: title },
+								} ) as string
+							}
+						>
 							{ translate( 'Upgrade' ) }
 						</Button>
 					</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #74321

## Proposed Changes

<img width="736" alt="image" src="https://user-images.githubusercontent.com/4044428/232162912-f29b382e-1a3a-4160-902d-f28e49465572.png">

<img width="1242" alt="image" src="https://user-images.githubusercontent.com/4044428/232163715-2def78bc-8cdd-41d4-a20a-da1109a66dd6.png">


* Add unique labels to links labeled as "View details" within the bar chart lists.
* Add unique labels to links labeled as "Upgrade" within the Jetpack products upsell section.
* Removed unnecessary aria-labels that weren't adding useful context.
* Added aria-label to the `main` container for Jetpack Stats.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live branch for this PR and navigate to the traffic stats page.
* Ensure that the new changes improve accessibility for screen readers.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
