### PR TITLE
Tailored ecommerce flow: Add Amulet to design carousel

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
@@ -31,7 +31,7 @@ const DesignCarousel: Step = function DesignCarousel( { navigation } ) {
 					require="@automattic/design-carousel"
 					placeholder={ null }
 					onPick={ pickDesign }
-					selectedDesignSlugs={ [ 'tsubaki', 'tazza', 'zaino', 'thriving-artist' ] }
+					selectedDesignSlugs={ [ 'tsubaki', 'amulet', 'tazza', 'zaino', 'thriving-artist' ] }
 				/>
 			}
 			recordTracksEvent={ recordTracksEvent }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #72311

## Proposed Changes

* Add new WooCommerce theme Amulet to the design picker for the tailored ecommerce flow.

<img width="1664" alt="Screen Shot 2023-04-18 at 11 16 05 AM" src="https://user-images.githubusercontent.com/2124984/232824837-bf85a893-9df6-48d5-8382-4c614f1da9f8.png">

## Testing Instructions

* Switch to this PR
* Navigate to `/setup/ecommerce`
* The design step should have Amulet as the second theme in the carousel.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
