### PR TITLE
Woo Express Trial: Update grid spacing for My Plans page

### DIFF
--- a/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
@@ -63,8 +63,16 @@ body.is-section-plans.is-ecommerce-trial-plan {
 			padding: 48px 24px 24px;
 		}
 
-		.feature-included-card__content .feature-included-card__title {
-			margin-bottom: 8px;
+		.feature-included-card__content {
+			margin-left: 24px;
+
+			@media (min-width: $break-large) {
+				margin-left: 0;
+			}
+
+			.feature-included-card__title {
+				margin-bottom: 8px;
+			}
 		}
 
 		.feature-included-card__illustration {
@@ -73,7 +81,6 @@ body.is-section-plans.is-ecommerce-trial-plan {
 			@media (min-width: $break-large) {
 				width: 60px;
 			}
-
 		}
 
 		.feature-included-card__text {

--- a/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
@@ -69,11 +69,9 @@ body.is-section-plans.is-ecommerce-trial-plan {
 
 		.feature-included-card__illustration {
 			width: 48px;
-			margin-right: 24px;
 
 			@media (min-width: $break-large) {
 				width: 60px;
-				margin-right: 0;
 			}
 
 		}

--- a/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
@@ -75,6 +75,10 @@ body.is-section-plans.is-ecommerce-trial-plan {
 			}
 
 		}
+
+		.feature-included-card__text {
+			margin-bottom: 8px;
+		}
 	}
 
 	.current-plan__content {

--- a/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
@@ -47,6 +47,38 @@ body.is-section-plans.is-ecommerce-trial-plan {
 		--color-surface-backdrop: var(--color-surface);
 	}
 
+	.feature-included-card__card {
+		display: flex;
+		flex-direction: row;
+		margin-bottom: 16px;
+		padding: 24px 16px;
+		width: 100%;
+
+		@media (min-width: $break-large) {
+			flex-direction: column;
+			width: calc(25% - 24px);
+			margin-right: 12px;
+			margin-left: 12px;
+			margin-bottom: 24px;
+			padding: 48px 24px 24px;
+		}
+
+		.feature-included-card__content .feature-included-card__title {
+			margin-bottom: 8px;
+		}
+
+		.feature-included-card__illustration {
+			width: 48px;
+			margin-right: 24px;
+
+			@media (min-width: $break-large) {
+				width: 60px;
+				margin-right: 0;
+			}
+
+		}
+	}
+
 	.current-plan__content {
 		.section-nav {
 			box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73311

## Proposed Changes

* Update grid spacing for the "What's included" section of the My Plan page when on an ecommerce trial.

**Before**

<img width="1079" alt="Screen Shot 2023-04-19 at 3 19 43 PM" src="https://user-images.githubusercontent.com/2124984/233178551-146b494a-e4c0-462b-a397-0b059f403d06.png">

<img width="283" alt="Screen Shot 2023-04-19 at 3 24 20 PM" src="https://user-images.githubusercontent.com/2124984/233179175-6f3ae8d3-87a1-4adc-9d16-e76222a313bb.png">

**After**

<img width="1039" alt="Screen Shot 2023-04-19 at 3 24 58 PM" src="https://user-images.githubusercontent.com/2124984/233179258-3755b606-0394-4c4a-b6b5-813944ab0bbd.png">

<img width="282" alt="Screen Shot 2023-04-19 at 3 25 22 PM" src="https://user-images.githubusercontent.com/2124984/233179327-75dc9df3-256a-4dcb-b490-20ca89d77929.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR and navigate to `/setup/wooexpress` to create a new trial site.
* Visit `/plans/my-plan` to see the "What's included in your plan" section.
* Note spacing differences and make sure everything looks good at different screen sizes, esp. mobile., compared to the original Figma lD0gTB4IqGsmSmsnjZNaP6-fi-470_15526

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?