### PR TITLE
Plans: Conditionally show div on mobile devices

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -292,9 +292,11 @@ const LoggedInPlansFeatureActionButton = ( {
 					<DummyDisabledButton>
 						{ translate( 'Downgrade', { context: 'verb' } ) }
 					</DummyDisabledButton>
-					<div className="plan-features-2023-grid__actions-downgrade-context-mobile">
-						{ isMobile() && translate( 'Please contact support to downgrade your plan.' ) }
-					</div>
+					{ isMobile() && (
+						<div className="plan-features-2023-grid__actions-downgrade-context-mobile">
+							{ translate( 'Please contact support to downgrade your plan.' ) }
+						</div>
+					) }
 				</Plans2023Tooltip>
 			);
 		} else if ( forceDisplayButton ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75903

## Proposed Changes

* Introducing a new div in #75903 threw off the plans page alignment; this wraps the div in the same conditional we used to add text on mobile devices.

**Before**

<img width="874" alt="Screen Shot 2023-04-19 at 12 15 03 PM" src="https://user-images.githubusercontent.com/2124984/233137145-bf3e5f26-cfcb-4f8f-b313-28f5bfc3198e.png">

**After**

<img width="864" alt="Screen Shot 2023-04-19 at 12 15 20 PM" src="https://user-images.githubusercontent.com/2124984/233137167-37142a2b-e805-4c8a-8ba6-75b7f17999c9.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, navigate to `/plans`
* Check the grid alignment on multiple sites with different types of plans, both WP.com (Free, Personal, Premium, Business, etc.) and Woo Express (create a site from `/setup/wooexpress`)
* Check for the presence of the tooltip text on a mobile device
* You may need to refresh the page if you resize your screen or use a mobile simulator to show/hide the text.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
