### PR TITLE
Design Picker: Retire generated designs 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -23,18 +23,10 @@ function makeSortCategoryToTop( slug: string ) {
 const sortBlogToTop = makeSortCategoryToTop( CATEGORY_BLOG );
 const sortStoreToTop = makeSortCategoryToTop( CATEGORY_STORE );
 
-export function getCategorizationOptions(
-	intent: string,
-	showAllFilter: boolean,
-	generatedDesignsFilter?: string
-) {
+export function getCategorizationOptions( intent: string ) {
 	const result = {
-		showAllFilter,
-		generatedDesignsFilter,
 		defaultSelection: null,
 	} as {
-		showAllFilter: boolean;
-		generatedDesignsFilter?: string;
 		defaultSelection: string | null;
 		sort: ( a: Category, b: Category ) => 0 | 1 | -1;
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/mocks/designs.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/mocks/designs.ts
@@ -1,8 +1,5 @@
 export const generateMockedStarterDesigns = () => {
 	return {
-		generated: {
-			designs: [],
-		},
 		static: {
 			designs: [],
 		},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -20,7 +20,6 @@ import { useQuerySitePurchases } from 'calypso/components/data/query-site-purcha
 import FormattedHeader from 'calypso/components/formatted-header';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
 import WebPreview from 'calypso/components/web-preview/content';
-import { useSiteVerticalQueryById } from 'calypso/data/site-verticals';
 import { ActiveTheme } from 'calypso/data/themes/use-active-theme-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { urlToSlug } from 'calypso/lib/url';
@@ -110,25 +109,21 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		)
 	);
 
-	// ********** Logic for vertical
-	const { data: siteVertical, isLoading: isLoadingSiteVertical } =
-		useSiteVerticalQueryById( siteVerticalId );
-
 	// ********** Logic for fetching designs
 	const selectStarterDesigns = ( allDesigns: StarterDesigns ) => {
-		allDesigns.static.designs = allDesigns.static.designs.filter(
+		allDesigns.designs = allDesigns.designs.filter(
 			( design ) => RETIRING_DESIGN_SLUGS.indexOf( design.slug ) === -1
 		);
 
-		const blankCanvasDesignOffset = allDesigns.static.designs.findIndex( isBlankCanvasDesign );
+		const blankCanvasDesignOffset = allDesigns.designs.findIndex( isBlankCanvasDesign );
 		if ( blankCanvasDesignOffset !== -1 ) {
 			// Extract the blank canvas design first and then insert it into the last one for the build and write intents
-			const blankCanvasDesign = allDesigns.static.designs.splice( blankCanvasDesignOffset, 1 );
+			const blankCanvasDesign = allDesigns.designs.splice( blankCanvasDesignOffset, 1 );
 			if (
 				isEnabled( 'signup/design-picker-pattern-assembler' ) &&
 				SITE_ASSEMBLER_AVAILABLE_INTENTS.includes( intent )
 			) {
-				allDesigns.static.designs.push( ...blankCanvasDesign );
+				allDesigns.designs.push( ...blankCanvasDesign );
 			}
 		}
 
@@ -149,29 +144,19 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		}
 	);
 
-	const generatedDesigns = allDesigns?.generated?.designs || [];
-	const staticDesigns = allDesigns?.static?.designs || [];
-
+	const designs = allDesigns?.designs || [];
 	const hasTrackedView = useRef( false );
 	useEffect( () => {
-		if ( ! hasTrackedView.current && staticDesigns.length > 0 ) {
+		if ( ! hasTrackedView.current && designs.length > 0 ) {
 			hasTrackedView.current = true;
 			recordTracksEvent( 'calypso_signup_unified_design_picker_view', {
 				vertical_id: siteVerticalId,
-				generated_designs: generatedDesigns.map( ( design ) => design.slug ).join( ',' ),
-				has_vertical_images:
-					generatedDesigns.some( ( design ) => design.verticalizable ) ||
-					staticDesigns.some( ( design ) => design.verticalizable ),
+				has_vertical_images: designs.some( ( design ) => design.verticalizable ),
 			} );
 		}
-	}, [ hasTrackedView, generatedDesigns, staticDesigns ] );
+	}, [ hasTrackedView, designs ] );
 
-	const categorizationOptions = getCategorizationOptions(
-		intent,
-		true,
-		generatedDesigns.length > 0 ? siteVertical?.title : undefined
-	);
-
+	const categorizationOptions = getCategorizationOptions( intent );
 	const categorization = useCategorizationFromApi(
 		allDesigns?.filters?.subject || {},
 		categorizationOptions
@@ -221,10 +206,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			return;
 		}
 
-		const { generated: generatedDesigns, static: staticDesigns } = allDesigns;
-
-		const designs = [ ...generatedDesigns.designs, ...staticDesigns.designs ];
-
+		const { designs } = allDesigns;
 		const requestedDesign = designs.find( ( design ) => design.slug === themeFromQueryString );
 		if ( ! requestedDesign ) {
 			return;
@@ -463,14 +445,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	function pickDesign( _selectedDesign: Design | undefined = selectedDesign ) {
 		setSelectedDesign( _selectedDesign );
 		if ( siteSlugOrId && _selectedDesign ) {
-			let positionIndex = generatedDesigns.findIndex(
-				( design ) => design.slug === _selectedDesign.slug
-			);
-			if ( positionIndex === -1 ) {
-				positionIndex = staticDesigns.findIndex(
-					( design ) => design.slug === _selectedDesign.slug
-				);
-			}
+			const positionIndex = designs.findIndex( ( design ) => design.slug === _selectedDesign.slug );
+
 			setPendingAction( () => {
 				if ( _selectedDesign.is_virtual ) {
 					return applyThemeWithPatterns(
@@ -602,7 +578,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	// ********** Main render logic
 
 	// Don't render until we've done fetching all the data needed for initial render.
-	if ( ! site || isLoadingSiteVertical || isLoadingDesigns ) {
+	if ( ! site || isLoadingDesigns ) {
 		return <StepperLoader />;
 	}
 
@@ -727,8 +703,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const stepContent = (
 		<UnifiedDesignPicker
-			generatedDesigns={ generatedDesigns }
-			staticDesigns={ staticDesigns }
+			designs={ designs }
 			verticalId={ siteVerticalId }
 			locale={ locale }
 			onSelectBlankCanvas={ pickBlankCanvasDesign }

--- a/packages/data-stores/src/starter-designs-queries/types.ts
+++ b/packages/data-stores/src/starter-designs-queries/types.ts
@@ -14,6 +14,5 @@ export interface StarterDesignsGenerated {
 
 export interface StarterDesigns {
 	filters: { subject: Record< string, Category > };
-	generated: { designs: Design[] };
-	static: { designs: Design[] };
+	designs: Design[];
 }

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -27,11 +27,10 @@ interface Options extends QueryOptions< StarterDesignsResponse, unknown > {
 
 interface StarterDesignsResponse {
 	filters: { subject: Record< string, Category > };
-	generated: { designs: GeneratedDesign[] };
-	static: { designs: StaticDesign[] };
+	static: { designs: StarterDesign[] };
 }
 
-interface StaticDesign {
+interface StarterDesign {
 	slug: string;
 	title: string;
 	description: string;
@@ -45,13 +44,6 @@ interface StaticDesign {
 	preview_data: PreviewData | null;
 }
 
-interface GeneratedDesign {
-	slug: string;
-	title: string;
-	recipe: DesignRecipe;
-	verticalizable: boolean;
-}
-
 export function useStarterDesignsQuery(
 	queryParams: StarterDesignsQueryParams,
 	{ select, ...queryOptions }: Options = {}
@@ -62,12 +54,7 @@ export function useStarterDesignsQuery(
 				filters: {
 					subject: response.filters?.subject || {},
 				},
-				generated: {
-					designs: response.generated?.designs?.map( apiStarterDesignsGeneratedToDesign ),
-				},
-				static: {
-					designs: response.static?.designs?.map( apiStarterDesignsStaticToDesign ),
-				},
+				designs: response.static?.designs?.map( apiStarterDesignsToDesign ),
 			};
 
 			return select ? select( allDesigns ) : allDesigns;
@@ -88,7 +75,7 @@ function fetchStarterDesigns(
 	} );
 }
 
-function apiStarterDesignsStaticToDesign( design: StaticDesign ): Design {
+function apiStarterDesignsToDesign( design: StarterDesign ): Design {
 	const {
 		slug,
 		title,
@@ -127,22 +114,5 @@ function apiStarterDesignsStaticToDesign( design: StaticDesign ): Design {
 		features: [],
 		template: '',
 		theme: '',
-	};
-}
-
-function apiStarterDesignsGeneratedToDesign( design: GeneratedDesign ): Design {
-	const { slug, title, recipe, verticalizable } = design;
-
-	return {
-		slug,
-		title,
-		recipe,
-		verticalizable,
-		is_premium: false,
-		categories: [],
-		features: [],
-		template: '',
-		theme: '',
-		design_type: 'vertical',
 	};
 }

--- a/packages/design-carousel/src/index.tsx
+++ b/packages/design-carousel/src/index.tsx
@@ -27,7 +27,7 @@ export default function DesignCarousel( { onPick, selectedDesignSlugs }: DesignC
 		_locale: locale,
 	} );
 
-	let selectedDesigns = allDesigns?.static.designs;
+	let selectedDesigns = allDesigns?.designs;
 
 	if ( selectedDesigns && selectedDesignSlugs ) {
 		// If we have a restricted set of designs, filter out all unwanted designs

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -383,29 +383,6 @@
 				grid-template-columns: 1fr 1fr 1fr;
 				column-gap: 24px;
 			}
-
-			.design-button-container--is-generated {
-				margin-top: 0;
-				max-height: 0;
-				overflow: hidden;
-
-				.theme-preview__container {
-					opacity: 0;
-					transition: opacity 1.5s ease-in-out;
-
-					.theme-preview__frame {
-						max-width: none;
-					}
-				}
-			}
-
-			.design-button-container--is-generated--is-showing {
-				max-height: none;
-
-				.theme-preview__container {
-					opacity: 1;
-				}
-			}
 		}
 	}
 
@@ -447,19 +424,6 @@
 		cursor: pointer;
 	}
 
-	.generated-design-thumbnail {
-		height: 500px;
-		min-height: auto;
-		max-height: none;
-		border: none;
-	}
-
-	.generated-design-thumbnail__image {
-		height: auto;
-		padding-top: 0;
-		flex: 1;
-	}
-
 	.components-button:focus::before {
 		box-shadow: none;
 	}
@@ -474,19 +438,6 @@
 
 	.unified-design-picker__designs {
 		min-height: 100vh;
-	}
-
-	.unified-design-picker__generated-designs {
-		max-height: 0;
-		overflow: hidden;
-
-		&.unified-design-picker__generated-designs--is-showing {
-			max-height: none;
-		}
-
-		.design-picker__grid {
-			padding-top: 32px;
-		}
 	}
 }
 
@@ -556,68 +507,5 @@
 			// `!important` is used because there is a default `background-color` with high specificity.
 			background-color: transparent !important; // to override
 		}
-	}
-}
-
-.generated-design-thumbnail {
-	align-items: stretch;
-	border: 1px solid #ddd;
-	border-radius: 4px;
-	box-sizing: border-box;
-	cursor: pointer;
-	display: flex;
-	flex-direction: column;
-	padding: 0;
-	overflow: hidden;
-	transition: border-color 0.15s ease-in-out;
-	width: 100%;
-
-	&:hover,
-	&.is-selected {
-		border-color: #117ac9;
-		outline: 0;
-	}
-
-	&:focus-visible {
-		border-color: #ddd;
-		outline: 2px solid var(--studio-blue-30);
-	}
-
-	.generated-design-thumbnail__image {
-		position: relative;
-		width: 100%;
-		height: 0;
-		padding-top: 100%;
-		overflow: hidden;
-
-		.mshots-image__container {
-			position: absolute;
-			left: 0;
-			top: 0;
-
-			@include break-small {
-				position: relative;
-			}
-		}
-
-		.mshots-image-visible {
-			object-fit: cover;
-			object-position: top;
-			width: 100%;
-		}
-
-		@include break-small {
-			height: auto;
-			padding-top: 0;
-			flex: 1;
-		}
-	}
-
-	@include break-small {
-		border-radius: 2px;
-		height: 170px;
-		min-height: 100px;
-		max-height: 300px;
-		flex-basis: 100%;
 	}
 }

--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -5,7 +5,6 @@ export const FONT_TITLES: Partial< Record< Font, string > > = {
 };
 
 export const SHOW_ALL_SLUG = 'CLIENT_ONLY_SHOW_ALL_SLUG';
-export const SHOW_GENERATED_DESIGNS_SLUG = 'CLIENT_ONLY_SHOW_GENERATED_DESIGNS_SLUG';
 
 /**
  * Pairings of fontFamilies

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -1,6 +1,6 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useMemo, useState } from 'react';
-import { SHOW_ALL_SLUG, SHOW_GENERATED_DESIGNS_SLUG } from '../constants';
+import { SHOW_ALL_SLUG } from '../constants';
 import { Category, Design } from '../types';
 import { gatherCategories } from '../utils';
 
@@ -12,14 +12,13 @@ export interface Categorization {
 
 interface UseCategorizationOptions {
 	defaultSelection: string | null;
-	showAllFilter: boolean;
-	generatedDesignsFilter?: string;
+	showAllFilter?: boolean;
 	sort?: ( a: Category, b: Category ) => number;
 }
 
 export function useCategorization(
 	designs: Design[],
-	{ defaultSelection, showAllFilter, generatedDesignsFilter, sort }: UseCategorizationOptions
+	{ defaultSelection, showAllFilter, sort }: UseCategorizationOptions
 ): Categorization {
 	const { __ } = useI18n();
 
@@ -27,13 +26,6 @@ export function useCategorization(
 		const result = gatherCategories( designs );
 		if ( sort ) {
 			result.sort( sort );
-		}
-
-		if ( generatedDesignsFilter ) {
-			result.unshift( {
-				name: generatedDesignsFilter,
-				slug: SHOW_GENERATED_DESIGNS_SLUG,
-			} );
 		}
 
 		if ( showAllFilter && designs.length ) {
@@ -44,18 +36,14 @@ export function useCategorization(
 		}
 
 		return result;
-	}, [ designs, showAllFilter, generatedDesignsFilter, sort, __ ] );
+	}, [ designs, showAllFilter, sort, __ ] );
 
 	const [ selection, onSelect ] = useState< string | null >(
 		chooseDefaultSelection( categories, defaultSelection )
 	);
 
 	useEffect( () => {
-		// When the category list changes check that the current selection
-		// still matches one of the given slugs, and if it doesn't reset
-		// the current selection.
-		const findResult = categories.find( ( { slug } ) => slug === selection );
-		if ( ! findResult ) {
+		if ( shouldSetToDefaultSelection( categories, selection ) ) {
 			onSelect( chooseDefaultSelection( categories, defaultSelection ) );
 		}
 	}, [ categories, defaultSelection, selection ] );
@@ -69,7 +57,7 @@ export function useCategorization(
 
 export function useCategorizationFromApi(
 	categoryMap: Record< string, Category >,
-	{ defaultSelection, showAllFilter, generatedDesignsFilter }: UseCategorizationOptions
+	{ defaultSelection }: UseCategorizationOptions
 ): Categorization {
 	const { __ } = useI18n();
 
@@ -82,14 +70,7 @@ export function useCategorizationFromApi(
 			slug,
 		} ) );
 
-		if ( generatedDesignsFilter && hasCategories ) {
-			result.unshift( {
-				name: generatedDesignsFilter,
-				slug: SHOW_GENERATED_DESIGNS_SLUG,
-			} );
-		}
-
-		if ( showAllFilter && hasCategories ) {
+		if ( hasCategories ) {
 			result.unshift( {
 				name: __( 'Show All', __i18n_text_domain__ ),
 				slug: SHOW_ALL_SLUG,
@@ -97,18 +78,14 @@ export function useCategorizationFromApi(
 		}
 
 		return result;
-	}, [ showAllFilter, generatedDesignsFilter, categoryMap, __ ] );
+	}, [ categoryMap, __ ] );
 
 	const [ selection, onSelect ] = useState< string | null >(
 		chooseDefaultSelection( categories, defaultSelection )
 	);
 
 	useEffect( () => {
-		// When the category list changes check that the current selection
-		// still matches one of the given slugs, and if it doesn't reset
-		// the current selection.
-		const findResult = categories.find( ( { slug } ) => slug === selection );
-		if ( ! findResult ) {
+		if ( shouldSetToDefaultSelection( categories, selection ) ) {
 			onSelect( chooseDefaultSelection( categories, defaultSelection ) );
 		}
 	}, [ categories, defaultSelection, selection ] );
@@ -118,6 +95,21 @@ export function useCategorizationFromApi(
 		selection,
 		onSelect,
 	};
+}
+
+/**
+ *	Check that the current selection still matches one of the category slugs,
+ *	and if it doesn't reset the current selection to the default selection.
+ *
+ *	@param categories the list of available categories
+ *	@param currentSelection the slug of the current selected category
+ *	@returns whether the current selection should be set to the default selection
+ */
+function shouldSetToDefaultSelection(
+	categories: Category[],
+	currentSelection: string | null
+): boolean {
+	return ! categories.find( ( { slug } ) => slug === currentSelection );
 }
 
 /**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75666

## Proposed Changes

This PR retires generated designs from the Onboarding Design Picker. This means that:

- The Design Picker will no longer show the vertical category tab.
- The Design Picker will no longer show generate designs in any of the category tabs.

![Screenshot 2023-04-20 at 2 44 58 PM](https://user-images.githubusercontent.com/797888/233283064-941e2654-e915-48cd-979e-cde392232886.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Onboarding Design Picker `/setup/site-setup/designSetup?siteSlug=${site_slug}`
* Ensure that the functionalities work as before.
  * Category filters.
  * Theme cards.
  * Pattern assembler CTA.
* Ensure that the Tracks event work as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
