### PR TITLE
Odyssey Widget: make legend not clickable

### DIFF
--- a/apps/odyssey-stats/src/widget/mini-chart.jsx
+++ b/apps/odyssey-stats/src/widget/mini-chart.jsx
@@ -6,6 +6,7 @@ import Chart from 'calypso/components/chart';
 import Legend from 'calypso/components/chart/legend';
 import { buildChartData } from 'calypso/my-sites/stats/stats-chart-tabs/utility';
 import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
+import nothing from '../components/nothing';
 import useVisitsQuery from '../hooks/use-visits-query';
 
 import './mini-chart.scss';
@@ -52,7 +53,7 @@ const MiniChart = ( { siteId, quantity = 7, gmtOffset, odysseyStatsBaseUrl } ) =
 					activeCharts={ [ 'visitors' ] }
 					tabs={ CHARTS }
 					activeTab={ CHART_VIEWS }
-					clickHandler={ null }
+					clickHandler={ nothing }
 				/>
 			</div>
 			{ ( isLoading || ! ( chartData?.length > 0 ) ) && (

--- a/apps/odyssey-stats/src/widget/mini-chart.scss
+++ b/apps/odyssey-stats/src/widget/mini-chart.scss
@@ -25,6 +25,10 @@ $barDarkColor: var(--color-primary-60);
 			display: none;
 		}
 
+		.chart__legend-label.is-selectable.form-label {
+			cursor: auto;
+		}
+
 		.chart__legend-color {
 			width: 14px;
 			height: 14px;


### PR DESCRIPTION
## Proposed Changes

Fix the on click handler, and changes cursor from pointer to auto.

## Testing Instructions

* Click 'Vistor' legend in the widget
* Ensure no error in console
* Hover cursor on Vistor legend
* Ensure the cursor is not a pointer

<img width="664" alt="image" src="https://user-images.githubusercontent.com/1425433/232956788-c3158685-27bc-45e0-a284-7ca8c23b3f05.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
