### PR TITLE
Checkout: change log severity for non-error logs

### DIFF
--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -76,7 +76,7 @@ export default function CheckoutMainWrapper( {
 			logToLogstash( {
 				feature: 'calypso_client',
 				message: 'CheckoutMainWrapper saw productSlug to add',
-				severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+				severity: config( 'env_id' ) === 'production' ? 'info' : 'debug',
 				extra: {
 					productSlug: productAliasFromUrl,
 				},

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -253,9 +253,7 @@ export default function CheckoutMain( {
 
 	const getThankYouUrl = useCallback( () => {
 		const url = getThankYouUrlBase();
-		logStashEvent( 'thank you url generated', {
-			url,
-		} );
+		logStashEvent( 'thank you url generated', { url }, 'info' );
 		return url;
 	}, [ getThankYouUrlBase ] );
 
@@ -600,9 +598,7 @@ export default function CheckoutMain( {
 
 	const handlePaymentMethodChanged = useCallback(
 		( method: string ) => {
-			logStashEvent( 'payment_method_select', {
-				newMethodId: String( method ),
-			} );
+			logStashEvent( 'payment_method_select', { newMethodId: String( method ) }, 'info' );
 			// Need to convert to the slug format used in old checkout so events are comparable
 			const rawPaymentMethodSlug = String( method );
 			const legacyPaymentMethodSlug = translateCheckoutPaymentMethodToTracksPaymentMethod(

--- a/client/my-sites/checkout/composite-checkout/lib/analytics.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/analytics.ts
@@ -29,12 +29,13 @@ export function logStashLoadErrorEvent(
 
 export function logStashEvent(
 	message: string,
-	dataForLog: Record< string, string > = {}
+	dataForLog: Record< string, string > = {},
+	severity: 'error' | 'warning' | 'info' = 'error'
 ): Promise< void > {
 	return logToLogstash( {
 		feature: 'calypso_client',
 		message,
-		severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+		severity: config( 'env_id' ) === 'production' ? severity : 'debug',
 		extra: {
 			env: config( 'env_id' ),
 			...dataForLog,


### PR DESCRIPTION
Searching Kibana for Checkout errors (`feature:calypso_client, severity:error`) shows a ton of messages for adding a product to Checkout from the URL (the primary way we add products in Checkout) and generating a thank you page URL. Neither of these things are errors and bury real errors.

This changes the log severity for non-error logstash calls to be 'info' in production. They'll remain 'debug' outside of production.

**To test:**
- a visual check should suffice. `logStashEvent`'s severity argument should default to `error` in production and be set to info for non-error logs (changing a payment method, generating a thank you url, adding a product from the url)
- you can run Calypso with `CALYPSO_ENV=production` to verify that those events don't log as errors