### PR TITLE
Social previews: add preview for FB posts shared by others

### DIFF
--- a/packages/social-previews/src/facebook-preview/default-link-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/default-link-preview.tsx
@@ -1,0 +1,8 @@
+import FacebookLinkPreview from './link-preview';
+import type { FacebookPreviewProps } from './types';
+
+const DefaultFacebookLinkPreview: React.FC< FacebookPreviewProps > = ( props ) => {
+	return <FacebookLinkPreview { ...props } compactDescription customText="" user={ undefined } />;
+};
+
+export default DefaultFacebookLinkPreview;

--- a/packages/social-previews/src/facebook-preview/index.tsx
+++ b/packages/social-previews/src/facebook-preview/index.tsx
@@ -1,5 +1,7 @@
+import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import SectionHeading from '../shared/section-heading';
+import DefaultFacebookLinkPreview from './default-link-preview';
 import FacebookLinkPreview from './link-preview';
 import FacebookPostPreview from './post-preview';
 import type { FacebookPreviewProps } from './types';
@@ -27,6 +29,25 @@ const FacebookPreview: React.FC< FacebookPreviewProps > = ( props ) => {
 				) : (
 					<FacebookLinkPreview { ...props } />
 				) }
+			</section>
+			<section className="social-preview__section facebook-preview__section">
+				<SectionHeading level={ props.headingsLevel }>
+					{
+						// translators: refers to a link to a Facebook post
+						__( 'Link preview', 'facebook-preview' )
+					}
+				</SectionHeading>
+				<p className="social-preview__section-desc">
+					{ __(
+						'This is what it will look like when someone shares the link to your WordPress post on Facebook.',
+						'facebook-preview'
+					) }
+					&nbsp;
+					<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
+						{ __( 'Learn more about links', 'facebook-preview' ) }
+					</ExternalLink>
+				</p>
+				<DefaultFacebookLinkPreview { ...props } />
 			</section>
 		</div>
 	);

--- a/packages/social-previews/src/facebook-preview/link-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/link-preview.tsx
@@ -8,7 +8,11 @@ import FacebookPostHeader from './post/header';
 import FacebookPostIcon from './post/icons';
 import type { FacebookPreviewProps } from './types';
 
-const FacebookLinkPreview: React.FC< FacebookPreviewProps > = ( {
+type Props = FacebookPreviewProps & {
+	compactDescription?: boolean;
+};
+
+const FacebookLinkPreview: React.FC< Props > = ( {
 	url,
 	title,
 	description,
@@ -17,6 +21,7 @@ const FacebookLinkPreview: React.FC< FacebookPreviewProps > = ( {
 	customText,
 	type,
 	imageMode,
+	compactDescription,
 } ) => {
 	const [ mode, isLoadingImage, imgProps ] = useImage( { mode: imageMode } );
 	const isArticle = type === TYPE_ARTICLE;
@@ -42,12 +47,16 @@ const FacebookLinkPreview: React.FC< FacebookPreviewProps > = ( {
 						</div>
 					) }
 					<div className="facebook-preview__text">
-						<div>
+						<div className="facebook-preview__text-wrapper">
 							<div className="facebook-preview__url">{ baseDomain( url ) }</div>
 							<div className="facebook-preview__title">
 								{ facebookTitle( title ) || baseDomain( url ) }
 							</div>
-							<div className="facebook-preview__description">
+							<div
+								className={ `facebook-preview__description ${
+									compactDescription ? 'is-compact' : ''
+								}` }
+							>
 								{ description && facebookDescription( description ) }
 								{ isArticle &&
 									! description &&

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -3,7 +3,7 @@
 
 .facebook-preview__section {
 	width: clamp(#{$facebook-preview-min-width}, 100%, #{$facebook-preview-max-width});
-	margin: 0 auto;
+	margin-inline: auto;
 }
 
 .facebook-preview__post {
@@ -73,6 +73,10 @@
 	word-break: break-word;
 }
 
+.facebook-preview__text-wrapper {
+	width: 100%;
+}
+
 .facebook-preview__url {
 	margin-bottom: 0.25rem;
 
@@ -99,6 +103,12 @@
 	/* stylelint-disable-next-line scales/font-sizes */
 	font-size: 0.9375rem; // 15px
 	line-height: 1.33;
+
+	.facebook-preview__body.is-landscape &.is-compact {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
 }
 
 .facebook-preview__image,

--- a/packages/social-previews/src/shared.scss
+++ b/packages/social-previews/src/shared.scss
@@ -24,5 +24,11 @@ $social-preview-light-text-color: #757575;
 
 	font-size: 0.75rem;
 	line-height: 1.33;
+
+	.components-external-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 1204250791794927-as-1204281808721012

## Proposed Changes

#75430 updated the Facebook link preview in the `social-previews` package. This PR updates the preview to include how the post looks when shared by others.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Prerequisites
- Make sure you have a Facebook account.
- Make sure you have a self-hosted site connected to Jetpack, with a subscription that includes Social.
- From the _Social_ or _My Jetpack_ page of your site WPadmin, activate Social.
- Then, connect your site to Facebook (check [these instructions](https://jetpack.com/support/jetpack-social/connecting-to-social-networks/) if you need help). You may need to create a test page.
- Spin up Calypso, by running this branch locally or using a live link below.

### Testing

- Create a new post from your site WPadmin
- Add a featured image (do not add a custom media)
- Publish it
- Visit `/posts/:site` in Calypso
- You should see the newly created post under the _Published_ tab
- In the post menu, click _Share_, then press the _Preview_ button
<img width="500" alt="Screenshot 2023-04-11 at 4 47 11 PM" src="https://user-images.githubusercontent.com/1620183/231284467-7d3c5008-321b-444f-a3f9-8b732eaa323c.png">

- Select the Facebook preview
- You should see a preview of how the post looks when shared

## Captures

_Landscape mode_

<img width="500" alt="Screenshot 2023-04-17 at 3 28 14 PM" src="https://user-images.githubusercontent.com/1620183/232594164-ad9fa33f-ec6d-4bca-8160-7f00458fa5a0.png">
<img width="500" alt="Screenshot 2023-04-17 at 3 28 24 PM" src="https://user-images.githubusercontent.com/1620183/232594169-a8e2ac45-7246-4d2f-8426-015a8c3e7922.png">

_Portrait mode_
<img width="500" alt="Screenshot 2023-04-17 at 3 28 50 PM" src="https://user-images.githubusercontent.com/1620183/232594171-ea1a446c-b499-433f-9832-dc093ef59167.png">
<img width="500" alt="Screenshot 2023-04-17 at 3 29 08 PM" src="https://user-images.githubusercontent.com/1620183/232594174-ce860e05-8855-41c4-8087-d3ec093f16ff.png">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?