### PR TITLE
Woo Express: Update Plans/My Plan page styles

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/style.scss
@@ -16,7 +16,7 @@ body.is-section-plans.is-ecommerce-trial-plan {
 
 	.plans,
 	.current-plan {
-		background-color: #fff;
+		background-color: var(--color-surface);
 	}
 
 	.formatted-header__title {

--- a/client/my-sites/plans/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/style.scss
@@ -14,7 +14,8 @@ body.is-section-plans.is-ecommerce-trial-plan {
 		margin: 20px 0;
 	}
 
-	.plans {
+	.plans,
+	.current-plan {
 		background-color: #fff;
 	}
 }

--- a/client/my-sites/plans/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/style.scss
@@ -13,4 +13,8 @@ body.is-section-plans.is-ecommerce-trial-plan {
 	.e-commerce-trial-plans__banner-wrapper {
 		margin: 20px 0;
 	}
+
+	.plans {
+		background-color: #fff;
+	}
 }

--- a/client/my-sites/plans/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/style.scss
@@ -18,4 +18,8 @@ body.is-section-plans.is-ecommerce-trial-plan {
 	.current-plan {
 		background-color: #fff;
 	}
+
+	.formatted-header__title {
+		font-family: $woo-title-font;
+	}
 }

--- a/client/my-sites/plans/woo-express-plans-page/style.scss
+++ b/client/my-sites/plans/woo-express-plans-page/style.scss
@@ -10,6 +10,11 @@ body.is-section-plans.is-woo-express-plan {
 		box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.05);
 	}
 
+	.plans,
+	.current-plan {
+		background-color: #fff;
+	}
+
 	.woo-express-plans-page__section-title {
 		font-size: $woo-font-title-medium;
 		text-align: center;

--- a/client/my-sites/plans/woo-express-plans-page/style.scss
+++ b/client/my-sites/plans/woo-express-plans-page/style.scss
@@ -12,7 +12,7 @@ body.is-section-plans.is-woo-express-plan {
 
 	.plans,
 	.current-plan {
-		background-color: #fff;
+		background-color: var(--color-surface);
 	}
 
 	.formatted-header__title {

--- a/client/my-sites/plans/woo-express-plans-page/style.scss
+++ b/client/my-sites/plans/woo-express-plans-page/style.scss
@@ -15,6 +15,10 @@ body.is-section-plans.is-woo-express-plan {
 		background-color: #fff;
 	}
 
+	.formatted-header__title {
+		font-family: $woo-title-font;
+	}
+
 	.woo-express-plans-page__section-title {
 		font-size: $woo-font-title-medium;
 		text-align: center;

--- a/packages/typography/styles/woo-commerce.scss
+++ b/packages/typography/styles/woo-commerce.scss
@@ -1,5 +1,7 @@
 @import "./variables.scss";
 
+$woo-title-font: "Proxima Nova", $sans;
+
 $woo-font-headline-large: rem(54px);
 $woo-font-headline-medium: rem(48px);
 $woo-font-headline-small: rem(36px);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73314

## Proposed Changes

* Switch to Proxima Nova with fallback to $sans for the page title font
* Switch to white background from light gray for the Plans/My Plan page backgrounds

**Before**

<img width="1390" alt="Screen Shot 2023-04-17 at 3 07 12 PM" src="https://user-images.githubusercontent.com/2124984/232590411-128f3ae8-abfb-46b0-96a6-5ffe98769f55.png">
<img width="1393" alt="Screen Shot 2023-04-17 at 3 09 34 PM" src="https://user-images.githubusercontent.com/2124984/232590418-1de239a5-a03c-4160-b500-19ee6b86f031.png">

**After**

<img width="1392" alt="Screen Shot 2023-04-17 at 3 17 35 PM" src="https://user-images.githubusercontent.com/2124984/232590490-21786c37-b4af-4ad6-b5a9-25601a4cc368.png">
<img width="1391" alt="Screen Shot 2023-04-17 at 3 17 44 PM" src="https://user-images.githubusercontent.com/2124984/232590493-641a022d-8283-4598-969c-45d8bdf35176.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this branch.
* Navigate to the Plans/My Plan pages on a site with the ecommerce trial, and on a site with a Woo Express plan.
* Verify that the background color has been changed from light gray to white.
* Verify that the page title font is displayed in Proxima Nova.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
