### PR TITLE
Jetpack Pro Dashboard: refactor TS types 

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
@@ -52,14 +52,14 @@ describe( '<SiteCard>', () => {
 				value: siteObj,
 				error: true,
 				type: 'site',
-				status: '',
+				status: 'active',
 			},
 			backup: {
 				type: 'backup',
-				status: '',
+				status: 'inactive',
 				value: '',
 			},
-			monitor: { error: false, type: 'monitor', status: '', value: '' },
+			monitor: { error: false, type: 'monitor', status: 'inactive', value: '' },
 			scan: { threats: 3, type: 'scan', status: 'failed', value: '3 Threats' },
 			plugin: { updates: 3, type: 'plugin', status: 'warning', value: '3 Available' },
 		};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
@@ -17,7 +17,7 @@ export default function SiteSelectCheckbox( { item, siteError, isLargeScreen }: 
 	);
 
 	function handleCheckboxClick() {
-		item.onSelect( item );
+		item.onSelect?.();
 		recordEvent( item.isSelected ? 'site_unselected' : 'site_selected' );
 	}
 
@@ -25,7 +25,7 @@ export default function SiteSelectCheckbox( { item, siteError, isLargeScreen }: 
 		<span className="site-select-checkbox">
 			<FormInputCheckbox
 				className="disable-card-expand"
-				id={ item.blog_id }
+				id={ `${ item.site.value.blog_id }` }
 				onClick={ handleCheckboxClick }
 				checked={ item.isSelected }
 				readOnly={ true }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
@@ -54,7 +54,7 @@ describe( '<SiteTableRow>', () => {
 			value: siteObj,
 			error: false,
 			type: 'site',
-			status: '',
+			status: 'active',
 		},
 		backup: {
 			type: 'backup',
@@ -96,6 +96,7 @@ describe( '<SiteTableRow>', () => {
 			throw new Error( 'Function not implemented.' );
 		},
 		isExpanded: false,
+		index: 0,
 	};
 	const initialState = {
 		partnerPortal: {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -56,7 +56,7 @@ describe( '<SiteTable>', () => {
 				value: siteObj,
 				error: false,
 				type: 'site',
-				status: '',
+				status: 'active',
 			},
 			backup: {
 				type: 'backup',

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/utils.ts
@@ -33,7 +33,7 @@ describe( 'utils', () => {
 				value: siteObj,
 				error: false,
 				type: 'site',
-				status: '',
+				status: 'active',
 			},
 			backup: {
 				type: 'backup',
@@ -201,7 +201,7 @@ describe( 'utils', () => {
 				{
 					site: {
 						error: true,
-						status: '',
+						status: 'active',
 						type: 'site',
 						value: sites[ 0 ],
 					},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -66,7 +66,7 @@ export interface Site {
 	monitor_last_status_change: string;
 	isSelected?: boolean;
 	site_stats: SiteStats;
-	onSelect?: ( value: boolean ) => void;
+	onSelect?: () => void;
 	jetpack_boost_scores: BoostData;
 	php_version_num: number;
 }
@@ -130,7 +130,7 @@ export interface SiteData {
 export interface RowMetaData {
 	row: {
 		value: Site | SiteStats | BoostData | ReactChild;
-		status: AllowedStatusTypes | string;
+		status: AllowedStatusTypes;
 		error?: boolean;
 	};
 	link: string;
@@ -150,11 +150,11 @@ export type Preference = {
 };
 
 export type StatusEventNames = {
-	[ key in AllowedStatusTypes | string ]: { small_screen: string; large_screen: string };
+	[ key in AllowedStatusTypes ]?: { small_screen: string; large_screen: string };
 };
 
 export type StatusTooltip = {
-	[ key in AllowedStatusTypes | string ]: ReactChild;
+	[ key in AllowedStatusTypes ]?: ReactChild;
 };
 
 export type AllowedActionTypes = 'issue_license' | 'view_activity' | 'view_site' | 'visit_wp_admin';
@@ -190,7 +190,7 @@ export type AgencyDashboardFilterOption =
 	| 'plugin_updates';
 
 export type AgencyDashboardFilter = {
-	issueTypes: Array< AgencyDashboardFilterOption | string >;
+	issueTypes: Array< AgencyDashboardFilterOption >;
 	showOnlyFavorites: boolean;
 };
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -57,7 +57,7 @@ export interface Site {
 	has_scan: boolean;
 	has_backup: boolean;
 	has_boost: boolean;
-	latest_scan_threats_found: Array< any >;
+	latest_scan_threats_found: Array< string >;
 	latest_backup_status: string;
 	is_connection_healthy: boolean;
 	awaiting_plugin_updates: Array< string >;
@@ -74,7 +74,7 @@ export interface SiteNode {
 	value: Site;
 	error: boolean;
 	type: AllowedTypes;
-	status: AllowedStatusTypes | string;
+	status: AllowedStatusTypes;
 }
 
 export interface StatsNode {
@@ -90,13 +90,13 @@ export interface BoostNode {
 }
 export interface BackupNode {
 	type: AllowedTypes;
-	status: AllowedStatusTypes | string;
+	status: AllowedStatusTypes;
 	value: ReactChild;
 }
 
 export interface ScanNode {
 	type: AllowedTypes;
-	status: AllowedStatusTypes | string;
+	status: AllowedStatusTypes;
 	value: ReactChild;
 	threats: number;
 }
@@ -109,7 +109,7 @@ interface PluginNode {
 }
 export interface MonitorNode {
 	type: AllowedTypes;
-	status: AllowedStatusTypes | string;
+	status: AllowedStatusTypes;
 	value: ReactChild;
 	error?: boolean;
 	settings?: MonitorSettings;
@@ -123,7 +123,8 @@ export interface SiteData {
 	plugin: PluginNode;
 	monitor: MonitorNode;
 	isFavorite?: boolean;
-	[ key: string ]: any;
+	isSelected?: boolean;
+	onSelect?: () => void;
 }
 
 export interface RowMetaData {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -362,14 +362,14 @@ const formatBoostData = ( site: Site ) => {
 };
 
 const formatBackupData = ( site: Site ) => {
-	const backup: BackupNode = {
+	const backup = {
 		value: '',
 		status: '',
 		type: 'backup',
 	};
 	if ( ! site.has_backup ) {
 		backup.status = 'inactive';
-		return backup;
+		return backup as BackupNode;
 	}
 	switch ( site.latest_backup_status ) {
 		case 'rewind_backup_complete':
@@ -392,11 +392,11 @@ const formatBackupData = ( site: Site ) => {
 			backup.status = 'progress';
 			break;
 	}
-	return backup;
+	return backup as BackupNode;
 };
 
 const formatScanData = ( site: Site ) => {
-	const scan: ScanNode = {
+	const scan = {
 		value: '',
 		status: '',
 		type: 'scan',
@@ -416,16 +416,16 @@ const formatScanData = ( site: Site ) => {
 					threats: scanThreats,
 				},
 			}
-		);
+		) as string;
 		scan.threats = scanThreats;
 	} else {
 		scan.status = 'success';
 	}
-	return scan;
+	return scan as ScanNode;
 };
 
 const formatMonitorData = ( site: Site ) => {
-	const monitor: MonitorNode = {
+	const monitor = {
 		value: '',
 		status: '',
 		type: 'monitor',
@@ -448,7 +448,7 @@ const formatMonitorData = ( site: Site ) => {
 	} else {
 		monitor.status = 'success';
 	}
-	return monitor;
+	return monitor as MonitorNode;
 };
 
 /**
@@ -461,7 +461,7 @@ export const formatSites = ( sites: Array< Site > = [] ): Array< SiteData > | []
 			site: {
 				value: site,
 				error: ! site.is_connection_healthy,
-				status: '',
+				status: 'active',
 				type: 'site',
 			},
 			stats: formatStatsData( site ),

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -190,7 +190,7 @@ const pluginEventNames: StatusEventNames = {
 // Returns event name needed for all the feature state clicks on the agency dashboard
 const getRowEventName = (
 	type: AllowedTypes,
-	status: AllowedStatusTypes | string,
+	status: AllowedStatusTypes,
 	isLargeScreen: boolean
 ) => {
 	const deviceKey = isLargeScreen ? 'large_screen' : 'small_screen';
@@ -237,7 +237,7 @@ const pluginTooltips: StatusTooltip = {
 	success: translate( 'No plugin updates found' ),
 };
 
-const getTooltip = ( type: AllowedTypes, status: string ) => {
+const getTooltip = ( type: AllowedTypes, status: AllowedStatusTypes ) => {
 	switch ( type ) {
 		case 'backup': {
 			return backupTooltips?.[ status ];

--- a/client/state/jetpack-agency-dashboard/actions.ts
+++ b/client/state/jetpack-agency-dashboard/actions.ts
@@ -3,6 +3,7 @@ import { AnyAction } from 'redux';
 import {
 	AgencyDashboardFilterOption,
 	PurchasedProductsInfo,
+	DashboardSortInterface,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import { addQueryArgs } from 'calypso/lib/url';
 import './init';
@@ -27,7 +28,7 @@ export const updateDashboardURLQueryArgs = ( {
 	search,
 }: {
 	filter?: AgencyDashboardFilterOption[];
-	sort?: { field: string; direction: string };
+	sort?: DashboardSortInterface;
 	search?: string;
 } ) => {
 	const params = new URLSearchParams( window.location.search );
@@ -60,7 +61,7 @@ export const updateFilter = ( filter: AgencyDashboardFilterOption[] ) => () => {
 	updateDashboardURLQueryArgs( { filter } );
 };
 
-export const updateSort = ( sort: { field: string; direction: string } ) => () => {
+export const updateSort = ( sort: DashboardSortInterface ) => () => {
 	updateDashboardURLQueryArgs( { sort } );
 };
 


### PR DESCRIPTION
Related to 1202619025189113-as-1204178452896202

## Proposed Changes

This PR updates the TS types used in the Jetpack Pro Dashboard. 

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/refactor-ts-types-in-pro-dashboard` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on `Edit all` and verify that select/unselect works as expected. Also, perform some actions like Pause Monitor, Resume Monitor, etc., by selecting/unselecting sites. 
4. Since this PR doesn't include any much logic changes and more of type changes, verify that the changes look good. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?