### PR TITLE
Stop tracking virtual themes properties when switching style variations

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -40,7 +40,6 @@ import {
 	getDesignTypeProps,
 	recordPreviewedDesign,
 	recordSelectedDesign,
-	getVirtualDesignProps,
 } from '../../analytics/record-design';
 import StepperLoader from '../../components/stepper-loader';
 import { PLACEHOLDER_SITE_ID } from '../pattern-assembler/constants';
@@ -273,7 +272,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	function onChangeVariation( design: Design, styleVariation?: StyleVariation ) {
 		recordTracksEvent( 'calypso_signup_design_picker_style_variation_button_click', {
 			...getEventPropsByDesign( design, styleVariation ),
-			...getVirtualDesignProps( design ),
 		} );
 	}
 


### PR DESCRIPTION
## Proposed Changes

Virtual themes no longer have style variations, so we don't need to add virtual themes properties to the `calypso_signup_design_picker_style_variation_button_click` event tracked when changing the previewed style variation.

## Testing Instructions

- Use the Calypso live link below.
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>`.
- Open the Network tab of the browser devtools.
- Observe the `t.gif` requests.
- Use the discs to change the previewed style variation of a design with style variations.
- Make sure the tracked `calypso_signup_design_picker_style_variation_button_click` doesn't have the `is_virtual`/`virtual_theme_pattern` properties.
