### PR TITLE
Remove site selection for payment method management in me/purchases

### DIFF
--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -110,19 +110,25 @@ export default ( router ) => {
 		clientRender
 	);
 
+	/**
+	 * The siteSelection middleware has been removed from this route.
+	 * No selected site!
+	 */
 	router(
 		paths.addPaymentMethod( ':site', ':purchaseId' ),
 		sidebar,
-		siteSelection,
 		controller.changePaymentMethod,
 		makeLayout,
 		clientRender
 	);
 
+	/**
+	 * The siteSelection middleware has been removed from this route.
+	 * No selected site!
+	 */
 	router(
 		paths.changePaymentMethod( ':site', ':purchaseId', ':cardId' ),
 		sidebar,
-		siteSelection,
 		controller.changePaymentMethod,
 		makeLayout,
 		clientRender

--- a/client/me/purchases/manage-purchase/change-payment-method/index.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.tsx
@@ -24,7 +24,6 @@ import {
 	hasLoadedUserPurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PaymentMethodSelector from '../payment-method-selector';
 import getPaymentMethodIdFromPayment from '../payment-method-selector/get-payment-method-id-from-payment';
 import useCreateAssignablePaymentMethods from './use-create-assignable-payment-methods';
@@ -46,14 +45,13 @@ function ChangePaymentMethod( {
 	const hasLoadedUserPurchases = useSelector( hasLoadedUserPurchasesFromServer );
 	const purchase = useSelector( ( state ) => getByPurchaseId( state, purchaseId ) );
 	const payment = useSelector( ( state ) => getByPurchaseId( state, purchaseId )?.payment );
-	const selectedSite = useSelector( getSelectedSite );
 	const { isLoading: isLoadingStoredCards } = useStoredPaymentMethods( { type: 'card' } );
 
 	const { isStripeLoading } = useStripe();
 
 	const isDataLoading =
 		! hasLoadedSites || ! hasLoadedUserPurchases || isLoadingStoredCards || isStripeLoading;
-	const isDataValid = purchase && selectedSite;
+	const isDataValid = purchase;
 
 	useEffect( () => {
 		if ( ! isDataLoading && ! isDataValid ) {

--- a/client/me/purchases/manage-purchase/change-payment-method/index.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.tsx
@@ -51,21 +51,20 @@ function ChangePaymentMethod( {
 
 	const isDataLoading =
 		! hasLoadedSites || ! hasLoadedUserPurchases || isLoadingStoredCards || isStripeLoading;
-	const isDataValid = purchase;
 
 	useEffect( () => {
-		if ( ! isDataLoading && ! isDataValid ) {
+		if ( ! isDataLoading && ! purchase ) {
 			// Redirect if invalid data
 			page( purchaseListUrl );
 		}
-	}, [ isDataLoading, isDataValid, purchaseListUrl ] );
+	}, [ isDataLoading, purchase, purchaseListUrl ] );
 
 	const currentPaymentMethodId = getPaymentMethodIdFromPayment( payment );
 	const changePaymentMethodTitle = getChangePaymentMethodTitleCopy( currentPaymentMethodId );
 	const paymentMethods = useCreateAssignablePaymentMethods( currentPaymentMethodId );
 	const reduxDispatch = useDispatch();
 
-	if ( isDataLoading || ! isDataValid ) {
+	if ( isDataLoading || ! purchase ) {
 		return (
 			<Fragment>
 				<QueryUserPurchases />

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -459,7 +459,11 @@ class ManagePurchase extends Component {
 	renderEditPaymentMethodNavItem() {
 		const { purchase, translate, siteSlug, getChangePaymentMethodUrlFor } = this.props;
 
-		if ( isPartnerPurchase( purchase ) || ! this.props.site ) {
+		if ( isPartnerPurchase( purchase ) ) {
+			return null;
+		}
+
+		if ( ! this.props.site && ! isAkismetTemporarySitePurchase( purchase ) ) {
 			return null;
 		}
 

--- a/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
@@ -35,7 +35,8 @@ function PurchaseMetaPaymentDetails( {
 	if (
 		! canEditPaymentDetails( purchase ) ||
 		! isPaidWithCreditCard( purchase ) ||
-		( ( ! site || ! siteSlug ) && ! isAkismetPurchase )
+		! siteSlug ||
+		( ! site && ! isAkismetPurchase )
 	) {
 		return <li>{ paymentDetails }</li>;
 	}

--- a/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
@@ -11,6 +11,7 @@ interface PaymentProps {
 	getChangePaymentMethodUrlFor: GetChangePaymentMethodUrlFor;
 	siteSlug?: string;
 	site?: string;
+	isAkismetPurchase: boolean;
 }
 
 function PurchaseMetaPaymentDetails( {
@@ -18,6 +19,7 @@ function PurchaseMetaPaymentDetails( {
 	getChangePaymentMethodUrlFor,
 	siteSlug,
 	site,
+	isAkismetPurchase,
 }: PaymentProps ) {
 	const { paymentMethods: cards } = useStoredPaymentMethods( { type: 'card' } );
 	const handleEditPaymentMethodClick = () => {
@@ -33,8 +35,7 @@ function PurchaseMetaPaymentDetails( {
 	if (
 		! canEditPaymentDetails( purchase ) ||
 		! isPaidWithCreditCard( purchase ) ||
-		! site ||
-		! siteSlug
+		( ( ! site || ! siteSlug ) && ! isAkismetPurchase )
 	) {
 		return <li>{ paymentDetails }</li>;
 	}

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -59,7 +59,7 @@ export default function PurchaseMeta( {
 	}
 
 	const showJetpackUserLicense = isJetpackProduct( purchase ) || isJetpackPlan( purchase );
-	const showAkismetApiKey = isAkismetTemporarySitePurchase( purchase );
+	const isAkismetPurchase = isAkismetTemporarySitePurchase( purchase );
 
 	const renewalPriceHeader =
 		getLocaleSlug().startsWith( 'en' ) || i18n.hasTranslation( 'Renewal Price' )
@@ -91,10 +91,11 @@ export default function PurchaseMeta( {
 					getChangePaymentMethodUrlFor={ getChangePaymentMethodUrlFor }
 					siteSlug={ siteSlug }
 					site={ site }
+					isAkismetPurchase={ isAkismetPurchase }
 				/>
 			</ul>
 			{ showJetpackUserLicense && <PurchaseJetpackUserLicense purchaseId={ purchaseId } /> }
-			{ showAkismetApiKey && <PurchaseAkismetApiKey /> }
+			{ isAkismetPurchase && <PurchaseAkismetApiKey /> }
 			<RenewErrorMessage purchase={ purchase } translate={ translate } site={ site } />
 		</>
 	);


### PR DESCRIPTION
Related to #75927

## Proposed Changes

* Adds a way to add or change payment methods for a siteless purchase (including Akismet)

## Testing Instructions

* Purchase a product from Akismet.com
* Navigate to /me/purchases and find your purchase in the list - click on it to go to the purchase management screen
* From the purchase management screen, you should now have the button/ action to change your payment method

![Screenshot 2023-04-18 at 6 02 10 PM](https://user-images.githubusercontent.com/18016357/232915975-713d2c74-ddca-4afd-b143-60551996163d.png)

* Test Jetpack and WordPress.com purchases as well from /me/purchases to make sure managing payment methods works as expected
* Test that payment management works as expected when accessed from the /my-sites/ routes (managing a purchase with a specific site selected in the site selector)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
