### PR TITLE
Stats: Improve accessibility for insights page

### DIFF
--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -156,7 +156,7 @@ export default function AllTimeHighlightsSection( {
 			<h2 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h2>
 			<DotPager>
 				<Card className="highlight-card">
-					<div className="highlight-card-heading">{ translate( 'All-time stats' ) }</div>
+					<h3 className="highlight-card-heading">{ translate( 'All-time stats' ) }</h3>
 					<div className="highlight-card-info-item-list">
 						{ infoItems
 							.filter( ( i ) => ! i.hidden )
@@ -182,7 +182,7 @@ export default function AllTimeHighlightsSection( {
 				{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
 					return (
 						<Card key={ card.id } className="highlight-card">
-							<div className="highlight-card-heading">{ card.heading }</div>
+							<h3 className="highlight-card-heading">{ card.heading }</h3>
 							<div className="highlight-card-detail-item-list">
 								{ card.items.map( ( item ) => {
 									return (
@@ -211,7 +211,7 @@ export default function AllTimeHighlightsSection( {
 
 			<div className="highlight-cards-list">
 				<Card className="highlight-card">
-					<div className="highlight-card-heading">{ translate( 'All-time stats' ) }</div>
+					<h3 className="highlight-card-heading">{ translate( 'All-time stats' ) }</h3>
 					<div className="highlight-card-info-item-list">
 						{ infoItems
 							.filter( ( i ) => ! i.hidden )
@@ -237,7 +237,7 @@ export default function AllTimeHighlightsSection( {
 				{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
 					return (
 						<Card key={ card.id } className="highlight-card">
-							<div className="highlight-card-heading">{ card.heading }</div>
+							<h3 className="highlight-card-heading">{ card.heading }</h3>
 							<div className="highlight-card-detail-item-list">
 								{ card.items.map( ( item ) => {
 									return (

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -153,7 +153,7 @@ export default function AllTimeHighlightsSection( {
 
 	const mobileCards = (
 		<div className="highlight-cards-mobile">
-			<h1 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h1>
+			<h2 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h2>
 			<DotPager>
 				<Card className="highlight-card">
 					<div className="highlight-card-heading">{ translate( 'All-time stats' ) }</div>
@@ -207,7 +207,7 @@ export default function AllTimeHighlightsSection( {
 
 	const highlightCards = (
 		<div className="highlight-cards">
-			<h1 className="highlight-cards-heading">{ translate( 'All-time highlights' ) }</h1>
+			<h2 className="highlight-cards-heading">{ translate( 'All-time highlights' ) }</h2>
 
 			<div className="highlight-cards-list">
 				<Card className="highlight-card">

--- a/client/my-sites/stats/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/all-time-highlights-section/index.tsx
@@ -153,10 +153,10 @@ export default function AllTimeHighlightsSection( {
 
 	const mobileCards = (
 		<div className="highlight-cards-mobile">
-			<h2 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h2>
+			<h3 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h3>
 			<DotPager>
 				<Card className="highlight-card">
-					<h3 className="highlight-card-heading">{ translate( 'All-time stats' ) }</h3>
+					<h4 className="highlight-card-heading">{ translate( 'All-time stats' ) }</h4>
 					<div className="highlight-card-info-item-list">
 						{ infoItems
 							.filter( ( i ) => ! i.hidden )
@@ -182,7 +182,7 @@ export default function AllTimeHighlightsSection( {
 				{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
 					return (
 						<Card key={ card.id } className="highlight-card">
-							<h3 className="highlight-card-heading">{ card.heading }</h3>
+							<h4 className="highlight-card-heading">{ card.heading }</h4>
 							<div className="highlight-card-detail-item-list">
 								{ card.items.map( ( item ) => {
 									return (
@@ -207,11 +207,11 @@ export default function AllTimeHighlightsSection( {
 
 	const highlightCards = (
 		<div className="highlight-cards">
-			<h2 className="highlight-cards-heading">{ translate( 'All-time highlights' ) }</h2>
+			<h3 className="highlight-cards-heading">{ translate( 'All-time highlights' ) }</h3>
 
 			<div className="highlight-cards-list">
 				<Card className="highlight-card">
-					<h3 className="highlight-card-heading">{ translate( 'All-time stats' ) }</h3>
+					<h4 className="highlight-card-heading">{ translate( 'All-time stats' ) }</h4>
 					<div className="highlight-card-info-item-list">
 						{ infoItems
 							.filter( ( i ) => ! i.hidden )
@@ -237,7 +237,7 @@ export default function AllTimeHighlightsSection( {
 				{ [ mostPopularTimeItems, bestViewsEverItems ].map( ( card ) => {
 					return (
 						<Card key={ card.id } className="highlight-card">
-							<h3 className="highlight-card-heading">{ card.heading }</h3>
+							<h4 className="highlight-card-heading">{ card.heading }</h4>
 							<div className="highlight-card-detail-item-list">
 								{ card.items.map( ( item ) => {
 									return (

--- a/client/my-sites/stats/all-time-views-section/index.tsx
+++ b/client/my-sites/stats/all-time-views-section/index.tsx
@@ -43,12 +43,12 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 			{ siteId && <QuerySiteStats statType="statsVisits" siteId={ siteId } query={ query } /> }
 
 			<div className="highlight-cards">
-				<h2 className="highlight-cards-heading">{ translate( 'All-time insights' ) }</h2>
+				<h3 className="highlight-cards-heading">{ translate( 'All-time insights' ) }</h3>
 
 				<div className="highlight-cards-list">
 					<Card className="highlight-card">
 						<div className="highlight-card-heading">
-							<h3>{ translate( 'Total views' ) }</h3>
+							<h4>{ translate( 'Total views' ) }</h4>
 							{ viewData && (
 								<SimplifiedSegmentedControl options={ monthViewOptions } onSelect={ toggleViews } />
 							) }

--- a/client/my-sites/stats/all-time-views-section/index.tsx
+++ b/client/my-sites/stats/all-time-views-section/index.tsx
@@ -48,7 +48,7 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 				<div className="highlight-cards-list">
 					<Card className="highlight-card">
 						<div className="highlight-card-heading">
-							<span>{ translate( 'Total views' ) }</span>
+							<h3>{ translate( 'Total views' ) }</h3>
 							{ viewData && (
 								<SimplifiedSegmentedControl options={ monthViewOptions } onSelect={ toggleViews } />
 							) }

--- a/client/my-sites/stats/all-time-views-section/index.tsx
+++ b/client/my-sites/stats/all-time-views-section/index.tsx
@@ -43,7 +43,7 @@ export default function AllTimeViewsSection( { siteId, slug }: { siteId: number;
 			{ siteId && <QuerySiteStats statType="statsVisits" siteId={ siteId } query={ query } /> }
 
 			<div className="highlight-cards">
-				<h1 className="highlight-cards-heading">{ translate( 'All-time insights' ) }</h1>
+				<h2 className="highlight-cards-heading">{ translate( 'All-time insights' ) }</h2>
 
 				<div className="highlight-cards-list">
 					<Card className="highlight-card">

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -47,7 +47,7 @@ class PostTrends extends Component {
 				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsStreak" query={ query } /> }
 
 				<div className="post-trends__heading">
-					<h2 className="post-trends__title">{ translate( 'Posting activity' ) }</h2>
+					<h3 className="post-trends__title">{ translate( 'Posting activity' ) }</h3>
 				</div>
 				<div ref={ this.wrapperRef } className="post-trends__wrapper">
 					<div ref={ this.yearRef } className="post-trends__year">

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -47,7 +47,7 @@ class PostTrends extends Component {
 				{ siteId && <QuerySiteStats siteId={ siteId } statType="statsStreak" query={ query } /> }
 
 				<div className="post-trends__heading">
-					<h1 className="post-trends__title">{ translate( 'Posting activity' ) }</h1>
+					<h2 className="post-trends__title">{ translate( 'Posting activity' ) }</h2>
 				</div>
 				<div ref={ this.wrapperRef } className="post-trends__wrapper">
 					<div ref={ this.yearRef } className="post-trends__year">

--- a/packages/components/src/highlight-cards/annual-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/annual-highlight-cards.tsx
@@ -28,7 +28,7 @@ export default function AnnualHighlightCards( {
 	const translate = useTranslate();
 
 	const header = (
-		<h2 className="highlight-cards-heading">
+		<h3 className="highlight-cards-heading">
 			{ Number.isFinite( year )
 				? translate( '%(year)s in review', { args: { year } } )
 				: translate( 'Year in review' ) }{ ' ' }
@@ -39,7 +39,7 @@ export default function AnnualHighlightCards( {
 					</a>
 				</small>
 			) : null }
-		</h2>
+		</h3>
 	);
 
 	return (

--- a/packages/components/src/highlight-cards/annual-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/annual-highlight-cards.tsx
@@ -28,7 +28,7 @@ export default function AnnualHighlightCards( {
 	const translate = useTranslate();
 
 	const header = (
-		<h1 className="highlight-cards-heading">
+		<h2 className="highlight-cards-heading">
 			{ Number.isFinite( year )
 				? translate( '%(year)s in review', { args: { year } } )
 				: translate( 'Year in review' ) }{ ' ' }
@@ -39,7 +39,7 @@ export default function AnnualHighlightCards( {
 					</a>
 				</small>
 			) : null }
-		</h1>
+		</h2>
 	);
 
 	return (

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -29,7 +29,7 @@ const StatsCard = ( {
 			{ title }
 		</a>
 	) : (
-		<h3 className={ `${ BASE_CLASS_NAME }-header__title` }>{ title }</h3>
+		<h4 className={ `${ BASE_CLASS_NAME }-header__title` }>{ title }</h4>
 	);
 
 	// On one line shows card title and value column header

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -11,6 +11,7 @@ const StatsCard = ( {
 	className,
 	title,
 	titleURL,
+	titleAriaLevel = 4,
 	footerAction,
 	isEmpty,
 	emptyMessage,
@@ -29,7 +30,13 @@ const StatsCard = ( {
 			{ title }
 		</a>
 	) : (
-		<h4 className={ `${ BASE_CLASS_NAME }-header__title` }>{ title }</h4>
+		<div
+			className={ `${ BASE_CLASS_NAME }-header__title` }
+			role="heading"
+			aria-level={ titleAriaLevel }
+		>
+			{ title }
+		</div>
 	);
 
 	// On one line shows card title and value column header

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -29,7 +29,7 @@ const StatsCard = ( {
 			{ title }
 		</a>
 	) : (
-		<div className={ `${ BASE_CLASS_NAME }-header__title` }>{ title }</div>
+		<h3 className={ `${ BASE_CLASS_NAME }-header__title` }>{ title }</h3>
 	);
 
 	// On one line shows card title and value column header

--- a/packages/components/src/horizontal-bar-list/types.ts
+++ b/packages/components/src/horizontal-bar-list/types.ts
@@ -56,6 +56,7 @@ export type StatsCardProps = {
 	headerClassName?: string;
 	title: string;
 	titleURL: string;
+	titleAriaLevel?: number;
 	footerAction?: {
 		label?: string;
 		url?: string;

--- a/packages/components/src/post-stats-card/index.tsx
+++ b/packages/components/src/post-stats-card/index.tsx
@@ -58,7 +58,7 @@ export default function PostStatsCard( {
 
 	return (
 		<Card className={ classes }>
-			<h3 className="post-stats-card__heading">{ heading }</h3>
+			<h4 className="post-stats-card__heading">{ heading }</h4>
 			<div className="post-stats-card__post-info">
 				<TitleTag className="post-stats-card__post-title" href={ titleLink }>
 					{ post?.title }

--- a/packages/components/src/post-stats-card/index.tsx
+++ b/packages/components/src/post-stats-card/index.tsx
@@ -58,7 +58,7 @@ export default function PostStatsCard( {
 
 	return (
 		<Card className={ classes }>
-			<div className="post-stats-card__heading">{ heading }</div>
+			<h3 className="post-stats-card__heading">{ heading }</h3>
 			<div className="post-stats-card__post-info">
 				<TitleTag className="post-stats-card__post-title" href={ titleLink }>
 					{ post?.title }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/74321

## Proposed Changes

This PR addresses the accessibility concerns on the Insights page by improving the heading hierarchy. Previously, the page contained only h1 headings, which is not ideal for users who rely on screen readers or other assistive technologies.

The updated heading structure now includes:

`h1` Insights (to be added after further input)
&nbsp;&nbsp;`h2` 2023 in Review
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`h3` All-time stats
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;...
&nbsp;&nbsp;`h2` All-time Highlights
&nbsp;&nbsp;`h2`Posting Activity
&nbsp;&nbsp;`h2` All-time Insights
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`h3` Total Views
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;...

This updated hierarchy will make the Insights page more accessible to all users, ensuring a better user experience.

Note that the h1 Insights heading is still awaiting integration. @jsnmoon I understand you are facing the same situation on the traffic page. How and where are you thinking of adding this additional H1 heading into the page?

## Testing Instructions

Open the live branch for this PR and navigate to the traffic stats page.
Confirm that the headings are correctly structured.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
