### PR TITLE
Write Flow: Fix theme-setup is not triggered when activating default theme

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -1,9 +1,3 @@
 export const WRITE_INTENT_DEFAULT_DESIGN = {
 	theme: 'livro',
 };
-
-export const WRITE_INTENT_DEFAULT_DESIGN_OPTIONS = {
-	styleVariation: {
-		slug: 'white',
-	},
-};

--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -1,0 +1,9 @@
+export const WRITE_INTENT_DEFAULT_DESIGN = {
+	theme: 'livro',
+};
+
+export const WRITE_INTENT_DEFAULT_DESIGN_OPTIONS = {
+	styleVariation: {
+		slug: 'white',
+	},
+};

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -4,7 +4,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { WRITE_INTENT_DEFAULT_DESIGN, WRITE_INTENT_DEFAULT_DESIGN_OPTIONS } from '../constants';
+import { WRITE_INTENT_DEFAULT_DESIGN } from '../constants';
 import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
@@ -131,13 +131,7 @@ const pluginBundleFlow: Flow = {
 						setGoalsOnSite( siteSlug, goals ),
 					];
 					if ( intent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
-						pendingActions.push(
-							setDesignOnSite(
-								siteSlug,
-								WRITE_INTENT_DEFAULT_DESIGN,
-								WRITE_INTENT_DEFAULT_DESIGN_OPTIONS
-							)
-						);
+						pendingActions.push( setDesignOnSite( siteSlug, WRITE_INTENT_DEFAULT_DESIGN ) );
 					}
 
 					Promise.all( pendingActions ).then( () => window.location.assign( to ) );

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -4,6 +4,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { WRITE_INTENT_DEFAULT_DESIGN, WRITE_INTENT_DEFAULT_DESIGN_OPTIONS } from '../constants';
 import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
@@ -25,8 +26,6 @@ import pluginBundleData from './plugin-bundle-data';
 import type { BundledPlugin } from './plugin-bundle-data';
 import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
 
-const WRITE_INTENT_DEFAULT_THEME = 'livro';
-const WRITE_INTENT_DEFAULT_THEME_STYLE_VARIATION = 'white';
 const SiteIntent = Onboard.SiteIntent;
 
 const pluginBundleFlow: Flow = {
@@ -98,7 +97,7 @@ const pluginBundleFlow: Flow = {
 		);
 		const { setPendingAction, setStepProgress, resetOnboardStoreWithSkipFlags } =
 			useDispatch( ONBOARD_STORE );
-		const { setIntentOnSite, setGoalsOnSite, setThemeOnSite } = useDispatch( SITE_STORE );
+		const { setIntentOnSite, setGoalsOnSite, setDesignOnSite } = useDispatch( SITE_STORE );
 		const siteDetails = useSelect(
 			( select ) => site && ( select( SITE_STORE ) as SiteSelect ).getSite( site.ID ),
 			[ site ]
@@ -133,10 +132,10 @@ const pluginBundleFlow: Flow = {
 					];
 					if ( intent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
 						pendingActions.push(
-							setThemeOnSite(
+							setDesignOnSite(
 								siteSlug,
-								WRITE_INTENT_DEFAULT_THEME,
-								WRITE_INTENT_DEFAULT_THEME_STYLE_VARIATION
+								WRITE_INTENT_DEFAULT_DESIGN,
+								WRITE_INTENT_DEFAULT_DESIGN_OPTIONS
 							)
 						);
 					}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -11,7 +11,7 @@ import { addQueryArgs } from 'calypso/lib/route';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
-import { WRITE_INTENT_DEFAULT_DESIGN, WRITE_INTENT_DEFAULT_DESIGN_OPTIONS } from '../constants';
+import { WRITE_INTENT_DEFAULT_DESIGN } from '../constants';
 import { useIsPluginBundleEligible } from '../hooks/use-is-plugin-bundle-eligible';
 import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
@@ -214,13 +214,7 @@ const siteSetupFlow: Flow = {
 					const pendingActions = [];
 
 					if ( siteIntent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
-						pendingActions.push(
-							setDesignOnSite(
-								siteSlug,
-								WRITE_INTENT_DEFAULT_DESIGN,
-								WRITE_INTENT_DEFAULT_DESIGN_OPTIONS
-							)
-						);
+						pendingActions.push( setDesignOnSite( siteSlug, WRITE_INTENT_DEFAULT_DESIGN ) );
 					}
 
 					// Update Launchpad option based on site intent

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -11,6 +11,7 @@ import { addQueryArgs } from 'calypso/lib/route';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getActiveTheme, getCanonicalTheme } from 'calypso/state/themes/selectors';
+import { WRITE_INTENT_DEFAULT_DESIGN, WRITE_INTENT_DEFAULT_DESIGN_OPTIONS } from '../constants';
 import { useIsPluginBundleEligible } from '../hooks/use-is-plugin-bundle-eligible';
 import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
@@ -59,8 +60,6 @@ import {
 } from './internals/types';
 import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
 
-const WRITE_INTENT_DEFAULT_THEME = 'livro';
-const WRITE_INTENT_DEFAULT_THEME_STYLE_VARIATION = 'white';
 const SiteIntent = Onboard.SiteIntent;
 const SiteGoal = Onboard.SiteGoal;
 
@@ -179,7 +178,7 @@ const siteSetupFlow: Flow = {
 		);
 		const { setPendingAction, setStepProgress, resetOnboardStoreWithSkipFlags, setIntent } =
 			useDispatch( ONBOARD_STORE );
-		const { setThemeOnSite } = useDispatch( SITE_STORE );
+		const { setDesignOnSite } = useDispatch( SITE_STORE );
 		const dispatch = reduxDispatch();
 
 		const flowProgress = useSiteSetupFlowProgress( currentStep, intent );
@@ -216,10 +215,10 @@ const siteSetupFlow: Flow = {
 
 					if ( siteIntent === SiteIntent.Write && ! selectedDesign && ! isAtomic ) {
 						pendingActions.push(
-							setThemeOnSite(
+							setDesignOnSite(
 								siteSlug,
-								WRITE_INTENT_DEFAULT_THEME,
-								WRITE_INTENT_DEFAULT_THEME_STYLE_VARIATION
+								WRITE_INTENT_DEFAULT_DESIGN,
+								WRITE_INTENT_DEFAULT_DESIGN_OPTIONS
 							)
 						);
 					}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/72410

## Proposed Changes

We made a change to [switch the design of the user's site to Livro White for write flow](https://github.com/Automattic/wp-calypso/pull/67141) but we didn't call the `theme-setup` endpoint to trigger the headstart so the “homepage displays“ setting is not aligned with headstart settings. Same for the initial posts.

So, this PR is focusing on replacing the `setThemeOnSite` function with the `setDesignOnSite` function to trigger the `theme-setup` endpoint and make their Home page look as expected.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start` to create a new site
* When you created a new site and land on the Goal screen, select “Write & Publish”
* Continue until you land on the Starting Point screen
* On the Starting Point screen, select “Draft your first post”
* Go to your homepage, and ensure it looks the same as the demo site
  <img src="https://i0.wp.com/s2.wp.com/wp-content/themes/pub/livro/screenshot.jpg?ssl=1" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
