### PR TITLE
Woo Express Trial: Remove right and left padding on doughnut

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-banner/style.scss
@@ -51,7 +51,7 @@
 		}
 
 		margin-left: 50px;
-		padding: 0 20px;
+		padding: 0;
 		text-align: center;
 
 		.e-commerce-trial-banner__chart-label {


### PR DESCRIPTION
Related to #73311

## Proposed Changes

* Remove 20px of right and left padding on the doughnut chart to align it fully to the right.

**Before**
<img width="1080" alt="Screen Shot 2023-04-19 at 2 18 27 PM" src="https://user-images.githubusercontent.com/2124984/233168656-0e834d38-8063-4b70-991f-78841ed54b62.png">


**After**
<img width="1074" alt="Screen Shot 2023-04-19 at 2 18 17 PM" src="https://user-images.githubusercontent.com/2124984/233168678-67811809-46cd-4921-bb7a-949bf819f136.png">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR and set up an ecommerce trial site at `/setup/wooexpress`
* Go to `/plans` on the new site and check out the spacing on the ecommerce trial card

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
