### PR TITLE
Virtual themes: Track recipe slug

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -92,14 +92,8 @@ export function getDesignEventProps( {
 }
 
 export function getVirtualDesignProps( design: Design ) {
-	/**
-	 * If the design is virtual, and it has a recipe with pattern_ids,
-	 * then we assume that it's a pattern based virtual theme.
-	 */
-	const virtual_theme_pattern = design.is_virtual ? design.recipe?.pattern_ids?.[ 0 ] : null;
-
 	return {
 		is_virtual: design.is_virtual,
-		virtual_theme_pattern,
+		slug: design.is_virtual ? design.recipe?.slug : design.slug,
 	};
 }

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -62,6 +62,7 @@ export interface DesignRecipe {
 	footer_pattern_ids?: number[] | string[];
 	color_variation_title?: string;
 	font_variation_title?: string;
+	slug?: string;
 }
 
 export interface SoftwareSet {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/75490
Fixes https://github.com/Automattic/dotcom-forge/issues/2099
Requires D108161-code

## Proposed changes

Uses the new `recipe.slug` property added in D108161-code as the tracked `slug` of the `calypso_signup_design_preview_select` and `calypso_signup_select_design` events, so we can identify with a human-readable string what pattern has been used to build the virtual theme.

## Testing instructions

- Use the Calypso live link below.
- Open the Network tab of the browser devtools.
- Observe the `t.gif` requests.
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>`.
- Click on a virtual theme to preview it.
- Make sure that the tracked `calypso_signup_design_preview_select` event uses the `recipe.slug` value (`<THEME_SLUG>-<PATTERN_SLUG>`) in the `slug` property.
- Proceed with the design selection.
- Make sure that the tracked `calypso_signup_select_design` event uses the `recipe.slug` value (`<THEME_SLUG>-<PATTERN_SLUG>`) in the `slug` property.