### PR TITLE
Iframed editor: Improve resilience of close editor action

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -380,7 +380,14 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 		}
 
 		if ( EditorActions.CloseEditor === action || EditorActions.GoToAllPosts === action ) {
-			const { unsavedChanges = false, destinationUrl = this.props.closeUrl } = payload;
+			let unsavedChanges = false;
+			let destinationUrl = this.props.closeUrl;
+			if ( payload?.unsavedChanges ) {
+				unsavedChanges = payload.unsavedChanges;
+			}
+			if ( payload?.destinationUrl ) {
+				destinationUrl = payload.destinationUrl;
+			}
 			this.props.setEditorIframeLoaded( false );
 			this.navigate( destinationUrl, unsavedChanges );
 		}


### PR DESCRIPTION
## Proposed Changes

Add a safeguard check to the logic that handles the `CloseEditor` action of the iframed editor to prevent a `TypeError` from happening when `payload` is `undefined`.

See p1681487729359109-slack-C04U5A26MJB

## Testing Instructions

We've been unable to find the underlying issue that was causing the error, so just check that there are no regression when testing the regular flow:

- Use the Calypso live link below
- Open one the iframed post editor (`/post/:site`).
- Click on the top-left button to open the block editor sidebar
- Click on "Dashboard"
- Make sure you land on My Home