### PR TITLE
Launchpad: Use Core's settings endpoint

### DIFF
--- a/client/data/sites/use-launchpad.ts
+++ b/client/data/sites/use-launchpad.ts
@@ -5,8 +5,8 @@ export const fetchLaunchpad = ( siteSlug: string | null ) => {
 	const slug = encodeURIComponent( siteSlug as string );
 
 	return wpcom.req.get( {
-		path: `/sites/${ slug }/launchpad`,
-		apiNamespace: 'wpcom/v2',
+		path: `/sites/${ slug }/settings`,
+		apiNamespace: 'wp/v2',
 	} );
 };
 
@@ -23,8 +23,8 @@ export const updateLaunchpadSettings = (
 	return wpcom.req
 		.post(
 			{
-				path: `/sites/${ slug }/launchpad`,
-				apiNamespace: 'wpcom/v2',
+				path: `/sites/${ slug }/settings`,
+				apiNamespace: 'wp/v2',
 			},
 			settings
 		)


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/30096

## Proposed Changes

* Switches Launchpad's custom API endpoint to Core's settings endpoint.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox public-api and apply D107960-code.
* Visit `/setup/free` on the generated calypso.live link.
* Open the Network tab in dev console and filter for `settings`.
* Navigate to the launchpad screen and click the "Choose a domain" task.
* Click the "Choose my domain later" link on the domain selection screen. It should be on the right side of the screen.
* Verify the "Choose a domain" task is marked as completed on the launchpad screen
* Make sure the calls to the settings endpoint contain the expected values.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
