### PR TITLE
Fix checkout notice for Jetpack version 8.5 or older

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/jetpack-plugin-required-version-notice.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/prepurchase-notices/jetpack-plugin-required-version-notice.jsx
@@ -18,7 +18,7 @@ const getMessage = ( translate, product, siteVersion, minVersion ) => {
 					minVersion: minVersion,
 				},
 				components: {
-					productName: displayName,
+					productName: <>{ displayName }</>,
 					strong: <strong />,
 				},
 			}
@@ -33,7 +33,7 @@ const getMessage = ( translate, product, siteVersion, minVersion ) => {
 				siteVersion: siteVersion,
 			},
 			components: {
-				productName: displayName,
+				productName: <>{ displayName }</>,
 				strong: <strong />,
 			},
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/75895 (1202858161751496-as-1204424595934524)

## Proposed Changes

* `JetpackPluginRequiredVersionNotice` only returns the correct notice if the name of the product is a `TranslateResult` and not a `string`. Thus, this patch adds support for strings by wrapping the result of `getJetpackProductDisplayName( product );` in `<>`. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install Jetpack version 8.5 or older.
* Go to checkout with Jetpack VaultPress Backup in the cart.
* Observe the notice at the top and verify it looks correct.

#### Demo — before
![image](https://user-images.githubusercontent.com/3418513/232922521-30e6669c-3ed1-4af7-ba9d-63ad771c8925.png)

#### Demo — after
<img width="572" alt="image" src="https://user-images.githubusercontent.com/3418513/232922564-a45a1f93-a8e5-44f0-8091-8f15928765b9.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?