### PR TITLE
PopoverMenuItem: more accurate itemComponent type

### DIFF
--- a/client/components/popover-menu/item.jsx
+++ b/client/components/popover-menu/item.jsx
@@ -17,7 +17,7 @@ export default class PopoverMenuItem extends Component {
 		onClick: PropTypes.func,
 		onMouseOver: PropTypes.func,
 		isExternalLink: PropTypes.bool,
-		itemComponent: PropTypes.oneOfType( [ PropTypes.func, PropTypes.string ] ),
+		itemComponent: PropTypes.elementType,
 	};
 
 	static defaultProps = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR fixes the following error triggered by `PopoverMenuItem`. It is caused by an inaccurate `PropType`.

<img width="616" alt="Screenshot 2023-04-18 at 12 17 03 PM" src="https://user-images.githubusercontent.com/1620183/232840876-981ce896-e80b-41b7-8f1f-5cc3944f95e7.png">

[Here's an explanation of the fix](https://github.com/facebook/prop-types/issues/334#issuecomment-776197270).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Spin up Calypso, using a live link below, or by running the branch locally
- Open the developer console
- Visit `/posts/:site`
- Click the 3 dotted menu of a post item
<img width="862" alt="Screenshot 2023-04-18 at 12 17 08 PM" src="https://user-images.githubusercontent.com/1620183/232842132-3d74a70c-2496-4631-bde0-bb277e414168.png">

- Check there's no error in the console

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
