### PR TITLE
Plans: Add downgrade context for mobile devices

### DIFF
--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
 import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
@@ -43,7 +44,6 @@ type PlanFeaturesActionsButtonProps = {
 	flowName: string;
 	buttonText?: string;
 	isWpcomEnterpriseGridPlan: boolean;
-	isWooExpressPlusPlan?: boolean;
 	selectedSiteSlug: string | null;
 };
 
@@ -291,6 +291,9 @@ const LoggedInPlansFeatureActionButton = ( {
 					<DummyDisabledButton>
 						{ translate( 'Downgrade', { context: 'verb' } ) }
 					</DummyDisabledButton>
+					<div className="plan-features-2023-grid__actions-downgrade-context-mobile">
+						{ isMobile() && translate( 'Please contact support to downgrade your plan.' ) }
+					</div>
 				</Plans2023Tooltip>
 			);
 		} else if ( forceDisplayButton ) {
@@ -323,7 +326,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	flowName,
 	buttonText,
 	isWpcomEnterpriseGridPlan = false,
-	isWooExpressPlusPlan = false,
 	selectedSiteSlug,
 } ) => {
 	const translate = useTranslate();
@@ -376,18 +378,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 							components: translateComponents,
 					  } ) }
 			</Button>
-		);
-	} else if ( isWooExpressPlusPlan ) {
-		return (
-			<ExternalLinkWithTracking
-				className={ classNames( classes ) }
-				href="https://woocommerce.com/get-in-touch/"
-				target="_blank"
-				tracksEventName="calypso_plan_step_woo_express_plus_click"
-				tracksEventProps={ { flow: flowName } }
-			>
-				{ translate( 'Get in touch' ) }
-			</ExternalLinkWithTracking>
 		);
 	} else if ( isLaunchPage ) {
 		return (

--- a/client/my-sites/plan-features-2023-grid/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/actions.tsx
@@ -44,6 +44,7 @@ type PlanFeaturesActionsButtonProps = {
 	flowName: string;
 	buttonText?: string;
 	isWpcomEnterpriseGridPlan: boolean;
+	isWooExpressPlusPlan?: boolean;
 	selectedSiteSlug: string | null;
 };
 
@@ -326,6 +327,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	flowName,
 	buttonText,
 	isWpcomEnterpriseGridPlan = false,
+	isWooExpressPlusPlan = false,
 	selectedSiteSlug,
 } ) => {
 	const translate = useTranslate();
@@ -378,6 +380,18 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 							components: translateComponents,
 					  } ) }
 			</Button>
+		);
+	} else if ( isWooExpressPlusPlan ) {
+		return (
+			<ExternalLinkWithTracking
+				className={ classNames( classes ) }
+				href="https://woocommerce.com/get-in-touch/"
+				target="_blank"
+				tracksEventName="calypso_plan_step_woo_express_plus_click"
+				tracksEventProps={ { flow: flowName } }
+			>
+				{ translate( 'Get in touch' ) }
+			</ExternalLinkWithTracking>
 		);
 	} else if ( isLaunchPage ) {
 		return (

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -167,7 +167,6 @@
 .plan-features-2023-grid__actions-downgrade-context-mobile {
 	font-size: $font-body-extra-small;
 	margin-top: 10px;
-	text-align: center;
 }
 
 .is-2023-pricing-grid .plans-wrapper {

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -164,6 +164,12 @@
 	text-align: center;
 }
 
+.plan-features-2023-grid__actions-downgrade-context-mobile {
+	font-size: $font-body-extra-small;
+	margin-top: 10px;
+	text-align: center;
+}
+
 .is-2023-pricing-grid .plans-wrapper {
 	margin: 0 auto;
 	padding: 28px 0 10px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75486

## Proposed Changes

* This button has a tooltip on desktop/larger screens, but users on mobile can't see it. 
* Add the text about downgrading underneath the grayed-out Downgrade button for mobile devices.

**Before**

<img width="395" alt="Screen Shot 2023-04-18 at 10 35 31 AM" src="https://user-images.githubusercontent.com/2124984/232810976-b9cf2ea4-9473-46b2-84c0-fe53392b1557.png">

**After**

<img width="396" alt="Screen Shot 2023-04-18 at 10 25 01 AM" src="https://user-images.githubusercontent.com/2124984/232810809-1da8e188-0d8b-4fa6-85ad-6c5951b4510d.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/plans` on a site with the Woo Express: Performance plan
* The Essential plan button should say "Downgrade" with a tooltip on hover that says `'Please contact support to downgrade your plan.'`
* Switch to a mobile device or mobile view and refresh the page
* The button should no longer have a tooltip, but small text underneath reads the same. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
