### PR TITLE
Add 2 year renewal option for Pro

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -930,6 +930,34 @@ export function shouldRenderMonthlyRenewalOption( purchase: Purchase ) {
 	return false;
 }
 
+export function shouldRenderBiennialRenewalOption( purchase: Purchase ) {
+	if ( ! purchase || ! purchase.expiryDate || ! isWpComPlan( purchase.productSlug ) ) {
+		return false;
+	}
+
+	const plan = getPlan( purchase.productSlug );
+
+	if ( TERM_ANNUALLY !== plan?.term || TYPE_PRO !== plan?.type ) {
+		return false;
+	}
+
+	const isAutorenewalEnabled = ! isExpiring( purchase );
+	const daysTillExpiry = moment( purchase.expiryDate ).diff( Date.now(), 'days' );
+
+	// Auto renew is off and expiration is <90 days from now
+	if ( ! isAutorenewalEnabled && daysTillExpiry < 90 ) {
+		return true;
+	}
+
+	// We attempted to bill them <30 days prior to their annual renewal and
+	// we weren’t able to do so for any other reason besides having auto renew off.
+	if ( isAutorenewalEnabled && daysTillExpiry < 30 ) {
+		return true;
+	}
+
+	return false;
+}
+
 const formatPurchasePrice = ( price: number, currency: string ) =>
 	formatCurrency( price, currency, {
 		isSmallestUnit: true,

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -234,6 +234,19 @@ class ManagePurchase extends Component {
 		page( checkoutUrlWithArgs );
 	};
 
+	handleRenewBiennially = () => {
+		const { relatedBiennialPlanSlug, siteSlug, redirectTo } = this.props;
+		recordTracksEvent( 'calypso_purchases_renew_biennially_click', {
+			product_slug: relatedBiennialPlanSlug,
+		} );
+
+		const checkoutUrlWithArgs = addQueryArgs(
+			{ ...( redirectTo && { redirect_to: redirectTo } ) },
+			`/checkout/${ relatedBiennialPlanSlug }/${ siteSlug || '' }`
+		);
+		page( checkoutUrlWithArgs );
+	};
+
 	handleRenewMultiplePurchases = ( purchases ) => {
 		const { siteSlug, redirectTo } = this.props;
 		const options = redirectTo ? { redirectTo } : undefined;
@@ -386,7 +399,7 @@ class ManagePurchase extends Component {
 					} ) }
 				</Badge>
 			</div>,
-			this.handleRenew
+			this.handleRenewBiennially
 		);
 	}
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -383,16 +383,16 @@ class ManagePurchase extends Component {
 	}
 
 	renderRenewBienniallyNavItem() {
-		const { translate, relatedBiennialPlanPrice, relatedMonthlyPlanPrice } = this.props;
+		const { translate, purchase, relatedBiennialPlanPrice } = this.props;
+		const annualPrice = getRenewalPrice( purchase );
 		const savings = Math.round(
-			( 100 * ( relatedMonthlyPlanPrice - relatedBiennialPlanPrice / 24 ) ) /
-				relatedMonthlyPlanPrice
+			( 100 * ( annualPrice - relatedBiennialPlanPrice / 2 ) ) / annualPrice
 		);
 		return this.renderRenewalNavItem(
 			<div>
 				{ translate( 'Renew for two years' ) }
 				<Badge className="manage-purchase__savings-badge" type="success">
-					{ translate( '%(savings)d%% cheaper than monthly', {
+					{ translate( '%(savings)d%% cheaper than annually', {
 						args: {
 							savings,
 						},


### PR DESCRIPTION
With Pro plans expiring, we are encouraging people to renew the plans. One of the initiatives is to show a 2-year renew option, see pebzTe-Vk-p2

<img width="942" alt="Screenshot 2023-04-20 at 17 08 53" src="https://user-images.githubusercontent.com/82778/233393332-69ddf042-f118-42a7-b734-2285a7fcefaa.png">


## Proposed Changes

* Add 2-year Pro in the purchase details page

## Testing Instructions

1. Add yourself an expiring 1-year Pro using Store Admin. Make it expire soon.
2. Go to me/purchases and click the plan
3. 2-year plan option should be available and should lead to a purchasable checkout
4. Complete the checkout, make sure it works
5. Try with any other plan, there should be no 2-year plan option

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
