### PR TITLE
Plan expiring notice on My Home not showing CTA

### DIFF
--- a/client/components/swipeable/index.js
+++ b/client/components/swipeable/index.js
@@ -95,6 +95,9 @@ export const Swipeable = ( {
 
 	useLayoutEffect( () => {
 		if ( ! updateEnabled ) {
+			if ( pagesStyle?.height ) {
+				setPagesStyle( { ...pagesStyle, height: false } );
+			}
 			return;
 		}
 		const targetHeight = pagesRef.current?.querySelector( '.is-current' )?.offsetHeight;

--- a/client/components/swipeable/index.js
+++ b/client/components/swipeable/index.js
@@ -95,8 +95,10 @@ export const Swipeable = ( {
 
 	useLayoutEffect( () => {
 		if ( ! updateEnabled ) {
+			// This is a fix for a bug when you have >1 pages and it update the component to just one but the height is still
+			// Related to https://github.com/Automattic/dotcom-forge/issues/2033
 			if ( pagesStyle?.height ) {
-				setPagesStyle( { ...pagesStyle, height: false } );
+				setPagesStyle( { ...pagesStyle, height: undefined } );
 			}
 			return;
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2033

## Proposed Changes

The Plan expiring notice on My Home is not showing the `CTA button` or the `hide this`.
This problem happens only when your site is not expiring, and you see the top carousel, then the site expires and you reload the page.
At first, it shows the carousel and adds the height CSS style to the swipeable card, but when the site loads the new cards (the site-expiring card only), it re-renders the component but keeps the height CSS style.
To avoid this, I clean the height CSS style when no needed (only 1 card)

## Screenshots
| Before | After |
| --- | --- |
| <img width="420" alt="image" src="https://user-images.githubusercontent.com/402286/231906861-3772c80e-f355-4804-a924-371221b8898a.png"> | <img width="420" alt="image" src="https://user-images.githubusercontent.com/402286/231906895-c18edd94-503e-4e25-a917-7da966645c2b.png"> |
| ![image](https://user-images.githubusercontent.com/402286/231907007-b896d721-b5f7-4854-ad68-fe71484db5c4.png) | ![image](https://user-images.githubusercontent.com/402286/231907046-c1c0a4fd-e59b-4dba-bda5-4b8f06deddf1.png) |



## Testing Instructions

* Go to /home using a site with a Business plan that not expires soon.
* You should see the Top carousel
* Change the expiration date of the site close to expire (you can use SA)
* Reload the /home page
* Verify it works with different screen resolutions

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
