### PR TITLE
Add E2E tests for the Site Assembler (wait for the "Continue" button to be enabled)

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
@@ -46,4 +46,15 @@ export class SiteAssemblerFlow {
 		const footer = this.page.locator( selectors.blockRenderer ).nth( 0 );
 		await footer.click();
 	}
+
+	/**
+	 * Click "Continue" and land on the Site Editor
+	 */
+	async gotoSiteEditor(): Promise< void > {
+		// Wait for the "Continue" button to be enabled.
+		// @see: https://github.com/Automattic/wp-calypso/pull/75606
+		const waitFor = ( ms: number ) => new Promise( ( resolve ) => setTimeout( resolve, ms ) );
+		await waitFor( 500 );
+		await this.clickButton( 'Continue' );
+	}
 }

--- a/test/e2e/specs/onboarding/setup__site-assembler.ts
+++ b/test/e2e/specs/onboarding/setup__site-assembler.ts
@@ -76,7 +76,7 @@ describe( DataHelper.createSuiteTitle( 'Site Assembler' ), () => {
 		} );
 
 		it( 'Click "Continue" and land on the Site Editor', async function () {
-			await startSiteFlow.clickButton( 'Continue' );
+			await startSiteFlow.gotoSiteEditor();
 			await page.waitForURL( /.*\/site-editor\/.*/, {
 				timeout: 120 * 1000,
 			} );

--- a/test/e2e/specs/onboarding/setup__site-assembler.ts
+++ b/test/e2e/specs/onboarding/setup__site-assembler.ts
@@ -78,7 +78,7 @@ describe( DataHelper.createSuiteTitle( 'Site Assembler' ), () => {
 		it( 'Click "Continue" and land on the Site Editor', async function () {
 			await startSiteFlow.gotoSiteEditor();
 			await page.waitForURL( /.*\/site-editor\/.*/, {
-				timeout: 120 * 1000,
+				timeout: 180 * 1000,
 			} );
 		} );
 	} );

--- a/test/e2e/specs/onboarding/setup__site-assembler.ts
+++ b/test/e2e/specs/onboarding/setup__site-assembler.ts
@@ -1,0 +1,85 @@
+/**
+ * @group calypso-release
+ */
+
+import {
+	DataHelper,
+	SecretsManager,
+	TestAccount,
+	SiteAssemblerFlow,
+} from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Site Assembler' ), () => {
+	const credentials = SecretsManager.secrets.testAccounts.defaultUser;
+	const siteSlug = credentials.testSites?.primary?.url as string;
+
+	let page: Page;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+
+		const testAccount = new TestAccount( 'defaultUser' );
+		await testAccount.authenticate( page );
+	} );
+
+	describe( 'Create a site with the Site Assembler', function () {
+		let startSiteFlow: SiteAssemblerFlow;
+
+		beforeAll( async function () {
+			startSiteFlow = new SiteAssemblerFlow( page );
+		} );
+
+		it( 'Enter Onboarding flow', async function () {
+			await page.goto( DataHelper.getCalypsoURL( '/setup/site-setup', { siteSlug } ), {
+				timeout: 30 * 1000,
+			} );
+		} );
+
+		it( 'Select "Continue" until it lands on the Design Picker', async function () {
+			await startSiteFlow.clickButton( 'Continue' );
+			await startSiteFlow.clickButton( 'Continue' );
+		} );
+
+		it( 'Select "Start designing" and land on the Site Assembler', async function () {
+			await startSiteFlow.clickButton( 'Start designing' );
+			await page.waitForURL(
+				DataHelper.getCalypsoURL( `/setup/site-setup/patternAssembler?siteSlug=${ siteSlug }` ),
+				{
+					timeout: 30 * 1000,
+				}
+			);
+		} );
+
+		it( 'Select "Header"', async function () {
+			await startSiteFlow.selectHeader();
+			await startSiteFlow.clickButton( 'Save' );
+			await page
+				.locator( '.pattern-large-preview__patterns .block-renderer' )
+				.count()
+				.then( ( count ) => {
+					expect( count ).toBe( 1 );
+				} );
+		} );
+
+		it( 'Select "Footer"', async function () {
+			await startSiteFlow.selectFooter();
+			await startSiteFlow.clickButton( 'Save' );
+			await page
+				.locator( '.pattern-large-preview__patterns .block-renderer' )
+				.count()
+				.then( ( count ) => {
+					expect( count ).toBe( 2 );
+				} );
+		} );
+
+		it( 'Click "Continue" and land on the Site Editor', async function () {
+			await startSiteFlow.clickButton( 'Continue' );
+			await page.waitForURL( /.*\/site-editor\/.*/, {
+				timeout: 120 * 1000,
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
E2E tests were failing since I was missing https://github.com/Automattic/wp-calypso/pull/75606 changes.
Changed to wait for the "Continue" button to be enabled. https://github.com/Automattic/wp-calypso/commit/f4a3a0d39c11e589f1107d47d89745032eb07b4f

Everything else is the same as https://github.com/Automattic/wp-calypso/pull/75607.