### PR TITLE
Clean up: Remove unused code in the Unified Design Picker

### DIFF
--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -178,10 +178,6 @@
 		}
 	}
 
-	.design-picker__image-frame-portrait {
-		padding-top: math.div(360px, 480px) * 200%; // Aspect ratio for the picker
-	}
-
 	.design-picker__image-frame-blank {
 		background: var(--studio-white);
 		display: flex;
@@ -232,15 +228,6 @@
 		margin-top: -0.1em;
 	}
 
-	.design-picker__options-style-variations {
-		align-items: center;
-		display: inline-flex;
-		justify-content: flex-end;
-		flex-grow: 1;
-		flex-wrap: wrap;
-		gap: 4px;
-	}
-
 	.design-picker__pricing-description {
 		align-items: flex-start;
 		color: #50575e;
@@ -264,63 +251,11 @@
 	}
 }
 
-// dark theme styles
-.design-picker.design-picker--theme-dark {
-	.design-picker__option-name {
-		color: var(--studio-white);
-	}
-
-	.design-picker__design-option {
-		.design-picker__design-option-header svg {
-			fill: var(--studio-gray-40);
-		}
-
-		.design-picker__design-option-header,
-		.design-picker__image-frame::after {
-			border-color: var(--studio-gray-40);
-		}
-
-		&:hover,
-		&:focus {
-			.design-picker__design-option-header,
-			.design-picker__image-frame::after {
-				border-color: var(--studio-white);
-			}
-		}
-	}
-
-	.design-button-container:hover,
-	.design-button-container:focus-within {
-		.design-picker__design-option-header,
-		.design-picker__image-frame::after {
-			border-color: var(--studio-white);
-		}
-	}
-
-	.theme-card {
-		&:hover,
-		&:focus-within {
-			.theme-card__image-container {
-				border-color: var(--studio-white);
-			}
-		}
-
-		.theme-card__image-container {
-			border-color: var(--studio-gray-40);
-		}
-	}
-
-	.design-button-container .design-picker__design-option .design-picker__image-frame:hover::after,
-	.theme-card .theme-card__image:hover::after {
-		background-color: rgba(255, 255, 255, 0.42);
-	}
-}
-
-// light theme styles
 .design-picker.design-picker--theme-light {
 	.design-picker__option-name {
 		color: var(--studio-gray-80);
 	}
+
 	.design-picker__design-option {
 		.design-picker__image-frame {
 			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
@@ -457,6 +392,10 @@
 				.theme-preview__container {
 					opacity: 0;
 					transition: opacity 1.5s ease-in-out;
+
+					.theme-preview__frame {
+						max-width: none;
+					}
 				}
 			}
 
@@ -620,7 +559,6 @@
 	}
 }
 
-
 .generated-design-thumbnail {
 	align-items: stretch;
 	border: 1px solid #ddd;
@@ -643,21 +581,6 @@
 	&:focus-visible {
 		border-color: #ddd;
 		outline: 2px solid var(--studio-blue-30);
-	}
-
-	.generated-design-thumbnail__header {
-		border-bottom: 1px solid #ddd;
-		box-sizing: border-box;
-		display: block;
-		height: 23px;
-		max-width: 100%;
-		padding: 0 12px;
-		position: relative;
-		text-align: left;
-
-		svg {
-			fill: var(--studio-gray-5);
-		}
 	}
 
 	.generated-design-thumbnail__image {
@@ -696,75 +619,5 @@
 		min-height: 100px;
 		max-height: 300px;
 		flex-basis: 100%;
-
-		.generated-design-thumbnail__header {
-			display: none;
-		}
-	}
-}
-
-.generated-design-picker__main {
-	height: 0;
-
-	@include break-small {
-		flex: 1;
-		height: auto;
-	}
-}
-
-.generated-design-preview {
-	.generated-design-preview__header {
-		align-items: center;
-		border-radius: 4px 4px 0 0;
-		border: 1px solid var(--studio-gray-5);
-		box-sizing: border-box;
-		display: flex;
-		height: 23px;
-		justify-content: center;
-		margin: 0 auto;
-		max-width: 100%;
-		position: relative;
-
-		svg {
-			fill: var(--studio-gray-5);
-			left: 8px;
-			position: absolute;
-		}
-	}
-
-	.generated-design-preview__frame {
-		border: 1px solid var(--studio-gray-5);
-		border-radius: 0 0 4px 4px;
-		border-top: 0;
-		box-sizing: border-box;
-		display: block;
-		line-height: 0;
-		max-height: 334px;
-		overflow: hidden;
-		position: relative;
-		width: 100%;
-	}
-
-	@include break-small {
-		display: none;
-
-		&.is-selected {
-			display: block;
-		}
-
-		.generated-design-preview__header {
-			border-radius: 8px 8px 0 0; /* stylelint-disable-line scales/radii */
-			height: 34px;
-
-			svg {
-				left: 12px;
-				transform: scale(1);
-			}
-		}
-
-		.generated-design-preview__frame {
-			border-radius: 0 0 8px 8px; /* stylelint-disable-line scales/radii */
-			max-height: none;
-		}
 	}
 }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -250,39 +250,6 @@ const DesignCard: React.FC< DesignCardProps > = ( {
 	);
 };
 
-interface DesignButtonContainerProps extends DesignCardProps {
-	category?: string | null;
-	onSelectBlankCanvas: ( design: Design, shouldGoToAssemblerStep: boolean ) => void;
-}
-
-const DesignButtonContainer: React.FC< DesignButtonContainerProps > = ( {
-	category,
-	onSelectBlankCanvas,
-	...props
-} ) => {
-	if ( isBlankCanvasDesign( props.design ) ) {
-		return (
-			<PatternAssemblerCta
-				onButtonClick={ ( shouldGoToAssemblerStep ) =>
-					onSelectBlankCanvas( props.design, shouldGoToAssemblerStep )
-				}
-			/>
-		);
-	}
-
-	return (
-		<DesignCard
-			category={ category }
-			design={ props.design }
-			locale={ props.locale }
-			verticalId={ props.verticalId }
-			isPremiumThemeAvailable={ props.isPremiumThemeAvailable }
-			onChangeVariation={ props.onChangeVariation }
-			onPreview={ props.onPreview }
-		/>
-	);
-};
-
 interface GeneratedDesignButtonContainerProps {
 	locale: string;
 	design: Design;
@@ -415,22 +382,34 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 				/>
 			) }
 			<div className="design-picker__grid">
-				{ filteredStaticDesigns.map( ( design, index ) => (
-					<DesignButtonContainer
-						category={ categorization?.selection }
-						key={ index }
-						design={ design }
-						locale={ locale }
-						onSelectBlankCanvas={ onSelectBlankCanvas }
-						onPreview={ onPreview }
-						onChangeVariation={ onChangeVariation }
-						isPremiumThemeAvailable={ isPremiumThemeAvailable }
-						verticalId={ verticalId }
-						hasPurchasedTheme={ wasThemePurchased( purchasedThemes, design ) }
-						currentPlanFeatures={ currentPlanFeatures }
-						shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
-					/>
-				) ) }
+				{ filteredStaticDesigns.map( ( design, index ) => {
+					if ( isBlankCanvasDesign( design ) ) {
+						return (
+							<PatternAssemblerCta
+								key={ index }
+								onButtonClick={ ( shouldGoToAssemblerStep ) =>
+									onSelectBlankCanvas( design, shouldGoToAssemblerStep )
+								}
+							/>
+						);
+					}
+
+					return (
+						<DesignCard
+							key={ index }
+							categories={ categorization?.categories }
+							design={ design }
+							locale={ locale }
+							verticalId={ verticalId }
+							currentPlanFeatures={ currentPlanFeatures }
+							hasPurchasedTheme={ wasThemePurchased( purchasedThemes, design ) }
+							isPremiumThemeAvailable={ isPremiumThemeAvailable }
+							shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
+							onChangeVariation={ onChangeVariation }
+							onPreview={ onPreview }
+						/>
+					);
+				} ) }
 				{ categorization?.selection === SHOW_GENERATED_DESIGNS_SLUG &&
 					generatedDesigns.map( ( design ) => (
 						<GeneratedDesignButtonContainer

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -397,7 +397,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 					return (
 						<DesignCard
 							key={ index }
-							category={ categorization?.categories }
+							category={ categorization?.selection }
 							design={ design }
 							locale={ locale }
 							verticalId={ verticalId }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -397,7 +397,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 					return (
 						<DesignCard
 							key={ index }
-							categories={ categorization?.categories }
+							category={ categorization?.categories }
 							design={ design }
 							locale={ locale }
 							verticalId={ verticalId }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75457

## Proposed Changes

This PR removes unused code caused by #75616, which delegates the rendering of theme cards to the `<ThemeCard />` component in `@automattic/design-picker`.

There is potentially much more code that can be removed, unfortunately the there are two existing components `<DesignPicker />` and `<UnifiedDesignPicker />` that are a bit intertwined. Both are still used in production. For the sake of timeboxing the clean-up task, this PR will focus on the code directly impacted #75616.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Onboarding Design Picker.
* Ensure that the UI works as the one in production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
