### PR TITLE
Woo Express: Adjust plan feature copy

### DIFF
--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -1884,11 +1884,11 @@ export const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_AUTOMATED_BACKUPS_SECURITY_SCAN ]: {
 		getSlug: () => FEATURE_AUTOMATED_BACKUPS_SECURITY_SCAN,
-		getTitle: () => i18n.translate( 'Automated backups and security scans' ),
+		getTitle: () => i18n.translate( 'Automated backup + quick restore' ),
 	},
 	[ FEATURE_INTEGRATED_SHIPMENT_TRACKING ]: {
 		getSlug: () => FEATURE_INTEGRATED_SHIPMENT_TRACKING,
-		getTitle: () => i18n.translate( 'Integrated shipment tracking' ),
+		getTitle: () => i18n.translate( 'Shipment tracking' ),
 	},
 	[ FEATURE_SELL_EGIFTS_AND_VOUCHERS ]: {
 		getSlug: () => FEATURE_SELL_EGIFTS_AND_VOUCHERS,
@@ -1905,7 +1905,7 @@ export const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_BACK_IN_STOCK_NOTIFICATIONS ]: {
 		getSlug: () => FEATURE_BACK_IN_STOCK_NOTIFICATIONS,
-		getTitle: () => i18n.translate( 'Back in stock notifications' ),
+		getTitle: () => i18n.translate( 'Back in stock emails' ),
 		getDescription: () =>
 			i18n.translate( 'Notify customers when an out-of-stock item is back in stock.' ),
 	},
@@ -1979,7 +1979,7 @@ export const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_MIN_MAX_ORDER_QUANTITY ]: {
 		getSlug: () => FEATURE_MIN_MAX_ORDER_QUANTITY,
-		getTitle: () => i18n.translate( 'Minimum/maximum order quantity' ),
+		getTitle: () => i18n.translate( 'Min/max order quantity' ),
 		getDescription: () =>
 			i18n.translate(
 				'Set minimum and maximum quantity limits for orders to prevent over-ordering or under-ordering.'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

These are minor tweaks to existing features. The goal was to make the copy shorter.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Compare the copy changes to the items marked as `c` in the spreadsheet linked in p1681499986012049-slack-C0Q664T29.

Discussion to change the copy across the board is here: peapX7-23G-p2#comment-2495

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?