### PR TITLE
Removing Explat test code and launching onboarding-pm test variant

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -26,7 +26,6 @@ import {
 	getFixedDomainSearch,
 } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getSiteTypePropertyValue } from 'calypso/lib/signup/site-type';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
 import wpcom from 'calypso/lib/wp';
@@ -142,13 +141,6 @@ class DomainsStep extends Component {
 				}
 			);
 		}
-
-		loadExperimentAssignment( 'paid_media_signup_2023_03_legacy_free_presentation' ).then(
-			( experimentName ) => {
-				this.setState( { experiment: experimentName } );
-				this.setState( { experimentIsLoading: false } );
-			}
-		);
 	}
 
 	getLocale() {

--- a/client/signup/steps/plans-pm/index.jsx
+++ b/client/signup/steps/plans-pm/index.jsx
@@ -8,7 +8,6 @@ import QueryPlans from 'calypso/components/data/query-plans';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import MarketingMessage from 'calypso/components/marketing-message';
 import Notice from 'calypso/components/notice';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { buildUpgradeFunction } from 'calypso/lib/signup/step-actions';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getDomainName, getIntervalType } from 'calypso/signup/steps/plans/util';
@@ -23,8 +22,6 @@ export class PlansStepPM extends Component {
 		super( props );
 		this.state = {
 			isDesktop: isDesktop(),
-			experiment: null,
-			experimentIsLoading: true,
 		};
 	}
 	componentDidMount() {
@@ -32,13 +29,6 @@ export class PlansStepPM extends Component {
 			this.setState( { isDesktop: matchesDesktop } )
 		);
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
-
-		loadExperimentAssignment( 'paid_media_signup_2023_03_legacy_free_presentation' ).then(
-			( experimentName ) => {
-				this.setState( { experiment: experimentName } );
-				this.setState( { experimentIsLoading: false } );
-			}
-		);
 	}
 
 	componentWillUnmount() {
@@ -74,7 +64,6 @@ export class PlansStepPM extends Component {
 					isAllPaidPlansShown={ true }
 					isInSignup={ true }
 					shouldShowPlansFeatureComparison={ this.state.isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
-					showBiannualToggle={ this.state.experiment?.variationName === 'treatment' }
 				/>
 			</div>
 		);
@@ -100,7 +89,7 @@ export class PlansStepPM extends Component {
 			<Button onClick={ () => buildUpgradeFunction( this.props, null ) } borderless />
 		);
 
-		if ( this.state.experiment?.variationName === 'treatment' && this.props.hideFreePlan ) {
+		if ( this.props.hideFreePlan ) {
 			if ( this.state.isDesktop ) {
 				return translate( "Pick one that's right for you and unlock features that help you grow." );
 			}
@@ -172,9 +161,6 @@ export class PlansStepPM extends Component {
 			'is-wide-layout': true,
 		} );
 
-		if ( this.state.experimentIsLoading ) {
-			return this.renderLoading();
-		}
 		return (
 			<>
 				<QueryPlans />

--- a/client/signup/steps/plans-pm/plans-features-main-pm.jsx
+++ b/client/signup/steps/plans-pm/plans-features-main-pm.jsx
@@ -209,7 +209,7 @@ PlansFeaturesMainPM.defaultProps = {
 	plansWithScroll: false,
 	planTypeSelector: 'interval',
 	showFAQ: true,
-	showBiannualToggle: false,
+	showBiannualToggle: true,
 	shouldShowPlansFeatureComparison: true,
 };
 


### PR DESCRIPTION
## Proposed Changes

* Launch the test variant of as the Explat experiment `paid_media_signup_2023_03_legacy_free_presentation` new control. Context at pbxNRc-2rF-p2.
* Remove the Explat config.

## Testing Instructions
* Checkout this PR and start Calypso locally.
* Navigate to `/start/onboarding-pm` 
* Go through signup using and confirm that it works properly:
* On the select a custom domain, a free domain, and then the skip option;
* Confirm that the option to choose Free is not present if the user selected a custom domain or the skip option.
* Confirm that the Free option IS available if the user chose a free domain.
* Confirm that the 1 year and 2 year term lengths are available on the Plans step (Monthly option should not be presented).
