### PR TITLE
Use the new pricing grid for the domain flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -327,7 +327,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'site-selected',
-			steps: [ 'themes-site-selected', 'plans-site-selected' ],
+			steps: [ 'themes-site-selected', 'plans-site-selected-legacy' ],
 			destination: getSiteDestination,
 			providesDependenciesInQuery: [ 'siteSlug', 'siteId' ],
 			optionalDependenciesInQuery: [ 'siteId' ],

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -38,6 +38,7 @@ const stepNameToModuleName = {
 	'plans-personal': 'plans',
 	'plans-premium': 'plans',
 	'plans-site-selected': 'plans',
+	'plans-site-selected-legacy': 'plans',
 	'plans-store-nux': 'plans-atomic-store',
 	'select-domain': 'domains',
 	site: 'site',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -112,6 +112,9 @@ export function generateSteps( {
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'cartItem' ],
+			props: {
+				hideFreePlan: true,
+			},
 		},
 
 		site: {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -118,6 +118,19 @@ export function generateSteps( {
 			},
 		},
 
+		// TODO
+		// The new pricing grid and the legacy one act differently
+		// when a paid domain is picked, and the new pricing grid is currently
+		// having different behavior on different flow on the paid domain +
+		// Free plan case. We can deprecate this once that specific behavior
+		// is settled and that we decide to migrate `site-selected` as a reskinned flow.
+		'plans-site-selected-legacy': {
+			stepName: 'plans-site-selected-legacy',
+			apiRequestFunction: addPlanToCart,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem' ],
+		},
+
 		site: {
 			stepName: 'site',
 			apiRequestFunction: createSite,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -114,6 +114,7 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem' ],
 			props: {
 				hideFreePlan: true,
+				hideEnterprisePlan: true,
 			},
 		},
 

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -80,6 +80,11 @@ export const is2023PricingGridActivePage = (
 		return isPricingGridEnabled;
 	}
 
+	// Is this the domain-only flow?
+	if ( currentRoutePath.startsWith( '/start/domain' ) ) {
+		return isPricingGridEnabled;
+	}
+
 	// Is this the launch site flow?
 	if ( currentRoutePath.startsWith( '/start/launch-site/plans-launch' ) ) {
 		return isPricingGridEnabled;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1533
Related to #74986 

## Proposed Changes

This PR exposes the new pricing grid to the /start/domain flow. A side effect of it will sort of address #74986, since the old pricing grid will be deprecated. The free plan is hidden according to the current behavior; the Enterprise plan is also hidden since I don't think it makes sense to show it in the domain flow.

<img width="1295" alt="image" src="https://user-images.githubusercontent.com/1842898/232720970-45c33973-4a27-4490-929e-53678c157ada.png">

To not impact `site-selected` flow(even though it is very broken right now, [there is still some traffic](https://github.com/Automattic/wp-calypso/pull/75869#pullrequestreview-1391340369)), I added a `plans-site-selected-legacy` step for showing the same legacy pricing grid in it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

/start/domain:
* Go to the domain flow: `/start/domain`
* Enter a domain in the domain step
* At the domain-only or new site step, click "Start site"
* You should see the new pricing grid shown for the plans step.

/start/site-selected?siteSlug=(site domain):
* Go to the site-selected flow /start/site-selected?siteSlug=(site domain)
* Pick a theme
* In the plans step, the same legacy pricing grid should be shown. Note that "start a new site" button is broken as it is in production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
