### PR TITLE
Subscription manager: add `useCacheKey` hook

### DIFF
--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -52,4 +52,26 @@ async function callApi< ReturnType >( {
 	} as APIFetchOptions );
 }
 
-export { callApi, getSubkey };
+interface PagedResult< T > {
+	pages: T[];
+	pageParams: number;
+}
+
+type KeyedObject< K extends string, T > = {
+	[ key in K ]: T[];
+};
+
+const applyCallbackToPages = < K extends string, T >(
+	pagedResult: PagedResult< KeyedObject< K, T > > | undefined,
+	callback: ( page: KeyedObject< K, T > ) => KeyedObject< K, T >
+): PagedResult< KeyedObject< K, T > > | undefined => {
+	if ( ! pagedResult ) {
+		return undefined;
+	}
+	return {
+		pages: pagedResult.pages.map( ( page ) => callback( page ) ),
+		pageParams: pagedResult.pageParams,
+	};
+};
+
+export { callApi, applyCallbackToPages, getSubkey };

--- a/packages/data-stores/src/reader/hooks/index.ts
+++ b/packages/data-stores/src/reader/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useIsLoggedIn } from './use-is-logged-in';
 export { default as useIsQueryEnabled } from './use-is-query-enabled';
 export { default as useSubscriberEmailAddress } from './use-subscriber-email-address';
+export { default as useCacheKey } from './use-cache-key';

--- a/packages/data-stores/src/reader/hooks/use-cache-key.ts
+++ b/packages/data-stores/src/reader/hooks/use-cache-key.ts
@@ -1,0 +1,9 @@
+import useIsLoggedIn from './use-is-logged-in';
+
+const useCacheKey = ( key: string[] ) => {
+	const { id, isLoggedIn } = useIsLoggedIn();
+
+	return [ ...key, isLoggedIn ? 'logged-in' : 'not-logged-in', id ? id : '' ];
+};
+
+export default useCacheKey;

--- a/packages/data-stores/src/reader/hooks/use-cache-key.ts
+++ b/packages/data-stores/src/reader/hooks/use-cache-key.ts
@@ -1,9 +1,12 @@
 import useIsLoggedIn from './use-is-logged-in';
 
+// change version to invalidate all cache keys
+const version = 'v1';
+
 const useCacheKey = ( key: string[] ) => {
 	const { id, isLoggedIn } = useIsLoggedIn();
 
-	return [ ...key, isLoggedIn ? 'logged-in' : 'not-logged-in', id ? id : '' ];
+	return [ ...key, version, isLoggedIn ? 'logged-in' : 'not-logged-in', id ? id : '' ];
 };
 
 export default useCacheKey;

--- a/packages/data-stores/src/reader/hooks/use-is-logged-in.ts
+++ b/packages/data-stores/src/reader/hooks/use-is-logged-in.ts
@@ -5,10 +5,18 @@ import type { UserSelect } from '../../user';
 const USER_STORE = registerUserStore( { client_id: '', client_secret: '' } );
 
 const useIsLoggedIn = () => {
-	return useSelect(
-		( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+	const currentUser = useSelect(
+		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
 		[]
-	) as boolean;
+	);
+
+	return {
+		id: currentUser?.ID,
+		isLoggedIn: useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+			[]
+		),
+	};
 };
 
 export default useIsLoggedIn;

--- a/packages/data-stores/src/reader/hooks/use-is-query-enabled.ts
+++ b/packages/data-stores/src/reader/hooks/use-is-query-enabled.ts
@@ -2,8 +2,8 @@ import { getSubkey } from '../helpers';
 import { useIsLoggedIn } from '.';
 
 const useIsQueryEnabled = () => {
-	const loggedIn = useIsLoggedIn();
-	if ( loggedIn || getSubkey() ) {
+	const { isLoggedIn } = useIsLoggedIn();
+	if ( isLoggedIn || getSubkey() ) {
 		return true;
 	}
 

--- a/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { callApi, applyCallbackToPages } from '../helpers';
-import { useIsLoggedIn } from '../hooks';
-import useCacheKey from '../hooks/use-cache-key';
+import { useCacheKey, useIsLoggedIn } from '../hooks';
 import type {
 	PagedQueryResult,
 	SiteSubscription,

--- a/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
@@ -1,7 +1,12 @@
 import { useMutation, useQueryClient } from 'react-query';
-import { callApi } from '../helpers';
+import { callApi, applyCallbackToPages } from '../helpers';
 import { useIsLoggedIn } from '../hooks';
-import type { SiteSubscription, SiteSubscriptionDeliveryFrequency } from '../types';
+import useCacheKey from '../hooks/use-cache-key';
+import type {
+	PagedQueryResult,
+	SiteSubscription,
+	SiteSubscriptionDeliveryFrequency,
+} from '../types';
 
 type SiteSubscriptionDeliveryFrequencyParams = {
 	delivery_frequency: SiteSubscriptionDeliveryFrequency;
@@ -22,8 +27,11 @@ type SiteSubscriptionDeliveryFrequencyResponse = {
 };
 
 const useSiteDeliveryFrequencyMutation = () => {
-	const isLoggedIn = useIsLoggedIn();
+	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
+
+	const siteSubscriptionsCacheKey = useCacheKey( [ 'read', 'site-subscriptions' ] );
+
 	return useMutation(
 		async ( params: SiteSubscriptionDeliveryFrequencyParams ) => {
 			if ( ! params.blog_id || ! params.delivery_frequency ) {
@@ -53,44 +61,44 @@ const useSiteDeliveryFrequencyMutation = () => {
 		},
 		{
 			onMutate: async ( params ) => {
-				await queryClient.cancelQueries( [ 'read', 'site-subscriptions', isLoggedIn ] );
-				const previousSiteSubscriptions = queryClient.getQueryData< SiteSubscription[] >( [
-					'read',
-					'site-subscriptions',
-					isLoggedIn,
-				] );
+				await queryClient.cancelQueries( siteSubscriptionsCacheKey );
 
-				const mutatedSiteSubscriptions = previousSiteSubscriptions?.map( ( siteSubscription ) => {
-					if ( siteSubscription.blog_ID === params.blog_id ) {
-						return {
-							...siteSubscription,
-							delivery_methods: {
-								...siteSubscription.delivery_methods,
-								email: {
-									...siteSubscription.delivery_methods?.email,
-									post_delivery_frequency: params.delivery_frequency,
-								},
-							},
-						};
-					}
-					return siteSubscription;
-				} );
+				const previousSiteSubscriptions =
+					queryClient.getQueryData< PagedQueryResult< SiteSubscription, 'subscriptions' > >(
+						siteSubscriptionsCacheKey
+					);
 
-				queryClient.setQueryData(
-					[ 'read', 'site-subscriptions', isLoggedIn ],
-					mutatedSiteSubscriptions
+				const mutatedSiteSubscriptions = applyCallbackToPages< 'subscriptions', SiteSubscription >(
+					previousSiteSubscriptions,
+					( page ) => ( {
+						subscriptions: page.subscriptions.map( ( siteSubscription ) => {
+							if ( siteSubscription.blog_ID === params.blog_id ) {
+								return {
+									...siteSubscription,
+									delivery_methods: {
+										...siteSubscription.delivery_methods,
+										email: {
+											...siteSubscription.delivery_methods?.email,
+											post_delivery_frequency: params.delivery_frequency,
+										},
+									},
+								};
+							}
+							return siteSubscription;
+						} ),
+					} )
 				);
+
+				queryClient.setQueryData( siteSubscriptionsCacheKey, mutatedSiteSubscriptions );
 
 				return { previousSiteSubscriptions };
 			},
 			onError: ( err, params, context ) => {
-				queryClient.setQueryData(
-					[ 'read', 'site-subscriptions', isLoggedIn ],
-					context?.previousSiteSubscriptions
-				);
+				queryClient.setQueryData( siteSubscriptionsCacheKey, context?.previousSiteSubscriptions );
 			},
 			onSettled: () => {
-				queryClient.invalidateQueries( [ 'read', 'site-subscriptions', isLoggedIn ] );
+				// pass in a more minimal key, everything to the right will be invalidated
+				queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
 			},
 		}
 	);

--- a/packages/data-stores/src/reader/mutations/use-site-unfollow-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unfollow-mutation.ts
@@ -2,7 +2,11 @@ import { useMutation, useQueryClient } from 'react-query';
 import { applyCallbackToPages, callApi } from '../helpers';
 import { useIsLoggedIn } from '../hooks';
 import useCacheKey from '../hooks/use-cache-key';
-import { SiteSubscription, SubscriptionManagerSubscriptionsCount } from '../types';
+import {
+	PagedQueryResult,
+	SiteSubscription,
+	SubscriptionManagerSubscriptionsCount,
+} from '../types';
 
 type SiteSubscriptionUnfollowParams = {
 	blog_id: number | string;
@@ -18,7 +22,7 @@ const useSiteUnfollowMutation = () => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
 	const siteSubscriptionsCacheKey = useCacheKey( [ 'read', 'site-subscriptions' ] );
-	const subscriptionsCountCacheKey = [ 'read', 'subscriptions-count' ];
+	const subscriptionsCountCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
 
 	return useMutation(
 		async ( params: SiteSubscriptionUnfollowParams ) => {

--- a/packages/data-stores/src/reader/mutations/use-site-unfollow-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unfollow-mutation.ts
@@ -2,11 +2,7 @@ import { useMutation, useQueryClient } from 'react-query';
 import { applyCallbackToPages, callApi } from '../helpers';
 import { useIsLoggedIn } from '../hooks';
 import useCacheKey from '../hooks/use-cache-key';
-import {
-	PagedQueryResult,
-	SiteSubscription,
-	SubscriptionManagerSubscriptionsCount,
-} from '../types';
+import { SiteSubscription, SubscriptionManagerSubscriptionsCount } from '../types';
 
 type SiteSubscriptionUnfollowParams = {
 	blog_id: number | string;

--- a/packages/data-stores/src/reader/mutations/use-site-unfollow-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unfollow-mutation.ts
@@ -1,7 +1,12 @@
 import { useMutation, useQueryClient } from 'react-query';
-import { callApi } from '../helpers';
+import { applyCallbackToPages, callApi } from '../helpers';
 import { useIsLoggedIn } from '../hooks';
-import { SiteSubscription, SubscriptionManagerSubscriptionsCount } from '../types';
+import useCacheKey from '../hooks/use-cache-key';
+import {
+	PagedQueryResult,
+	SiteSubscription,
+	SubscriptionManagerSubscriptionsCount,
+} from '../types';
 
 type SiteSubscriptionUnfollowParams = {
 	blog_id: number | string;
@@ -14,8 +19,11 @@ type SiteSubscriptionUnfollowResponse = {
 };
 
 const useSiteUnfollowMutation = () => {
-	const isLoggedIn = useIsLoggedIn();
+	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
+	const siteSubscriptionsCacheKey = useCacheKey( [ 'read', 'site-subscriptions' ] );
+	const subscriptionsCountCacheKey = [ 'read', 'subscriptions-count' ];
+
 	return useMutation(
 		async ( params: SiteSubscriptionUnfollowParams ) => {
 			if ( ! params.blog_id ) {
@@ -42,36 +50,37 @@ const useSiteUnfollowMutation = () => {
 		},
 		{
 			onMutate: async ( params ) => {
-				await queryClient.cancelQueries( [ 'read', 'site-subscriptions', isLoggedIn ] );
-				await queryClient.cancelQueries( [ 'read', 'subscriptions-count', isLoggedIn ] );
+				await queryClient.cancelQueries( siteSubscriptionsCacheKey );
+				await queryClient.cancelQueries( subscriptionsCountCacheKey );
 
-				const previousSiteSubscriptions = queryClient.getQueryData< SiteSubscription[] >( [
-					'read',
-					'site-subscriptions',
-					isLoggedIn,
-				] );
-
+				const previousSiteSubscriptions =
+					queryClient.getQueryData< PagedQueryResult< SiteSubscription, 'subscriptions' > >(
+						siteSubscriptionsCacheKey
+					);
 				// remove blog from site subscriptions
 				if ( previousSiteSubscriptions ) {
-					queryClient.setQueryData< SiteSubscription[] >(
-						[ [ 'read', 'site-subscriptions', isLoggedIn ] ],
-						previousSiteSubscriptions.filter(
-							( siteSubscription ) => siteSubscription.blog_ID !== params.blog_id
-						)
-					);
+					const mutatedSiteSubscriptions = applyCallbackToPages<
+						'subscriptions',
+						SiteSubscription
+					>( previousSiteSubscriptions, ( page ) => {
+						return {
+							subscriptions: page.subscriptions.filter(
+								( siteSubscription ) => siteSubscription.blog_ID !== params.blog_id
+							),
+						};
+					} );
+					queryClient.setQueryData( siteSubscriptionsCacheKey, mutatedSiteSubscriptions );
 				}
 
 				const previousSubscriptionsCount =
-					queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >( [
-						'read',
-						'subscriptions-count',
-						isLoggedIn,
-					] );
+					queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >(
+						subscriptionsCountCacheKey
+					);
 
 				// decrement the blog count
 				if ( previousSubscriptionsCount ) {
 					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
-						[ 'read', 'subscriptions-count', isLoggedIn ],
+						subscriptionsCountCacheKey,
 						{
 							...previousSubscriptionsCount,
 							blogs: previousSubscriptionsCount?.blogs
@@ -85,21 +94,19 @@ const useSiteUnfollowMutation = () => {
 			},
 			onError: ( error, variables, context ) => {
 				if ( context?.previousSiteSubscriptions ) {
-					queryClient.setQueryData< SiteSubscription[] >(
-						[ 'read', 'site-subscriptions', isLoggedIn ],
-						context.previousSiteSubscriptions
-					);
+					queryClient.setQueryData( siteSubscriptionsCacheKey, context.previousSiteSubscriptions );
 				}
 				if ( context?.previousSubscriptionsCount ) {
 					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
-						[ 'read', 'subscriptions-count', isLoggedIn ],
+						subscriptionsCountCacheKey,
 						context.previousSubscriptionsCount
 					);
 				}
 			},
 			onSettled: () => {
-				queryClient.invalidateQueries( [ 'read', 'site-subscriptions', isLoggedIn ] );
-				queryClient.invalidateQueries( [ 'read', 'subscriptions-count', isLoggedIn ] );
+				// pass in more minimal keys, everything to the right will be invalidated
+				queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
+				queryClient.invalidateQueries( [ 'read', 'subscriptions-count' ] );
 			},
 		}
 	);

--- a/packages/data-stores/src/reader/mutations/use-site-unfollow-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unfollow-mutation.ts
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { applyCallbackToPages, callApi } from '../helpers';
-import { useIsLoggedIn } from '../hooks';
-import useCacheKey from '../hooks/use-cache-key';
+import { useCacheKey, useIsLoggedIn } from '../hooks';
 import {
 	PagedQueryResult,
 	SiteSubscription,

--- a/packages/data-stores/src/reader/mutations/use-user-settings-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-user-settings-mutation.ts
@@ -1,7 +1,7 @@
 import { translate } from 'i18n-calypso';
 import { useMutation, useQueryClient } from 'react-query';
 import { callApi } from '../helpers';
-import { useIsLoggedIn } from '../hooks';
+import { useCacheKey, useIsLoggedIn } from '../hooks';
 import type { SubscriptionManagerUserSettings, EmailSettingsAPIResponse } from '../types';
 
 type MutationContext = {
@@ -11,7 +11,7 @@ type MutationContext = {
 const useUserSettingsMutation = () => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
-	const emailSettingsCacheKey = [ 'read', 'email-settings' ];
+	const emailSettingsCacheKey = useCacheKey( [ 'read', 'email-settings' ] );
 	return useMutation< SubscriptionManagerUserSettings, Error, SubscriptionManagerUserSettings >(
 		async ( data: SubscriptionManagerUserSettings ) => {
 			const { settings } = await callApi< EmailSettingsAPIResponse >( {

--- a/packages/data-stores/src/reader/mutations/use-user-settings-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-user-settings-mutation.ts
@@ -39,7 +39,7 @@ const useUserSettingsMutation = () => {
 				const previousSettings =
 					queryClient.getQueryData< SubscriptionManagerUserSettings >( emailSettingsCacheKey );
 
-				queryClient.setQueryData< SubscriptionManagerUserSettings >( [ 'read', 'email-settings' ], {
+				queryClient.setQueryData< SubscriptionManagerUserSettings >( emailSettingsCacheKey, {
 					...previousSettings,
 					...data,
 				} );

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useInfiniteQuery } from 'react-query';
 import { callApi } from '../helpers';
 import { useIsLoggedIn, useIsQueryEnabled } from '../hooks';
+import useCacheKey from '../hooks/use-cache-key';
 import type { SiteSubscription } from '../types';
 
 type SubscriptionManagerSiteSubscriptions = {
@@ -24,12 +25,13 @@ const useSiteSubscriptionsQuery = ( {
 	sort = defaultSort,
 	number = 100,
 }: SubscriptionManagerSiteSubscriptionsQueryProps = {} ) => {
-	const isLoggedIn = useIsLoggedIn();
+	const { isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
+	const cacheKey = useCacheKey( [ 'read', 'site-subscriptions' ] );
 
 	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isFetching, ...rest } =
 		useInfiniteQuery< SubscriptionManagerSiteSubscriptions >(
-			[ 'read', 'site-subscriptions', isLoggedIn ],
+			cacheKey,
 			async ( { pageParam = 1 } ) => {
 				return await callApi< SubscriptionManagerSiteSubscriptions >( {
 					path: `/read/following/mine?number=${ number }&page=${ pageParam }`,

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -57,12 +57,15 @@ const useSiteSubscriptionsQuery = ( {
 
 	// Flatten all the pages into a single array containing all subscriptions
 	const flattenedData = data?.pages?.map( ( page ) => page.subscriptions ).flat();
-	// Transform the dates into Date objects
-	const transformedData = flattenedData?.map( ( subscription ) => ( {
-		...subscription,
-		last_updated: new Date( subscription.last_updated ),
-		date_subscribed: new Date( subscription.date_subscribed ),
-	} ) );
+
+	// Transform the dates into Date objects, when no subscriptions are present, the data is null, so filter it
+	const transformedData = flattenedData
+		?.filter( ( item ) => item !== null )
+		.map( ( subscription ) => ( {
+			...subscription,
+			last_updated: new Date( subscription.last_updated ),
+			date_subscribed: new Date( subscription.date_subscribed ),
+		} ) );
 
 	return {
 		data: transformedData?.filter( filter ).sort( sort ),

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -1,8 +1,7 @@
 import { useEffect } from 'react';
 import { useInfiniteQuery } from 'react-query';
 import { callApi } from '../helpers';
-import { useIsLoggedIn, useIsQueryEnabled } from '../hooks';
-import useCacheKey from '../hooks/use-cache-key';
+import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { SiteSubscription } from '../types';
 
 type SubscriptionManagerSiteSubscriptions = {

--- a/packages/data-stores/src/reader/queries/use-subscriptions-count-query.ts
+++ b/packages/data-stores/src/reader/queries/use-subscriptions-count-query.ts
@@ -1,14 +1,16 @@
 import { useQuery } from 'react-query';
 import { callApi } from '../helpers';
 import { useIsLoggedIn, useIsQueryEnabled } from '../hooks';
+import useCacheKey from '../hooks/use-cache-key';
 import type { SubscriptionManagerSubscriptionsCount } from '../types';
 
 const useSubscriptionsCountQuery = () => {
-	const isLoggedIn = useIsLoggedIn();
+	const { isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
+	const cacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
 
 	return useQuery< SubscriptionManagerSubscriptionsCount >(
-		[ 'read', 'subscriptions-count', isLoggedIn ],
+		cacheKey,
 		async () => {
 			return await callApi< SubscriptionManagerSubscriptionsCount >( {
 				path: '/read/subscriptions-count',

--- a/packages/data-stores/src/reader/queries/use-subscriptions-count-query.ts
+++ b/packages/data-stores/src/reader/queries/use-subscriptions-count-query.ts
@@ -1,7 +1,6 @@
 import { useQuery } from 'react-query';
 import { callApi } from '../helpers';
-import { useIsLoggedIn, useIsQueryEnabled } from '../hooks';
-import useCacheKey from '../hooks/use-cache-key';
+import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { SubscriptionManagerSubscriptionsCount } from '../types';
 
 const useSubscriptionsCountQuery = () => {

--- a/packages/data-stores/src/reader/queries/use-user-settings-query.ts
+++ b/packages/data-stores/src/reader/queries/use-user-settings-query.ts
@@ -1,13 +1,15 @@
 import { useQuery } from 'react-query';
 import { callApi } from '../helpers';
 import { useIsLoggedIn, useIsQueryEnabled } from '../hooks';
+import useCacheKey from '../hooks/use-cache-key';
 import type { SubscriptionManagerUserSettings, EmailSettingsAPIResponse } from '../types';
 
 const useUserSettingsQuery = () => {
-	const isLoggedIn = useIsLoggedIn();
+	const { isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
+	const cacheKey = useCacheKey( [ 'read', 'email-settings' ] );
 	return useQuery< SubscriptionManagerUserSettings >(
-		[ 'read', 'email-settings', isLoggedIn ],
+		cacheKey,
 		async () => {
 			const { settings } = await callApi< EmailSettingsAPIResponse >( {
 				path: '/read/email-settings',

--- a/packages/data-stores/src/reader/queries/use-user-settings-query.ts
+++ b/packages/data-stores/src/reader/queries/use-user-settings-query.ts
@@ -1,7 +1,6 @@
 import { useQuery } from 'react-query';
 import { callApi } from '../helpers';
-import { useIsLoggedIn, useIsQueryEnabled } from '../hooks';
-import useCacheKey from '../hooks/use-cache-key';
+import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { SubscriptionManagerUserSettings, EmailSettingsAPIResponse } from '../types';
 
 const useUserSettingsQuery = () => {

--- a/packages/data-stores/src/reader/test/mutations.tsx
+++ b/packages/data-stores/src/reader/test/mutations.tsx
@@ -10,6 +10,7 @@ import useSiteDeliveryFrequencyMutation from '../mutations/use-site-delivery-fre
 // Mock the useIsLoggedIn function
 jest.mock( '../hooks', () => ( {
 	useIsLoggedIn: jest.fn().mockReturnValue( { isLoggedIn: true } ),
+	useCacheKey: jest.fn(),
 } ) );
 
 // Mock the entire Helpers module

--- a/packages/data-stores/src/reader/test/mutations.tsx
+++ b/packages/data-stores/src/reader/test/mutations.tsx
@@ -9,12 +9,13 @@ import useSiteDeliveryFrequencyMutation from '../mutations/use-site-delivery-fre
 
 // Mock the useIsLoggedIn function
 jest.mock( '../hooks', () => ( {
-	useIsLoggedIn: jest.fn().mockReturnValue( true ),
+	useIsLoggedIn: jest.fn().mockReturnValue( { isLoggedIn: true } ),
 } ) );
 
 // Mock the entire Helpers module
 jest.mock( '../helpers', () => ( {
 	callApi: jest.fn(),
+	applyCallbackToPages: jest.fn(),
 } ) );
 
 const client = new QueryClient();

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -44,6 +44,13 @@ type SiteSubscriptionDeliveryMethods = {
 	};
 };
 
+export type PagedQueryResult< TDataType, TKey extends string > = {
+	pages: {
+		[ K in TKey ]: TDataType[];
+	}[];
+	pageParams: number;
+};
+
 export type SiteSubscription = {
 	ID: string;
 	blog_ID: string;


### PR DESCRIPTION
## Proposed Changes

This PR adds an useCacheKey hook, that returns the cache key entered, concatenated with 

```js
const useCacheKey = ( key: string[] ) => {
	const { id, isLoggedIn } = useIsLoggedIn();

	return [ ...key, isLoggedIn ? 'logged-in' : 'not-logged-in', id ? id : '' ];
};
```

It also changes the return signature for `useIsLoggedIn` from `boolan` to `{id: number|undefined, isLoggedIn: boolean }`.

Finally, it also fixes a bug where the invalidation of the Site subscriptions list would fail. useInfiniteQuery stores this list in the query cache in it's raw paged form. To make optimistic updates easier on this paged cache results, this PR also introduces a `applyCallbackToPages` function.


## Testing Instructions

1. Apply this PR and make sure a valid subkey is set
2. Visit all three tabs
3. Change delivery frequency of a site subscription, change should be instant
4. Delete a site subscription, change should be instant in both tab count & site list
5. Do a good code review because this PR touches a lot.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
