### PR TITLE
Newsletter Flow: Update header and subheader of setup step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -100,9 +100,9 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 			formattedHeader={
 				<FormattedHeader
 					id="newsletter-setup-header"
-					headerText={ translate( 'Make it yours.' ) }
+					headerText={ translate( 'It begins with a name.' ) }
 					subHeaderText={ translate(
-						'Personalize your newsletter with a name, description, and accent color that sets it apart.'
+						'A catchy name, description, and accent color can set a newsletter apart.'
 					) }
 					align="center"
 				/>


### PR DESCRIPTION
## What
This PR changes the copy of the header and subheader in the newsletter setup step.

Old:
`Make it yours.`
`Personalize your newsletter with a name, description, and accent color that sets it apart.`

New:
`It begins with a name.`
`A catchy name, description, and accent color can set a newsletter apart.`

![image](https://user-images.githubusercontent.com/52076348/232457746-1d970608-3cbb-44b9-97d0-fa8fc0c9e13d.png)


## Testing
1. Checkout branch and `yarn start` OR visit the Live Link
2. Reach `/setup/newsletter/newsletterSetup`
3. Check the header and subheader copy


Fixes https://github.com/Automattic/wp-calypso/issues/75783