### PR TITLE
Domains: Change `submitting` state when uploading the verification documents

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-verification-card.tsx
@@ -128,6 +128,7 @@ const ContactVerificationCard: FunctionComponent< Props > = ( props ) => {
 			return;
 		}
 
+		setSubmitting( true );
 		const formData: [ string, File, string ][] = [];
 		[ ...selectedFiles ].forEach( ( file: File ) => {
 			formData.push( [ 'files[]', file, file.name ] );


### PR DESCRIPTION
Super minor PR that adds the `busy` state to the "Submit" button. The state was already there, but it wasn't changed once we clicked on "Submit". This PR adds it 😬 

Related to #75096.

## Testing Instructions
- Hack the back end so that your domain gets requested for contact verification - this patch does it: 2fe2e-pb/#diff;
- Go to your domain management page;
- On the contact verification section, add any document;
- Click the "Submit" button and make sure the state/`busy` prop is changed correctly:

https://user-images.githubusercontent.com/18705930/232889134-65f78ceb-fc6e-444f-8eb4-a57cc07a3598.mov


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?