### PR TITLE
Site Editor: remove the need for `postId` and `postTemplate` args

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -1,7 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { makeLayout, render } from 'calypso/controller';
 import { addQueryArgs } from 'calypso/lib/route';
-import wpcom from 'calypso/lib/wp';
 import { EDITOR_START, POST_EDIT } from 'calypso/state/action-types';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { getAdminMenu, getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
@@ -280,25 +279,15 @@ export const redirectSiteEditor = async ( context ) => {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 
-	const { home_template } = await wpcom.req
-		.get( {
-			path: `/sites/${ siteId }/block-editor`,
-			apiNamespace: 'wpcom/v2',
-		} )
-		.catch( () => {} );
-
-	let queryArgs = {};
+	const queryArgs = {};
 	// Only add the origin if it's not wordpress.com.
 	if ( location.origin !== 'https://wordpress.com' ) {
 		queryArgs.calypso_origin = location.origin;
 	}
-	// Adds home_template.post_id and home_template.postType if we received them.
-	if ( home_template ) {
-		queryArgs = { ...queryArgs, ...home_template };
-	}
+
 	// We aren't using `getSiteEditorUrl` because it still thinks we should gutenframe the Site Editor.
 	const siteAdminUrl = getSiteAdminUrl( state, siteId );
 	const siteEditorUrl = addQueryArgs( queryArgs, `${ siteAdminUrl }site-editor.php` );
-	// Calling replace to avoid adding an entry to the browser history.
+	// Calling replace to avoid adding an entry to the browser history upon redirect.
 	return location.replace( siteEditorUrl );
 };


### PR DESCRIPTION
Now that https://github.com/WordPress/gutenberg/pull/49861 has landed on wpcom, we can remove our workaround of adding the query args ourselves.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75183 and https://github.com/WordPress/gutenberg/pull/49861

## Proposed Changes

* Remove the call to `/sites/SITE/block-editor` in the `/site-editor/SITE` redirect.
* The `wpcom` request was also generating some improperly-handled errors, so good to get rid of it.

## Testing Instructions

Try accessing `/site-editor/SITE` with this branch built. You should see no query args in the redirected Site Editor URL (other than `calypso_origin` if running locally). 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
