### PR TITLE
Subscribers import form: Fix style issues

### DIFF
--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -193,7 +193,7 @@
 		font-size: 0.875rem;
 		line-height: 1.25;
 		color: var(--studio-gray-50);
-		margin-bottom: 1.5rem;
+		margin-top: 1.5rem;
 
 		a,
 		button {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75767

## Proposed Changes

* Fixed margin style issue

## Testing Instructions

* Go to `/people/subscribers/{SITE_SLUG}`
* Click on the "Add subscribers" button
* Enter a valid email
* Check if the disclaimer paragraph has margin-top (see screenshots)

## Screenshots

<table>
  <tr>
    <td>
      <img width="771" alt="Screenshot 2023-04-13 at 14 25 11" src="https://user-images.githubusercontent.com/1241413/232063011-6a3d93e9-c913-4c80-95fd-6d743a9befe8.png">
    <td>
      <img width="744" alt="Screenshot 2023-04-14 at 15 40 40" src="https://user-images.githubusercontent.com/1241413/232063106-7fb8b962-9693-4bc2-875a-52df8e45907f.png">
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
