### PR TITLE
Social previews: add preview for custom FB posts shared by others

### DIFF
--- a/packages/social-previews/src/facebook-preview/default-post-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/default-post-preview.tsx
@@ -1,0 +1,43 @@
+import { PORTRAIT_MODE } from '../constants';
+import CustomText from './custom-text';
+import useImage from './hooks/use-image-hook';
+import FacebookPostActions from './post/actions';
+import FacebookPostHeader from './post/header';
+import type { FacebookPreviewProps } from './types';
+
+type Props = FacebookPreviewProps & {
+	compactDescription?: boolean;
+};
+
+const DefaultFacebookPostPreview: React.FC< Props > = ( {
+	url,
+	customImage,
+	user,
+	customText,
+} ) => {
+	const [ mode, isLoadingImage, imgProps ] = useImage();
+	const modeClass = `is-${ mode === PORTRAIT_MODE ? 'portrait' : 'landscape' }`;
+
+	return (
+		<div className="facebook-preview__post">
+			<FacebookPostHeader user={ undefined } />
+			<div className="facebook-preview__content">
+				<div
+					className={ `facebook-preview__window ${ modeClass } ${
+						customImage && isLoadingImage ? 'is-loading' : ''
+					}` }
+				>
+					<div className={ `facebook-preview__custom-image ${ modeClass }` }>
+						{ /* eslint-disable jsx-a11y/alt-text */ }
+						<img src={ customImage } { ...imgProps } />
+					</div>
+					<FacebookPostHeader user={ user } timeElapsed hideOptions />
+					{ customText && <CustomText text={ customText } url={ url } forceUrlDisplay /> }
+				</div>
+			</div>
+			<FacebookPostActions />
+		</div>
+	);
+};
+
+export default DefaultFacebookPostPreview;

--- a/packages/social-previews/src/facebook-preview/default-post-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/default-post-preview.tsx
@@ -14,8 +14,9 @@ const DefaultFacebookPostPreview: React.FC< Props > = ( {
 	customImage,
 	user,
 	customText,
+	imageMode,
 } ) => {
-	const [ mode, isLoadingImage, imgProps ] = useImage();
+	const [ mode, isLoadingImage, imgProps ] = useImage( { mode: imageMode } );
 	const modeClass = `is-${ mode === PORTRAIT_MODE ? 'portrait' : 'landscape' }`;
 
 	return (

--- a/packages/social-previews/src/facebook-preview/index.tsx
+++ b/packages/social-previews/src/facebook-preview/index.tsx
@@ -2,6 +2,7 @@ import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import SectionHeading from '../shared/section-heading';
 import DefaultFacebookLinkPreview from './default-link-preview';
+import DefaultFacebookPostPreview from './default-post-preview';
 import FacebookLinkPreview from './link-preview';
 import FacebookPostPreview from './post-preview';
 import type { FacebookPreviewProps } from './types';
@@ -47,7 +48,11 @@ const FacebookPreview: React.FC< FacebookPreviewProps > = ( props ) => {
 						{ __( 'Learn more about links', 'facebook-preview' ) }
 					</ExternalLink>
 				</p>
-				<DefaultFacebookLinkPreview { ...props } />
+				{ isPostPreview ? (
+					<DefaultFacebookPostPreview { ...props } />
+				) : (
+					<DefaultFacebookLinkPreview { ...props } />
+				) }
 			</section>
 		</div>
 	);

--- a/packages/social-previews/src/facebook-preview/post/header/index.tsx
+++ b/packages/social-previews/src/facebook-preview/post/header/index.tsx
@@ -6,7 +6,13 @@ import type { FacebookUser } from '../../types';
 
 import './styles.scss';
 
-const FacebookPostHeader: React.FC< { user?: FacebookUser } > = ( { user } ) => {
+type Props = {
+	user?: FacebookUser;
+	timeElapsed?: boolean;
+	hideOptions?: boolean;
+};
+
+const FacebookPostHeader: React.FC< Props > = ( { user, timeElapsed, hideOptions } ) => {
 	const [ avatarSrc, setAvatarSrc ] = useState< string >( user?.avatarUrl || defaultAvatar );
 	const onImageError = useCallback( () => {
 		if ( avatarSrc !== defaultAvatar ) {
@@ -31,10 +37,11 @@ const FacebookPostHeader: React.FC< { user?: FacebookUser } > = ( { user } ) => 
 					</div>
 					<div className="facebook-preview__post-header-share">
 						<span className="facebook-preview__post-header-time">
-							{
-								// translators: temporal indication of when a post was published
-								__( 'Just now', 'facebook-preview' )
-							}
+							{ timeElapsed
+								? // translators: short version of `1 hour`
+								  __( '1h', 'facebook-preview' )
+								: // translators: temporal indication of when a post was published
+								  __( 'Just now', 'facebook-preview' ) }
 						</span>
 						<span className="facebook-preview__post-header-dot" aria-hidden="true">
 							·
@@ -43,7 +50,7 @@ const FacebookPostHeader: React.FC< { user?: FacebookUser } > = ( { user } ) => 
 					</div>
 				</div>
 			</div>
-			<div className="facebook-preview__post-header-more"></div>
+			{ ! hideOptions && <div className="facebook-preview__post-header-more"></div> }
 		</div>
 	);
 };

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -120,6 +120,15 @@
 	}
 }
 
+.facebook-preview__image,
+.facebook-preview__custom-image {
+	img {
+		display: block;
+
+		object-fit: cover;
+	}
+}
+
 .facebook-preview__image {
 	&.is-empty {
 		width: 140px;

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -120,15 +120,6 @@
 	}
 }
 
-.facebook-preview__image,
-.facebook-preview__custom-image {
-	img {
-		display: block;
-
-		object-fit: cover;
-	}
-}
-
 .facebook-preview__image {
 	&.is-empty {
 		width: 140px;

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -198,3 +198,22 @@
 		filter: invert(8%);
 	}
 }
+
+.facebook-preview__window {
+	margin: 0 0.75rem;
+
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 16px;
+	border: $facebook-preview-body-border;
+
+	.facebook-preview__image,
+	.facebook-preview__custom-image {
+		border-top-right-radius: inherit;
+		border-top-left-radius: inherit;
+
+		img {
+			border-top-right-radius: inherit;
+			border-top-left-radius: inherit;
+		}
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

#75844 updated the Facebook previews in the `social-previews` package to include the preview of a post shared by others. This PR completes that preview by handling posts with a custom image.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Prerequisites
- Make sure you have a Facebook account.
- Make sure you have a self-hosted site connected to Jetpack, with a subscription that includes Social.
- From the _Social_ or _My Jetpack_ page of your site WPadmin, activate Social.
- Then, connect your site to Facebook (check [these instructions](https://jetpack.com/support/jetpack-social/connecting-to-social-networks/) if you need help). You may need to create a test page.
- Spin up Calypso, by running this branch locally or using a live link below.

### Testing

- Create a new post from your site WPadmin
- Add a custom media

![Artboard 1](https://user-images.githubusercontent.com/1620183/232824470-df051296-8df6-4937-9e43-82018479c743.png)

- Publish it
- Visit `/posts/:site` in Calypso
- You should see the newly created post under the _Published_ tab
- In the post menu, click _Share_, then press the _Preview_ button
<img width="500" alt="Screenshot 2023-04-11 at 4 47 11 PM" src="https://user-images.githubusercontent.com/1620183/231284467-7d3c5008-321b-444f-a3f9-8b732eaa323c.png">

- Select the Facebook preview
- You should see a preview of how the post looks when shared

## Captures

_Landscape mode_
<img width="500" alt="Screenshot 2023-04-18 at 11 10 12 AM" src="https://user-images.githubusercontent.com/1620183/232824603-6882e188-ec57-43e0-9bf5-4ab907a3539b.png">
<img width="500" alt="Screenshot 2023-04-18 at 11 10 20 AM" src="https://user-images.githubusercontent.com/1620183/232824616-0f075a26-ea90-4881-bb7b-a40c189f41ed.png">


_Portrait mode_
<img width="500" alt="Screenshot 2023-04-18 at 11 11 52 AM" src="https://user-images.githubusercontent.com/1620183/232824672-f92e88cb-6aea-4fa2-b915-2dd6f55f08bd.png">
<img width="500" alt="Screenshot 2023-04-18 at 11 12 10 AM" src="https://user-images.githubusercontent.com/1620183/232824683-c680c3de-cbf4-4813-9b63-3c4285734a35.png">
<img width="500" alt="Screenshot 2023-04-18 at 11 12 19 AM" src="https://user-images.githubusercontent.com/1620183/232824695-a5a1927d-b7ea-44d4-86b0-5e80cc9c1966.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
