### PR TITLE
Refactor: Remove ONBOARD_STORE dependency from usePremiumGlobalStyles

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -20,6 +20,7 @@ import SelectDropdown from 'calypso/components/select-dropdown';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { tip } from 'calypso/signup/icons';
 import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
+import { useSite } from '../../../../../hooks/use-site';
 import './style.scss';
 import ColorSwatch from './color-swatch';
 
@@ -58,7 +59,8 @@ const AccentColorControl = ( {
 	const [ customColor, setCustomColor ] = useState< AccentColor | null >( null );
 	const [ colorPickerOpen, setColorPickerOpen ] = useState< boolean >( false );
 	const accentColorRef = useRef< HTMLInputElement >( null );
-	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles();
+	const site = useSite();
+	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles( site?.ID );
 
 	const getColorOptions = useCallback(
 		(): ColorOption[] => [

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -84,7 +84,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			( site && ( select( SITE_STORE ) as SiteSelect ).getSiteVerticalId( site.ID ) ) || '',
 		[ site ]
 	);
-	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles();
+	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles( site?.ID );
 
 	const { goToCheckout } = useCheckout();
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -26,7 +26,7 @@ const LaunchpadSitePreview = ( {
 } ) => {
 	const translate = useTranslate();
 	const site = useSite();
-	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles( site?.ID );
+	const { globalStylesInUse } = usePremiumGlobalStyles( site?.ID );
 	const isInVideoPressFlow = isVideoPressFlow( flow );
 	const enableEditOverlay = ! isNewsletterFlow( flow );
 
@@ -74,7 +74,7 @@ const LaunchpadSitePreview = ( {
 			// hide cookies popup
 			preview: true,
 			do_preview_no_interactions: ! isInVideoPressFlow,
-			...( globalStylesInUse && shouldLimitGlobalStyles && { 'preview-global-styles': true } ),
+			...( globalStylesInUse && { 'preview-global-styles': true } ),
 		} );
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -25,8 +25,8 @@ const LaunchpadSitePreview = ( {
 	flow: string | null;
 } ) => {
 	const translate = useTranslate();
-	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles();
 	const site = useSite();
+	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles( site?.ID );
 	const isInVideoPressFlow = isVideoPressFlow( flow );
 	const enableEditOverlay = ! isNewsletterFlow( flow );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -62,7 +62,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 	const clipboardButtonEl = useRef< HTMLButtonElement >( null );
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 
-	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles();
+	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles( site?.ID );
 	const {
 		data: { checklist_statuses },
 	} = useLaunchpad( siteSlug );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-global-styles-upgrade-modal.tsx
@@ -30,7 +30,7 @@ const useGlobalStylesUpgradeModal = ( {
 	const site = useSite();
 	const siteSlug = useSiteSlugParam();
 	const siteUrl = siteSlug || urlToSlug( site?.URL || '' ) || '';
-	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles();
+	const { shouldLimitGlobalStyles } = usePremiumGlobalStyles( site?.ID );
 	const translate = useTranslate();
 	const { goToCheckout } = useCheckout();
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -941,7 +941,7 @@ const getFormSettings = ( settings ) => {
 };
 
 const SiteSettingsFormGeneralWithGlobalStylesNotice = ( props ) => {
-	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles();
+	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles( props.site?.ID );
 
 	return (
 		<SiteSettingsFormGeneral

--- a/client/state/sites/hooks/use-premium-global-styles.ts
+++ b/client/state/sites/hooks/use-premium-global-styles.ts
@@ -1,7 +1,5 @@
-import { select } from '@wordpress/data';
 import { useQuery } from 'react-query';
 import { useSelector } from 'react-redux';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
@@ -9,25 +7,20 @@ import {
 	getGlobalStylesInfoForSite,
 } from './use-site-global-styles-status';
 import type { GlobalStylesStatus } from './use-site-global-styles-status';
-import type { OnboardSelect } from '@automattic/data-stores';
 
-export function usePremiumGlobalStyles(): GlobalStylesStatus {
-	const params = new URLSearchParams( window.location.search );
-	const siteSlugParam = params.get( 'siteSlug' );
-	const siteIdParam = params.get( 'siteId' );
+export function usePremiumGlobalStyles(
+	siteIdOrSlug: number | string | null = 0
+): GlobalStylesStatus {
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const onboard = ( select( ONBOARD_STORE ) as OnboardSelect ).getState();
 
 	// When site id is null it means that the site hasn't been created yet.
 	const siteId = useSelector( ( state ) => {
-		const siteIdOrSlug =
-			onboard?.stepProgress !== undefined ? siteIdParam ?? siteSlugParam : selectedSiteId;
-
-		if ( ! siteIdOrSlug ) {
+		const currentSiteId = siteIdOrSlug ?? selectedSiteId;
+		if ( ! currentSiteId ) {
 			return null;
 		}
 
-		const site = getSite( state, siteIdOrSlug );
+		const site = getSite( state, currentSiteId );
 		return site?.ID ?? null;
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/71653

## Proposed Changes

* Get rid of `ONBOARD_STORE` from `usePremiumGlobalStyles`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Newsletter

* Go to `/setup/newsletter`
* Click “Launch your newsletter”
* Ensure the options of the `Favorite color` contain the “Unlock more colors with a Premium plan” text, and the colors below have the “lock” icon
  ![image](https://user-images.githubusercontent.com/13596067/232459336-44b63b69-7bb4-4f4b-8952-16ddfca007ec.png)
 

* Go to `/setup/newsletter-post-setup/newsletterPostSetup?siteSlug=<your_site>`
  * If your site is under the **free or personal plan**, same as above
  * If your site is under the **premium plan or above**, ensure the options of the `Favorite color` don't contain the “Unlock more colors with a Premium plan” text, and the colors below don't have the “lock” icon
    ![image](https://user-images.githubusercontent.com/13596067/232459412-23bd4fa4-4f4e-4bb9-924d-5404e40309ff.png)


### Design Picker

* Go to `/setup/designSetup?siteSlug=<your_site>`
* Select a design with style variations
  * If your site is under the **free or personal plan**, ensure the style variations are displaying **with** the “Upgrade” badge
  * If your site is under the **premium plan or above**, ensure the style variations are displaying **without** the “Upgrade” badge

### Launchpad

* Go to `/setup/newsletter/launchpad?siteSlug=<your_site>&showLaunchpad=true
* If your site is under the **free or personal plan** with the selected style variation, ensure the preview works well and “Choose a plan” has the upsell message
  ![image](https://user-images.githubusercontent.com/13596067/232461741-a91abbfd-a747-4764-a332-5b16017628ed.png)
* If your site is under the **premium plan or above** with the selected style variation, ensure the preview works well and “Choose a plan” doesn't have the upsell message
  ![image](https://user-images.githubusercontent.com/13596067/232461799-853b7eff-6347-4fe3-9879-dd3cd13a7a8b.png)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
