### PR TITLE
`/subscriptions/pending`: Add confirm & delete actions for pending sites.

### DIFF
--- a/client/landing/subscriptions/components/pending-site-list/pending-site-row.tsx
+++ b/client/landing/subscriptions/components/pending-site-list/pending-site-row.tsx
@@ -1,9 +1,13 @@
 import { Gridicon } from '@automattic/components';
+import { SubscriptionManager } from '@automattic/data-stores';
 import { useMemo } from 'react';
 import TimeSince from 'calypso/components/time-since';
+import { PendingSiteSettings } from '../settings-popover';
 import type { PendingSiteSubscription } from '@automattic/data-stores/src/reader/types';
 
 export default function PendingSiteRow( {
+	id,
+	activation_key,
 	site_title,
 	site_icon,
 	site_url,
@@ -16,6 +20,11 @@ export default function PendingSiteRow( {
 		}
 		return <Gridicon className="icon" icon="globe" size={ 48 } />;
 	}, [ site_icon, site_title ] );
+
+	const { mutate: confirmPendingSubscription, isLoading: confirmingPendingSubscription } =
+		SubscriptionManager.usePendingSiteConfirmMutation();
+	const { mutate: deletePendingSubscription, isLoading: deletingPendingSubscription } =
+		SubscriptionManager.usePendingSiteDeleteMutation();
 
 	return (
 		<li className="row" role="row">
@@ -31,7 +40,14 @@ export default function PendingSiteRow( {
 			<span className="date" role="cell">
 				<TimeSince date={ date_subscribed.toISOString?.() ?? date_subscribed } />
 			</span>
-			<span className="actions" role="cell"></span>
+			<span className="actions" role="cell">
+				<PendingSiteSettings
+					onConfirm={ () => confirmPendingSubscription( { id, activation_key } ) }
+					onDelete={ () => deletePendingSubscription( { id } ) }
+					confirming={ confirmingPendingSubscription }
+					deleting={ deletingPendingSubscription }
+				/>
+			</span>
 		</li>
 	);
 }

--- a/client/landing/subscriptions/components/settings-popover/index.ts
+++ b/client/landing/subscriptions/components/settings-popover/index.ts
@@ -1,2 +1,3 @@
 export { SiteSettings } from './site-settings';
 export { CommentSettings } from './comment-settings';
+export { PendingSiteSettings } from './pending-site-settings';

--- a/client/landing/subscriptions/components/settings-popover/pending-site-settings/confirm-pending-site-button.tsx
+++ b/client/landing/subscriptions/components/settings-popover/pending-site-settings/confirm-pending-site-button.tsx
@@ -1,0 +1,24 @@
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+
+type ConfirmPendingSiteButtonProps = {
+	onConfirm: () => void;
+	confirming: boolean;
+};
+
+const ConfirmPendingSiteButton = ( { onConfirm, confirming }: ConfirmPendingSiteButtonProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<PopoverMenuItem
+			className={ classNames( 'settings-popover__item-button', { 'is-loading': confirming } ) }
+			disabled={ confirming }
+			onClick={ onConfirm }
+		>
+			{ translate( 'Confirm' ) }
+		</PopoverMenuItem>
+	);
+};
+
+export default ConfirmPendingSiteButton;

--- a/client/landing/subscriptions/components/settings-popover/pending-site-settings/delete-pending-site-button.tsx
+++ b/client/landing/subscriptions/components/settings-popover/pending-site-settings/delete-pending-site-button.tsx
@@ -1,0 +1,24 @@
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+
+type DeletePendingSiteButtonProps = {
+	onDelete: () => void;
+	deleting: boolean;
+};
+
+const DeletePendingSiteButton = ( { onDelete, deleting }: DeletePendingSiteButtonProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<PopoverMenuItem
+			className={ classNames( 'settings-popover__item-button', { 'is-loading': deleting } ) }
+			disabled={ deleting }
+			onClick={ onDelete }
+		>
+			{ translate( 'Delete' ) }
+		</PopoverMenuItem>
+	);
+};
+
+export default DeletePendingSiteButton;

--- a/client/landing/subscriptions/components/settings-popover/pending-site-settings/index.ts
+++ b/client/landing/subscriptions/components/settings-popover/pending-site-settings/index.ts
@@ -1,0 +1,1 @@
+export { default as PendingSiteSettings } from './pending-site-settings';

--- a/client/landing/subscriptions/components/settings-popover/pending-site-settings/pending-site-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/pending-site-settings/pending-site-settings.tsx
@@ -1,0 +1,28 @@
+import Separator from 'calypso/components/popover-menu/separator';
+import SettingsPopover from '../settings-popover';
+import ConfirmPendingSiteButton from './confirm-pending-site-button';
+import DeletePendingSiteButton from './delete-pending-site-button';
+
+type PendingSiteSettingsProps = {
+	onConfirm: () => void;
+	confirming: boolean;
+	onDelete: () => void;
+	deleting: boolean;
+};
+
+const PendingSiteSettings = ( {
+	onConfirm,
+	confirming,
+	onDelete,
+	deleting,
+}: PendingSiteSettingsProps ) => {
+	return (
+		<SettingsPopover>
+			<ConfirmPendingSiteButton confirming={ confirming } onConfirm={ onConfirm } />
+			<Separator />
+			<DeletePendingSiteButton deleting={ deleting } onDelete={ onDelete } />
+		</SettingsPopover>
+	);
+};
+
+export default PendingSiteSettings;

--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -3,7 +3,7 @@ import wpcomRequest from 'wpcom-proxy-request';
 
 type callApiParams = {
 	path: string;
-	method?: 'GET' | 'POST';
+	method?: 'GET' | 'POST' | 'DELETE';
 	body?: object;
 	isLoggedIn?: boolean;
 	apiVersion?: string;
@@ -48,7 +48,7 @@ async function callApi< ReturnType >( {
 		path: apiPath,
 		apiVersion,
 		method,
-		body: method === 'POST' ? JSON.stringify( body ) : undefined,
+		body: method === 'POST' || method === 'DELETE' ? JSON.stringify( body ) : undefined,
 		credentials: 'same-origin',
 		headers: {
 			Authorization: `X-WPSUBKEY ${ encodeURIComponent( subkey ) }`,

--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -3,7 +3,7 @@ import wpcomRequest from 'wpcom-proxy-request';
 
 type callApiParams = {
 	path: string;
-	method?: 'GET' | 'POST' | 'DELETE';
+	method?: 'GET' | 'POST';
 	body?: object;
 	isLoggedIn?: boolean;
 	apiVersion?: string;
@@ -48,7 +48,7 @@ async function callApi< ReturnType >( {
 		path: apiPath,
 		apiVersion,
 		method,
-		body: method === 'POST' || method === 'DELETE' ? JSON.stringify( body ) : undefined,
+		body: method === 'POST' ? JSON.stringify( body ) : undefined,
 		credentials: 'same-origin',
 		headers: {
 			Authorization: `X-WPSUBKEY ${ encodeURIComponent( subkey ) }`,

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -4,6 +4,8 @@ import {
 	useSiteDeliveryFrequencyMutation,
 	useSiteUnfollowMutation,
 	useUserSettingsMutation,
+	usePendingSiteConfirmMutation,
+	usePendingSiteDeleteMutation,
 } from './mutations';
 import {
 	SiteSubscriptionsSortBy,
@@ -26,6 +28,8 @@ export const SubscriptionManager = {
 	useUserSettingsQuery,
 	useUserSettingsMutation,
 	usePendingSiteSubscriptionsQuery,
+	usePendingSiteConfirmMutation,
+	usePendingSiteDeleteMutation,
 };
 
 // Types

--- a/packages/data-stores/src/reader/mutations/index.ts
+++ b/packages/data-stores/src/reader/mutations/index.ts
@@ -2,3 +2,5 @@ export { default as usePostUnfollowMutation } from './use-post-unfollow-mutation
 export { default as useSiteDeliveryFrequencyMutation } from './use-site-delivery-frequency-mutation';
 export { default as useSiteUnfollowMutation } from './use-site-unfollow-mutation';
 export { default as useUserSettingsMutation } from './use-user-settings-mutation';
+export { default as usePendingSiteConfirmMutation } from './use-pending-site-confirm-mutation';
+export { default as usePendingSiteDeleteMutation } from './use-pending-site-delete-mutation';

--- a/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
@@ -25,7 +25,7 @@ const usePendingSiteConfirmMutation = () => {
 			}
 
 			const response = await callApi< PendingSiteConfirmResponse >( {
-				path: `/pending-blog-subscriptions/${ params.activation_key }`,
+				path: `/pending-blog-subscriptions/${ params.activation_key }/confirm`,
 				method: 'POST',
 				apiVersion: '2',
 			} );

--- a/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
@@ -1,0 +1,104 @@
+import { useMutation, useQueryClient } from 'react-query';
+import { callApi } from '../helpers';
+import { useIsLoggedIn } from '../hooks';
+import { PendingSiteSubscription, SubscriptionManagerSubscriptionsCount } from '../types';
+
+type PendingSiteConfirmParams = {
+	id: string;
+	activation_key: string;
+};
+
+type PendingSiteConfirmResponse = {
+	confirmed: boolean;
+};
+
+const usePendingSiteConfirmMutation = () => {
+	const isLoggedIn = useIsLoggedIn();
+	const queryClient = useQueryClient();
+	return useMutation(
+		async ( params: PendingSiteConfirmParams ) => {
+			if ( ! params.activation_key ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Invalid activation key.'
+				);
+			}
+
+			const response = await callApi< PendingSiteConfirmResponse >( {
+				path: `/pending-blog-subscriptions/${ params.activation_key }`,
+				method: 'POST',
+				apiVersion: '2',
+			} );
+			if ( ! response.confirmed ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while confirming subscription.'
+				);
+			}
+
+			return response;
+		},
+		{
+			onMutate: async ( params ) => {
+				await queryClient.cancelQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+				await queryClient.cancelQueries( [ 'read', 'subscriptions-count', isLoggedIn ] );
+
+				const previousPendingSiteSubscriptions = queryClient.getQueryData<
+					PendingSiteSubscription[]
+				>( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+
+				// remove blog from pending site subscriptions
+				if ( previousPendingSiteSubscriptions ) {
+					queryClient.setQueryData< PendingSiteSubscription[] >(
+						[ [ 'read', 'pending-site-subscriptions', isLoggedIn ] ],
+						previousPendingSiteSubscriptions.filter(
+							( pendingSiteSubscription ) => pendingSiteSubscription.id !== params.id
+						)
+					);
+				}
+
+				const previousSubscriptionsCount =
+					queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >( [
+						'read',
+						'subscriptions-count',
+						isLoggedIn,
+					] );
+
+				// decrement the blog count
+				if ( previousSubscriptionsCount ) {
+					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
+						[ 'read', 'subscriptions-count', isLoggedIn ],
+						{
+							...previousSubscriptionsCount,
+							blogs: previousSubscriptionsCount?.pending
+								? previousSubscriptionsCount?.pending - 1
+								: null,
+						}
+					);
+				}
+
+				return { previousPendingSiteSubscriptions, previousSubscriptionsCount };
+			},
+			onError: ( error, variables, context ) => {
+				if ( context?.previousPendingSiteSubscriptions ) {
+					queryClient.setQueryData< PendingSiteSubscription[] >(
+						[ 'read', 'pending-site-subscriptions', isLoggedIn ],
+						context.previousPendingSiteSubscriptions
+					);
+				}
+				if ( context?.previousSubscriptionsCount ) {
+					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
+						[ 'read', 'subscriptions-count', isLoggedIn ],
+						context.previousSubscriptionsCount
+					);
+				}
+			},
+			onSettled: () => {
+				queryClient.invalidateQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+				queryClient.invalidateQueries( [ 'read', 'subscriptions-count', isLoggedIn ] );
+			},
+		}
+	);
+};
+
+export default usePendingSiteConfirmMutation;

--- a/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
@@ -1,0 +1,103 @@
+import { useMutation, useQueryClient } from 'react-query';
+import { callApi } from '../helpers';
+import { useIsLoggedIn } from '../hooks';
+import { PendingSiteSubscription, SubscriptionManagerSubscriptionsCount } from '../types';
+
+type PendingSiteDeleteParams = {
+	id: number | string;
+};
+
+type PendingSiteDeleteResponse = {
+	confirmed: boolean;
+};
+
+const usePendingSiteDeleteMutation = () => {
+	const isLoggedIn = useIsLoggedIn();
+	const queryClient = useQueryClient();
+	return useMutation(
+		async ( params: PendingSiteDeleteParams ) => {
+			if ( ! params.id ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'ID is missing.'
+				);
+			}
+
+			const response = await callApi< PendingSiteDeleteResponse >( {
+				path: `/pending-blog-subscriptions/${ params.id }`,
+				method: 'DELETE',
+				apiVersion: '2',
+			} );
+			if ( ! response.confirmed ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while deleting pending subscription.'
+				);
+			}
+
+			return response;
+		},
+		{
+			onMutate: async ( params ) => {
+				await queryClient.cancelQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+				await queryClient.cancelQueries( [ 'read', 'subscriptions-count', isLoggedIn ] );
+
+				const previousPendingSiteSubscriptions = queryClient.getQueryData<
+					PendingSiteSubscription[]
+				>( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+
+				// remove blog from pending site subscriptions
+				if ( previousPendingSiteSubscriptions ) {
+					queryClient.setQueryData< PendingSiteSubscription[] >(
+						[ [ 'read', 'pending-site-subscriptions', isLoggedIn ] ],
+						previousPendingSiteSubscriptions.filter(
+							( pendingSiteSubscription ) => pendingSiteSubscription.id !== params.id
+						)
+					);
+				}
+
+				const previousSubscriptionsCount =
+					queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >( [
+						'read',
+						'subscriptions-count',
+						isLoggedIn,
+					] );
+
+				// decrement the blog count
+				if ( previousSubscriptionsCount ) {
+					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
+						[ 'read', 'subscriptions-count', isLoggedIn ],
+						{
+							...previousSubscriptionsCount,
+							blogs: previousSubscriptionsCount?.pending
+								? previousSubscriptionsCount?.pending - 1
+								: null,
+						}
+					);
+				}
+
+				return { previousPendingSiteSubscriptions, previousSubscriptionsCount };
+			},
+			onError: ( error, variables, context ) => {
+				if ( context?.previousPendingSiteSubscriptions ) {
+					queryClient.setQueryData< PendingSiteSubscription[] >(
+						[ 'read', 'pending-site-subscriptions', isLoggedIn ],
+						context.previousPendingSiteSubscriptions
+					);
+				}
+				if ( context?.previousSubscriptionsCount ) {
+					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
+						[ 'read', 'subscriptions-count', isLoggedIn ],
+						context.previousSubscriptionsCount
+					);
+				}
+			},
+			onSettled: () => {
+				queryClient.invalidateQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+				queryClient.invalidateQueries( [ 'read', 'subscriptions-count', isLoggedIn ] );
+			},
+		}
+	);
+};
+
+export default usePendingSiteDeleteMutation;

--- a/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
@@ -24,8 +24,8 @@ const usePendingSiteDeleteMutation = () => {
 			}
 
 			const response = await callApi< PendingSiteDeleteResponse >( {
-				path: `/pending-blog-subscriptions/${ params.id }`,
-				method: 'DELETE',
+				path: `/pending-blog-subscriptions/${ params.id }/delete`,
+				method: 'POST',
 				apiVersion: '2',
 			} );
 			if ( ! response.confirmed ) {

--- a/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
@@ -8,7 +8,7 @@ type PendingSiteDeleteParams = {
 };
 
 type PendingSiteDeleteResponse = {
-	confirmed: boolean;
+	deleted: boolean;
 };
 
 const usePendingSiteDeleteMutation = () => {
@@ -28,7 +28,7 @@ const usePendingSiteDeleteMutation = () => {
 				method: 'POST',
 				apiVersion: '2',
 			} );
-			if ( ! response.confirmed ) {
+			if ( ! response.deleted ) {
 				throw new Error(
 					// reminder: translate this string when we add it to the UI
 					'Something went wrong while deleting pending subscription.'

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -27,8 +27,8 @@ const sortByDateSubscribed = ( a: SiteSubscription, b: SiteSubscription ) =>
 	b.date_subscribed.getTime() - a.date_subscribed.getTime();
 
 const sortByLastUpdated = ( a: SiteSubscription, b: SiteSubscription ) =>
-	a.last_updated.getTime && b.last_updated.getTime
-		? b.date_subscribed.getTime() - a.date_subscribed.getTime()
+	a.last_updated instanceof Date && b.last_updated instanceof Date
+		? b.last_updated.getTime() - a.last_updated.getTime()
 		: 0;
 
 const sortBySiteName = ( a: SiteSubscription, b: SiteSubscription ) =>

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -27,7 +27,9 @@ const sortByDateSubscribed = ( a: SiteSubscription, b: SiteSubscription ) =>
 	b.date_subscribed.getTime() - a.date_subscribed.getTime();
 
 const sortByLastUpdated = ( a: SiteSubscription, b: SiteSubscription ) =>
-	b.last_updated.getTime() - a.last_updated.getTime();
+	a.last_updated.getTime && b.last_updated.getTime
+		? b.date_subscribed.getTime() - a.date_subscribed.getTime()
+		: 0;
 
 const sortBySiteName = ( a: SiteSubscription, b: SiteSubscription ) =>
 	a.name.localeCompare( b.name );

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -93,3 +93,14 @@ export type PendingSiteSubscription = {
 	date_subscribed: Date;
 	organization_id: number;
 };
+
+export type PendingPostSubscription = {
+	id: string;
+	title: string;
+	excerpt: string;
+	url: string;
+	site_title: string;
+	site_icon: string;
+	site_url: string;
+	date_subscribed: Date;
+};


### PR DESCRIPTION
Closes #75793

* This PR is still in draft. Currently, the DELETE http method doesn't work with apiFetch.

## Proposed Changes

* This patch adds Confirm & Delete buttons & mutations for pending sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To be updated.

![2023-04-14_21-13-35](https://user-images.githubusercontent.com/1287077/232124973-f109cbf2-55db-4894-a9e9-12548ae69907.png)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
