### PR TITLE
Newsletter: Fix subscribers disclaimer font

### DIFF
--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -190,17 +190,17 @@
 	}
 
 	.add-subscriber__form--disclaimer {
-		font-size: 0.875rem;
+		font-size: $font-body-small;
 		line-height: 1.25;
 		color: var(--studio-gray-50);
 		margin-bottom: 1.5rem;
 
 		a,
 		button {
+			font-size: $font-body-small;
 			color: var(--color-text);
 			text-decoration: underline;
 			height: unset;
-			font-size: 0.875rem;
 
 			&:hover {
 				color: var(--color-text-subtle);

--- a/packages/subscriber/src/components/add-form/style.scss
+++ b/packages/subscriber/src/components/add-form/style.scss
@@ -200,6 +200,7 @@
 			color: var(--color-text);
 			text-decoration: underline;
 			height: unset;
+			font-size: 0.875rem;
 
 			&:hover {
 				color: var(--color-text-subtle);


### PR DESCRIPTION
## What
Thesparagraphs in the Add subcribers step have different font sizes. The p has font-size: 14px and all the links, font-size: 13px. It should be Base/Regular (14px).

![image](https://user-images.githubusercontent.com/52076348/233328450-cc5ad5b3-827e-49a4-9a2a-5fddfbd04f95.png)

## Testing
1. Live link
2. Reach the Subscribers step in the Newsletter flow
3. Inspect the font sizes


Fixes https://github.com/Automattic/wp-calypso/issues/75686