### PR TITLE
Subscription management: fix optimistic update failing

### DIFF
--- a/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
@@ -70,6 +70,7 @@ const useSiteDeliveryFrequencyMutation = () => {
 				const mutatedSiteSubscriptions = applyCallbackToPages< 'subscriptions', SiteSubscription >(
 					previousSiteSubscriptions,
 					( page ) => ( {
+						...page,
 						subscriptions: page.subscriptions.map( ( siteSubscription ) => {
 							if ( siteSubscription.blog_ID === params.blog_id ) {
 								return {

--- a/packages/data-stores/src/reader/mutations/use-site-unfollow-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unfollow-mutation.ts
@@ -63,6 +63,7 @@ const useSiteUnfollowMutation = () => {
 						SiteSubscription
 					>( previousSiteSubscriptions, ( page ) => {
 						return {
+							...page,
 							subscriptions: page.subscriptions.filter(
 								( siteSubscription ) => siteSubscription.blog_ID !== params.blog_id
 							),


### PR DESCRIPTION
## Proposed Changes

* This fixes the optimistic update of the `useSiteUnfollowMutation` and `useSiteDeliveryFrequencyMutation`.

https://user-images.githubusercontent.com/528287/233288632-6e4c3572-383a-4166-9cd7-279ca08ec8a8.mp4

## Testing Instructions

1. Apply this PR and make sure the subkey is set
2. Follow at least 2 sites
3. Update the delivery frequency of a site, change should be instant in the list
4. Unfollow the site, it should be removed from the list instantly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
