### PR TITLE
E2E: adjust `CoBlock: Cover` spec to work with both Gutenberg prod and edge.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/cover-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/cover-block.ts
@@ -1,4 +1,4 @@
-import { ImageBlock } from './image-block';
+import { Locator } from 'playwright';
 
 const coverStylesArray = [ 'Default', 'Bottom Wave', 'Top Wave' ] as const;
 export type coverStyles = ( typeof coverStylesArray )[ number ];
@@ -6,10 +6,42 @@ export type coverStyles = ( typeof coverStylesArray )[ number ];
 /**
  * Represents the Cover block.
  */
-export class CoverBlock extends ImageBlock {
+export class CoverBlock {
 	static blockName = 'Cover';
 	static blockEditorSelector = '[aria-label="Block: Cover"]';
 	static coverStyles = coverStylesArray;
+	block: Locator;
+	editor: Locator;
+
+	/**
+	 * Constructs an instance of this block.
+	 *
+	 * @param {Locator} editor Editor window.
+	 * @param {Locator} block Handle referencing the block as inserted on the Gutenberg editor.
+	 */
+	constructor( editor: Locator, block: Locator ) {
+		this.editor = editor;
+		this.block = block;
+	}
+
+	/**
+	 * Uploads an image file to the Cover block.
+	 *
+	 * @param {string} path Path to the file on disk.
+	 */
+	async upload( path: string ): Promise< void > {
+		await this.block.locator( 'input[type="file"]' ).setInputFiles( path );
+		await this.block.locator( 'img[src^="blob:"]' ).waitFor( {
+			timeout: 20 * 1000,
+			state: 'detached',
+		} );
+
+		// After uploading the image the focus is switched to the inner
+		// paragraph block (Cover title), so we need to switch it back outside.
+		await this.editor
+			.locator( CoverBlock.blockEditorSelector )
+			.click( { position: { x: 1, y: 1 } } );
+	}
 
 	/**
 	 * Adds the title text over the block's image.
@@ -17,8 +49,16 @@ export class CoverBlock extends ImageBlock {
 	 * @param text The title text.
 	 */
 	async addTitle( text: string ): Promise< void > {
-		const titleHandle = await this.block.waitForSelector( 'p' );
-		await titleHandle.type( text );
+		await this.block.locator( 'p' ).fill( text );
+	}
+
+	/**
+	 * Activates the tab for the Cover block.
+	 *
+	 * @param {'Settings'|'Styles'} name Supported tabs.
+	 */
+	async activateTab( name: 'Settings' | 'Styles' ) {
+		await this.editor.locator( `[aria-label="${ name }"]` ).click();
 	}
 
 	/**
@@ -27,15 +67,12 @@ export class CoverBlock extends ImageBlock {
 	 * @param {coverStyles} style The title of one of the Cover style buttons
 	 */
 	async setCoverStyle( style: coverStyles ): Promise< void > {
-		const editorFrame = await this.block.ownerFrame();
-
-		const styleButton = await editorFrame?.waitForSelector( `button[aria-label="${ style }"]` );
-		await styleButton?.click();
+		await this.editor.locator( `button[aria-label="${ style }"]` ).click();
 
 		const blockId = await this.block.getAttribute( 'data-block' );
 		const styleSelector = `.is-style-${ style.toLowerCase().replace( ' ', '-' ) }`;
 		const blockSelector = `[data-block="${ blockId }"]`;
 
-		await editorFrame?.waitForSelector( blockSelector + styleSelector );
+		await this.editor.locator( blockSelector + styleSelector ).waitFor();
 	}
 }

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -11,7 +11,7 @@ import {
 	getTestAccountByFeature,
 	envToFeatureKey,
 } from '@automattic/calypso-e2e';
-import { Page, Browser, Locator } from 'playwright';
+import { Page, Browser } from 'playwright';
 import { TEST_IMAGE_PATH } from '../constants';
 
 declare const browser: Browser;
@@ -34,15 +34,16 @@ describe( 'CoBlocks: Extensions: Cover Styles', function () {
 	let editorPage: EditorPage;
 	let imageFile: TestFile;
 	let coverBlock: CoverBlock;
-	let editorWindowLocator: Locator;
 
 	beforeAll( async () => {
-		page = await browser.newPage();
 		imageFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
-		testAccount = new TestAccount( accountName );
-		editorPage = new EditorPage( page, { target: features.siteType } );
 
+		page = await browser.newPage();
+
+		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
+
+		editorPage = new EditorPage( page, { target: features.siteType } );
 	} );
 
 	it( 'Go to the new post page', async () => {
@@ -50,32 +51,27 @@ describe( 'CoBlocks: Extensions: Cover Styles', function () {
 	} );
 
 	it( 'Insert Cover block', async () => {
-		const blockHandle = await editorPage.addBlockFromSidebar(
-			CoverBlock.blockName,
-			CoverBlock.blockEditorSelector
+		await editorPage.addBlockFromSidebar( CoverBlock.blockName, CoverBlock.blockEditorSelector );
+		coverBlock = new CoverBlock(
+			editorPage.getEditorWindowLocator(),
+			editorPage.getEditorCanvasLocator().locator( CoverBlock.blockEditorSelector )
 		);
-		coverBlock = new CoverBlock( blockHandle );
 	} );
 
 	it( 'Upload image', async () => {
 		await coverBlock.upload( imageFile.fullpath );
-		// After uploading the image the focus is switched to the inner
-		// paragraph block (Cover title), so we need to switch it back outside.
-		editorWindowLocator = editorPage.getEditorWindowLocator();
-		await editorWindowLocator.locator( '.wp-block-cover' ).click( { position: { x: 1, y: 1 } } );
 	} );
 
 	it( 'Open settings sidebar', async function () {
 		await editorPage.openSettings();
 	} );
 
-	it( 'Click on the Styles button', async () => {
-		const stylesButton = await editorWindowLocator.locator( `button[aria-label="Styles"]` );
-		await stylesButton?.click();
+	it( 'Click on the Styles tab', async () => {
+		await coverBlock.activateTab( 'Styles' );
 	} );
 
 	it.each( CoverBlock.coverStyles )( 'Verify "%s" style is available', async ( style ) => {
-		await editorWindowLocator.locator( `button[aria-label="${ style }"]` ).waitFor();
+		await coverBlock.setCoverStyle( style );
 	} );
 
 	it( 'Set "Bottom Wave" style', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #75748

## Proposed Changes

This PR alters the aforementioned spec to work with Gutenberg 15.5.1 while maintaining backward compatibility.

Key changes
- decouple the implementation of the Cover block from Image block.
- replace the usage of ElementHandles with Locators to perform actions.

Context:

With Gutenberg 15.5.1, the previously used method to locate and perform actions on the block using ElementHandle no longer works within multiple steps within the `CoBlocks: Cover Block` spec. However, Locator has no problems locating various elements and attributes within the Cover block.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg simple E2E tests edge (desktop)
  - [x] Gutenberg simple E2E tests production (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
