### PR TITLE
Preload stepper steps in parallel

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -59,6 +59,11 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	);
 	const previousProgressValue = stepProgress ? previousProgress / stepProgress.count : 0;
 
+	// this pre-loads all the lazy steps down the flow.
+	useEffect( () => {
+		Promise.all( flowSteps.map( ( step ) => 'asyncComponent' in step && step.asyncComponent() ) );
+	}, stepPaths );
+
 	const isFlowStart = useCallback( () => {
 		if ( ! flow || ! stepProgress ) {
 			return false;


### PR DESCRIPTION
This simple change buffers all the steps a Stepper flow depends on. This comes with no downside, since it loads them in parallel and a non-blocker manner, but it removes the fading WordPress logo between steps. 

### Testing
1. Go to https://wordpress.com/setup/newsletter (yes in prod)
2. Open DevTools, enable Network throttling to slow 3G.
3. Click "Launch your Newsletter". You'll see a fading W.
4. Repeat against the live link in this PR, you shouldn't.

