### PR TITLE
Help Center: Remove a8c button to prevent style leaks

### DIFF
--- a/packages/help-center/src/components/back-button.tsx
+++ b/packages/help-center/src/components/back-button.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { Icon, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useNavigate } from 'react-router-dom';
@@ -18,11 +18,7 @@ export const BackButton: FC< Props > = ( { onClick, backToRoot = false } ) => {
 		}
 	}
 	return (
-		<Button
-			className="back-button__help-center"
-			borderless={ true }
-			onClick={ onClick || defaultOnClick }
-		>
+		<Button className="back-button__help-center" onClick={ onClick || defaultOnClick }>
 			<Icon icon={ chevronLeft } size={ 18 } />
 			{ __( 'Back', __i18n_text_domain__ ) }
 		</Button>

--- a/packages/help-center/src/components/back-to-top-button.scss
+++ b/packages/help-center/src/components/back-to-top-button.scss
@@ -1,7 +1,6 @@
 $animation-timing: 300ms;
 
 .help-center__container {
-
 	.back-to-top-button__help-center {
 		position: sticky;
 		bottom: 0;
@@ -14,10 +13,9 @@ $animation-timing: 300ms;
 
 		background-color: var(--studio-white);
 		color: var(--studio-black);
-		border-color: rgba(0, 0, 0, 0.1);
 
 		border-radius: 0;
-		border-width: 1px 0 0;
+		border-top: 1px solid rgba(0, 0, 0, 0.1);
 
 		visibility: hidden;
 		opacity: 0;

--- a/packages/help-center/src/components/back-to-top-button.tsx
+++ b/packages/help-center/src/components/back-to-top-button.tsx
@@ -1,4 +1,5 @@
-import { Button, useScrollToTop } from '@automattic/components';
+import { useScrollToTop } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useCallback, useRef } from '@wordpress/element';
 import { Icon, arrowUp } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -24,7 +25,7 @@ export const BackToTopButton: FC = () => {
 
 	return (
 		<Button
-			ref={ ( element ) => {
+			ref={ ( element: HTMLButtonElement ) => {
 				elementRef.current = element?.parentElement ?? null;
 			} }
 			className={ classnames( 'back-to-top-button__help-center', {

--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -121,7 +121,7 @@ section.contact-form-submit {
 			border: 1px solid var(--color-neutral-5) !important;
 			color: var(--color-neutral-20) !important;
 		}
-		&:hover {
+		&:hover:not(:disabled) {
 			color: var(--wp-components-color-accent-inverted, #fff) !important;
 		}
 	}

--- a/packages/help-center/src/components/help-center-contact-form.scss
+++ b/packages/help-center/src/components/help-center-contact-form.scss
@@ -109,30 +109,20 @@ section.contact-form-submit {
 	background: #fff;
 	padding: 16px;
 
-	.button.help-center-contact-form__site-picker-cta.is-primary {
-		background-color: var(--color-accent);
-		border-color: var(--color-accent);
-		color: var(--color-text-inverted);
-		line-height: 2.7;
-
-		&:hover,
-		&:focus {
-			color: var(--color-text-inverted);
-			background-color: var(--color-accent-60);
-			border-color: var(--color-accent-60);
-		}
-
-		&:focus {
-			border: none;
-			box-shadow: none;
-			outline: solid 2px var(--color-accent-60);
-			outline-offset: 2px;
-		}
+	.help-center-contact-form__site-picker-cta.is-primary {
+		text-align: center;
+		padding: 16px;
+		width: 100%;
+		display: block;
+		height: unset;
 
 		&:disabled {
 			background-color: var(--color-surface) !important;
-			border-color: var(--color-neutral-5) !important;
+			border: 1px solid var(--color-neutral-5) !important;
 			color: var(--color-neutral-20) !important;
+		}
+		&:hover {
+			color: var(--wp-components-color-accent-inverted, #fff) !important;
 		}
 	}
 
@@ -154,11 +144,6 @@ section.contact-form-submit {
 .help-center-contact-form__site-picker-form-warning,
 .help-center-contact-form__site-picker-form-subtitle {
 	color: var(--studio-gray-60);
-}
-
-.help-center-contact-form__site-picker-cta {
-	width: 100%;
-	padding: 5px 16px !important;
 }
 
 .help-center-contact-form__label {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -5,7 +5,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { getPlan, getPlanTermLabel, isFreePlanProduct } from '@automattic/calypso-products';
-import { Button, FormInputValidation, Popover } from '@automattic/components';
+import { FormInputValidation, Popover } from '@automattic/components';
 import {
 	useSubmitTicketMutation,
 	useSubmitForumsMutation,
@@ -18,7 +18,7 @@ import {
 } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { SitePickerDropDown, SitePickerSite } from '@automattic/site-picker';
-import { TextControl, CheckboxControl, Tip } from '@wordpress/components';
+import { Button, TextControl, CheckboxControl, Tip } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
@@ -441,7 +441,7 @@ export const HelpCenterContactForm = () => {
 				<Button
 					disabled={ isCTADisabled() }
 					onClick={ handleCTA }
-					primary
+					isPrimary
 					className="help-center-contact-form__site-picker-cta"
 				>
 					{ getCTALabel() }
@@ -548,7 +548,8 @@ export const HelpCenterContactForm = () => {
 				<Button
 					disabled={ isCTADisabled() }
 					onClick={ handleCTA }
-					primary
+					isPrimary
+					isLarge
 					className="help-center-contact-form__site-picker-cta"
 				>
 					{ getCTALabel() }

--- a/packages/help-center/src/components/help-center-embed-result.tsx
+++ b/packages/help-center/src/components/help-center-embed-result.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Button } from '@automattic/components';
-import { Flex, FlexItem } from '@wordpress/components';
+import { Button, Flex, FlexItem } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { Icon, external } from '@wordpress/icons';
 import React from 'react';
@@ -56,7 +55,6 @@ export const HelpCenterEmbedResult: React.FC = () => {
 					</FlexItem>
 					<FlexItem>
 						<Button
-							borderless={ true }
 							href={ link ?? '' }
 							target="_blank"
 							className="help-center-embed-result__external-button"

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -30,7 +30,7 @@ export const HelpCenterSearch = () => {
 		( select ) => siteId && ( select( SITE_STORE ) as SiteSelect ).getSite( siteId ),
 		[ siteId ]
 	);
-	let launchpadEnabled = site && site?.options.launchpad_screen === 'full';
+	let launchpadEnabled = site && site?.options?.launchpad_screen === 'full';
 
 	if ( ! launchpadEnabled ) {
 		launchpadEnabled = window?.helpCenterData?.currentSite?.launchpad_screen === 'full';

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -207,13 +207,24 @@ $head-foot-height: 50px;
 		color: #000;
 		font-size: $font-body-small;
 		padding: 0;
-		align-items: flex-start;
 
 		&:focus {
 			color: #043959;
 			box-shadow: 0 0 0 1px #4f94d4, 0 0 2px 1px rgba(79, 148, 212, 0.8);
 			outline: 1px solid transparent;
 			border-color: inherit;
+		}
+
+		svg {
+			margin-top: 1px;
+			margin-right: 3px;
+		}
+
+		&:hover {
+			svg {
+				margin-left: -2px;
+				margin-right: 5px;
+			}
 		}
 	}
 

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -202,12 +202,12 @@ $head-foot-height: 50px;
 		}
 	}
 
-	button.button.back-button__help-center.is-borderless {
+	.back-button__help-center {
 		display: flex;
-		align-items: center;
 		color: #000;
 		font-size: $font-body-small;
-		padding-right: 5px;
+		padding: 0;
+		align-items: flex-start;
 
 		&:focus {
 			color: #043959;
@@ -399,7 +399,6 @@ $head-foot-height: 50px;
 	max-width: 100%;
 	animation: fadeIn 0.2s;
 }
-
 
 .help-center__promotion-popover-inner {
 	text-align: initial;


### PR DESCRIPTION
## Proposed Changes

- This removes all instances of `@automattic/button` because it leaks CSS under the generic class `.button`.
- Uses wp.button instead.

## Testing Instructions

We're testing in call together (@heavyweight).


Context: pdDR7T-Jm-p2#comment-769
