### PR TITLE
Jetpack Pro Dashboard: improve site connection healthy indication

### DIFF
--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -64,7 +64,7 @@ const useFetchDashboardSites = (
 						] );
 						return {
 							...site,
-							is_connected: data ? data.connected : true,
+							is_connected: data?.hasOwnProperty( 'connected' ) ? data.connected : true,
 						};
 					} ),
 					total: data.total,

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -1,11 +1,12 @@
 import { useTranslate } from 'i18n-calypso';
-import { useQuery } from 'react-query';
+import { useQuery, useQueryClient } from 'react-query';
 import { useDispatch } from 'react-redux';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import { errorNotice } from 'calypso/state/notices/actions';
 import type {
 	AgencyDashboardFilter,
 	DashboardSortInterface,
+	Site,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 
 const agencyDashboardFilterToQueryObject = ( filter: AgencyDashboardFilter ) => {
@@ -37,6 +38,7 @@ const useFetchDashboardSites = (
 ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const queryClient = useQueryClient();
 	return useQuery(
 		[ 'jetpack-agency-dashboard-sites', searchQuery, currentPage, filter, sort ],
 		() =>
@@ -55,7 +57,16 @@ const useFetchDashboardSites = (
 		{
 			select: ( data ) => {
 				return {
-					sites: data.sites,
+					sites: data.sites.map( ( site: Site ) => {
+						const data: { connected: boolean } | undefined = queryClient.getQueryData( [
+							'jetpack-agency-test-connection',
+							site.blog_id,
+						] );
+						return {
+							...site,
+							is_connected: data ? data.connected : true,
+						};
+					} ),
 					total: data.total,
 					perPage: data.per_page,
 					totalFavorites: data.total_favorites,

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -58,6 +58,10 @@ const useFetchDashboardSites = (
 			select: ( data ) => {
 				return {
 					sites: data.sites.map( ( site: Site ) => {
+						// Since the "sites" API includes the "is_connected" property in the cache of the query set by
+						// the "useFetchTestConnection" hook, we are setting it here again since the "sites" API gets called
+						// more often than the "/test-connection" API which will flush the cache set by the
+						// "useFetchTestConnection" hook
 						const data: { connected: boolean } | undefined = queryClient.getQueryData( [
 							'jetpack-agency-test-connection',
 							site.blog_id,

--- a/client/data/agency-dashboard/use-fetch-test-connection.ts
+++ b/client/data/agency-dashboard/use-fetch-test-connection.ts
@@ -31,6 +31,10 @@ const useFetchTestConnection = (
 			// five minutes after the first successful one.
 			staleTime: 1000 * 60 * 5,
 			onSuccess: ( data ) => {
+				// We are setting the "is_connected" property of the site in the query cache of the "sites"
+				// API to the value returned by the /test-connection endpoint. We are doing this to filter
+				// the site with connection issues easily in the UI and to have a single source of truth for
+				// the connection state of a site to avoid inconsistencies.
 				const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter, sort ];
 				queryClient.setQueryData( queryKey, ( oldSites: any ) => {
 					return {

--- a/client/data/agency-dashboard/use-fetch-test-connection.ts
+++ b/client/data/agency-dashboard/use-fetch-test-connection.ts
@@ -39,7 +39,7 @@ const useFetchTestConnection = (
 							if ( site.blog_id === siteId ) {
 								return {
 									...site,
-									is_connected: data.connected,
+									is_connected: data?.hasOwnProperty( 'connected' ) ? data.connected : true,
 								};
 							}
 							return site;

--- a/client/data/agency-dashboard/use-fetch-test-connection.ts
+++ b/client/data/agency-dashboard/use-fetch-test-connection.ts
@@ -28,8 +28,8 @@ const useFetchTestConnection = (
 			enabled: isPartnerOAuthTokenLoaded,
 			refetchOnWindowFocus: false,
 			// We don't want to trigger another API request to the /test-connection endpoint for a given site
-			// five minutes after the first successful one.
-			staleTime: 1000 * 60 * 5,
+			// one minute after the first successful one.
+			staleTime: 1000 * 60,
 			onSuccess: ( data ) => {
 				// We are setting the "is_connected" property of the site in the query cache of the "sites"
 				// API to the value returned by the /test-connection endpoint. We are doing this to filter

--- a/client/data/agency-dashboard/use-fetch-test-connection.ts
+++ b/client/data/agency-dashboard/use-fetch-test-connection.ts
@@ -1,4 +1,7 @@
-import { useQuery } from 'react-query';
+import { useContext } from 'react';
+import { useQuery, useQueryClient } from 'react-query';
+import SitesOverviewContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/context';
+import { Site } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import wpcom from 'calypso/lib/wp';
 
 const useFetchTestConnection = (
@@ -6,6 +9,8 @@ const useFetchTestConnection = (
 	isConnectionHealthy: boolean,
 	siteId: number
 ) => {
+	const queryClient = useQueryClient();
+	const { search, currentPage, filter, sort } = useContext( SitesOverviewContext );
 	return useQuery(
 		[ 'jetpack-agency-test-connection', siteId ],
 		() =>
@@ -25,6 +30,23 @@ const useFetchTestConnection = (
 			// We don't want to trigger another API request to the /test-connection endpoint for a given site
 			// five minutes after the first successful one.
 			staleTime: 1000 * 60 * 5,
+			onSuccess: ( data ) => {
+				const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter, sort ];
+				queryClient.setQueryData( queryKey, ( oldSites: any ) => {
+					return {
+						...oldSites,
+						sites: oldSites?.sites.map( ( site: Site ) => {
+							if ( site.blog_id === siteId ) {
+								return {
+									...site,
+									is_connected: data.connected,
+								};
+							}
+							return site;
+						} ),
+					};
+				} );
+			},
 		}
 	);
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
@@ -22,7 +22,7 @@ export default function EditButton( { sites, isLargeScreen, isLoading }: Props )
 
 	const handleToggleSelect = () => {
 		// Filter sites with site error as they are not selectable.
-		const filteredSite = sites.filter( ( site ) => ! site.site.error );
+		const filteredSite = sites.filter( ( site ) => site.site.value.is_connected );
 		setSelectedSites( filteredSite.map( ( item ) => item.site.value ) );
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
@@ -21,8 +21,10 @@ export default function EditButton( { sites, isLargeScreen, isLoading }: Props )
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, isLargeScreen );
 
 	const handleToggleSelect = () => {
-		// Filter sites with site error as they are not selectable.
-		const filteredSite = sites.filter( ( site ) => site.site.value.is_connected );
+		// Filter sites with site error or monitor error as they are not selectable.
+		const filteredSite = sites.filter(
+			( site ) => site.site.value.is_connected && ! site.monitor.error
+		);
 		setSelectedSites( filteredSite.map( ( item ) => item.site.value ) );
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -30,8 +30,10 @@ export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Pro
 	};
 
 	const handleToggleSelect = () => {
-		// Filter sites with site error as they are not selectable.
-		const filteredSites = sites.filter( ( site ) => site.site.value.is_connected );
+		// Filter sites with site error or monitor error as they are not selectable.
+		const filteredSites = sites.filter(
+			( site ) => site.site.value.is_connected && ! site.monitor.error
+		);
 		const isChecked = isAllChecked( filteredSites );
 
 		const allSelectedSites = isChecked

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -31,7 +31,7 @@ export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Pro
 
 	const handleToggleSelect = () => {
 		// Filter sites with site error as they are not selectable.
-		const filteredSites = sites.filter( ( { site: { error } } ) => ! error );
+		const filteredSites = sites.filter( ( site ) => site.site.value.is_connected );
 		const isChecked = isAllChecked( filteredSites );
 
 		const allSelectedSites = isChecked

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -109,7 +109,7 @@ export default function SiteCard( { rows, columns }: Props ) {
 						rows={ rows }
 						type={ headerItem.type }
 						isFavorite={ isFavorite }
-						siteError={ siteError }
+						siteError={ ! isSiteConnected }
 					/>
 				</span>
 				<SiteActions site={ site } siteError={ siteError } />
@@ -139,7 +139,7 @@ export default function SiteCard( { rows, columns }: Props ) {
 														<SiteStatusContent
 															rows={ rows }
 															type={ row.type }
-															siteError={ siteError }
+															siteError={ ! isSiteConnected }
 														/>
 													</span>
 													<span className="site-card__expanded-column">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -127,7 +127,7 @@ export default function SiteCard( { rows, columns }: Props ) {
 									<div
 										className={ classNames(
 											'site-card__expanded-content-list',
-											! site.error && 'site-card__content-list-no-error'
+											isSiteConnected && 'site-card__content-list-no-error'
 										) }
 										key={ index }
 									>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -36,9 +36,9 @@ export default function SiteCard( { rows, columns }: Props ) {
 	const blogId = rows.site.value.blog_id;
 	const isConnectionHealthy = rows.site.value?.is_connection_healthy;
 
-	const { data } = useFetchTestConnection( isPartnerOAuthTokenLoaded, isConnectionHealthy, blogId );
+	useFetchTestConnection( isPartnerOAuthTokenLoaded, isConnectionHealthy, blogId );
 
-	const isSiteConnected = data ? data.connected : true;
+	const isSiteConnected = rows.site.value.is_connected;
 
 	const handleSetExpandedColumn = ( column: AllowedTypes ) => {
 		recordEvent( 'expandable_block_column_toggled', {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -74,7 +74,7 @@ export default function SiteCard( { rows, columns }: Props ) {
 	const headerItem = rows[ 'site' ];
 
 	const site = rows.site;
-	const siteError = site.error || rows.monitor.error || ! isSiteConnected;
+	const siteError = rows.monitor.error || ! isSiteConnected;
 	const siteUrl = site.value.url;
 	const isFavorite = rows.isFavorite;
 
@@ -105,7 +105,12 @@ export default function SiteCard( { rows, columns }: Props ) {
 					tabIndex={ 0 }
 				>
 					{ toggleContent }
-					<SiteStatusContent rows={ rows } type={ headerItem.type } isFavorite={ isFavorite } />
+					<SiteStatusContent
+						rows={ rows }
+						type={ headerItem.type }
+						isFavorite={ isFavorite }
+						siteError={ siteError }
+					/>
 				</span>
 				<SiteActions site={ site } siteError={ siteError } />
 			</div>
@@ -131,7 +136,11 @@ export default function SiteCard( { rows, columns }: Props ) {
 												<span className="site-card__expanded-content-key">{ column.title }</span>
 												<span className="site-card__expanded-content-value">
 													<span className="site-card__expanded-content-status">
-														<SiteStatusContent rows={ rows } type={ row.type } />
+														<SiteStatusContent
+															rows={ rows }
+															type={ row.type }
+															siteError={ siteError }
+														/>
 													</span>
 													<span className="site-card__expanded-column">
 														{ column.isExpandable && (
@@ -152,7 +161,7 @@ export default function SiteCard( { rows, columns }: Props ) {
 													isSmallScreen
 													site={ rows.site.value }
 													columns={ [ column.key ] }
-													hasError={ site.error || ! isSiteConnected }
+													hasError={ siteError }
 												/>
 											) }
 										</>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -112,7 +112,7 @@ export default function SiteCard( { rows, columns }: Props ) {
 
 			{ isExpanded && (
 				<div className="site-card__expanded-content">
-					{ ( site.error || ! isSiteConnected ) && <SiteErrorContent siteUrl={ siteUrl } /> }
+					{ ! isSiteConnected && <SiteErrorContent siteUrl={ siteUrl } /> }
 					{ columns
 						.filter( ( column ) => column.key !== 'site' )
 						.map( ( column, index ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -68,7 +68,7 @@ export default function SiteStatusContent( {
 	// since monitor is clickable when site is down.
 	const disabledStatus = siteError || ( type !== 'monitor' && siteDown );
 
-	// Disale selection and toggle when there is a site error or site is down
+	// Disable selection and toggle when there is a site error or site is down
 	const hasAnyError = !! ( siteError || siteDown );
 
 	const statusContentRef = useRef< HTMLSpanElement | null >( null );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -68,6 +68,9 @@ export default function SiteStatusContent( {
 	// since monitor is clickable when site is down.
 	const disabledStatus = siteError || ( type !== 'monitor' && siteDown );
 
+	// Disale selection and toggle when there is a site error or site is down
+	const hasAnyError = !! ( siteError || siteDown );
+
 	const statusContentRef = useRef< HTMLSpanElement | null >( null );
 	const [ showTooltip, setShowTooltip ] = useState( false );
 
@@ -151,7 +154,7 @@ export default function SiteStatusContent( {
 					<SiteSelectCheckbox
 						isLargeScreen={ isLargeScreen }
 						item={ rows }
-						siteError={ siteError }
+						siteError={ hasAnyError }
 					/>
 				) : (
 					<SiteSetFavorite
@@ -198,7 +201,7 @@ export default function SiteStatusContent( {
 					status={ status }
 					tooltip={ tooltip }
 					tooltipId={ tooltipId }
-					siteError={ siteError }
+					siteError={ hasAnyError }
 					isLargeScreen={ isLargeScreen }
 				/>
 			);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -28,6 +28,7 @@ interface Props {
 	type: AllowedTypes;
 	isLargeScreen?: boolean;
 	isFavorite?: boolean;
+	siteError: boolean;
 }
 
 export default function SiteStatusContent( {
@@ -35,6 +36,7 @@ export default function SiteStatusContent( {
 	type,
 	isLargeScreen = false,
 	isFavorite = false,
+	siteError,
 }: Props ) {
 	const dispatch = useDispatch();
 
@@ -42,7 +44,6 @@ export default function SiteStatusContent( {
 		link,
 		isExternalLink,
 		row: { value, status, error },
-		siteError,
 		tooltipId,
 		siteDown,
 		eventName,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -43,7 +43,7 @@ export default function SiteStatusContent( {
 	const {
 		link,
 		isExternalLink,
-		row: { value, status, error },
+		row: { value, status },
 		tooltipId,
 		siteDown,
 		eventName,
@@ -126,7 +126,7 @@ export default function SiteStatusContent( {
 			isHighSeverityError = true;
 		}
 		let errorContent;
-		if ( error ) {
+		if ( siteError ) {
 			errorContent = (
 				<span className="sites-overview__status-critical">
 					<Gridicon size={ 24 } icon="notice-outline" />

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -32,7 +32,6 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 	const site = item.site;
 	const blogId = site.value.blog_id;
 	const isConnectionHealthy = site.value?.is_connection_healthy;
-	const siteError = site.error || item.monitor.error;
 	const isFavorite = item.isFavorite;
 
 	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
@@ -50,7 +49,8 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 	const shouldDisableLicenseSelection =
 		selectedLicenses?.length && ! currentSiteHasSelectedLicenses;
 
-	const hasSiteError = ! isSiteConnected;
+	const hasSiteConnectionError = ! isSiteConnected;
+	const siteError = item.monitor.error || hasSiteConnectionError;
 
 	return (
 		<Fragment>
@@ -58,7 +58,7 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 				className={ classNames( 'site-table__table-row', {
 					'site-table__table-row-disabled': shouldDisableLicenseSelection,
 					'site-table__table-row-active': currentSiteHasSelectedLicenses,
-					'site-table__table-row-site-error': hasSiteError,
+					'site-table__table-row-site-error': hasSiteConnectionError,
 					'is-expanded': isExpanded,
 				} ) }
 				onClick={ ( event ) => {
@@ -73,7 +73,7 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 			>
 				{ columns.map( ( column ) => {
 					const row = item[ column.key ];
-					if ( hasSiteError && column.key !== 'site' ) {
+					if ( hasSiteConnectionError && column.key !== 'site' ) {
 						return null;
 					}
 					const isCritical = 'critical' === row.status;
@@ -91,13 +91,14 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 									type={ row.type }
 									isLargeScreen
 									isFavorite={ isFavorite }
+									siteError={ siteError }
 								/>
 							</td>
 						);
 					}
 				} ) }
 				{ /* Show error content when there is a site error */ }
-				{ hasSiteError && (
+				{ hasSiteConnectionError && (
 					<td
 						className={ classNames( 'site-table__error padding-0', {
 							'site-table__td-without-border-bottom': isExpanded,
@@ -126,7 +127,7 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 			{ isExpanded && (
 				<tr className="site-table__table-row-expanded">
 					<td colSpan={ Object.keys( item ).length + 1 }>
-						<SiteExpandedContent site={ site.value } hasError={ hasSiteError } />
+						<SiteExpandedContent site={ site.value } hasError={ siteError } />
 						<SitePhpVersion phpVersion={ site.value.php_version_num } />
 					</td>
 				</tr>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -89,7 +89,7 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 									type={ row.type }
 									isLargeScreen
 									isFavorite={ isFavorite }
-									siteError={ siteError }
+									siteError={ hasSiteConnectionError }
 								/>
 							</td>
 						);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -38,9 +38,7 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 	const selectedLicenses = useSelector( getSelectedLicenses );
 	const selectedLicensesSiteId = useSelector( getSelectedLicensesSiteId );
 
-	const { data } = useFetchTestConnection( isPartnerOAuthTokenLoaded, isConnectionHealthy, blogId );
-
-	const isSiteConnected = data ? data.connected : true;
+	useFetchTestConnection( isPartnerOAuthTokenLoaded, isConnectionHealthy, blogId );
 
 	const currentSiteHasSelectedLicenses =
 		selectedLicensesSiteId === blogId && selectedLicenses?.length;
@@ -49,7 +47,7 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 	const shouldDisableLicenseSelection =
 		selectedLicenses?.length && ! currentSiteHasSelectedLicenses;
 
-	const hasSiteConnectionError = ! isSiteConnected;
+	const hasSiteConnectionError = ! item.site.value.is_connected;
 	const siteError = item.monitor.error || hasSiteConnectionError;
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -50,7 +50,7 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 	const shouldDisableLicenseSelection =
 		selectedLicenses?.length && ! currentSiteHasSelectedLicenses;
 
-	const hasSiteError = site.error || ! isSiteConnected;
+	const hasSiteError = ! isSiteConnected;
 
 	return (
 		<Fragment>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -49,6 +49,7 @@ describe( '<SiteTable>', () => {
 		is_connection_healthy: true,
 		awaiting_plugin_updates: [],
 		is_favorite: false,
+		is_connected: true,
 	};
 	const items: Array< SiteData > = [
 		{

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/utils.ts
@@ -85,7 +85,6 @@ describe( 'utils', () => {
 				link: `/backup/${ site.url }`,
 				row: rows.backup,
 				siteDown: false,
-				siteError: false,
 				tooltip: 'Latest backup failed',
 				tooltipId: `${ site.blog_id }-backup`,
 			};
@@ -97,7 +96,6 @@ describe( 'utils', () => {
 				link: `/scan/${ site.url }`,
 				row: rows.scan,
 				siteDown: false,
-				siteError: false,
 				tooltip: 'Potential threats found',
 				tooltipId: `${ site.blog_id }-scan`,
 			};
@@ -110,7 +108,6 @@ describe( 'utils', () => {
 				link: `https://jptools.wordpress.com/debug/?url=${ site.url }`,
 				row: rows.monitor,
 				siteDown: false,
-				siteError: false,
 				tooltip: 'Site appears to be offline',
 				tooltipId: `${ site.blog_id }-monitor`,
 			};
@@ -122,7 +119,6 @@ describe( 'utils', () => {
 				link: `https://wordpress.com/plugins/updates/${ site.url }`,
 				row: rows.plugin,
 				siteDown: false,
-				siteError: false,
 				tooltip: 'Plugin updates are available',
 				tooltipId: `${ site.blog_id }-plugin`,
 			};
@@ -134,7 +130,6 @@ describe( 'utils', () => {
 				link: '',
 				row: rows.stats,
 				siteDown: false,
-				siteError: false,
 				tooltip: undefined,
 				tooltipId: `${ site.blog_id }-stats`,
 			};
@@ -146,7 +141,6 @@ describe( 'utils', () => {
 				link: '',
 				row: rows.boost,
 				siteDown: false,
-				siteError: false,
 				tooltip: undefined,
 				tooltipId: `${ site.blog_id }-boost`,
 			};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -135,7 +135,6 @@ export interface RowMetaData {
 	};
 	link: string;
 	isExternalLink: boolean;
-	siteError: boolean;
 	tooltip: ReactChild | undefined;
 	tooltipId: string;
 	siteDown?: boolean;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -131,7 +131,6 @@ export interface RowMetaData {
 	row: {
 		value: Site | SiteStats | BoostData | ReactChild;
 		status: AllowedStatusTypes;
-		error?: boolean;
 	};
 	link: string;
 	isExternalLink: boolean;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -69,6 +69,7 @@ export interface Site {
 	onSelect?: () => void;
 	jetpack_boost_scores: BoostData;
 	php_version_num: number;
+	is_connected: boolean;
 }
 export interface SiteNode {
 	value: Site;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -314,7 +314,6 @@ export const getRowMetaData = (
 	const row = rows[ type ];
 	const siteUrl = rows.site?.value?.url;
 	const siteUrlWithScheme = rows.site?.value?.url_with_scheme;
-	const siteError = rows.site.error;
 	const siteId = rows.site?.value?.blog_id;
 	const { link, isExternalLink } = getLinks( type, row.status, siteUrl, siteUrlWithScheme );
 	const tooltip = getTooltip( type, row.status );
@@ -323,7 +322,6 @@ export const getRowMetaData = (
 		row,
 		link,
 		isExternalLink,
-		siteError,
 		tooltip,
 		tooltipId: `${ siteId }-${ type }`,
 		siteDown: rows.monitor.error,


### PR DESCRIPTION
Related to 1202619025189113-as-1204433221954589

## Proposed Changes

- Show site error based on the /test-connection API only and not based on `site.is_connection_healthy`.
- Update the sites' cache to include `is_connected` from the `test-connection` API.
- Use a single source of truth - `site.is_connected` to show the error.
- Disable selection of sites(single, manual, pre-selection) if the site is not connected or if the monitor has an error.


#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout update/improve-site-connection-healthy-indication` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify the site with an error has the error banner as shown below

<img width="1364" alt="Screenshot 2023-04-21 at 10 58 26 AM" src="https://user-images.githubusercontent.com/10586875/233574405-1c487156-a12c-499e-8060-4e10ef9e2020.png">

<img width="1358" alt="Screenshot 2023-04-21 at 10 58 33 AM" src="https://user-images.githubusercontent.com/10586875/233574416-f9458edc-1470-4528-a61a-a166900cc1bd.png">

4. Verify the site with a monitor error is as shown below

<img width="1385" alt="Screenshot 2023-04-21 at 1 13 51 PM" src="https://user-images.githubusercontent.com/10586875/233574939-b39ea641-3625-4a3f-a5df-f80d0f7fb8ff.png">

5. Verify the site with any error(site connection or monitor error) is not available for selection(i.e, the site should not be able to be selected, should not be pre-selected when clicked on `Edit All`, should not be selected when clicked on the checkbox on the table header - the bulk select checkbox)


https://user-images.githubusercontent.com/10586875/233575636-4aca85f1-cd46-4a12-8a44-bdd2c7efaf00.mov


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?