### PR TITLE
Backup: Update used storage decimals

### DIFF
--- a/client/components/backup-storage-space/hooks.tsx
+++ b/client/components/backup-storage-space/hooks.tsx
@@ -73,6 +73,20 @@ export const useStorageUsageText = (
 			);
 		}
 
+		if ( availableUnit === StorageUnits.Terabyte && availableUnitAmount % 1 !== 0 ) {
+			return translate(
+				'Using {{usedStorage}}%(usedGigabytes).1fGB{{/usedStorage}} of %(availableUnitAmount).2fTB',
+				'Using {{usedStorage}}%(usedGigabytes).1fGB{{/usedStorage}} of %(availableUnitAmount).2fTB',
+				{
+					count: usedGigabytes,
+					args: { usedGigabytes, availableUnitAmount },
+					comment:
+						'Must use unit abbreviation; describes used vs available storage amounts (e.g., Using 20.0GB of 1.01TB, Using 0.5GB of 2TB)',
+					components: { usedStorage: <span className="used-space__span" /> },
+				}
+			);
+		}
+
 		return translate(
 			'Using {{usedStorage}}%(usedGigabytes).1fGB{{/usedStorage}} of %(availableUnitAmount)dTB',
 			'Using {{usedStorage}}%(usedGigabytes).1fGB{{/usedStorage}} of %(availableUnitAmount)dTB',
@@ -150,10 +164,10 @@ export const useStorageText = ( storageInBytes: number ): TranslateResult | stri
 						} );
 					}
 
-					return translate( '%(storageInBytes).1fTB', {
+					return translate( '%(storageInBytes).2fTB', {
 						args: { storageInBytes: unitAmount },
 						comment:
-							'Must use unit abbreviation; describes an storage amounts with 1 decimal point (e.g., 1.5TB)',
+							'Must use unit abbreviation; describes an storage amounts with 2 decimal point (e.g., 1.50TB)',
 					} );
 			}
 		}

--- a/client/components/backup-storage-space/test/hooks.js
+++ b/client/components/backup-storage-space/test/hooks.js
@@ -83,7 +83,7 @@ describe( 'useStorageUsageText', () => {
 		[ TERABYTE * 3, 3 ],
 		[ TERABYTE * 4, 4 ],
 	] )(
-		'shows available storage in integer terabytes if bytesAvailable is >= 1TB and the amout is a whole number',
+		'shows available storage in integer terabytes if bytesAvailable is >= 1TB and the amount is a whole number',
 		( bytesAvailable, expectedTB ) => {
 			const text = renderStorageUsageText( 0, bytesAvailable );
 			expect( text ).toHaveTextContent( `${ expectedTB }TB` );

--- a/client/components/backup-storage-space/test/hooks.js
+++ b/client/components/backup-storage-space/test/hooks.js
@@ -65,12 +65,25 @@ describe( 'useStorageUsageText', () => {
 	);
 
 	test.each( [
+		[ TERABYTE + GIGABYTE * 10, '1.01' ],
+		[ TERABYTE + GIGABYTE * 100, '1.10' ],
+		[ TERABYTE * 2 + GIGABYTE * 10, '2.01' ],
+		[ TERABYTE * 2 + GIGABYTE * 100, '2.10' ],
+	] )(
+		'displays available storage in terabytes with two decimals when it exceeds 1TB and the amount is not a whole number.',
+		( bytesAvailable, expectedTB ) => {
+			const text = renderStorageUsageText( 0, bytesAvailable );
+			expect( text ).toHaveTextContent( `${ expectedTB }TB` );
+		}
+	);
+
+	test.each( [
 		[ TERABYTE, 1 ],
-		[ TERABYTE + 1, 1 ],
-		[ TERABYTE * 4 - 1, 3 ],
+		[ TERABYTE * 2, 2 ],
+		[ TERABYTE * 3, 3 ],
 		[ TERABYTE * 4, 4 ],
 	] )(
-		'shows available storage in integer terabytes if bytesAvailable is >= 1TB',
+		'shows available storage in integer terabytes if bytesAvailable is >= 1TB and the amout is a whole number',
 		( bytesAvailable, expectedTB ) => {
 			const text = renderStorageUsageText( 0, bytesAvailable );
 			expect( text ).toHaveTextContent( `${ expectedTB }TB` );
@@ -147,7 +160,7 @@ describe( 'useStorageText', () => {
 		[ 2 ** 30 * 3, '3GB' ],
 		[ 2 ** 40 / 2, '512GB' ],
 		[ 2 ** 40 * 2, '2TB' ],
-		[ 2 ** 40 * 3.5, '3.5TB' ],
+		[ 2 ** 40 * 3.5, '3.50TB' ],
 		[ null, '' ],
 		[ -1, '' ],
 	] )( 'renders storage in human readable format for %s bytes', ( storageInBytes, expected ) => {


### PR DESCRIPTION
Currently, if a site has a 10 GB backup plan and then purchases a 1 TB storage add-on, Jetpack Cloud UI just displays 1 TB. This is because we are rounding units higher than 1TB to not use decimals.

After discussing in p1681284898661269-slack-CS8UYNPEE we agreed to update the storage unit to consider two decimals when the amount is higher than 1TB.

## Proposed Changes

* Add two decimals on storage available amounts that are higher than 1 TB and is not a whole number on backups and settings sections in Jetpack Cloud.

## Screenshots

| Page | Before | After |
|---|---|---|
| VaultPress Backup | <img src="https://user-images.githubusercontent.com/1488641/232868512-378556fe-138a-4fcf-b57a-db236d11b499.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1488641/232866450-f8b182c4-7405-4dcf-8b64-0ffa9ba0dd01.png" width="300" />
| Settings | <img src="https://user-images.githubusercontent.com/1488641/232868767-2fab9cb4-7002-495f-a9f5-bf031f881d52.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1488641/232866794-b9ac03c0-fca7-4e6b-8e11-6faa2c7a3786.png" width="300" /> |

## Testing Instructions

* Spin up a Jetpack Cloud live site
* Select a site with Jetpack VaultPress Backup with 10 GB plan.
* Purchase 1 TB storage add-on. You can use the following link replacing with your site slug:
  * `https://wordpress.com/checkout/YOUR_SITE_SLUG/jetpack_backup_addon_storage_1tb_monthly`
* Visit VaultPress Backup and Settings page and ensure you see 1.01TB as space limit/available, instead of just 1TB.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?