### PR TITLE
Fix Happy Blocks path transform

### DIFF
--- a/apps/happy-blocks/webpack.config.js
+++ b/apps/happy-blocks/webpack.config.js
@@ -53,14 +53,20 @@ function getWebpackConfig( env = { block: '' }, argv ) {
 						from: path.resolve( blockPath, 'index.php' ),
 						to: path.resolve( blockPath, 'build', '[name][ext]' ),
 						transform( content ) {
-							return content.toString().replace( '/build/rtl', '/rtl' ).replace( '/build', '/' );
+							return content
+								.toString()
+								.replaceAll( '/build/rtl', '/rtl' )
+								.replaceAll( '/build', '' );
 						},
 					} ),
 					ifExists( {
 						from: path.resolve( blockPath, 'includes.php' ),
 						to: path.resolve( blockPath, 'build', '[name][ext]' ),
 						transform( content ) {
-							return content.toString().replace( '/build/rtl', '/rtl' ).replace( '/build', '/' );
+							return content
+								.toString()
+								.replaceAll( '/build/rtl', '/rtl' )
+								.replaceAll( '/build', '' );
 						},
 					} ),
 					ifExists( {


### PR DESCRIPTION
## Proposed Changes

In the Webpack build of Happy Blocks, we remove `build` of the path because the `build` folder doesn't exist in the production build. But it's needed in the development build.

We remove by `str.replace`, but it removes the first instance only. This changes it to replaceAll to replace all instances.

## Testing Instructions

1. cd apps/happy-blocks.
2. Run `yarn build`.
3. Build files of universal-header shouldn't contain "Build".