### PR TITLE
Pattern Assembler: Fix avoiding misclick doesn't work

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -46,7 +46,12 @@ const ScreenMain = ( {
 		if ( disabled ) {
 			event.preventDefault();
 			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.CONTINUE_MISCLICK );
-			return;
+		}
+	};
+
+	const handleClick = () => {
+		if ( ! disabled ) {
+			onContinueClick();
 		}
 	};
 
@@ -126,7 +131,7 @@ const ScreenMain = ( {
 					primary
 					aria-disabled={ disabled }
 					onMouseDown={ handleMouseDown }
-					onClick={ onContinueClick }
+					onClick={ handleClick }
 				>
 					{ shouldUnlockGlobalStyles && ! isDismissedGlobalStylesUpgradeModal
 						? translate( 'Unlock this style' )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/75865#issuecomment-1512710410, https://github.com/Automattic/wp-calypso/pull/75865#issuecomment-1512710410

## Proposed Changes

* The `event.preventDefault()` doesn't avoid the click event fired. So, making a new function to avoid triggering the `onContinueClick` function when it's disabled to fix the issue

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_free_site>
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll to the bottom and select "Start designing"
* On the Pattern Assembler screen
  * Navigate to any sub-screen, e.g. Colors
  * Double-click on the "Save" button
  * Ensure you're not proceeding to the next step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
