### PR TITLE
Social previews: enable image mode as a prop

### DIFF
--- a/packages/social-previews/src/facebook-preview/hooks/use-image-hook.ts
+++ b/packages/social-previews/src/facebook-preview/hooks/use-image-hook.ts
@@ -1,28 +1,30 @@
 import { __ } from '@wordpress/i18n';
 import { useCallback, useState } from 'react';
 import { LANDSCAPE_MODE, PORTRAIT_MODE } from '../../constants';
+import type { ImageMode } from '../../types';
 
-type Mode = typeof LANDSCAPE_MODE | typeof PORTRAIT_MODE | undefined;
 type ImageEventHandler = ( event: React.SyntheticEvent< HTMLImageElement > ) => void;
 type ImgProps = {
 	alt: string;
 	onLoad: ImageEventHandler;
 	onError: ImageEventHandler;
 };
-type UseImage = () => [ Mode, boolean, ImgProps ];
+type UseImage = ( mode?: ImageMode ) => [ ImageMode | undefined, boolean, ImgProps ];
 
-const useImage: UseImage = () => {
-	const [ mode, setMode ] = useState< typeof LANDSCAPE_MODE | typeof PORTRAIT_MODE | undefined >();
+const useImage: UseImage = ( initialMode ) => {
+	const [ mode, setMode ] = useState< ImageMode | undefined >( initialMode );
 	const [ isLoadingImage, setLoadingImage ] = useState< boolean >( true );
 
 	const onLoad = useCallback(
 		( { target } ) => {
-			setMode( target.naturalWidth > target.naturalHeight ? LANDSCAPE_MODE : PORTRAIT_MODE );
+			if ( ! mode ) {
+				setMode( target.naturalWidth > target.naturalHeight ? LANDSCAPE_MODE : PORTRAIT_MODE );
+			}
 			setLoadingImage( false );
 		},
-		[ setMode, setLoadingImage ]
+		[ mode ]
 	);
-	const onError = useCallback( () => setLoadingImage( false ), [ setLoadingImage ] );
+	const onError = useCallback( () => setLoadingImage( false ), [] );
 
 	return [
 		mode,

--- a/packages/social-previews/src/facebook-preview/hooks/use-image-hook.ts
+++ b/packages/social-previews/src/facebook-preview/hooks/use-image-hook.ts
@@ -9,9 +9,9 @@ type ImgProps = {
 	onLoad: ImageEventHandler;
 	onError: ImageEventHandler;
 };
-type UseImage = ( mode?: ImageMode ) => [ ImageMode | undefined, boolean, ImgProps ];
+type UseImage = ( arg0: { mode?: ImageMode } ) => [ ImageMode | undefined, boolean, ImgProps ];
 
-const useImage: UseImage = ( initialMode ) => {
+const useImage: UseImage = ( { mode: initialMode } ) => {
 	const [ mode, setMode ] = useState< ImageMode | undefined >( initialMode );
 	const [ isLoadingImage, setLoadingImage ] = useState< boolean >( true );
 

--- a/packages/social-previews/src/facebook-preview/link-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/link-preview.tsx
@@ -18,7 +18,7 @@ const FacebookLinkPreview: React.FC< FacebookPreviewProps > = ( {
 	type,
 	imageMode,
 } ) => {
-	const [ mode, isLoadingImage, imgProps ] = useImage( imageMode );
+	const [ mode, isLoadingImage, imgProps ] = useImage( { mode: imageMode } );
 	const isArticle = type === TYPE_ARTICLE;
 	const portraitMode = ( isArticle && ! image ) || mode === PORTRAIT_MODE;
 	const modeClass = `is-${ portraitMode ? 'portrait' : 'landscape' }`;

--- a/packages/social-previews/src/facebook-preview/link-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/link-preview.tsx
@@ -16,8 +16,9 @@ const FacebookLinkPreview: React.FC< FacebookPreviewProps > = ( {
 	user,
 	customText,
 	type,
+	imageMode,
 } ) => {
-	const [ mode, isLoadingImage, imgProps ] = useImage();
+	const [ mode, isLoadingImage, imgProps ] = useImage( imageMode );
 	const isArticle = type === TYPE_ARTICLE;
 	const portraitMode = ( isArticle && ! image ) || mode === PORTRAIT_MODE;
 	const modeClass = `is-${ portraitMode ? 'portrait' : 'landscape' }`;

--- a/packages/social-previews/src/facebook-preview/post-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/post-preview.tsx
@@ -12,7 +12,7 @@ const FacebookPostPreview: React.FC< FacebookPreviewProps > = ( {
 	customImage,
 	imageMode,
 } ) => {
-	const [ mode, isLoadingImage, imgProps ] = useImage( imageMode );
+	const [ mode, isLoadingImage, imgProps ] = useImage( { mode: imageMode } );
 	const modeClass = `is-${ mode === PORTRAIT_MODE ? 'portrait' : 'landscape' }`;
 
 	return (

--- a/packages/social-previews/src/facebook-preview/post-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/post-preview.tsx
@@ -10,8 +10,9 @@ const FacebookPostPreview: React.FC< FacebookPreviewProps > = ( {
 	user,
 	customText,
 	customImage,
+	imageMode,
 } ) => {
-	const [ mode, isLoadingImage, imgProps ] = useImage();
+	const [ mode, isLoadingImage, imgProps ] = useImage( imageMode );
 	const modeClass = `is-${ mode === PORTRAIT_MODE ? 'portrait' : 'landscape' }`;
 
 	return (

--- a/packages/social-previews/src/types.ts
+++ b/packages/social-previews/src/types.ts
@@ -1,3 +1,7 @@
+import { LANDSCAPE_MODE, PORTRAIT_MODE } from './constants';
+
+export type ImageMode = typeof LANDSCAPE_MODE | typeof PORTRAIT_MODE;
+
 export type PreviewProps = {
 	url: string;
 	title: string;
@@ -6,4 +10,5 @@ export type PreviewProps = {
 	image?: string;
 	customImage?: string;
 	headingsLevel?: number;
+	imageMode?: ImageMode;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The Facebook preview in the `social-previews` package needs to load the post image before knowing what layout to display (the preview has a different layout in landscape or portrait mode). This PR enables the passing of an `imageMode` prop in case we know the image dimensions beforehand. This allows starting the render of the preview layout without waiting for the image to load.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

A code review should be enough. Optionally, follow the steps below.

### Prerequisites
- Make sure you have a Facebook account.
- Make sure you have a self-hosted site connected to Jetpack, with a subscription that includes Social.
- From the _Social_ or _My Jetpack_ page of your site WPadmin, activate Social.
- Then, connect your site to Facebook (check [these instructions](https://jetpack.com/support/jetpack-social/connecting-to-social-networks/) if you need help). You may need to create a test page.
- Spin up Calypso, by running this branch locally or using a live link below.

### Testing

- Create a new post from your site WPadmin
- Add a featured image
- Publish it
- Visit `/posts/:site` in Calypso
- You should see the newly created post under the _Published_ tab
- In the post menu, click _Share_, then press the _Preview_ button
<img width="500" alt="Screenshot 2023-04-11 at 4 47 11 PM" src="https://user-images.githubusercontent.com/1620183/231284467-7d3c5008-321b-444f-a3f9-8b732eaa323c.png">

- Select the Facebook preview
- Check that the preview looks like it does in production

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
