### PR TITLE
Improve visual style on /tags page

### DIFF
--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -21,9 +21,12 @@ const commonDefaultProps = {
 };
 
 export function calculateOffset() {
-	// Offset to account for Masterbar
 	const headerEl = document.getElementById( 'header' );
-	return headerEl ? headerEl.getBoundingClientRect().height : 0;
+	// Offset to account for Masterbar if it is fixed position
+	if ( headerEl && getComputedStyle( headerEl ).position === 'fixed' ) {
+		return headerEl.getBoundingClientRect().height;
+	}
+	return 0;
 }
 
 export function getBlockStyle( state ) {

--- a/client/components/sticky-panel/test/index.js
+++ b/client/components/sticky-panel/test/index.js
@@ -13,6 +13,7 @@ beforeAll( () => {
 		.spyOn( document, 'getElementById' )
 		.mockImplementation( ( id ) => ( id === 'header' ? header : null ) );
 	jest.spyOn( ReactDom, 'findDOMNode' ).mockImplementation( ( node ) => node );
+	jest.spyOn( window, 'getComputedStyle' ).mockImplementation( () => ( { position: 'fixed' } ) );
 } );
 
 describe( 'calculateOffset', () => {

--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import titlecase from 'to-title-case';
+import StickyPanel from 'calypso/components/sticky-panel';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { AlphabeticTagsResult, Tag } from './controller';
@@ -102,20 +103,22 @@ export default function AlphabeticTags( { alphabeticTags }: AlphabeticTagsProps 
 
 	return (
 		<>
-			<div className="alphabetic-tags__header">
-				<h2>{ translate( 'Tags from A — Z' ) }</h2>
-				<div className="alphabetic-tags__tag-links">
-					{ Object.keys( tagTables ).map( ( letter: string ) => (
-						<Button
-							isLink
-							key={ 'alphabetic-tags-link-' + letter }
-							onClick={ () => scrollToLetter( letter ) }
-						>
-							{ letter }
-						</Button>
-					) ) }
+			<StickyPanel>
+				<div className="alphabetic-tags__header">
+					<h2>{ translate( 'Tags from A — Z' ) }</h2>
+					<div className="alphabetic-tags__tag-links">
+						{ Object.keys( tagTables ).map( ( letter: string ) => (
+							<Button
+								isLink
+								key={ 'alphabetic-tags-link-' + letter }
+								onClick={ () => scrollToLetter( letter ) }
+							>
+								{ letter }
+							</Button>
+						) ) }
+					</div>
 				</div>
-			</div>
+			</StickyPanel>
 			{ Object.keys( tagTables ).map( ( letter: string ) => (
 				<div className="alphabetic-tags__table" key={ 'alphabetic-tags-table-' + letter }>
 					{ /* eslint-disable jsx-a11y/no-noninteractive-tabindex */ }

--- a/client/reader/tags/controller.tsx
+++ b/client/reader/tags/controller.tsx
@@ -43,10 +43,10 @@ function renderHeaderSection() {
 			<h1>
 				{
 					// translators: The title of the reader trending tags page
-					translate( 'Tags' )
+					translate( 'All the Tags' )
 				}
 			</h1>
-			<p>{ translate( 'Discover unique topics, follow your interests, or start writing.' ) }</p>
+			<p>{ translate( "For every one of your interests, there's a tag on WordPress.com." ) }</p>
 		</>
 	);
 }

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -34,6 +34,10 @@
 	margin-bottom: 15px;
 }
 
+.trending-tags__container {
+	padding-bottom: 58px;
+}
+
 .trending-tags__row {
 	padding: 0;
 
@@ -84,12 +88,12 @@
 	}
 }
 .alphabetic-tags__header {
-	padding-top: 72px;
+	background: var(--studio-white);
+	padding-top: 20px;
 	padding-bottom: 10px;
 	border-bottom: 1px solid var(--studio-gray-5);
 	margin-bottom: 26px;
 	padding-left: 10px;
-	position: sticky;
 
 	@include break-small {
 		padding-left: 0;

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -6,6 +6,8 @@
 }
 
 .layout.has-header-section.is-section-reader .layout__header-section-content {
+	max-width: 1140px;
+	margin: 0 auto;
 	h1 {
 		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
 		font-size: 60px; /* stylelint-disable-line declaration-property-unit-allowed-list */
@@ -26,6 +28,10 @@
 	@include break-medium {
 		padding-left: 108px;
 		padding-right: 108px;
+	}
+	@include break-wide {
+		padding-left: 0;
+		padding-right: 0;
 	}
 }
 

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -20,6 +20,9 @@
 .has-no-sidebar .layout__content {
 	padding-left: 24px;
 	padding-right: 24px;
+	max-width: 1140px;
+	margin: 0 auto;
+
 	@include break-medium {
 		padding-left: 108px;
 		padding-right: 108px;
@@ -86,6 +89,8 @@
 	border-bottom: 1px solid var(--studio-gray-5);
 	margin-bottom: 26px;
 	padding-left: 10px;
+	position: sticky;
+
 	@include break-small {
 		padding-left: 0;
 	}
@@ -146,6 +151,8 @@
 	.alphabetic-tags__letter-title {
 		font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		margin-bottom: 22px;
+		font-weight: 500;
+
 		&:focus-visible {
 			text-decoration: underline;
 		}
@@ -170,7 +177,12 @@
 			a {
 				color: var(--studio-gray-80);
 				font-weight: 400;
+				display: inline-block;
+				border-bottom: 1px solid transparent;
 
+				&:hover {
+					border-bottom: 1px solid var(--studio-gray-80);
+				}
 				&:focus {
 					outline: none;
 				}

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -6,8 +6,19 @@
 }
 
 .layout.has-header-section.is-section-reader .layout__header-section-content {
+	box-sizing: border-box;
 	max-width: 1140px;
 	margin: 0 auto;
+
+	@include break-medium {
+		padding-left: 108px;
+		padding-right: 108px;
+	}
+	@include break-wide {
+		padding-left: 0;
+		padding-right: 0;
+	}
+
 	h1 {
 		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
 		font-size: 60px; /* stylelint-disable-line declaration-property-unit-allowed-list */

--- a/client/reader/tags/trending-tags.tsx
+++ b/client/reader/tags/trending-tags.tsx
@@ -46,7 +46,7 @@ export default function TrendingTags( { trendingTags }: TrendingTagsProps ) {
 	}
 
 	return (
-		<div>
+		<div className="trending-tags__container">
 			{ tagRows.map( ( tagRow: TagResult[], index ) => (
 				<div className="trending-tags__row" key={ 'tags-row-' + index }>
 					<TagRow


### PR DESCRIPTION
Addresses some feedback on the /tags page from @ollierozdarz
 
> * I think give the contents a max-width, same as in the design (1140px). On a big monitor it's far too stretched out
> * The idea was to make the A-Z list position: sticky once it hits the top of the viewport. Would be cool to see that working.
> * We should give the tags themselves a hover state (especially all of those in the A-Z). A simple border-bottom: 1px solid grey100; (or similar)
> * The large Letter at the start of each tag section should be font-weight: medium;
> * Content marketing gave us a new title for the page: All the Tags and subtitle For every one of your interests, there's a  tag on [WordPress.com](http://wordpress.com/).

#### Testing instructions

The only interesting change I see is making the sticky panel test for whether the header is fixed position or not. I manually tested that change on the /tags page by setting the header back to `position:fixed`. In code I found references to stickypanel on the themes and media library components, but I couldn't see it in use on wordpress.com