### PR TITLE
Use predefined list of category filters for both Theme Showcase and Onboarding Design Picker

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -4,7 +4,7 @@ import { Button } from '@automattic/components';
 import { Onboard, useStarterDesignBySlug, useStarterDesignsQuery } from '@automattic/data-stores';
 import {
 	UnifiedDesignPicker,
-	useCategorization,
+	useCategorizationStatic,
 	getDesignPreviewUrl,
 	isBlankCanvasDesign,
 } from '@automattic/design-picker';
@@ -116,6 +116,15 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	// ********** Logic for fetching designs
 	const selectStarterDesigns = ( allDesigns: StarterDesigns ) => {
+		const { filters = {} } = allDesigns;
+
+		if ( filters.subject ) {
+			allDesigns.filters.subject = Object.keys( filters.subject ).map( ( slug ) => ( {
+				slug,
+				...filters.subject[ slug ],
+			} ) );
+		}
+
 		allDesigns.static.designs = allDesigns.static.designs.filter(
 			( design ) => RETIRING_DESIGN_SLUGS.indexOf( design.slug ) === -1
 		);
@@ -149,6 +158,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		}
 	);
 
+	const staticCategoryList = allDesigns?.filters?.subject || {};
 	const generatedDesigns = allDesigns?.generated?.designs || [];
 	const staticDesigns = allDesigns?.static?.designs || [];
 
@@ -172,7 +182,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		generatedDesigns.length > 0 ? siteVertical?.title : undefined
 	);
 
-	const categorization = useCategorization( staticDesigns, categorizationOptions );
+	const categorization = useCategorizationStatic( staticCategoryList, categorizationOptions );
 
 	// ********** Logic for selecting a design and style variation
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -116,11 +116,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	// ********** Logic for fetching designs
 	const selectStarterDesigns = ( allDesigns: StarterDesigns ) => {
-		// allDesigns.filters.subject = Object.keys( allDesigns.filters.subject ).map( ( slug ) => ( {
-		// 	slug,
-		// 	...allDesigns.filters.subject[ slug ],
-		// } ) );
-
 		allDesigns.static.designs = allDesigns.static.designs.filter(
 			( design ) => RETIRING_DESIGN_SLUGS.indexOf( design.slug ) === -1
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -4,7 +4,7 @@ import { Button } from '@automattic/components';
 import { Onboard, useStarterDesignBySlug, useStarterDesignsQuery } from '@automattic/data-stores';
 import {
 	UnifiedDesignPicker,
-	useCategorizationStatic,
+	useCategorizationFromApi,
 	getDesignPreviewUrl,
 	isBlankCanvasDesign,
 } from '@automattic/design-picker';
@@ -116,14 +116,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	// ********** Logic for fetching designs
 	const selectStarterDesigns = ( allDesigns: StarterDesigns ) => {
-		const { filters = {} } = allDesigns;
-
-		if ( filters.subject ) {
-			allDesigns.filters.subject = Object.keys( filters.subject ).map( ( slug ) => ( {
-				slug,
-				...filters.subject[ slug ],
-			} ) );
-		}
+		// allDesigns.filters.subject = Object.keys( allDesigns.filters.subject ).map( ( slug ) => ( {
+		// 	slug,
+		// 	...allDesigns.filters.subject[ slug ],
+		// } ) );
 
 		allDesigns.static.designs = allDesigns.static.designs.filter(
 			( design ) => RETIRING_DESIGN_SLUGS.indexOf( design.slug ) === -1
@@ -158,7 +154,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		}
 	);
 
-	const staticCategoryList = allDesigns?.filters?.subject || {};
 	const generatedDesigns = allDesigns?.generated?.designs || [];
 	const staticDesigns = allDesigns?.static?.designs || [];
 
@@ -182,7 +177,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		generatedDesigns.length > 0 ? siteVertical?.title : undefined
 	);
 
-	const categorization = useCategorizationStatic( staticCategoryList, categorizationOptions );
+	const categorization = useCategorizationFromApi(
+		allDesigns?.filters?.subject || {},
+		categorizationOptions
+	);
 
 	// ********** Logic for selecting a design and style variation
 

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import { localize, translate } from 'i18n-calypso';
-import { compact, omit, pickBy } from 'lodash';
+import { compact, pickBy } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
@@ -567,8 +567,6 @@ class ThemeShowcase extends Component {
 }
 
 const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
-	const allowedSubjects = omit( getThemeFilterTerms( state, 'subject' ) || {}, [ 'newsletter' ] );
-
 	return {
 		isLoggedIn: isUserLoggedIn( state ),
 		isAtomicSite: isAtomicSite( state, siteId ),
@@ -578,7 +576,7 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => {
 		siteSlug: getSiteSlug( state, siteId ),
 		description: getThemeShowcaseDescription( state, { filter, tier, vertical } ),
 		title: getThemeShowcaseTitle( state, { filter, tier, vertical } ),
-		subjects: allowedSubjects,
+		subjects: getThemeFilterTerms( state, 'subject' ) || {},
 		premiumThemesEnabled: arePremiumThemesEnabled( state, siteId ),
 		filterString: prependThemeFilterKeys( state, filter ),
 		filterToTermTable: getThemeFilterToTermTable( state ),

--- a/packages/data-stores/src/starter-designs-queries/types.ts
+++ b/packages/data-stores/src/starter-designs-queries/types.ts
@@ -1,4 +1,4 @@
-import type { DesignRecipe, Design } from '@automattic/design-picker/src/types';
+import type { Category, DesignRecipe, Design } from '@automattic/design-picker/src/types';
 
 export interface StarterDesignsGeneratedQueryParams {
 	vertical_id: string;
@@ -13,6 +13,7 @@ export interface StarterDesignsGenerated {
 }
 
 export interface StarterDesigns {
+	filters: { subject: Record< string, Category > };
 	generated: { designs: Design[] };
 	static: { designs: Design[] };
 }

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -25,7 +25,7 @@ interface Options extends QueryOptions< StarterDesignsResponse, unknown > {
 }
 
 interface StarterDesignsResponse {
-	filters: { subject: string[] };
+	filters: { subject: Record< string, Category > };
 	generated: { designs: GeneratedDesign[] };
 	static: { designs: StaticDesign[] };
 }
@@ -57,7 +57,9 @@ export function useStarterDesignsQuery(
 	return useQuery( [ 'starter-designs', queryParams ], () => fetchStarterDesigns( queryParams ), {
 		select: ( response: StarterDesignsResponse ) => {
 			const allDesigns = {
-				filters: response.filters || {},
+				filters: {
+					subject: response.filters?.subject || {},
+				},
 				generated: {
 					designs: response.generated?.designs?.map( apiStarterDesignsGeneratedToDesign ),
 				},

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -25,6 +25,7 @@ interface Options extends QueryOptions< StarterDesignsResponse, unknown > {
 }
 
 interface StarterDesignsResponse {
+	filters: { subject: string[] };
 	generated: { designs: GeneratedDesign[] };
 	static: { designs: StaticDesign[] };
 }
@@ -56,6 +57,7 @@ export function useStarterDesignsQuery(
 	return useQuery( [ 'starter-designs', queryParams ], () => fetchStarterDesigns( queryParams ), {
 		select: ( response: StarterDesignsResponse ) => {
 			const allDesigns = {
+				filters: response.filters || {},
 				generated: {
 					designs: response.generated?.designs?.map( apiStarterDesignsGeneratedToDesign ),
 				},

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -363,7 +363,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 	currentPlanFeatures,
 	shouldLimitGlobalStyles,
 } ) => {
-	const hasCategories = !! categorization?.categories.length;
+	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 	const filteredStaticDesigns = useMemo( () => {
 		if ( categorization?.selection ) {
 			return filterDesignsByCategory( staticDesigns, categorization.selection );
@@ -460,7 +460,7 @@ const UnifiedDesignPicker: React.FC< UnifiedDesignPickerProps > = ( {
 	shouldLimitGlobalStyles,
 } ) => {
 	const translate = useTranslate();
-	const hasCategories = !! categorization?.categories.length;
+	const hasCategories = !! Object.keys( categorization?.categories || {} ).length;
 	const hasGeneratedDesigns = generatedDesigns.length > 0;
 	const isShowAll = ! categorization?.selection || categorization?.selection === SHOW_ALL_SLUG;
 

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -74,19 +74,22 @@ export function useCategorizationFromApi(
 	const { __ } = useI18n();
 
 	const categories = useMemo( () => {
-		const result = Object.keys( categoryMap ).map( ( slug ) => ( {
+		const categoryMapKeys = Object.keys( categoryMap ) || [];
+		const hasCategories = !! categoryMapKeys.length;
+
+		const result = categoryMapKeys.map( ( slug ) => ( {
 			...categoryMap[ slug ],
 			slug,
 		} ) );
 
-		if ( generatedDesignsFilter ) {
+		if ( generatedDesignsFilter && hasCategories ) {
 			result.unshift( {
 				name: generatedDesignsFilter,
 				slug: SHOW_GENERATED_DESIGNS_SLUG,
 			} );
 		}
 
-		if ( showAllFilter ) {
+		if ( showAllFilter && hasCategories ) {
 			result.unshift( {
 				name: __( 'Show All', __i18n_text_domain__ ),
 				slug: SHOW_ALL_SLUG,

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -67,14 +67,18 @@ export function useCategorization(
 	};
 }
 
-export function useCategorizationStatic(
-	staticCategoryList: Category[],
+export function useCategorizationFromApi(
+	categoryMap: Record< string, Category >,
 	{ defaultSelection, showAllFilter, generatedDesignsFilter }: UseCategorizationOptions
 ): Categorization {
 	const { __ } = useI18n();
 
 	const categories = useMemo( () => {
-		const result = [ ...staticCategoryList ];
+		const result = Object.keys( categoryMap ).map( ( slug ) => ( {
+			...categoryMap[ slug ],
+			slug,
+		} ) );
+
 		if ( generatedDesignsFilter ) {
 			result.unshift( {
 				name: generatedDesignsFilter,
@@ -90,7 +94,7 @@ export function useCategorizationStatic(
 		}
 
 		return result;
-	}, [ showAllFilter, generatedDesignsFilter, staticCategoryList, __ ] );
+	}, [ showAllFilter, generatedDesignsFilter, categoryMap, __ ] );
 
 	const [ selection, onSelect ] = useState< string | null >(
 		chooseDefaultSelection( categories, defaultSelection )

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -67,6 +67,52 @@ export function useCategorization(
 	};
 }
 
+export function useCategorizationStatic(
+	staticCategoryList: Category[],
+	{ defaultSelection, showAllFilter, generatedDesignsFilter }: UseCategorizationOptions
+): Categorization {
+	const { __ } = useI18n();
+
+	const categories = useMemo( () => {
+		const result = [ ...staticCategoryList ];
+		if ( generatedDesignsFilter ) {
+			result.unshift( {
+				name: generatedDesignsFilter,
+				slug: SHOW_GENERATED_DESIGNS_SLUG,
+			} );
+		}
+
+		if ( showAllFilter ) {
+			result.unshift( {
+				name: __( 'Show All', __i18n_text_domain__ ),
+				slug: SHOW_ALL_SLUG,
+			} );
+		}
+
+		return result;
+	}, [ showAllFilter, generatedDesignsFilter, staticCategoryList, __ ] );
+
+	const [ selection, onSelect ] = useState< string | null >(
+		chooseDefaultSelection( categories, defaultSelection )
+	);
+
+	useEffect( () => {
+		// When the category list changes check that the current selection
+		// still matches one of the given slugs, and if it doesn't reset
+		// the current selection.
+		const findResult = categories.find( ( { slug } ) => slug === selection );
+		if ( ! findResult ) {
+			onSelect( chooseDefaultSelection( categories, defaultSelection ) );
+		}
+	}, [ categories, defaultSelection, selection ] );
+
+	return {
+		categories,
+		selection,
+		onSelect,
+	};
+}
+
 /**
  * Chooses which category is the one that should be used by default.
  * If `defaultSelection` is a valid category slug then it'll be used, otherwise it'll be whichever

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -36,5 +36,5 @@ export type {
 	StyleVariationPreviewColorPalette,
 	StyleVariationStylesColor,
 } from './types';
-export { useCategorization, useCategorizationStatic } from './hooks/use-categorization';
+export { useCategorization, useCategorizationFromApi } from './hooks/use-categorization';
 export { useThemeDesignsQuery } from './hooks/use-theme-designs-query';

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -36,5 +36,5 @@ export type {
 	StyleVariationPreviewColorPalette,
 	StyleVariationStylesColor,
 } from './types';
-export { useCategorization } from './hooks/use-categorization';
+export { useCategorization, useCategorizationStatic } from './hooks/use-categorization';
 export { useThemeDesignsQuery } from './hooks/use-theme-designs-query';

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -12,6 +12,7 @@ export interface FontPair {
 export interface Category {
 	slug: string;
 	name: string;
+	description?: string;
 }
 
 export interface StyleVariation {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75662

## Proposed Changes

Depends on D108008-code. This PR updates the Theme Showcase and Onboarding Design Picker to use category filters retrieved from their respective API endpoints. The expected list of category filters is:

Blog, Business, Portfolio, Single Page, Store, Photography, Link in Bio, Newsletter, and Podcast.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Theme Showcase

![Screenshot 2023-04-19 at 10 25 31 AM](https://user-images.githubusercontent.com/797888/232950487-48201456-11ae-46a9-8d82-fd675eb7b626.png)


* Head to the Theme Showcase `/themes/${site_slug}`.
* Ensure that the list of category filters is as described above.
* Ensure that clicking the category filters works as before.

### Onboarding Design Picker.

![Screenshot 2023-04-19 at 10 25 05 AM](https://user-images.githubusercontent.com/797888/232950422-8f23d37d-4abf-4a0f-ab89-672e234329ce.png)

* Head to the Onboarding Design Picker step `/setup/site-setup/designSetup?siteSlug=${site_slug}`.
* Ensure that the list of category filters is as described above.
* Ensure that clicking the category filters works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?