### PR TITLE
Setting "livro" as our default theme for the new start writing flow

### DIFF
--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -10,6 +10,7 @@ import {
 	Flow,
 	ProvidedDependencies,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { setDesignOnSite } from 'calypso/lib/signup/step-actions';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const startWriting: Flow = {
@@ -40,9 +41,21 @@ const startWriting: Flow = {
 							checklist_statuses: { first_post_published: true },
 						} );
 
+						const defaultFlowThemeSlug = 'livro';
 						const siteOrigin = window.location.origin;
-						return redirect(
-							`https://${ providedDependencies?.siteSlug }/wp-admin/post-new.php?showLaunchpad=true&origin=${ siteOrigin }`
+
+						setDesignOnSite(
+							() => {
+								redirect(
+									`https://${ providedDependencies?.siteSlug }/wp-admin/post-new.php?showLaunchpad=true&origin=${ siteOrigin }`
+								);
+							},
+							{
+								siteSlug: providedDependencies?.siteSlug,
+								selectedDesign: {
+									theme: defaultFlowThemeSlug,
+								},
+							}
 						);
 					}
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2178

## Proposed Changes

* Set the "Livro" theme as default in the new start-writing flow:

https://user-images.githubusercontent.com/1044309/233179390-f6bb550e-6df5-44d5-9205-1dec3e8b0963.mp4



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In this branch, [run the new start-writing flow](calypso.localhost:3000/setup/start-writing/).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
