### PR TITLE
E2E: Stabilize the Editor post schedule tests

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -647,21 +647,24 @@ export class EditorPage {
 		const [ response ] = await Promise.all( [
 			// First URL matches Atomic requests while the second matches Simple requests.
 			Promise.race( [
-				this.page.waitForResponse( /v2\/(posts|pages)\/[\d]+/ ),
-				this.page.waitForResponse( /.*v2\/sites\/[\d]+\/(posts|pages)\/[\d]+.*/ ),
+				this.page.waitForResponse(
+					async ( response ) =>
+						/v2\/(posts|pages)\/[\d]+/.test( response.url() ) &&
+						response.request().method() === 'POST'
+				),
+				this.page.waitForResponse(
+					async ( response ) =>
+						/.*v2\/sites\/[\d]+\/(posts|pages)\/[\d]+.*/.test( response.url() ) &&
+						response.request().method() === 'PUT'
+				),
 			] ),
 			...actionsArray,
 		] );
 
 		const json = await response.json();
-
 		// AT and Simple sites have slightly differing response from the API.
-		let publishedURL: string;
-		if ( json.link ) {
-			publishedURL = json.link;
-		} else if ( json.body.link ) {
-			publishedURL = json.body.link;
-		} else {
+		const publishedURL = json.link || json.body?.link;
+		if ( ! publishedURL ) {
 			throw new Error( 'No published article URL found in response.' );
 		}
 


### PR DESCRIPTION
## Proposed Changes

Stabilize the Editor `publish` action.

The `editor__schedule.ts` suite is failing randomly, throwing the following error:

```js
  ● Editor: Schedule › Schedule: future › Publish post

    TypeError: Cannot read properties of undefined (reading 'link')

      588 |             if ( json.link ) {
      589 |                     publishedURL = json.link;
    > 590 |             } else if ( json.body.link ) {
          |                                   ^
      591 |                     publishedURL = json.body.link;
      592 |             } else {
      593 |                     throw new Error( 'No published article URL found in response.' );

      at EditorPage.publish (../../packages/calypso-e2e/src/lib/pages/editor-page.ts:590:25)
      at Object.<anonymous> (specs/editor/editor__schedule.ts:83:14)
```

This turned out to be a race condition where a wrong response is retrieved after publishing the post. That response is the schema response that has the same URL but a different request method – `GET`. The correct response is the one to the `POST`/`PUT` (AT/Simple) request, which is what has been updated in this PR.


## Testing Instructions

The following should be 🟢 when running locally and in CI:

```
TEST_ON_ATOMIC=true yarn workspace wp-e2e-tests test editor__schedule.ts
```