### PR TITLE
Add a sample component to the root Storybook (component with redux state)

### DIFF
--- a/.storybook/index.scss
+++ b/.storybook/index.scss
@@ -1,0 +1,9 @@
+@import "@automattic/calypso-color-schemes";
+
+// Calypso style needs these variables
+@import "@automattic/typography/styles/variables";
+// stylelint-disable-next-line scss/at-import-no-partial-leading-underscore
+@import "../client/assets/stylesheets/shared/mixins/_breakpoints.scss";
+
+// Calypso style
+@import "../client/assets/stylesheets/style.scss";

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,5 +1,17 @@
+const sharedConfig = require( '../config/_shared.json' );
+const devConfig = require( '../config/development.json' );
 const storybookDefaultConfig = require( '@automattic/calypso-storybook' );
 
-module.exports = storybookDefaultConfig( {
+const storybookConfig = storybookDefaultConfig( {
 	stories: [ '../client/**/*.stories.{ts,tsx}' ],
 } );
+
+const configData = { ...sharedConfig, ...devConfig };
+storybookConfig.previewHead = ( head ) => `
+	${ head }
+	<script>
+		window.configData = ${ JSON.stringify( configData ) };
+	</script>
+`;
+
+module.exports = storybookConfig;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,1 +1,5 @@
-import '@wordpress/components/build-style/style.css';
+import './index.scss';
+
+export const parameters = {
+	layout: 'fullscreen',
+};

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
 				],
 			},
 		],
+		'jest/no-mocks-import': 'off',
 	},
 	overrides: [
 		{

--- a/client/__mocks__/storybook/redux.tsx
+++ b/client/__mocks__/storybook/redux.tsx
@@ -1,0 +1,25 @@
+import { FC } from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+/**
+ * Store mock for DocumentHead.
+ *
+ * @see https://github.com/Automattic/wp-calypso/blob/2186d1580ada4812c72eaa1fe799f90efa0b9642/client/components/data/document-head/index.jsx#L17
+ */
+export const documentHeadStoreMock = {
+	documentHead: { title: 'title' },
+	ui: { section: '', selectedSiteId: 0 },
+};
+
+const mockStore = configureStore();
+
+export const ReduxDecorator: FC< {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	store: Record< string, any >;
+} > = ( { children, store } ) => {
+	const _store = mockStore( {
+		...store,
+	} );
+	return <Provider store={ _store }>{ children }</Provider>;
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.stories.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.stories.tsx
@@ -3,9 +3,13 @@ import { Story, Meta } from '@storybook/react';
 import { ComponentProps } from 'react';
 import { documentHeadStoreMock, ReduxDecorator } from 'calypso/__mocks__/storybook/redux';
 import ScreenCategoryList from './screen-category-list';
+
+/**
+ * FIXME: This component should depend only on local `./style.scss`.
+ */
 import '../../../internals/global.scss';
-import './style.scss';
 import './navigator-buttons/style.scss';
+import './style.scss';
 
 export default {
 	title: 'client/landing/pattern-assembler/ScreenCategoryList',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.stories.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.stories.tsx
@@ -1,0 +1,144 @@
+import { action } from '@storybook/addon-actions';
+import { Story, Meta } from '@storybook/react';
+import { ComponentProps } from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import ScreenCategoryList from './screen-category-list';
+import '../../../internals/global.scss';
+import './style.scss';
+import './navigator-buttons/style.scss';
+
+export default {
+	title: 'client/pattern-assembler/ScreenCategoryList',
+	// 'client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/ScreenCategoryList',
+	component: ScreenCategoryList,
+} as Meta;
+
+const mockStore = configureStore();
+/**
+ * Store mock for DocumentHead.
+ *
+ * @see https://github.com/Automattic/wp-calypso/blob/2186d1580ada4812c72eaa1fe799f90efa0b9642/client/components/data/document-head/index.jsx#L17
+ */
+const documentHeadStoreMock = {
+	documentHead: { title: 'title' },
+	ui: { section: '', selectedSiteId: 0 },
+};
+const store = mockStore( {
+	...documentHeadStoreMock,
+} );
+
+type ScreenCategoryListStory = Story< ComponentProps< typeof ScreenCategoryList > >;
+const Template: ScreenCategoryListStory = ( args ) => (
+	<Provider store={ store }>
+		<div
+			className="pattern-assembler"
+			/**
+			 * The following style is for fixing the position of the PatternListPanel.
+			 * It depends on `348px` since it uses `margin-inline-start: 348px;` for its position.
+			 */
+			style={ { width: '348px', padding: '32px', boxSizing: 'border-box' } }
+		>
+			<ScreenCategoryList { ...args } />
+		</div>
+	</Provider>
+);
+
+const defaultArgs = {
+	categories: [
+		{ name: 'about', label: 'About', description: 'Introduce yourself.' },
+		{ name: 'blog', label: 'Blog' },
+	],
+	patternsMapByCategory: {
+		about: [
+			{
+				ID: 7814,
+				site_id: 174455321,
+				title: 'Hero with Heading and Cover Image',
+				name: 'hero-with-heading-and-cover-image',
+				description: '',
+				html: '<div>test</div>',
+				categories: { about: { slug: 'about', title: 'About', description: '' } },
+				virtual_theme_categories: [],
+				tags: { pattern: { slug: 'pattern', title: 'Pattern', description: '' } },
+				pattern_meta: { is_web: true },
+				source_url: 'https://dotcompatterns.wordpress.com/?p=7814',
+				modified_date: '2022-11-30 09:20:46',
+			},
+			{
+				ID: 6306,
+				site_id: 174455321,
+				title: 'Team',
+				name: 'team-4',
+				description: '',
+				html: '<div>test</div>',
+				categories: {
+					about: { slug: 'about', title: 'About', description: '' },
+					wireframe: { slug: 'wireframe', title: 'Wireframe', description: '' },
+				},
+				virtual_theme_categories: [],
+				tags: { pattern: { slug: 'pattern', title: 'Pattern', description: '' } },
+				pattern_meta: { is_web: true },
+				source_url: 'https://blockpatterns.mystagingwebsite.com/?p=64',
+				modified_date: '2023-03-29 07:25:38',
+			},
+		],
+		blog: [
+			{
+				ID: 3681,
+				site_id: 174455321,
+				title: 'Blog',
+				name: 'blog-8',
+				description: '',
+				html: '<div>test</div>',
+				categories: {
+					blog: { slug: 'blog', title: 'Blog', description: '' },
+					featured: { slug: 'featured', title: 'Featured', description: '' },
+				},
+				virtual_theme_categories: [],
+				tags: {
+					layout: { slug: 'layout', title: 'Layout', description: '' },
+					pattern: { slug: 'pattern', title: 'Pattern', description: '' },
+				},
+				pattern_meta: { is_mobile: true, is_web: true },
+				source_url: 'https://dotcompatterns.wordpress.com/?p=3681',
+				modified_date: '2023-02-10 13:55:09',
+			},
+			{
+				ID: 1593,
+				site_id: 174455321,
+				title: 'Heading and Three Images',
+				name: 'heading-and-three-images',
+				description: '',
+				html: '<div>test</div>',
+				categories: {
+					blog: { slug: 'blog', title: 'Blog', description: '' },
+					featured: { slug: 'featured', title: 'Featured', description: '' },
+				},
+				virtual_theme_categories: [],
+				tags: { pattern: { slug: 'pattern', title: 'Pattern', description: '' } },
+				pattern_meta: { is_web: true },
+				source_url: 'https://dotcompatterns.wordpress.com/?p=1593',
+				modified_date: '2022-10-04 16:38:31',
+			},
+		],
+	},
+	replacePatternMode: false,
+	selectedPattern: null,
+	wrapperRef: null,
+	onDoneClick: action( 'onDoneClick' ),
+	onSelect: action( 'onSelect' ),
+	onTogglePatternPanelList: action( 'onTogglePatternPanelList' ),
+	recordTracksEvent: action( 'recordTracksEvent' ),
+};
+
+export const AddPattern = Template.bind( {} );
+AddPattern.args = {
+	...defaultArgs,
+};
+
+export const ReplacePattern = Template.bind( {} );
+ReplacePattern.args = {
+	...defaultArgs,
+	replacePatternMode: true,
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.stories.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.stories.tsx
@@ -1,8 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import { Story, Meta } from '@storybook/react';
 import { ComponentProps } from 'react';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
+import { documentHeadStoreMock, ReduxDecorator } from 'calypso/__mocks__/storybook/redux';
 import ScreenCategoryList from './screen-category-list';
 import '../../../internals/global.scss';
 import './style.scss';
@@ -11,37 +10,33 @@ import './navigator-buttons/style.scss';
 export default {
 	title: 'client/landing/pattern-assembler/ScreenCategoryList',
 	component: ScreenCategoryList,
+	decorators: [
+		( Story ) => {
+			return (
+				<ReduxDecorator store={ { ...documentHeadStoreMock } }>
+					<Story></Story>
+				</ReduxDecorator>
+			);
+		},
+		( Story ) => {
+			return (
+				<div
+					className="pattern-assembler"
+					/**
+					 * The following style is for fixing the position of the PatternListPanel.
+					 * It depends on `348px` since it uses `margin-inline-start: 348px;` for its position.
+					 */
+					style={ { width: '348px', padding: '32px', boxSizing: 'border-box' } }
+				>
+					<Story></Story>
+				</div>
+			);
+		},
+	],
 } as Meta;
 
-const mockStore = configureStore();
-/**
- * Store mock for DocumentHead.
- *
- * @see https://github.com/Automattic/wp-calypso/blob/2186d1580ada4812c72eaa1fe799f90efa0b9642/client/components/data/document-head/index.jsx#L17
- */
-const documentHeadStoreMock = {
-	documentHead: { title: 'title' },
-	ui: { section: '', selectedSiteId: 0 },
-};
-const store = mockStore( {
-	...documentHeadStoreMock,
-} );
-
 type ScreenCategoryListStory = Story< ComponentProps< typeof ScreenCategoryList > >;
-const Template: ScreenCategoryListStory = ( args ) => (
-	<Provider store={ store }>
-		<div
-			className="pattern-assembler"
-			/**
-			 * The following style is for fixing the position of the PatternListPanel.
-			 * It depends on `348px` since it uses `margin-inline-start: 348px;` for its position.
-			 */
-			style={ { width: '348px', padding: '32px', boxSizing: 'border-box' } }
-		>
-			<ScreenCategoryList { ...args } />
-		</div>
-	</Provider>
-);
+const Template: ScreenCategoryListStory = ( args ) => <ScreenCategoryList { ...args } />;
 
 const defaultArgs = {
 	categories: [

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.stories.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.stories.tsx
@@ -9,8 +9,7 @@ import './style.scss';
 import './navigator-buttons/style.scss';
 
 export default {
-	title: 'client/pattern-assembler/ScreenCategoryList',
-	// 'client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/ScreenCategoryList',
+	title: 'client/landing/pattern-assembler/ScreenCategoryList',
 	component: ScreenCategoryList,
 } as Meta;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -1,3 +1,4 @@
+@import "@automattic/typography/styles/variables";
 @import "./keyframes";
 
 @font-face {

--- a/client/package.json
+++ b/client/package.json
@@ -218,6 +218,7 @@
 		"@testing-library/react-hooks": "7.0.2",
 		"@testing-library/user-event": "^14.2.0",
 		"@types/jest": "^27.4.0",
+		"@types/redux-mock-store": "1.0.3",
 		"autoprefixer": "^10.2.5",
 		"component-event": "^0.2.0",
 		"component-query": "^0.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7093,6 +7093,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/redux-mock-store@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@types/redux-mock-store@npm:1.0.3"
+  dependencies:
+    redux: ^4.0.5
+  checksum: 5027e4ecd654efc8b98418c41e9286c257db54206943ee2f541d751f6579e740b733597d58d1a79df133da0693f8c34772e6bed85c5ef6d9ae8636d342d7df88
+  languageName: node
+  linkType: hard
+
 "@types/resolve@npm:0.0.8":
   version: 0.0.8
   resolution: "@types/resolve@npm:0.0.8"
@@ -11674,6 +11683,7 @@ __metadata:
     "@testing-library/react-hooks": 7.0.2
     "@testing-library/user-event": ^14.2.0
     "@types/jest": ^27.4.0
+    "@types/redux-mock-store": 1.0.3
     "@wordpress/a11y": ^3.22.0
     "@wordpress/api-fetch": ^6.19.0
     "@wordpress/base-styles": ^4.13.0
@@ -27556,7 +27566,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"redux@npm:^4.0.0, redux@npm:^4.0.4, redux@npm:^4.1.2, redux@npm:^4.2.0":
+"redux@npm:^4.0.0, redux@npm:^4.0.4, redux@npm:^4.0.5, redux@npm:^4.1.2, redux@npm:^4.2.0":
   version: 4.2.1
   resolution: "redux@npm:4.2.1"
   dependencies:


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/75167

## Proposed Changes

* Add a story for `ScreenCategoryList` (in the Site Assembler)
* This can be a sample story for components with redux state

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn storybook:start` locally
* Access to http://localhost:6006/?path=/story/client-landing-pattern-assembler-screencategorylist--add-pattern

https://user-images.githubusercontent.com/5287479/232984143-357c3b56-7526-4e65-854f-bff6ea63283d.mov

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
