### PR TITLE
Authentication E2E: use first locator for the password field for Google spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/external/google-login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/external/google-login-page.ts
@@ -32,7 +32,7 @@ export class GoogleLoginPage {
 	private async waitUntilStable( locator: Locator ) {
 		const elementHandle = await locator.elementHandle();
 		await Promise.all( [
-			locator.waitFor( { state: 'visible' } ),
+			locator.first().waitFor( { state: 'visible' } ),
 			elementHandle?.waitForElementState( 'stable' ),
 		] );
 	}


### PR DESCRIPTION

Closes #75739.

## Proposed Changes

This PR uses the first locator when testing the Google Authentication spec.

## Testing Instructions
Ensure the following build configurations are passing:
  - [x] Authentication E2E

![image](https://user-images.githubusercontent.com/6549265/231937201-f59a939a-4ea3-429c-8bd9-d20213add484.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
