### PR TITLE
Social previews: make section heading level a prop

### DIFF
--- a/packages/social-previews/src/facebook-preview/index.tsx
+++ b/packages/social-previews/src/facebook-preview/index.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import SectionHeading from '../shared/section-heading';
 import FacebookLinkPreview from './link-preview';
 import type { FacebookPreviewProps } from './types';
 
@@ -8,12 +9,12 @@ const FacebookPreview: React.FC< FacebookPreviewProps > = ( props ) => {
 	return (
 		<div className="social-preview facebook-preview">
 			<section className="social-preview__section facebook-preview__section">
-				<h3 className="social-preview__section-heading">
+				<SectionHeading level={ props.headingsLevel }>
 					{
 						// translators: refers to a social post on Facebook
 						__( 'Your post', 'facebook-preview' )
 					}
-				</h3>
+				</SectionHeading>
 				<p className="social-preview__section-desc">
 					{ __( 'This is what your social post will look like on Facebook:', 'facebook-preview' ) }
 				</p>

--- a/packages/social-previews/src/shared/section-heading/index.tsx
+++ b/packages/social-previews/src/shared/section-heading/index.tsx
@@ -1,0 +1,19 @@
+import { createElement } from 'react';
+
+type Props = {
+	className?: string;
+	level?: number;
+	children?: React.ReactNode;
+};
+
+const HEADING_LEVELS = [ 2, 3, 4, 5, 6 ];
+
+const SectionHeading: React.FC< Props > = ( { className, level, children } ) => {
+	return createElement(
+		`h${ level && HEADING_LEVELS.indexOf( level ) > -1 ? level : 3 }`,
+		{ className: `social-preview__section-heading ${ className ?? '' }` },
+		children
+	);
+};
+
+export default SectionHeading;

--- a/packages/social-previews/src/types.ts
+++ b/packages/social-previews/src/types.ts
@@ -4,6 +4,7 @@ export type PreviewProps = {
 	description?: string;
 	customText?: string;
 	image?: string;
+	headingsLevel?: number;
 };
 
 export type TextFormatter = ( text: string ) => string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

[Changes](https://github.com/Automattic/wp-calypso/pull/75430) in the  `social-previews` package involve having separate sections for various preview types. These sections start with a heading, that's currently hardcoded as a `h3`.

This diff adds the possibility to set the heading level as a prop, so that developers using the preview components in this package can control the outline of their page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you have a self-hosted Jetpack site
* Spin up Calypso by using a live link below or by running this branch locally
* Open the dev console
* VIsit `/marketing/traffic/:site`
* Click _Show Previews_ in the _Website Meta_ section, then select the Facebook preview
* Check that the heading looks like it does on production

<img width="742" alt="Screenshot 2023-04-14 at 11 15 56 AM" src="https://user-images.githubusercontent.com/1620183/232084759-86efd1ad-281f-4651-9f4b-3e3ee112a0cd.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
