### PR TITLE
HelpCenterSearch: guard against non-existing site options

### DIFF
--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -30,7 +30,7 @@ export const HelpCenterSearch = () => {
 		( select ) => siteId && ( select( SITE_STORE ) as SiteSelect ).getSite( siteId ),
 		[ siteId ]
 	);
-	let launchpadEnabled = site && site?.options.launchpad_screen === 'full';
+	let launchpadEnabled = site && site?.options?.launchpad_screen === 'full';
 
 	if ( ! launchpadEnabled ) {
 		launchpadEnabled = window?.helpCenterData?.currentSite?.launchpad_screen === 'full';


### PR DESCRIPTION
While testing something unrelated I noticed a crash of the help center.
The help center search component uses `site.options.launchpad_screen` and `site.options` might not be available for a site. 
This PR adds a simple guard for this.

## Testing Instructions
- Sandbox learncft.wordpress.com
- Run `clean` and `build` for the help center package
- In the etk run `yarn dev --sync`
- Visit the [page admin](PeJtcW-1T3-p2.php?post_type=page)
- Open the help center
- The help center should stay opened and no console errors should be shown.
