### PR TITLE
Social: Fix navigation when owning the basic subscription.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/items-list/all-items.tsx
@@ -111,9 +111,10 @@ export const AllItems: React.FC< AllItemsProps > = ( {
 					// except for Jetpack Social when it isn't owned or included in an active plan,
 					// in which case we open a modal.
 					const ctaHref =
-						isSocialProduct && ! ( isOwned || isIncludedInPlanOrSuperseded )
+						isSocialProduct && ! isIncludedInPlanOrSuperseded
 							? `#${ item.productSlug }`
 							: getCheckoutURL( item );
+
 					const onClickCta = isSocialProduct
 						? onClickMoreInfoFactory( item )
 						: getOnClickPurchase( item );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1204272127368434-as-1204203043230842

## Proposed Changes

* The href value set for the manage subscription button has been tweaked to allow choosing of the advanced plan when you own the basic plan.  

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot up a new JN site and buy the Social Basic yearly subscription
* Go to the https://cloud.jetpack.com/pricing/your-jetpack.site and click on the manage subscription button. You will see that the modal will open up, but you will be redirected the purchases page. 
* Boot Calypso Green on local and go to the same page, by checking out this branch and running `yarn start-jetpack-cloud` and going to the `http://jetpack.cloud.localhost:3000/pricing/your-jetpack.site` page. Make sure you're logged in to your jetpack cloud account on the local host as well. Click on the manage subscription button and ensure that you're able to load the social modal and can see the social advanced plan. You can also use the live links instead of booting up jetpack cloud on your localhost. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?