### PR TITLE
Stats: Improve accessibility via unified header component

### DIFF
--- a/client/blocks/stats-navigation/constants.ts
+++ b/client/blocks/stats-navigation/constants.ts
@@ -16,38 +16,47 @@ export const emailIntervals = [ hour, day ];
 /**
  * Nav items
  */
+type NavItem = {
+	label: string;
+	path: string;
+	showIntervals: boolean;
+};
 const traffic = {
 	label: translate( 'Traffic' ),
 	path: '/stats',
 	showIntervals: true,
-};
+} as NavItem;
 const insights = {
 	label: translate( 'Insights' ),
 	path: '/stats/insights',
 	showIntervals: false,
-};
+} as NavItem;
 // TODO: Consider adding subscriber counts into this nav item in the future.
 // See client/blocks/subscribers-count/index.jsx.
 const subscribers = {
 	label: translate( 'Subscribers' ),
 	path: '/stats/subscribers',
 	showIntervals: false,
-};
+} as NavItem;
 const store = {
 	label: translate( 'Store' ),
 	path: '/store/stats/orders',
 	showIntervals: true,
-};
+} as NavItem;
 const wordads = {
 	label: translate( 'Ads' ),
 	path: '/stats/ads',
 	showIntervals: true,
-};
+} as NavItem;
 const googleMyBusiness = {
 	label: translate( 'Google My Business' ),
 	path: '/google-my-business/stats',
 	showIntervals: false,
-};
+} as NavItem;
+
+interface NavItems {
+	[ key: string ]: NavItem;
+}
 
 const assembleNavItems = () => {
 	const navItems = {
@@ -56,7 +65,7 @@ const assembleNavItems = () => {
 		store,
 		wordads,
 		googleMyBusiness,
-	};
+	} as NavItems;
 
 	if ( config.isEnabled( 'stats/subscribers-section' ) ) {
 		navItems.subscribers = subscribers;

--- a/client/blocks/stats-navigation/constants.ts
+++ b/client/blocks/stats-navigation/constants.ts
@@ -54,8 +54,13 @@ const googleMyBusiness = {
 	showIntervals: false,
 } as NavItem;
 
-interface NavItems {
-	[ key: string ]: NavItem;
+export interface NavItems {
+	traffic: NavItem;
+	insights: NavItem;
+	store: NavItem;
+	wordads: NavItem;
+	googleMyBusiness: NavItem;
+	subscribers?: NavItem;
 }
 
 const assembleNavItems = () => {

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -9,7 +9,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
@@ -18,6 +17,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import GoogleMyBusinessLocation from 'calypso/my-sites/google-my-business/location';
 import GoogleMyBusinessStatsChart from 'calypso/my-sites/google-my-business/stats/chart';
+import StatsPageHeader from 'calypso/my-sites/stats/stats-page-header';
 import { enhanceWithSiteType, recordTracksEvent } from 'calypso/state/analytics/actions';
 import getGoogleMyBusinessConnectedLocation from 'calypso/state/selectors/get-google-my-business-connected-location';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -207,12 +207,10 @@ class GoogleMyBusinessStats extends Component {
 				<QueryKeyringServices />
 
 				<div className="stats">
-					<FormattedHeader
-						brandFont
-						className="stats__section-header modernized-header"
+					<StatsPageHeader
+						page="googleMyBusiness"
 						headerText={ translate( 'Google My Business' ) }
-						align="left"
-						subHeaderText={ translate(
+						subheaderText={ translate(
 							'Integrate your business with Google and get stats on your locations. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 							{
 								components: {

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -210,7 +210,7 @@ class GoogleMyBusinessStats extends Component {
 					<StatsPageHeader
 						page="googleMyBusiness"
 						headerText={ translate( 'Google My Business' ) }
-						subheaderText={ translate(
+						subHeaderText={ translate(
 							'Integrate your business with Google and get stats on your locations. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 							{
 								components: {

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -209,7 +209,6 @@ class GoogleMyBusinessStats extends Component {
 				<div className="stats">
 					<StatsPageHeader
 						page="googleMyBusiness"
-						headerText={ translate( 'Google My Business' ) }
 						subHeaderText={ translate(
 							'Integrate your business with Google and get stats on your locations. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
 							{

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -10,7 +10,6 @@ $sidebar-appearance-break-point: 783px;
 
 // Elements above main layout content per pages
 .stats__section-header,
-.store-stats__section-header,
 .stats-navigation,
 .stats-banner-wrapper {
 	background-color: var(--studio-white);

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -18,7 +18,6 @@ import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
@@ -44,6 +43,7 @@ import DatePicker from './stats-date-picker';
 import StatsModule from './stats-module';
 import StatsModuleEmails from './stats-module-emails';
 import StatsNotices from './stats-notices';
+import StatsPageHeader from './stats-page-header';
 import StatsPeriodHeader from './stats-period-header';
 import StatsPeriodNavigation from './stats-period-navigation';
 import statsStrings from './stats-strings';
@@ -170,12 +170,9 @@ class StatsSite extends Component {
 						<JetpackBackupCredsBanner event="stats-backup-credentials" />
 					</div>
 				) }
-				<FormattedHeader
-					brandFont
-					className="stats__section-header modernized-header"
-					headerText={ translate( 'Jetpack Stats' ) }
-					align="left"
-					subHeaderText={ translate(
+				<StatsPageHeader
+					page="traffic"
+					subheaderText={ translate(
 						"Learn more about the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
 						{
 							components: {

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -172,7 +172,7 @@ class StatsSite extends Component {
 				) }
 				<StatsPageHeader
 					page="traffic"
-					subheaderText={ translate(
+					subHeaderText={ translate(
 						"Learn more about the activity and behavior of your site's visitors. {{learnMoreLink}}Learn more{{/learnMoreLink}}",
 						{
 							components: {

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -51,7 +51,7 @@ const StatsInsights = ( props ) => {
 			<div className="stats">
 				<StatsPageHeader
 					page="insights"
-					subheaderText={ translate( "View your site's performance and learn from trends." ) }
+					subHeaderText={ translate( "View your site's performance and learn from trends." ) }
 				/>
 				<StatsNavigation selectedItem="insights" siteId={ siteId } slug={ siteSlug } />
 				<AnnualHighlightsSection siteId={ siteId } />

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import DomainTip from 'calypso/blocks/domain-tip';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -21,6 +20,7 @@ import PostingActivity from '../post-trends';
 import Comments from '../stats-comments';
 import Followers from '../stats-followers';
 import StatsModule from '../stats-module';
+import StatsPageHeader from '../stats-page-header';
 import Reach from '../stats-reach';
 import StatShares from '../stats-shares';
 import statsStrings from '../stats-strings';
@@ -49,12 +49,9 @@ const StatsInsights = ( props ) => {
 			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
 			<PageViewTracker path="/stats/insights/:site" title="Stats > Insights" />
 			<div className="stats">
-				<FormattedHeader
-					brandFont
-					className="stats__section-header modernized-header"
-					headerText={ translate( 'Jetpack Stats' ) }
-					subHeaderText={ translate( "View your site's performance and learn from trends." ) }
-					align="left"
+				<StatsPageHeader
+					page="insights"
+					subheaderText={ translate( "View your site's performance and learn from trends." ) }
 				/>
 				<StatsNavigation selectedItem="insights" siteId={ siteId } slug={ siteSlug } />
 				<AnnualHighlightsSection siteId={ siteId } />

--- a/client/my-sites/stats/stats-page-header/index.tsx
+++ b/client/my-sites/stats/stats-page-header/index.tsx
@@ -6,13 +6,13 @@ import { preventWidows } from 'calypso/lib/formatting';
 interface StatsPageHeaderProps {
 	page: 'traffic' | 'insights' | 'store' | 'wordads' | 'googleMyBusiness' | 'subscribers';
 	headerText: string;
-	subheaderText: string;
+	subHeaderText: string;
 }
 
 export default function StatsPageHeader( {
 	page,
 	headerText,
-	subheaderText,
+	subHeaderText,
 }: StatsPageHeaderProps ) {
 	const translate = useTranslate();
 
@@ -28,7 +28,7 @@ export default function StatsPageHeader( {
 				the currently selected NavItem in StatsNavigation.
 				*/ }
 			<h2 className="screen-reader-text">{ navItems[ page ]?.label }</h2>
-			<p className="formatted-header__subtitle">{ preventWidows( subheaderText, 2 ) }</p>
+			<p className="formatted-header__subtitle">{ preventWidows( subHeaderText, 2 ) }</p>
 		</FormattedHeader>
 	);
 }

--- a/client/my-sites/stats/stats-page-header/index.tsx
+++ b/client/my-sites/stats/stats-page-header/index.tsx
@@ -5,15 +5,10 @@ import { preventWidows } from 'calypso/lib/formatting';
 
 interface StatsPageHeaderProps {
 	page: keyof NavItems;
-	headerText?: string;
 	subHeaderText?: string;
 }
 
-export default function StatsPageHeader( {
-	page,
-	headerText,
-	subHeaderText,
-}: StatsPageHeaderProps ) {
+export default function StatsPageHeader( { page, subHeaderText }: StatsPageHeaderProps ) {
 	const translate = useTranslate();
 
 	return (
@@ -21,7 +16,7 @@ export default function StatsPageHeader( {
 			align="left"
 			brandFont
 			className="stats__section-header modernized-header"
-			headerText={ preventWidows( headerText ?? translate( 'Jetpack Stats' ), 2 ) } // This is the H1 header.
+			headerText={ preventWidows( translate( 'Jetpack Stats' ), 2 ) } // This is the H1 header.
 		>
 			{ /*
 				The secondary H2 header is only used for screen readers. This text should be identical to 

--- a/client/my-sites/stats/stats-page-header/index.tsx
+++ b/client/my-sites/stats/stats-page-header/index.tsx
@@ -5,8 +5,8 @@ import { preventWidows } from 'calypso/lib/formatting';
 
 interface StatsPageHeaderProps {
 	page: keyof NavItems;
-	headerText: string;
-	subHeaderText: string;
+	headerText?: string;
+	subHeaderText?: string;
 }
 
 export default function StatsPageHeader( {
@@ -28,7 +28,9 @@ export default function StatsPageHeader( {
 				the currently selected NavItem in StatsNavigation.
 				*/ }
 			<h2 className="screen-reader-text">{ navItems[ page ]?.label }</h2>
-			<p className="formatted-header__subtitle">{ preventWidows( subHeaderText, 2 ) }</p>
+			{ subHeaderText && (
+				<p className="formatted-header__subtitle">{ preventWidows( subHeaderText, 2 ) }</p>
+			) }
 		</FormattedHeader>
 	);
 }

--- a/client/my-sites/stats/stats-page-header/index.tsx
+++ b/client/my-sites/stats/stats-page-header/index.tsx
@@ -1,0 +1,34 @@
+import { useTranslate } from 'i18n-calypso';
+import { navItems } from 'calypso/blocks/stats-navigation/constants';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { preventWidows } from 'calypso/lib/formatting';
+
+interface StatsPageHeaderProps {
+	page: 'traffic' | 'insights' | 'store' | 'wordads' | 'googleMyBusiness' | 'subscribers';
+	headerText: string;
+	subheaderText: string;
+}
+
+export default function StatsPageHeader( {
+	page,
+	headerText,
+	subheaderText,
+}: StatsPageHeaderProps ) {
+	const translate = useTranslate();
+
+	return (
+		<FormattedHeader
+			align="left"
+			brandFont
+			className="stats__section-header modernized-header"
+			headerText={ preventWidows( headerText ?? translate( 'Jetpack Stats' ), 2 ) } // This is the H1 header.
+		>
+			{ /*
+				The secondary H2 header is only used for screen readers. This text should be identical to 
+				the currently selected NavItem in StatsNavigation.
+				*/ }
+			<h2 className="screen-reader-text">{ navItems[ page ]?.label }</h2>
+			<p className="formatted-header__subtitle">{ preventWidows( subheaderText, 2 ) }</p>
+		</FormattedHeader>
+	);
+}

--- a/client/my-sites/stats/stats-page-header/index.tsx
+++ b/client/my-sites/stats/stats-page-header/index.tsx
@@ -1,10 +1,10 @@
 import { useTranslate } from 'i18n-calypso';
-import { navItems } from 'calypso/blocks/stats-navigation/constants';
+import { navItems, NavItems } from 'calypso/blocks/stats-navigation/constants';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { preventWidows } from 'calypso/lib/formatting';
 
 interface StatsPageHeaderProps {
-	page: 'traffic' | 'insights' | 'store' | 'wordads' | 'googleMyBusiness' | 'subscribers';
+	page: keyof NavItems;
 	headerText: string;
 	subHeaderText: string;
 }

--- a/client/my-sites/stats/stats-subscribers-page/index.jsx
+++ b/client/my-sites/stats/stats-subscribers-page/index.jsx
@@ -5,7 +5,6 @@ import { useSelector } from 'react-redux';
 import DomainTip from 'calypso/blocks/domain-tip';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -15,6 +14,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import AnnualHighlightsSection from '../annual-highlights-section';
 import Followers from '../stats-followers';
 import StatsModuleEmails from '../stats-module-emails';
+import StatsPageHeader from '../stats-page-header';
 import Reach from '../stats-reach';
 import SubscribersSection from '../subscribers-section';
 
@@ -48,12 +48,9 @@ const StatsSubscribersPage = ( { period } ) => {
 			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
 			<PageViewTracker path="/stats/subscribers/:site" title="Stats > Subscribers" />
 			<div className="stats">
-				<FormattedHeader
-					brandFont
-					className="stats__section-header modernized-header"
-					headerText={ translate( 'Jetpack Stats' ) }
-					subHeaderText={ translate( "View your site's performance and learn from trends." ) }
-					align="left"
+				<StatsPageHeader
+					page="subscribers"
+					subheaderText={ translate( "View your site's performance and learn from trends." ) }
 				/>
 				<StatsNavigation selectedItem="subscribers" siteId={ siteId } slug={ siteSlug } />
 				{ /* TODO: replace annual highlight */ }

--- a/client/my-sites/stats/stats-subscribers-page/index.jsx
+++ b/client/my-sites/stats/stats-subscribers-page/index.jsx
@@ -50,7 +50,7 @@ const StatsSubscribersPage = ( { period } ) => {
 			<div className="stats">
 				<StatsPageHeader
 					page="subscribers"
-					subheaderText={ translate( "View your site's performance and learn from trends." ) }
+					subHeaderText={ translate( "View your site's performance and learn from trends." ) }
 				/>
 				<StatsNavigation selectedItem="subscribers" siteId={ siteId } slug={ siteSlug } />
 				{ /* TODO: replace annual highlight */ }

--- a/client/my-sites/stats/wordads/earnings.jsx
+++ b/client/my-sites/stats/wordads/earnings.jsx
@@ -246,7 +246,7 @@ class WordAdsEarnings extends Component {
 		return (
 			<>
 				<div className="ads__table-header">
-					<h1 className="ads__table-header-title">{ header_text }</h1>
+					<h3 className="ads__table-header-title">{ header_text }</h3>
 					<button
 						className="ads__table-header-button"
 						aria-label={ translate( 'Show or hide panel information' ) }

--- a/client/my-sites/stats/wordads/highlights-section.jsx
+++ b/client/my-sites/stats/wordads/highlights-section.jsx
@@ -97,7 +97,7 @@ function HighlightsSectionHeader( props ) {
 	} );
 	const showNotices = notices?.length > 0;
 	return (
-		<h1 className="highlight-cards-heading">
+		<h3 className="highlight-cards-heading">
 			{ localizedTitle }{ ' ' }
 			{ showNotices && (
 				<>
@@ -123,7 +123,7 @@ function HighlightsSectionHeader( props ) {
 					</Popover>
 				</>
 			) }
-		</h1>
+		</h3>
 	);
 }
 

--- a/client/my-sites/stats/wordads/highlights-section.scss
+++ b/client/my-sites/stats/wordads/highlights-section.scss
@@ -1,5 +1,5 @@
 .highlight-cards.wordads {
-	h1 {
+	.highlight-cards-heading {
 		display: flex;
 		flex-flow: nowrap;
 		align-items: center;

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -174,7 +174,7 @@ class WordAds extends Component {
 				<div className="stats">
 					<StatsPageHeader
 						page="ads"
-						subheaderText={ translate( 'See how ads are performing on your site.' ) }
+						subHeaderText={ translate( 'See how ads are performing on your site.' ) }
 					/>
 
 					{ ! canAccessAds && (

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -173,7 +173,7 @@ class WordAds extends Component {
 
 				<div className="stats">
 					<StatsPageHeader
-						page="ads"
+						page="wordads"
 						subHeaderText={ translate( 'See how ads are performing on your site.' ) }
 					/>
 

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -16,7 +16,6 @@ import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -30,6 +29,7 @@ import {
 } from 'calypso/state/ui/selectors';
 import PromoCards from '../promo-cards';
 import DatePicker from '../stats-date-picker';
+import StatsPageHeader from '../stats-page-header';
 import StatsPeriodHeader from '../stats-period-header';
 import StatsPeriodNavigation from '../stats-period-navigation';
 import WordAdsChartTabs from '../wordads-chart-tabs';
@@ -172,12 +172,9 @@ class WordAds extends Component {
 				/>
 
 				<div className="stats">
-					<FormattedHeader
-						brandFont
-						className="stats__section-header modernized-header"
-						headerText={ translate( 'Jetpack Stats' ) }
-						subHeaderText={ translate( 'See how ads are performing on your site.' ) }
-						align="left"
+					<StatsPageHeader
+						page="ads"
+						subheaderText={ translate( 'See how ads are performing on your site.' ) }
 					/>
 
 					{ ! canAccessAds && (

--- a/client/my-sites/store/app/store-stats/index.js
+++ b/client/my-sites/store/app/store-stats/index.js
@@ -23,6 +23,7 @@ import Module from './store-stats-module';
 import Chart from './store-stats-orders-chart';
 import WidgetList from './store-stats-widget-list';
 import { getEndPeriod, getQueries, getWidgetPath } from './utils';
+import StatsPageHeader from 'calypso/my-sites/stats/stats-page-header';
 
 class StoreStats extends Component {
 	static propTypes = {
@@ -66,11 +67,8 @@ class StoreStats extends Component {
 				) }
 
 				<div className="stats">
-					<FormattedHeader
-						brandFont
-						className="store-stats__section-header modernized-header"
-						headerText={ translate( 'Jetpack Stats' ) }
-						align="left"
+					<StatsPageHeader
+						page="store"
 						subHeaderText={ translate(
 							'Learn valuable insights about the purchases made on your store.'
 						) }

--- a/client/my-sites/store/app/store-stats/index.js
+++ b/client/my-sites/store/app/store-stats/index.js
@@ -8,12 +8,12 @@ import titlecase from 'to-title-case';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
-import FormattedHeader from 'calypso/components/formatted-header';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import DatePicker from 'calypso/my-sites/stats/stats-date-picker';
+import StatsPageHeader from 'calypso/my-sites/stats/stats-page-header';
 import StatsPeriodHeader from 'calypso/my-sites/stats/stats-period-header';
 import StatsPeriodNavigation from 'calypso/my-sites/stats/stats-period-navigation';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -23,7 +23,6 @@ import Module from './store-stats-module';
 import Chart from './store-stats-orders-chart';
 import WidgetList from './store-stats-widget-list';
 import { getEndPeriod, getQueries, getWidgetPath } from './utils';
-import StatsPageHeader from 'calypso/my-sites/stats/stats-page-header';
 
 class StoreStats extends Component {
 	static propTypes = {

--- a/packages/components/src/highlight-cards/index.tsx
+++ b/packages/components/src/highlight-cards/index.tsx
@@ -46,7 +46,7 @@ export default function HighlightCards( {
 
 	return (
 		<div className={ classNames( 'highlight-cards', className ?? null ) }>
-			<h1 className="highlight-cards-heading">
+			<h3 className="highlight-cards-heading">
 				{ translate( '7-day highlights' ) }{ ' ' }
 				<span
 					className="highlight-cards-heading-icon"
@@ -84,7 +84,7 @@ export default function HighlightCards( {
 						</div>
 					</div>
 				</Popover>
-			</h1>
+			</h3>
 
 			<div className="highlight-cards-list">
 				<HighlightCard


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/74321#issuecomment-1507512647

## Proposed Changes

* Adds a new component named "StatsPageHeader", which unifies all stats page headers into a single component.
* Updates traffic, insights, ads, GMB, store, and subscriber pages to use the new `StatsPageHeader`.
* Lowers the header hierarchy for "7-day highlights" and several ads page section headers to level 3.
* Converts the constants file used by StatsNavigation to TypeScript.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check the traffic, insights, ads, GMP, store, and subscriber pages to ensure that the pages continue to work as expected.
* For each page, check that the header hierarchies make more sense than prior to this change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
