### PR TITLE
Anchor: flip sunset flag

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -13,7 +13,7 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
-		"anchor/sunset-integration": false,
+		"anchor/sunset-integration": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/production.json
+++ b/config/production.json
@@ -20,7 +20,7 @@
 	"features": {
 		"ad-tracking": true,
 		"akismet/siteless-checkout": true,
-		"anchor/sunset-integration": false,
+		"anchor/sunset-integration": true,
 		"bilmur-script": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -18,7 +18,7 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
-		"anchor/sunset-integration": false,
+		"anchor/sunset-integration": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/test.json
+++ b/config/test.json
@@ -25,7 +25,7 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
-		"anchor/sunset-integration": false,
+		"anchor/sunset-integration": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -18,7 +18,7 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
-		"anchor/sunset-integration": false,
+		"anchor/sunset-integration": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,


### PR DESCRIPTION
This PR will turn the sunset Anchor.fm flag to true on all environments.

Context: paYKcK-2Rq-p2#comment-2085

## Testing instructions
* Navigate to `/setup/anchor-fm/?anchor_podcast=22b6608`
* You should be redirected to `/setup/anchor-fm/error?anchor_podcast=22b6608`, and a discontinuation message should be presented.