### PR TITLE
`/subscriptions/pending`: Ability to show site list.

### DIFF
--- a/client/landing/subscriptions/components/pending-site-list/index.ts
+++ b/client/landing/subscriptions/components/pending-site-list/index.ts
@@ -1,0 +1,1 @@
+export { default as PendingSiteList } from './pending-site-list';

--- a/client/landing/subscriptions/components/pending-site-list/pending-site-list.tsx
+++ b/client/landing/subscriptions/components/pending-site-list/pending-site-list.tsx
@@ -1,0 +1,30 @@
+import { useTranslate } from 'i18n-calypso';
+import PendingSiteRow from './pending-site-row';
+import './styles.scss';
+import type { PendingSiteSubscription } from '@automattic/data-stores/src/reader/types';
+
+type PendingSiteListProps = {
+	pendingSites?: PendingSiteSubscription[];
+};
+
+export default function PendingSiteList( { pendingSites }: PendingSiteListProps ) {
+	const translate = useTranslate();
+
+	return (
+		<ul className="subscription-manager__pending-site-list" role="table">
+			<li className="row header" role="row">
+				<span className="title-box" role="columnheader">
+					{ translate( 'Subscribed site' ) }
+				</span>
+				<span className="date" role="columnheader">
+					{ translate( 'Since' ) }
+				</span>
+				<span className="actions" role="columnheader" />
+			</li>
+			{ pendingSites &&
+				pendingSites.map( ( pendingSite ) => (
+					<PendingSiteRow key={ `pendingSites.siterow.${ pendingSite.id }` } { ...pendingSite } />
+				) ) }
+		</ul>
+	);
+}

--- a/client/landing/subscriptions/components/pending-site-list/pending-site-row.tsx
+++ b/client/landing/subscriptions/components/pending-site-list/pending-site-row.tsx
@@ -1,0 +1,37 @@
+import { Gridicon } from '@automattic/components';
+import { useMemo } from 'react';
+import TimeSince from 'calypso/components/time-since';
+import type { PendingSiteSubscription } from '@automattic/data-stores/src/reader/types';
+
+export default function PendingSiteRow( {
+	site_title,
+	site_icon,
+	site_url,
+	date_subscribed,
+}: PendingSiteSubscription ) {
+	const hostname = useMemo( () => new URL( site_url ).hostname, [ site_url ] );
+	const siteIcon = useMemo( () => {
+		if ( site_icon ) {
+			return <img className="icon" src={ site_icon } alt={ site_title } />;
+		}
+		return <Gridicon className="icon" icon="globe" size={ 48 } />;
+	}, [ site_icon, site_title ] );
+
+	return (
+		<li className="row" role="row">
+			<a href={ site_url } rel="noreferrer noopener" className="title-box" target="_blank">
+				<span className="title-box" role="cell">
+					{ siteIcon }
+					<span className="title-column">
+						<span className="name">{ site_title }</span>
+						<span className="url">{ hostname }</span>
+					</span>
+				</span>
+			</a>
+			<span className="date" role="cell">
+				<TimeSince date={ date_subscribed.toISOString?.() ?? date_subscribed } />
+			</span>
+			<span className="actions" role="cell"></span>
+		</li>
+	);
+}

--- a/client/landing/subscriptions/components/pending-site-list/styles.scss
+++ b/client/landing/subscriptions/components/pending-site-list/styles.scss
@@ -1,0 +1,107 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+
+$max-list-width: 1300px;
+
+.subscription-manager__pending-site-list {
+	max-width: $max-list-width;
+
+	.row {
+		border-bottom: 1px solid var(--color-border-subtle);
+		display: flex;
+		align-items: center;
+		flex-direction: row;
+		padding-top: 20px;
+		padding-bottom: 20px;
+
+		* {
+			flex: 1;
+		}
+
+		&.header {
+			padding-bottom: $font-code;
+			padding-top: 0;
+		}
+
+		.title-box {
+			display: flex;
+			align-items: center;
+			flex: 1.83;
+			min-width: 0;
+
+			.icon {
+				fill: var(--color-text-subtle);
+				width: 40px;
+				height: 40px;
+				flex: none;
+				border-radius: 50%;
+			}
+
+			.title-column {
+				display: flex;
+				flex-direction: column;
+				min-width: 0;
+				padding-left: 12px;
+
+				.name {
+					font-weight: 600;
+					font-size: $font-code;
+					line-height: 22px;
+					color: $studio-gray-100;
+					letter-spacing: -0.24px;
+					text-overflow: ellipsis;
+					white-space: nowrap;
+					overflow: hidden;
+					padding-right: 10px;
+
+					&:hover {
+						text-decoration: underline;
+					}
+				}
+
+				.url {
+					font-weight: 400;
+					font-size: $font-body-extra-small;
+					line-height: 18px;
+					color: $studio-gray-40;
+					text-overflow: ellipsis;
+					white-space: nowrap;
+					overflow: hidden;
+
+					&:hover {
+						text-decoration: underline;
+					}
+				}
+			}
+		}
+
+		.title-box,
+		.date {
+			font-weight: 400;
+			font-size: $font-body-small;
+			line-height: 20px;
+			letter-spacing: -0.15px;
+			color: $studio-gray-60;
+		}
+
+		.actions {
+			flex-basis: 36px;
+			flex-grow: initial;
+
+			.gridicon {
+				fill: $studio-gray-50;
+			}
+		}
+
+		&:last-child {
+			border-bottom: none;
+		}
+	}
+
+	@media (max-width: $break-small) {
+		.date {
+			display: none;
+		}
+	}
+}

--- a/client/landing/subscriptions/components/tab-views/pending/pending.tsx
+++ b/client/landing/subscriptions/components/tab-views/pending/pending.tsx
@@ -1,9 +1,20 @@
+import { SubscriptionManager } from '@automattic/data-stores';
+import { PendingSiteList } from 'calypso/landing/subscriptions/components/pending-site-list';
 import TabView from '../tab-view';
 
 const Pending = () => {
+	const {
+		data: pendingSites,
+		isLoading,
+		error,
+	} = SubscriptionManager.usePendingSiteSubscriptionsQuery();
+
+	// todo: translate when we have agreed on the error message
+	const errorMessage = error ? 'An error occurred while fetching your subscriptions.' : '';
+
 	return (
-		<TabView errorMessage="" isLoading={ false }>
-			<p>Hello world!</p>
+		<TabView errorMessage={ errorMessage } isLoading={ isLoading }>
+			<PendingSiteList pendingSites={ pendingSites } />
 		</TabView>
 	);
 };

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -11,6 +11,7 @@ import {
 	usePostSubscriptionsQuery,
 	useSubscriptionsCountQuery,
 	useUserSettingsQuery,
+	usePendingSiteSubscriptionsQuery,
 } from './queries';
 
 export const SubscriptionManager = {
@@ -24,6 +25,7 @@ export const SubscriptionManager = {
 	useSubscriberEmailAddress,
 	useUserSettingsQuery,
 	useUserSettingsMutation,
+	usePendingSiteSubscriptionsQuery,
 };
 
 // Types

--- a/packages/data-stores/src/reader/queries/index.ts
+++ b/packages/data-stores/src/reader/queries/index.ts
@@ -5,3 +5,4 @@ export {
 	SiteSubscriptionsSortBy,
 } from './use-site-subscriptions-query';
 export { default as usePostSubscriptionsQuery } from './use-post-subscriptions-query';
+export { default as usePendingSiteSubscriptionsQuery } from './use-pending-site-subscriptions-query';

--- a/packages/data-stores/src/reader/queries/use-pending-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-pending-site-subscriptions-query.ts
@@ -15,9 +15,10 @@ type SubscriptionManagerPendingSiteSubscriptionsQueryProps = {
 
 const callPendingBlogSubscriptionsEndpoint = async (): Promise< PendingSiteSubscription[] > => {
 	const data = [];
+	const perPage = 1000; // TODO: This is a temporary workaround to get all pending subscriptions. We should remove this once we decide how to handle pagination.
 
 	const incoming = await callApi< SubscriptionManagerPendingSiteSubscriptions >( {
-		path: `/pending-blog-subscriptions`,
+		path: `/pending-blog-subscriptions?per_page=${ perPage }`,
 		apiVersion: '2',
 	} );
 

--- a/packages/data-stores/src/reader/queries/use-pending-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-pending-site-subscriptions-query.ts
@@ -1,0 +1,63 @@
+import { useQuery } from 'react-query';
+import { callApi } from '../helpers';
+import { useIsLoggedIn, useIsQueryEnabled } from '../hooks';
+import type { PendingSiteSubscription } from '../types';
+
+type SubscriptionManagerPendingSiteSubscriptions = {
+	pending_blog_subscriptions: PendingSiteSubscription[];
+	total_pending_blog_subscriptions_count: number;
+};
+
+type SubscriptionManagerPendingSiteSubscriptionsQueryProps = {
+	filter?: ( item?: PendingSiteSubscription ) => boolean;
+	sort?: ( a?: PendingSiteSubscription, b?: PendingSiteSubscription ) => number;
+};
+
+const callPendingBlogSubscriptionsEndpoint = async (): Promise< PendingSiteSubscription[] > => {
+	const data = [];
+
+	const incoming = await callApi< SubscriptionManagerPendingSiteSubscriptions >( {
+		path: `/pending-blog-subscriptions`,
+		apiVersion: '2',
+	} );
+
+	if ( incoming && incoming.pending_blog_subscriptions ) {
+		data.push(
+			...incoming.pending_blog_subscriptions.map( ( pendingSubscription ) => ( {
+				...pendingSubscription,
+				date_subscribed: new Date( pendingSubscription.date_subscribed ),
+			} ) )
+		);
+	}
+
+	return data;
+};
+
+const defaultFilter = () => true;
+const defaultSort = () => 0;
+
+const usePendingSiteSubscriptionsQuery = ( {
+	filter = defaultFilter,
+	sort = defaultSort,
+}: SubscriptionManagerPendingSiteSubscriptionsQueryProps = {} ) => {
+	const isLoggedIn = useIsLoggedIn();
+	const enabled = useIsQueryEnabled();
+
+	const { data, ...rest } = useQuery< PendingSiteSubscription[] >(
+		[ 'read', 'pending-site-subscriptions', isLoggedIn ],
+		async () => {
+			return await callPendingBlogSubscriptionsEndpoint();
+		},
+		{
+			enabled,
+			refetchOnWindowFocus: false,
+		}
+	);
+
+	return {
+		data: data?.filter( filter ).sort( sort ),
+		...rest,
+	};
+};
+
+export default usePendingSiteSubscriptionsQuery;

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -83,3 +83,13 @@ export type PostSubscription = {
 	post_excerpt: string;
 	post_url: string;
 };
+
+export type PendingSiteSubscription = {
+	id: string;
+	activation_key: string;
+	site_title: string;
+	site_icon: string;
+	site_url: string;
+	date_subscribed: Date;
+	organization_id: number;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/75765

## Proposed Changes

* Ability to show list of pending sites.

![image](https://user-images.githubusercontent.com/1287077/232027221-0cb287b7-9d3e-4e9f-8984-e653be02ddcf.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure your external user has pending site subscriptions (the tab doesn't show when you don't have).
* Inject subkey into `calypso.localhost:3000`.
* Go to `/subscriptions/pending`.
* You should see list of pending subscriptions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
