### PR TITLE
Sidebar Heading: fix React error

### DIFF
--- a/client/layout/sidebar/heading.jsx
+++ b/client/layout/sidebar/heading.jsx
@@ -13,6 +13,12 @@ const SidebarHeading = ( { children, onClick, ...props } ) => {
 		};
 	}
 
+	const linkAttrs = { ...props };
+
+	// These are not valid HTML attribute for a <a> tag
+	delete linkAttrs.navigationLabel;
+	delete linkAttrs.url;
+
 	/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 	return (
 		<li>
@@ -21,7 +27,7 @@ const SidebarHeading = ( { children, onClick, ...props } ) => {
 				className="sidebar__heading"
 				onKeyDown={ onKeyDown }
 				onClick={ onClick }
-				{ ...props }
+				{ ...linkAttrs }
 			>
 				{ children }
 			</a>

--- a/client/layout/sidebar/heading.jsx
+++ b/client/layout/sidebar/heading.jsx
@@ -19,9 +19,9 @@ const SidebarHeading = ( { children, onClick, ...props } ) => {
 	delete linkAttrs.navigationLabel;
 	delete linkAttrs.url;
 
-	/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 	return (
 		<li>
+			{ /* eslint-disable jsx-a11y/no-static-element-interactions */ }
 			<a
 				tabIndex={ tabIndex }
 				className="sidebar__heading"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR fixes the following error triggered by the `SidebarHeading` component. Invalid HTML attributes are passed to a `a` tag.

<img width="417" alt="Screenshot 2023-04-18 at 11 39 15 AM" src="https://user-images.githubusercontent.com/1620183/232837034-5027f758-80f0-4b16-ba9f-bbbc1e75c342.png">

## Implementation Notes

A proper solution would be not to pass `...props`, but only the desired attributes. Since I'm not aware of all the use cases for this component and what `props` might hold, I'm being conservative with this fix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Spin up Calypso, using a live link below, or by running the branch locally
- Open the developer console
- Visit `/posts`, for instance
- Check there's no error in the console

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
