### PR TITLE
update/pricing page empty cart detect jetpack site

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { resemblesUrl } from 'calypso/lib/url';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import { isJetpackSite, getSiteId } from 'calypso/state/sites/selectors';
 
 const getAllowedHosts = ( siteSlug?: string ) => {
 	const basicHosts = [
@@ -22,7 +23,8 @@ const getAllowedHosts = ( siteSlug?: string ) => {
 
 const useValidCheckoutBackUrl = ( siteSlug: string | undefined ): string | undefined => {
 	const { checkoutBackUrl } = useSelector( getInitialQueryArguments ) ?? {};
-
+	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug as string | null ) );
+	const jetpackSite = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	return useMemo( () => {
 		if ( ! checkoutBackUrl ) {
 			// For akismet specific checkout, if navigated with direct link
@@ -30,6 +32,11 @@ const useValidCheckoutBackUrl = ( siteSlug: string | undefined ): string | undef
 			const isAkismetCheckout = window.location.pathname.startsWith( '/checkout/akismet' );
 			if ( ! siteSlug && isAkismetCheckout ) {
 				return 'https://akismet.com/pricing';
+			}
+			// For Jetpack specific checkout, if navigated with direct link
+			// We should redirect to the jetpack pricing page
+			if ( jetpackSite ) {
+				return 'https://cloud.jetpack.com/pricing/' + ( siteSlug || '' );
 			}
 			return undefined;
 		}


### PR DESCRIPTION

Related to # https://github.com/orgs/Automattic/projects/587/views/1?pane=issue&itemId=22640934

## Proposed Changes

* When a jetpack user goes directly to the checkout page (eg: https://wordpress.com/checkout/mygroovysite.com) the go back button redirects to the WordPress.com cart, but they should really be pointed to the Jetpack Pricing Page
* This PR updates the logic the use valid checkout back URL to check if the site in the URL is a jetpack site.  If so, it returns the go back URL as cloud.jepack.com/pricing/site 

## Testing Instructions

* Use the calpso.live site (or run this PR locally) add /checkout/[site] to the URL, where site is a valid jetpack site
* Note that you must not have anything in your cart for that site.
* You'll see the empty cart page, click the go back button
* Confirm you're redirected to the Jetpack pricing page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
