### PR TITLE
Subscriptions Management: Fix multiple styling and copy issues on the Comments page

### DIFF
--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import { SubscriptionManager } from '@automattic/data-stores';
 import { memo, useMemo } from 'react';
 import TimeSince from 'calypso/components/time-since';
@@ -24,6 +25,7 @@ const CommentRow = ( {
 	forwardedRef,
 	style,
 }: CommentRowProps ) => {
+	const translate = useTranslate();
 	const hostname = useMemo( () => new URL( site_url ).hostname, [ site_url ] );
 	const siteIcon = useMemo( () => {
 		if ( site_icon ) {
@@ -39,10 +41,10 @@ const CommentRow = ( {
 				<span className="post" role="cell">
 					<div className="title">
 						<a href={ post_url } target="_blank" rel="noreferrer noopener">
-							{ post_title }
+							{ post_title || translate( 'Untitled' ) }
 						</a>
 					</div>
-					<div className="excerpt">{ post_excerpt }</div>
+					{ post_excerpt && <div className="excerpt">{ post_excerpt }</div> }
 				</span>
 				<a href={ site_url } rel="noreferrer noopener" className="title-box" target="_blank">
 					<span className="title-box" role="cell">

--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -1,6 +1,6 @@
 import { Gridicon } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
 import { SubscriptionManager } from '@automattic/data-stores';
+import { useTranslate } from 'i18n-calypso';
 import { memo, useMemo } from 'react';
 import TimeSince from 'calypso/components/time-since';
 import { CommentSettings } from '../settings-popover';

--- a/client/landing/subscriptions/components/comment-list/styles.scss
+++ b/client/landing/subscriptions/components/comment-list/styles.scss
@@ -9,6 +9,7 @@ $max-list-width: 1300px;
 	text-overflow: ellipsis;
 	overflow: hidden;
 }
+
 .subscription-manager__comment-list {
 	max-width: $max-list-width;
 	min-width: 300px;
@@ -22,6 +23,7 @@ $max-list-width: 1300px;
 			}
 		}
 	}
+
 	.row {
 		display: flex;
 		align-items: center;

--- a/client/landing/subscriptions/components/comment-list/styles.scss
+++ b/client/landing/subscriptions/components/comment-list/styles.scss
@@ -9,7 +9,6 @@ $max-list-width: 1300px;
 	text-overflow: ellipsis;
 	overflow: hidden;
 }
-
 .subscription-manager__comment-list {
 	max-width: $max-list-width;
 	min-width: 300px;
@@ -23,11 +22,11 @@ $max-list-width: 1300px;
 			}
 		}
 	}
-
 	.row {
 		display: flex;
 		align-items: center;
 		flex-direction: row;
+		min-height: 44px;
 		margin-top: 20px;
 		margin-bottom: 20px;
 		justify-content: space-between;
@@ -37,6 +36,7 @@ $max-list-width: 1300px;
 		}
 
 		&.header {
+			min-height: auto;
 			padding-bottom: $font-code;
 			padding-top: 0;
 			margin: 0;
@@ -46,6 +46,7 @@ $max-list-width: 1300px;
 			flex: 0 0 403px;
 			font-size: $font-body-small;
 			line-height: 20px;
+			color: $studio-gray-60;
 
 			.title {
 				max-width: 350px;

--- a/client/landing/subscriptions/components/comment-list/styles.scss
+++ b/client/landing/subscriptions/components/comment-list/styles.scss
@@ -15,7 +15,7 @@ $max-list-width: 1300px;
 	min-width: 300px;
 
 	.row-wrapper {
-		border-bottom: 1px solid var(--color-border-subtle);
+		border-block-end: 1px solid rgb(238, 238, 238);
 
 		&.header {
 			@media (max-width: $break-small) {

--- a/client/landing/subscriptions/components/tab-views/comments/comments.tsx
+++ b/client/landing/subscriptions/components/tab-views/comments/comments.tsx
@@ -50,7 +50,7 @@ const Comments = () => {
 				<div className="subscriptions-manager__list-actions-bar">
 					<SearchInput
 						// todo: translate when we have agreed on the placeholder
-						placeholder="Search by post name…"
+						placeholder="Search by post, site title, or address…"
 						searchIcon={ <SearchIcon size={ 18 } /> }
 						onSearch={ handleSearch }
 					/>

--- a/client/landing/subscriptions/components/tab-views/comments/comments.tsx
+++ b/client/landing/subscriptions/components/tab-views/comments/comments.tsx
@@ -49,8 +49,7 @@ const Comments = () => {
 			{ isListControlsEnabled && (
 				<div className="subscriptions-manager__list-actions-bar">
 					<SearchInput
-						// todo: translate when we have agreed on the placeholder
-						placeholder="Search by post, site title, or address…"
+						placeholder={ translate( 'Search by post, site title, or address…' ) }
 						searchIcon={ <SearchIcon size={ 18 } /> }
 						onSearch={ handleSearch }
 					/>


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/76139.

## Proposed Changes

* if a post doesn't have a title, display `Untitled` instead
* if a post doesn't have any excerpt, don't display the excerpt div at all and center the post title horizontally
* update `SearchInput`'s placeholder from "Search by post name…" to "Search by post, site title, or address…" (context: pdDOJh-1Kg-p2#comment-1395)
* fix row line color to match it with the one used at https://wordpress.com/sites
* fix post "Subscribed post " table header color to match with the color in the design

![Markup on 2023-04-25 at 11:01:09](https://user-images.githubusercontent.com/25105483/234227914-1c736719-62be-4b83-a4cf-1d717f51d5b0.png)

General context: pdDOJh-1Kg-p2

## Testing Instructions

1. Check out and build the PR locally.
2. Apply the correct `subkey` cookie value to your `calypso.localhost:3000` host.
3. Make sure the related user has existing comment subscriptions from which at least:
  - one has no title
  - one has no excerpt
4. Navigate to http://calypso.localhost:3000/subscriptions/comments and review the page. → All the PR changes should be applied correctly. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?