### PR TITLE
Odyssey Stats: Resolve duplicate main aria landmarks

### DIFF
--- a/apps/odyssey-stats/src/app.jsx
+++ b/apps/odyssey-stats/src/app.jsx
@@ -16,7 +16,11 @@ import wpcomApiMiddleware from 'calypso/state/data-layer/wpcom-api-middleware';
 import { setStore } from 'calypso/state/redux-store';
 import sites from 'calypso/state/sites/reducer';
 import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
+<<<<<<< HEAD
 import config from './lib/config-api';
+=======
+import { removeMainRoleFromExistingElements } from './lib/a11y';
+>>>>>>> 9c94c48f61 (import function into app startup)
 import setLocale from './lib/set-locale';
 import { setupContextMiddleware } from './page-middleware/setup-context';
 import registerStatsPages from './routes';
@@ -25,6 +29,7 @@ import 'calypso/assets/stylesheets/style.scss';
 import './app.scss';
 
 async function AppBoot() {
+	removeMainRoleFromExistingElements();
 	const siteId = config( 'blog_id' );
 	const localeSlug = config( 'i18n_locale_slug' ) || config( 'i18n_default_locale_slug' ) || 'en';
 

--- a/apps/odyssey-stats/src/lib/a11y.js
+++ b/apps/odyssey-stats/src/lib/a11y.js
@@ -1,0 +1,10 @@
+// Description: This file contains all the a11y related functions.
+
+// removes the role="main" attribute from all elements that are not the main element
+export function removeMainRoleFromExistingElements() {
+	const elementsToRemoveRole = document.querySelectorAll( '[role=main]:not(main)' );
+
+	elementsToRemoveRole.forEach( ( element ) => {
+		element.removeAttribute( 'role' );
+	} );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
