### PR TITLE
Flaky E2E: refactor the spec to `Plugins: Add multiple to cart`.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -301,6 +301,8 @@ export class PluginsPage {
 				// the text shown on the install button is slightly different.
 				this.page.getByRole( 'button', { name: /(Purchase|Upgrade) and activate/ } ).click(),
 			] );
+			// Modal will appear to re-confirm to the user that an upgrade is necessary.
+			// Accept the confirmation.
 			await this.page.getByRole( 'button', { name: 'Upgrade and activate plugin' } ).click();
 		} else {
 			await Promise.all( [

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -39,9 +39,6 @@ const selectors = {
 	openRemoveMenuButton: '.plugin-details-cta__manage-plugin-menu button[title="Toggle menu"]',
 	removeButton: '.popover__menu button:has-text("Remove")',
 
-	// Elegibility warnings
-	eligibilityWarning: '.eligibility-warnings__title',
-
 	// Category selector
 	selectedCategory: ( categoryTitle: string ) => `.categories__header:text("${ categoryTitle }")`,
 

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -287,29 +287,30 @@ export class PluginsPage {
 	}
 
 	/**
-	 * Clicks on the Install Plugin button.
+	 * Clicks on the button to install the plugin.
+	 *
+	 * For sites without a supported plan, this method will click on the additional
+	 * modal that appears prompting the user to purchase a plan upgrade.
 	 */
 	async clickInstallPlugin(): Promise< void > {
-		const locator = this.page.locator( selectors.installButton );
-		await Promise.all( [ this.page.waitForResponse( /.*install\?.*/ ), locator.click() ] );
-	}
+		const needsPlanUpgrade = await this.page
+			.locator( 'span.plugin-details-cta__upgrade-required-icon' )
+			.count();
 
-	/**
-	 * Clicks on the `Purchase and Activate` button and get Elegibility warning.
-	 */
-	async clickPurchasePlugin(): Promise< void > {
-		await this.page.getByText( 'Purchase and activate' ).click();
-	}
-
-	/**
-	 * Validate Elegibility Warning and click on the `Upgrade and Activate` button.
-	 */
-	async validateAndContinueElebigilityWarning(): Promise< void > {
-		await this.page
-			.locator( selectors.eligibilityWarning )
-			.getByText( 'Upgrade your plan to install plugins' )
-			.waitFor();
-		await this.page.getByText( 'Upgrade and activate plugin' ).click();
+		if ( needsPlanUpgrade ) {
+			await Promise.all( [
+				this.page.waitForResponse( /eligibility/ ),
+				// Depending on whethe the plugin is free or requires a monthly subscription,
+				// the text shown on the install button is slightly different.
+				this.page.getByRole( 'button', { name: /(Purchase|Upgrade) and activate/ } ).click(),
+			] );
+			await this.page.getByRole( 'button', { name: 'Upgrade and activate plugin' } ).click();
+		} else {
+			await Promise.all( [
+				this.page.waitForResponse( /.*install\?.*/ ),
+				this.page.getByRole( 'button', { name: 'Install and activate' } ).click(),
+			] );
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -45,6 +45,7 @@ const selectors = {
 	// Plugin details view
 	pluginDetailsHeaderTitle: ( section: string ) =>
 		`.plugin-details-header__name:text("${ section }")`,
+	planUpgradeRequiredIcon: 'span.plugin-details-cta__upgrade-required-icon',
 
 	// Post install
 	installedPluginCard: '.thank-you__step',
@@ -290,9 +291,7 @@ export class PluginsPage {
 	 * modal that appears prompting the user to purchase a plan upgrade.
 	 */
 	async clickInstallPlugin(): Promise< void > {
-		const needsPlanUpgrade = await this.page
-			.locator( 'span.plugin-details-cta__upgrade-required-icon' )
-			.count();
+		const needsPlanUpgrade = await this.page.locator( selectors.planUpgradeRequiredIcon ).count();
 
 		if ( needsPlanUpgrade ) {
 			await Promise.all( [

--- a/test/e2e/specs/plugins/plugins__purchase.ts
+++ b/test/e2e/specs/plugins/plugins__purchase.ts
@@ -52,7 +52,7 @@ describe( 'Plugins: Add multiple to cart', function () {
 			await page.getByText( 'You need to upgrade your plan to install plugins' ).waitFor();
 		} );
 
-		it( 'Click on plan upgrade CTA button', async function () {
+		it( 'Click on install button', async function () {
 			await pluginsPage.clickInstallPlugin();
 		} );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/75960.

## Proposed Changes

This PR is a major refactor of the `PluginsPage` POM and the `test/e2e/specs/plugins/plugins__purchase.ts` spec.

Key changes:
- parametrize the `Plugins: Add multiple to cart` spec.
- remove unnecessary steps from the spec.
- combine the multiple methods from the PluginPage into one, steering away from single-purpose methods to a more generic approach.

## Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Pre-Release E2E

I've also executed 30 total loops of the spec locally and verified its functionality.

```
 PASS  specs/plugins/plugins__purchase.ts (16.22 s)
  Plugins: Add multiple to cart
    Add Sensei Pro plugin to cart
      ✓ Go to plugins page for Sensei Pro (1131 ms)
      ✓ Plan upgrade CTA is shown on page (1861 ms)
      ✓ Click on plan upgrade CTA button (375 ms)
      ✓ WordPress.com Business is added to cart (1871 ms)
      ✓ Sensei Pro is added to cart (390 ms)
    Add AutomateWoo plugin to cart
      ✓ Go to plugins page for AutomateWoo (1379 ms)
      ✓ Plan upgrade CTA is shown on page (874 ms)
      ✓ Click on plan upgrade CTA button (421 ms)
      ✓ WordPress.com Business is added to cart (1521 ms)
      ✓ AutomateWoo is added to cart (248 ms)

Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        16.374 s, estimated 17 s
Ran all test suites matching /test\/e2e\/specs\/plugins\/plugins__purchase.ts/i.
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
