### PR TITLE
Theme Showcase: Update the theme community badge

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -457,11 +457,12 @@ export class Theme extends Component {
 			return (
 				<PremiumBadge
 					{ ...commonProps }
-					className={ classNames( commonProps.className, 'theme__community-theme' ) }
+					className={ classNames( commonProps.className, 'badge--info' ) }
 					labelText={ translate( 'Community', {
 						context: 'This theme is developed and supported by a community',
 						textOnly: true,
 					} ) }
+					shouldHideIcon
 				/>
 			);
 		}

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -53,8 +53,7 @@ $theme-info-height: 54px;
 		fill: #fff;
 	}
 
-	&.premium-badge.theme__marketplace-theme,
-	&.premium-badge.theme__community-theme {
+	&.premium-badge.theme__marketplace-theme {
 		background: var(--color-primary);
 	}
 

--- a/packages/design-picker/src/components/premium-badge/index.tsx
+++ b/packages/design-picker/src/components/premium-badge/index.tsx
@@ -12,6 +12,7 @@ interface Props {
 	tooltipClassName?: string;
 	tooltipPosition?: string;
 	isPremiumThemeAvailable?: boolean;
+	shouldHideIcon?: boolean;
 	shouldHideTooltip?: boolean;
 	focusOnShow?: boolean;
 }
@@ -23,6 +24,7 @@ const PremiumBadge: FunctionComponent< Props > = ( {
 	tooltipClassName,
 	tooltipPosition = 'bottom left',
 	isPremiumThemeAvailable,
+	shouldHideIcon,
 	shouldHideTooltip,
 	focusOnShow,
 } ) => {
@@ -47,8 +49,12 @@ const PremiumBadge: FunctionComponent< Props > = ( {
 			onMouseEnter={ () => setIsPopoverVisible( true ) }
 			onMouseLeave={ () => setIsPopoverVisible( false ) }
 		>
-			{ /*  eslint-disable-next-line wpcalypso/jsx-gridicon-size */ }
-			<Gridicon className="premium-badge__logo" icon="star" size={ 14 } />
+			{ ! shouldHideIcon && (
+				<>
+					{ /*  eslint-disable-next-line wpcalypso/jsx-gridicon-size */ }
+					<Gridicon className="premium-badge__logo" icon="star" size={ 14 } />
+				</>
+			) }
 			<span>{ labelText || __( 'Premium' ) }</span>
 			{ ! shouldHideTooltip && (
 				<Popover


### PR DESCRIPTION
## Proposed Changes

As mentioned in https://github.com/Automattic/wp-calypso/pull/75618#issuecomment-1511995172, we want to update the theme community badge. See the screenshot below for comparison:

| Before | After |
| --- | --- |
| ![Screenshot 2023-04-20 at 11 32 48 AM](https://user-images.githubusercontent.com/797888/233251535-33bf00a7-b78b-41ac-8786-d8aab3d06c2e.png) | ![Screenshot 2023-04-20 at 11 32 54 AM](https://user-images.githubusercontent.com/797888/233251546-3e5b9aab-9db2-4113-b646-0e07836eab50.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Search for a community theme, such as Astra.
* Ensure that the community badge is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
