### PR TITLE
Removed Lodash from sort-imports codemod

### DIFF
--- a/packages/calypso-codemods/transforms/sort-imports.js
+++ b/packages/calypso-codemods/transforms/sort-imports.js
@@ -97,7 +97,9 @@ const addNewlineBeforeDocBlock = ( str ) => str.replace( /(import.*\n)(\/\*\*)/,
  * @returns {Array} the sorted set of import nodes
  */
 const sortImports = ( importNodes ) =>
-	importNodes.sort( ( nodeA, nodeB ) => nodeA.source.value.localeCompare( nodeB.source.value ) );
+	[ ...importNodes ].sort( ( nodeA, nodeB ) =>
+		nodeA.source.value.localeCompare( nodeB.source.value )
+	);
 
 module.exports = function ( file, api ) {
 	const j = api.jscodeshift;
@@ -112,7 +114,8 @@ module.exports = function ( file, api ) {
 		externalDependenciesSet.has( importNode.source.value.split( '/' )[ 0 ] );
 
 	// if there are no deps at all, then return early.
-	if ( ! declarations.nodes() || declarations.nodes().length === 0 ) {
+	const nodes = declarations.nodes();
+	if ( ! nodes || nodes.length === 0 ) {
 		return file.source;
 	}
 

--- a/packages/calypso-codemods/transforms/sort-imports.js
+++ b/packages/calypso-codemods/transforms/sort-imports.js
@@ -8,7 +8,6 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const nodeJsDeps = require( 'repl' )._builtinLibs;
-const _ = require( 'lodash' );
 
 function findPkgJson( target ) {
 	let root = path.dirname( target );
@@ -97,7 +96,8 @@ const addNewlineBeforeDocBlock = ( str ) => str.replace( /(import.*\n)(\/\*\*)/,
  * @param {Array} importNodes the import nodes to sort
  * @returns {Array} the sorted set of import nodes
  */
-const sortImports = ( importNodes ) => _.sortBy( importNodes, ( node ) => node.source.value );
+const sortImports = ( importNodes ) =>
+	importNodes.sort( ( nodeA, nodeB ) => nodeA.source.value.localeCompare( nodeB.source.value ) );
 
 module.exports = function ( file, api ) {
 	const j = api.jscodeshift;
@@ -112,7 +112,7 @@ module.exports = function ( file, api ) {
 		externalDependenciesSet.has( importNode.source.value.split( '/' )[ 0 ] );
 
 	// if there are no deps at all, then return early.
-	if ( _.isEmpty( declarations.nodes() ) ) {
+	if ( ! declarations.nodes() || declarations.nodes().length === 0 ) {
 		return file.source;
 	}
 


### PR DESCRIPTION

## Description

This change is for the sort-imports.js codemods script( that adds import comment blocks and sorts them as necessary). I have modified the code to remove the Lodash functions from this script.

## Proposed Changes

Replaced the following Lodash functions with the native JS code

1. _.sortBy
2. _.isEmpty

## Testing Instructions

- Open the file
- Click on Run and Debug
Ensure the values returned by the new functionality are the same as those returned with the Lodash functions.


## Checklist

Verify all tests still pass.