### PR TITLE
wpcom-proxy-request: don't default a falsy response

### DIFF
--- a/packages/wpcom-proxy-request/History.md
+++ b/packages/wpcom-proxy-request/History.md
@@ -2,6 +2,8 @@
 
 ## Next / TBD
 
+- Don't modify a falsy boolean JSON response body by defaulting it.
+
 ## 6.0.0 / 2021-03-19
 
 - Add "support" for streamed responses and `onStreamRecord`. Doesn't implement, just tolerates the callback.

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -137,7 +137,7 @@ const makeRequest = ( originalParams, fn ) => {
 			}
 
 			called = true;
-			const body = e.response || xhr.response;
+			const body = e.response ?? xhr.response;
 			debug( 'body: ', body );
 			debug( 'headers: ', e.headers );
 			fn( null, body, e.headers );
@@ -148,7 +148,7 @@ const makeRequest = ( originalParams, fn ) => {
 			}
 
 			called = true;
-			const error = e.error || e.err || e;
+			const error = e.error ?? e.err ?? e;
 			debug( 'error: ', error );
 			debug( 'headers: ', e.headers );
 			fn( error, null, e.headers );


### PR DESCRIPTION
Fixes a little bug in `wpcom-proxy-request` that I discovered when testing the React Query upgrade in #74381, namely the `useHasNeverPublishedPost` query (introduced in #61849). The endpoint the query uses returns a body that is a plain boolean, not wrapped in an object or anything:

<img width="800" alt="Screenshot 2023-04-18 at 15 44 20" src="https://user-images.githubusercontent.com/664258/233111836-a7ae99f4-cde8-446c-8736-4738bf818c7c.png">

Then there is a `e.response || xhr.response` that incorrrectly defaults a `false` response to `xhr.response`, which is an empty string -- because the `xhr` object was never used for sending a request.

Then the hook returns `''` instead of `false`. That's still a falsy value, so it's not that bad, but it's still an incorrect value that also doesn't satisfy the declared type.

Fixing this by using the `??` operator instead. That should be fine until we start receiving `body: null` responses 🙂 Hopefully that never happens.
