### PR TITLE
Social previews: handle Facebook image loading

### DIFF
--- a/packages/social-previews/src/facebook-preview/link-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/link-preview.tsx
@@ -19,16 +19,20 @@ const FacebookLinkPreview: React.FC< FacebookPreviewProps > = ( {
 	customText,
 	type,
 } ) => {
-	const [ mode, setMode ] = useState( LANDSCAPE_MODE );
+	const [ mode, setMode ] = useState< typeof LANDSCAPE_MODE | typeof PORTRAIT_MODE | undefined >();
+	const [ isLoadingImage, setLoadingImage ] = useState< boolean >( !! image );
 	const isArticle = type === TYPE_ARTICLE;
 	const portraitMode = ( isArticle && ! image ) || mode === PORTRAIT_MODE;
 	const modeClass = `is-${ portraitMode ? 'portrait' : 'landscape' }`;
 
 	const handleImageLoad = useCallback(
-		( { target } ) =>
-			setMode( target.naturalWidth > target.naturalHeight ? LANDSCAPE_MODE : PORTRAIT_MODE ),
-		[ setMode ]
+		( { target } ) => {
+			setMode( target.naturalWidth > target.naturalHeight ? LANDSCAPE_MODE : PORTRAIT_MODE );
+			setLoadingImage( false );
+		},
+		[ setMode, setLoadingImage ]
 	);
+	const handleImageError = useCallback( () => setLoadingImage( false ), [ setLoadingImage ] );
 
 	return (
 		<div className="facebook-preview__post">
@@ -37,7 +41,11 @@ const FacebookLinkPreview: React.FC< FacebookPreviewProps > = ( {
 				{ customText && (
 					<p className="facebook-preview__custom-text">{ facebookCustomText( customText ) }</p>
 				) }
-				<div className={ `facebook-preview__body ${ modeClass }` }>
+				<div
+					className={ `facebook-preview__body ${ modeClass } ${
+						isLoadingImage ? 'is-loading' : ''
+					}` }
+				>
 					{ ( image || isArticle ) && (
 						<div
 							className={ `facebook-preview__image ${ image ? '' : 'is-empty' } ${ modeClass }` }
@@ -47,6 +55,7 @@ const FacebookLinkPreview: React.FC< FacebookPreviewProps > = ( {
 									alt={ __( 'Facebook Preview Thumbnail', 'facebook-preview' ) }
 									src={ image }
 									onLoad={ handleImageLoad }
+									onError={ handleImageError }
 								/>
 							) }
 						</div>

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -38,6 +38,10 @@
 	border-top: $facebook-preview-body-border;
 	border-bottom: $facebook-preview-body-border;
 
+	&.is-loading {
+		visibility: hidden;
+	}
+
 	&.is-portrait {
 		flex-direction: row;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The Facebook preview was updated in #75780. The layout of the preview content depends on the orientation of the image (portrait or landscape). Since the image needs to be loaded first in order to know the orientation and that the default currently is landscape, there can be a perceivable layout glitch once an image in portrait mode has loaded.

This diff fixes that by hiding the card body while the image is loading.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This is difficult to test since images can load quite quickly, and the loading state can therefore not be perceivable. We can try throttling the connection, but if we're testing from `/posts/:site` in Calypso, images will be loaded at that point. We can at least test that nothing broke. For this, we can follow the steps to test a post in [this PR ](https://github.com/Automattic/wp-calypso/pull/75430)testing instructions.

<img width="702" alt="Screenshot 2023-04-14 at 11 41 45 AM" src="https://user-images.githubusercontent.com/1620183/232090986-44ff8495-d4ae-45e2-aa64-fc4b8511eeb9.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
