### PR TITLE
Plugins: Switch from Plugin to PluginComponentProps

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -9,22 +9,22 @@ import { resetPluginStatuses } from 'calypso/state/plugins/installed/status/acti
 import PluginsList from './plugins-list';
 import UpdatePlugins from './update-plugins';
 import { pluginsEmptyMessage } from './utils/get-plugins-empty-message';
-import type { Plugin } from './types';
+import type { PluginComponentProps } from './types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { PluginFilter } from 'calypso/state/plugins/installed/types';
 
 import './style.scss';
 
 interface Props {
-	plugins: Array< Plugin >;
+	plugins: Array< PluginComponentProps >;
 	isLoading: boolean;
 	requestError: boolean;
 	selectedSite: SiteDetails;
 	searchTerm: string;
 	isBulkManagementActive: boolean;
 	toggleBulkManagement: () => void;
-	removePluginNotice: ( plugin: Plugin ) => void;
-	updatePlugin: ( plugin: Plugin ) => void;
+	removePluginNotice: ( plugin: PluginComponentProps ) => void;
+	updatePlugin: ( plugin: PluginComponentProps ) => void;
 	isJetpackCloud: boolean;
 	filter: PluginFilter;
 }

--- a/client/my-sites/plugins/plugin-management-v2/plugin-card/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-card/index.tsx
@@ -1,10 +1,10 @@
 import PluginCommonCard from '../plugin-common/plugin-common-card';
-import type { Columns, PluginRowFormatterArgs, Plugin } from '../types';
+import type { Columns, PluginRowFormatterArgs, PluginComponentProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { ReactNode } from 'react';
 
 interface Props {
-	item: Plugin;
+	item: PluginComponentProps;
 	selectedSite: SiteDetails;
 	rowFormatter: ( args: PluginRowFormatterArgs ) => ReactNode;
 	columns: Columns;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/index.tsx
@@ -18,7 +18,7 @@ import {
 } from 'calypso/state/plugins/installed/selectors';
 import { resetPluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import { isFetching as isWporgPluginFetchingSelector } from 'calypso/state/plugins/wporg/selectors';
-import type { Plugin } from '../types';
+import type { PluginComponentProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
@@ -26,7 +26,7 @@ import './style.scss';
 interface Props {
 	selectedSite: SiteDetails;
 	pluginSlug: string;
-	fullPlugin: Plugin;
+	fullPlugin: PluginComponentProps;
 	sitesWithPlugins: Array< SiteDetails >;
 	showPlaceholder: boolean;
 	isMarketplaceProduct: boolean;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/plugin-available-on-sites-list.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/plugin-available-on-sites-list.tsx
@@ -2,7 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { getSitesWithSecondarySites } from 'calypso/my-sites/plugins/plugin-management-v2/utils/get-sites-with-secondary-sites';
 import SitesList from '../sites-list';
-import type { Plugin } from '../types';
+import type { PluginComponentProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
@@ -11,7 +11,7 @@ interface Props {
 	sites: Array< SiteDetails | null | undefined >;
 	selectedSite: SiteDetails;
 	isLoading: boolean;
-	plugin: Plugin;
+	plugin: PluginComponentProps;
 }
 
 export default function PluginAvailableOnSitesList( props: Props ) {

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/sites-with-installed-plugin-list.tsx
@@ -7,7 +7,7 @@ import PluginManageConnection from '../plugin-manage-connection';
 import PluginManageSubcription from '../plugin-manage-subscription';
 import RemovePlugin from '../remove-plugin';
 import SitesList from '../sites-list';
-import type { Plugin } from '../types';
+import type { PluginComponentProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
@@ -16,7 +16,7 @@ interface Props {
 	sites: Array< SiteDetails | null | undefined >;
 	selectedSite: SiteDetails;
 	isLoading: boolean;
-	plugin: Plugin;
+	plugin: PluginComponentProps;
 	isWpCom?: boolean;
 }
 

--- a/client/my-sites/plugins/plugin-management-v2/plugin-manage-connection/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-manage-connection/index.tsx
@@ -2,14 +2,14 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useTranslate } from 'i18n-calypso';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { getManageConnectionHref } from 'calypso/lib/plugins/utils';
-import type { Plugin } from '../types';
+import type { PluginComponentProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 
 import '../style.scss';
 
 interface Props {
 	site: SiteDetails;
-	plugin: Plugin;
+	plugin: PluginComponentProps;
 }
 
 export default function PluginManageConnection( { site, plugin }: Props ) {

--- a/client/my-sites/plugins/plugin-management-v2/plugin-manage-subscription/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-manage-subscription/index.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { getPluginPurchased } from 'calypso/lib/plugins/utils';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
-import type { Plugin } from '../types';
+import type { PluginComponentProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { ReactElement } from 'react';
 
@@ -11,7 +11,7 @@ import '../style.scss';
 
 interface Props {
 	site: SiteDetails;
-	plugin: Plugin;
+	plugin: PluginComponentProps;
 }
 
 type Purchase = {

--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -19,7 +19,7 @@ import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import PluginActionStatus from '../plugin-action-status';
 import { getAllowedPluginActions } from '../utils/get-allowed-plugin-actions';
 import { getPluginActionStatuses } from '../utils/get-plugin-action-statuses';
-import type { Plugin } from '../types';
+import type { PluginComponentProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { MomentInput } from 'moment';
 import type { MouseEventHandler, PropsWithChildren } from 'react';
@@ -27,12 +27,12 @@ import type { MouseEventHandler, PropsWithChildren } from 'react';
 import './style.scss';
 
 interface Props {
-	item: Plugin;
+	item: PluginComponentProps;
 	columnKey: string;
 	selectedSite?: SiteDetails;
 	isSmallScreen?: boolean;
 	className?: string;
-	updatePlugin?: ( plugin: Plugin ) => void;
+	updatePlugin?: ( plugin: PluginComponentProps ) => void;
 }
 
 export default function PluginRowFormatter( {

--- a/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
@@ -5,19 +5,19 @@ import PluginCommonList from '../plugin-common/plugin-common-list';
 import PluginManageConnection from '../plugin-manage-connection';
 import PluginRowFormatter from '../plugin-row-formatter';
 import RemovePlugin from '../remove-plugin';
-import type { Columns, PluginRowFormatterArgs, Plugin } from '../types';
+import type { Columns, PluginRowFormatterArgs, PluginComponentProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 
 import '../style.scss';
 
 interface Props {
 	selectedSite: SiteDetails;
-	items: Array< Plugin >;
+	items: Array< PluginComponentProps >;
 	isLoading: boolean;
 	columns: Columns;
 	className?: string;
-	removePluginNotice: ( plugin: Plugin ) => void;
-	updatePlugin: ( plugin: Plugin ) => void;
+	removePluginNotice: ( plugin: PluginComponentProps ) => void;
+	updatePlugin: ( plugin: PluginComponentProps ) => void;
 }
 
 export default function PluginsList( {
@@ -51,12 +51,12 @@ export default function PluginsList( {
 		} );
 	};
 
-	const onRemoveClick = ( plugin: Plugin ) => () => {
+	const onRemoveClick = ( plugin: PluginComponentProps ) => () => {
 		removePluginNotice( plugin );
 		trackRemovePlugin( plugin.slug );
 	};
 
-	const renderActions = ( plugin: Plugin ) => {
+	const renderActions = ( plugin: PluginComponentProps ) => {
 		return (
 			<>
 				<PopoverMenuItem

--- a/client/my-sites/plugins/plugin-management-v2/plugins-table/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-table/index.tsx
@@ -1,11 +1,11 @@
 import PluginCommonTable from '../plugin-common/plugin-common-table';
-import type { Columns, PluginRowFormatterArgs, Plugin } from '../types';
+import type { Columns, PluginRowFormatterArgs, PluginComponentProps } from '../types';
 import type { ReactNode } from 'react';
 
 interface Props {
 	isLoading: boolean;
 	columns: Columns;
-	items: Array< Plugin >;
+	items: Array< PluginComponentProps >;
 	rowFormatter: ( args: PluginRowFormatterArgs ) => ReactNode;
 	hasMoreActions: boolean;
 	primaryKey: string;

--- a/client/my-sites/plugins/plugin-management-v2/remove-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/remove-plugin/index.tsx
@@ -1,14 +1,14 @@
 import { useSelector } from 'react-redux';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 import PluginRemoveButton from '../../plugin-remove-button';
-import type { Plugin } from '../types';
+import type { PluginComponentProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 
 import '../style.scss';
 
 interface Props {
 	site: SiteDetails;
-	plugin: Plugin;
+	plugin: PluginComponentProps;
 }
 
 export default function RemovePlugin( { site, plugin }: Props ) {

--- a/client/my-sites/plugins/plugin-management-v2/sites-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/sites-list/index.tsx
@@ -2,7 +2,7 @@ import { useDispatch } from 'react-redux';
 import { updatePlugin } from 'calypso/state/plugins/installed/actions';
 import PluginCommonList from '../plugin-common/plugin-common-list';
 import PluginRowFormatter from '../plugin-row-formatter';
-import type { Columns, SiteRowFormatterArgs, Plugin } from '../types';
+import type { Columns, SiteRowFormatterArgs, PluginComponentProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { ReactElement } from 'react';
 
@@ -11,7 +11,7 @@ interface Props {
 	items: Array< SiteDetails | null | undefined >;
 	isLoading: boolean;
 	columns: Columns;
-	plugin: Plugin;
+	plugin: PluginComponentProps;
 	renderActions?: ( args: any ) => ReactElement;
 }
 

--- a/client/my-sites/plugins/plugin-management-v2/types.ts
+++ b/client/my-sites/plugins/plugin-management-v2/types.ts
@@ -14,7 +14,7 @@ import {
 	PLUGIN_INSTALLATION_UP_TO_DATE,
 } from 'calypso/state/plugins/installed/status/constants';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { MomentInput } from 'moment';
+import type { Plugin } from 'calypso/state/plugins/installed/types';
 import type { ReactNode } from 'react';
 
 export type Columns = Array< {
@@ -23,20 +23,6 @@ export type Columns = Array< {
 	smallColumn?: boolean;
 	colSpan?: number;
 } >;
-
-export type PluginSite = { [ key: string ]: { ID: number; canUpdateFiles: boolean } };
-
-export interface Plugin {
-	id: string;
-	last_updated: MomentInput;
-	sites: PluginSite;
-	icon: string;
-	name: string;
-	pluginsOnSites: Array< any >;
-	slug: string;
-	wporg: boolean;
-	[ key: string ]: any;
-}
 
 export type SiteWithPlugin = { site: SiteDetails; secondarySites: Array< object > | null };
 
@@ -48,7 +34,7 @@ export interface RowFormatterArgs {
 	selectedSite?: SiteDetails;
 }
 export interface PluginRowFormatterArgs extends RowFormatterArgs {
-	item: Plugin;
+	item: PluginComponentProps;
 }
 export interface SiteRowFormatterArgs extends RowFormatterArgs {
 	item: SiteDetails;
@@ -82,4 +68,13 @@ export type PluginActionStatusMessage = {
 		[ PLUGIN_INSTALLATION_ERROR ]: ReactNode;
 		[ PLUGIN_INSTALLATION_UP_TO_DATE ]?: ReactNode;
 	};
+};
+
+// Some component code adds properties onto the plugin objects and then passes that to other components.
+// This type is used to account for that behavior.
+export type PluginComponentProps = Plugin & {
+	isSelectable?: boolean;
+	isSelected: boolean;
+	isMarketplaceProduct?: boolean;
+	onClick: () => void;
 };

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -34,7 +34,7 @@ export default function UpdatePlugin( { plugin, selectedSite, className, updateP
 			return {
 				...site,
 				...plugin.sites[ siteId ],
-			};
+			} as any; // This must be cast as any until this file is updated to work with the selectors in state/plugins/installed/selectors
 		} );
 	};
 

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -34,7 +34,7 @@ export default function UpdatePlugin( { plugin, selectedSite, className, updateP
 			return {
 				...site,
 				...plugin.sites[ siteId ],
-			};
+			} as any;
 		} );
 	};
 

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -34,7 +34,7 @@ export default function UpdatePlugin( { plugin, selectedSite, className, updateP
 			return {
 				...site,
 				...plugin.sites[ siteId ],
-			} as any;
+			};
 		} );
 	};
 

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -11,16 +11,16 @@ import getSites from 'calypso/state/selectors/get-sites';
 import PluginActionStatus from '../plugin-action-status';
 import { getAllowedPluginActions } from '../utils/get-allowed-plugin-actions';
 import { getPluginActionStatuses } from '../utils/get-plugin-action-statuses';
-import type { Plugin } from '../types';
+import type { PluginComponentProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
 
 interface Props {
-	plugin: Plugin;
+	plugin: PluginComponentProps;
 	selectedSite?: SiteDetails;
 	className?: string;
-	updatePlugin?: ( plugin: Plugin ) => void;
+	updatePlugin?: ( plugin: PluginComponentProps ) => void;
 }
 
 export default function UpdatePlugin( { plugin, selectedSite, className, updatePlugin }: Props ) {
@@ -28,7 +28,7 @@ export default function UpdatePlugin( { plugin, selectedSite, className, updateP
 	const allSites = useSelector( getSites );
 	const state = useSelector( ( state ) => state );
 
-	const getPluginSites = ( plugin: Plugin ) => {
+	const getPluginSites = ( plugin: PluginComponentProps ) => {
 		return Object.keys( plugin.sites ).map( ( siteId ) => {
 			const site = allSites.find( ( s ) => s?.ID === parseInt( siteId ) );
 			return {

--- a/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugins/index.tsx
@@ -16,13 +16,13 @@ import {
 	handleUpdatePlugins,
 	siteObjectsToSiteIds,
 } from '../../utils';
-import type { Plugin } from '../types';
+import type { PluginComponentProps } from '../types';
 import type { ReactElement } from 'react';
 
 import '../style.scss';
 
 interface Props {
-	plugins: Array< Plugin >;
+	plugins: Array< PluginComponentProps >;
 	isWpCom?: boolean;
 }
 
@@ -48,13 +48,13 @@ export default function UpdatePlugins( { plugins, isWpCom }: Props ): ReactEleme
 
 	const pluginUpdateCount = pluginsWithUpdates.length;
 
-	const updateAction = ( siteId: number, sitePlugin: Plugin ) => {
+	const updateAction = ( siteId: number, sitePlugin: PluginComponentProps ) => {
 		dispatch( updatePlugin( siteId, sitePlugin ) );
 	};
 
 	function recordEvent( eventAction: string ) {
 		eventAction += selectedSite ? '' : ' on Multisite';
-		const pluginSlugs = pluginsWithUpdates.map( ( plugin: Plugin ) => plugin.slug );
+		const pluginSlugs = pluginsWithUpdates.map( ( plugin: PluginComponentProps ) => plugin.slug );
 		dispatch( recordGoogleEvent( 'Plugins', eventAction, 'Plugins', pluginSlugs ) );
 	}
 

--- a/client/my-sites/plugins/plugin-management-v2/utils/get-allowed-plugin-actions.ts
+++ b/client/my-sites/plugins/plugin-management-v2/utils/get-allowed-plugin-actions.ts
@@ -2,12 +2,12 @@ import { WPCOM_FEATURES_MANAGE_PLUGINS } from '@automattic/calypso-products';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import type { Plugin } from '../types';
+import type { PluginComponentProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { AppState } from 'calypso/types';
 
 export const getAllowedPluginActions = (
-	plugin: Plugin,
+	plugin: PluginComponentProps,
 	state: AppState,
 	selectedSite?: SiteDetails
 ) => {

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -132,6 +132,12 @@ export interface SiteDetails {
 	was_ecommerce_trial?: boolean;
 	wpcom_url?: string;
 	user_interactions?: string[];
+
+	// Jetpack computed properties
+	canAutoupdateFiles?: boolean;
+	canUpdateFiles?: boolean;
+	isMainNetworkSite?: boolean;
+	isSecondaryNetworkSite?: boolean;
 }
 
 export interface SiteDetailsCapabilities {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR adds the part from https://github.com/Automattic/wp-calypso/pull/72363 which switches `Props` for `PluginComponentProps` and adds the Jetpack computed properties from `client/state/sites/selectors/get-jetpack-computed-attributes.js` to `packages/data-stores/src/site/types.ts`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Build both Calypso and Jetpack Cloud and make sure that neither has type errors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
