### PR TITLE
Newsletters: scaffold paid subscribers step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -62,6 +62,7 @@ button {
 .newsletter-post-setup,
 .plans,
 .domains,
+.paid-subscribers,
 .patterns,
 .link-in-bio-setup,
 .link-in-bio-post-setup,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/paid-subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/paid-subscribers/index.tsx
@@ -1,0 +1,80 @@
+import { Button } from '@automattic/components';
+import { StepContainer } from '@automattic/onboarding';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+import type { OnboardSelect } from '@automattic/data-stores';
+import './style.scss';
+
+const PaidSubscribers: Step = ( { navigation } ) => {
+	const { submit } = navigation;
+	const translate = useTranslate();
+
+	const { setPaidSubscribers } = useDispatch( ONBOARD_STORE );
+	const state = useSelect( ( select ) => select( ONBOARD_STORE ) as OnboardSelect, [] ).getState();
+
+	useEffect( () => {
+		const { paidSubscribers } = state;
+		setPaidSubscribers( paidSubscribers );
+	}, [ state ] );
+
+	const paidSubscribersContinue = ( value: boolean ) => {
+		setPaidSubscribers( value );
+		submit?.();
+	};
+
+	return (
+		<StepContainer
+			stepName="paid-subscribers"
+			isWideLayout={ true }
+			hideBack={ true }
+			flowName="newsletter"
+			formattedHeader={
+				<FormattedHeader
+					headerText={ translate(
+						// 'Are you going to share exclusive content with paid subscribers?'
+						'Get paid and be supported by your subscribers'
+					) }
+					subHeaderText={ translate(
+						// "Don't worry, ..."
+						'You can turn on monetization at any point later on.'
+					) }
+					align="center"
+				/>
+			}
+			stepContent={
+				<>
+					<div className="paid-subscribers__intro">
+						{ translate(
+							'You can publish your newsletter for free, and choose to let your subscribers support you with a monthly fee. Your posts can stay public, subscribers-only, or paywalled.'
+						) }
+					</div>
+
+					<img
+						alt=""
+						className="paid-subscribers__image"
+						src="https://i0.wp.com/live-patreon-marketing.pantheonsite.io/wp-content/uploads/2020/12/For-communities-03_2x-1.jpg"
+					/>
+
+					<div className="paid-subscribers__cta">
+						<Button onClick={ () => paidSubscribersContinue( true ) } primary>
+							{ translate( 'Yes, set up payments for subscribers' ) }
+						</Button>
+						<br /> <br />
+						<Button onClick={ () => paidSubscribersContinue( false ) }>
+							{ translate( 'Not at this time' ) }
+						</Button>
+					</div>
+				</>
+			}
+			recordTracksEvent={ recordTracksEvent }
+			showJetpackPowered
+		/>
+	);
+};
+
+export default PaidSubscribers;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/paid-subscribers/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/paid-subscribers/style.scss
@@ -1,0 +1,43 @@
+@import "../style";
+
+.paid-subscribers {
+	&.step-container {
+		padding-top: 20px;
+		@include break-medium {
+			padding-top: 0;
+		}
+	}
+
+	.step-container__header {
+		margin-bottom: 40px;
+		@include break-medium {
+			margin-top: 36px;
+			margin-bottom: 58px;
+		}
+
+		.formatted-header p.formatted-header__subtitle {
+			text-align: center;
+		}
+	}
+
+	.step-container__content {
+		text-align: center;
+	}
+
+	.paid-subscribers__intro {
+		max-width: 520px;
+		text-align: center;
+		margin: 0 auto 40px auto;
+	}
+
+	.paid-subscribers__image {
+		max-width: 300px;
+		min-width: 200px;
+		border-radius: 10px; /* stylelint-disable-line scales/radii */
+		margin: 0 auto 40px auto;
+	}
+
+	.paid-subscribers__cta {
+		margin: 0 auto 20px auto;
+	}
+}

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -38,6 +39,10 @@ const newsletter: Flow = {
 			{
 				slug: 'subscribers',
 				asyncComponent: () => import( './internals/steps-repository/subscribers' ),
+			},
+			{
+				slug: 'paidSubscribers',
+				asyncComponent: () => import( './internals/steps-repository/paid-subscribers' ),
 			},
 			{
 				slug: 'siteCreationStep',
@@ -139,6 +144,11 @@ const newsletter: Flow = {
 					);
 
 				case 'subscribers':
+					return isEnabled( 'newsletter/paid-subscribers' )
+						? navigate( 'paidSubscribers' )
+						: navigate( 'launchpad' );
+
+				case 'paidSubscribers':
 					return navigate( 'launchpad' );
 			}
 		}

--- a/config/development.json
+++ b/config/development.json
@@ -204,6 +204,7 @@
 		"wpcom-user-bootstrap": false,
 		"yolo/staging-sites-i1": true,
 		"newsletter/stats": true,
+		"newsletter/paid-subscribers": true,
 		"woa-logging": true,
 		"woa-logging-moved": true
 	}

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -94,6 +94,7 @@
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
 		"newsletter/stats": false,
+		"newsletter/paid-subscribers": true,
 		"network-connection": true,
 		"onboarding/import": true,
 		"onboarding/import-from-blogger": true,

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -470,6 +470,11 @@ export const setProfilerData = ( profilerData: ProfilerData ) => ( {
 	profilerData,
 } );
 
+export const setPaidSubscribers = ( paidSubscribers: boolean ) => ( {
+	type: 'SET_PAID_SUBSCRIBERS' as const,
+	paidSubscribers,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -525,4 +530,5 @@ export type OnboardAction = ReturnType<
 	| typeof setProductCartItems
 	| typeof setPlanCartItem
 	| typeof setIsMigrateFromWp
+	| typeof setPaidSubscribers
 >;

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -42,6 +42,7 @@ export function register(): typeof STORE_KEY {
 			'hasUsedPlansStep',
 			'hideFreePlan',
 			'intent',
+			'paidSubscribers',
 			'lastLocation',
 			'planProductId',
 			'randomizedDesigns',

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -509,6 +509,16 @@ export const profilerData: Reducer< ProfilerData | undefined, OnboardAction > = 
 	return state;
 };
 
+const paidSubscribers: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
+	if ( action.type === 'SET_PAID_SUBSCRIBERS' ) {
+		return action.paidSubscribers;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return false;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	anchorPodcastId,
 	anchorEpisodeId,
@@ -554,6 +564,7 @@ const reducer = combineReducers( {
 	isMigrateFromWp,
 	pluginsToVerify,
 	profilerData,
+	paidSubscribers,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -60,3 +60,4 @@ export const getHideFreePlan = ( state: State ) => state.hideFreePlan;
 export const getIsMigrateFromWp = ( state: State ) => state.isMigrateFromWp;
 export const getPluginsToVerify = ( state: State ) => state.pluginsToVerify;
 export const getProfilerData = ( state: State ) => state.profilerData;
+export const getPaidSubscribers = ( state: State ) => state.paidSubscribers;

--- a/packages/onboarding/src/flow-progress/use-flow-progress.ts
+++ b/packages/onboarding/src/flow-progress/use-flow-progress.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	ECOMMERCE_FLOW,
 	LINK_IN_BIO_FLOW,
@@ -22,6 +23,7 @@ const flows: Record< string, { [ step: string ]: number } > = {
 		domains: 2,
 		'plans-newsletter': 3,
 		subscribers: 4,
+		...( isEnabled( 'newsletter/paid-subscribers' ) && { paidSubscribers: 5 } ),
 		launchpad: 5,
 	},
 	[ LINK_IN_BIO_FLOW ]: {


### PR DESCRIPTION
Adds scaffolding of paid membership question during the onboarding, as discussed earlier in walkthrough (_see the video at pbOQVh-3j9-p2 from 39:20_).

Setting up payments tasks at launchpad (reverted in https://github.com/Automattic/wp-calypso/pull/75437) should then appear only if you care to set paid subscribers. [PR in Jetpack](https://github.com/Automattic/jetpack/pull/29468) is also relevant.

Otherwise, we don't surface those tasks at the initial launchpad and perhaps show them at the post-launch launchpad at My Home.

This is just a mockup to get us try the experience but still needs a design.

If we merge before copy is finalized, let's remove `translate()` functions to avoid translating mockup texts.

Next:
- Design, copy (please no feedback on those just yet)
- Tie into payment tasks at launchpad and reverting https://github.com/Automattic/wp-calypso/pull/75437

## Proposed Changes

* Adds scaffolding of "paid subscribers" question during onboarding behind `newsletter/paid-subscribers` feature flag.

<img width="1353" alt="Screenshot 2023-04-20 at 13 24 43" src="https://user-images.githubusercontent.com/87168/233340545-959832c9-c022-4bb0-a18a-efd755fc60f3.png">


**Before**

https://user-images.githubusercontent.com/87168/233347328-70b9e23d-b27d-48e4-9cb7-d439fb5eb3d0.mov


**After**

https://user-images.githubusercontent.com/87168/233347315-3203a88e-88be-4b6c-97ef-8f0f0b019008.mov



## Testing Instructions

* At localhost or Calypso live, open http://calypso.localhost:3000/setup/newsletter
* After "add subscribers" step, and before launchpad you should see a new step
* You don't yet see the steps at launchpad; needs more work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
