### PR TITLE
Hide expiration notice for Akismet Free

### DIFF
--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -5,6 +5,7 @@ import {
 	isPlan,
 	isDomainRegistration,
 	isMonthly,
+	PRODUCT_AKISMET_FREE,
 } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { isEmpty, merge, minBy } from 'lodash';
@@ -265,6 +266,7 @@ class PurchaseNotice extends Component {
 	};
 
 	renderPurchaseExpiringNotice() {
+		const EXCLUDED_PRODUCTS = [ 'ecommerce-trial-bundle-monthly', PRODUCT_AKISMET_FREE ];
 		const {
 			moment,
 			purchase,
@@ -290,7 +292,7 @@ class PurchaseNotice extends Component {
 
 		if (
 			! isExpiring( currentPurchase ) ||
-			'ecommerce-trial-bundle-monthly' === currentPurchase?.productSlug
+			EXCLUDED_PRODUCTS.includes( currentPurchase?.productSlug )
 		) {
 			return null;
 		}


### PR DESCRIPTION
## Proposed Changes

Akismet Free it's a freemium plan that should be indefinitely active if not canceled by the user. By design, it doesn't expire, but under the hood is valid for one year and auto-renews unconditionally.

Currently, the notice displayed to users in the purchase management dashboard is confusing - we want to hide it for this specific plan.

## Testing Instructions

* Checkout this PR
* "Purchase" Akismet Free: http://calypso.localhost:3000/checkout/akismet/ak_free_yearly
* It should be displayed in the https://calypso.localhost:3000/me/purchases dashboard - click to open more details
* The below notice "(plan) will expire and be removed from your site in a year" shouldn't be displayed:

![image](https://user-images.githubusercontent.com/8419292/232822504-418adbed-bd5f-4200-b245-f450a18f404c.png)
 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
