### PR TITLE
(DRAFT) Launchpad: Integrate New Checklist Endpoint

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -3,6 +3,7 @@ import { useSelect, useDispatch as useWPDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
+import { useLaunchpadChecklist } from 'calypso/../packages/help-center/src/hooks/use-launchpad';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useLaunchpad } from 'calypso/data/sites/use-launchpad';
@@ -17,7 +18,6 @@ import { successNotice } from 'calypso/state/notices/actions';
 import { useQuery } from '../../../../hooks/use-query';
 import StepContent from './step-content';
 import { areLaunchpadTasksCompleted } from './task-helper';
-import { launchpadFlowTasks } from './tasks';
 import type { Step } from '../../types';
 import type { SiteSelect } from '@automattic/data-stores';
 
@@ -36,8 +36,14 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	const site = useSite();
 	const {
 		isError: launchpadFetchError,
-		data: { launchpad_screen: launchpadScreenOption, checklist_statuses, site_intent },
+		data: { launchpad_screen: launchpadScreenOption, site_intent: siteIntentOption },
 	} = useLaunchpad( siteSlug );
+	const {
+		data: { checklist: launchpadChecklist },
+	} = useLaunchpadChecklist( siteSlug, siteIntentOption );
+
+	console.log( { launchpadChecklist } );
+
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 	const recordSignupComplete = useRecordSignupComplete( flow );
 	const dispatch = useDispatch();
@@ -61,14 +67,9 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		redirectToSiteHome( siteSlug, flow );
 	}
 
-	if (
-		areLaunchpadTasksCompleted(
-			site_intent,
-			launchpadFlowTasks,
-			checklist_statuses,
-			isSiteLaunched
-		)
-	) {
+	console.log( 'completed: ', areLaunchpadTasksCompleted( launchpadChecklist, isSiteLaunched ) );
+
+	if ( areLaunchpadTasksCompleted( launchpadChecklist, isSiteLaunched ) ) {
 		saveSiteSettings( site?.ID, { launchpad_screen: 'off' } );
 		redirectToSiteHome( siteSlug, flow );
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -15,7 +15,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isVideoPressFlow } from 'calypso/signup/utils';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { launchpadFlowTasks } from './tasks';
-import { LaunchpadFlowTaskList, LaunchpadStatuses, Task } from './types';
+import { LaunchpadFlowTaskList, LaunchpadStatuses, Task, LaunchpadChecklist } from './types';
 import type { SiteDetails } from '@automattic/data-stores';
 
 export function getEnhancedTasks(
@@ -415,21 +415,16 @@ export function getArrayOfFilteredTasks(
  * @returns {boolean} - True if the final task for the given site_intent is completed
  */
 export function areLaunchpadTasksCompleted(
-	site_intent: string,
-	launchpadFlowTasks: LaunchpadFlowTaskList,
-	checklist_statuses: LaunchpadStatuses,
+	checklist: LaunchpadChecklist,
 	isSiteLaunched: boolean
 ) {
-	if ( ! site_intent ) {
-		return false;
+	const lastTask = checklist[ checklist.length - 1 ];
+
+	// If last task is site_launched, return true if site is launched OR site_launched task is completed
+	// Else return the status of the last task (will be false if task is not in checklist_statuses)
+	if ( lastTask.id === 'site_launched' && isSiteLaunched ) {
+		return true;
 	}
 
-	const lastTask =
-		launchpadFlowTasks[ site_intent ][ launchpadFlowTasks[ site_intent ].length - 1 ];
-
-	// If last task is site_launched, return true if site is launched OR site_launch task is completed
-	// Else return the status of the last task (will be false if task is not in checklist_statuses)
-	return lastTask === 'site_launched'
-		? isSiteLaunched || Boolean( checklist_statuses[ lastTask ] )
-		: Boolean( checklist_statuses[ lastTask as keyof LaunchpadStatuses ] );
+	return lastTask.completed;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -1,5 +1,5 @@
 export interface Task {
-	id: string;
+	id: TaskId;
 	completed: boolean;
 	disabled: boolean;
 	title?: string;
@@ -9,6 +9,16 @@ export interface Task {
 	isLaunchTask?: boolean;
 	warning?: boolean;
 }
+
+export type TaskId =
+	| 'links_edited'
+	| 'site_edited'
+	| 'site_launched'
+	| 'first_post_published'
+	| 'video_uploaded'
+	| 'publish_first_course'
+	| 'plan_completed'
+	| 'domain_upsell_deferred';
 
 export interface LaunchpadFlowTaskList {
 	[ string: string ]: string[];
@@ -21,19 +31,10 @@ export interface TranslatedLaunchpadStrings {
 	subtitle: string;
 }
 
-export interface LaunchpadStatuses {
-	links_edited?: boolean;
-	site_edited?: boolean;
-	site_launched?: boolean;
-	first_post_published?: boolean;
-	video_uploaded?: boolean;
-	publish_first_course?: boolean;
-	plan_completed?: boolean;
-	domain_upsell_deferred?: boolean;
-}
+export type LaunchpadChecklist = Array< Task >;
 
 export interface LaunchpadResponse {
 	site_intent: string;
 	launchpad_screen: boolean | string;
-	checklist_statuses: LaunchpadStatuses[];
+	checklist_statuses: LaunchpadChecklist[];
 }

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,8 +1,8 @@
 import { isEcommerce } from '@automattic/calypso-products/src';
 import page from 'page';
+import { useLaunchpadChecklist } from 'calypso/../packages/help-center/src/hooks/use-launchpad';
 import { fetchLaunchpad } from 'calypso/data/sites/use-launchpad';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
-import { launchpadFlowTasks } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
@@ -45,23 +45,22 @@ export async function maybeRedirect( context, next ) {
 	const siteId = getSelectedSiteId( state );
 	const site = getSelectedSite( state );
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
+	const {
+		data: { checklist: launchpadChecklist },
+	} = useLaunchpadChecklist( siteSlug, siteIntentOption );
 
 	try {
-		const { launchpad_screen, checklist_statuses, site_intent } = await fetchLaunchpad( slug );
+		const { launchpad_screen: launchpadScreenOption, site_intent: siteIntentOption } =
+			await fetchLaunchpad( slug );
 		if (
-			launchpad_screen === 'full' &&
-			! areLaunchpadTasksCompleted(
-				site_intent,
-				launchpadFlowTasks,
-				checklist_statuses,
-				isSiteLaunched
-			)
+			launchpadScreenOption === 'full' &&
+			! areLaunchpadTasksCompleted( launchpadChecklist, isSiteLaunched )
 		) {
 			// The new stepper launchpad onboarding flow isn't registered within the "page"
 			// client-side router, so page.redirect won't work. We need to use the
 			// traditional window.location Web API.
 			const verifiedParam = getQueryArgs()?.verified;
-			redirectToLaunchpad( slug, site_intent, verifiedParam );
+			redirectToLaunchpad( slug, siteIntentOption, verifiedParam );
 			return;
 		}
 	} catch ( error ) {}

--- a/packages/help-center/src/components/help-center-launchpad.tsx
+++ b/packages/help-center/src/components/help-center-launchpad.tsx
@@ -44,7 +44,7 @@ export const HelpCenterLaunchpad = () => {
 		siteSlug = window?.location?.host;
 	}
 
-	const { data } = useLaunchpadChecklist( siteSlug );
+	const { data } = useLaunchpadChecklist( siteSlug, siteIntent || '' );
 	const totalLaunchpadSteps = data?.checklist?.length || 4;
 	const completeLaunchpadSteps =
 		data?.checklist?.filter( ( checklistItem ) => checklistItem.completed ).length || 1;

--- a/packages/help-center/src/components/help-center-launchpad.tsx
+++ b/packages/help-center/src/components/help-center-launchpad.tsx
@@ -8,6 +8,7 @@ import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { useLaunchpadChecklist } from '../hooks/use-launchpad';
 import { SITE_STORE } from '../stores';
 import type { SiteSelect } from '@automattic/data-stores';
 
@@ -43,6 +44,11 @@ export const HelpCenterLaunchpad = () => {
 		siteSlug = window?.location?.host;
 	}
 
+	const { data } = useLaunchpadChecklist( siteSlug );
+	const totalLaunchpadSteps = data?.checklist?.length || 4;
+	const completeLaunchpadSteps =
+		data?.checklist?.filter( ( checklistItem ) => checklistItem.completed ).length || 1;
+
 	const launchpadURL = `${ getEnvironmentHostname() }/setup/${ siteIntent }/launchpad?siteSlug=${ siteSlug }`;
 	const sectionName = useSelector( ( state ) => getSectionName( state ) );
 	const handleLaunchpadHelpLinkClick = () => {
@@ -69,7 +75,11 @@ export const HelpCenterLaunchpad = () => {
 					handleLaunchpadHelpLinkClick();
 				} }
 			>
-				<CircularProgressBar size={ 32 } currentStep={ 1 } numberOfSteps={ 4 } />
+				<CircularProgressBar
+					size={ 32 }
+					currentStep={ completeLaunchpadSteps }
+					numberOfSteps={ totalLaunchpadSteps }
+				/>
 				<span className="inline-help-launchpad-link-text">
 					{ __( 'Continue setting up your site with these next steps.' ) }
 				</span>

--- a/packages/help-center/src/hooks/use-launchpad.tsx
+++ b/packages/help-center/src/hooks/use-launchpad.tsx
@@ -23,24 +23,27 @@ interface LaunchpadTasks {
 	checklist: LaunchpadTask[];
 }
 
-export const fetchLaunchpadChecklist = ( siteSlug: string | null ): Promise< LaunchpadTasks > => {
+export const fetchLaunchpadChecklist = (
+	siteSlug: string | null,
+	siteIntent: string
+): Promise< LaunchpadTasks > => {
 	const slug = encodeURIComponent( siteSlug as string );
 
 	return canAccessWpcomApis()
 		? wpcomRequest( {
-				path: `sites/${ slug }/launchpad/checklist?checklist_slug=newsletter`,
+				path: `sites/${ slug }/launchpad/checklist?checklist_slug=${ siteIntent }`,
 				apiNamespace: 'wpcom/v2/',
 				apiVersion: '2',
 		  } )
 		: apiFetch( {
 				global: true,
-				path: `sites/${ slug }/launchpad/checklist?checklist_slug=newsletter`,
+				path: `sites/${ slug }/launchpad/checklist?checklist_slug=${ siteIntent }`,
 		  } as APIFetchOptions );
 };
 
-export const useLaunchpadChecklist = ( siteSlug: string | null ) => {
+export const useLaunchpadChecklist = ( siteSlug: string | null, siteIntent: string ) => {
 	const key = [ 'launchpad', siteSlug ];
-	return useQuery( key, () => fetchLaunchpadChecklist( siteSlug ), {
+	return useQuery( key, () => fetchLaunchpadChecklist( siteSlug, siteIntent ), {
 		retry: 3,
 		initialData: {
 			checklist: [],

--- a/packages/help-center/src/hooks/use-launchpad.tsx
+++ b/packages/help-center/src/hooks/use-launchpad.tsx
@@ -1,0 +1,49 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useQuery } from 'react-query';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+
+interface APIFetchOptions {
+	global: boolean;
+	path: string;
+}
+
+interface LaunchpadTask {
+	id?: string;
+	completed?: boolean;
+	disabled?: boolean;
+	title?: string;
+	subtitle?: string;
+	badgeText?: string;
+	actionDispatch?: () => void;
+	isLaunchTask?: boolean;
+	warning?: boolean;
+}
+
+interface LaunchpadTasks {
+	checklist: LaunchpadTask[];
+}
+
+export const fetchLaunchpadChecklist = ( siteSlug: string | null ): Promise< LaunchpadTasks > => {
+	const slug = encodeURIComponent( siteSlug as string );
+
+	return canAccessWpcomApis()
+		? wpcomRequest( {
+				path: `sites/${ slug }/launchpad/checklist?checklist_slug=newsletter`,
+				apiNamespace: 'wpcom/v2/',
+				apiVersion: '2',
+		  } )
+		: apiFetch( {
+				global: true,
+				path: `sites/${ slug }/launchpad/checklist?checklist_slug=newsletter`,
+		  } as APIFetchOptions );
+};
+
+export const useLaunchpadChecklist = ( siteSlug: string | null ) => {
+	const key = [ 'launchpad', siteSlug ];
+	return useQuery( key, () => fetchLaunchpadChecklist( siteSlug ), {
+		retry: 3,
+		initialData: {
+			checklist: [],
+		},
+	} );
+};


### PR DESCRIPTION
## Proposed Changes
Integrate New Checklist Endpoint

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
