### PR TITLE
VideoPress onboarding: poll video status instead of relying on playback event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -127,7 +127,7 @@
 		}
 
 		.intro__video.loading-frame {
-			transition: opacity 0.3s ease-in-out;
+			transition: opacity 0.31s ease-in-out;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -125,6 +125,10 @@
 			margin-top: 32px;
 			font-size: 1.25rem;
 		}
+
+		.intro__video.loading-frame {
+			transition: opacity 0.3s ease-in-out;
+		}
 	}
 
 	min-height: 100%;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/styles.scss
@@ -127,7 +127,7 @@
 		}
 
 		.intro__video.loading-frame {
-			transition: opacity 0.31s ease-in-out;
+			transition: opacity 0.3s ease-in-out;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/videopress-intro-background.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/videopress-intro-background.tsx
@@ -3,11 +3,10 @@ import * as VideoPressIframeApi from './videopress-iframe-api';
 
 const VideoPressIntroBackground = () => {
 	const iframeRef = createRef< HTMLIFrameElement >();
-	const divRef = createRef< HTMLDivElement >();
 	const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
 
 	useEffect( () => {
-		if ( ! divRef.current || prefersReducedMotion ) {
+		if ( prefersReducedMotion ) {
 			return;
 		}
 
@@ -15,16 +14,20 @@ const VideoPressIntroBackground = () => {
 			document.getElementById( 'videopress-intro-video-frame' ),
 			() => {
 				const pollPlayer = () => {
-					if ( '0' === divRef.current?.style.opacity ) {
+					const divRef = document.getElementById( 'videopress-intro-loading-frame' );
+					if ( null === divRef ) {
+						setTimeout( pollPlayer, 100 );
+						return;
+					}
+
+					if ( '0' === divRef.style.opacity ) {
 						return;
 					}
 
 					iframeApi.status.player().then( ( status: string ) => {
 						if ( 'playing' === status ) {
 							iframeApi.controls.seek( 0 ).then( () => {
-								if ( divRef.current ) {
-									divRef.current.style.opacity = '0';
-								}
+								divRef.style.opacity = '0';
 							} );
 						} else {
 							setTimeout( pollPlayer, 100 );
@@ -35,7 +38,7 @@ const VideoPressIntroBackground = () => {
 				pollPlayer();
 			}
 		);
-	}, [ divRef, prefersReducedMotion ] );
+	}, [] );
 
 	return (
 		<>
@@ -45,10 +48,11 @@ const VideoPressIntroBackground = () => {
 					id="videopress-intro-video-frame"
 					className="intro__video"
 					title="Video"
+					allow="autoplay; fullscreen"
 					src="https://video.wordpress.com/v/l9GrBaPw?autoPlay=true&amp;controls=false&amp;muted=true&amp;loop=true&amp;cover=true&amp;playsinline=true"
 				></iframe>
 			) }
-			<div ref={ divRef } className="intro__video loading-frame"></div>
+			<div id="videopress-intro-loading-frame" className="intro__video loading-frame"></div>
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/videopress-intro-background.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/videopress-intro-background.tsx
@@ -7,24 +7,32 @@ const VideoPressIntroBackground = () => {
 	const prefersReducedMotion = window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
 
 	useEffect( () => {
-		if ( prefersReducedMotion ) {
+		if ( ! divRef.current || prefersReducedMotion ) {
 			return;
 		}
+
 		const iframeApi = VideoPressIframeApi(
 			document.getElementById( 'videopress-intro-video-frame' ),
 			() => {
-				const callbackId = iframeApi.status.onPlayerStatusChanged(
-					( oldStatus: string, newStatus: string ) => {
-						if ( 'playing' === newStatus ) {
+				const pollPlayer = () => {
+					if ( '0' === divRef.current?.style.opacity ) {
+						return;
+					}
+
+					iframeApi.status.player().then( ( status: string ) => {
+						if ( 'playing' === status ) {
 							iframeApi.controls.seek( 0 ).then( () => {
 								if ( divRef.current ) {
-									divRef.current.style.display = 'none';
+									divRef.current.style.opacity = '0';
 								}
-								iframeApi.status.offPlayerStatusChanged( callbackId );
 							} );
+						} else {
+							setTimeout( pollPlayer, 100 );
 						}
-					}
-				);
+					} );
+				};
+
+				pollPlayer();
 			}
 		);
 	}, [ divRef, prefersReducedMotion ] );


### PR DESCRIPTION
## Proposed Changes

This PR polls the player on VideoPress onboarding intro instead of relying on status change, in case the player is already playing before we attach the iframe API to it.
It also adds a slight opacity transition to make the still image to video transition a bit smoother.

## Testing Instructions

* Apply PR
* Go to /setup/videopress
* ✅ The video should play at some point
* ✅ The transition between the still frame and the video should be less choppy

