### PR TITLE
Add credits balance to calypso

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -23,6 +23,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/billing-history/',
 		post_id: 40792,
 	},
+	blaze_credits: {
+		link: 'https://wordpress.com/support/blaze-credits/',
+		post_id: 240330,
+	},
 	cancel_purchase: {
 		link: 'https://wordpress.com/support/manage-purchases/#cancel-a-purchase',
 		post_id: 111349,

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import request, { requestAllBlogsAccess } from 'wpcom-proxy-request';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
@@ -133,6 +134,11 @@ export enum PromoteWidgetStatus {
 	DISABLED = 'disabled',
 }
 
+export enum BlazeCreditStatus {
+	ENABLED = 'enabled',
+	DISABLED = 'disabled',
+}
+
 /**
  * Hook to verify if we should enable the promote widget.
  *
@@ -151,4 +157,16 @@ export const usePromoteWidget = (): PromoteWidgetStatus => {
 		default:
 			return PromoteWidgetStatus.FETCHING;
 	}
+};
+
+/**
+ * Hook to verify if we should enable blaze credits
+ *
+ * @returns bool
+ */
+export const useBlazeCredits = (): BlazeCreditStatus => {
+	return useSelector( ( state ) => {
+		const userData = getCurrentUser( state );
+		return userData?.blaze_credits_enabled ? BlazeCreditStatus.ENABLED : BlazeCreditStatus.DISABLED;
+	} );
 };

--- a/client/lib/user/shared-utils/filter-user-object.js
+++ b/client/lib/user/shared-utils/filter-user-object.js
@@ -16,6 +16,7 @@ const allowedKeys = [
 	'phone_account',
 	'email',
 	'email_verified',
+	'blaze_credits_enabled',
 	'is_valid_google_apps_country',
 	'user_ip_country_code',
 	'logout_URL',

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -20,6 +20,7 @@ export type OptionalUserData = {
 	display_name: string;
 	email: string;
 	email_verified: boolean;
+	blaze_credits_enabled: boolean;
 	has_unseen_notes: boolean;
 	is_new_reader: boolean;
 	is_valid_google_apps_country: boolean;

--- a/client/my-sites/promote-post/components/credit-balance/index.tsx
+++ b/client/my-sites/promote-post/components/credit-balance/index.tsx
@@ -1,0 +1,41 @@
+import './style.scss';
+import { memo, useState } from '@wordpress/element';
+import { translate } from 'i18n-calypso';
+import InfoPopover from 'calypso/components/info-popover';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import { BlazeCreditStatus, useBlazeCredits } from 'calypso/lib/promote-post';
+
+const CreditBalance = () => {
+	const [ balance ] = useState( 0 ); // Todo: Fetch balance from the API
+	const creditsEnabled = useBlazeCredits() === BlazeCreditStatus.ENABLED;
+
+	if ( ! balance || ! creditsEnabled ) {
+		return null;
+	}
+
+	const tooltipText = translate(
+		'Available credits that will be automatically applied toward your next campaigns. {{learnMoreLink}}Learn more.{{/learnMoreLink}}',
+		{
+			components: {
+				learnMoreLink: <InlineSupportLink supportContext="blaze_credits" showIcon={ false } />,
+			},
+		}
+	);
+
+	return (
+		<div className="credit-balance__nav-item">
+			{ `Credits: $${ balance }` }
+			<InfoPopover
+				className="credit-balance__help-icon"
+				icon="help-outline"
+				position="right"
+				iconSize={ 18 }
+				showOnHover={ true }
+			>
+				{ tooltipText }
+			</InfoPopover>
+		</div>
+	);
+};
+
+export default memo( CreditBalance );

--- a/client/my-sites/promote-post/components/credit-balance/index.tsx
+++ b/client/my-sites/promote-post/components/credit-balance/index.tsx
@@ -1,12 +1,13 @@
 import './style.scss';
 import { memo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { translate } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { BlazeCreditStatus, useBlazeCredits } from 'calypso/lib/promote-post';
 
 const CreditBalance = () => {
-	const [ balance ] = useState( 0 ); // Todo: Fetch balance from the API
+	const [ balance ] = useState( 200 ); // Todo: Fetch balance from the API
 	const creditsEnabled = useBlazeCredits() === BlazeCreditStatus.ENABLED;
 
 	if ( ! balance || ! creditsEnabled ) {
@@ -24,7 +25,7 @@ const CreditBalance = () => {
 
 	return (
 		<div className="credit-balance__nav-item">
-			{ `Credits: $${ balance }` }
+			{ __( `Credits: ` ) + `$${ balance }` }
 			<InfoPopover
 				className="credit-balance__help-icon"
 				icon="help-outline"

--- a/client/my-sites/promote-post/components/credit-balance/style.scss
+++ b/client/my-sites/promote-post/components/credit-balance/style.scss
@@ -1,0 +1,20 @@
+$breakpoint-small: 480px;
+
+.credit-balance__nav-item {
+	padding: 15px;
+	display: flex;
+
+	@media (max-width: $breakpoint-small) {
+		flex-direction: row-reverse;
+		justify-content: flex-end;
+	}
+}
+
+.credit-balance__help-icon {
+	margin-left: 8px;
+
+	@media (max-width: $breakpoint-small) {
+		margin-right: 8px;
+		margin-left: 0;
+	}
+}

--- a/client/my-sites/promote-post/components/promoted-post-filter/index.tsx
+++ b/client/my-sites/promote-post/components/promoted-post-filter/index.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
+import CreditBalance from 'calypso/my-sites/promote-post/components/credit-balance';
 import { TabType } from 'calypso/my-sites/promote-post/main';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
@@ -14,7 +15,9 @@ type Props = {
 export default function PromotePostTabBar( { tabs, selectedTab }: Props ) {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 
-	const sectionNavProps = isMobile() ? { allowDropdown: false, className: 'is-open' } : {};
+	const sectionNavProps = isMobile()
+		? { allowDropdown: false, className: 'is-open promote-post__section-nav' }
+		: {};
 
 	return (
 		<SectionNav { ...sectionNavProps }>
@@ -30,6 +33,7 @@ export default function PromotePostTabBar( { tabs, selectedTab }: Props ) {
 					);
 				} ) }
 			</NavTabs>
+			<CreditBalance />
 		</SectionNav>
 	);
 }

--- a/client/my-sites/promote-post/style.scss
+++ b/client/my-sites/promote-post/style.scss
@@ -1,3 +1,5 @@
+$breakpoint-small: 480px;
+
 .promote-post__loading-container {
 	text-align: center;
 }
@@ -9,6 +11,33 @@
 
 	.promote-post__heading {
 		flex: 1;
+	}
+}
+
+.promote-post__section-nav.section-nav.is-open {
+	@media (max-width: $breakpoint-small) {
+		box-shadow: none;
+	}
+}
+
+.promote-post__section-nav {
+	.section-nav__panel {
+		display: flex;
+
+		@media (max-width: $breakpoint-small) {
+			flex-direction: column-reverse;
+			padding-bottom: 0 !important;
+
+			.section-nav-group {
+				margin-top: 0;
+			}
+		}
+	}
+}
+
+.posts-list-banner__container {
+	@media (max-width: $breakpoint-small) {
+		margin-bottom: 0 !important;
 	}
 }
 

--- a/client/my-sites/promote-post/test/credit-balance.test.tsx
+++ b/client/my-sites/promote-post/test/credit-balance.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { BlazeCreditStatus, useBlazeCredits } from 'calypso/lib/promote-post';
+import CreditBalance from '../components/credit-balance';
+
+// Mock the useBlazeCredits hook, so we can tell TS about MockReturnValue
+type UseBlazeCreditsMock = jest.Mock< BlazeCreditStatus >;
+
+jest.mock( 'calypso/lib/promote-post', () => {
+	const module = jest.requireActual( 'calypso/lib/promote-post' );
+	return {
+		...module,
+		useBlazeCredits: jest.fn< UseBlazeCreditsMock, [] >(),
+	};
+} );
+
+describe( 'CreditBalance component', () => {
+	test( 'displays null when balance is 0', () => {
+		const { container } = render( <CreditBalance /> );
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	describe( 'CreditBalance component when balance is set', () => {
+		const mockBalance = 10;
+
+		beforeEach( () => {
+			jest.clearAllMocks();
+
+			// Set the balance
+			const useStateSpy = jest.spyOn( React, 'useState' );
+			useStateSpy.mockReturnValueOnce( [ mockBalance, jest.fn() ] );
+		} );
+
+		test( 'still returns null when credits are not enabled for the user', () => {
+			// Disable credits for this user
+			( useBlazeCredits as UseBlazeCreditsMock ).mockReturnValue( BlazeCreditStatus.DISABLED );
+
+			// Render the component
+			const { container } = render( <CreditBalance /> );
+
+			// Expectations
+			expect( container.firstChild ).toBeNull();
+		} );
+
+		test( 'displays "Credits: $10" when balance is set to 10', () => {
+			// Enable credits for this user
+			( useBlazeCredits as UseBlazeCreditsMock ).mockReturnValue( BlazeCreditStatus.ENABLED );
+
+			// Render the component
+			render( <CreditBalance /> );
+
+			// Expectations
+			const balance = screen.getByText( /Credits: \$\d+/ );
+			expect( balance ).toHaveTextContent( `Credits: $${ mockBalance }` );
+		} );
+	} );
+} );


### PR DESCRIPTION
Related to SELFSERVE-392-jira-tumblr

## Proposed Changes

* Adds support for a credit balance, this balance should only appear if the user has available credits
* Adds a link to FAQ page

## Testing Instructions

- [ ] Hit `/advertising/yoursite.co.uk` 
- [ ] Because the balance is 0 - you should not see a credit balance
- [ ] Load up the branch locally and change the balance to a non-zero number (`client/my-sites/promote-post/components/credit-balance/index.tsx:9`)
- [ ] Login as an A12
- [ ] Credit balance should appear on desktop (on the right)
- [ ] Credit balance should appear on mobile (above the tabs)
- [ ] Logout and log in as someone that is not an A12
- [ ] Ensure you don't see the balance. 

**Desktop:**
![Screenshot 2023-04-18 at 12 53 18](https://user-images.githubusercontent.com/6440498/232769317-0ae06857-092e-487e-a494-a478efb50a7f.png)

**Tooltip:**
![Screenshot 2023-04-18 at 12 55 35](https://user-images.githubusercontent.com/6440498/232769478-c0f7f604-4ed8-4416-b03a-f62a6d78794c.png)

**Mobile**
![Screenshot 2023-04-18 at 12 54 28](https://user-images.githubusercontent.com/6440498/232769320-450835fa-5fad-4d81-822d-cb785846cc51.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
