### PR TITLE
Display marketplace product type on purchases page

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -867,7 +867,7 @@ export function purchaseType( purchase: Purchase ) {
 	}
 
 	if ( purchase.productType === 'marketplace_plugin' || purchase.productType === 'saas_plugin' ) {
-		return i18n.translate( 'Marketplace Product' );
+		return null;
 	}
 
 	if ( purchase.meta ) {

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -867,7 +867,7 @@ export function purchaseType( purchase: Purchase ) {
 	}
 
 	if ( purchase.productType === 'marketplace_plugin' || purchase.productType === 'saas_plugin' ) {
-		return null;
+		return i18n.translate( 'Plugin' );
 	}
 
 	if ( purchase.meta ) {

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -866,6 +866,10 @@ export function purchaseType( purchase: Purchase ) {
 		} );
 	}
 
+	if ( purchase.productType === 'marketplace_plugin' || purchase.productType === 'saas_plugin' ) {
+		return i18n.translate( 'Marketplace Product' );
+	}
+
 	if ( purchase.meta ) {
 		return purchase.meta;
 	}


### PR DESCRIPTION
Related to #75840 

## Proposed Changes

* Returns null for marketplace_plugins and saas_plugin productTypes

## Testing Instructions

* Checkout this branch on your local environment
* Go to /plugins and purchase a Marketplace plugin
* Got to Upgrades -> Purchases
* Check the product type is not displayed for marketplace_plugins and saas_plugin

- To check with a SaaS product follow these testing instructions D105222-code

Before
<img width="1084" alt="Screenshot 2023-04-17 at 1 45 35 PM" src="https://user-images.githubusercontent.com/351784/232615342-c6c17caf-37a6-4306-9299-adf14f594ce4.png">
After

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?