### PR TITLE
Subscriptions Management: Fix links of `Comments` and `Pending` tabs for non-EN users

### DIFF
--- a/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
+++ b/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
@@ -51,7 +51,7 @@ const TabsSwitcher = () => {
 							shouldEnableCommentsTab
 								? navigate( commentsPath )
 								: window.location.replace(
-										'https://wordpress.com/email-subscriptions/?option=comments'
+										`https://wordpress.com/email-subscriptions/?option=comments&locale=${ locale }`
 								  );
 						} }
 						count={ counts?.comments || undefined }
@@ -66,7 +66,7 @@ const TabsSwitcher = () => {
 								shouldEnablePendingTab
 									? navigate( pendingPath )
 									: window.location.replace(
-											'https://wordpress.com/email-subscriptions/?option=pending'
+											`https://wordpress.com/email-subscriptions/?option=pending&locale=${ locale }`
 									  );
 							} }
 							count={ counts?.pending || undefined }


### PR DESCRIPTION
 Fixes https://github.com/Automattic/wp-calypso/issues/75970.

## Proposed Changes

* make sure the "Comments" and "Pending" tab links include the `&locale` URL parameter

## Testing Instructions

1. Check out and build the PR locally.
2. Apply the correct `subkey` cookie value to your `calypso.localhost:3000` host.
3. Navigate to http://calypso.localhost:3000/subscriptions/sites.
4. Click on the "Comments" link. → You should get to the "Comments" page in Calypso.
5. Navigate to http://calypso.localhost:3000/subscriptions/sites/pt-br (or use any other Mag-16 language).
6. Click on the "Comments" link. → You should get to the "Comments" page in the Reskinned portal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
