### PR TITLE
Plans grid: update copy of sharing feature

### DIFF
--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -2080,7 +2080,7 @@ export const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_LTD_SOCIAL_MEDIA_JP ]: {
 		getSlug: () => FEATURE_LTD_SOCIAL_MEDIA_JP,
-		getTitle: () => i18n.translate( 'Limited shares in social media' ),
+		getTitle: () => i18n.translate( 'Limited automatic shares in social media' ),
 		getDescription: () =>
 			i18n.translate(
 				'Get 30 social shares per month to promote your posts on Facebook, Twitter, Tumblr, and more.'
@@ -2135,7 +2135,7 @@ export const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_UNLTD_SOCIAL_MEDIA_JP ]: {
 		getSlug: () => FEATURE_UNLTD_SOCIAL_MEDIA_JP,
-		getTitle: () => i18n.translate( 'Unlimited shares in social media' ),
+		getTitle: () => i18n.translate( 'Unlimited automatic shares in social media' ),
 		getDescription: () =>
 			i18n.translate( 'Share your latest posts to your social channels, without limits.' ),
 	},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#1669

## Proposed Changes

* Updates the copy for the sharing features.

<img width="1675" alt="image" src="https://user-images.githubusercontent.com/5436027/233264250-2a2ec440-c817-4e49-b2d5-77e64b239555.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start and proceed to the plans page.
* Confirm that the copy matches the screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
