### PR TITLE
Added pending post subscription confirm action

### DIFF
--- a/client/landing/subscriptions/components/pending-list/pending-post-list/pending-post-row.tsx
+++ b/client/landing/subscriptions/components/pending-list/pending-post-list/pending-post-row.tsx
@@ -1,10 +1,12 @@
 import { Gridicon } from '@automattic/components';
 import { useMemo } from 'react';
+import { SubscriptionManager } from 'calypso/../packages/data-stores/src';
 import TimeSince from 'calypso/components/time-since';
 import { PendingPostSettings } from '../../settings-popover';
 import type { PendingPostSubscription } from '@automattic/data-stores/src/reader/types';
 
 export default function PendingPostRow( {
+	id,
 	subscription_date,
 	site_icon,
 	post_title,
@@ -21,10 +23,8 @@ export default function PendingPostRow( {
 		return <Gridicon className="icon" icon="globe" size={ 48 } />;
 	}, [ site_icon, post_title ] );
 
-	const { mutate: confirmPendingSubscription, isLoading: confirmingPendingSubscription } = {
-		mutate: () => null,
-		isLoading: false,
-	};
+	const { mutate: confirmPendingSubscription, isLoading: confirmingPendingSubscription } =
+		SubscriptionManager.usePendingPostConfirmMutation();
 	const { mutate: deletePendingSubscription, isLoading: deletingPendingSubscription } = {
 		mutate: () => null,
 		isLoading: false,
@@ -55,7 +55,7 @@ export default function PendingPostRow( {
 				</span>
 				<span className="actions" role="cell">
 					<PendingPostSettings
-						onConfirm={ () => confirmPendingSubscription() }
+						onConfirm={ () => confirmPendingSubscription( { id } ) }
 						onDelete={ () => deletePendingSubscription() }
 						confirming={ confirmingPendingSubscription }
 						deleting={ deletingPendingSubscription }

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -6,6 +6,7 @@ import {
 	useUserSettingsMutation,
 	usePendingSiteConfirmMutation,
 	usePendingSiteDeleteMutation,
+	usePendingPostConfirmMutation,
 } from './mutations';
 import {
 	SiteSubscriptionsSortBy,
@@ -32,6 +33,7 @@ export const SubscriptionManager = {
 	usePendingPostSubscriptionsQuery,
 	usePendingSiteConfirmMutation,
 	usePendingSiteDeleteMutation,
+	usePendingPostConfirmMutation,
 };
 
 // Types

--- a/packages/data-stores/src/reader/mutations/index.ts
+++ b/packages/data-stores/src/reader/mutations/index.ts
@@ -4,3 +4,4 @@ export { default as useSiteUnfollowMutation } from './use-site-unfollow-mutation
 export { default as useUserSettingsMutation } from './use-user-settings-mutation';
 export { default as usePendingSiteConfirmMutation } from './use-pending-site-confirm-mutation';
 export { default as usePendingSiteDeleteMutation } from './use-pending-site-delete-mutation';
+export { default as usePendingPostConfirmMutation } from './use-pending-post-confirm-mutation';

--- a/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
@@ -1,0 +1,103 @@
+import { useMutation, useQueryClient } from 'react-query';
+import { callApi } from '../helpers';
+import { useIsLoggedIn } from '../hooks';
+import { PendingPostSubscription, SubscriptionManagerSubscriptionsCount } from '../types';
+
+type PendingPostConfirmParams = {
+	id: string;
+};
+
+type PendingPostConfirmResponse = {
+	confirmed: boolean;
+};
+
+const usePendingPostConfirmMutation = () => {
+	const isLoggedIn = useIsLoggedIn();
+	const queryClient = useQueryClient();
+	return useMutation(
+		async ( { id }: PendingPostConfirmParams ) => {
+			if ( ! id ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Invalid subscription key'
+				);
+			}
+
+			const response = await callApi< PendingPostConfirmResponse >( {
+				path: `/post-comment-subscriptions/${ id }/confirm`,
+				method: 'POST',
+				apiVersion: '2',
+			} );
+			if ( ! response.confirmed ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while confirming subscription.'
+				);
+			}
+
+			return response;
+		},
+		{
+			onMutate: async ( { id } ) => {
+				await queryClient.cancelQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
+				await queryClient.cancelQueries( [ 'read', 'subscriptions-count', isLoggedIn ] );
+
+				const previousPendingPostSubscriptions = queryClient.getQueryData<
+					PendingPostSubscription[]
+				>( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
+
+				// remove blog from pending post subscriptions
+				if ( previousPendingPostSubscriptions ) {
+					queryClient.setQueryData< PendingPostSubscription[] >(
+						[ [ 'read', 'pending-post-subscriptions', isLoggedIn ] ],
+						previousPendingPostSubscriptions.filter(
+							( pendingPostSubscription ) => pendingPostSubscription.id !== id
+						)
+					);
+				}
+
+				const previousSubscriptionsCount =
+					queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >( [
+						'read',
+						'subscriptions-count',
+						isLoggedIn,
+					] );
+
+				// decrement the blog count
+				if ( previousSubscriptionsCount ) {
+					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
+						[ 'read', 'subscriptions-count', isLoggedIn ],
+						{
+							...previousSubscriptionsCount,
+							blogs: previousSubscriptionsCount?.pending
+								? previousSubscriptionsCount?.pending - 1
+								: null,
+						}
+					);
+				}
+
+				return { previousPendingPostSubscriptions, previousSubscriptionsCount };
+			},
+			onError: ( error, variables, context ) => {
+				if ( context?.previousPendingPostSubscriptions ) {
+					queryClient.setQueryData< PendingPostSubscription[] >(
+						[ 'read', 'pending-post-subscriptions', isLoggedIn ],
+						context.previousPendingPostSubscriptions
+					);
+				}
+				if ( context?.previousSubscriptionsCount ) {
+					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
+						[ 'read', 'subscriptions-count', isLoggedIn ],
+						context.previousSubscriptionsCount
+					);
+				}
+			},
+			onSettled: () => {
+				queryClient.invalidateQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
+				queryClient.invalidateQueries( [ 'read', 'subscriptions-count', isLoggedIn ] );
+			},
+		}
+	);
+};
+
+export default usePendingPostConfirmMutation;

--- a/packages/data-stores/src/reader/queries/use-pending-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-pending-post-subscriptions-query.ts
@@ -18,7 +18,7 @@ const callPendingBlogSubscriptionsEndpoint = async (): Promise< PendingPostSubsc
 	const perPage = 1000; // TODO: This is a temporary workaround to get all pending subscriptions. We should remove this once we decide how to handle pagination.
 
 	const incoming = await callApi< SubscriptionManagerPendingPostSubscriptions >( {
-		path: `/post-comment-subscriptions?per_page=${ perPage }`,
+		path: `/post-comment-subscriptions?status=pending&per_page=${ perPage }`,
 		apiVersion: '2',
 	} );
 


### PR DESCRIPTION
## Proposed Changes

This change adds the confirm action to the pending post comment subscription list.
<img width="362" alt="Screenshot 2023-04-20 at 15 37 00" src="https://user-images.githubusercontent.com/3832570/233383468-80c52281-8279-4017-8251-31b41106a4ab.png">


## Testing Instructions

1. Apply this PR and run the application.
2. Apply this patch to your sandbox
3. Subscribe to a blog with a non-WP.com user (for example, your-email+testing@gmail.com)
4. You should receive a confirmation e-mail that contains a "Manage subscriptions" button
5. Copy the button's link & visit in an incognito window
6. Open dev tools & copy the cookie. Make sure "Show URL decoded" is checked. Copy the value from the subkey cookie.
7. Add the subkey cookie to `calypso.localhost:3000`.
8. Go to `/subscriptions/pending`.
9. Open the meatballs menu in any of your comment subscriptions and click "confirm".
10. The pending subscription should be removed from the list and added to the list in Comments tab.
