### PR TITLE
WooExpress: Heading colors on checkout success

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/confirmation-task/style.scss
@@ -31,6 +31,7 @@
 	}
 
 	.confirmation-task__title {
+		color: var(--color-neutral-100);
 		margin-top: 24px;
 		font-size: $font-body-small;
 		font-weight: 600;
@@ -39,6 +40,6 @@
 	.confirmation-task__subtitle {
 		margin-top: 6px;
 		font-size: var(--subtitle-font-size);
-		color: var(--color-neutral-40);
+		color: var(--color-neutral-60);
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/74511

## Proposed Changes

* Set colors to the ones specified in the issue.

| Before  | After |
| ------------- | ------------- |
|<img width="1087" alt="image" src="https://user-images.githubusercontent.com/375980/232591159-1b9dbcfd-2cf0-4fea-aeef-30243b8a470f.png">  | <img width="1102" alt="image" src="https://user-images.githubusercontent.com/375980/232591234-090ed3f6-4521-44b5-a30f-df11780fcf06.png"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Update a trial site to Essential and verify the colors match the before/after screenshots.
* If you already have a site that's been updated to essential you can go directly to `/plans/my-plan/trial-upgraded/[YOUR_SITE]`
