### PR TITLE
Re-add Akismet overlapping products message

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -16,6 +16,7 @@ import QueryPostCounts from 'calypso/components/data/query-post-counts';
 import QueryProducts from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import { recordAddEvent } from 'calypso/lib/analytics/cart';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import useSiteDomains from 'calypso/my-sites/checkout/composite-checkout/hooks/use-site-domains';
@@ -683,6 +684,7 @@ export default function CheckoutMain( {
 			<QueryJetpackSaleCoupon />
 			<QuerySitePlans siteId={ updatedSiteId } />
 			<QuerySitePurchases siteId={ updatedSiteId } />
+			{ isSiteless && <QueryUserPurchases /> }
 			<QueryPlans />
 			<QueryProducts />
 			<QueryContactDetailsCache />

--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/index.jsx
@@ -110,7 +110,16 @@ const PrePurchaseNotices = () => {
 			return null;
 		}
 
-		return lowerTierProducts[ 0 ];
+		const highestTierOverlappedProduct = lowerTierProducts[ lowerTierProducts.length - 1 ];
+
+		// If the highest tiered product is Akismet Free, return null
+		// We don't need to display a notice about multiple paid plans in this case
+		if ( highestTierOverlappedProduct.productSlug === 'ak_free_yearly' ) {
+			return null;
+		}
+
+		// Returns the highest tiered product
+		return lowerTierProducts[ lowerTierProducts.length - 1 ];
 	}, [ cartItemSlugs, userActivePurchases ] );
 
 	const siteProductThatOverlapsCartPlan = useMemo( () => {


### PR DESCRIPTION
This PR undo's [this PR](https://github.com/Automattic/wp-calypso/pull/75184) and re-enables the overlapping akismet notice that tells the user when they have a lesser plan they might want to cancel 

## Proposed Changes

* Add the overlapping akismet notice back to the checkout page

## Testing Instructions

1. Checkout these changes
2. Sandbox `public-api.wordpress.com`
3. In your 0-sandbox.php file, add the following line
```
lang=php
define( 'USE_STORE_SANDBOX', true );
```
4. If you do not already have an Akismet product, go to http://calypso.localhost:3000/checkout/akismet/ak_plus_yearly_1 and complete the checkout
5. Next, try added a better plan to the cart, in the case above, that would be http://calypso.localhost:3000/checkout/akismet/ak_plus_yearly_2
6. You should now see the notice letting the user know they have a lesser plan they might want to cancel manually
![image](https://user-images.githubusercontent.com/65001528/232602512-0af43f7e-c383-4084-b9da-c1bf116d82ff.png)
7. Make sure the link to the plan management page works

NOTE: This only shows up when trying to buy a *better* plan than the one you currently have. If it is the same plan or less, it does not show up because sometimes people buy 2 10K plans on purpose, or if they already have a 60K plan (business), they'll add a 10K plan because they don't want to upgrade to Enterprise. In other words, this notice is just to let users know their lower plan will not be auto-cancelled when "upgrading" 

Bonus: You can try the following combinations to ensure it is working correctly

1. If you have an Akismet Free plan and are purchasing an Akismet Plus Yearly plan, the notice should not show
2. If you have an Akismet Free plan and an Akismet Plus 10K Yearly plan, and are purchasing an Akismet Plus 20K or higher plan, the notice should show, referring to and linking to the Akismet Plus Yearly plan
3. You can tests all these plans with the "monthly" versions as well to make sure they behave normally

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
