### PR TITLE
Hosting onboarding: highlight refund window in hosting flow's checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -194,7 +194,13 @@ function CheckoutSummaryGiftFeaturesList( { siteSlug }: { siteSlug: string } ) {
 	);
 }
 
-function CheckoutSummaryRefundWindows( { cart }: { cart: ResponseCart } ) {
+function CheckoutSummaryRefundWindows( {
+	cart,
+	highlight = false,
+}: {
+	cart: ResponseCart;
+	highlight?: boolean;
+} ) {
 	const translate = useTranslate();
 
 	const refundPolicies = getRefundPolicies( cart );
@@ -291,7 +297,7 @@ function CheckoutSummaryRefundWindows( { cart }: { cart: ResponseCart } ) {
 	return (
 		<CheckoutSummaryFeaturesListItem>
 			<WPCheckoutCheckIcon id="features-list-refund-text" />
-			{ text }
+			{ highlight ? <strong>{ text }</strong> : text }
 		</CheckoutSummaryFeaturesListItem>
 	);
 }
@@ -378,7 +384,9 @@ function CheckoutSummaryFlowFeaturesList( { flowName }: { flowName: string } ) {
 					</CheckoutSummaryFeaturesListItem>
 				);
 			} ) }
-			{ isHostingFlow( flowName ) && <CheckoutSummaryRefundWindows cart={ responseCart } /> }
+			{ isHostingFlow( flowName ) && (
+				<CheckoutSummaryRefundWindows cart={ responseCart } highlight />
+			) }
 		</CheckoutSummaryFeaturesListWrapper>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2121
Reviewer can merge, but check the conversation above that this is the change we actually want to make.

**Notice that this PR isn't based off the `trunk` branch**

## Proposed Changes

Further highlights the refund window in the hosting flow's checkout by bolding the refund item in the list.

![image](https://user-images.githubusercontent.com/1500769/231952761-b2a74486-90ed-4fb9-93c7-53bdb520fb2e.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Business and Commerce plans selected in the hosting flow show the refund window in bold
* The link-in-bio flow's checkout shouldn't show the refund window in the list, and it certainly shouldn't be bold
* The regular `/start/onboarding` flow still shows the refund window in the checkout, but it shouldn't be bold

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
