### PR TITLE
Stats Widget: Add loading states placeholder for querying

### DIFF
--- a/apps/odyssey-stats/src/widget/highlights.jsx
+++ b/apps/odyssey-stats/src/widget/highlights.jsx
@@ -13,13 +13,11 @@ function TopColumn( { items, viewAllUrl, viewAllText, title, isLoading, classNam
 		<div className={ classNames( 'stats-widget-highlights-card', className ) }>
 			<label className="stats-widget-highlights-card__title">{ title }</label>
 			{ items.length === 0 && (
-				<div className="stats-widget-highlights-card__empty">
-					<span>
-						{ isLoading
-							? `${ translate( 'Loading' ) }...`
-							: translate( 'Sorry, nothing to report.' ) }
-					</span>
-				</div>
+				<p className="stats-widget-highlights-card__empty">
+					{ isLoading
+						? `${ translate( 'Loading' ) }...`
+						: translate( 'Sorry, nothing to report.' ) }
+				</p>
 			) }
 			{ items.length > 0 && (
 				<ul className="stats-widget-highlights-card__list">

--- a/apps/odyssey-stats/src/widget/highlights.jsx
+++ b/apps/odyssey-stats/src/widget/highlights.jsx
@@ -6,7 +6,7 @@ import useTopPostsQuery from '../hooks/use-top-posts-query';
 
 import './hightlights.scss';
 
-function TopColumn( { items, viewAllUrl, viewAllText, title, className = null } ) {
+function TopColumn( { items, viewAllUrl, viewAllText, title, isLoading, className = null } ) {
 	const translate = useTranslate();
 
 	return (
@@ -14,7 +14,11 @@ function TopColumn( { items, viewAllUrl, viewAllText, title, className = null } 
 			<label className="stats-widget-highlights-card__title">{ title }</label>
 			{ items.length === 0 && (
 				<div className="stats-widget-highlights-card__empty">
-					<span>{ translate( 'Sorry, nothing to report.' ) }</span>
+					<span>
+						{ isLoading
+							? `${ translate( 'Loading' ) }...`
+							: translate( 'Sorry, nothing to report.' ) }
+					</span>
 				</div>
 			) }
 			{ items.length > 0 && (
@@ -40,9 +44,18 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 		.utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 )
 		.format( 'YYYY-MM-DD' );
 
-	// TODO: add a loading state placeholder with isFetching returned from the query.
-	const { data: topPostsAndPages = [] } = useTopPostsQuery( siteId, 'day', 7, queryDate );
-	const { data: topReferrers = [] } = useReferrersQuery( siteId, 'day', 7, queryDate );
+	const { data: topPostsAndPages = [], isFetching: isFetchingPostsAndPages } = useTopPostsQuery(
+		siteId,
+		'day',
+		7,
+		queryDate
+	);
+	const { data: topReferrers = [], isFetching: isFetchingReferrers } = useReferrersQuery(
+		siteId,
+		'day',
+		7,
+		queryDate
+	);
 
 	return (
 		<div className="stats-widget-highlights stats-widget-card">
@@ -57,6 +70,7 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 					viewAllUrl={ odysseyStatsBaseUrl }
 					viewAllText={ translate( 'View all posts & pages stats' ) }
 					items={ topPostsAndPages }
+					isLoading={ isFetchingPostsAndPages }
 				/>
 				<TopColumn
 					className="stats-widget-highlights__column"
@@ -64,6 +78,7 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 					viewAllUrl={ odysseyStatsBaseUrl }
 					viewAllText={ translate( 'View all referrer stats' ) }
 					items={ topReferrers }
+					isLoading={ isFetchingReferrers }
 				/>
 			</div>
 		</div>

--- a/apps/odyssey-stats/src/widget/hightlights.scss
+++ b/apps/odyssey-stats/src/widget/hightlights.scss
@@ -59,8 +59,7 @@
 	.stats-widget-highlights-card__empty {
 		min-height: 40px;
 		margin-top: $font-body;
-		// TODO: use a variable for this
-		color: #999;
+		color: var(--studio-gray-40);
 	}
 
 	.stats-widget-highlights-card__list {

--- a/apps/odyssey-stats/src/widget/hightlights.scss
+++ b/apps/odyssey-stats/src/widget/hightlights.scss
@@ -46,6 +46,7 @@
 	}
 
 	.stats-widget-highlights__column {
+		// Make sure the highlight section doesn't overflow the container, which makes ellipsis work.
 		min-width: 0;
 	}
 
@@ -76,7 +77,6 @@
 			letter-spacing: -0.24px;
 			line-height: 20px;
 
-			width: 100%;
 			overflow: hidden;
 			white-space: nowrap;
 			text-overflow: ellipsis;

--- a/apps/odyssey-stats/src/widget/modules.jsx
+++ b/apps/odyssey-stats/src/widget/modules.jsx
@@ -6,13 +6,13 @@ import useModuleDataQuery from '../hooks/use-module-data-query';
 
 import './modules.scss';
 
-function ModuleCard( { icon, title, value, className = null } ) {
+function ModuleCard( { icon, title, value, isLoading, className = null } ) {
 	return (
 		<div className={ classNames( 'stats-widget-module stats-widget-card', className ) }>
 			<div className="stats-widget-module__icon">{ icon }</div>
 			<div className="stats-widget-module__title">{ title }</div>
 			<div className="stats-widget-module__value">
-				<ShortenedNumber value={ value } />
+				{ isLoading ? '-' : <ShortenedNumber value={ value } /> }
 			</div>
 		</div>
 	);
@@ -21,9 +21,8 @@ function ModuleCard( { icon, title, value, className = null } ) {
 export default function Modules() {
 	const translate = useTranslate();
 
-	// TODO: add a loading state placeholder with isFetching returned from the query.
-	const { data: akismetData } = useModuleDataQuery( 'akismet' );
-	const { data: protectData } = useModuleDataQuery( 'protect' );
+	const { data: akismetData, isFetching: isFetchingAkismet } = useModuleDataQuery( 'akismet' );
+	const { data: protectData, isFetching: isFetchingProtect } = useModuleDataQuery( 'protect' );
 
 	return (
 		<div className="stats-widget-modules">
@@ -31,11 +30,13 @@ export default function Modules() {
 				icon={ protect }
 				title={ translate( 'Total blocked login attempts' ) }
 				value={ protectData }
+				isLoading={ isFetchingProtect }
 			/>
 			<ModuleCard
 				icon={ akismet }
 				title={ translate( 'Total blocked spam comments' ) }
 				value={ akismetData }
+				isLoading={ isFetchingAkismet }
 			/>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/75323#discussion_r1162138268

## Proposed Changes

* Use the state `isFetching` returned from the query to determine the loading states of highlights and modules.
* Update empty state text color to `gray-40` for readability.

|Loading|Empty|
|-|-|
|<img width="565" alt="截圖 2023-04-17 下午11 57 00" src="https://user-images.githubusercontent.com/6869813/232542904-100a43f3-8a90-4dcd-8d8a-3ef353ecca27.png">|<img width="558" alt="截圖 2023-04-17 下午11 56 44" src="https://user-images.githubusercontent.com/6869813/232542946-51a9873c-662d-4454-a176-4858d82a48c4.png">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open your local Jetpack site.
* Check out the branch of the Jetpack to the latest `trunk`.
* Build Jetpack if necessary: `jetpack build plugins/jetpack`.
* Run `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev` under `calypso/apps/odyssey-stats`.
* Navigate to `/wp-admin/index.php?odyssey_widget=1`.
* Ensure the highlight and module cards display loading states after loading the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
