### PR TITLE
Add more translations for BlazePress

### DIFF
--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -31,13 +31,18 @@ const BlazePressStrings = () => {
 	translate( 'You can pause spending at any time.' );
 	translate( 'Saved cards' );
 	translate( 'Add new card' );
+	translate( '(ending %(lastFour)s)' );
+	translate( 'Expires on %(month)s/%(year)s' );
 	translate( 'What will be the Goal?' );
 	translate( 'Expand your target audience by adjusting audience setting' );
 	translate( 'Budget' );
 	translate( 'Daily budget' );
+	translate( 'Min amount is $%(minBudget)s' );
+	translate( 'Max amount is $%(maxBudget)s' );
 	translate( 'Between' );
 	translate( 'Days' );
-	translate( 'Max' );
+	translate( 'Min %(minDays)d day' );
+	translate( 'Max %(maxDays)d days' );
 	translate( 'Start date' );
 	translate( 'Creating your Ad' );
 	translate( 'Oops!' );
@@ -53,7 +58,7 @@ const BlazePressStrings = () => {
 		'Cannot create subscription. Please {{supportLink}}contact support{{/supportLink}} or try again later.'
 	);
 	translate(
-		'There was an error with the address. Please, verify that all the required data is valid'
+		'There was an error with the address. Please verify that all the required data is valid'
 	);
 	translate(
 		'There was an error with the address. The province, state or region should be filled'


### PR DESCRIPTION
Related to #

- More translations from BlazePress widget


<img width="548" alt="image" src="https://user-images.githubusercontent.com/43957544/233117847-28685717-7e55-4caa-b811-05a1894e7dd1.png">

<img width="294" alt="image" src="https://user-images.githubusercontent.com/43957544/233118099-3e84e9e1-142f-4757-abea-dc537ebeb6f0.png">

<img width="310" alt="image" src="https://user-images.githubusercontent.com/43957544/233118137-393758a3-e324-48b5-b295-8b327e25eaf6.png">


<img width="300" alt="image" src="https://user-images.githubusercontent.com/43957544/233118214-776db340-6e6c-4527-b355-f02b2c156a5b.png">

<img width="280" alt="image" src="https://user-images.githubusercontent.com/43957544/233118254-63df3e85-0fb6-4b4a-89fa-9cbe72082df2.png">

<img width="184" alt="image" src="https://user-images.githubusercontent.com/43957544/233118542-b67a2837-5784-4daf-8442-78106fbb06de.png">

<img width="515" alt="image" src="https://user-images.githubusercontent.com/43957544/233118652-f62d7335-9981-44b0-8f79-0c2d78e3e6b4.png">


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
