### PR TITLE
Subscriptions Management: Create usePostUnfollowMutation

### DIFF
--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -1,5 +1,6 @@
 import { useSubscriberEmailAddress } from './hooks';
 import {
+	usePostUnfollowMutation,
 	useSiteDeliveryFrequencyMutation,
 	useSiteUnfollowMutation,
 	useUserSettingsMutation,
@@ -11,6 +12,7 @@ import {
 } from './queries';
 
 export const SubscriptionManager = {
+	usePostUnfollowMutation,
 	useSiteDeliveryFrequencyMutation,
 	useSiteSubscriptionsQuery,
 	useSiteUnfollowMutation,

--- a/packages/data-stores/src/reader/mutations/index.ts
+++ b/packages/data-stores/src/reader/mutations/index.ts
@@ -1,3 +1,4 @@
+export { default as usePostUnfollowMutation } from './use-post-unfollow-mutation';
 export { default as useSiteDeliveryFrequencyMutation } from './use-site-delivery-frequency-mutation';
 export { default as useSiteUnfollowMutation } from './use-site-unfollow-mutation';
 export { default as useUserSettingsMutation } from './use-user-settings-mutation';

--- a/packages/data-stores/src/reader/mutations/use-post-unfollow-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-post-unfollow-mutation.ts
@@ -15,7 +15,7 @@ type PostSubscriptionUnfollowResponse = {
 };
 
 const usePostUnfollowMutation = () => {
-	const isLoggedIn = useIsLoggedIn();
+	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
 	return useMutation(
 		async ( params: PostSubscriptionUnfollowParams ) => {

--- a/packages/data-stores/src/reader/mutations/use-post-unfollow-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-post-unfollow-mutation.ts
@@ -1,0 +1,110 @@
+import { useMutation, useQueryClient } from 'react-query';
+import { callApi } from '../helpers';
+import { useIsLoggedIn } from '../hooks';
+import { PostSubscription, SubscriptionManagerSubscriptionsCount } from '../types';
+
+type PostSubscriptionUnfollowParams = {
+	blog_id: number | string;
+	post_id: number | string;
+};
+
+type PostSubscriptionUnfollowResponse = {
+	success: boolean;
+	subscribed: boolean;
+	subscription: null;
+};
+
+const usePostUnfollowMutation = () => {
+	const isLoggedIn = useIsLoggedIn();
+	const queryClient = useQueryClient();
+	return useMutation(
+		async ( params: PostSubscriptionUnfollowParams ) => {
+			if ( ! params.blog_id ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while unsubscribing.'
+				);
+			}
+
+			const response = await callApi< PostSubscriptionUnfollowResponse >( {
+				path: `/read/site/${ params.blog_id }/comment_email_subscriptions/delete?post_id=${ params.post_id }`,
+				method: 'POST',
+				isLoggedIn,
+				apiVersion: '1.2',
+			} );
+
+			if ( ! response.success ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while unsubscribing.'
+				);
+			}
+
+			return response;
+		},
+		{
+			onMutate: async ( params ) => {
+				await queryClient.cancelQueries( [ 'read', 'post-subscriptions', isLoggedIn ] );
+				await queryClient.cancelQueries( [ 'read', 'subscriptions-count', isLoggedIn ] );
+
+				const previousPostSubscriptions = queryClient.getQueryData< PostSubscription[] >( [
+					'read',
+					'post-subscriptions',
+					isLoggedIn,
+				] );
+
+				// remove post from comment subscriptions
+				if ( previousPostSubscriptions ) {
+					queryClient.setQueryData< PostSubscription[] >(
+						[ [ 'read', 'post-subscriptions', isLoggedIn ] ],
+						previousPostSubscriptions.filter(
+							( postSubscription ) => postSubscription.id !== params.post_id
+						)
+					);
+				}
+
+				const previousSubscriptionsCount =
+					queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >( [
+						'read',
+						'subscriptions-count',
+						isLoggedIn,
+					] );
+
+				// decrement the comments count
+				if ( previousSubscriptionsCount ) {
+					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
+						[ 'read', 'subscriptions-count', isLoggedIn ],
+						{
+							...previousSubscriptionsCount,
+							comments: previousSubscriptionsCount?.comments
+								? previousSubscriptionsCount?.comments - 1
+								: null,
+						}
+					);
+				}
+
+				return { previousPostSubscriptions, previousSubscriptionsCount };
+			},
+			onError: ( error, variables, context ) => {
+				if ( context?.previousPostSubscriptions ) {
+					queryClient.setQueryData< PostSubscription[] >(
+						[ 'read', 'post-subscriptions', isLoggedIn ],
+						context.previousPostSubscriptions
+					);
+				}
+				if ( context?.previousSubscriptionsCount ) {
+					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
+						[ 'read', 'subscriptions-count', isLoggedIn ],
+						context.previousSubscriptionsCount
+					);
+				}
+			},
+			onSettled: () => {
+				queryClient.invalidateQueries( [ 'read', 'post-subscriptions', isLoggedIn ] );
+				queryClient.invalidateQueries( [ 'read', 'subscriptions-count', isLoggedIn ] );
+			},
+		}
+	);
+};
+
+export default usePostUnfollowMutation;

--- a/packages/data-stores/src/reader/test/mutations/use-post-unfollow-mutation.test.tsx
+++ b/packages/data-stores/src/reader/test/mutations/use-post-unfollow-mutation.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, waitFor } from '@testing-library/react';
+import React, { useEffect } from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { callApi } from '../../helpers';
+import usePostUnfollowMutation from '../../mutations/use-post-unfollow-mutation';
+
+// Mock the useIsLoggedIn function
+jest.mock( '../../hooks', () => ( {
+	useIsLoggedIn: jest.fn().mockReturnValue( true ),
+} ) );
+
+// Mock the entire Helpers module
+jest.mock( '../../helpers', () => ( {
+	callApi: jest.fn(),
+} ) );
+
+const client = new QueryClient();
+const Parent = ( { children } ) => (
+	<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
+);
+
+describe( 'usePostUnfollowMutation()', () => {
+	it( 'calls the right API', async () => {
+		const Skeleton = () => {
+			const { mutate } = usePostUnfollowMutation();
+			useEffect( () => {
+				mutate( {
+					blog_id: 123,
+					post_id: 456,
+				} );
+			}, [ mutate ] );
+
+			return <p></p>;
+		};
+
+		( callApi as jest.Mock ).mockResolvedValue( {
+			success: true,
+		} );
+
+		render(
+			<Parent>
+				<Skeleton />
+			</Parent>
+		);
+
+		await waitFor( () =>
+			expect( callApi ).toHaveBeenCalledWith( {
+				apiVersion: '1.2',
+				path: '/read/site/123/comment_email_subscriptions/delete?post_id=456',
+				isLoggedIn: true,
+				method: 'POST',
+			} )
+		);
+	} );
+} );

--- a/packages/data-stores/src/reader/test/mutations/use-site-delivery-frequency-mutation.test.tsx
+++ b/packages/data-stores/src/reader/test/mutations/use-site-delivery-frequency-mutation.test.tsx
@@ -2,19 +2,19 @@
  * @jest-environment jsdom
  */
 import { render, waitFor } from '@testing-library/react';
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { callApi } from '../helpers';
-import useSiteDeliveryFrequencyMutation from '../mutations/use-site-delivery-frequency-mutation';
+import { callApi } from '../../helpers';
+import useSiteDeliveryFrequencyMutation from '../../mutations/use-site-delivery-frequency-mutation';
 
 // Mock the useIsLoggedIn function
-jest.mock( '../hooks', () => ( {
+jest.mock( '../../hooks', () => ( {
 	useIsLoggedIn: jest.fn().mockReturnValue( { isLoggedIn: true } ),
 	useCacheKey: jest.fn(),
 } ) );
 
 // Mock the entire Helpers module
-jest.mock( '../helpers', () => ( {
+jest.mock( '../../helpers', () => ( {
 	callApi: jest.fn(),
 	applyCallbackToPages: jest.fn(),
 } ) );
@@ -24,7 +24,7 @@ const Parent = ( { children } ) => (
 	<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
 );
 
-describe( 'useSubscriptionManagerSiteDeliveryFrequencyMutation()', () => {
+describe( 'useSiteDeliveryFrequencyMutation()', () => {
 	it( 'calls the right API', async () => {
 		const Skeleton = () => {
 			const { mutate } = useSiteDeliveryFrequencyMutation();


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/75708

## Proposed Changes

* Creates `usePostUnfollowMutation` hook
* Creates tests for `usePostUnfollowMutation`
* Rename `useSiteDeliveryFrequencyMutation` tests

## Testing Instructions

* Run this PR on your local env
* Edit `CommentRow` component with the following changes:
  * Replace `SITE_ID` and `POST_ID` with your own ids
  * The test user should be following the post you want to unfollow
```js
import { SubscriptionManager } from '@automattic/data-stores';
...
const { mutate: unfollowPost } = SubscriptionManager.usePostUnfollowMutation();
...
<CommentSettings
    onUnfollow={ () => unfollowPost( { blog_id: <SITE_ID>, post_id: <POST_ID> } ) }
    unfollowing={ false }
/>

```
* Go to http://calypso.localhost:3000/subscriptions/comments
* On any row, click on ellipsis button, then on Unfollow Comments button
  * Check if the request succeeded
  * Go to https://wordpress.com/email-subscriptions/?option=comments
  * On comments tab, verify if the post was unfollowed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
