### PR TITLE
Subscriptions Management: Fix `subscription_date` timezone offset and `post_title` overflow on the Comments page

### DIFF
--- a/client/landing/subscriptions/components/comment-list/styles.scss
+++ b/client/landing/subscriptions/components/comment-list/styles.scss
@@ -42,6 +42,7 @@ $max-list-width: 1300px;
 			line-height: 20px;
 
 			.title {
+				max-width: 350px;
 				@extend %ellipsis;
 
 				a {

--- a/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
@@ -60,7 +60,7 @@ const usePostSubscriptionsQuery = ( {
 		// Transform the dates into Date objects
 		const transformedData = flattenedData?.map( ( comment_subscription ) => ( {
 			...comment_subscription,
-			subscription_date: new Date( comment_subscription.subscription_date ),
+			subscription_date: new Date( comment_subscription.subscription_date + ' UTC' ),
 		} ) );
 		return transformedData?.filter( filter ).sort( sort );
 	}, [ data, filter, sort ] );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/75902 and https://github.com/Automattic/wp-calypso/issues/75901 

## Proposed Changes

* fix `subscription_date` timezone offset: The timestamp received from the endpoint is in UTC, but is missing timezone information. → This PR adds it in.
* fix `post_title` overflow

![Markup on 2023-04-18 at 16:25:25](https://user-images.githubusercontent.com/25105483/232808089-292d56c3-df73-4ab6-a7fb-5a35323bda3f.png)

## Testing Instructions

1. Check out and build the PR locally.
2. Apply the correct `subkey` cookie value to your `calypso.localhost:3000` host.
3. Make sure the related user has existing comment subscriptions - while at least one of the posts needs to have a long post title.
4. Subscribe to comments on one of your posts and note the current time.
5. Navigate to http://calypso.localhost:3000/subscriptions/comments and review the page.
6. Check if the long post title is not overflowing and that the subscription date matches with the time you noted in the point 4 (you can hover over the date to see it in full)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
