### PR TITLE
Blog onboarding: writer flow v1 hide the W icon

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -2,6 +2,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/edit-post';
 import { useEffect, createPortal, useState } from '@wordpress/element';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
+import { getQueryArg } from '@wordpress/url';
 import WpcomBlockEditorNavSidebar from './components/nav-sidebar';
 import ToggleSidebarButton from './components/toggle-sidebar-button';
 
@@ -33,6 +34,7 @@ if ( typeof MainDashboardButton !== 'undefined' ) {
 				// eslint-disable-next-line react-hooks/exhaustive-deps
 			}, [] );
 
+			const showLaunchpad = getQueryArg( window.location.search, 'showLaunchpad' );
 			const [ clickGuardRoot ] = useState( () => document.createElement( 'div' ) );
 			useEffect( () => {
 				document.body.appendChild( clickGuardRoot );
@@ -52,6 +54,10 @@ if ( typeof MainDashboardButton !== 'undefined' ) {
 					),
 				[]
 			);
+
+			if ( showLaunchpad ) {
+				return <MainDashboardButton></MainDashboardButton>;
+			}
 
 			if ( isSiteEditor || ! isFullscreenActive ) {
 				return null;

--- a/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/full-side-editor-nav-sidebar-component.ts
@@ -1,7 +1,7 @@
 import { Page, Locator } from 'playwright';
 
 const selectors = {
-	exitButton: `a[aria-label="Go back to the dashboard"]`,
+	exitButton: `a[aria-label="Go back to the Dashboard"]`,
 	templatePartsItem: 'button[id="/wp_template_part"]',
 	manageAllTemplatePartsItem: 'button:text("Manage all template parts")',
 	navigationScreenTitle: '.edit-site-sidebar-navigation-screen__title',
@@ -27,7 +27,9 @@ export class FullSiteEditorNavSidebarComponent {
 	 * Clicks the Dashboard menu link to exit the editor.
 	 */
 	async exit(): Promise< void > {
-		const exitButtonLocator = this.editor.locator( selectors.exitButton );
+		const exitButtonLocator = this.editor
+			.getByRole( 'region', { name: 'Navigation sidebar' } )
+			.locator( selectors.exitButton );
 		await exitButtonLocator.click();
 	}
 
@@ -44,7 +46,10 @@ export class FullSiteEditorNavSidebarComponent {
 	 */
 	async ensureNavigationTopLevel(): Promise< void > {
 		const waitForNavigationTopLevel = async () => {
-			await this.editor.locator( selectors.exitButton ).waitFor();
+			await this.editor
+				.getByRole( 'region', { name: 'Navigation sidebar' } )
+				.locator( selectors.exitButton )
+				.waitFor();
 		};
 
 		const headerLocator = this.editor.locator( selectors.navigationScreenTitle );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2184

## Proposed Changes

* While using the special flag `showLaunchpad=true` from a new post page (without iFrame), the W (WordPress icon) on the top left should not show.

https://user-images.githubusercontent.com/402286/233170817-5758160f-927f-47f3-9577-32c9fc59bdc0.mp4

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Apply this branch on your local Calypso
* Make sure your site is sandboxed (like `yoursite.wordpress.com`).
* Go to `apps/editing-toolkit`
* Run `yarn dev --sync` (to sync it to your sandbox)
* Create a new post using the onboarding flag: http://calypso.localhost:3000/post/{domain}?showLaunchpad=true
* Inspect the page and open the iFrame URL in a new tab
* The editor should show the WordPress icon at the top left of the screen
* Add `&showLaunchpad=true` to the URL
* The editor now should not show the WordPress icon.

## To Do
- [ ] Add tests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~