### PR TITLE
Flaky E2E: revamp the `SiteAssemberFlow` POM and the corresponding spec.

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
@@ -1,9 +1,5 @@
 import { Page } from 'playwright';
-
-const selectors = {
-	button: ( text: string ) => `button:text("${ text }")`,
-	blockRenderer: '.block-renderer',
-};
+type LayoutType = 'Header' | 'Sections' | 'Footer';
 
 /**
  * Class encapsulating the Site Assembler flow
@@ -26,35 +22,20 @@ export class SiteAssemblerFlow {
 	 * @param {string} text User-visible text on the button.
 	 */
 	async clickButton( text: string ): Promise< void > {
-		await this.page.click( selectors.button( text ) );
+		await this.page.getByRole( 'button', { name: text } ).click();
 	}
 
 	/**
-	 * Select Header
+	 * Given two parameters, type and index, selects a layout component matching
+	 * the specifications.
+	 *
+	 * @param {LayoutType} type Type of the layout component.
+	 * @param {number} index Index of the item to choose. Defaults to 0.
 	 */
-	async selectHeader(): Promise< void > {
-		await this.page.getByText( 'Header' ).click();
-		const header = this.page.locator( selectors.blockRenderer ).nth( 0 );
-		await header.click();
-	}
+	async selectLayoutComponent( type: LayoutType, index = 0 ): Promise< void > {
+		await this.page.getByRole( 'button', { name: type } ).click();
+		await this.page.waitForLoadState( 'networkidle' );
 
-	/**
-	 * Select Footer
-	 */
-	async selectFooter(): Promise< void > {
-		await this.page.getByText( 'Footer' ).click();
-		const footer = this.page.locator( selectors.blockRenderer ).nth( 0 );
-		await footer.click();
-	}
-
-	/**
-	 * Click "Continue" and land on the Site Editor
-	 */
-	async gotoSiteEditor(): Promise< void > {
-		// Wait for the "Continue" button to be enabled.
-		// @see: https://github.com/Automattic/wp-calypso/pull/75606
-		const waitFor = ( ms: number ) => new Promise( ( resolve ) => setTimeout( resolve, ms ) );
-		await waitFor( 500 );
-		await this.clickButton( 'Continue' );
+		await this.page.locator( '.pattern-list-renderer__pattern-list-item' ).nth( index ).click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/site-assembler-flow.ts
@@ -26,16 +26,20 @@ export class SiteAssemblerFlow {
 	}
 
 	/**
-	 * Given two parameters, type and index, selects a layout component matching
-	 * the specifications.
+	 * Given a component type, clicks on the heading item to show available components.
 	 *
 	 * @param {LayoutType} type Type of the layout component.
+	 */
+	async selectLayoutComponentType( type: LayoutType ): Promise< void > {
+		await this.page.getByRole( 'button', { name: type } ).click();
+	}
+
+	/**
+	 * Selects a layout component at matching index.
+	 *
 	 * @param {number} index Index of the item to choose. Defaults to 0.
 	 */
-	async selectLayoutComponent( type: LayoutType, index = 0 ): Promise< void > {
-		await this.page.getByRole( 'button', { name: type } ).click();
-		await this.page.waitForLoadState( 'networkidle' );
-
+	async selectLayoutComponent( index = 0 ): Promise< void > {
 		await this.page.locator( '.pattern-list-renderer__pattern-list-item' ).nth( index ).click();
 	}
 }

--- a/test/e2e/specs/onboarding/setup__site-assembler.ts
+++ b/test/e2e/specs/onboarding/setup__site-assembler.ts
@@ -8,7 +8,7 @@ import {
 	TestAccount,
 	SiteAssemblerFlow,
 } from '@automattic/calypso-e2e';
-import { Browser, Page } from 'playwright';
+import { Browser, Locator, Page } from 'playwright';
 
 declare const browser: Browser;
 
@@ -26,9 +26,7 @@ describe( DataHelper.createSuiteTitle( 'Site Assembler' ), () => {
 	} );
 
 	describe( 'Create a site with the Site Assembler', function () {
-		const assembledPreviewLocator = page.locator(
-			'.pattern-large-preview__patterns .block-renderer'
-		);
+		let assembledPreviewLocator: Locator;
 		let startSiteFlow: SiteAssemblerFlow;
 
 		beforeAll( async function () {
@@ -59,10 +57,13 @@ describe( DataHelper.createSuiteTitle( 'Site Assembler' ), () => {
 		it( 'Select "Header"', async function () {
 			await startSiteFlow.selectLayoutComponent( 'Header', 1 );
 			await startSiteFlow.clickButton( 'Save' );
+
+			assembledPreviewLocator = page.locator( '.pattern-large-preview__patterns .block-renderer' );
 			expect( await assembledPreviewLocator.count() ).toBe( 1 );
 		} );
 
 		it( 'Select "Footer"', async function () {
+			await startSiteFlow.selectLayoutComponent( 'Footer', 1 );
 			await startSiteFlow.clickButton( 'Save' );
 			expect( await assembledPreviewLocator.count() ).toBe( 2 );
 		} );

--- a/test/e2e/specs/onboarding/setup__site-assembler.ts
+++ b/test/e2e/specs/onboarding/setup__site-assembler.ts
@@ -52,25 +52,37 @@ describe( DataHelper.createSuiteTitle( 'Site Assembler' ), () => {
 					timeout: 30 * 1000,
 				}
 			);
+
+			assembledPreviewLocator = page.locator( '.pattern-large-preview__patterns .block-renderer' );
 		} );
 
 		it( 'Select "Header"', async function () {
-			await startSiteFlow.selectLayoutComponent( 'Header', 1 );
-			await startSiteFlow.clickButton( 'Save' );
+			await startSiteFlow.selectLayoutComponentType( 'Header' );
+			await startSiteFlow.selectLayoutComponent( 1 );
 
-			assembledPreviewLocator = page.locator( '.pattern-large-preview__patterns .block-renderer' );
 			expect( await assembledPreviewLocator.count() ).toBe( 1 );
+
+			await startSiteFlow.clickButton( 'Save' );
 		} );
 
 		it( 'Select "Footer"', async function () {
-			await startSiteFlow.selectLayoutComponent( 'Footer', 1 );
-			await startSiteFlow.clickButton( 'Save' );
+			await startSiteFlow.selectLayoutComponentType( 'Footer' );
+			await startSiteFlow.selectLayoutComponent( 1 );
+
 			expect( await assembledPreviewLocator.count() ).toBe( 2 );
+
+			await startSiteFlow.clickButton( 'Save' );
 		} );
 
 		it( 'Click "Continue" and land on the Site Editor', async function () {
-			await page.waitForLoadState( 'networkidle' );
-			await startSiteFlow.clickButton( 'Continue' );
+			// This is temporary.
+			// Read: This is TEMPORARY!
+			// See: https://github.com/Automattic/wp-calypso/pull/75606#issuecomment-1512538989
+			await page.waitForTimeout( 500 );
+			await Promise.all( [
+				page.waitForURL( /processing/ ),
+				startSiteFlow.clickButton( 'Continue' ),
+			] );
 			await page.waitForURL( /site-editor/, {
 				timeout: 45 * 1000,
 			} );

--- a/test/e2e/specs/onboarding/setup__site-assembler.ts
+++ b/test/e2e/specs/onboarding/setup__site-assembler.ts
@@ -26,6 +26,9 @@ describe( DataHelper.createSuiteTitle( 'Site Assembler' ), () => {
 	} );
 
 	describe( 'Create a site with the Site Assembler', function () {
+		const assembledPreviewLocator = page.locator(
+			'.pattern-large-preview__patterns .block-renderer'
+		);
 		let startSiteFlow: SiteAssemblerFlow;
 
 		beforeAll( async function () {
@@ -54,31 +57,24 @@ describe( DataHelper.createSuiteTitle( 'Site Assembler' ), () => {
 		} );
 
 		it( 'Select "Header"', async function () {
-			await startSiteFlow.selectHeader();
+			// await startSiteFlow.selectHeader();
+			await startSiteFlow.selectLayoutComponent( 'Header', 1 );
 			await startSiteFlow.clickButton( 'Save' );
-			await page
-				.locator( '.pattern-large-preview__patterns .block-renderer' )
-				.count()
-				.then( ( count ) => {
-					expect( count ).toBe( 1 );
-				} );
+			expect( await assembledPreviewLocator.count() ).toBe( 1 );
 		} );
 
 		it( 'Select "Footer"', async function () {
-			await startSiteFlow.selectFooter();
+			// await startSiteFlow.selectFooter();
+			await startSiteFlow.selectLayoutComponent( 'Footer', 1 );
 			await startSiteFlow.clickButton( 'Save' );
-			await page
-				.locator( '.pattern-large-preview__patterns .block-renderer' )
-				.count()
-				.then( ( count ) => {
-					expect( count ).toBe( 2 );
-				} );
+			expect( await assembledPreviewLocator.count() ).toBe( 2 );
 		} );
 
 		it( 'Click "Continue" and land on the Site Editor', async function () {
-			await startSiteFlow.gotoSiteEditor();
-			await page.waitForURL( /.*\/site-editor\/.*/, {
-				timeout: 180 * 1000,
+			await page.waitForLoadState( 'networkidle' );
+			await startSiteFlow.clickButton( 'Continue' );
+			await page.waitForURL( /site-editor/, {
+				timeout: 45 * 1000,
 			} );
 		} );
 	} );

--- a/test/e2e/specs/onboarding/setup__site-assembler.ts
+++ b/test/e2e/specs/onboarding/setup__site-assembler.ts
@@ -57,15 +57,12 @@ describe( DataHelper.createSuiteTitle( 'Site Assembler' ), () => {
 		} );
 
 		it( 'Select "Header"', async function () {
-			// await startSiteFlow.selectHeader();
 			await startSiteFlow.selectLayoutComponent( 'Header', 1 );
 			await startSiteFlow.clickButton( 'Save' );
 			expect( await assembledPreviewLocator.count() ).toBe( 1 );
 		} );
 
 		it( 'Select "Footer"', async function () {
-			// await startSiteFlow.selectFooter();
-			await startSiteFlow.selectLayoutComponent( 'Footer', 1 );
 			await startSiteFlow.clickButton( 'Save' );
 			expect( await assembledPreviewLocator.count() ).toBe( 2 );
 		} );

--- a/test/e2e/specs/onboarding/setup__site-assembler.ts
+++ b/test/e2e/specs/onboarding/setup__site-assembler.ts
@@ -39,7 +39,7 @@ describe( DataHelper.createSuiteTitle( 'Site Assembler' ), () => {
 			} );
 		} );
 
-		it( 'Select "Continue" until it lands on the Design Picker', async function () {
+		it( 'Skip until the Design Picker', async function () {
 			await startSiteFlow.clickButton( 'Continue' );
 			await startSiteFlow.clickButton( 'Continue' );
 		} );
@@ -75,10 +75,6 @@ describe( DataHelper.createSuiteTitle( 'Site Assembler' ), () => {
 		} );
 
 		it( 'Click "Continue" and land on the Site Editor', async function () {
-			// This is temporary.
-			// Read: This is TEMPORARY!
-			// See: https://github.com/Automattic/wp-calypso/pull/75606#issuecomment-1512538989
-			await page.waitForTimeout( 500 );
 			await Promise.all( [
 				page.waitForURL( /processing/ ),
 				startSiteFlow.clickButton( 'Continue' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #75812.

## Proposed Changes

This PR reworks the POM and the associated spec to hopefully eliminate an issue with the `Select Footer` step.

Key changes:
- merge the `selectHeader` and `selectFooter` methods into one.
- save and use the locator to perform `expect` checks.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Pre-Release E2E

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
