### PR TITLE
Woo Express: Plan comparison grid footnotes

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -707,7 +707,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 		isInSignup,
 	] );
 
-	const restructureFootnotes = useMemo( () => {
+	const restructuredFootnotes = useMemo( () => {
 		// This is the main list of all footnotes. It is displayed at the bottom of the comparison grid.
 		const footnoteList: string[] = [];
 		// This is a map of features to the index of the footnote in the main list of footnotes.
@@ -887,7 +887,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 									allJetpackFeatures={ allJetpackFeatures }
 									visiblePlansProperties={ visiblePlansProperties }
 									restructuredFeatures={ restructuredFeatures }
-									restructuredFootnotes={ restructureFootnotes }
+									restructuredFootnotes={ restructuredFootnotes }
 									isStorageFeature={ false }
 								/>
 							) ) }
@@ -898,7 +898,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 									allJetpackFeatures={ allJetpackFeatures }
 									visiblePlansProperties={ visiblePlansProperties }
 									restructuredFeatures={ restructuredFeatures }
-									restructuredFootnotes={ restructureFootnotes }
+									restructuredFootnotes={ restructuredFootnotes }
 									isStorageFeature={ true }
 								/>
 							) : null }
@@ -922,10 +922,10 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 			</Grid>
 
 			<div className="plan-comparison-grid__footer">
-				{ restructureFootnotes?.footnoteList && (
+				{ restructuredFootnotes?.footnoteList && (
 					<FeatureFootnotes>
 						<ol>
-							{ restructureFootnotes?.footnoteList?.map( ( footnote, index ) => {
+							{ restructuredFootnotes?.footnoteList?.map( ( footnote, index ) => {
 								return <li key={ `${ footnote }-${ index }` }>{ footnote }</li>;
 							} ) }
 						</ol>

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -1,5 +1,6 @@
 import {
 	applyTestFiltersToPlansList,
+	Feature,
 	FeatureGroup,
 	getPlanClass,
 	isWpcomEnterpriseGridPlan,
@@ -257,6 +258,29 @@ const StorageButton = styled.div`
 	` ) }
 `;
 
+const FeatureFootnotes = styled.div`
+	ol {
+		margin: 2em 0 0 1em;
+	}
+
+	ol li {
+		font-size: 11px;
+		padding-left: 1em;
+	}
+`;
+
+const FeatureFootnote = styled.span`
+	position: relative;
+	font-size: 50%;
+	font-weight: 600;
+
+	sup {
+		position: absolute;
+		top: -10px;
+		left: 0;
+	}
+`;
+
 type PlanComparisonGridProps = {
 	planProperties?: Array< PlanProperties >;
 	intervalType: string;
@@ -290,6 +314,11 @@ type RestructuredFeatures = {
 	featureMap: Record< string, Set< string > >;
 	conditionalFeatureMap: Record< string, Set< string > >;
 	planStorageOptionsMap: Record< string, string >;
+};
+
+type RestructuredFootnotes = {
+	footnoteList: string[];
+	footnotesByFeature: Record< Feature, number >;
 };
 
 const PlanComparisonGridHeaderCell: React.FunctionComponent<
@@ -541,6 +570,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	allJetpackFeatures: Set< string >;
 	visiblePlansProperties: PlanProperties[];
 	restructuredFeatures: RestructuredFeatures;
+	restructuredFootnotes: RestructuredFootnotes;
 	isStorageFeature: boolean;
 } > = ( {
 	feature,
@@ -548,12 +578,15 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	allJetpackFeatures,
 	visiblePlansProperties,
 	restructuredFeatures,
+	restructuredFootnotes,
 	isStorageFeature,
 } ) => {
 	const translate = useTranslate();
 	const rowClasses = classNames( 'plan-comparison-grid__feature-group-row', {
 		'is-storage-feature': isStorageFeature,
 	} );
+	const featureSlug = feature?.getSlug() || '';
+	const footnote = restructuredFootnotes?.footnotesByFeature?.[ featureSlug ];
 
 	return (
 		<Row isHiddenInMobile={ isHiddenInMobile } className={ rowClasses }>
@@ -568,6 +601,11 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 							<>
 								<Plans2023Tooltip text={ feature.getDescription?.() }>
 									{ feature.getTitle() }
+									{ footnote && (
+										<FeatureFootnote>
+											<sup>{ footnote }</sup>
+										</FeatureFootnote>
+									) }
 								</Plans2023Tooltip>
 								{ allJetpackFeatures.has( feature.getSlug() ) ? (
 									<JetpackIconContainer>
@@ -668,6 +706,39 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 		displayedPlansProperties,
 		isInSignup,
 	] );
+
+	const restructureFootnotes = useMemo( () => {
+		// This is the main list of all footnotes. It is displayed at the bottom of the comparison grid.
+		const footnoteList: string[] = [];
+		// This is a map of features to the index of the footnote in the main list of footnotes.
+		const footnotesByFeature: Record< Feature, number > = {};
+
+		Object.values( featureGroupMap ).map( ( featureGroup: FeatureGroup ) => {
+			const footnotes = featureGroup?.getFootnotes?.();
+
+			if ( ! footnotes ) {
+				return;
+			}
+
+			Object.keys( footnotes ).map( ( footnote ) => {
+				const footnoteFeatures = footnotes[ footnote ];
+
+				// First we add the footnote to the main list of footnotes.
+				footnoteList.push( footnote );
+
+				// Then we add each feature that has this footnote to the map of footnotes by feature.
+				const currentFootnoteIndex = footnoteList.length;
+				footnoteFeatures.map( ( feature ) => {
+					footnotesByFeature[ feature ] = currentFootnoteIndex;
+				} );
+			} );
+		} );
+
+		return {
+			footnoteList,
+			footnotesByFeature,
+		};
+	}, [ featureGroupMap ] );
 
 	const restructuredFeatures = useMemo( () => {
 		let previousPlan = null;
@@ -816,6 +887,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 									allJetpackFeatures={ allJetpackFeatures }
 									visiblePlansProperties={ visiblePlansProperties }
 									restructuredFeatures={ restructuredFeatures }
+									restructuredFootnotes={ restructureFootnotes }
 									isStorageFeature={ false }
 								/>
 							) ) }
@@ -826,6 +898,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 									allJetpackFeatures={ allJetpackFeatures }
 									visiblePlansProperties={ visiblePlansProperties }
 									restructuredFeatures={ restructuredFeatures }
+									restructuredFootnotes={ restructureFootnotes }
 									isStorageFeature={ true }
 								/>
 							) : null }
@@ -847,6 +920,18 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 					onUpgradeClick={ onUpgradeClick }
 				/>
 			</Grid>
+
+			<div className="plan-comparison-grid__footer">
+				{ restructureFootnotes?.footnoteList && (
+					<FeatureFootnotes>
+						<ol>
+							{ restructureFootnotes?.footnoteList?.map( ( footnote, index ) => {
+								return <li key={ `${ footnote }-${ index }` }>{ footnote }</li>;
+							} ) }
+						</ol>
+					</FeatureFootnotes>
+				) }
+			</div>
 		</div>
 	);
 };

--- a/packages/calypso-products/src/feature-group-plan-map.ts
+++ b/packages/calypso-products/src/feature-group-plan-map.ts
@@ -253,6 +253,14 @@ export const wooExpressFeatureGroups: Partial< FeatureGroupMap > = {
 			FEATURE_ACCEPT_LOCAL_PAYMENTS,
 			FEATURE_RECURRING_PAYMENTS,
 		],
+		getFootnotes: () => ( {
+			'Available as standard in WooCommerce Payments (restrictions apply). Additional extensions may be required for other payment providers.':
+				[
+					FEATURE_INTERNATIONAL_PAYMENTS,
+					FEATURE_ACCEPT_LOCAL_PAYMENTS,
+					FEATURE_RECURRING_PAYMENTS,
+				],
+		} ),
 	},
 	[ FEATURE_GROUP_MARKETING_EMAIL ]: {
 		slug: FEATURE_GROUP_MARKETING_EMAIL,
@@ -281,5 +289,9 @@ export const wooExpressFeatureGroups: Partial< FeatureGroupMap > = {
 			FEATURE_DISCOUNTED_SHIPPING,
 			FEATURE_PRINT_SHIPPING_LABELS,
 		],
+		getFootnotes: () => ( {
+			'Only available in the U.S. – an additional extension will be required for other countries.':
+				[ FEATURE_DISCOUNTED_SHIPPING, FEATURE_PRINT_SHIPPING_LABELS ],
+		} ),
 	},
 };

--- a/packages/calypso-products/src/feature-group-plan-map.ts
+++ b/packages/calypso-products/src/feature-group-plan-map.ts
@@ -254,12 +254,13 @@ export const wooExpressFeatureGroups: Partial< FeatureGroupMap > = {
 			FEATURE_RECURRING_PAYMENTS,
 		],
 		getFootnotes: () => ( {
-			'Available as standard in WooCommerce Payments (restrictions apply). Additional extensions may be required for other payment providers.':
-				[
-					FEATURE_INTERNATIONAL_PAYMENTS,
-					FEATURE_ACCEPT_LOCAL_PAYMENTS,
-					FEATURE_RECURRING_PAYMENTS,
-				],
+			[ i18n.translate(
+				'Available as standard in WooCommerce Payments (restrictions apply). Additional extensions may be required for other payment providers.'
+			) ]: [
+				FEATURE_INTERNATIONAL_PAYMENTS,
+				FEATURE_ACCEPT_LOCAL_PAYMENTS,
+				FEATURE_RECURRING_PAYMENTS,
+			],
 		} ),
 	},
 	[ FEATURE_GROUP_MARKETING_EMAIL ]: {
@@ -290,8 +291,9 @@ export const wooExpressFeatureGroups: Partial< FeatureGroupMap > = {
 			FEATURE_PRINT_SHIPPING_LABELS,
 		],
 		getFootnotes: () => ( {
-			'Only available in the U.S. – an additional extension will be required for other countries.':
-				[ FEATURE_DISCOUNTED_SHIPPING, FEATURE_PRINT_SHIPPING_LABELS ],
+			[ i18n.translate(
+				'Only available in the U.S. – an additional extension will be required for other countries.'
+			) ]: [ FEATURE_DISCOUNTED_SHIPPING, FEATURE_PRINT_SHIPPING_LABELS ],
 		} ),
 	},
 };

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -153,10 +153,25 @@ export type FeatureGroupSlug =
 	| typeof FEATURE_GROUP_MARKETING_EMAIL
 	| typeof FEATURE_GROUP_SHIPPING;
 
+export interface FeatureFootnotes {
+	[ key: string ]: Feature[];
+}
+
 export type FeatureGroup = {
 	slug: FeatureGroupSlug;
 	getTitle: () => string;
 	get2023PricingGridSignupWpcomFeatures: () => Feature[];
+	/**
+	 * This optionally returns an object containing footnotes and the features that should display the footnote.
+	 *
+	 * For example:
+	 * getFootnotes: () => ( {
+	 * 	'This is the text displayed at the bottom of the comparison grid': [ 'feature-1', 'feature-2' ],
+	 * }).
+	 *
+	 * Footnotes will be automatically numbered in the order the feature groups are listed. For example, in the wooExpressFeatureGroups, FEATURE_GROUP_PAYMENTS and FEATURE_GROUP_SHIPPING each have a single footnote which will be numbered 1 and 2 respectively.
+	 */
+	getFootnotes?: () => FeatureFootnotes;
 };
 export type FeatureGroupMap = Record< FeatureGroupSlug, FeatureGroup >;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75383

## Proposed Changes

Adds the ability to include footnotes associated with features in a group
    
A feature group can now have an optional `getFootnotes` function which returns an object containing one or more footnotes and the features that that footnote should apply to.
    
This also adds a single footnote to both the Payments and Shipping feature groups for Woo Express.

This is part of several PRs related to plan features and the plan comparison grid:
* #75918 (this PR) which adds all of the plan features and groups.
* #75769 which enables the plan comparison grid for Woo Express.
* #75883 which adds footnotes to the plan comparison grid.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch or use the calypso.live link.
* For any Woo Express site (including the Trial), visit `/plans`.
* Click the "Compare plans" button.
* Verify that the "Payments" and "Shipping" features below have footnote numbers as pictured below.
![image](https://user-images.githubusercontent.com/917632/232849060-045282e6-43fe-42c5-9338-38671888958d.png)
![image](https://user-images.githubusercontent.com/917632/232849096-0598c1e9-02c3-4f82-bd48-722d5e370b82.png)
* Verify that the full footnote copy is visible at the bottom of the comparison grid.
![image](https://user-images.githubusercontent.com/917632/232849182-a5fea001-016d-4c4c-873d-6fa949132a8e.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
