### PR TITLE
Improve info about 50% first year on pricing page

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -147,6 +147,7 @@ const Paid: React.FC< OwnProps > = ( props ) => {
 					billingTerm={ billingTerm }
 					discountedPriceDuration={ discountedPriceDuration }
 					formattedOriginalPrice={ formattedOriginalPrice }
+					isDiscounted={ isDiscounted }
 				/>
 			</span>
 		</>

--- a/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/time-frame.tsx
@@ -10,6 +10,7 @@ interface TimeFrameProps {
 	billingTerm: Duration;
 	discountedPriceDuration?: number;
 	formattedOriginalPrice?: string;
+	isDiscounted?: boolean;
 }
 
 interface RegularTimeFrameProps {
@@ -153,12 +154,24 @@ const PartialDiscountTimeFrame: React.FC< PartialDiscountTimeFrameProps & A11yPr
 	return <span className="display-price__billing-time-frame">{ text }</span>;
 };
 
+const OneYearDiscountTimeFrame: React.FC< A11yProps > = ( { forScreenReader } ) => {
+	const translate = useTranslate();
+	const text = translate( 'per month for the first year, billed yearly' );
+
+	if ( forScreenReader ) {
+		return <>{ text }</>;
+	}
+
+	return <span className="display-price__billing-time-frame">{ text }</span>;
+};
+
 const TimeFrame: React.FC< TimeFrameProps & A11yProps > = ( {
 	expiryDate,
 	billingTerm,
 	discountedPriceDuration,
 	formattedOriginalPrice,
 	forScreenReader,
+	isDiscounted,
 } ) => {
 	const moment = useLocalizedMoment();
 	const productExpiryDate =
@@ -168,15 +181,20 @@ const TimeFrame: React.FC< TimeFrameProps & A11yProps > = ( {
 		return <ExpiringDateTimeFrame productExpiryDate={ productExpiryDate } />;
 	}
 
-	if ( discountedPriceDuration && formattedOriginalPrice ) {
-		return (
-			<PartialDiscountTimeFrame
-				billingTerm={ billingTerm }
-				discountedPriceDuration={ discountedPriceDuration }
-				forScreenReader={ forScreenReader }
-				formattedOriginalPrice={ formattedOriginalPrice }
-			/>
-		);
+	// `1 === discountedPriceDuration` condition taken from client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx:56
+	if ( isDiscounted ) {
+		if ( 1 === discountedPriceDuration && formattedOriginalPrice ) {
+			return (
+				<PartialDiscountTimeFrame
+					billingTerm={ billingTerm }
+					discountedPriceDuration={ discountedPriceDuration }
+					forScreenReader={ forScreenReader }
+					formattedOriginalPrice={ formattedOriginalPrice }
+				/>
+			);
+		}
+
+		return <OneYearDiscountTimeFrame forScreenReader={ forScreenReader } />;
 	}
 
 	return <RegularTimeFrame billingTerm={ billingTerm } forScreenReader={ forScreenReader } />;

--- a/client/components/jetpack/intro-pricing-banner/index.tsx
+++ b/client/components/jetpack/intro-pricing-banner/index.tsx
@@ -7,7 +7,10 @@ import CloudCart from 'calypso/jetpack-cloud/sections/pricing/jpcom-masterbar/cl
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 import { preventWidows } from 'calypso/lib/formatting';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { GUARANTEE_DAYS } from 'calypso/my-sites/plans/jetpack-plans/constants';
+import {
+	GUARANTEE_DAYS,
+	INTRO_PRICING_DISCOUNT_PERCENTAGE,
+} from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { isConnectStore } from 'calypso/my-sites/plans/jetpack-plans/product-grid/utils';
 import './style.scss';
 import { isJetpackCloudCartEnabled } from 'calypso/state/sites/selectors';
@@ -15,6 +18,7 @@ import guaranteeBadge from './14-day-badge.svg';
 import useBoundingClientRect from './hooks/use-bounding-client-rect';
 import { usePrevious } from './hooks/use-previous';
 import people from './people.svg';
+import rocket from './rocket.svg';
 
 const CALYPSO_MASTERBAR_HEIGHT = 47;
 const CLOUD_MASTERBAR_HEIGHT = 47;
@@ -68,6 +72,16 @@ const IntroPricingBanner: React.FC = () => {
 			<div className="intro-pricing-banner__viewport-sentinel" { ...outerDivProps }></div>
 			<div className={ `intro-pricing-banner ${ classModifier }` }>
 				<div className="intro-pricing-banner__content">
+					<div className="intro-pricing-banner__item">
+						<img className="intro-pricing-banner__item-icon" src={ rocket } alt="" />
+						<span className="intro-pricing-banner__item-label">
+							{ preventWidows(
+								translate( 'Get %(percent)d% off your first year', {
+									args: { percent: INTRO_PRICING_DISCOUNT_PERCENTAGE },
+								} )
+							) }
+						</span>
+					</div>
 					<div className="intro-pricing-banner__item">
 						<img className="intro-pricing-banner__item-icon" src={ guaranteeBadge } alt="" />
 						<span className="intro-pricing-banner__item-label">

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
@@ -89,6 +89,7 @@ const PaymentPlan: React.FC< PaymentPlanProps > = ( {
 									formattedOriginalPrice={ formatCurrency( originalPrice, currencyCode, {
 										stripZeros: true,
 									} ) }
+									isDiscounted={ !! discountedPrice }
 								/>
 							</div>
 						</div>


### PR DESCRIPTION
## Proposed Changes

We introduced new pricing and want to improve on informing users about 50% first-year offers on the pricing page. We've implemented small changes to make it more clear.

<img width="949" alt="CleanShot 2023-04-14 at 16 09 06@2x" src="https://user-images.githubusercontent.com/8419292/232068084-711ced37-edff-4e70-94ee-ed618b695658.png">

<img width="620" alt="CleanShot 2023-04-14 at 16 09 14@2x" src="https://user-images.githubusercontent.com/8419292/232068122-2a48551e-7999-4ae2-ac67-f2437bc30bce.png">

## Testing Instructions

* Checkout the PR
* Go to `http://jetpack.cloud.localhost:3001/pricing`
* You should see updated header text and price caption, as can be seen above
* Click through pricing (click "More about ..." links) to make sure that the captions for non-discounted items stayed correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
