### PR TITLE
Changed comment subscription date format to accommodate changes in endpoint

### DIFF
--- a/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
@@ -63,7 +63,7 @@ const usePostSubscriptionsQuery = ( {
 		// Transform the dates into Date objects
 		const transformedData = flattenedData?.map( ( comment_subscription ) => ( {
 			...comment_subscription,
-			subscription_date: new Date( comment_subscription.subscription_date + ' UTC' ),
+			subscription_date: new Date( comment_subscription.subscription_date ),
 		} ) );
 
 		const searchTermLowerCase = searchTerm.toLowerCase();


### PR DESCRIPTION
## Proposed Changes

There was a problem with the dates in comment subscriptions tab in Firefox. The endpoint that returns the list of comment subscriptions has changed. Now it returns the subscription date in this format: `2011-12-08T01:15:36-08:00`. This PR accommodates those changes.

## Testing Instructions

1. Apply this PR and run the application.
2. Apply this patch to your sandbox
3. Subscribe to a blog with a non-WP.com user (for example, [your-email+testing@gmail.com](mailto:your-email+testing@gmail.com))
4. You should receive a confirmation e-mail that contains a "Manage subscriptions" button
5. Copy the button's link & visit in an incognito window
6. Open dev tools & copy the cookie. Make sure "Show URL decoded" is checked. Copy the value from the subkey cookie.
7. Add the subkey cookie to calypso.localhost:3000.
8. Go to /subscriptions/comments.
9. The dates should work on Firefox too.

