### PR TITLE
Global Styles Preview: Fix focus state

### DIFF
--- a/packages/global-styles/src/components/global-styles-variation-container/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variation-container/index.tsx
@@ -60,7 +60,13 @@ const GlobalStylesVariationContainer = ( {
 			contentRef={ useRefEffect( ( bodyElement ) => {
 				// Disable moving focus to the writing flow wrapper if the focus disappears
 				// See https://github.com/WordPress/gutenberg/blob/aa8e1c52c7cb497e224a479673e584baaca97113/packages/block-editor/src/components/writing-flow/use-tab-nav.js#L136
-				const onFocusOut = ( event: Event ) => event.stopImmediatePropagation();
+				const onFocusOut = ( event: Event ) => {
+					event.stopImmediatePropagation();
+
+					// Explicitly call blur handler, if available.
+					props.onBlur?.();
+				};
+
 				bodyElement.addEventListener( 'focusout', onFocusOut );
 				return () => {
 					bodyElement.removeEventListener( 'focusout', onFocusOut );

--- a/packages/global-styles/src/components/global-styles-variation-container/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variation-container/index.tsx
@@ -13,6 +13,7 @@ interface Props {
 	inlineCss?: string;
 	containerResizeListener: JSX.Element;
 	children: JSX.Element;
+	onFocusOut?: () => void;
 }
 
 const GlobalStylesVariationContainer = ( {
@@ -21,6 +22,7 @@ const GlobalStylesVariationContainer = ( {
 	inlineCss,
 	containerResizeListener,
 	children,
+	onFocusOut,
 	...props
 }: Props ) => {
 	const [ styles ] = useGlobalStylesOutput();
@@ -60,16 +62,16 @@ const GlobalStylesVariationContainer = ( {
 			contentRef={ useRefEffect( ( bodyElement ) => {
 				// Disable moving focus to the writing flow wrapper if the focus disappears
 				// See https://github.com/WordPress/gutenberg/blob/aa8e1c52c7cb497e224a479673e584baaca97113/packages/block-editor/src/components/writing-flow/use-tab-nav.js#L136
-				const onFocusOut = ( event: Event ) => {
+				const handleFocusOut = ( event: Event ) => {
 					event.stopImmediatePropagation();
 
-					// Explicitly call blur handler, if available.
-					props.onBlur?.();
+					// Explicitly call the focusOut handler, if available.
+					onFocusOut?.();
 				};
 
-				bodyElement.addEventListener( 'focusout', onFocusOut );
+				bodyElement.addEventListener( 'focusout', handleFocusOut );
 				return () => {
-					bodyElement.removeEventListener( 'focusout', onFocusOut );
+					bodyElement.removeEventListener( 'focusout', handleFocusOut );
 				};
 			}, [] ) }
 			scrolling="no"

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -59,6 +59,8 @@ const GlobalStylesVariation = ( {
 				'is-active': isActive,
 			} ) }
 			role="button"
+			onBlur={ () => setIsFocused( false ) }
+			onFocus={ () => setIsFocused( true ) }
 			onClick={ onSelect }
 			onKeyDown={ selectOnEnter }
 			tabIndex={ 0 }
@@ -77,8 +79,7 @@ const GlobalStylesVariation = ( {
 						title={ globalStylesVariation.title }
 						inlineCss={ globalStylesVariation.inline_css }
 						isFocused={ isFocused || showOnlyHoverView }
-						onBlur={ () => setIsFocused( false ) }
-						onFocus={ () => setIsFocused( true ) }
+						onFocusOut={ () => setIsFocused( false ) }
 					/>
 				</GlobalStylesContext.Provider>
 			</div>

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -59,8 +59,6 @@ const GlobalStylesVariation = ( {
 				'is-active': isActive,
 			} ) }
 			role="button"
-			onBlur={ () => setIsFocused( false ) }
-			onFocus={ () => setIsFocused( true ) }
 			onClick={ onSelect }
 			onKeyDown={ selectOnEnter }
 			tabIndex={ 0 }
@@ -79,6 +77,8 @@ const GlobalStylesVariation = ( {
 						title={ globalStylesVariation.title }
 						inlineCss={ globalStylesVariation.inline_css }
 						isFocused={ isFocused || showOnlyHoverView }
+						onBlur={ () => setIsFocused( false ) }
+						onFocus={ () => setIsFocused( true ) }
 					/>
 				</GlobalStylesContext.Provider>
 			</div>

--- a/packages/global-styles/src/components/global-styles-variations/preview.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/preview.tsx
@@ -52,9 +52,17 @@ interface Props {
 	title?: string;
 	inlineCss?: string;
 	isFocused?: boolean;
+	onBlur?: () => void;
+	onFocus?: () => void;
 }
 
-const GlobalStylesVariationPreview = ( { title, inlineCss, isFocused }: Props ) => {
+const GlobalStylesVariationPreview = ( {
+	title,
+	inlineCss,
+	isFocused,
+	onBlur,
+	onFocus,
+}: Props ) => {
 	const [ fontWeight ] = useStyle( 'typography.fontWeight' );
 	const [ fontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
 	const [ headingFontFamily = fontFamily ] = useStyle( 'elements.h1.typography.fontFamily' );
@@ -87,6 +95,8 @@ const GlobalStylesVariationPreview = ( { title, inlineCss, isFocused }: Props ) 
 			height={ normalizedHeight * ratio }
 			inlineCss={ inlineCss }
 			containerResizeListener={ containerResizeListener }
+			onBlur={ onBlur }
+			onFocus={ onFocus }
 		>
 			<motion.div
 				style={ {

--- a/packages/global-styles/src/components/global-styles-variations/preview.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/preview.tsx
@@ -52,17 +52,10 @@ interface Props {
 	title?: string;
 	inlineCss?: string;
 	isFocused?: boolean;
-	onBlur?: () => void;
-	onFocus?: () => void;
+	onFocusOut?: () => void;
 }
 
-const GlobalStylesVariationPreview = ( {
-	title,
-	inlineCss,
-	isFocused,
-	onBlur,
-	onFocus,
-}: Props ) => {
+const GlobalStylesVariationPreview = ( { title, inlineCss, isFocused, onFocusOut }: Props ) => {
 	const [ fontWeight ] = useStyle( 'typography.fontWeight' );
 	const [ fontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
 	const [ headingFontFamily = fontFamily ] = useStyle( 'elements.h1.typography.fontFamily' );
@@ -95,8 +88,7 @@ const GlobalStylesVariationPreview = ( {
 			height={ normalizedHeight * ratio }
 			inlineCss={ inlineCss }
 			containerResizeListener={ containerResizeListener }
-			onBlur={ onBlur }
-			onFocus={ onFocus }
+			onFocusOut={ onFocusOut }
 		>
 			<motion.div
 				style={ {


### PR DESCRIPTION
## Proposed Changes

This PR fixes the issue where the global styles preview is stuck in the focused state. The issue occurs because the focus out event is prevented from bubbling, hence the blur handler is never triggered.

![Screen Capture on 2023-04-14 at 17-13-51](https://user-images.githubusercontent.com/797888/232001791-30e2bc94-b679-4515-a7a4-6ddfd9a782ce.gif)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Select a theme with style variations.
* Select a non-default style, and ensure that the preview shows its focus state.
* Click outside the preview, and ensure that the preview is no longer in its focus state. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
