### PR TITLE
Newsletters: update intro copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -87,7 +87,7 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 			return {
 				title: __( 'The Newsletter. Elevated.' ),
 				text: __(
-					'Unlimited subscribers. Beautiful design. And everything you need to grow your audience. Powered by WordPress.com.'
+					'Everything you need to reach and grow an audience, with the power and permanence of WordPress.com.'
 				),
 				buttonText: __( 'Launch your Newsletter' ),
 			};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Solves https://github.com/Automattic/wp-calypso/issues/75761

## Proposed Changes

* Update the intro copy

**Before**

<img width="1335" alt="image" src="https://user-images.githubusercontent.com/87168/232008733-1196de3c-acca-4e2c-a8be-3241b65bff5c.png">


**After**

<img width="1490" alt="image" src="https://user-images.githubusercontent.com/87168/232031996-8abd568c-66c1-4a73-9d67-ea704c30aa84.png">
<img width="410" alt="image" src="https://user-images.githubusercontent.com/87168/232032190-9efa534c-4a7d-46e7-a320-f483b682d2b2.png">


## Testing Instructions

Open `/setup/newsletter/` and check the copy.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
