### PR TITLE
Site Assembler - Avoid fetching rendered patterns if patternIds length does not change

### DIFF
--- a/packages/block-renderer/src/hooks/use-rendered-patterns.ts
+++ b/packages/block-renderer/src/hooks/use-rendered-patterns.ts
@@ -61,7 +61,7 @@ const useRenderedPatterns = (
 				pages.reduce( ( previous, current ) => ( { ...previous, ...current } ), {} )
 			);
 		} );
-	}, [ patternIds ] );
+	}, [ patternIds.length ] );
 
 	return renderedPatterns;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75813 #75326

## Proposed Changes

* Avoid fetching rendered patterns if `patternIds` length does not change

This issue was introduced in #75326.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the `Calypso live` link on the first comment below
* Create a new site and continue until the Design Picker
* Click `Start designing` from the bottom of the design picker 
* Click `Header` and click on different headers
* Verify in the Network panel in Dev Tools that the requests `/block-renderer/patterns/render` are not done every time a header is selected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
