### PR TITLE
Reenable help center launchpad endpoint

### DIFF
--- a/packages/help-center/src/components/help-center-launchpad.tsx
+++ b/packages/help-center/src/components/help-center-launchpad.tsx
@@ -8,7 +8,7 @@ import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
 import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
-// import { useLaunchpadChecklist } from '../hooks/use-launchpad';
+import { useLaunchpadChecklist } from '../hooks/use-launchpad';
 import { SITE_STORE } from '../stores';
 import type { SiteSelect } from '@automattic/data-stores';
 
@@ -44,12 +44,10 @@ export const HelpCenterLaunchpad = () => {
 		siteSlug = window?.location?.host;
 	}
 
-	// We are commenting this out temporarily while we wait
-	// for new endpoint in jetpack-mu-wpcom to be deployed.
-	// const { data } = useLaunchpadChecklist( siteSlug, siteIntent || '' );
-	// const totalLaunchpadSteps = data?.checklist?.length || 4;
-	// const completeLaunchpadSteps =
-	// 	data?.checklist?.filter( ( checklistItem ) => checklistItem.completed ).length || 1;
+	const { data } = useLaunchpadChecklist( siteSlug, siteIntent || '' );
+	const totalLaunchpadSteps = data?.checklist?.length || 4;
+	const completeLaunchpadSteps =
+		data?.checklist?.filter( ( checklistItem ) => checklistItem.completed ).length || 1;
 
 	const launchpadURL = `${ getEnvironmentHostname() }/setup/${ siteIntent }/launchpad?siteSlug=${ siteSlug }`;
 	const sectionName = useSelector( ( state ) => getSectionName( state ) );
@@ -77,7 +75,11 @@ export const HelpCenterLaunchpad = () => {
 					handleLaunchpadHelpLinkClick();
 				} }
 			>
-				<CircularProgressBar size={ 32 } currentStep={ 1 } numberOfSteps={ 4 } />
+				<CircularProgressBar
+					size={ 32 }
+					currentStep={ completeLaunchpadSteps }
+					numberOfSteps={ totalLaunchpadSteps }
+				/>
 				<span className="inline-help-launchpad-link-text">
 					{ __( 'Continue setting up your site with these next steps.' ) }
 				</span>


### PR DESCRIPTION
### Proposed Changes

Related to: https://github.com/Automattic/wp-calypso/pull/75575 and https://github.com/Automattic/wp-calypso/pull/75933

This PR re-enables the new Launchpad endpoint for the Launchpad icon in Help Center, and sets the progress bar on the icon dynamically based on completed / total steps. This had been commented out in one of the PRs above until the endpoint was deployed as part of the jetpack-mu-plugin. 

<img width="879" alt="launchpad icon" src="https://user-images.githubusercontent.com/21228350/231255601-1c3d772d-0229-4c5d-8d01-5141ff54a932.png">

### Testing Instructions

1. Checkout this branch and run yarn and yarn start. 
   - These changes are part of a package. Yarn commands should build the help center package fresh for testing. If for some reason you need to rebuild the package, run `yarn build-packages`.
3. Create or use a launchpad enabled site.
4. Go to `http://calypso.localhost:3000/post/YOURSITESLUG`
5. TEST: Click on the help / question mark icon in the upper right icon and confirm the Launchpad icon shows. 
6. TEST: Confirm the progress status on the icon is being dynamically set (before it was always set to 25%). 
   - Ideally, the percentage complete should directly match launchpad. You can check that by clicking Home on the dashboard, which will redirect you to the launchpad screen. However, note that some of our data may not be accurate, as we're still adding the logic needed to set completion status correctly in the new endpoint. For now, it's probably enough to confirm the progress bar is being set dynamically. 