### PR TITLE
Update: The gallery cards to use the Dotpager component

### DIFF
--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -1,110 +1,63 @@
-import classnames from 'classnames';
-import PropTypes from 'prop-types';
-import { Component } from 'react';
 import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
 import AutoDirection from 'calypso/components/auto-direction';
+import DotPager from 'calypso/components/dot-pager';
 import cssSafeUrl from 'calypso/lib/css-safe-url';
 import resizeImageUrl from 'calypso/lib/resize-image-url';
 import { getImagesFromPostToDisplay } from 'calypso/state/reader/posts/normalization-rules';
 import { READER_CONTENT_WIDTH } from 'calypso/state/reader/posts/sizes';
 
-class PostGallery extends Component {
-	state = {
-		itemSelected: 0,
-		imagesToDisplay: [],
-		listItems: null,
-	};
+function PostGallery( { post, isDiscover, children } ) {
+	const imagesToDisplay = getImagesFromPostToDisplay( post, 10 );
 
-	handleClick = ( event ) => {
+	function handleClick( event ) {
 		event.preventDefault();
-		let updateItemSelected = this.state.itemSelected + 1;
-		if ( updateItemSelected >= this.state.imagesToDisplay.length ) {
-			updateItemSelected = 0;
+	}
+
+	if ( ! imagesToDisplay || imagesToDisplay.length < 2 ) {
+		return null;
+	}
+
+	const listItems = imagesToDisplay.map( ( image, index ) => {
+		const imageUrl = resizeImageUrl( image.src, {
+			w: READER_CONTENT_WIDTH,
+		} );
+		const safeCssUrl = cssSafeUrl( imageUrl );
+		let imageStyle = { background: 'none' };
+		if ( safeCssUrl ) {
+			imageStyle = {
+				backgroundImage: 'url(' + safeCssUrl + ')',
+				backgroundSize: 'cover',
+				backgroundPosition: '50% 50%',
+				backgroundRepeat: 'no-repeat',
+			};
 		}
-		this.setState( { itemSelected: updateItemSelected } );
-	};
-
-	renderGallery = () => {
-		const { post } = this.props;
-		const listItems = this.state.imagesToDisplay.map( ( image, index ) => {
-			const imageUrl = resizeImageUrl( image.src, {
-				w: READER_CONTENT_WIDTH,
-			} );
-			const safeCssUrl = cssSafeUrl( imageUrl );
-			let imageStyle = { background: 'none' };
-			if ( safeCssUrl ) {
-				imageStyle = {
-					backgroundImage: 'url(' + safeCssUrl + ')',
-					backgroundSize: 'cover',
-					backgroundPosition: '50% 50%',
-					backgroundRepeat: 'no-repeat',
-				};
-			}
-
-			const classes = classnames( {
-				'reader-post-card__gallery-item': true,
-				hide: index !== this.state.itemSelected,
-				show: index === this.state.itemSelected,
-			} );
-
-			return (
-				<li key={ `post-${ post.ID }-image-${ index }` } className={ classes }>
-					<div className="reader-post-card__gallery-image" style={ imageStyle } />
-				</li>
-			);
-		} );
-		const circles = listItems.map( ( value, index ) => {
-			const classes = classnames( {
-				'reader-post-card__gallery-circle': true,
-				'is-selected': index === this.state.itemSelected,
-			} );
-			return <div key={ `post-${ post.ID }-circle-${ index }` } className={ classes } />;
-		} );
 		return (
 			<div
-				className="reader-post-card__gallery-container"
-				onClick={ this.handleClick }
-				role="presentation"
-			>
-				<ul className="reader-post-card__gallery">{ listItems }</ul>
-				<div className="reader-post-card__gallery-circles">{ circles }</div>
-			</div>
+				className="reader-post-card__gallery-image"
+				key={ `post-${ post.ID }-image-${ index }` }
+				style={ imageStyle }
+			/>
 		);
-	};
+	} );
 
-	componentDidUpdate() {
-		{
-			this.renderGallery();
-		}
-	}
-
-	render() {
-		const { post, children, isDiscover } = this.props;
-		this.state.imagesToDisplay = getImagesFromPostToDisplay( post, 10 );
-		const gallery = this.renderGallery();
-		return (
-			<div className="reader-post-card__post">
-				{ gallery }
-				<div className="reader-post-card__post-details">
-					<AutoDirection>
-						<h2 className="reader-post-card__title">
-							<a className="reader-post-card__title-link" href={ post.URL }>
-								{ post.title }
-							</a>
-						</h2>
-					</AutoDirection>
-					<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
-					{ children }
-				</div>
+	return (
+		<div className="reader-post-card__post">
+			<div onClick={ handleClick } role="presentation">
+				<DotPager>{ listItems }</DotPager>
 			</div>
-		);
-	}
+			<div className="reader-post-card__post-details">
+				<AutoDirection>
+					<h2 className="reader-post-card__title">
+						<a className="reader-post-card__title-link" href={ post.URL }>
+							{ post.title }
+						</a>
+					</h2>
+				</AutoDirection>
+				<ReaderExcerpt post={ post } isDiscover={ isDiscover } />
+				{ children }
+			</div>
+		</div>
+	);
 }
-
-PostGallery.propTypes = {
-	post: PropTypes.object.isRequired,
-	isDiscover: PropTypes.bool,
-	onClick: PropTypes.func,
-};
 
 export default PostGallery;

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -43,7 +43,7 @@ function PostGallery( { post, isDiscover, children } ) {
 	return (
 		<div className="reader-post-card__post">
 			<div onClick={ handleClick } role="presentation">
-				<DotPager>{ listItems }</DotPager>
+				<DotPager isClickEnabled={ true }>{ listItems }</DotPager>
 			</div>
 			<div className="reader-post-card__post-details">
 				<AutoDirection>

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -121,6 +121,15 @@
 
 	&.is-gallery .reader-post-card__post {
 		flex-direction: column;
+
+		.dot-pager__controls {
+			margin-bottom: 0;
+			margin-top: 16px;
+		}
+		.dot-pager {
+			display: flex;
+			flex-direction: column-reverse;
+		}
 	}
 
 	&.is-gallery,
@@ -653,27 +662,6 @@
 	position: relative;
 }
 
-.reader-post-card__gallery-item {
-	cursor: pointer;
-	flex: 1;
-	height: auto;
-	list-style-type: none;
-	opacity: 1;
-	position: relative;
-	transition: opacity 1s ease-out;
-	width: auto;
-
-	&:last-child {
-		margin-right: 0;
-	}
-
-	&.hide {
-		display: block;
-		opacity: 0;
-		position: absolute;
-	}
-}
-
 .reader-post-card .reader-featured-video__video {
 	padding-bottom: 17px;
 }
@@ -682,27 +670,6 @@
 	border-radius: 4px;
 	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
 	height: 300px;
-}
-
-.reader-post-card__gallery-circles {
-	width: 100%;
-	justify-content: center;
-	display: flex;
-}
-
-.reader-post-card__gallery-circle {
-	border-radius: 50%;
-	width: 7px;
-	height: 7px;
-	background: var(--color-neutral-5);
-	border: 0;
-	position: relative;
-	float: left;
-	margin-right: 9px;
-
-	&.is-selected {
-		background: var(--color-neutral-100);
-	}
 }
 
 .reader-post-card__blocked-description {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -655,13 +655,6 @@
 }
 
 // Gallery cards
-.reader-post-card__gallery {
-	display: flex;
-	margin: 0 0 17px;
-	padding: 0;
-	position: relative;
-}
-
 .reader-post-card .reader-featured-video__video {
 	padding-bottom: 17px;
 }

--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -81,6 +81,7 @@ export const DotPager = ( {
 	children,
 	className = '',
 	onPageSelected = null,
+	isClickEnabled = false,
 	...props
 } ) => {
 	// Filter out the empty children
@@ -115,6 +116,7 @@ export const DotPager = ( {
 				currentPage={ currentPage }
 				pageClassName="dot-pager__page"
 				containerClassName="dot-pager__pages"
+				isClickEnabled={ isClickEnabled }
 			>
 				{ normalizedChildren }
 			</Swipeable>

--- a/client/components/swipeable/index.js
+++ b/client/components/swipeable/index.js
@@ -63,6 +63,7 @@ export const Swipeable = ( {
 	onPageSelect,
 	pageClassName,
 	containerClassName,
+	isClickEnabled,
 	...otherProps
 } ) => {
 	const [ swipeableArea, setSwipeableArea ] = useState();
@@ -109,6 +110,15 @@ export const Swipeable = ( {
 		}
 	}, [ pagesRef, currentPage, pagesStyle, updateEnabled, containerWidth, childrenOrder ] );
 
+	const resetDragData = useCallback( () => {
+		delete pagesStyle.transform;
+		setPagesStyle( {
+			...pagesStyle,
+			transitionDuration: TRANSITION_DURATION,
+		} );
+		setDragData( null );
+	}, [ pagesStyle, setPagesStyle, setDragData ] );
+
 	const handleDragStart = useCallback(
 		( event ) => {
 			const position = getDragPositionAndTime( event );
@@ -147,14 +157,20 @@ export const Swipeable = ( {
 			const verticalAbsoluteDelta = Math.abs( dragPosition.y - dragData.start.y );
 			const angle = ( Math.atan2( verticalAbsoluteDelta, absoluteDelta ) * 180 ) / Math.PI;
 
+			// Is click or tap?
+			if ( velocity === 0 && isClickEnabled ) {
+				if ( numPages !== currentPage + 1 ) {
+					onPageSelect( currentPage + 1 );
+				} else {
+					onPageSelect( 0 );
+				}
+				resetDragData();
+				return;
+			}
+
 			// Is vertical scroll detected?
 			if ( angle > VERTICAL_THRESHOLD_ANGLE ) {
-				delete pagesStyle.transform;
-				setPagesStyle( {
-					...pagesStyle,
-					transitionDuration: TRANSITION_DURATION,
-				} );
-				setDragData( null );
+				resetDragData();
 				return;
 			}
 
@@ -189,6 +205,7 @@ export const Swipeable = ( {
 			onPageSelect,
 			pagesStyle,
 			containerWidth,
+			isClickEnabled,
 		]
 	);
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -357,12 +357,6 @@
 		white-space: normal;
 	}
 
-	.reader-post-card.is-gallery .reader-post-card__gallery-item:last-child {
-		@include breakpoint-deprecated( "<960px" ) {
-			display: block;
-		}
-	}
-
 	.reader-share__button-label,
 	.comment-button__label-status,
 	.like-button__label-status {


### PR DESCRIPTION

## Proposed Changes

* This PR implements the dotpager component in the reader. 
This is mainly done for consistency with other PRs and allows for the paged gallery to be swipeable.

Before:
<img width="578" alt="Screenshot 2023-04-17 at 4 33 08 PM" src="https://user-images.githubusercontent.com/115071/232632644-554098be-d976-46c8-b84e-a5dfb4986544.png">


After:
<img width="578" alt="Screenshot 2023-04-17 at 4 32 45 PM" src="https://user-images.githubusercontent.com/115071/232632663-a4689c6b-9dd6-43bb-a144-1d6d94ba2de5.png">

Please note: The UI is not quite the same as before but it does match the other dotpage components. 
I think the Dotpage component could be updated to remove the left and right arrows and move the dots in the middle. 
If we need this to be the same. 

Note also that when the user clicks on the images nothing happends where as before that was the way to cycle thought the images. 

## Testing Instructions

* Load up this PR in the reader. User the reader acorss different devices. Notice that the gallery posts are now swipable.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
