### PR TITLE
Launchpad: Update all strings to sentence case

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -99,7 +99,7 @@ export function getEnhancedTasks(
 					break;
 				case 'setup_newsletter':
 					taskData = {
-						title: translate( 'Personalize Newsletter' ),
+						title: translate( 'Personalize newsletter' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
@@ -131,7 +131,7 @@ export function getEnhancedTasks(
 					break;
 				case 'plan_selected':
 					taskData = {
-						title: translate( 'Choose a Plan' ),
+						title: translate( 'Choose a plan' ),
 						subtitle: planWarningText,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
@@ -157,7 +157,7 @@ export function getEnhancedTasks(
 					break;
 				case 'subscribers_added':
 					taskData = {
-						title: translate( 'Add Subscribers' ),
+						title: translate( 'Add subscribers' ),
 						actionDispatch: () => {
 							if ( goToStep ) {
 								recordTaskClickTracksEvent( flow, task.completed, task.id );
@@ -267,7 +267,7 @@ export function getEnhancedTasks(
 								const { launchSite } = dispatch( SITE_STORE );
 
 								setPendingAction( async () => {
-									setProgressTitle( __( 'Launching Website' ) );
+									setProgressTitle( __( 'Launching website' ) );
 									await launchSite( site.ID );
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
@@ -349,7 +349,7 @@ export function getEnhancedTasks(
 				case 'verify_email':
 					taskData = {
 						completed: isEmailVerified,
-						title: translate( 'Confirm Email (Check Your Inbox)' ),
+						title: translate( 'Confirm email (check your inbox)' ),
 					};
 					break;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -104,21 +104,21 @@ describe( 'StepContent', () => {
 		it( 'renders correct sidebar tasks', () => {
 			renderStepContent( false, NEWSLETTER_FLOW );
 
-			expect( screen.getByText( 'Personalize Newsletter' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Choose a Plan' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Add Subscribers' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Confirm Email (Check Your Inbox)' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Personalize newsletter' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Choose a plan' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Add subscribers' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Confirm email (check your inbox)' ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'button', { name: 'Start writing' } ) ).toBeInTheDocument();
 		} );
 
 		it( 'renders correct status for each task', () => {
 			renderStepContent( false, NEWSLETTER_FLOW );
 
-			const personalizeListItem = screen.getByText( 'Personalize Newsletter' ).closest( 'li' );
-			const choosePlanListItem = screen.getByText( 'Choose a Plan' ).closest( 'li' );
-			const addSubscribersListItem = screen.getByText( 'Add Subscribers' ).closest( 'li' );
+			const personalizeListItem = screen.getByText( 'Personalize newsletter' ).closest( 'li' );
+			const choosePlanListItem = screen.getByText( 'Choose a plan' ).closest( 'li' );
+			const addSubscribersListItem = screen.getByText( 'Add subscribers' ).closest( 'li' );
 			const confirmEmailListItem = screen
-				.getByText( 'Confirm Email (Check Your Inbox)' )
+				.getByText( 'Confirm email (check your inbox)' )
 				.closest( 'li' );
 			const firstPostListItem = screen
 				.getByRole( 'button', { name: 'Start writing' } )


### PR DESCRIPTION
### Proposed Changes

Resolves https://github.com/Automattic/wp-calypso/issues/75693

This is a simple PR that addresses some design feedback by changing any remaining Launchpad strings to 'sentence case' (ie, other than special words, only the first letter in the sentence is capitalized). 

<img width="2749" alt="231728935-68329588-6ee4-4dae-bfe0-25dfa5965b49" src="https://user-images.githubusercontent.com/21228350/233167284-437bac2d-be9c-4327-88a1-2f1152ad6a10.png">

### Testing Instructions

**Review time: short**
**Testing time: short**

1. Check out this branch and run yarn and yarn start if needed. 
2. Either start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro and proceed to launchpad, or simply go to http://calypso.localhost:3000/setup/newsletter/launchpad?siteSlug=SITESLUG for any launchpad enabled site. 
3. TEST: Confirm all strings are in sentence case. 
4. Either start a Link in Bio site at http://calypso.localhost:3000/setup/link-in-bio/intro and proceed to launchpad, or simply go to http://calypso.localhost:3000/setup/link-in-bio/launchpad?siteSlug=SITESLUG for any launchpad enabled site.
5. TEST: Confirm all strings are in sentence case.  
   - Per the design issue, the exception on this screen is the actual phrase "Link in Bio", which is still using caps. 