### PR TITLE
Subscription manager: Change `useSiteSubscriptionsQuery` to use `useInfiniteQuery`

### DIFF
--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -1,4 +1,5 @@
-import { useQuery } from 'react-query';
+import { useEffect } from 'react';
+import { useInfiniteQuery } from 'react-query';
 import { callApi } from '../helpers';
 import { useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { SiteSubscription } from '../types';
@@ -15,37 +16,6 @@ type SubscriptionManagerSiteSubscriptionsQueryProps = {
 	number?: number;
 };
 
-const callFollowingEndPoint = async (
-	page: number,
-	number: number,
-	isLoggedIn: boolean
-): Promise< SiteSubscription[] > => {
-	const data = [];
-
-	const incoming = await callApi< SubscriptionManagerSiteSubscriptions >( {
-		path: `/read/following/mine?number=${ number }&page=${ page }`,
-		isLoggedIn,
-		apiVersion: '1.2',
-	} );
-
-	if ( incoming && incoming.subscriptions ) {
-		data.push(
-			...incoming.subscriptions.map( ( subscription ) => ( {
-				...subscription,
-				last_updated: new Date( subscription.last_updated ),
-				date_subscribed: new Date( subscription.date_subscribed ),
-			} ) )
-		);
-	}
-
-	if ( incoming.page * number < incoming.total_subscriptions ) {
-		const next = await callFollowingEndPoint( page + 1, number, isLoggedIn );
-		data.push( ...next );
-	}
-
-	return data;
-};
-
 const defaultFilter = () => true;
 const defaultSort = () => 0;
 
@@ -57,19 +27,44 @@ const useSiteSubscriptionsQuery = ( {
 	const isLoggedIn = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
 
-	const { data, ...rest } = useQuery< SiteSubscription[] >(
-		[ 'read', 'site-subscriptions', isLoggedIn ],
-		async () => {
-			return await callFollowingEndPoint( 1, number, isLoggedIn );
-		},
-		{
-			enabled,
-			refetchOnWindowFocus: false,
+	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isFetching, ...rest } =
+		useInfiniteQuery< SubscriptionManagerSiteSubscriptions >(
+			[ 'read', 'site-subscriptions', isLoggedIn ],
+			async ( { pageParam = 1 } ) => {
+				return await callApi< SubscriptionManagerSiteSubscriptions >( {
+					path: `/read/following/mine?number=${ number }&page=${ pageParam }`,
+					isLoggedIn,
+					apiVersion: '1.2',
+				} );
+			},
+			{
+				enabled,
+				getNextPageParam: ( lastPage, pages ) => {
+					return lastPage.page * number < lastPage.total_subscriptions
+						? pages.length + 1
+						: undefined;
+				},
+				refetchOnWindowFocus: false,
+			}
+		);
+
+	useEffect( () => {
+		if ( hasNextPage && ! isFetchingNextPage && ! isFetching ) {
+			fetchNextPage();
 		}
-	);
+	}, [ hasNextPage, isFetchingNextPage, isFetching, fetchNextPage ] );
+
+	// Flatten all the pages into a single array containing all subscriptions
+	const flattenedData = data?.pages?.map( ( page ) => page.subscriptions ).flat();
+	// Transform the dates into Date objects
+	const transformedData = flattenedData?.map( ( subscription ) => ( {
+		...subscription,
+		last_updated: new Date( subscription.last_updated ),
+		date_subscribed: new Date( subscription.date_subscribed ),
+	} ) );
 
 	return {
-		data: data?.filter( filter ).sort( sort ),
+		data: transformedData?.filter( filter ).sort( sort ),
 		...rest,
 	};
 };

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -65,6 +65,9 @@ const useSiteSubscriptionsQuery = ( {
 
 	return {
 		data: transformedData?.filter( filter ).sort( sort ),
+		isFetchingNextPage,
+		isFetching,
+		hasNextPage,
 		...rest,
 	};
 };


### PR DESCRIPTION
Closes [#75749](https://github.com/Automattic/wp-calypso/issues/75749)

## Proposed Changes

This changes the behavior of `useSiteSubscriptionsQuery` to use `useInfiniteQuery` under the hood. The advantage of this is that we will get data to display while the query is still fetching all the pages.

If we ever want to implement this as a real infinite scrolling list (load next page when reaching the end of the virtualized table), we just have to delete the `useEffect` and export `fetchNextPage` from this hook. 

## Testing Instructions

1. Apply this PR and make sure you have a valid subkey set
2. Since you probably don't have 100+ subscribers, update this file `packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts` and change line 25 to ```number = 1``` to make it fetch 1 subscription per fetch request.
3. Go to `http://calypso.localhost:3000/subscriptions/sites`
4. You should see data load one by one

![CleanShot 2023-04-14 at 08 40 24](https://user-images.githubusercontent.com/528287/231963723-f794d90d-e405-453d-bdce-305dd5dd782f.gif)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
