### PR TITLE
Add initial designs for campaign table

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -87,7 +87,7 @@ export default function CampaignItem( props: Props ) {
 			<td>{ budgetString }</td>
 			<td>{ formatNumber( impressions_total ) }</td>
 			<td>{ formatNumber( clicks_total ) }</td>
-			<td>{ campaignContainsData && <Button icon={ chevronRight } onClick={ () => {} } /> }</td>
+			<td>{ campaignContainsData && <Button icon={ chevronRight } /> }</td>
 		</tr>
 	);
 }

--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -1,0 +1,93 @@
+import { safeImageUrl } from '@automattic/calypso-url';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { chevronRight } from '@wordpress/icons';
+import React, { useMemo } from 'react';
+import Badge from 'calypso/components/badge';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { Campaign } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
+import resizeImageUrl from 'calypso/lib/resize-image-url';
+import {
+	campaignStatus,
+	formatCents,
+	formatNumber,
+	getCampaignBudgetData,
+	getCampaignStatus,
+	getCampaignStatusBadgeColor,
+	isCampaignFinished,
+} from '../../utils';
+
+interface Props {
+	campaign: Campaign;
+}
+
+const getCampaignEndText = ( localizedMomentInstance: any, status: string, end_date: string ) => {
+	if (
+		[ campaignStatus.SCHEDULED, campaignStatus.CREATED, campaignStatus.REJECTED ].includes( status )
+	) {
+		return '-';
+	} else if ( [ campaignStatus.APPROVED, campaignStatus.ACTIVE ].includes( status ) ) {
+		return __( 'Ongoing' );
+	} else if ( [ campaignStatus.CANCELED, campaignStatus.FINISHED ].includes( status ) ) {
+		// return moment in format similar to 27 June
+		return localizedMomentInstance( end_date ).format( 'D MMMM' );
+	}
+	return '-';
+};
+
+export default function CampaignItem( props: Props ) {
+	const { campaign } = props;
+	const {
+		name,
+		content_config,
+		display_name,
+		status,
+		end_date,
+		budget_cents,
+		impressions_total,
+		clicks_total,
+		spent_budget_cents,
+		start_date,
+	} = campaign;
+
+	const moment = useLocalizedMoment();
+
+	const safeUrl = safeImageUrl( content_config.imageUrl );
+	const adCreativeUrl = safeUrl && resizeImageUrl( safeUrl, { h: 80 }, 0 );
+
+	const { totalBudget, totalBudgetLeft, campaignDays } = useMemo(
+		() => getCampaignBudgetData( budget_cents, start_date, end_date, spent_budget_cents ),
+		[ budget_cents, end_date, spent_budget_cents, start_date ]
+	);
+
+	const totalBudgetLeftString = `($${ formatCents( totalBudgetLeft || 0 ) } ${ __( 'left' ) })`;
+	const budgetString = campaignDays ? `$${ totalBudget } ${ totalBudgetLeftString }` : '-';
+
+	const campaignContainsData = isCampaignFinished( status );
+
+	return (
+		<tr>
+			<td>
+				<div className="promote-post__campaign-item-wrapper">
+					{ adCreativeUrl && (
+						<div className="campaign-item__header-image">
+							<img src={ adCreativeUrl } alt="" />
+						</div>
+					) }
+					{ name }
+				</div>
+			</td>
+			<td>{ display_name }</td>
+			<td>
+				<Badge type={ getCampaignStatusBadgeColor( status ) }>
+					{ getCampaignStatus( status ) }
+				</Badge>
+			</td>
+			<td>{ getCampaignEndText( moment, campaign.status, campaign.end_date ) }</td>
+			<td>{ budgetString }</td>
+			<td>{ formatNumber( impressions_total ) }</td>
+			<td>{ formatNumber( clicks_total ) }</td>
+			<td>{ campaignContainsData && <Button icon={ chevronRight } onClick={ () => {} } /> }</td>
+		</tr>
+	);
+}

--- a/client/my-sites/promote-post-i2/components/campaigns-filter/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-filter/index.tsx
@@ -1,0 +1,43 @@
+import { useTranslate } from 'i18n-calypso';
+import SegmentedControl from 'calypso/components/segmented-control';
+
+export type CampaignsFilterType = 'all' | 'active' | 'in_moderation' | 'rejected';
+
+interface Props {
+	campaignsFilter: CampaignsFilterType;
+	handleChangeFilter: ( type: CampaignsFilterType ) => void;
+}
+
+export default function CampaignsFilter( props: Props ) {
+	const translate = useTranslate();
+
+	const { handleChangeFilter, campaignsFilter } = props;
+	return (
+		<SegmentedControl compact primary>
+			<SegmentedControl.Item
+				selected={ campaignsFilter === 'all' }
+				onClick={ handleChangeFilter( 'all' ) }
+			>
+				{ translate( 'All' ) }
+			</SegmentedControl.Item>
+			<SegmentedControl.Item
+				selected={ campaignsFilter === 'active' }
+				onClick={ handleChangeFilter( 'active' ) }
+			>
+				{ translate( 'Active', { context: 'comment status' } ) }
+			</SegmentedControl.Item>
+			<SegmentedControl.Item
+				selected={ campaignsFilter === 'in_moderation' }
+				onClick={ handleChangeFilter( 'in_moderation' ) }
+			>
+				{ translate( 'In moderation', { context: 'comment status' } ) }
+			</SegmentedControl.Item>
+			<SegmentedControl.Item
+				selected={ campaignsFilter === 'rejected' }
+				onClick={ handleChangeFilter( 'rejected' ) }
+			>
+				{ translate( 'Rejected', { context: 'comment status' } ) }
+			</SegmentedControl.Item>
+		</SegmentedControl>
+	);
+}

--- a/client/my-sites/promote-post-i2/components/campaigns-list/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-list/index.tsx
@@ -1,0 +1,99 @@
+import { translate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import SitePlaceholder from 'calypso/blocks/site/placeholder';
+import ListEnd from 'calypso/components/list-end';
+import Notice from 'calypso/components/notice';
+import { Campaign } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import CampaignItem from 'calypso/my-sites/promote-post/components/campaign-item';
+import './style.scss';
+import CampaignsEmpty from 'calypso/my-sites/promote-post/components/campaigns-empty';
+import CampaignsTable from '../campaigns-table';
+import EmptyPromotionList from '../empty-promotion-list';
+import SearchBar from '../search-bar';
+
+const noCampaignListMessage = translate(
+	'There was a problem obtaining the campaign list. Please try again or {{contactSupportLink}}contact support{{/contactSupportLink}}.',
+	{
+		components: {
+			contactSupportLink: <a href={ CALYPSO_CONTACT } />,
+		},
+		comment: 'Validation error when filling out domain checkout contact details form',
+	}
+);
+
+export default function CampaignsList( {
+	isLoading,
+	isError,
+	hasLocalUser,
+	campaigns,
+	expandedCampaigns,
+	setExpandedCampaigns,
+}: {
+	isLoading: boolean;
+	hasLocalUser: boolean;
+	isError: boolean;
+	campaigns: Campaign[];
+	expandedCampaigns: number[];
+	setExpandedCampaigns: ( campaigns: number[] ) => void;
+} ) {
+	const memoCampaigns = useMemo< Campaign[] >( () => campaigns || [], [ campaigns ] );
+
+	const isEmpty = ! memoCampaigns.length;
+
+	if ( isError && hasLocalUser ) {
+		return (
+			<Notice status="is-error" icon="mention">
+				{ noCampaignListMessage }
+			</Notice>
+		);
+	}
+
+	if ( isLoading ) {
+		return (
+			<div className="campaigns-list__loading-container">
+				<SitePlaceholder />
+			</div>
+		);
+	}
+
+	if ( ! memoCampaigns.length ) {
+		return <EmptyPromotionList type="campaigns" />;
+	}
+
+	const handleClickCampaign = ( isExpanded: boolean, campaign: Campaign ) => {
+		if ( isExpanded ) {
+			setExpandedCampaigns( [ ...expandedCampaigns, campaign.campaign_id ] );
+		} else {
+			setExpandedCampaigns( expandedCampaigns.filter( ( id ) => id !== campaign.campaign_id ) );
+		}
+	};
+
+	return (
+		<>
+			<SearchBar mode="campaigns" />
+
+			{ isEmpty && ! isError && <CampaignsEmpty /> }
+
+			<CampaignsTable campaigns={ memoCampaigns } />
+
+			{ ! isEmpty && ! isError && (
+				<>
+					{ /*{ memoCampaigns.map( function ( campaign ) {
+						return (
+							<CampaignItem
+								key={ campaign.campaign_id }
+								campaign={ campaign }
+								expanded={ expandedCampaigns.includes( campaign.campaign_id ) }
+								onClickCampaign={ ( isExpanded: boolean ) =>
+									handleClickCampaign( isExpanded, campaign )
+								}
+							/>
+						);
+					} ) }*/ }
+					<ListEnd />
+				</>
+			) }
+		</>
+	);
+}

--- a/client/my-sites/promote-post-i2/components/campaigns-list/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-list/index.tsx
@@ -5,7 +5,6 @@ import ListEnd from 'calypso/components/list-end';
 import Notice from 'calypso/components/notice';
 import { Campaign } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
-import CampaignItem from 'calypso/my-sites/promote-post/components/campaign-item';
 import './style.scss';
 import CampaignsEmpty from 'calypso/my-sites/promote-post/components/campaigns-empty';
 import CampaignsTable from '../campaigns-table';
@@ -27,8 +26,6 @@ export default function CampaignsList( {
 	isError,
 	hasLocalUser,
 	campaigns,
-	expandedCampaigns,
-	setExpandedCampaigns,
 }: {
 	isLoading: boolean;
 	hasLocalUser: boolean;
@@ -60,14 +57,6 @@ export default function CampaignsList( {
 	if ( ! memoCampaigns.length ) {
 		return <EmptyPromotionList type="campaigns" />;
 	}
-
-	const handleClickCampaign = ( isExpanded: boolean, campaign: Campaign ) => {
-		if ( isExpanded ) {
-			setExpandedCampaigns( [ ...expandedCampaigns, campaign.campaign_id ] );
-		} else {
-			setExpandedCampaigns( expandedCampaigns.filter( ( id ) => id !== campaign.campaign_id ) );
-		}
-	};
 
 	return (
 		<>

--- a/client/my-sites/promote-post-i2/components/campaigns-list/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaigns-list/style.scss
@@ -1,0 +1,7 @@
+.promote-post {
+	.posts-list__loading-container {
+		display: flex;
+		justify-content: center;
+	}
+
+}

--- a/client/my-sites/promote-post-i2/components/campaigns-table/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/index.tsx
@@ -1,0 +1,34 @@
+import { Campaign } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
+import CampaignItem from '../campaign-item';
+
+import './style.scss';
+
+interface Props {
+	campaigns: Campaign[];
+}
+
+export default function CampaignsTable( props: Props ) {
+	const { campaigns } = props;
+	return (
+		<div>
+			<table className="promote-post__table">
+				<thead>
+					<tr>
+						<th>Campaign</th>
+						<th>User</th>
+						<th>Status</th>
+						<th>Ends</th>
+						<th>Budget</th>
+						<th>Impressions</th>
+						<th>Clicks</th>
+					</tr>
+				</thead>
+				<tbody>
+					{ campaigns.map( ( campaign ) => {
+						return <CampaignItem campaign={ campaign } />;
+					} ) }
+				</tbody>
+			</table>
+		</div>
+	);
+}

--- a/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
@@ -1,0 +1,86 @@
+@import "@automattic/typography/styles/variables";
+
+$font-sf-pro-display: "SF Pro Display", $sans;
+$font-sf-pro-text: "SF Pro Text", $sans;
+
+.promote-post__table {
+	th {
+		font-family: $font-sf-pro-text;
+		font-style: normal;
+		font-weight: 400;
+		font-size: 1rem;
+		line-height: 20px;
+		letter-spacing: -0.15px;
+		color: #50575e;
+		padding-bottom: 8px;
+	}
+
+	tr {
+		font-size: 1rem;
+	}
+
+	tr td:last-child {
+		border: 0;
+	}
+
+	td {
+		padding-top: 16px;
+		padding-bottom: 12px;
+		border-top: 1px solid #d8d8d8; /* #EEEEEE if bg is white */
+		font-size: 1rem;
+		vertical-align: middle;
+	}
+
+
+	.promote-post__campaign-item-wrapper {
+		display: flex;
+		align-items: center;
+	}
+
+	.campaign-item__header-image img {
+		border-radius: 4px;
+		width: 108px;
+		height: 78px;
+		margin-right: 16px;
+	}
+
+	.badge {
+		border-radius: 4px;
+		font-size: 0.875rem;
+
+		&.badge--error {
+			background-color: #facfd2;
+			color: #8a2424;
+		}
+
+		&.badge--warning {
+			color: #4f3500;
+			background-color: #f5e6b3;
+		}
+
+		&.badge--success {
+			color: #00450c;
+			background-color: #b8e6bf;
+		}
+
+		&.badge--info {
+			color: var(--color-neutral-70);
+			background-color: var(--color-neutral-5);
+		}
+
+		&.badge--info-blue {
+			background-color: #bbe0fa;
+			color: #02395c;
+		}
+
+		&.badge--info-green {
+			color: var(--studio-green-80);
+			background-color: rgba(184, 230, 191, 0.64);
+		}
+
+		&.badge--info-purple {
+			color: var(--studio-woocommerce-purple-80);
+			background-color: var(--studio-woocommerce-purple-5);
+		}
+	}
+}

--- a/client/my-sites/promote-post-i2/components/empty-promotion-list/index.tsx
+++ b/client/my-sites/promote-post-i2/components/empty-promotion-list/index.tsx
@@ -1,0 +1,51 @@
+import './style.scss';
+import { __ } from '@wordpress/i18n';
+
+type Props = {
+	type: 'campaigns' | 'posts';
+};
+
+export const PromoteTypes = {
+	campaigns: 'campaigns',
+	posts: 'posts',
+};
+
+type PromoteStrings = {
+	[ key in keyof typeof PromoteTypes ]: {
+		title: string;
+		body: string;
+		linkTitle?: string;
+		linkUrl?: string;
+	};
+};
+
+const strings: PromoteStrings = {
+	campaigns: {
+		title: __( 'There are no campaigns yet.' ),
+		body: __(
+			'Start promoting a post or page from the list of content ready to promote or find your post or a page, then from the ellipsis, select promote.'
+		),
+		linkTitle: __( 'Learn how to start a campaign' ),
+		linkUrl: '',
+	},
+	posts: {
+		title: __( 'You have no posts or pages.' ),
+		body: __( "Start by creating a post or a page and start promoting it once it's ready." ),
+	},
+};
+
+export default function EmptyPromotionList( props: Props ) {
+	const { type } = props;
+	return (
+		<div className="empty-promotion-list__container">
+			<h3 className="empty-promotion-list__title">{ strings[ type ].title }</h3>
+			<p className="empty-promotion-list__body">{ strings[ type ].body }</p>
+
+			{ strings[ type ].linkUrl && (
+				<p className="empty-promotion-list__link">
+					<a href={ strings[ type ].linkUrl }>{ strings[ type ].linkTitle }</a>
+				</p>
+			) }
+		</div>
+	);
+}

--- a/client/my-sites/promote-post-i2/components/empty-promotion-list/style.scss
+++ b/client/my-sites/promote-post-i2/components/empty-promotion-list/style.scss
@@ -1,0 +1,14 @@
+.promote-post {
+
+	.empty-promotion-list__container {
+		text-align: center;
+		margin-top: 80px;
+		padding: 0 20px;
+		.empty-promotion-list__title {
+			font-weight: 700;
+			font-size: $font-title-small;
+			margin-bottom: 20px;
+		}
+	}
+
+}

--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -4,7 +4,7 @@ import './style.scss';
 import Gridicon from 'calypso/../packages/components/src/gridicon';
 import Search from 'calypso/components/search';
 import SelectDropdown from 'calypso/components/select-dropdown';
-import CampaignsFilter, { CampaignsFilterType } from '../campaigns-filter';
+import CampaignsFilter from '../campaigns-filter';
 
 interface Props {
 	mode: 'campaigns' | 'posts';
@@ -22,7 +22,6 @@ export default function SearchBar( props: Props ) {
 	const translate = useTranslate();
 	const [ searchInput, setSearchInput ] = React.useState( '' );
 	const [ currentSortOption, setSortOption ] = React.useState( sortOptions[ 0 ].value );
-	const [ campaignFilter, setCampaignFilter ] = React.useState< CampaignsFilterType >( 'all' );
 
 	const onSearch = () => {
 		return;
@@ -32,11 +31,8 @@ export default function SearchBar( props: Props ) {
 		setSearchInput( '' );
 	};
 
-	const [ data, setData ] = React.useState( [] );
-
-	const onChangeFilter = ( type: CampaignsFilterType ) => {
+	const onChangeFilter = () => {
 		setSearchInput( '' );
-		setCampaignFilter( type );
 	};
 
 	return (

--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -1,0 +1,95 @@
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import './style.scss';
+import Gridicon from 'calypso/../packages/components/src/gridicon';
+import Search from 'calypso/components/search';
+import SelectDropdown from 'calypso/components/select-dropdown';
+import CampaignsFilter, { CampaignsFilterType } from '../campaigns-filter';
+
+interface Props {
+	mode: 'campaigns' | 'posts';
+}
+
+const sortOptions = [
+	{
+		label: 'Last published',
+		value: 'last_published',
+	},
+];
+export default function SearchBar( props: Props ) {
+	const { mode } = props;
+
+	const translate = useTranslate();
+	const [ searchInput, setSearchInput ] = React.useState( '' );
+	const [ currentSortOption, setSortOption ] = React.useState( sortOptions[ 0 ].value );
+	const [ campaignFilter, setCampaignFilter ] = React.useState< CampaignsFilterType >( 'all' );
+
+	const onSearch = () => {
+		return;
+	};
+
+	const onClearIconClick = () => {
+		setSearchInput( '' );
+	};
+
+	const [ data, setData ] = React.useState( [] );
+
+	const onChangeFilter = ( type: CampaignsFilterType ) => {
+		setSearchInput( '' );
+		setCampaignFilter( type );
+	};
+
+	return (
+		<div className="promote-post__search-bar-wrapper">
+			<Search
+				className="promote-post__search-bar-search"
+				initialValue={ searchInput }
+				value={ searchInput }
+				placeholder={ translate( 'Search…' ) }
+				onSearch={ onSearch }
+				onSearchChange={ ( inputValue: string ) => {
+					// findTextForSuggestions( inputValue );
+					setSearchInput( inputValue );
+					// setIsApplySearch( false );
+				} }
+			>
+				{ searchInput !== '' && (
+					<div className="search-themes-card__icon">
+						<Gridicon
+							icon="cross"
+							className="search-themes-card__icon-close"
+							tabIndex={ 0 }
+							aria-controls="search-component-search-themes"
+							aria-label={ translate( 'Clear Search' ) }
+							onClick={ onClearIconClick }
+						/>
+					</div>
+				) }
+			</Search>
+
+			{ mode === 'posts' && (
+				<SelectDropdown
+					className="promote-post__search-bar-dropdown"
+					selectedText=""
+					/*
+				selectedIcon={ <Gridicon size={ 18 } icon={ selectedDevice.icon } /> }
+*/
+				>
+					{ sortOptions.map( ( sortOption ) => (
+						<SelectDropdown.Item
+							key={ sortOption.value }
+							selected={ sortOption.value === currentSortOption }
+							onClick={ () => setSortOption( sortOption.value ) }
+						>
+							{ sortOption.label }
+						</SelectDropdown.Item>
+					) ) }
+				</SelectDropdown>
+			) }
+
+			{ mode === 'campaigns' && (
+				<CampaignsFilter handleChangeFilter={ onChangeFilter } campaignsFilter="all" />
+			) }
+		</div>
+	);
+}

--- a/client/my-sites/promote-post-i2/components/search-bar/style.scss
+++ b/client/my-sites/promote-post-i2/components/search-bar/style.scss
@@ -1,0 +1,20 @@
+.promote-post__search-bar-wrapper {
+	margin-bottom: 20px;
+	flex-wrap: wrap;
+	display: grid;
+	grid-template-columns: 70% 30%;
+
+	.promote-post__search-bar-dropdown {
+		&.select-dropdown {
+			height: 50px;
+		}
+
+		.select-dropdown__container {
+			width: 100%;
+		}
+
+		.select-dropdown__header {
+			height: 50px;
+		}
+	}
+}

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -17,10 +17,10 @@ import useCampaignsStatsQuery from 'calypso/data/promote-post/use-promote-post-c
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import memoizeLast from 'calypso/lib/memoize-last';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
-import CampaignsList from 'calypso/my-sites/promote-post/components/campaigns-list';
 import PostsList from 'calypso/my-sites/promote-post/components/posts-list';
 import PostsListBanner from 'calypso/my-sites/promote-post/components/posts-list-banner';
 import PromotePostTabBar from 'calypso/my-sites/promote-post/components/promoted-post-filter';
+import CampaignsList from 'calypso/my-sites/promote-post-i2/components/campaigns-list';
 import {
 	getSitePost,
 	getPostsForQuery,

--- a/client/my-sites/promote-post-i2/utils/index.ts
+++ b/client/my-sites/promote-post-i2/utils/index.ts
@@ -13,6 +13,7 @@ export const campaignStatus = {
 	ACTIVE: 'active',
 	CANCELED: 'canceled',
 	FINISHED: 'finished',
+	PROCESSING: 'processing',
 };
 
 export const getPostType = ( type: string ) => {
@@ -37,7 +38,7 @@ export const getCampaignStatusBadgeColor = ( status: string ) => {
 			return 'info-blue';
 		}
 		case campaignStatus.CREATED: {
-			return 'info-blue';
+			return 'warning';
 		}
 		case campaignStatus.REJECTED: {
 			return 'error';
@@ -52,11 +53,17 @@ export const getCampaignStatusBadgeColor = ( status: string ) => {
 			return 'error';
 		}
 		case campaignStatus.FINISHED: {
-			return 'info-purple';
+			return 'info-blue';
 		}
 		default:
 			return 'warning';
 	}
+};
+
+export const isCampaignFinished = ( status: string ) => {
+	return [ campaignStatus.CANCELED, campaignStatus.ACTIVE, campaignStatus.FINISHED ].includes(
+		status
+	);
 };
 
 export const getCampaignStatus = ( status: string ) => {
@@ -65,7 +72,7 @@ export const getCampaignStatus = ( status: string ) => {
 			return __( 'Scheduled' );
 		}
 		case campaignStatus.CREATED: {
-			return __( 'Pending review' );
+			return __( 'In moderation' );
 		}
 		case campaignStatus.REJECTED: {
 			return __( 'Rejected' );
@@ -81,6 +88,9 @@ export const getCampaignStatus = ( status: string ) => {
 		}
 		case campaignStatus.FINISHED: {
 			return __( 'Finished' );
+		}
+		case campaignStatus.PROCESSING: {
+			return __( 'Creating' );
 		}
 		default:
 			return status;
@@ -200,6 +210,13 @@ export const getCampaignEstimatedImpressions = ( displayDeliveryEstimate: string
 	}
 	const [ minEstimate, maxEstimate ] = displayDeliveryEstimate.split( ':' );
 	return `${ ( +minEstimate ).toLocaleString() } - ${ ( +maxEstimate ).toLocaleString() }`;
+};
+
+export const formatNumber = ( number: number ) => {
+	if ( ! number ) {
+		return '-';
+	}
+	return number.toLocaleString();
 };
 
 export const canCancelCampaign = ( status: string ) => {


### PR DESCRIPTION
Initial approach of the campaigns table redesign in BlazePress

![image](https://user-images.githubusercontent.com/43957544/232071916-72c47162-1bf8-4989-8e5a-50dcc7a0ef9a.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
