### PR TITLE
Subscription Management: Fix pending tab display and empty view

### DIFF
--- a/client/landing/subscriptions/components/tab-views/pending/pending.tsx
+++ b/client/landing/subscriptions/components/tab-views/pending/pending.tsx
@@ -1,16 +1,17 @@
 import { SubscriptionManager } from '@automattic/data-stores';
+import { Notice } from 'calypso/landing/subscriptions/components/notice';
 import { PendingPostList, PendingSiteList } from '../../pending-list';
 import TabView from '../tab-view';
 
 const Pending = () => {
 	const {
-		data: pendingSites,
+		data: { pendingSites, totalCount: totalPendingSitesCount },
 		isLoading: isLoadingPendingSites,
 		error: errorPendingSites,
 	} = SubscriptionManager.usePendingSiteSubscriptionsQuery();
 
 	const {
-		data: pendingPosts,
+		data: { pendingPosts, totalCount: totalPendingPostsCount },
 		isLoading: isLoadingPendingPosts,
 		error: errorPendingPosts,
 	} = SubscriptionManager.usePendingPostSubscriptionsQuery();
@@ -23,13 +24,23 @@ const Pending = () => {
 		errorMessage = 'An error occurred while fetching your post subscriptions.';
 	}
 
+	if (
+		! isLoadingPendingSites &&
+		! isLoadingPendingPosts &&
+		! totalPendingSitesCount &&
+		! totalPendingPostsCount
+	) {
+		// todo: translate when we have agreed on the empty view message
+		return <Notice type="warning">No pending subscriptions were found.</Notice>;
+	}
+
 	return (
 		<TabView
 			errorMessage={ errorMessage }
 			isLoading={ isLoadingPendingSites || isLoadingPendingPosts }
 		>
-			<PendingSiteList pendingSites={ pendingSites } />
-			<PendingPostList pendingPosts={ pendingPosts } />
+			{ totalPendingSitesCount && <PendingSiteList pendingSites={ pendingSites } /> }
+			{ totalPendingPostsCount && <PendingPostList pendingPosts={ pendingPosts } /> }
 		</TabView>
 	);
 };

--- a/client/landing/subscriptions/components/tab-views/pending/pending.tsx
+++ b/client/landing/subscriptions/components/tab-views/pending/pending.tsx
@@ -5,13 +5,13 @@ import TabView from '../tab-view';
 
 const Pending = () => {
 	const {
-		data: { pendingSites, totalCount: totalPendingSitesCount },
+		data: { pendingSites, totalCount: totalPendingSitesCount = 0 },
 		isLoading: isLoadingPendingSites,
 		error: errorPendingSites,
 	} = SubscriptionManager.usePendingSiteSubscriptionsQuery();
 
 	const {
-		data: { pendingPosts, totalCount: totalPendingPostsCount },
+		data: { pendingPosts, totalCount: totalPendingPostsCount = 0 },
 		isLoading: isLoadingPendingPosts,
 		error: errorPendingPosts,
 	} = SubscriptionManager.usePendingPostSubscriptionsQuery();
@@ -39,8 +39,8 @@ const Pending = () => {
 			errorMessage={ errorMessage }
 			isLoading={ isLoadingPendingSites || isLoadingPendingPosts }
 		>
-			{ totalPendingSitesCount && <PendingSiteList pendingSites={ pendingSites } /> }
-			{ totalPendingPostsCount && <PendingPostList pendingPosts={ pendingPosts } /> }
+			{ totalPendingSitesCount > 0 && <PendingSiteList pendingSites={ pendingSites } /> }
+			{ totalPendingPostsCount > 0 && <PendingPostList pendingPosts={ pendingPosts } /> }
 		</TabView>
 	);
 };

--- a/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
+++ b/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
@@ -60,7 +60,7 @@ const TabsSwitcher = () => {
 						{ translate( 'Comments' ) }
 					</NavItem>
 
-					{ shouldEnablePendingTab && counts?.pending ? (
+					{ shouldEnablePendingTab && ( counts?.pending || pathname.includes( 'pending' ) ) ? (
 						<NavItem
 							onClick={ () => {
 								shouldEnablePendingTab

--- a/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn } from '../hooks';
-import { PendingPostSubscription, SubscriptionManagerSubscriptionsCount } from '../types';
+import { PendingPostSubscriptionsResult, SubscriptionManagerSubscriptionsCount } from '../types';
 
 type PendingPostDeleteParams = {
 	id: number | string;
@@ -43,17 +43,23 @@ const usePendingPostDeleteMutation = () => {
 				await queryClient.cancelQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
 				await queryClient.cancelQueries( countCacheKey );
 
-				const previousPendingPostSubscriptions = queryClient.getQueryData<
-					PendingPostSubscription[]
-				>( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
+				const previousPendingPostSubscriptions =
+					queryClient.getQueryData< PendingPostSubscriptionsResult >( [
+						'read',
+						'pending-post-subscriptions',
+						isLoggedIn,
+					] );
 
 				// remove post comment from pending post subscriptions
-				if ( previousPendingPostSubscriptions ) {
-					queryClient.setQueryData< PendingPostSubscription[] >(
+				if ( previousPendingPostSubscriptions?.pendingPosts ) {
+					queryClient.setQueryData< PendingPostSubscriptionsResult >(
 						[ [ 'read', 'pending-post-subscriptions', isLoggedIn ] ],
-						previousPendingPostSubscriptions.filter(
-							( pendingPostSubscription ) => pendingPostSubscription.id !== params.id
-						)
+						{
+							pendingPosts: previousPendingPostSubscriptions.pendingPosts.filter(
+								( pendingPostSubscription ) => pendingPostSubscription.id !== params.id
+							),
+							totalCount: previousPendingPostSubscriptions.totalCount - 1,
+						}
 					);
 				}
 
@@ -74,7 +80,7 @@ const usePendingPostDeleteMutation = () => {
 			},
 			onError: ( error, variables, context ) => {
 				if ( context?.previousPendingPostSubscriptions ) {
-					queryClient.setQueryData< PendingPostSubscription[] >(
+					queryClient.setQueryData< PendingPostSubscriptionsResult >(
 						[ 'read', 'pending-post-subscriptions', isLoggedIn ],
 						context.previousPendingPostSubscriptions
 					);

--- a/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn } from '../hooks';
-import { PendingSiteSubscription, SubscriptionManagerSubscriptionsCount } from '../types';
+import { PendingSiteSubscriptionsResult, SubscriptionManagerSubscriptionsCount } from '../types';
 
 type PendingSiteConfirmParams = {
 	id: string;
@@ -44,17 +44,23 @@ const usePendingSiteConfirmMutation = () => {
 				await queryClient.cancelQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
 				await queryClient.cancelQueries( countCacheKey );
 
-				const previousPendingSiteSubscriptions = queryClient.getQueryData<
-					PendingSiteSubscription[]
-				>( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+				const previousPendingSiteSubscriptions =
+					queryClient.getQueryData< PendingSiteSubscriptionsResult >( [
+						'read',
+						'pending-site-subscriptions',
+						isLoggedIn,
+					] );
 
 				// remove blog from pending site subscriptions
-				if ( previousPendingSiteSubscriptions ) {
-					queryClient.setQueryData< PendingSiteSubscription[] >(
+				if ( previousPendingSiteSubscriptions?.pendingSites ) {
+					queryClient.setQueryData< PendingSiteSubscriptionsResult >(
 						[ [ 'read', 'pending-site-subscriptions', isLoggedIn ] ],
-						previousPendingSiteSubscriptions.filter(
-							( pendingSiteSubscription ) => pendingSiteSubscription.id !== params.id
-						)
+						{
+							pendingSites: previousPendingSiteSubscriptions.pendingSites.filter(
+								( pendingSiteSubscription ) => pendingSiteSubscription.id !== params.id
+							),
+							totalCount: previousPendingSiteSubscriptions.totalCount - 1,
+						}
 					);
 				}
 
@@ -76,7 +82,7 @@ const usePendingSiteConfirmMutation = () => {
 			},
 			onError: ( error, variables, context ) => {
 				if ( context?.previousPendingSiteSubscriptions ) {
-					queryClient.setQueryData< PendingSiteSubscription[] >(
+					queryClient.setQueryData< PendingSiteSubscriptionsResult >(
 						[ 'read', 'pending-site-subscriptions', isLoggedIn ],
 						context.previousPendingSiteSubscriptions
 					);

--- a/packages/data-stores/src/reader/queries/use-pending-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-pending-post-subscriptions-query.ts
@@ -1,11 +1,11 @@
 import { useQuery } from 'react-query';
 import { callApi } from '../helpers';
 import { useIsLoggedIn, useIsQueryEnabled } from '../hooks';
-import type { PendingPostSubscription } from '../types';
+import type { PendingPostSubscription, PendingPostSubscriptionsResult } from '../types';
 
 type SubscriptionManagerPendingPostSubscriptions = {
 	comment_subscriptions: PendingPostSubscription[];
-	total_comment_subscriptions_count: string; // TODO: This should be a number, but the API returns a string.
+	total_comment_subscriptions_count: number;
 };
 
 type SubscriptionManagerPendingPostSubscriptionsQueryProps = {
@@ -13,13 +13,8 @@ type SubscriptionManagerPendingPostSubscriptionsQueryProps = {
 	sort?: ( a?: PendingPostSubscription, b?: PendingPostSubscription ) => number;
 };
 
-type PendingPostSubscriptionQueryResult = {
-	pendingPosts: PendingPostSubscription[];
-	totalCount: string; // TODO: This should be a number, but the API returns a string.
-};
-
 const callPendingBlogSubscriptionsEndpoint =
-	async (): Promise< PendingPostSubscriptionQueryResult > => {
+	async (): Promise< PendingPostSubscriptionsResult > => {
 		const pendingPosts = [];
 		const perPage = 1000; // TODO: This is a temporary workaround to get all pending subscriptions. We should remove this once we decide how to handle pagination.
 
@@ -39,7 +34,7 @@ const callPendingBlogSubscriptionsEndpoint =
 
 		return {
 			pendingPosts,
-			totalCount: incoming.total_comment_subscriptions_count,
+			totalCount: incoming?.total_comment_subscriptions_count ?? 0,
 		};
 	};
 
@@ -53,7 +48,7 @@ const usePendingPostSubscriptionsQuery = ( {
 	const isLoggedIn = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
 
-	const { data, ...rest } = useQuery< PendingPostSubscriptionQueryResult >(
+	const { data, ...rest } = useQuery< PendingPostSubscriptionsResult >(
 		[ 'read', 'pending-post-subscriptions', isLoggedIn ],
 		async () => {
 			return await callPendingBlogSubscriptionsEndpoint();
@@ -66,7 +61,7 @@ const usePendingPostSubscriptionsQuery = ( {
 
 	return {
 		data: {
-			pendingPosts: data?.pendingPosts.filter( filter ).sort( sort ),
+			pendingPosts: data?.pendingPosts?.filter( filter ).sort( sort ),
 			totalCount: data?.totalCount,
 		},
 		...rest,

--- a/packages/data-stores/src/reader/queries/use-pending-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-pending-site-subscriptions-query.ts
@@ -5,7 +5,7 @@ import type { PendingSiteSubscription } from '../types';
 
 type SubscriptionManagerPendingSiteSubscriptions = {
 	pending_blog_subscriptions: PendingSiteSubscription[];
-	total_pending_blog_subscriptions_count: number;
+	total_pending_blog_subscriptions_count: string; // TODO: This should be a number, but the API returns a string.
 };
 
 type SubscriptionManagerPendingSiteSubscriptionsQueryProps = {
@@ -13,26 +13,35 @@ type SubscriptionManagerPendingSiteSubscriptionsQueryProps = {
 	sort?: ( a?: PendingSiteSubscription, b?: PendingSiteSubscription ) => number;
 };
 
-const callPendingBlogSubscriptionsEndpoint = async (): Promise< PendingSiteSubscription[] > => {
-	const data = [];
-	const perPage = 1000; // TODO: This is a temporary workaround to get all pending subscriptions. We should remove this once we decide how to handle pagination.
-
-	const incoming = await callApi< SubscriptionManagerPendingSiteSubscriptions >( {
-		path: `/pending-blog-subscriptions?per_page=${ perPage }`,
-		apiVersion: '2',
-	} );
-
-	if ( incoming && incoming.pending_blog_subscriptions ) {
-		data.push(
-			...incoming.pending_blog_subscriptions.map( ( pendingSubscription ) => ( {
-				...pendingSubscription,
-				date_subscribed: new Date( pendingSubscription.date_subscribed ),
-			} ) )
-		);
-	}
-
-	return data;
+type PendingSiteSubscriptionQueryResult = {
+	pendingSites: PendingSiteSubscription[];
+	totalCount: string; // TODO: This should be a number, but the API returns a string.
 };
+
+const callPendingSiteSubscriptionsEndpoint =
+	async (): Promise< PendingSiteSubscriptionQueryResult > => {
+		const pendingSites = [];
+		const perPage = 1000; // TODO: This is a temporary workaround to get all pending subscriptions. We should remove this once we decide how to handle pagination.
+
+		const incoming = await callApi< SubscriptionManagerPendingSiteSubscriptions >( {
+			path: `/pending-blog-subscriptions?per_page=${ perPage }`,
+			apiVersion: '2',
+		} );
+
+		if ( incoming && incoming.pending_blog_subscriptions ) {
+			pendingSites.push(
+				...incoming.pending_blog_subscriptions.map( ( pendingSubscription ) => ( {
+					...pendingSubscription,
+					date_subscribed: new Date( pendingSubscription.date_subscribed ),
+				} ) )
+			);
+		}
+
+		return {
+			pendingSites,
+			totalCount: incoming.total_pending_blog_subscriptions_count,
+		};
+	};
 
 const defaultFilter = () => true;
 const defaultSort = () => 0;
@@ -44,10 +53,10 @@ const usePendingSiteSubscriptionsQuery = ( {
 	const isLoggedIn = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
 
-	const { data, ...rest } = useQuery< PendingSiteSubscription[] >(
+	const { data, ...rest } = useQuery< PendingSiteSubscriptionQueryResult >(
 		[ 'read', 'pending-site-subscriptions', isLoggedIn ],
 		async () => {
-			return await callPendingBlogSubscriptionsEndpoint();
+			return await callPendingSiteSubscriptionsEndpoint();
 		},
 		{
 			enabled,
@@ -56,7 +65,10 @@ const usePendingSiteSubscriptionsQuery = ( {
 	);
 
 	return {
-		data: data?.filter( filter ).sort( sort ),
+		data: {
+			pendingSites: data?.pendingSites?.filter( filter ).sort( sort ),
+			totalCount: parseInt( data?.totalCount || '0' ),
+		},
 		...rest,
 	};
 };

--- a/packages/data-stores/src/reader/queries/use-pending-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-pending-site-subscriptions-query.ts
@@ -1,7 +1,7 @@
 import { useQuery } from 'react-query';
 import { callApi } from '../helpers';
 import { useIsLoggedIn, useIsQueryEnabled } from '../hooks';
-import type { PendingSiteSubscription } from '../types';
+import type { PendingSiteSubscription, PendingSiteSubscriptionsResult } from '../types';
 
 type SubscriptionManagerPendingSiteSubscriptions = {
 	pending_blog_subscriptions: PendingSiteSubscription[];
@@ -13,13 +13,8 @@ type SubscriptionManagerPendingSiteSubscriptionsQueryProps = {
 	sort?: ( a?: PendingSiteSubscription, b?: PendingSiteSubscription ) => number;
 };
 
-type PendingSiteSubscriptionQueryResult = {
-	pendingSites: PendingSiteSubscription[];
-	totalCount: string; // TODO: This should be a number, but the API returns a string.
-};
-
 const callPendingSiteSubscriptionsEndpoint =
-	async (): Promise< PendingSiteSubscriptionQueryResult > => {
+	async (): Promise< PendingSiteSubscriptionsResult > => {
 		const pendingSites = [];
 		const perPage = 1000; // TODO: This is a temporary workaround to get all pending subscriptions. We should remove this once we decide how to handle pagination.
 
@@ -39,7 +34,7 @@ const callPendingSiteSubscriptionsEndpoint =
 
 		return {
 			pendingSites,
-			totalCount: incoming.total_pending_blog_subscriptions_count,
+			totalCount: parseInt( incoming?.total_pending_blog_subscriptions_count ?? 0 ),
 		};
 	};
 
@@ -53,7 +48,7 @@ const usePendingSiteSubscriptionsQuery = ( {
 	const isLoggedIn = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
 
-	const { data, ...rest } = useQuery< PendingSiteSubscriptionQueryResult >(
+	const { data, ...rest } = useQuery< PendingSiteSubscriptionsResult >(
 		[ 'read', 'pending-site-subscriptions', isLoggedIn ],
 		async () => {
 			return await callPendingSiteSubscriptionsEndpoint();
@@ -67,7 +62,7 @@ const usePendingSiteSubscriptionsQuery = ( {
 	return {
 		data: {
 			pendingSites: data?.pendingSites?.filter( filter ).sort( sort ),
-			totalCount: parseInt( data?.totalCount || '0' ),
+			totalCount: data?.totalCount,
 		},
 		...rest,
 	};

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -109,3 +109,13 @@ export type PendingPostSubscription = {
 	post_excerpt: string;
 	post_url: string;
 };
+
+export type PendingSiteSubscriptionsResult = {
+	pendingSites: PendingSiteSubscription[];
+	totalCount: number;
+};
+
+export type PendingPostSubscriptionsResult = {
+	pendingPosts: PendingPostSubscription[];
+	totalCount: number;
+};


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/76037

## Proposed Changes

- Adds empty view to Pending tab, displayed when there is no Pending Site or Post on the lists
  - Additionally, it doesn't render `PendingSiteList` if the pending site list is empty
  - And it doesn't render `PendingPostList` if the pending post list is empty
- Fixes display of the Pending tab
  - If the pending count is > 0, it displays the Pending tab
  - If the user accessed directly to the pending route, it displays the Pending tab
  - If the user is on the pending tab and confirm/delete all the items, it continues to display the Pending tab
- Updates the queries to return the list and the total for both sites and posts
- Update the pending mutations to use the new query result structure

cc @JuanLucha 

## Testing Instructions

* Run this PR on your local env
* Use a account with pending site subscriptions
* Go to http://calypso.localhost:3000/subscriptions/sites
* Verify if the Pending site is displayed as expected
* Click on Pending tab and verify if it is rendered as expected
* Accept the pending subscription (by clicking on confirmation email) and verify if the empty view appears as expected
* Go to http://calypso.localhost:3000/subscriptions/pending and verify if the page is rendered with an empty view

<img width="881" alt="image" src="https://user-images.githubusercontent.com/3113712/233393371-21d747ad-af4f-4937-bc58-b3c9580f5a07.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
