### PR TITLE
Blog onboarding: Hide "post publish" sidebar on "writer flow v1"

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -1,4 +1,4 @@
-import { select, subscribe } from '@wordpress/data';
+import { dispatch, select, subscribe } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
 import { getQueryArg } from '@wordpress/url';
 
@@ -19,6 +19,7 @@ export function redirectOnboardingUserAfterPublishingPost() {
 		if ( ! isSavingPost && isCurrentPostPublished && getCurrentPostRevisionsCount === 1 ) {
 			unsubscribe();
 
+			dispatch( 'core/edit-post' ).closePublishSidebar();
 			window.location.href =
 				siteOrigin + '/setup/write/launchpad?siteSlug=' + siteSlug + '&showLaunchpad=true';
 		}

--- a/apps/wpcom-block-editor/src/wpcom/features/test/redirect-onboarding-user-after-publishing-post.test.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/test/redirect-onboarding-user-after-publishing-post.test.js
@@ -6,6 +6,7 @@ import { redirectOnboardingUserAfterPublishingPost } from '../redirect-onboardin
 beforeAll( () => {} );
 
 const mockUnSubscribe = jest.fn();
+const mockClosePublishSidebar = jest.fn();
 let mockSubscribeFunction = null;
 let mockIsSaving = false;
 
@@ -23,6 +24,13 @@ jest.mock( '@wordpress/data', () => ( {
 				getCurrentPostRevisionsCount: () => 1,
 			};
 		}
+	},
+	dispatch: () => {
+		return {
+			closePublishSidebar: () => {
+				mockClosePublishSidebar();
+			},
+		};
 	},
 } ) );
 
@@ -74,6 +82,7 @@ describe( 'redirectOnboardingUserAfterPublishingPost', () => {
 		mockSubscribeFunction();
 
 		expect( mockUnSubscribe ).toBeCalledTimes( 1 );
+		expect( mockClosePublishSidebar ).toBeCalledTimes( 1 );
 		expect( global.window.location.href ).toBe(
 			'https://calypso.localhost:3000/setup/write/launchpad?siteSlug=wordpress.com&showLaunchpad=true'
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2185

## Proposed Changes

* While using the special flag `showLaunchpad=true` from a new post page (without iFrame), the Post-publish sidebar should close when redirecting

![image](https://user-images.githubusercontent.com/402286/233423672-0a3ecd8c-6769-4f14-b944-361af66a9fed.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch on your local Calypso
* Make sure `widgets.wp.com` is sandboxed.
* Follow the [wpcom-block-editor sync flow](https://github.com/Automattic/wp-calypso/tree/trunk/apps/wpcom-block-editor#dev-workflow). In summary: 
  - `cd apps/wpcom-block-editor/src`
  - `yarn dev --sync`
* Create a new post using the onboarding flag: http://calypso.localhost:3000/post/{domain}?showLaunchpad=true
* Inspect the page and open the iFrame URL in a new tab
* The post-publish sidebar should not show

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~