### PR TITLE
Add Pro 2-years to config

### DIFF
--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -46,6 +46,7 @@ export const PLAN_P2_FREE = 'p2_free_plan'; // Not a real plan; it's a renamed W
 export const PLAN_WPCOM_FLEXIBLE = 'wpcom-flexible'; // Not a real plan; it's a renamed WP.com Free for the plans overhaul.
 export const PLAN_WPCOM_PRO = 'pro-plan';
 export const PLAN_WPCOM_PRO_MONTHLY = 'pro-plan-monthly';
+export const PLAN_WPCOM_PRO_2_YEARS = 'pro-plan-2y';
 export const PLAN_WPCOM_STARTER = 'starter-plan';
 export const PLAN_ENTERPRISE_GRID_WPCOM = 'plan-enterprise-grid-wpcom'; // Not a real plan; we show the VIP section in the plans grid as part of pdgrnI-1Qp-p2.
 
@@ -79,6 +80,7 @@ export const WPCOM_PLANS = <const>[
 	PLAN_WPCOM_FLEXIBLE,
 	PLAN_WPCOM_PRO,
 	PLAN_WPCOM_PRO_MONTHLY,
+	PLAN_WPCOM_PRO_2_YEARS,
 	PLAN_WPCOM_STARTER,
 	PLAN_ENTERPRISE_GRID_WPCOM,
 	PLAN_WOOEXPRESS_MEDIUM,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -189,6 +189,7 @@ import {
 	PLAN_WPCOM_STARTER,
 	PLAN_WPCOM_PRO,
 	PLAN_WPCOM_PRO_MONTHLY,
+	PLAN_WPCOM_PRO_2_YEARS,
 	PREMIUM_DESIGN_FOR_STORES,
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
@@ -2336,7 +2337,6 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 			[
 				PLAN_FREE,
 				PLAN_WPCOM_STARTER,
-				PLAN_WPCOM_PRO,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_MONTHLY,
@@ -2348,6 +2348,8 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 				PLAN_BUSINESS,
 				PLAN_BUSINESS_MONTHLY,
 				PLAN_WPCOM_PRO_MONTHLY,
+				PLAN_WPCOM_PRO,
+				PLAN_WPCOM_PRO_2_YEARS,
 			].includes( plan ),
 		getProductId: () => 1028,
 		getStoreSlug: () => PLAN_BUSINESS_2_YEARS,
@@ -2362,7 +2364,6 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 			[
 				PLAN_FREE,
 				PLAN_WPCOM_STARTER,
-				PLAN_WPCOM_PRO,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_MONTHLY,
@@ -2377,6 +2378,8 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 				PLAN_BUSINESS_MONTHLY,
 				PLAN_BUSINESS_2_YEARS,
 				PLAN_WPCOM_PRO_MONTHLY,
+				PLAN_WPCOM_PRO,
+				PLAN_WPCOM_PRO_2_YEARS,
 			].includes( plan ),
 		getProductId: () => 1048,
 		getStoreSlug: () => PLAN_BUSINESS_3_YEARS,
@@ -2445,7 +2448,9 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 			[
 				PLAN_FREE,
 				PLAN_WPCOM_STARTER,
+				PLAN_WPCOM_PRO_MONTHLY,
 				PLAN_WPCOM_PRO,
+				PLAN_WPCOM_PRO_2_YEARS,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_MONTHLY,
@@ -2459,7 +2464,6 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 				PLAN_BUSINESS_2_YEARS,
 				PLAN_ECOMMERCE_MONTHLY,
 				PLAN_ECOMMERCE,
-				PLAN_WPCOM_PRO_MONTHLY,
 				PLAN_ECOMMERCE_TRIAL_MONTHLY,
 			].includes( plan ),
 		getProductId: () => 1031,
@@ -2544,7 +2548,9 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 			[
 				PLAN_FREE,
 				PLAN_WPCOM_STARTER,
+				PLAN_WPCOM_PRO_MONTHLY,
 				PLAN_WPCOM_PRO,
+				PLAN_WPCOM_PRO_2_YEARS,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_MONTHLY,
@@ -2562,7 +2568,6 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 				PLAN_ECOMMERCE_MONTHLY,
 				PLAN_ECOMMERCE,
 				PLAN_ECOMMERCE_2_YEARS,
-				PLAN_WPCOM_PRO_MONTHLY,
 				PLAN_ECOMMERCE_TRIAL_MONTHLY,
 			].includes( plan ),
 		getProductId: () => 1051,
@@ -3050,6 +3055,17 @@ PLANS_LIST[ PLAN_WPCOM_PRO_MONTHLY ] = {
 	getProductId: () => 1034,
 	getStoreSlug: () => PLAN_WPCOM_PRO_MONTHLY,
 	getPathSlug: () => 'pro-monthly',
+};
+
+PLANS_LIST[ PLAN_WPCOM_PRO_2_YEARS ] = {
+	...getPlanProDetails(),
+	term: TERM_BIENNIALLY,
+	availableFor: ( plan ) =>
+		[ PLAN_FREE, PLAN_WPCOM_STARTER, PLAN_WPCOM_PRO, PLAN_WPCOM_PRO_MONTHLY ].includes( plan ),
+	getProductId: () => 1035,
+	getStoreSlug: () => PLAN_WPCOM_PRO_2_YEARS,
+	getPathSlug: () => 'pro-2-years',
+	getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
 };
 
 PLANS_LIST[ PLAN_ECOMMERCE_TRIAL_MONTHLY ] = {

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -68,6 +68,7 @@ import {
 	PLAN_WOOEXPRESS_SMALL,
 	PLAN_WOOEXPRESS_SMALL_MONTHLY,
 	PLAN_WOOEXPRESS_PLUS,
+	PLAN_WPCOM_PRO_2_YEARS,
 } from '../src/constants';
 import {
 	getPlan,
@@ -1025,6 +1026,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_PREMIUM_2_YEARS,
 			PLAN_BUSINESS_2_YEARS,
 			PLAN_ECOMMERCE_2_YEARS,
+			PLAN_WPCOM_PRO_2_YEARS,
 		] );
 		expect( findPlansKeys( { term: TERM_TRIENNIALLY } ) ).toEqual( [
 			PLAN_PERSONAL_3_YEARS,
@@ -1148,6 +1150,7 @@ describe( 'findPlansKeys', () => {
 			PLAN_WPCOM_FLEXIBLE,
 			PLAN_WPCOM_PRO,
 			PLAN_WPCOM_PRO_MONTHLY,
+			PLAN_WPCOM_PRO_2_YEARS,
 			PLAN_ECOMMERCE_TRIAL_MONTHLY,
 		] );
 		expect( findPlansKeys( { group: GROUP_JETPACK } ) ).toEqual( [


### PR DESCRIPTION
The recent 2-year plan promotions have produced some 2-year Pro plan subscriptions. Pro 2 years, however, seems not to be added to our configs, which leads to some pages like /plans not functioning properly for users who have that subscription.

Before:
<img width="1256" alt="Screenshot 2023-04-20 at 14 24 32" src="https://user-images.githubusercontent.com/82778/233352469-50e58dfc-d30b-4117-9082-6c431b6b01e6.png">

After:
<img width="1256" alt="Screenshot 2023-04-20 at 14 20 58" src="https://user-images.githubusercontent.com/82778/233352498-316aaba6-d856-4d19-88dc-2dec8d94321a.png">


Related to #

## Proposed Changes

Add 2 year Pro to config

## Testing Instructions

1. On your test account, add a 2-year Pro
2. Go to /plans
3. You should see credits available notice and should be able to proceed to checkout for Business and eCommerce

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
