### PR TITLE
E2E: another round of updates to the Editor: Advanced Post Flow for AT/Simple compatibility.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/paragraph-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/paragraph-block.ts
@@ -1,9 +1,5 @@
 import { Page, ElementHandle } from 'playwright';
 
-const selectors = {
-	block: 'p',
-};
-
 /**
  * Represents the Paragraph block.
  */
@@ -43,7 +39,7 @@ export class ParagraphBlock {
 		contents: ( string | number )[]
 	): Promise< void > {
 		for await ( const content of contents ) {
-			await page.waitForSelector( `${ selectors.block }:text("${ content.toString() }")` );
+			await page.locator( `:text("${ content.toString() }"):visible` ).waitFor();
 		}
 	}
 }

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -46,15 +46,14 @@ describe( `Editor: Advanced Post Flow`, function () {
 	} );
 
 	describe( 'Publish post', function () {
-		beforeAll( async function () {
+		it( 'Start a new post from the Posts page', async function () {
 			postsPage = new PostsPage( page );
 			await postsPage.visit();
 			await postsPage.newPost();
-
-			editorPage = new EditorPage( page, { target: features.siteType } );
 		} );
 
 		it( 'Enter post title', async function () {
+			editorPage = new EditorPage( page, { target: features.siteType } );
 			await editorPage.enterTitle( postTitle );
 		} );
 
@@ -92,7 +91,7 @@ describe( `Editor: Advanced Post Flow`, function () {
 	} );
 
 	describe( 'Edit published post', function () {
-		beforeAll( async () => {
+		it( 'Re-open the published post from the Posts page', async function () {
 			// Redefine the `EditorPage` without the `target`
 			// optional parameter.
 			// This is critical because even AT sites load with
@@ -145,7 +144,7 @@ describe( `Editor: Advanced Post Flow`, function () {
 	} );
 
 	describe( 'Revert post to draft', function () {
-		beforeAll( async () => {
+		it( 'Re-open the published post from the Posts page', async function () {
 			// See: https://github.com/Automattic/wp-calypso/issues/74925
 			await postsPage.visit();
 			await postsPage.clickPost( postTitle );

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -14,22 +14,26 @@ import {
 	getTestAccountByFeature,
 	envToFeatureKey,
 	ElementHelper,
+	RestAPIClient,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function () {
+describe( `Editor: Advanced Post Flow`, function () {
+	// Authentication setup.
 	const features = envToFeatureKey( envVariables );
 	const accountName = getTestAccountByFeature( features, [
 		{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },
 	] );
 
+	// Post content setup.
 	const postTitle = `Post Life Cycle: ${ DataHelper.getTimestamp() }`;
 	const originalContent = DataHelper.getRandomPhrase();
 	const additionalContent = 'Updated post content';
 
 	let page: Page;
+	let testAccount: TestAccount;
 	let editorPage: EditorPage;
 	let postsPage: PostsPage;
 	let paragraphBlock: ParagraphBlock;
@@ -38,19 +42,19 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 	beforeAll( async function () {
 		page = await browser.newPage();
 
-		const testAccount = new TestAccount( accountName );
+		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
-
-		postsPage = new PostsPage( page );
-		await postsPage.visit();
-		await postsPage.newPost();
-	} );
-
-	beforeAll( async function () {
-		editorPage = new EditorPage( page, { target: features.siteType } );
 	} );
 
 	describe( 'Publish post', function () {
+		beforeAll( async function () {
+			postsPage = new PostsPage( page );
+			await postsPage.visit();
+			await postsPage.newPost();
+
+			editorPage = new EditorPage( page, { target: features.siteType } );
+		} );
+
 		it( 'Enter post title', async function () {
 			await editorPage.enterTitle( postTitle );
 		} );
@@ -73,12 +77,13 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 		 * Validates post in the same tab to work around an issue with AT caching.
 		 *
 		 * @see https://github.com/Automattic/wp-calypso/pull/67964
+		 *
+		 * Retries due to possible cache issue.
+		 * @see https://github.com/Automattic/wp-calypso/issues/57503
 		 */
 		it( 'Validate post', async function () {
 			await page.goto( postURL.href );
 
-			// Work around issue:
-			// https://github.com/Automattic/wp-calypso/issues/57503
 			await ElementHelper.reloadAndRetry( page, validatePublishedPage );
 
 			async function validatePublishedPage(): Promise< void > {
@@ -89,8 +94,11 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 
 	describe( 'Edit published post', function () {
 		beforeAll( async () => {
-			// See: https://github.com/Automattic/wp-calypso/issues/74925
-			await page.goBack();
+			// // See: https://github.com/Automattic/wp-calypso/issues/74925
+			// await page.goBack();
+			await postsPage.visit();
+			await postsPage.clickPost( postTitle );
+			editorPage = new EditorPage( page );
 		} );
 
 		it( 'Editor is shown', async function () {
@@ -115,15 +123,33 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 		 * Validates post in the same tab to work around an issue with AT caching.
 		 *
 		 * @see https://github.com/Automattic/wp-calypso/pull/67964
+		 *
+		 * Retries due to possible cache issue.
+		 * @see https://github.com/Automattic/wp-calypso/issues/57503
 		 */
 		it( 'Ensure published post contains additional content', async function () {
 			await page.goto( postURL.href );
-			await ParagraphBlock.validatePublishedContent( page, [ originalContent, additionalContent ] );
-			await page.goBack();
+
+			await ElementHelper.reloadAndRetry( page, validatePublishedPage );
+
+			async function validatePublishedPage(): Promise< void > {
+				await ParagraphBlock.validatePublishedContent( page, [
+					originalContent,
+					additionalContent,
+				] );
+			}
 		} );
 	} );
 
 	describe( 'Revert post to draft', function () {
+		beforeAll( async () => {
+			// See: https://github.com/Automattic/wp-calypso/issues/74925
+			// await page.goBack();
+			await postsPage.visit();
+			await postsPage.clickPost( postTitle );
+			editorPage = new EditorPage( page );
+		} );
+
 		it( 'Switch to draft', async function () {
 			await editorPage.unpublish();
 		} );
@@ -176,5 +202,9 @@ describe( DataHelper.createSuiteTitle( `Editor: Advanced Post Flow` ), function 
 				type: 'Success',
 			} );
 		} );
+	} );
+
+	afterAll( async function () {
+		const restAPIClient = new RestAPIClient( testAccount.credentials );
 	} );
 } );

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -14,7 +14,6 @@ import {
 	getTestAccountByFeature,
 	envToFeatureKey,
 	ElementHelper,
-	RestAPIClient,
 } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
@@ -202,9 +201,5 @@ describe( `Editor: Advanced Post Flow`, function () {
 				type: 'Success',
 			} );
 		} );
-	} );
-
-	afterAll( async function () {
-		const restAPIClient = new RestAPIClient( testAccount.credentials );
 	} );
 } );

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -93,8 +93,12 @@ describe( `Editor: Advanced Post Flow`, function () {
 
 	describe( 'Edit published post', function () {
 		beforeAll( async () => {
-			// // See: https://github.com/Automattic/wp-calypso/issues/74925
-			// await page.goBack();
+			// Redefine the `EditorPage` without the `target`
+			// optional parameter.
+			// This is critical because even AT sites load with
+			// an iframe when the post is opened from the
+			// PostsPage.
+			// See: https://github.com/Automattic/wp-calypso/issues/74925
 			await postsPage.visit();
 			await postsPage.clickPost( postTitle );
 			editorPage = new EditorPage( page );
@@ -143,7 +147,6 @@ describe( `Editor: Advanced Post Flow`, function () {
 	describe( 'Revert post to draft', function () {
 		beforeAll( async () => {
 			// See: https://github.com/Automattic/wp-calypso/issues/74925
-			// await page.goBack();
 			await postsPage.visit();
 			await postsPage.clickPost( postTitle );
 			editorPage = new EditorPage( page );


### PR DESCRIPTION
Fixes #75670.

## Proposed Changes

This PR is the latest round in attempts to make the Editor: Advanced Post Flow more compatible between AT and Simple.

For previous attempts, please see https://github.com/Automattic/wp-calypso/pull/74982, https://github.com/Automattic/wp-calypso/pull/73561, https://github.com/Automattic/wp-calypso/pull/67964 and https://github.com/Automattic/wp-calypso/pull/63037.

Key changes:
- re-opening the editor to make further changes to the published post is now done through the `PostsPage` POM.

Context:
Due to issue described in https://github.com/Automattic/wp-calypso/issues/74925#issuecomment-1483692670, the editor that is loaded from `PostsPage` is the Calypso iFramed editor - even if the site is AT, which _should not_ have the iframe. The root cause for this is unknown, but to work around this issue, the `EditorPage` POM is redefined in subsequent test steps without the optional `features.siteType` being passed in.

## Testing Instructions
Ensure the following build configurations are passing:
  - [x] Gutenberg E2E AT (desktop)
  - [x] Gutenberg E2E Simple (desktop)
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)

Gutenberg E2E AT (desktop)
![image](https://user-images.githubusercontent.com/6549265/231929281-755e8ca6-476c-4bfc-87b0-1be3bace01ba.png)

Gutenberg E2E Simple (desktop)
![image](https://user-images.githubusercontent.com/6549265/231929318-5e0e6919-714d-4247-b77b-89dfe9982917.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
