### PR TITLE
Help Center: Comment out Launchpad api request

### DIFF
--- a/packages/help-center/src/components/help-center-launchpad.tsx
+++ b/packages/help-center/src/components/help-center-launchpad.tsx
@@ -8,7 +8,7 @@ import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { useLaunchpadChecklist } from '../hooks/use-launchpad';
+// import { useLaunchpadChecklist } from '../hooks/use-launchpad';
 import { SITE_STORE } from '../stores';
 import type { SiteSelect } from '@automattic/data-stores';
 
@@ -44,10 +44,12 @@ export const HelpCenterLaunchpad = () => {
 		siteSlug = window?.location?.host;
 	}
 
-	const { data } = useLaunchpadChecklist( siteSlug, siteIntent || '' );
-	const totalLaunchpadSteps = data?.checklist?.length || 4;
-	const completeLaunchpadSteps =
-		data?.checklist?.filter( ( checklistItem ) => checklistItem.completed ).length || 1;
+	// We are commenting this out temporarily while we wait
+	// for new endpoint in jetpack-mu-wpcom to be deployed.
+	// const { data } = useLaunchpadChecklist( siteSlug, siteIntent || '' );
+	// const totalLaunchpadSteps = data?.checklist?.length || 4;
+	// const completeLaunchpadSteps =
+	// 	data?.checklist?.filter( ( checklistItem ) => checklistItem.completed ).length || 1;
 
 	const launchpadURL = `${ getEnvironmentHostname() }/setup/${ siteIntent }/launchpad?siteSlug=${ siteSlug }`;
 	const sectionName = useSelector( ( state ) => getSectionName( state ) );
@@ -75,11 +77,7 @@ export const HelpCenterLaunchpad = () => {
 					handleLaunchpadHelpLinkClick();
 				} }
 			>
-				<CircularProgressBar
-					size={ 32 }
-					currentStep={ completeLaunchpadSteps }
-					numberOfSteps={ totalLaunchpadSteps }
-				/>
+				<CircularProgressBar size={ 32 } currentStep={ 1 } numberOfSteps={ 4 } />
 				<span className="inline-help-launchpad-link-text">
 					{ __( 'Continue setting up your site with these next steps.' ) }
 				</span>


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/Automattic/wp-calypso/pull/75575

The above commit made the Help Center Launchpad Icon dynamic based on data fetched from a new endpoint. That endpoint has been merged to Jetpack for a week, but is not deployed yet to WordPress.com. While the request fails gracefully and the component renders correctly, we've decided to comment out the api request until the associated endpoint is deployed to avoid potential noise on the failed api request in Sentry or other places. 

### Testing Instructions

Review Time: Short
Testing Time: Short

1. Checkout this branch and run `yarn` and `yarn start` if needed. 
2. Go to any Launchpad-enabled site and go to the posts page: `http://calypso.localhost:3000/posts/SITESLUG`
3. Click on the Help Center (question mark) icon in the upper right, and confirm a) that the help center loads correctly, b) that the launchpad icon shows with 25% progress (hard coded default), and c) that there are no errors or failed requests in the dev tools > network tab. 