### PR TITLE
Site Assembler: Update colors and fonts track events

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
@@ -58,4 +58,10 @@ export const PATTERN_ASSEMBLER_EVENTS = {
 		'calypso_signup_pattern_assembler_global_styles_gating_modal_checkout_button_click',
 	GLOBAL_STYLES_GATING_MODAL_UPGRADE_LATER_BUTTON_CLICK:
 		'calypso_signup_pattern_assembler_global_styles_gating_modal_upgrade_later_button_click',
+
+	/**
+	 * Large Preview
+	 */
+	LARGE_PREVIEW_ADD_HEADER_BUTTON_CLICK:
+		'calypso_signup_pattern_assembler_large_preview_add_header_button_click',
 } as const;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -38,7 +38,7 @@ import ScreenFooter from './screen-footer';
 import ScreenHeader from './screen-header';
 import ScreenMain from './screen-main';
 import ScreenSection from './screen-section';
-import { encodePatternId } from './utils';
+import { encodePatternId, getVariationTitle, getVariationType } from './utils';
 import withGlobalStylesProvider from './with-global-styles-provider';
 import type { Pattern } from './types';
 import type { StepProps } from '../../types';
@@ -111,8 +111,10 @@ const PatternAssembler = ( {
 				step: stepName,
 				intent,
 				stylesheet,
-				color_variation_title: colorVariation?.title,
-				font_variation_title: fontVariation?.title,
+				color_variation_title: getVariationTitle( colorVariation ),
+				color_variation_type: getVariationType( colorVariation ),
+				font_variation_title: getVariationTitle( fontVariation ),
+				font_variation_type: getVariationType( fontVariation ),
 			} ),
 		[ flow, stepName, intent, stylesheet, colorVariation, fontVariation ]
 	);
@@ -451,7 +453,8 @@ const PatternAssembler = ( {
 	const onScreenColorsSelect = ( variation: GlobalStylesObject | null ) => {
 		setColorVariation( variation );
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_COLORS_PREVIEW_CLICK, {
-			color_variation_title: variation?.title,
+			color_variation_title: getVariationTitle( variation ),
+			color_variation_type: getVariationType( variation ),
 		} );
 	};
 
@@ -466,7 +469,8 @@ const PatternAssembler = ( {
 	const onScreenFontsSelect = ( variation: GlobalStylesObject | null ) => {
 		setFontVariation( variation );
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_FONTS_PREVIEW_CLICK, {
-			font_variation_title: variation?.title,
+			font_variation_title: getVariationTitle( variation ),
+			font_variation_type: getVariationType( variation ),
 		} );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -451,7 +451,7 @@ const PatternAssembler = ( {
 	const onScreenColorsSelect = ( variation: GlobalStylesObject | null ) => {
 		setColorVariation( variation );
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_COLORS_PREVIEW_CLICK, {
-			title: variation?.title,
+			color_variation_title: variation?.title,
 		} );
 	};
 
@@ -466,7 +466,7 @@ const PatternAssembler = ( {
 	const onScreenFontsSelect = ( variation: GlobalStylesObject | null ) => {
 		setFontVariation( variation );
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_FONTS_PREVIEW_CLICK, {
-			title: variation?.title,
+			font_variation_title: variation?.title,
 		} );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -599,6 +599,7 @@ const PatternAssembler = ( {
 				onMoveDownSection={ onMoveDownSection }
 				onDeleteHeader={ onDeleteHeader }
 				onDeleteFooter={ onDeleteFooter }
+				recordTracksEvent={ recordTracksEvent }
 			/>
 			<PremiumGlobalStylesUpgradeModal { ...globalStylesUpgradeModalProps } />
 		</NavigatorProvider>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -6,12 +6,12 @@ import { Icon, layout } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useEffect, useState, CSSProperties } from 'react';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { NAVIGATOR_PATHS, STYLES_PATHS } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import PatternActionBar from './pattern-action-bar';
 import { encodePatternId } from './utils';
 import type { Pattern } from './types';
+import type { MouseEvent } from 'react';
 import './pattern-large-preview.scss';
 
 interface Props {
@@ -24,6 +24,7 @@ interface Props {
 	onMoveDownSection: ( position: number ) => void;
 	onDeleteHeader: () => void;
 	onDeleteFooter: () => void;
+	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 }
 
 // The pattern renderer element has 1px min height before the pattern is loaded
@@ -39,6 +40,7 @@ const PatternLargePreview = ( {
 	onMoveDownSection,
 	onDeleteHeader,
 	onDeleteFooter,
+	recordTracksEvent,
 }: Props ) => {
 	const translate = useTranslate();
 	const navigator = useNavigator();
@@ -57,6 +59,12 @@ const PatternLargePreview = ( {
 
 	const goToSelectHeaderPattern = () => {
 		navigator.goTo( NAVIGATOR_PATHS.HEADER );
+	};
+
+	const handleAddHeaderClick = ( event: MouseEvent ) => {
+		event.preventDefault();
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.LARGE_PREVIEW_ADD_HEADER_BUTTON_CLICK );
+		goToSelectHeaderPattern();
 	};
 
 	const renderPattern = ( type: string, pattern: Pattern, position = -1 ) => {
@@ -189,10 +197,7 @@ const PatternLargePreview = ( {
 													href="#"
 													target="_blank"
 													rel="noopener noreferrer"
-													onClick={ ( event ) => {
-														event.preventDefault();
-														goToSelectHeaderPattern();
-													} }
+													onClick={ handleAddHeaderClick }
 												/>
 											),
 										},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -1,7 +1,17 @@
+import { DEFAULT_VARIATION_TITLE, VariationType } from '@automattic/global-styles';
 import { PATTERN_SOURCE_SITE_ID } from './constants';
+import type { GlobalStylesObject } from '@automattic/global-styles';
 
 export const encodePatternId = ( patternId: number ) =>
 	`${ patternId }-${ PATTERN_SOURCE_SITE_ID }`;
 
 export const decodePatternId = ( encodedPatternId: number | string ) =>
 	`${ encodedPatternId }`.split( '-' )[ 0 ];
+
+export const getVariationTitle = ( variation: GlobalStylesObject | null ) =>
+	variation?.title ?? DEFAULT_VARIATION_TITLE;
+
+export const getVariationType = ( variation: GlobalStylesObject | null ): VariationType =>
+	variation && variation.title !== DEFAULT_VARIATION_TITLE
+		? VariationType.Premium
+		: VariationType.Free;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_VARIATION_TITLE, VariationType } from '@automattic/global-styles';
+import {
+	DEFAULT_GLOBAL_STYLES_VARIATION_TITLE,
+	GlobalStylesVariationType,
+} from '@automattic/global-styles';
 import { PATTERN_SOURCE_SITE_ID } from './constants';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 
@@ -9,9 +12,11 @@ export const decodePatternId = ( encodedPatternId: number | string ) =>
 	`${ encodedPatternId }`.split( '-' )[ 0 ];
 
 export const getVariationTitle = ( variation: GlobalStylesObject | null ) =>
-	variation?.title ?? DEFAULT_VARIATION_TITLE;
+	variation?.title ?? DEFAULT_GLOBAL_STYLES_VARIATION_TITLE;
 
-export const getVariationType = ( variation: GlobalStylesObject | null ): VariationType =>
-	variation && variation.title !== DEFAULT_VARIATION_TITLE
-		? VariationType.Premium
-		: VariationType.Free;
+export const getVariationType = (
+	variation: GlobalStylesObject | null
+): GlobalStylesVariationType =>
+	variation && variation.title !== DEFAULT_GLOBAL_STYLES_VARIATION_TITLE
+		? GlobalStylesVariationType.Premium
+		: GlobalStylesVariationType.Free;

--- a/packages/global-styles/src/constants.ts
+++ b/packages/global-styles/src/constants.ts
@@ -2,6 +2,6 @@ export const STYLE_PREVIEW_WIDTH = 248;
 export const STYLE_PREVIEW_HEIGHT = 152;
 export const STYLE_PREVIEW_COLOR_SWATCH_SIZE = 32;
 
-export const DEFAULT_VARIATION_TITLE = 'default';
+export const DEFAULT_GLOBAL_STYLES_VARIATION_TITLE = 'default';
 export const DEFAULT_GLOBAL_STYLES_VARIATION_SLUG = 'default';
 export const SYSTEM_FONT_SLUG = 'system-font';

--- a/packages/global-styles/src/constants.ts
+++ b/packages/global-styles/src/constants.ts
@@ -2,5 +2,6 @@ export const STYLE_PREVIEW_WIDTH = 248;
 export const STYLE_PREVIEW_HEIGHT = 152;
 export const STYLE_PREVIEW_COLOR_SWATCH_SIZE = 32;
 
+export const DEFAULT_VARIATION_TITLE = 'default';
 export const DEFAULT_GLOBAL_STYLES_VARIATION_SLUG = 'default';
 export const SYSTEM_FONT_SLUG = 'system-font';

--- a/packages/global-styles/src/index.tsx
+++ b/packages/global-styles/src/index.tsx
@@ -1,7 +1,10 @@
 // Re-export useStyle from `@automattic/global-styles` to avoid calypso using `@wordpress/edit-site` directly
 export { useStyle } from '@wordpress/edit-site/build-module/components/global-styles/hooks';
 export * from './components';
-export { DEFAULT_VARIATION_TITLE, DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from './constants';
+export {
+	DEFAULT_GLOBAL_STYLES_VARIATION_TITLE,
+	DEFAULT_GLOBAL_STYLES_VARIATION_SLUG,
+} from './constants';
 export {
 	useColorPaletteVariations,
 	useFontPairingVariations,

--- a/packages/global-styles/src/index.tsx
+++ b/packages/global-styles/src/index.tsx
@@ -1,6 +1,7 @@
 // Re-export useStyle from `@automattic/global-styles` to avoid calypso using `@wordpress/edit-site` directly
 export { useStyle } from '@wordpress/edit-site/build-module/components/global-styles/hooks';
 export * from './components';
+export { DEFAULT_VARIATION_TITLE, DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from './constants';
 export {
 	useColorPaletteVariations,
 	useFontPairingVariations,

--- a/packages/global-styles/src/types.ts
+++ b/packages/global-styles/src/types.ts
@@ -40,7 +40,7 @@ export interface GlobalStylesObject {
 	};
 }
 
-export enum VariationType {
+export enum GlobalStylesVariationType {
 	Free = 'free',
 	Premium = 'premium',
 }

--- a/packages/global-styles/src/types.ts
+++ b/packages/global-styles/src/types.ts
@@ -39,3 +39,8 @@ export interface GlobalStylesObject {
 		typography?: Typography;
 	};
 }
+
+export enum VariationType {
+	Free = 'free',
+	Premium = 'premium',
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2159

## Proposed Changes

* Change the `title` prop to `color_variation_title` or `font_variation_title` to make it clear. I think we don't need to know the previously selected variation when the user clicks other variations. But if we want, we can just rename it to something like `next_color_variation_title`.
* Add the props called `color_variation_type` and `font_variation_type` to track whether the selected variation is free or premium
* Add a new event to track the `adding a header pattern` button

![Screenshot 2023-04-14 at 2 14 20 PM](https://user-images.githubusercontent.com/13596067/231957693-4be4a460-9b99-42fc-bb7b-d759e60204ed.png)

![Screenshot 2023-04-14 at 2 14 59 PM](https://user-images.githubusercontent.com/13596067/231957711-c9ce5717-3c47-405d-b3fb-3fb9fdd4b087.png)

![image](https://user-images.githubusercontent.com/13596067/231981145-5e7c8a20-9e00-4a75-89bc-ba23740031ed.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_free_site>
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll to the bottom and select "Start designing"
* On the Pattern Assembler screen
  * Select `Colors`
  * Click the `adding a header pattern` text on the large preview, and verify `calypso_signup_pattern_assembler_large_preview_add_header_button_click` is fired
  * Select any color variation
  * Verify the track event, `calypso_signup_pattern_assembler_screen_colors_preview_click`, is fired with both `color_variation_title` and `color_variation_type`
  * Go back to select `Fonts`
  * Select any font variation
  * Verify the track event, `calypso_signup_pattern_assembler_screen_fonts_preview_click`, is fired with both `font_variation_title` and `font_variation_type`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
