### PR TITLE
Stats: Getting Subscribers data from an API endpoint

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-query.js
+++ b/client/my-sites/stats/hooks/use-subscribers-query.js
@@ -14,7 +14,6 @@ function querySubscribers( siteId, period, quantity ) {
 			http_envelope: 1,
 		}
 	);
-	} );
 }
 
 function selectSubscribers( payload ) {

--- a/client/my-sites/stats/hooks/use-subscribers-query.js
+++ b/client/my-sites/stats/hooks/use-subscribers-query.js
@@ -2,10 +2,18 @@ import { useQuery } from 'react-query';
 import wpcom from 'calypso/lib/wp';
 
 function querySubscribers( siteId, period, quantity ) {
-	return wpcom.req.get( {
-		method: 'GET',
-		apiNamespace: 'rest/v1.1',
-		path: `/sites/${ siteId }/stats/subscribers?unit=${ period }&quantity=${ quantity }&http_envelope=1`,
+	return wpcom.req.get(
+		{
+			method: 'GET',
+			apiNamespace: 'rest/v1.1',
+			path: `/sites/${ siteId }/stats/subscribers`,
+		},
+		{
+			unit: period,
+			quantity,
+			http_envelope: 1,
+		}
+	);
 	} );
 }
 

--- a/client/my-sites/stats/hooks/use-subscribers-query.js
+++ b/client/my-sites/stats/hooks/use-subscribers-query.js
@@ -1,79 +1,30 @@
 import { useQuery } from 'react-query';
-// import wpcom from 'calypso/lib/wp';
+import wpcom from 'calypso/lib/wp';
 
-const mockData = {
-	items: [
-		{
-			date: '2023-03-16',
-			unit: 'month',
-			fields: [ 'period', 'subscribers', 'subscribers_change' ],
-			data: [
-				[ '2023-03-01', 51131, 547 ],
-				[ '2023-02-01', 51881, 750 ],
-				[ '2023-01-01', 52662, 781 ],
-				[ '2022-12-01', 52782, 120 ],
-				[ '2022-11-01', 53541, 759 ],
-				[ '2022-10-01', 53527, -14 ],
-				[ '2022-09-01', 53853, 326 ],
-				[ '2022-08-01', 54243, 390 ],
-				[ '2022-07-01', 55097, 854 ],
-				[ '2022-06-01', 55088, -9 ],
-				[ '2022-05-01', 55208, 120 ],
-				[ '2022-04-01', 55764, 556 ],
-				[ '2022-03-01', 56622, 858 ],
-				[ '2022-02-01', 57363, 741 ],
-				[ '2022-01-01', 57279, -84 ],
-				[ '2021-12-01', 57468, 189 ],
-				[ '2021-11-01', 57444, -24 ],
-				[ '2021-10-01', 57530, 86 ],
-				[ '2021-09-01', 58404, 874 ],
-				[ '2021-08-01', 58468, 64 ],
-				[ '2021-07-01', 58512, 44 ],
-				[ '2021-06-01', 59469, 957 ],
-				[ '2021-05-01', 59795, 326 ],
-				[ '2021-04-01', 60511, 716 ],
-				[ '2021-03-01', 61193, 682 ],
-				[ '2021-02-01', 61448, 255 ],
-				[ '2021-01-01', 61682, 234 ],
-				[ '2020-12-01', 61934, 252 ],
-				[ '2020-11-01', 62927, 993 ],
-				[ '2020-10-01', 62957, 30 ],
-				[ '2020-09-01', 63385, 428 ],
-			],
-		},
-	],
-};
-
-function querySubscribers() {
-	// TODO: remove when the endpoint is ready
-	return new Promise( ( resolve ) => {
-		setTimeout( () => resolve( mockData ), 3000 );
+function querySubscribers( siteId, period, quantity ) {
+	return wpcom.req.get( {
+		method: 'GET',
+		apiNamespace: 'rest/v1.1',
+		path: `/sites/${ siteId }/stats/subscribers?unit=${ period }&quantity=${ quantity }&http_envelope=1`,
 	} );
-
-	// return wpcom.req
-	// 	.get( {
-	// 		apiNamespace: 'rest/v1.1',
-	// 		path: `/sites/${ siteId }/stats/subscribers?unit=${ period }&quantity=${ quantity }`,
-	// 	} )
-	// 	.then( ( data ) => {
-	// 		return data;
-	// 	} );
 }
 
-function selectSubscribers( api ) {
-	return api?.items?.map( ( item ) => {
-		return {
-			date: item.date,
-			unit: item.unit,
-			data: item.data.map( ( dataSet ) => {
-				return {
-					[ item.fields[ 0 ] ]: dataSet[ 0 ],
-					[ item.fields[ 1 ] ]: dataSet[ 1 ],
-					[ item.fields[ 2 ] ]: dataSet[ 2 ],
-				};
-			} ),
-		};
-	} )?.[ 0 ];
+function selectSubscribers( payload ) {
+	if ( ! payload || ! payload.data ) {
+		return [];
+	}
+
+	return {
+		date: payload.date,
+		unit: payload.unit,
+		data: payload.data.map( ( dataSet ) => {
+			return {
+				[ payload.fields[ 0 ] ]: dataSet[ 0 ],
+				[ payload.fields[ 1 ] ]: dataSet[ 1 ],
+				[ payload.fields[ 2 ] ]: dataSet[ 2 ],
+			};
+		} ),
+	};
 }
 
 export default function useSubscribersQuery( siteId, period, quantity ) {
@@ -83,6 +34,7 @@ export default function useSubscribersQuery( siteId, period, quantity ) {
 		() => querySubscribers( siteId, period, quantity ),
 		{
 			select: selectSubscribers,
+			staleTime: 1000 * 60 * 5, // 5 minutes
 		}
 	);
 }

--- a/client/my-sites/stats/stats-subscribers-page/index.jsx
+++ b/client/my-sites/stats/stats-subscribers-page/index.jsx
@@ -65,7 +65,7 @@ const StatsSubscribersPage = ( { period } ) => {
 						vendor={ getSuggestionsVendor() }
 					/>
 				) }
-				<SubscribersSection slug={ siteSlug } period={ period } />
+				<SubscribersSection siteId={ siteId } slug={ siteSlug } period={ period } />
 				<div className={ statsModuleListClass }>
 					<Followers path="followers" />
 					<Reach />

--- a/client/my-sites/stats/subscribers-section/index.tsx
+++ b/client/my-sites/stats/subscribers-section/index.tsx
@@ -34,9 +34,11 @@ function transformData( data: SubscribersData[] ): uPlot.AlignedData {
 }
 
 export default function SubscribersSection( {
+	siteId,
 	slug,
 	period = 'month',
 }: {
+	siteId: string;
 	slug?: string;
 	period?: string;
 } ) {
@@ -48,7 +50,7 @@ export default function SubscribersSection( {
 		data,
 		// error,
 		status,
-	}: UseQueryResult< SubscribersDataResult > = useSubscribersQuery( period, quantity );
+	}: UseQueryResult< SubscribersDataResult > = useSubscribersQuery( siteId, period, quantity );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 	const legendRef = useRef< HTMLDivElement >( null );
 	const translate = useTranslate();

--- a/client/my-sites/stats/subscribers-section/index.tsx
+++ b/client/my-sites/stats/subscribers-section/index.tsx
@@ -19,6 +19,8 @@ interface SubscribersData {
 
 interface SubscribersDataResult {
 	data: SubscribersData[];
+	unit: string;
+	date: string;
 }
 
 // New Subscriber Stats
@@ -50,7 +52,7 @@ export default function SubscribersSection( {
 		data,
 		// error,
 		status,
-	}: UseQueryResult< SubscribersDataResult > = useSubscribersQuery( siteId, period, quantity );
+	} = useSubscribersQuery( siteId, period, quantity ) as UseQueryResult< SubscribersDataResult >;
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 	const legendRef = useRef< HTMLDivElement >( null );
 	const translate = useTranslate();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75315

## Proposed Changes

* replace hard-coded array data with a call to an API endpoint (still returning mock data)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live branch for this PR
* Navigate to the traffic stats page at `/stats/day/:siteSlug`
* Add the query string `?flags=stats/subscribers-section` to enable the subscriber counts page
* Navigate to the page and verify that it loads with a line chart

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
