### PR TITLE
Hosting onboarding: add refund notice to plans

### DIFF
--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -22,6 +22,7 @@ import {
 	PlanSlug,
 } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
+import { isHostingFlow } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
@@ -381,6 +382,7 @@ export class PlanFeatures2023Grid extends Component<
 					<tr>{ this.renderPlanPrice( planPropertiesObj ) }</tr>
 					<tr>{ this.renderBillingTimeframe( planPropertiesObj ) }</tr>
 					<tr>{ this.renderTopButtons( planPropertiesObj ) }</tr>
+					<tr>{ this.maybeRenderRefundNotice( planPropertiesObj ) }</tr>
 					<tr>{ this.renderPreviousFeaturesIncludedTitle( planPropertiesObj ) }</tr>
 					<tr>{ this.renderPlanFeaturesList( planPropertiesObj ) }</tr>
 					<tr>{ this.renderPlanStorageOptions( planPropertiesObj ) }</tr>
@@ -689,6 +691,32 @@ export class PlanFeatures2023Grid extends Component<
 					</Container>
 				);
 			} );
+	}
+
+	maybeRenderRefundNotice( planPropertiesObj: PlanProperties[] ) {
+		const { translate, flowName } = this.props;
+
+		if ( ! isHostingFlow( flowName ) ) {
+			return false;
+		}
+
+		return planPropertiesObj
+			.filter( ( { isVisible } ) => isVisible )
+			.map( ( planProperties ) => (
+				<td>
+					<div
+						className={ `plan-features-2023-grid__refund-notice ${ getPlanClass(
+							planProperties.planName
+						) }` }
+					>
+						{ translate( 'Refundable within %(dayCount)s days. No questions asked.', {
+							args: {
+								dayCount: planProperties.billingPeriod === 365 ? 14 : 7,
+							},
+						} ) }
+					</div>
+				</td>
+			) );
 	}
 
 	renderEnterpriseClientLogos() {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -449,6 +449,7 @@ export class PlanFeatures2023Grid extends Component<
 						{ this.renderBillingTimeframe( [ properties ], { isMobile: true } ) }
 						{ this.renderMobileFreeDomain( properties.planName, properties.isMonthlyPlan ) }
 						{ this.renderTopButtons( [ properties ], { isMobile: true } ) }
+						{ this.maybeRenderRefundNotice( [ properties ], { isMobile: true } ) }
 						<CardContainer
 							header={ translate( 'Show all features' ) }
 							planName={ properties.planName }
@@ -693,7 +694,7 @@ export class PlanFeatures2023Grid extends Component<
 			} );
 	}
 
-	maybeRenderRefundNotice( planPropertiesObj: PlanProperties[] ) {
+	maybeRenderRefundNotice( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
 		const { translate, flowName } = this.props;
 
 		if ( ! isHostingFlow( flowName ) ) {
@@ -703,7 +704,7 @@ export class PlanFeatures2023Grid extends Component<
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( planProperties ) => (
-				<td key={ planProperties.planName }>
+				<Container key={ planProperties.planName } isMobile={ options?.isMobile }>
 					<div
 						className={ `plan-features-2023-grid__refund-notice ${ getPlanClass(
 							planProperties.planName
@@ -715,7 +716,7 @@ export class PlanFeatures2023Grid extends Component<
 							},
 						} ) }
 					</div>
-				</td>
+				</Container>
 			) );
 	}
 

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -703,7 +703,7 @@ export class PlanFeatures2023Grid extends Component<
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( planProperties ) => (
-				<td>
+				<td key={ planProperties.planName }>
 					<div
 						className={ `plan-features-2023-grid__refund-notice ${ getPlanClass(
 							planProperties.planName

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -704,7 +704,11 @@ export class PlanFeatures2023Grid extends Component<
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( planProperties ) => (
-				<Container key={ planProperties.planName } isMobile={ options?.isMobile }>
+				<Container
+					key={ planProperties.planName }
+					className="plan-features-2023-grid__table-item"
+					isMobile={ options?.isMobile }
+				>
 					<div
 						className={ `plan-features-2023-grid__refund-notice ${ getPlanClass(
 							planProperties.planName

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -1049,3 +1049,18 @@ body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup_
 	margin-left: auto !important;
 	margin-right: auto !important;
 }
+
+.plan-features-2023-grid__refund-notice {
+	text-align: center;
+	padding-top: 8px;
+	font-size: $font-body-extra-small;
+	line-height: 16px;
+
+	&.is-business-plan {
+		color: #7f54b3;
+	}
+
+	&.is-ecommerce-plan {
+		color: #55347d;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/2116

## Proposed Changes

* Add refund copy below the plan top button. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Try `/start` to see the regular plans are unchanged
* Visit `/start/hosting` and confirm you see the message shown below (mobile and desktop)

![image](https://user-images.githubusercontent.com/6851384/231938657-03a8a51e-1614-4498-a901-da7ea68e7cf1.png)

<img width="1007" alt="Screenshot 2566-04-14 at 10 48 52" src="https://user-images.githubusercontent.com/6851384/231936860-ea9fb4d5-b507-4d73-a4f0-6b57fe6e8765.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
