### PR TITLE
Social previews: add Facebook preview for post w/ custom image

### DIFF
--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -42,8 +42,6 @@ export class FacebookSharePreview extends PureComponent {
 				description={ decodeEntities( originalExcerpt || articleContent ) }
 				image={ imageUrl }
 				customText={ decodeEntities( message || originalExcerpt || articleContent || seoTitle ) }
-				// customImage="https://encouraging-red.jurassic.ninja/wp-content/uploads/2023/04/f349df9cdd8e448e6a670f328c5df26e.jpg"
-				customImage="https://encouraging-red.jurassic.ninja/wp-content/uploads/2023/04/0-featured_morrocco_jeff_garriock-scaled.jpg"
 				user={ { displayName: externalDisplay, avatarUrl: externalProfilePicture } }
 				type={ TYPE_ARTICLE }
 			/>

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -42,6 +42,8 @@ export class FacebookSharePreview extends PureComponent {
 				description={ decodeEntities( originalExcerpt || articleContent ) }
 				image={ imageUrl }
 				customText={ decodeEntities( message || originalExcerpt || articleContent || seoTitle ) }
+				// customImage="https://encouraging-red.jurassic.ninja/wp-content/uploads/2023/04/f349df9cdd8e448e6a670f328c5df26e.jpg"
+				customImage="https://encouraging-red.jurassic.ninja/wp-content/uploads/2023/04/0-featured_morrocco_jeff_garriock-scaled.jpg"
 				user={ { displayName: externalDisplay, avatarUrl: externalProfilePicture } }
 				type={ TYPE_ARTICLE }
 			/>

--- a/packages/social-previews/src/constants.ts
+++ b/packages/social-previews/src/constants.ts
@@ -4,3 +4,6 @@ export const DEFAULT_LINK_PREVIEW = 'DEFAULT_LINK_PREVIEW';
 
 export const TYPE_WEBSITE = 'website';
 export const TYPE_ARTICLE = 'article';
+
+export const LANDSCAPE_MODE = 'landscape';
+export const PORTRAIT_MODE = 'portrait';

--- a/packages/social-previews/src/facebook-preview/custom-text.tsx
+++ b/packages/social-previews/src/facebook-preview/custom-text.tsx
@@ -4,12 +4,13 @@ import { facebookCustomText } from './helpers';
 type Props = {
 	text: string;
 	url: string;
+	forceUrlDisplay?: boolean;
 };
 
-const CustomText: React.FC< Props > = ( { text, url } ) => {
+const CustomText: React.FC< Props > = ( { text, url, forceUrlDisplay } ) => {
 	let postLink;
 
-	if ( hasTag( text, 'a' ) ) {
+	if ( forceUrlDisplay || hasTag( text, 'a' ) ) {
 		postLink = (
 			<a
 				className="facebook-preview__custom-text-post-url"

--- a/packages/social-previews/src/facebook-preview/hooks/use-image-hook.ts
+++ b/packages/social-previews/src/facebook-preview/hooks/use-image-hook.ts
@@ -1,0 +1,38 @@
+import { __ } from '@wordpress/i18n';
+import { useCallback, useState } from 'react';
+import { LANDSCAPE_MODE, PORTRAIT_MODE } from '../../constants';
+
+type Mode = typeof LANDSCAPE_MODE | typeof PORTRAIT_MODE | undefined;
+type ImageEventHandler = ( event: React.SyntheticEvent< HTMLImageElement > ) => void;
+type ImgProps = {
+	alt: string;
+	onLoad: ImageEventHandler;
+	onError: ImageEventHandler;
+};
+type UseImage = () => [ Mode, boolean, ImgProps ];
+
+const useImage: UseImage = () => {
+	const [ mode, setMode ] = useState< typeof LANDSCAPE_MODE | typeof PORTRAIT_MODE | undefined >();
+	const [ isLoadingImage, setLoadingImage ] = useState< boolean >( true );
+
+	const onLoad = useCallback(
+		( { target } ) => {
+			setMode( target.naturalWidth > target.naturalHeight ? LANDSCAPE_MODE : PORTRAIT_MODE );
+			setLoadingImage( false );
+		},
+		[ setMode, setLoadingImage ]
+	);
+	const onError = useCallback( () => setLoadingImage( false ), [ setLoadingImage ] );
+
+	return [
+		mode,
+		isLoadingImage,
+		{
+			alt: __( 'Facebook Preview Thumbnail', 'facebook-preview' ),
+			onLoad,
+			onError,
+		},
+	];
+};
+
+export default useImage;

--- a/packages/social-previews/src/facebook-preview/index.tsx
+++ b/packages/social-previews/src/facebook-preview/index.tsx
@@ -1,11 +1,15 @@
 import { __ } from '@wordpress/i18n';
 import SectionHeading from '../shared/section-heading';
 import FacebookLinkPreview from './link-preview';
+import FacebookPostPreview from './post-preview';
 import type { FacebookPreviewProps } from './types';
 
 import './style.scss';
 
 const FacebookPreview: React.FC< FacebookPreviewProps > = ( props ) => {
+	const { customImage } = props;
+	const isPostPreview = !! customImage;
+
 	return (
 		<div className="social-preview facebook-preview">
 			<section className="social-preview__section facebook-preview__section">
@@ -18,7 +22,11 @@ const FacebookPreview: React.FC< FacebookPreviewProps > = ( props ) => {
 				<p className="social-preview__section-desc">
 					{ __( 'This is what your social post will look like on Facebook:', 'facebook-preview' ) }
 				</p>
-				<FacebookLinkPreview { ...props } />
+				{ isPostPreview ? (
+					<FacebookPostPreview { ...props } />
+				) : (
+					<FacebookLinkPreview { ...props } />
+				) }
 			</section>
 		</div>
 	);

--- a/packages/social-previews/src/facebook-preview/link-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/link-preview.tsx
@@ -1,15 +1,12 @@
 import { __ } from '@wordpress/i18n';
-import { useCallback, useState } from 'react';
-import { TYPE_ARTICLE } from '../constants';
+import { TYPE_ARTICLE, PORTRAIT_MODE } from '../constants';
 import CustomText from './custom-text';
 import { baseDomain, facebookTitle, facebookDescription } from './helpers';
+import useImage from './hooks/use-image-hook';
 import FacebookPostActions from './post/actions';
 import FacebookPostHeader from './post/header';
 import FacebookPostIcon from './post/icons';
 import type { FacebookPreviewProps } from './types';
-
-const LANDSCAPE_MODE = 'landscape';
-const PORTRAIT_MODE = 'portrait';
 
 const FacebookLinkPreview: React.FC< FacebookPreviewProps > = ( {
 	url,
@@ -20,20 +17,10 @@ const FacebookLinkPreview: React.FC< FacebookPreviewProps > = ( {
 	customText,
 	type,
 } ) => {
-	const [ mode, setMode ] = useState< typeof LANDSCAPE_MODE | typeof PORTRAIT_MODE | undefined >();
-	const [ isLoadingImage, setLoadingImage ] = useState< boolean >( !! image );
+	const [ mode, isLoadingImage, imgProps ] = useImage();
 	const isArticle = type === TYPE_ARTICLE;
 	const portraitMode = ( isArticle && ! image ) || mode === PORTRAIT_MODE;
 	const modeClass = `is-${ portraitMode ? 'portrait' : 'landscape' }`;
-
-	const handleImageLoad = useCallback(
-		( { target } ) => {
-			setMode( target.naturalWidth > target.naturalHeight ? LANDSCAPE_MODE : PORTRAIT_MODE );
-			setLoadingImage( false );
-		},
-		[ setMode, setLoadingImage ]
-	);
-	const handleImageError = useCallback( () => setLoadingImage( false ), [ setLoadingImage ] );
 
 	return (
 		<div className="facebook-preview__post">
@@ -42,21 +29,15 @@ const FacebookLinkPreview: React.FC< FacebookPreviewProps > = ( {
 				{ customText && <CustomText text={ customText } url={ url } /> }
 				<div
 					className={ `facebook-preview__body ${ modeClass } ${
-						isLoadingImage ? 'is-loading' : ''
+						image && isLoadingImage ? 'is-loading' : ''
 					}` }
 				>
 					{ ( image || isArticle ) && (
 						<div
 							className={ `facebook-preview__image ${ image ? '' : 'is-empty' } ${ modeClass }` }
 						>
-							{ image && (
-								<img
-									alt={ __( 'Facebook Preview Thumbnail', 'facebook-preview' ) }
-									src={ image }
-									onLoad={ handleImageLoad }
-									onError={ handleImageError }
-								/>
-							) }
+							{ /* eslint-disable jsx-a11y/alt-text */ }
+							{ image && <img src={ image } { ...imgProps } /> }
 						</div>
 					) }
 					<div className="facebook-preview__text">

--- a/packages/social-previews/src/facebook-preview/post-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/post-preview.tsx
@@ -1,0 +1,34 @@
+import { PORTRAIT_MODE } from '../constants';
+import CustomText from './custom-text';
+import useImage from './hooks/use-image-hook';
+import FacebookPostActions from './post/actions';
+import FacebookPostHeader from './post/header';
+import type { FacebookPreviewProps } from './types';
+
+const FacebookPostPreview: React.FC< FacebookPreviewProps > = ( {
+	url,
+	user,
+	customText,
+	customImage,
+} ) => {
+	const [ mode, isLoadingImage, imgProps ] = useImage();
+	const modeClass = `is-${ mode === PORTRAIT_MODE ? 'portrait' : 'landscape' }`;
+
+	return (
+		<div className="facebook-preview__post">
+			<FacebookPostHeader user={ user } />
+			<div className="facebook-preview__content">
+				{ customText && <CustomText text={ customText } url={ url } forceUrlDisplay /> }
+				<div className={ `facebook-preview__body ${ isLoadingImage ? 'is-loading' : '' }` }>
+					<div className={ `facebook-preview__custom-image ${ modeClass }` }>
+						{ /* eslint-disable jsx-a11y/alt-text */ }
+						<img src={ customImage } { ...imgProps } />
+					</div>
+				</div>
+			</div>
+			<FacebookPostActions />
+		</div>
+	);
+};
+
+export default FacebookPostPreview;

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -95,6 +95,15 @@
 	line-height: 1.33;
 }
 
+.facebook-preview__image,
+.facebook-preview__custom-image {
+	img {
+		display: block;
+
+		object-fit: cover;
+	}
+}
+
 .facebook-preview__image {
 	&.is-empty {
 		width: 140px;
@@ -104,26 +113,43 @@
 	}
 
 	&.is-portrait {
-		> img {
+		img {
 			width: 278px;
 			height: 430px;
 		}
 	}
 
 	&.is-landscape {
-		> img {
-			// At the moment of writing, the post card on Facebook.com goes from 508 to 680px wide.
-			// In landscape mode, the image takes the full width of the card, and respect the 1.91
-			// aspect ratio at any width.
+		img {
+			// At the moment of writing, the post card on Facebook.com goes from 508 to 680px wide
+			// on desktop. In landscape mode, the image takes the full width of the card, and
+			// respect the 1.91 aspect ratio at any width.
 			width: 100%;
 			aspect-ratio: 1.91;
 		}
 	}
+}
 
-	> img {
-		display: block;
+.facebook-preview__custom-image {
+	display: flex;
+	justify-content: center;
 
-		object-fit: cover;
+	width: 100%;
+
+	background-color: $facebook-preview-image-background;
+
+	&.is-portrait {
+		img {
+			width: 500px;
+			height: 685px;
+		}
+	}
+
+	&.is-landscape {
+		img {
+			width: 100%;
+			aspect-ratio: 1.78;
+		}
 	}
 }
 

--- a/packages/social-previews/src/facebook-preview/variables.scss
+++ b/packages/social-previews/src/facebook-preview/variables.scss
@@ -8,3 +8,4 @@ $facebook-preview-card-border-radius: 4px;
 $facebook-preview-card-box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2), 0 -1px 0 rgb(0 0 0 / 5%);
 $facebook-preview-text-background-color: #f0f2f5;
 $facebook-preview-body-border: 1px solid #d4d0d4;
+$facebook-preview-image-background: #121212;

--- a/packages/social-previews/src/types.ts
+++ b/packages/social-previews/src/types.ts
@@ -4,5 +4,6 @@ export type PreviewProps = {
 	description?: string;
 	customText?: string;
 	image?: string;
+	customImage?: string;
 	headingsLevel?: number;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1203820933396971-as-1204281808721010

## Proposed Changes

#75430 updated the Facebook link preview in the `social-previews` package. This PR updates the preview for posts with a custom image.

## Implementation Notes

- This PR doesn't handle link truncation as displayed on the Facebook.com captures below.
- The logic to generate `img` props has been moved to the hook `use-image-hook.ts`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Prerequisites
- Make sure you have a Facebook account.
- Make sure you have a self-hosted site connected to Jetpack, with a subscription that includes Social.
- From the _Social_ or _My Jetpack_ page of your site WPadmin, activate Social.
- Then, connect your site to Facebook (check [these instructions](https://jetpack.com/support/jetpack-social/connecting-to-social-networks/) if you need help). You may need to create a test page.
- Spin up Calypso by running this branch locally.

### Regression testing

- Create a new post from your site WPadmin
- Add a featured image (do not add a custom media)
- Publish it
- Visit `/posts/:site` in Calypso
- You should see the newly created post under the _Published_ tab
- In the post menu, click _Share_, then press the _Preview_ button
<img width="500" alt="Screenshot 2023-04-11 at 4 47 11 PM" src="https://user-images.githubusercontent.com/1620183/231284467-7d3c5008-321b-444f-a3f9-8b732eaa323c.png">

- Select the Facebook preview
- Notice that the preview is similar to what's in production
- For the next step, copy the URL of the image

### Social post testing

- In `client/components/share/facebook-share-preview/index.jsx`, add the prop `customImage` to `FacebookPreview` with the value you've just copied
- Reload the page
- Check the post preview as you did before, and notice it looks like the capture below
- Optionally, test with an image of a different orientation

_Don't mind the fact that the user actions are not shown in the Facebook.com captures._
| Orientation | WordPress.com | Facebook.com |
|------|-----------------|----------------|
| Landscape |<img width="400" alt="Screenshot 2023-04-17 at 11 22 10 AM" src="https://user-images.githubusercontent.com/1620183/232560706-b5ad6846-034f-4623-ab79-5e4e5082365b.png">|<img width="400" alt="Screenshot 2023-04-17 at 11 05 23 AM" src="https://user-images.githubusercontent.com/1620183/232560699-46363dad-048a-4d18-8d12-ac31b5b93483.png">|
| Portrait |<img width="400" alt="Screenshot 2023-04-17 at 11 33 44 AM" src="https://user-images.githubusercontent.com/1620183/232560711-f6412368-d193-4250-92c2-67d4da443a34.png">|<img width="400" alt="Screenshot 2023-04-17 at 11 33 23 AM" src="https://user-images.githubusercontent.com/1620183/232560709-125db08f-d956-4379-9059-53cd3c58acfd.png">|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?