### PR TITLE
Woo Express Trial: Update spacing in Ready to start selling section

### DIFF
--- a/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
@@ -88,6 +88,28 @@ body.is-section-plans.is-ecommerce-trial-plan {
 		}
 	}
 
+	.feature-not-included-card__card {
+		.feature-not-included-card__content {
+			padding-left: 16px;
+
+			@media (min-width: $break-large) {
+				padding-left: 25px;
+			}
+
+			.feature-not-included-card__title {
+				margin-bottom: 2px;
+
+				@media (min-width: $break-large) {
+					margin-bottom: 8px;
+				}
+			}
+
+			.feature-not-included-card__text {
+				margin-bottom: 8px;
+			}
+		}
+	}
+
 	.current-plan__content {
 		.section-nav {
 			box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.05);
@@ -102,12 +124,17 @@ body.is-section-plans.is-ecommerce-trial-plan {
 			text-align: center;
 			font-weight: 400;
 			color: var(--color-neutral-80);
-			margin: 40px 0 10px 0;
+			margin: 40px 0 10px;
 
 			@media (max-width: $break-mobile) {
 				text-align: left;
 				font-size: $font-title-small;
 				padding: 0 20px;
+			}
+
+			&:nth-of-type(2) {
+				margin-top: 56px;
+				margin-bottom: 12px;
 			}
 		}
 
@@ -166,7 +193,6 @@ body.is-section-plans.is-ecommerce-trial-plan {
 
 		.e-commerce-trial-current-plan__cta-wrapper {
 			text-align: center;
-			margin-top: 30px;
 			margin-bottom: 30px;
 
 			@media (max-width: $break-mobile) {

--- a/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
+++ b/client/my-sites/plans/current-plan/ecommerce-trial/style.scss
@@ -89,6 +89,11 @@ body.is-section-plans.is-ecommerce-trial-plan {
 	}
 
 	.feature-not-included-card__card {
+
+		&:last-of-type {
+			margin-bottom: 4px;
+		}
+
 		.feature-not-included-card__content {
 			padding-left: 16px;
 
@@ -188,6 +193,7 @@ body.is-section-plans.is-ecommerce-trial-plan {
 				.feature-not-included-card__text {
 					font-size: $woo-font-body-extra-small;
 				}
+				margin-top: 12px;
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #73311

## Proposed Changes

* Update padding/spacing around elements in the "Ready to start selling?" section of the My Plan page when on the ecommerce trial.

**Before**
<img width="1049" alt="Screen Shot 2023-04-19 at 4 32 03 PM" src="https://user-images.githubusercontent.com/2124984/233193676-69883c0c-5ac5-4b95-9e0a-f08986d4593e.png">

<img width="269" alt="Screen Shot 2023-04-19 at 4 31 38 PM" src="https://user-images.githubusercontent.com/2124984/233193717-4630d4cf-a7bd-44de-9c76-75ebc2fbf72b.png">


**After**
<img width="1053" alt="Screen Shot 2023-04-19 at 4 32 27 PM" src="https://user-images.githubusercontent.com/2124984/233193692-0bddf4c4-c42e-4ec1-a874-3b4055e3cf52.png">

<img width="269" alt="Screen Shot 2023-04-19 at 4 31 08 PM" src="https://user-images.githubusercontent.com/2124984/233193745-d60081aa-7cf6-4820-8e38-f5c6a9087a1b.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, create a new trial site from `/setup/wooexpress`
* Visit `/plans/my-plan` on your new site
* Check out the spacing in the "Ready to start selling?" section, esp. on mobile. Compare to original designs: lD0gTB4IqGsmSmsnjZNaP6-fi-1_144

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?