### PR TITLE
AT E2E: use separate comments for like and unlike operations.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/comments-component.ts
+++ b/packages/calypso-e2e/src/lib/components/comments-component.ts
@@ -87,6 +87,7 @@ export class CommentsComponent {
 		}
 
 		await this.page.getByText( comment ).scrollIntoViewIfNeeded();
+		await likeButton.waitFor();
 		await likeButton.click();
 		await likedStatus.waitFor();
 	}
@@ -118,6 +119,7 @@ export class CommentsComponent {
 		}
 
 		await this.page.getByText( comment ).scrollIntoViewIfNeeded();
+		await unlikeButton.waitFor();
 		await unlikeButton.click();
 		await unlikedStatus.waitFor();
 	}

--- a/packages/calypso-e2e/src/lib/components/comments-component.ts
+++ b/packages/calypso-e2e/src/lib/components/comments-component.ts
@@ -73,12 +73,12 @@ export class CommentsComponent {
 			// do nothing.
 			await waitForWPWidgetsIfNecessary( this.page );
 
-			const likeButtonFrame = this.page.frameLocator(
-				`iframe[name^="like-comment-frame"]:below(:text("${ comment }"))`
-			);
+			const likeButtonFrame = this.page
+				.frameLocator( `iframe[name^="like-comment-frame"]:below(:text("${ comment }"))` )
+				.first();
 
-			likeButton = likeButtonFrame.locator( 'a:text-is("Like"):visible' );
-			likedStatus = likeButtonFrame.locator( ':text("Liked by"):visible' );
+			likeButton = likeButtonFrame.getByRole( 'link', { name: 'Like' } );
+			likedStatus = likeButtonFrame.getByRole( 'link', { name: 'Liked by you' } );
 		} else {
 			const commentContent = this.page.locator( '.comment-content', { hasText: comment } );
 
@@ -105,12 +105,12 @@ export class CommentsComponent {
 			// See the like() method for info on the following method call.
 			await waitForWPWidgetsIfNecessary( this.page );
 
-			const likeButtonFrame = this.page.frameLocator(
-				`iframe[name^="like-comment-frame"]:below(:text("${ comment }"))`
-			);
+			const likeButtonFrame = this.page
+				.frameLocator( `iframe[name^="like-comment-frame"]:below(:text("${ comment }"))` )
+				.first();
 
-			unlikeButton = likeButtonFrame.locator( 'a:text("Liked by")' );
-			unlikedStatus = likeButtonFrame.locator( 'a:text-is("Like")' );
+			unlikeButton = likeButtonFrame.getByRole( 'link', { name: 'Liked by you' } );
+			unlikedStatus = likeButtonFrame.getByRole( 'link', { name: 'Like' } );
 		} else {
 			const commentContent = this.page.locator( '.comment-content', { hasText: comment } );
 

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -160,6 +160,7 @@ export interface ReaderResponse {
 
 export interface NewCommentResponse {
 	ID: number;
+	raw_content: string;
 }
 
 export interface CommentLikeResponse {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/75669.

## Proposed Changes

This PR proposes a rethink of how we perform the Likes: Comments spec.

Until this point, the spec has used the same comment to test both like and unlike operations.
This was carried over from the Selenium-based framework where every interaction was prohibitively slow.

This is a problem for Playwright as the Like/Unlike button has a fade in/out animation which is unreliable. AT sites add further complication on top in the form of iframes.

With the ability to set up the test environment programmatically, it may make sense to use two separate comments, one for like and one for unlike, set the state prior to the test, then execute the click actions and the validation afterwards.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E AT prod (desktop)
  - [x] Gutenberg E2E AT edge (desktop)
  - [x] Gutenberg E2E Simple prod (desktop)
  - [x] Gutenberg E2E Simple edge (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
