### PR TITLE
`/subscriptions/comments`: Fix infinite page requests on comments.

### DIFF
--- a/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
@@ -23,7 +23,7 @@ const usePostSubscriptionsQuery = ( {
 	searchTerm = '',
 	filter = defaultFilter,
 	sort = defaultSort,
-	number = 100,
+	number = 500,
 }: SubscriptionManagerPostSubscriptionsQueryProps = {} ) => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
@@ -42,9 +42,8 @@ const usePostSubscriptionsQuery = ( {
 			{
 				enabled,
 				getNextPageParam: ( lastPage, pages ) => {
-					return pages.length < lastPage.total_comment_subscriptions_count
-						? pages.length + 1
-						: undefined;
+					const total = pages.reduce( ( sum, page ) => sum + page.comment_subscriptions.length, 0 );
+					return total < lastPage.total_comment_subscriptions_count ? pages.length + 1 : undefined;
 				},
 				refetchOnWindowFocus: false,
 			}


### PR DESCRIPTION
## Proposed Changes

* Fix page requests happening indefinitely due to incorrect next page calculation.
* Increase per_page pagination to 500 to reduce number of api requests.

## Testing Instructions

* Go to `/subscriptions/comments`.
* Open up the network panel.
* It should stop making API requests once all items are fetched.

before:
<img width="1023" alt="image" src="https://user-images.githubusercontent.com/1287077/233337791-1fb3959c-3b52-405f-91ed-c13d7e981fa3.png">

after:
<img width="661" alt="image" src="https://user-images.githubusercontent.com/1287077/233337880-ec3a9c40-38fe-4cc0-8feb-b668f0908bf3.png">

reference on the shape of pages & lastPage:
<img width="580" alt="image" src="https://user-images.githubusercontent.com/1287077/233337806-d848923a-3159-4191-9293-68d8740aa434.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
