### PR TITLE
Subscription management: Add sorting to Sites view

### DIFF
--- a/client/landing/subscriptions/components/sort-controls/index.ts
+++ b/client/landing/subscriptions/components/sort-controls/index.ts
@@ -1,0 +1,2 @@
+export { default as SortControls } from './sort-controls';
+export type { Option } from './sort-controls';

--- a/client/landing/subscriptions/components/sort-controls/sort-controls.tsx
+++ b/client/landing/subscriptions/components/sort-controls/sort-controls.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import React, { useState, useEffect, ChangeEvent, ReactElement } from 'react';
+import { useState, useEffect, ChangeEvent, ReactElement } from 'react';
 import './styles.scss';
 
 export type Option = {
@@ -9,17 +9,14 @@ export type Option = {
 
 type SortControlsProps< T > = {
 	options: Option[];
-	onChange?: ( sortOrder: T ) => void;
 	value: T;
+	onChange: ( sortOrder: T ) => void;
 };
-
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
 
 const SortControls: < T extends string >( props: SortControlsProps< T > ) => ReactElement = ( {
 	options,
-	onChange = noop,
 	value,
+	onChange,
 } ) => {
 	const translate = useTranslate();
 	const [ selected, setSelected ] = useState( value );

--- a/client/landing/subscriptions/components/sort-controls/sort-controls.tsx
+++ b/client/landing/subscriptions/components/sort-controls/sort-controls.tsx
@@ -1,0 +1,56 @@
+import { useTranslate } from 'i18n-calypso';
+import React, { useState, useEffect, ChangeEvent, ReactElement } from 'react';
+import './styles.scss';
+
+export type Option = {
+	label: string;
+	value: string;
+};
+
+type SortControlsProps< T > = {
+	options: Option[];
+	onChange?: ( sortOrder: T ) => void;
+	value: T;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
+const SortControls: < T extends string >( props: SortControlsProps< T > ) => ReactElement = ( {
+	options,
+	onChange = noop,
+	value,
+} ) => {
+	const translate = useTranslate();
+	const [ selected, setSelected ] = useState( value );
+
+	useEffect( () => {
+		setSelected( value );
+	}, [ value ] );
+
+	const handleSelectChange = ( event: ChangeEvent< HTMLSelectElement > ) => {
+		onChange( event?.target.value as typeof value );
+	};
+
+	return (
+		<div className="subscription-manager-sort-controls">
+			<label htmlFor="subscription-manager-sort-controls__select">
+				{ translate( 'Sort by:' ) }
+				<select
+					id="subscription-manager-sort-controls__select"
+					className="subscription-manager-sort-controls__select"
+					onChange={ handleSelectChange }
+					value={ selected }
+				>
+					{ options.map( ( option ) => (
+						<option key={ `${ option.value }.${ option.label }` } value={ option.value }>
+							{ option.label }
+						</option>
+					) ) }
+				</select>
+			</label>
+		</div>
+	);
+};
+
+export default SortControls;

--- a/client/landing/subscriptions/components/sort-controls/styles.scss
+++ b/client/landing/subscriptions/components/sort-controls/styles.scss
@@ -1,0 +1,29 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@automattic/typography/styles/fonts";
+@import "@automattic/color-studio/dist/color-variables";
+
+.subscription-manager-sort-controls {
+	select,
+	label {
+		font-weight: 500;
+		color: $studio-gray-60;
+		line-height: $font-title-small;
+		font-size: $font-body-small;
+	}
+
+	select {
+		border: none;
+
+		&:focus {
+			border-color: var(--color-primary);
+			border-radius: 2px;
+			box-shadow: 0 0 0 1px var(--color-primary), 0 0 0 4px var(--color-primary-10);
+		}
+
+		&:focus-visible {
+			outline: none;
+		}
+	}
+
+
+}

--- a/client/landing/subscriptions/components/sort-controls/styles.scss
+++ b/client/landing/subscriptions/components/sort-controls/styles.scss
@@ -24,6 +24,4 @@
 			outline: none;
 		}
 	}
-
-
 }

--- a/client/landing/subscriptions/components/tab-views/sites/sites.tsx
+++ b/client/landing/subscriptions/components/tab-views/sites/sites.tsx
@@ -12,7 +12,7 @@ import TabView from '../tab-view';
 
 const SortBy = SubscriptionManager.SiteSubscriptionsSortBy;
 
-const isSearchEnabled = config.isEnabled( 'subscription-management/sites-search' );
+const isListControlsEnabled = config.isEnabled( 'subscription-management/sites-list-controls' );
 
 const sortOptions: Option[] = [
 	{ value: SortBy.LastUpdated, label: 'Last updated' },
@@ -43,7 +43,7 @@ const Sites = () => {
 
 	return (
 		<TabView errorMessage={ errorMessage } isLoading={ isLoading }>
-			{ isSearchEnabled && (
+			{ isListControlsEnabled && (
 				<div className="subscriptions-manager__list-actions-bar">
 					<SearchInput
 						placeholder={ translate( 'Search by site name or address…' ) }

--- a/client/landing/subscriptions/components/tab-views/sites/sites.tsx
+++ b/client/landing/subscriptions/components/tab-views/sites/sites.tsx
@@ -7,16 +7,27 @@ import { useDebounce } from 'use-debounce';
 import { SearchIcon } from 'calypso/landing/subscriptions/components/icons';
 import { Notice } from 'calypso/landing/subscriptions/components/notice';
 import { SiteList } from 'calypso/landing/subscriptions/components/site-list';
+import { SortControls, Option } from 'calypso/landing/subscriptions/components/sort-controls';
 import TabView from '../tab-view';
 
+const SortBy = SubscriptionManager.SiteSubscriptionsSortBy;
+
 const isSearchEnabled = config.isEnabled( 'subscription-management/sites-search' );
+
+const sortOptions: Option[] = [
+	{ value: SortBy.LastUpdated, label: 'Last updated' },
+	{ value: SortBy.DateSubscribed, label: 'Date subscribed' },
+	{ value: SortBy.SiteName, label: 'Site name' },
+];
 
 const Sites = () => {
 	const translate = useTranslate();
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const [ debouncedSearchTerm ] = useDebounce( searchTerm, 300 );
+	const [ sortTerm, setSortTerm ] = useState( SortBy.LastUpdated );
 	const { data, isLoading, error } = SubscriptionManager.useSiteSubscriptionsQuery( {
 		searchTerm: debouncedSearchTerm,
+		sortTerm,
 	} );
 	const { subscriptions, totalCount } = data ?? {};
 	// todo: translate when we have agreed on the error message
@@ -39,12 +50,13 @@ const Sites = () => {
 						searchIcon={ <SearchIcon size={ 18 } /> }
 						onSearch={ handleSearch }
 					/>
+					<SortControls value={ sortTerm } onChange={ setSortTerm } options={ sortOptions } />
 				</div>
 			) }
 
 			<SiteList sites={ subscriptions } />
 
-			{ totalCount && subscriptions.length === 0 && (
+			{ totalCount > 0 && subscriptions.length === 0 && (
 				<Notice type="warning">
 					{ translate( 'Sorry, no sites match {{italic}}%s.{{/italic}}', {
 						components: { italic: <i /> },

--- a/client/landing/subscriptions/components/tab-views/sites/sites.tsx
+++ b/client/landing/subscriptions/components/tab-views/sites/sites.tsx
@@ -50,7 +50,7 @@ const Sites = () => {
 						searchIcon={ <SearchIcon size={ 18 } /> }
 						onSearch={ handleSearch }
 					/>
-					<SortControls value={ sortTerm } onChange={ setSortTerm } options={ sortOptions } />
+					<SortControls options={ sortOptions } value={ sortTerm } onChange={ setSortTerm } />
 				</div>
 			) }
 

--- a/client/landing/subscriptions/components/tab-views/sites/sites.tsx
+++ b/client/landing/subscriptions/components/tab-views/sites/sites.tsx
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { SubscriptionManager } from '@automattic/data-stores';
 import SearchInput from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useDebounce } from 'use-debounce';
 import { SearchIcon } from 'calypso/landing/subscriptions/components/icons';
 import { Notice } from 'calypso/landing/subscriptions/components/notice';
@@ -14,11 +14,16 @@ const SortBy = SubscriptionManager.SiteSubscriptionsSortBy;
 
 const isListControlsEnabled = config.isEnabled( 'subscription-management/sites-list-controls' );
 
-const sortOptions: Option[] = [
-	{ value: SortBy.LastUpdated, label: 'Last updated' },
+const getSortOptions = ( translate: ReturnType< typeof useTranslate > ): Option[] => [
+	{ value: SortBy.LastUpdated, label: translate( 'Last updated' ) },
+	// todo: translate when we have agreed on the label
 	{ value: SortBy.DateSubscribed, label: 'Date subscribed' },
+	// todo: translate when we have agreed on the label
 	{ value: SortBy.SiteName, label: 'Site name' },
 ];
+
+const useSortOptions = ( translate: ReturnType< typeof useTranslate > ): Option[] =>
+	useMemo( () => getSortOptions( translate ), [ translate ] );
 
 const Sites = () => {
 	const translate = useTranslate();
@@ -30,6 +35,7 @@ const Sites = () => {
 		sortTerm,
 	} );
 	const { subscriptions, totalCount } = data ?? {};
+	const sortOptions = useSortOptions( translate );
 	// todo: translate when we have agreed on the error message
 	const errorMessage = error ? 'An error occurred while fetching your subscriptions.' : '';
 

--- a/client/landing/subscriptions/styles.scss
+++ b/client/landing/subscriptions/styles.scss
@@ -46,6 +46,13 @@ body {
 	.subscriptions-manager {
 		&__list-actions-bar {
 			margin-bottom: 57px;
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+
+			.subscription-manager__sort-controls {
+				margin-left: auto;
+			}
 		}
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -186,7 +186,7 @@
 		"subscription-management": true,
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
-		"subscription-management/sites-search": true,
+		"subscription-management/sites-list-controls": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/display-thank-you-page": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -129,7 +129,7 @@
 		"subscription-gifting": true,
 		"subscription-management": true,
 		"subscription-management-comments-view": false,
-		"subscription-management/sites-search": false,
+		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/display-thank-you-page": false,
 		"themes/premium": true,

--- a/config/production.json
+++ b/config/production.json
@@ -150,7 +150,7 @@
 		"subscription-gifting": true,
 		"subscription-management": true,
 		"subscription-management-comments-view": false,
-		"subscription-management/sites-search": false,
+		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/display-thank-you-page": false,
 		"themes/premium": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -146,7 +146,7 @@
 		"subscription-gifting": true,
 		"subscription-management": true,
 		"subscription-management-comments-view": false,
-		"subscription-management/sites-search": false,
+		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/display-thank-you-page": false,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -157,7 +157,7 @@
 		"subscription-gifting": true,
 		"subscription-management": true,
 		"subscription-management-comments-view": false,
-		"subscription-management/sites-search": false,
+		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/display-thank-you-page": false,
 		"themes/premium": true,

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -6,6 +6,7 @@ import {
 	useUserSettingsMutation,
 } from './mutations';
 import {
+	SiteSubscriptionsSortBy,
 	useSiteSubscriptionsQuery,
 	usePostSubscriptionsQuery,
 	useSubscriptionsCountQuery,
@@ -13,6 +14,7 @@ import {
 } from './queries';
 
 export const SubscriptionManager = {
+	SiteSubscriptionsSortBy,
 	usePostUnfollowMutation,
 	useSiteDeliveryFrequencyMutation,
 	useSiteSubscriptionsQuery,

--- a/packages/data-stores/src/reader/queries/index.ts
+++ b/packages/data-stores/src/reader/queries/index.ts
@@ -1,4 +1,7 @@
 export { default as useUserSettingsQuery } from './use-user-settings-query';
 export { default as useSubscriptionsCountQuery } from './use-subscriptions-count-query';
-export { default as useSiteSubscriptionsQuery } from './use-site-subscriptions-query';
+export {
+	default as useSiteSubscriptionsQuery,
+	SiteSubscriptionsSortBy,
+} from './use-site-subscriptions-query';
 export { default as usePostSubscriptionsQuery } from './use-post-subscriptions-query';

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -4,6 +4,12 @@ import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { SiteSubscription } from '../types';
 
+export enum SiteSubscriptionsSortBy {
+	SiteName = 'site_name',
+	LastUpdated = 'last_updated',
+	DateSubscribed = 'date_subscribed',
+}
+
 type SubscriptionManagerSiteSubscriptions = {
 	subscriptions: SiteSubscription[];
 	page: number;
@@ -13,17 +19,38 @@ type SubscriptionManagerSiteSubscriptions = {
 type SubscriptionManagerSiteSubscriptionsQueryProps = {
 	searchTerm?: string;
 	filter?: ( item?: SiteSubscription ) => boolean;
-	sort?: ( a?: SiteSubscription, b?: SiteSubscription ) => number;
+	sortTerm?: SiteSubscriptionsSortBy;
 	number?: number;
 };
 
+const sortByDateSubscribed = ( a: SiteSubscription, b: SiteSubscription ) =>
+	b.date_subscribed.getTime() - a.date_subscribed.getTime();
+
+const sortByLastUpdated = ( a: SiteSubscription, b: SiteSubscription ) =>
+	b.last_updated.getTime() - a.last_updated.getTime();
+
+const sortBySiteName = ( a: SiteSubscription, b: SiteSubscription ) =>
+	a.name.localeCompare( b.name );
+
+const getSortFunction = ( sortTerm: SiteSubscriptionsSortBy ) => {
+	switch ( sortTerm ) {
+		case SiteSubscriptionsSortBy.DateSubscribed:
+			return sortByDateSubscribed;
+		case SiteSubscriptionsSortBy.LastUpdated:
+			return sortByLastUpdated;
+		case SiteSubscriptionsSortBy.SiteName:
+			return sortBySiteName;
+		default:
+			return undefined;
+	}
+};
+
 const defaultFilter = () => true;
-const defaultSort = () => 0;
 
 const useSiteSubscriptionsQuery = ( {
 	searchTerm = '',
 	filter = defaultFilter,
-	sort = defaultSort,
+	sortTerm = SiteSubscriptionsSortBy.LastUpdated,
 	number = 100,
 }: SubscriptionManagerSiteSubscriptionsQueryProps = {} ) => {
 	const { isLoggedIn } = useIsLoggedIn();
@@ -83,6 +110,7 @@ const useSiteSubscriptionsQuery = ( {
 				item.URL.toLowerCase().includes( searchTermLowerCase )
 			);
 		};
+		const sort = getSortFunction( sortTerm );
 
 		return {
 			subscriptions:
@@ -92,7 +120,7 @@ const useSiteSubscriptionsQuery = ( {
 			totalCount: data?.pages?.[ 0 ]?.total_subscriptions ?? 0,
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ data?.pages, filter, searchTerm, sort ] );
+	}, [ data?.pages, filter, searchTerm, sortTerm ] );
 
 	return {
 		data: resultData,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/75877

## Proposed Changes

* Create `SortControls` component and render it together with the Sites view
* Implement sorting on the frontend as part of the `useSiteSubscriptionsQuery` 

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build it locally.
2. Get the `subkey` cookie by sending yourself the confirmation email at https://wordpress.com/email-subscriptions and clicking the verification link in the Incognito browser window:

 ![Markup on 2023-03-30 at 11:48:02](https://user-images.githubusercontent.com/25105483/228798142-3b09d1f3-0d7e-40e2-8912-e208919292f6.png)

3. Navigate to http://calypso.localhost:3000/ and set the `subkey` cookie:

![Markup on 2023-03-30 at 11:50:36](https://user-images.githubusercontent.com/25105483/228798729-c31cd569-d69a-45cc-be7f-a6a2d03773f1.png)

4. Make sure the External user you test with, has multiple subscriptions.

If you like, you can use the `https://public-api.wordpress.com/rest/v1.2/read/site/SITE_ID/post_email_subscriptions/new` endpoint to quickly subscribe to multiple sites:

![Markup on 2023-03-30 at 11:44:38](https://user-images.githubusercontent.com/25105483/228797427-f18ae7b7-2c4b-457e-8457-b22ad07e27be.png)

Please note that `SITE_ID` represents the site you are subscribing to and the `Authorization` header needs to match the `subkey` cookie value in the form of `X-WPSUBKEY subkey_value`.

5. Navigate to http://calypso.localhost:3000/subscriptions/sites and try out the sort controls select element.

(Credit for the test instructions goes to @ivan-ottinger - https://github.com/Automattic/wp-calypso/pull/75115)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
