### PR TITLE
Social previews: allow links in Facebook custom text

### DIFF
--- a/packages/social-previews/src/facebook-preview/custom-text.tsx
+++ b/packages/social-previews/src/facebook-preview/custom-text.tsx
@@ -1,0 +1,36 @@
+import { hasTag } from '../helpers';
+import { facebookCustomText } from './helpers';
+
+type Props = {
+	text: string;
+	url: string;
+};
+
+const CustomText: React.FC< Props > = ( { text, url } ) => {
+	let postLink;
+
+	if ( hasTag( text, 'a' ) ) {
+		postLink = (
+			<a
+				className="facebook-preview__custom-text-post-url"
+				href={ url }
+				rel="nofollow noopener noreferrer"
+				target="_blank"
+			>
+				{ url }
+			</a>
+		);
+	}
+
+	return (
+		<p className="facebook-preview__custom-text">
+			<span
+				// eslint-disable-next-line react/no-danger
+				dangerouslySetInnerHTML={ { __html: facebookCustomText( text, { allowedTags: [ 'a' ] } ) } }
+			/>
+			{ postLink }
+		</p>
+	);
+};
+
+export default CustomText;

--- a/packages/social-previews/src/facebook-preview/helpers.ts
+++ b/packages/social-previews/src/facebook-preview/helpers.ts
@@ -1,29 +1,28 @@
-import { firstValid, hardTruncation, shortEnough, stripHtmlTags } from '../helpers';
-import { TextFormatter } from '../types';
+import { firstValid, hardTruncation, shortEnough, stripHtmlTags, Formatter } from '../helpers';
 
 const TITLE_LENGTH = 110;
 const DESCRIPTION_LENGTH = 200;
 const CUSTOM_TEXT_LENGTH = 440;
 
-export const baseDomain: TextFormatter = ( url ) =>
+export const baseDomain: Formatter = ( url ) =>
 	url
 		.replace( /^[^/]+[/]*/, '' ) // strip leading protocol
 		.replace( /\/.*$/, '' ); // strip everything after the domain
 
-export const facebookTitle: TextFormatter = ( text ) =>
+export const facebookTitle: Formatter = ( text ) =>
 	firstValid(
 		shortEnough( TITLE_LENGTH ),
 		hardTruncation( TITLE_LENGTH )
 	)( stripHtmlTags( text ) ) || '';
 
-export const facebookDescription: TextFormatter = ( text ) =>
+export const facebookDescription: Formatter = ( text ) =>
 	firstValid(
 		shortEnough( DESCRIPTION_LENGTH ),
 		hardTruncation( DESCRIPTION_LENGTH )
 	)( stripHtmlTags( text ) ) || '';
 
-export const facebookCustomText: TextFormatter = ( text ) =>
+export const facebookCustomText: Formatter = ( text, options ) =>
 	firstValid(
 		shortEnough( CUSTOM_TEXT_LENGTH ),
 		hardTruncation( CUSTOM_TEXT_LENGTH )
-	)( stripHtmlTags( text ) ) || '';
+	)( stripHtmlTags( text, options?.allowedTags ) ) || '';

--- a/packages/social-previews/src/facebook-preview/link-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/link-preview.tsx
@@ -1,7 +1,8 @@
 import { __ } from '@wordpress/i18n';
 import { useCallback, useState } from 'react';
 import { TYPE_ARTICLE } from '../constants';
-import { baseDomain, facebookTitle, facebookDescription, facebookCustomText } from './helpers';
+import CustomText from './custom-text';
+import { baseDomain, facebookTitle, facebookDescription } from './helpers';
 import FacebookPostActions from './post/actions';
 import FacebookPostHeader from './post/header';
 import FacebookPostIcon from './post/icons';
@@ -38,9 +39,7 @@ const FacebookLinkPreview: React.FC< FacebookPreviewProps > = ( {
 		<div className="facebook-preview__post">
 			<FacebookPostHeader user={ user } />
 			<div className="facebook-preview__content">
-				{ customText && (
-					<p className="facebook-preview__custom-text">{ facebookCustomText( customText ) }</p>
-				) }
+				{ customText && <CustomText text={ customText } url={ url } /> }
 				<div
 					className={ `facebook-preview__body ${ modeClass } ${
 						isLoadingImage ? 'is-loading' : ''

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -31,6 +31,11 @@
 	word-break: break-word;
 }
 
+.facebook-preview__custom-text-post-url {
+	display: block;
+	margin-top: 0.5rem;
+}
+
 .facebook-preview__body {
 	display: flex;
 	flex-direction: column;

--- a/packages/social-previews/src/helpers.ts
+++ b/packages/social-previews/src/helpers.ts
@@ -1,4 +1,4 @@
-type Formatter = ( arg0: string ) => string;
+export type Formatter = ( text: string, options?: any ) => string;
 type AugmentFormatterReturnType< T extends Formatter, TNewReturn > = (
 	...a: Parameters< T >
 ) => ReturnType< T > | TNewReturn;
@@ -27,8 +27,17 @@ export const firstValid: ( ...args: ConditionalFormatter[] ) => NullableFormatte
 	( a ) =>
 		( predicates.find( ( p ) => false !== p( a ) ) as Formatter )?.( a );
 
-export const stripHtmlTags: Formatter = ( description ) =>
-	description ? description.replace( /(<([^>]+)>)/gi, '' ) : '';
+export const stripHtmlTags: Formatter = ( description, allowedTags = [] ) => {
+	const pattern = new RegExp( `(<([^${ allowedTags.join( '' ) }>]+)>)`, 'gi' );
+
+	return description ? description.replace( pattern, '' ) : '';
+};
+
+export const hasTag = ( text: string, tag: string ): boolean => {
+	const pattern = new RegExp( `<${ tag }[^>]*>`, 'gi' );
+
+	return pattern.test( text );
+};
 
 export const formatTweetDate: DateFormatter = new Intl.DateTimeFormat( 'en-US', {
 	// Result: "Apr 7", "Dec 31"

--- a/packages/social-previews/src/types.ts
+++ b/packages/social-previews/src/types.ts
@@ -6,5 +6,3 @@ export type PreviewProps = {
 	image?: string;
 	headingsLevel?: number;
 };
-
-export type TextFormatter = ( text: string ) => string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

#75430 updated the Facebook previews in the `social-previews` package. This diff updates a post custom text so that it accepts links, to follow facebook.com behaviour.

## Testing Instructions

Follow the instructions to test a post in [this PR](https://github.com/Automattic/wp-calypso/pull/75430) testing instructions.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

_Facebook.com_
<img width="400" alt="Screenshot 2023-04-14 at 1 12 42 PM" src="https://user-images.githubusercontent.com/1620183/232119916-5a7e7435-a32a-42d9-b532-dc6d887fb59f.png">

_Preview in Calypso_
<img width="400" alt="Screenshot 2023-04-14 at 1 37 50 PM" src="https://user-images.githubusercontent.com/1620183/232119918-8e57d660-0273-4ebf-be4c-8749535d3239.png">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
