### PR TITLE
Subscriptions Management: Enable `subscription-management-comments-view` feature flag

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -128,7 +128,7 @@
 		"subscriber-importer": true,
 		"subscription-gifting": true,
 		"subscription-management": true,
-		"subscription-management-comments-view": false,
+		"subscription-management-comments-view": true,
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,

--- a/config/production.json
+++ b/config/production.json
@@ -149,7 +149,7 @@
 		"subscriber-importer": true,
 		"subscription-gifting": true,
 		"subscription-management": true,
-		"subscription-management-comments-view": false,
+		"subscription-management-comments-view": true,
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -145,7 +145,7 @@
 		"subscriber-importer": true,
 		"subscription-gifting": true,
 		"subscription-management": true,
-		"subscription-management-comments-view": false,
+		"subscription-management-comments-view": true,
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -155,7 +155,7 @@
 		"subscriber-importer": true,
 		"subscription-gifting": true,
 		"subscription-management": true,
-		"subscription-management-comments-view": false,
+		"subscription-management-comments-view": true,
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/75879.

⚠️ Please do not merge until we are ready to launch the "Comments" tab to EN users. ⚠️

## Proposed Changes

* enable the `subscription-management-comments-view` feature flag in production (and in all preceding environments)

## Testing Instructions

The changes will be visible only once this PR is merged and deployed. Prior merging, we can review the code and make sure it doesn't introduce any regressions.

Once the merge is finished, we can navigate to http://wordpress.com/subscriptions/sites as a verified external user with English locale. → Clicking on the "Comments" tab should lead us to http://wordpress.com/subscriptions/comments.

Then, when we navigate to http://wordpress.com/subscriptions/sites/it (or use any other Mag-16 locale), the "Comments" tab should lead to the old Comments page on the Reskinned portal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
