### PR TITLE
Plan look-up functions should be term-agnostic when it is for the Free plan.

### DIFF
--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -518,7 +518,9 @@ export function planMatches( planKey: string | Plan, query: PlanMatchesQuery = {
 	if (
 		( ! ( 'type' in query ) || plan.type === query.type ) &&
 		( ! ( 'group' in query ) || plan.group === query.group ) &&
-		( ! ( 'term' in query ) || plan.term === query.term )
+		// the Free plan doesn't have the concept of term.
+		// However, we often have to query a list of plans with a term. Thus
+		( ! ( 'term' in query ) || plan.term === query.term || plan.type === TYPE_FREE )
 	) {
 		return true;
 	}

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -1216,6 +1216,20 @@ describe( 'planMatches - general', () => {
 	} );
 } );
 
+describe( 'planMatches - free', () => {
+	test( 'should return true for matching queries', () => {
+		expect( planMatches( PLAN_FREE, { type: TYPE_FREE } ) ).toEqual( true );
+
+		// see the explanation in packages/calypso-products/src/main.ts:planMatches()
+		// tl;dr the Free plan doesn't have the concept of terms.
+		expect( planMatches( PLAN_FREE, { type: TYPE_FREE } ) ).toEqual( true );
+		expect( planMatches( PLAN_FREE, { type: TYPE_FREE, term: TERM_MONTHLY } ) ).toEqual( true );
+		expect( planMatches( PLAN_FREE, { type: TYPE_FREE, term: TERM_ANNUALLY } ) ).toEqual( true );
+		expect( planMatches( PLAN_FREE, { type: TYPE_FREE, term: TERM_BIENNIALLY } ) ).toEqual( true );
+		expect( planMatches( PLAN_FREE, { type: TYPE_FREE, term: TERM_TRIENNIALLY } ) ).toEqual( true );
+	} );
+} );
+
 describe( 'planMatches - personal', () => {
 	test( 'should return true for matching queries', () => {
 		expect( planMatches( PLAN_PERSONAL, { type: TYPE_PERSONAL } ) ).toEqual( true );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

WIP

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
