### PR TITLE
Newsletter flow: Remove translate function from emails

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -52,9 +52,9 @@ const Subscribers: Step = function ( { navigation } ) {
 							) }
 							showSubtitle={ true }
 							emailPlaceholders={ [
-								translate( 'sue@email.com' ),
-								translate( 'thomaswhigginson@email.com' ),
-								translate( 'ed.dickinson@email.com' ),
+								'sue@email.com',
+								'thomaswhigginson@email.com',
+								'ed.dickinson@email.com',
 							] }
 						/>
 					) }


### PR DESCRIPTION
## What
We used the `translate` function for the emails, while there is no need for that.

## Testing
1. Use Live link
2. Go through the Newsletter flow and reach the subscriber step
3. Email placeholders should still be there

Related to https://github.com/Automattic/wp-calypso/pull/75821#pullrequestreview-1388267641