### PR TITLE
Fix timing issue when purchasing a Commerce plan via /start

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -175,11 +175,11 @@ export class CheckoutThankYou extends Component {
 		const {
 			domainOnlySiteFlow,
 			isFetchingSitePlugins,
+			isWooCommerceInstalled,
 			receiptId,
 			selectedSite,
 			selectedSiteSlug,
 			transferComplete,
-			wooCommerceInstalled,
 		} = this.props;
 
 		this.redirectIfThemePurchased();
@@ -194,7 +194,7 @@ export class CheckoutThankYou extends Component {
 		}
 
 		// If the site has been transferred to Atomc and we're not already requesting the site plugins, request them.
-		if ( selectedSite && transferComplete && ! isFetchingSitePlugins && ! wooCommerceInstalled ) {
+		if ( selectedSite && transferComplete && ! isFetchingSitePlugins && ! isWooCommerceInstalled ) {
 			this.props.fetchSitePlugins?.( selectedSite.ID );
 		}
 
@@ -456,7 +456,7 @@ export class CheckoutThankYou extends Component {
 
 		if ( wasEcommercePlanPurchased ) {
 			// Continue to show the TransferPending progress bar until both the Atomic transfer is complete _and_ we've verified WooCommerce is finished installed.
-			if ( ! this.props.transferComplete || ! this.props.wooCommerceInstalled ) {
+			if ( ! this.props.transferComplete || ! this.props.isWooCommerceInstalled ) {
 				return (
 					<TransferPending orderId={ this.props.receiptId } siteId={ this.props.selectedSite.ID } />
 				);
@@ -742,7 +742,7 @@ export class CheckoutThankYou extends Component {
 	};
 }
 
-function checkWooCommerceInstalled( sitePlugins ) {
+function isWooCommercePluginInstalled( sitePlugins ) {
 	return sitePlugins.length > 0 && sitePlugins.some( ( item ) => item.slug === 'woocommerce' );
 }
 
@@ -758,7 +758,7 @@ export default connect(
 			receipt: getReceiptById( state, props.receiptId ),
 			gsuiteReceipt: props.gsuiteReceiptId ? getReceiptById( state, props.gsuiteReceiptId ) : null,
 			sitePlans: getPlansBySite( state, props.selectedSite ),
-			wooCommerceInstalled: checkWooCommerceInstalled( sitePlugins ),
+			isWooCommerceInstalled: isWooCommercePluginInstalled( sitePlugins ),
 			isFetchingSitePlugins: isRequestingSitePlugins( state, siteId ),
 			upgradeIntent: props.upgradeIntent || getCheckoutUpgradeIntent( state ),
 			isSimplified:

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -60,7 +60,10 @@ import {
 import { recordStartTransferClickInThankYou } from 'calypso/state/domains/actions';
 import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
-import { getPlugins, isRequesting } from 'calypso/state/plugins/installed/selectors';
+import {
+	getPlugins as getInstalledPlugins,
+	isRequesting as isRequestingSitePlugins,
+} from 'calypso/state/plugins/installed/selectors';
 import { isProductsListFetching } from 'calypso/state/products-list/selectors';
 import { fetchReceipt } from 'calypso/state/receipts/actions';
 import { getReceiptById } from 'calypso/state/receipts/selectors';
@@ -171,7 +174,7 @@ export class CheckoutThankYou extends Component {
 	componentDidUpdate( prevProps ) {
 		const {
 			domainOnlySiteFlow,
-			isRequestingSitePlugins,
+			isFetchingSitePlugins,
 			receiptId,
 			selectedSite,
 			selectedSiteSlug,
@@ -191,7 +194,7 @@ export class CheckoutThankYou extends Component {
 		}
 
 		// If the site has been transferred to Atomc and we're not already requesting the site plugins, request them.
-		if ( selectedSite && transferComplete && ! isRequestingSitePlugins && ! wooCommerceInstalled ) {
+		if ( selectedSite && transferComplete && ! isFetchingSitePlugins && ! wooCommerceInstalled ) {
 			this.props.fetchSitePlugins?.( selectedSite.ID );
 		}
 
@@ -747,7 +750,7 @@ export default connect(
 	( state, props ) => {
 		const siteId = getSelectedSiteId( state );
 		const activeTheme = getActiveTheme( state, siteId );
-		const sitePlugins = getPlugins( state, [ siteId ] );
+		const sitePlugins = getInstalledPlugins( state, [ siteId ] );
 
 		return {
 			isProductsListFetching: isProductsListFetching( state ),
@@ -756,7 +759,7 @@ export default connect(
 			gsuiteReceipt: props.gsuiteReceiptId ? getReceiptById( state, props.gsuiteReceiptId ) : null,
 			sitePlans: getPlansBySite( state, props.selectedSite ),
 			wooCommerceInstalled: checkWooCommerceInstalled( sitePlugins ),
-			isRequestingSitePlugins: isRequesting( state, siteId ),
+			isFetchingSitePlugins: isRequestingSitePlugins( state, siteId ),
 			upgradeIntent: props.upgradeIntent || getCheckoutUpgradeIntent( state ),
 			isSimplified:
 				[ 'install_theme', 'install_plugin', 'browse_plugins' ].indexOf( props.upgradeIntent ) !==

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -170,13 +170,13 @@ export class CheckoutThankYou extends Component {
 
 	componentDidUpdate( prevProps ) {
 		const {
-			receiptId,
-			selectedSiteSlug,
-			selectedSite,
 			domainOnlySiteFlow,
 			isRequestingSitePlugins,
-			wooCommerceInstalled,
+			receiptId,
+			selectedSite,
+			selectedSiteSlug,
 			transferComplete,
+			wooCommerceInstalled,
 		} = this.props;
 
 		this.redirectIfThemePurchased();

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -172,7 +172,7 @@ describe( 'CheckoutThankYou', () => {
 
 		test( 'Should be there for AT', () => {
 			render(
-				<CheckoutThankYou { ...props } transferComplete={ true } wooCommerceInstalled={ true } />
+				<CheckoutThankYou { ...props } transferComplete={ true } isWooCommerceInstalled={ true } />
 			);
 			expect( screen.queryByTestId( 'atomic-store-thank-you-card' ) ).toBeVisible();
 		} );

--- a/client/my-sites/checkout/checkout-thank-you/test/index.js
+++ b/client/my-sites/checkout/checkout-thank-you/test/index.js
@@ -171,7 +171,9 @@ describe( 'CheckoutThankYou', () => {
 		} );
 
 		test( 'Should be there for AT', () => {
-			render( <CheckoutThankYou { ...props } transferComplete={ true } /> );
+			render(
+				<CheckoutThankYou { ...props } transferComplete={ true } wooCommerceInstalled={ true } />
+			);
 			expect( screen.queryByTestId( 'atomic-store-thank-you-card' ) ).toBeVisible();
 		} );
 


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #75951

## Proposed Changes

It was possible, after purchasing a Commerce plan, to click the 'Create Store' link before WooCommerce was fully installed which lead to an error page.

Now the CheckoutThankYou component waits for both the Atomic transfer to finish, and for WooCommerce to be fully installed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This is a bit tricky to test since it's a timing issue. Here are the steps to reproduce the error _(making sure this patch isn't installed yet)_.

### Recreating the error (prior to changing to this branch)

1. While logged in, visit (https://wordpress.com/start/)
1. On the domains step, click on the option to choose a domain later
1. On the plans step, pick the Commerce/eCommerce plan
1. Complete checkout to purchase the plan
1. Wait for the loading screens to complete, and get ready to click the CTA to "Create your store" as soon as it appears
1. When the "Thank you for your purchase" screen appears, click on the CTA as quickly as you can
1. Sometimes (but not always), this triggers an error, because the site is not fully set up yet, either because Jetpack SSO isn't configured yet, or because WooCommerce is not installed and activated yet

### Verify we're checking installed plugins (after changing to this branch).

1. Open the dev console on your browser and make sure you're logging XHR requests (or looking at the Network tab).
1. Go to `/start`.
1. Purchase a Commerce plan (either monthly or yearly)
1. Wait until the pending transfer screen is gone and "Thank you for your purchase" appears.
1. Check the browser console. You should see the last call to `/sites/:siteSlug/transfers/lastest` should have `status: "completed"`.
1. At that point, you should see multiple calls to `/sites/:siteSlug/plugins`.
1. The last call to `/sites/:siteSlug/plugins` should have WooCommerce in the result.

![image](https://user-images.githubusercontent.com/917632/233409210-3ea23605-05e3-4b8a-8e52-c543daa4d7be.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
