### PR TITLE
Plugin Management: update the empty state messages on the Plugins page.

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -383,6 +383,7 @@ export class PluginsMain extends Component {
 				isLoading={ this.props.requestingPluginsForSites }
 				isJetpackCloud={ this.props.isJetpackCloud }
 				searchTerm={ search }
+				filter={ this.props.filter }
 				requestPluginsError={ this.props.requestPluginsError }
 			/>
 		);

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -8,8 +8,10 @@ import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-
 import { resetPluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import PluginsList from './plugins-list';
 import UpdatePlugins from './update-plugins';
+import { pluginsEmptyMessage } from './utils/get-plugins-empty-message';
 import type { Plugin } from './types';
 import type { SiteDetails } from '@automattic/data-stores';
+import type { PluginFilter } from 'calypso/state/plugins/installed/types';
 
 import './style.scss';
 
@@ -24,6 +26,7 @@ interface Props {
 	removePluginNotice: ( plugin: Plugin ) => void;
 	updatePlugin: ( plugin: Plugin ) => void;
 	isJetpackCloud: boolean;
+	filter: PluginFilter;
 }
 export default function PluginManagementV2( {
 	plugins,
@@ -36,6 +39,7 @@ export default function PluginManagementV2( {
 	updatePlugin,
 	isJetpackCloud,
 	requestError,
+	filter,
 }: Props ): ReactElement | null {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -112,7 +116,7 @@ export default function PluginManagementV2( {
 		if ( requestError ) {
 			return null;
 		}
-		let emptyStateMessage = translate( 'No plugins found' );
+		let emptyStateMessage = pluginsEmptyMessage?.[ filter ];
 		if ( searchTerm ) {
 			emptyStateMessage = translate( 'No results found. Please try refining your search.' );
 		}

--- a/client/my-sites/plugins/plugin-management-v2/utils/get-plugins-empty-message.ts
+++ b/client/my-sites/plugins/plugin-management-v2/utils/get-plugins-empty-message.ts
@@ -1,0 +1,9 @@
+import { translate } from 'i18n-calypso';
+import { PluginFilter } from 'calypso/state/plugins/installed/types';
+
+export const pluginsEmptyMessage: { [ key in PluginFilter ]?: string } = {
+	all: translate( 'No plugins found.' ),
+	active: translate( 'No plugins are active.' ),
+	inactive: translate( 'No plugins are inactive.' ),
+	updates: translate( 'All plugins are up to date.' ),
+};

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -83,6 +83,10 @@ export class PluginsList extends Component {
 			return true;
 		}
 
+		if ( this.props.filter !== nextProps.filter ) {
+			return true;
+		}
+
 		if ( this.state.bulkManagementActive !== nextState.bulkManagementActive ) {
 			return true;
 		}
@@ -569,6 +573,7 @@ export class PluginsList extends Component {
 					isLoading={ this.props.isLoading }
 					selectedSite={ this.props.selectedSite }
 					searchTerm={ this.props.searchTerm }
+					filter={ this.props.filter }
 					isBulkManagementActive={ this.state.bulkManagementActive }
 					toggleBulkManagement={ this.toggleBulkManagement }
 					removePluginNotice={ this.removePluginDialog }


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/75756

## Proposed Changes

This PR updates the empty state messages on the Plugins page.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/plugins-empty-message-in-pro-dashboard` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on `Plugins` on the left nav
4. Verify the empty messages on all the tabs are as shown below. Click on any site name and verify the same on the Plugins page of the individual site.

The `All` tab

<img width="1418" alt="Screenshot 2023-04-14 at 2 23 13 PM" src="https://user-images.githubusercontent.com/10586875/231997748-1a03d1b5-d1a0-4b3a-9c7d-128aaf55dba4.png">

`Active` tab

<img width="1418" alt="Screenshot 2023-04-14 at 2 23 08 PM" src="https://user-images.githubusercontent.com/10586875/231997740-83b8ddb0-0734-41d8-a162-728669fddeb4.png">

`Inactive` tab

<img width="1418" alt="Screenshot 2023-04-14 at 2 21 57 PM" src="https://user-images.githubusercontent.com/10586875/231997729-0741133f-e297-45f1-94dc-00b9e12c3af8.png">

`Updates` tab

<img width="1418" alt="Screenshot 2023-04-14 at 2 19 26 PM" src="https://user-images.githubusercontent.com/10586875/231997713-8f25ef21-7768-42a8-9180-b77869698a30.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
