### PR TITLE
Flaky E2E: navigate directly to the Legacy Widgets page.

### DIFF
--- a/test/e2e/specs/appearance/widgets__legacy-visibility.ts
+++ b/test/e2e/specs/appearance/widgets__legacy-visibility.ts
@@ -4,7 +4,6 @@
 
 import {
 	envVariables,
-	SidebarComponent,
 	TestAccount,
 	BlockWidgetEditorComponent,
 	getTestAccountByFeature,
@@ -24,13 +23,13 @@ declare const browser: Browser;
 skipDescribeIf( envVariables.TEST_ON_ATOMIC || envVariables.VIEWPORT_NAME === 'mobile' )(
 	'Widget (Legacy): Visibility option is present',
 	function () {
-		let sidebarComponent: SidebarComponent;
+		let testAccount: TestAccount;
 		let page: Page;
 
 		beforeAll( async () => {
 			page = await browser.newPage();
 
-			const testAccount = new TestAccount( accountName );
+			testAccount = new TestAccount( accountName );
 			await testAccount.authenticate( page );
 
 			// Clear out existing widgets.
@@ -41,8 +40,9 @@ skipDescribeIf( envVariables.TEST_ON_ATOMIC || envVariables.VIEWPORT_NAME === 'm
 		} );
 
 		it( 'Navigate to Appearance > Widgets', async function () {
-			sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.navigate( 'Appearance', 'Widgets' );
+			await page.goto(
+				`https://${ testAccount.credentials.testSites?.primary.url }/wp-admin/widgets.php`
+			);
 		} );
 
 		it( 'Dismiss the Welcome modals', async function () {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/75816.

## Proposed Changes

This PR replaces the `SidebarComponent` based navigation for the `Widgets: Legacy" spec with a direct navigation to the page.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
