### PR TITLE
Plugin Selectors: Add getPluginStatusesByType to selectors-ts

### DIFF
--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -228,6 +228,15 @@ export const getFilteredAndSortedPlugins = createSelector(
 	}
 );
 
+export function getPluginsWithUpdates( state: AppState, siteIds: number[] ) {
+	return getFilteredAndSortedPlugins( state, siteIds, undefined )
+		.filter( _filters.updates )
+		.map( ( plugin ) => ( {
+			...plugin,
+			type: 'plugin',
+		} ) );
+}
+
 export function getPluginsOnSites( state: AppState, plugins: Plugin[] ) {
 	return plugins.reduce( ( acc: { [ pluginSlug: string ]: Plugin }, plugin: Plugin ) => {
 		const siteIds = Object.keys( plugin.sites ).map( Number );

--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -229,12 +229,10 @@ export const getFilteredAndSortedPlugins = createSelector(
 );
 
 export function getPluginsWithUpdates( state: AppState, siteIds: number[] ) {
-	return getFilteredAndSortedPlugins( state, siteIds, undefined )
-		.filter( _filters.updates )
-		.map( ( plugin ) => ( {
-			...plugin,
-			type: 'plugin',
-		} ) );
+	return getFilteredAndSortedPlugins( state, siteIds, 'updates' ).map( ( plugin ) => ( {
+		...plugin,
+		type: 'plugin',
+	} ) );
 }
 
 export function getPluginsOnSites( state: AppState, plugins: Plugin[] ) {

--- a/client/state/plugins/installed/test/selectors-ts.ts
+++ b/client/state/plugins/installed/test/selectors-ts.ts
@@ -317,9 +317,9 @@ describe( 'getPluginsWithUpdates', () => {
 		expect( plugins ).toHaveLength( 0 );
 	} );
 
-	test( 'Should get a plugin list of length 1 when we can update files on the site', () => {
+	test( 'Should get a plugin list with the Jetpack site with "type: plugin" on it', () => {
 		const plugins = getPluginsWithUpdates( state, [ siteOneId, siteTwoId ] );
-		expect( plugins ).toHaveLength( 1 );
+		expect( plugins ).toEqual( [ { ...jetpackWithSites, type: 'plugin' } ] );
 	} );
 } );
 

--- a/client/state/plugins/installed/test/selectors-ts.ts
+++ b/client/state/plugins/installed/test/selectors-ts.ts
@@ -14,6 +14,7 @@ import {
 	getPluginOnSite,
 	getPluginOnSites,
 	getPluginsOnSite,
+	getPluginsWithUpdates,
 	getSiteObjectsWithPlugin,
 	getSitesWithPlugin,
 	getSitesWithoutPlugin,
@@ -306,6 +307,18 @@ describe( 'getFilteredAndSortedPlugins', () => {
 
 	test( 'Should get a plugin list of length 1 if inactive plugins on site 1 is requested', () => {
 		const plugins = getFilteredAndSortedPlugins( state, [ siteOneId ], 'inactive' );
+		expect( plugins ).toHaveLength( 1 );
+	} );
+} );
+
+describe( 'getPluginsWithUpdates', () => {
+	test( 'Should get an empty array if the requested site is not in the current state', () => {
+		const plugins = getPluginsWithUpdates( state, [ nonExistingSiteId1 ] );
+		expect( plugins ).toHaveLength( 0 );
+	} );
+
+	test( 'Should get a plugin list of length 1 when we can update files on the site', () => {
+		const plugins = getPluginsWithUpdates( state, [ siteOneId, siteTwoId ] );
 		expect( plugins ).toHaveLength( 1 );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR adds the final plugins selector from https://github.com/Automattic/wp-calypso/pull/72363 to `selectors-ts.ts`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run the tests and make sure that they pass. 

Since this is the last selector from https://github.com/Automattic/wp-calypso/pull/72363, compare the selectors.ts file there to `selectors-ts.ts` here and ensure that no selectors have been missed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
