### PR TITLE
Enable the flag themes/display-thank-you-page

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -132,7 +132,7 @@
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,
-		"themes/display-thank-you-page": false,
+		"themes/display-thank-you-page": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/production.json
+++ b/config/production.json
@@ -153,7 +153,7 @@
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,
-		"themes/display-thank-you-page": false,
+		"themes/display-thank-you-page": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -149,7 +149,7 @@
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,
-		"themes/display-thank-you-page": false,
+		"themes/display-thank-you-page": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -159,7 +159,7 @@
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,
-		"themes/display-thank-you-page": false,
+		"themes/display-thank-you-page": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,


### PR DESCRIPTION

## Proposed Changes

Enable the flag themes/display-thank-you-page, making the installation of free and premium themes redirect to the Marketplace Thank You page.

## Testing Instructions
* From a premium site, activate a Premium Theme
* It should redirect to the Marketplace Thank You page
* From any site, activate a Free Theme
* It should redirect to the Marketplace Thank You page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
