### PR TITLE
Pattern Assembler: Update copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -1,6 +1,7 @@
 import { PatternRenderer } from '@automattic/block-renderer';
 import { DeviceSwitcher } from '@automattic/components';
 import { useStyle } from '@automattic/global-styles';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
 import { Icon, layout } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -43,6 +44,7 @@ const PatternLargePreview = ( {
 	recordTracksEvent,
 }: Props ) => {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const navigator = useNavigator();
 	const hasSelectedPattern = header || sections.length || footer;
 	const shouldShowSelectPatternHint =
@@ -65,6 +67,33 @@ const PatternLargePreview = ( {
 		event.preventDefault();
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.LARGE_PREVIEW_ADD_HEADER_BUTTON_CLICK );
 		goToSelectHeaderPattern();
+	};
+
+	const getDescription = () => {
+		if ( ! shouldShowSelectPatternHint ) {
+			return translate( "It's time to get creative. Add your first pattern to get started." );
+		}
+
+		const options = {
+			components: {
+				link: (
+					// eslint-disable-next-line jsx-a11y/anchor-is-valid
+					<a href="#" target="_blank" rel="noopener noreferrer" onClick={ handleAddHeaderClick } />
+				),
+			},
+		};
+
+		return hasEnTranslation(
+			'You can view your color and font selections after you select a pattern. Get started by {{link}}adding a header pattern{{/link}}'
+		)
+			? translate(
+					'You can view your color and font selections after you select a pattern. Get started by {{link}}adding a header pattern{{/link}}',
+					options
+			  )
+			: translate(
+					'You can view your color and font selections after you select a pattern, get started by {{link}}adding a header pattern{{/link}}',
+					options
+			  );
 	};
 
 	const renderPattern = ( type: string, pattern: Pattern, position = -1 ) => {
@@ -185,26 +214,7 @@ const PatternLargePreview = ( {
 				<div className="pattern-large-preview__placeholder">
 					<Icon className="pattern-large-preview__placeholder-icon" icon={ layout } size={ 72 } />
 					<h2>{ translate( 'Welcome to your blank canvas' ) }</h2>
-					<span>
-						{ shouldShowSelectPatternHint
-							? translate(
-									'You can view your color and font selections after you select a pattern, get started by {{link}}adding a header pattern{{/link}}',
-									{
-										components: {
-											link: (
-												// eslint-disable-next-line jsx-a11y/anchor-is-valid
-												<a
-													href="#"
-													target="_blank"
-													rel="noopener noreferrer"
-													onClick={ handleAddHeaderClick }
-												/>
-											),
-										},
-									}
-							  )
-							: translate( "It's time to get creative. Add your first pattern to get started." ) }
-					</span>
+					<span>{ getDescription() }</span>
 				</div>
 			) }
 		</DeviceSwitcher>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-color-palettes.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import { ColorPaletteVariations } from '@automattic/global-styles';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { __experimentalNavigatorBackButton as NavigatorBackButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import NavigatorHeader from './navigator-header';
@@ -23,14 +24,23 @@ const ScreenColorPalettes = ( {
 	onDoneClick,
 }: Props ) => {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 
 	return (
 		<>
 			<NavigatorHeader
 				title={ translate( 'Colors' ) }
-				description={ translate(
-					'Select from our curated color palettes or tweak to your heart’s content when you upgrade to the Premium plan or higher.'
-				) }
+				description={
+					hasEnTranslation(
+						'Choose from our curated color palettes when you upgrade to the Premium plan or above.'
+					)
+						? translate(
+								'Choose from our curated color palettes when you upgrade to the Premium plan or above.'
+						  )
+						: translate(
+								'Select from our curated color palettes or tweak to your heart’s content when you upgrade to the Premium plan or higher.'
+						  )
+				}
 				isPremium
 				onBack={ onBack }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-font-pairings.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import { FontPairingVariations } from '@automattic/global-styles';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { __experimentalNavigatorBackButton as NavigatorBackButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import NavigatorHeader from './navigator-header';
@@ -23,14 +24,23 @@ const ScreenFontPairings = ( {
 	onDoneClick,
 }: Props ) => {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 
 	return (
 		<>
 			<NavigatorHeader
 				title={ translate( 'Fonts' ) }
-				description={ translate(
-					'Select from our hand-picked font pairings or expanded library when you upgrade to the Premium plan or higher.'
-				) }
+				description={
+					hasEnTranslation(
+						'Choose from our curated font pairings when you upgrade to the Premium plan or above.'
+					)
+						? translate(
+								'Choose from our curated font pairings when you upgrade to the Premium plan or above.'
+						  )
+						: translate(
+								'Select from our hand-picked font pairings or expanded library when you upgrade to the Premium plan or higher.'
+						  )
+				}
 				isPremium
 				onBack={ onBack }
 			/>

--- a/packages/i18n-utils/src/index.ts
+++ b/packages/i18n-utils/src/index.ts
@@ -4,7 +4,13 @@ export {
 	withLocalizeUrl,
 	urlLocalizationMapping,
 } from './localize-url';
-export { LocaleProvider, useLocale, withLocale, useIsEnglishLocale } from './locale-context';
+export {
+	LocaleProvider,
+	useLocale,
+	withLocale,
+	useIsEnglishLocale,
+	useHasEnTranslation,
+} from './locale-context';
 export * from './locales';
 export { default as guessTimezone } from './guess-timezone';
 export * from './utils';

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -1,6 +1,6 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
 import * as i18n from '@wordpress/i18n';
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import * as React from 'react';
 import { englishLocales } from './locales';
 import type { Locale } from './locales';
@@ -123,4 +123,15 @@ export const withLocale = createHigherOrderComponent(
 export function useIsEnglishLocale(): boolean {
 	const locale = useLocale();
 	return englishLocales.includes( locale );
+}
+
+type HasTranslation = ( single: string, context?: string, domain?: string ) => boolean;
+
+export function useHasEnTranslation(): HasTranslation {
+	const isEnglishLocale = useIsEnglishLocale();
+
+	return useCallback(
+		( ...args ) => isEnglishLocale || i18n.hasTranslation( ...args ),
+		[ isEnglishLocale ]
+	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/75871, https://github.com/Automattic/wp-calypso/pull/75110#issuecomment-1514047876

## Proposed Changes

* Add a new hook called `useHasEnTranslation` to return the `hasEnTranslation` function so we can simply use it to check whether the locale is en or we have the translation
* Update the copy to make it clear

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/13596067/232966199-efae089a-5a75-4cae-8202-66472c78cd42.png) | ![image](https://user-images.githubusercontent.com/13596067/232966106-7db7b2a7-c80d-4693-8433-813be1712663.png) |
| ![image](https://user-images.githubusercontent.com/13596067/232966237-64121dca-aaaf-448e-ad59-3280164b3ac0.png) | ![image](https://user-images.githubusercontent.com/13596067/232966077-67b82b8d-2f2c-41b4-be4a-0c0b7960c522.png) |
| ![image](https://user-images.githubusercontent.com/13596067/232966285-85911fc6-947a-4051-96ea-2b4667983066.png) | ![image](https://user-images.githubusercontent.com/13596067/232966135-17183eb4-49e3-4ef4-a237-3092c7ff7234.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/site-setup?siteSlug=<your_free_site>
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Select `Colors` and verify the copy is update-to-date
  * Select `Fonts` and verify the copy is update-to-date
  * Verify the copy on the large preview is update-to-date

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
