### PR TITLE
Blog onboarding: "writer flow v1" Hide the product tour

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -4,6 +4,7 @@ import { WpcomTourKit, usePrefetchTourAssets } from '@automattic/tour-kit';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { useDispatch, useSelect, dispatch } from '@wordpress/data';
 import { useEffect, useMemo } from '@wordpress/element';
+import { getQueryArg } from '@wordpress/url';
 import useSiteIntent from '../../../dotcom-fse/lib/site-intent/use-site-intent';
 import useSitePlan from '../../../dotcom-fse/lib/site-plan/use-site-plan';
 import { selectors as starterPageTemplatesSelectors } from '../../../starter-page-templates/store';
@@ -47,11 +48,15 @@ function LaunchWpcomWelcomeTour() {
 	const { siteIntent, siteIntentFetched } = useSiteIntent();
 	const localeSlug = useLocale();
 	const editorType = getEditorType();
+	const showLaunchpad = getQueryArg( window.location.search, 'showLaunchpad' );
 
 	// Preload first card image (others preloaded after open state confirmed)
 	usePrefetchTourAssets( [ getTourSteps( localeSlug, false, false, null, siteIntent )[ 0 ] ] );
 
 	useEffect( () => {
+		if ( showLaunchpad ) {
+			return;
+		}
 		if ( ! show && ! isNewPageLayoutModalOpen ) {
 			return;
 		}
@@ -74,9 +79,10 @@ function LaunchWpcomWelcomeTour() {
 		siteIntent,
 		siteIntentFetched,
 		editorType,
+		showLaunchpad,
 	] );
 
-	if ( ! show || isNewPageLayoutModalOpen ) {
+	if ( ! show || isNewPageLayoutModalOpen || showLaunchpad ) {
 		return null;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2182

## Proposed Changes

* While using the special flag `showLaunchpad=true` from a new post page (without iFrame), the Welcome Tour dialog should not show

https://user-images.githubusercontent.com/402286/233117767-1f995436-851a-45e3-81ce-fd77bf1759e4.mov

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Apply this branch on your local Calypso
* Make sure your site is sandboxed (like `yoursite.wordpress.com`).
* Go to `apps/editing-toolkit`
* Run `yarn dev --sync` (to sync it to your sandbox)
* Create a new post using the onboarding flag: http://calypso.localhost:3000/post/{domain}?showLaunchpad=true
* Inspect the page and open the iFrame URL in a new tab
* The editor should show the Welcome Tour (except you hide it before)
* Add `&showLaunchpad=true` to the URL
* The editor now should not show the Welcome Tour

## To Do
- [ ] Add tests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~