### PR TITLE
Newsletter: fix email domain on subscriber step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -52,7 +52,7 @@ const Subscribers: Step = function ( { navigation } ) {
 							) }
 							showSubtitle={ true }
 							emailPlaceholders={ [
-								translate( 'sue@example.com' ),
+								translate( 'sue@email.com' ),
 								translate( 'thomaswhigginson@email.com' ),
 								translate( 'ed.dickinson@email.com' ),
 							] }


### PR DESCRIPTION
## What
The email domain of the placeholder example on the subscriber step should be sue@email.com instead of sue@example.com.

![Image](https://user-images.githubusercontent.com/25607244/231711258-c21a6a41-b187-4b8a-8604-ae16d0d3019c.jpg)

## Testing
1. Checkout branch and `yarn start` OR visit the Live Link
2. Reach `/setup/newslettter/newsletterSetup`
3. Check the header and subheader copy

Fixes https://github.com/Automattic/wp-calypso/issues/75687