### PR TITLE
Allow utf-8 characters in some domain contact fields

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -189,11 +189,16 @@ export class ContactDetailsFormFields extends Component {
 
 	sanitize = ( fieldValues, onComplete ) => {
 		const sanitizedFieldValues = Object.assign( {}, fieldValues );
+		const fieldsToDeburr = [ 'email', 'phone', 'postalCode', 'countryCode', 'fax' ];
 
 		CONTACT_DETAILS_FORM_FIELDS.forEach( ( fieldName ) => {
 			if ( typeof fieldValues[ fieldName ] === 'string' ) {
 				// TODO: Deep
-				sanitizedFieldValues[ fieldName ] = deburr( fieldValues[ fieldName ].trim() );
+				if ( fieldsToDeburr.includes( fieldName ) ) {
+					sanitizedFieldValues[ fieldName ] = deburr( fieldValues[ fieldName ].trim() );
+				} else {
+					sanitizedFieldValues[ fieldName ] = fieldValues[ fieldName ].trim();
+				}
 				// TODO: Do this on submit. Is it too annoying?
 				if ( fieldName === 'postalCode' ) {
 					sanitizedFieldValues[ fieldName ] = tryToGuessPostalCodeFormat(


### PR DESCRIPTION
## Proposed Changes

We want to allow UTF-8 characters in some contact fields.

Enabled by backend changes in D107942-code

## Testing Instructions

Make sure that it's possible to use accented characters in first name, last name, organization, city, state, address 1, address 2 fields for the domain contacts.
