### PR TITLE
Social previews: add fallback for avatar not loading

### DIFF
--- a/packages/social-previews/src/facebook-preview/post/header/index.tsx
+++ b/packages/social-previews/src/facebook-preview/post/header/index.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { useCallback, useState } from 'react';
 import FacebookPostIcon from '../icons';
 import defaultAvatar from './default-avatar.png';
 import type { FacebookUser } from '../../types';
@@ -6,13 +7,21 @@ import type { FacebookUser } from '../../types';
 import './styles.scss';
 
 const FacebookPostHeader: React.FC< { user?: FacebookUser } > = ( { user } ) => {
+	const [ avatarSrc, setAvatarSrc ] = useState< string >( user?.avatarUrl || defaultAvatar );
+	const onImageError = useCallback( () => {
+		if ( avatarSrc !== defaultAvatar ) {
+			setAvatarSrc( defaultAvatar );
+		}
+	}, [ avatarSrc ] );
+
 	return (
 		<div className="facebook-preview__post-header">
 			<div className="facebook-preview__post-header-content">
 				<img
 					className="facebook-preview__post-header-avatar"
-					src={ user?.avatarUrl || defaultAvatar }
+					src={ avatarSrc }
 					alt=""
+					onError={ onImageError }
 				/>
 				<div>
 					<div className="facebook-preview__post-header-name">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR implements a fallback if the avatar in the Facebook preview fails to load. It tries to load the default FB avatar instead.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

A code review should be enough. Optionally, follow the steps below.

### Prerequisites
- Make sure you have a Facebook account.
- Make sure you have a self-hosted site connected to Jetpack, with a subscription that includes Social.
- From the _Social_ or _My Jetpack_ page of your site WPadmin, activate Social.
- Then, connect your site to Facebook (check [these instructions](https://jetpack.com/support/jetpack-social/connecting-to-social-networks/) if you need help). You may need to create a test page.
- Spin up Calypso by running this branch locally.

### Regression Testing

- Create a new post from your site WPadmin
- Publish it
- Visit `/posts/:site` in Calypso
- You should see the newly created post under the _Published_ tab
- In the post menu, click _Share_, then press the _Preview_ button
<img width="500" alt="Screenshot 2023-04-11 at 4 47 11 PM" src="https://user-images.githubusercontent.com/1620183/231284467-7d3c5008-321b-444f-a3f9-8b732eaa323c.png">

- Select the Facebook preview
- Check that the avatar loads as expected

### Testing
- In `FacebookPostHeader`, replace `user?.avatarUrl` by a URL you know returns a 404 status code
- Refresh the page
- Repeat the step above, and notice the default avatar is loaded

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
