### PR TITLE
Tailored flows: Make LIB flow async

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -143,7 +143,7 @@
 // Launchpad - Sidebar heading text
 
 .newsletter,
-.link-in-bio:not(.domains),
+.link-in-bio.launchpad,
 .link-in-bio-tld:not(.domains),
 .free,
 .build,

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -13,14 +13,6 @@ import {
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
-import DomainsStep from './internals/steps-repository/domains';
-import Intro from './internals/steps-repository/intro';
-import LaunchPad from './internals/steps-repository/launchpad';
-import LinkInBioSetup from './internals/steps-repository/link-in-bio-setup';
-import PatternsStep from './internals/steps-repository/patterns';
-import PlansStep from './internals/steps-repository/plans';
-import Processing from './internals/steps-repository/processing-step';
-import SiteCreationStep from './internals/steps-repository/site-creation-step';
 import type { Flow, ProvidedDependencies } from './internals/types';
 import type { UserSelect } from '@automattic/data-stores';
 
@@ -31,14 +23,26 @@ const linkInBio: Flow = {
 	},
 	useSteps() {
 		return [
-			{ slug: 'intro', component: Intro },
-			{ slug: 'linkInBioSetup', component: LinkInBioSetup },
-			{ slug: 'domains', component: DomainsStep },
-			{ slug: 'plans', component: PlansStep },
-			{ slug: 'patterns', component: PatternsStep },
-			{ slug: 'siteCreationStep', component: SiteCreationStep },
-			{ slug: 'processing', component: Processing },
-			{ slug: 'launchpad', component: LaunchPad },
+			{ slug: 'intro', asyncComponent: () => import( './internals/steps-repository/intro' ) },
+			{
+				slug: 'linkInBioSetup',
+				asyncComponent: () => import( './internals/steps-repository/link-in-bio-setup' ),
+			},
+			{ slug: 'domains', asyncComponent: () => import( './internals/steps-repository/domains' ) },
+			{ slug: 'plans', asyncComponent: () => import( './internals/steps-repository/plans' ) },
+			{ slug: 'patterns', asyncComponent: () => import( './internals/steps-repository/patterns' ) },
+			{
+				slug: 'siteCreationStep',
+				asyncComponent: () => import( './internals/steps-repository/site-creation-step' ),
+			},
+			{
+				slug: 'processing',
+				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
+			},
+			{
+				slug: 'launchpad',
+				asyncComponent: () => import( './internals/steps-repository/launchpad' ),
+			},
 		];
 	},
 


### PR DESCRIPTION
## Proposed Changes

[Flows now can be sync or async](pdDR7T-J3-p2), this PR makes LiB flow async in order to improve Web Vitals scores

## Testing Instructions

- Pull and run this branch or use calypso live links
- Navigate to LiB flow `setup/link-in-bio/intro`
- Complete the flow, nothing should behave differently besides this [known behaviour](pdDR7T-J3-p2)
- Please check also mobile and try to find any style issues.

Context [pdDR7T-J3-p2](pdDR7T-J3-p2)