### PR TITLE
Facebook preview: support custom images

### DIFF
--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -117,6 +117,10 @@ class SharingPreviewPane extends PureComponent {
 						{ ...previewProps }
 						articleExcerpt={ post.excerpt }
 						articleContent={ post.content }
+						customImage={
+							post.metadata?.find( ( meta ) => meta.key === '_wpas_options' )?.value
+								?.attached_media?.[ 0 ]?.url
+						}
 					/>
 				);
 			case 'tumblr':

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -11,6 +11,7 @@ export class FacebookSharePreview extends PureComponent {
 		articleUrl: PropTypes.string,
 		externalProfilePicture: PropTypes.string,
 		imageUrl: PropTypes.string,
+		customImage: PropTypes.string,
 		message: PropTypes.string,
 		seoTitle: PropTypes.string,
 	};
@@ -25,6 +26,7 @@ export class FacebookSharePreview extends PureComponent {
 			imageUrl,
 			message,
 			seoTitle,
+			customImage,
 		} = this.props;
 
 		// The post object in the state has a default excerpt, which is the first words of the
@@ -42,6 +44,7 @@ export class FacebookSharePreview extends PureComponent {
 				description={ decodeEntities( originalExcerpt || articleContent ) }
 				image={ imageUrl }
 				customText={ decodeEntities( message || originalExcerpt || articleContent || seoTitle ) }
+				customImage={ customImage }
 				user={ { displayName: externalDisplay, avatarUrl: externalProfilePicture } }
 				type={ TYPE_ARTICLE }
 			/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR adds support for custom images to the Facebook post preview.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


### Prerequisites
- Make sure you have a Facebook account.
- Make sure you have a self-hosted site connected to Jetpack, with a subscription that includes Social.
- From the _Social_ or _My Jetpack_ page of your site WPadmin, activate Social.
- Then, connect your site to Facebook (check [these instructions](https://jetpack.com/support/jetpack-social/connecting-to-social-networks/) if you need help). You may need to create a test page.
- Spin up Calypso by running this branch locally or using a live link below

### Testing

- Create a new post from your site WPadmin
- Add a custom media

![Artboard 1](https://user-images.githubusercontent.com/1620183/232824470-df051296-8df6-4937-9e43-82018479c743.png)

- Publish it
- Visit `/posts/:site` in Calypso
- You should see the newly created post under the _Published_ tab
- In the post menu, click _Share_, then press the _Preview_ button
<img width="500" alt="Screenshot 2023-04-11 at 4 47 11 PM" src="https://user-images.githubusercontent.com/1620183/231284467-7d3c5008-321b-444f-a3f9-8b732eaa323c.png">

- Select the Facebook preview
- Notice you see the custom image

<img width="400" alt="Screenshot 2023-04-20 at 9 24 52 AM" src="https://user-images.githubusercontent.com/1620183/233381452-e9ede166-f34c-4023-9c88-f81ddfb43425.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
