### PR TITLE
Flaky E2E: only run the `Support: Show me where` spec for Simple sites and switch to locator.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/support-component.ts
+++ b/packages/calypso-e2e/src/lib/components/support-component.ts
@@ -87,13 +87,10 @@ export class SupportComponent {
 
 	/**
 	 * Wait for and scroll to expose the Support card, present only on My Home.
-	 *
-	 * @returns {Promise<void>} No return value.
 	 */
 	async showSupportCard(): Promise< void > {
-		const elementHandle = await this.page.waitForSelector( selectors.supportCard );
-		await elementHandle.waitForElementState( 'stable' );
-		await elementHandle.scrollIntoViewIfNeeded();
+		const locator = this.page.locator( selectors.supportCard );
+		await Promise.all( [ locator.waitFor(), locator.scrollIntoViewIfNeeded() ] );
 	}
 
 	/* Result methods */

--- a/test/e2e/specs/support/support__showme-where.ts
+++ b/test/e2e/specs/support/support__showme-where.ts
@@ -2,46 +2,35 @@
  * @group calypso-pr
  */
 
-import {
-	DataHelper,
-	SupportComponent,
-	TestAccount,
-	TestAccountName,
-} from '@automattic/calypso-e2e';
+import { SupportComponent, TestAccount } from '@automattic/calypso-e2e';
 import { Browser, Page } from 'playwright';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Support: Show me where' ), function () {
+describe( 'Support: Show me where', function () {
 	let page: Page;
+	let supportComponent: SupportComponent;
 
-	describe.each( [
-		{ siteType: 'Simple', accountName: 'defaultUser' as TestAccountName },
-		{ siteType: 'Atomic', accountName: 'atomicUser' as TestAccountName },
-	] )( 'Search and view a support article ($siteType)', function ( { accountName } ) {
-		let supportComponent: SupportComponent;
+	beforeAll( async () => {
+		page = await browser.newPage();
 
-		beforeAll( async () => {
-			page = await browser.newPage();
+		const testAccount = new TestAccount( 'defaultUser' );
+		await testAccount.authenticate( page );
+	} );
 
-			const testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
-		} );
+	it( 'Search for help: Create a site', async function () {
+		supportComponent = new SupportComponent( page );
+		await supportComponent.showSupportCard();
+		await supportComponent.search( 'create a site' );
+		const results = await supportComponent.getResults( 'article' );
+		expect( await results.count() ).toBeGreaterThan( 0 );
+	} );
 
-		it( 'Search for help: Create a site', async function () {
-			supportComponent = new SupportComponent( page );
-			await supportComponent.showSupportCard();
-			await supportComponent.search( 'create a site' );
-			const results = await supportComponent.getResults( 'article' );
-			expect( await results.count() ).toBeGreaterThan( 0 );
-		} );
+	it( 'Click on result under Show me where', async function () {
+		await supportComponent.clickResult( 'where', 1 );
+	} );
 
-		it( 'Click on result under Show me where', async function () {
-			await Promise.all( [ page.waitForNavigation(), supportComponent.clickResult( 'where', 1 ) ] );
-		} );
-
-		it( 'Signup flow is started', async function () {
-			await page.waitForURL( '**/start/**' );
-		} );
+	it( 'Signup flow is started', async function () {
+		await page.waitForURL( /start/ );
 	} );
 } );


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/75673.

## Proposed Changes

This PR makes changes to the scope of the aforementioned spec as well as replacing the use of ElementHandle with a Locator.

Key changes:
- discontinue running the spec for AT users. 
- use Locator instead of ElementHandle when locating the support card.

For the reduction in scope, the justification is two-part
1. while the coverage for AT can be useful, we have not seen the Support card fail on AT but not on Simple (or vice versa).
2. this spec is likely better suited as a React component test.

## Testing Instructions
Ensure the following build configurations are passing:
  - [ ] Calypso E2E (desktop)
  - [ ] Calypso E2E (mobile)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
