### PR TITLE
Added pending post subscription delete action

### DIFF
--- a/client/landing/subscriptions/components/pending-list/pending-post-list/pending-post-row.tsx
+++ b/client/landing/subscriptions/components/pending-list/pending-post-list/pending-post-row.tsx
@@ -25,10 +25,8 @@ export default function PendingPostRow( {
 
 	const { mutate: confirmPendingSubscription, isLoading: confirmingPendingSubscription } =
 		SubscriptionManager.usePendingPostConfirmMutation();
-	const { mutate: deletePendingSubscription, isLoading: deletingPendingSubscription } = {
-		mutate: () => null,
-		isLoading: false,
-	};
+	const { mutate: deletePendingSubscription, isLoading: deletingPendingSubscription } =
+		SubscriptionManager.usePendingPostDeleteMutation();
 
 	return (
 		<div className="row-wrapper">
@@ -56,7 +54,7 @@ export default function PendingPostRow( {
 				<span className="actions" role="cell">
 					<PendingPostSettings
 						onConfirm={ () => confirmPendingSubscription( { id } ) }
-						onDelete={ () => deletePendingSubscription() }
+						onDelete={ () => deletePendingSubscription( { id } ) }
 						confirming={ confirmingPendingSubscription }
 						deleting={ deletingPendingSubscription }
 					/>

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -7,6 +7,7 @@ import {
 	usePendingSiteConfirmMutation,
 	usePendingSiteDeleteMutation,
 	usePendingPostConfirmMutation,
+	usePendingPostDeleteMutation,
 } from './mutations';
 import {
 	SiteSubscriptionsSortBy,
@@ -34,6 +35,7 @@ export const SubscriptionManager = {
 	usePendingSiteConfirmMutation,
 	usePendingSiteDeleteMutation,
 	usePendingPostConfirmMutation,
+	usePendingPostDeleteMutation,
 };
 
 // Types

--- a/packages/data-stores/src/reader/mutations/index.ts
+++ b/packages/data-stores/src/reader/mutations/index.ts
@@ -5,3 +5,4 @@ export { default as useUserSettingsMutation } from './use-user-settings-mutation
 export { default as usePendingSiteConfirmMutation } from './use-pending-site-confirm-mutation';
 export { default as usePendingSiteDeleteMutation } from './use-pending-site-delete-mutation';
 export { default as usePendingPostConfirmMutation } from './use-pending-post-confirm-mutation';
+export { default as usePendingPostDeleteMutation } from './use-pending-post-delete-mutation';

--- a/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
@@ -1,22 +1,22 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn } from '../hooks';
-import { PendingSiteSubscription, SubscriptionManagerSubscriptionsCount } from '../types';
+import { PendingPostSubscription, SubscriptionManagerSubscriptionsCount } from '../types';
 
-type PendingSiteDeleteParams = {
+type PendingPostDeleteParams = {
 	id: number | string;
 };
 
-type PendingSiteDeleteResponse = {
+type PendingPostDeleteResponse = {
 	deleted: boolean;
 };
 
-const usePendingSiteDeleteMutation = () => {
+const usePendingPostDeleteMutation = () => {
 	const isLoggedIn = useIsLoggedIn();
 	const queryClient = useQueryClient();
 	const countCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
 	return useMutation(
-		async ( params: PendingSiteDeleteParams ) => {
+		async ( params: PendingPostDeleteParams ) => {
 			if ( ! params.id ) {
 				throw new Error(
 					// reminder: translate this string when we add it to the UI
@@ -24,8 +24,8 @@ const usePendingSiteDeleteMutation = () => {
 				);
 			}
 
-			const response = await callApi< PendingSiteDeleteResponse >( {
-				path: `/pending-blog-subscriptions/${ params.id }/delete`,
+			const response = await callApi< PendingPostDeleteResponse >( {
+				path: `/post-comment-subscriptions/${ params.id }/delete`,
 				method: 'POST',
 				apiVersion: '2',
 			} );
@@ -40,19 +40,19 @@ const usePendingSiteDeleteMutation = () => {
 		},
 		{
 			onMutate: async ( params ) => {
-				await queryClient.cancelQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+				await queryClient.cancelQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
 				await queryClient.cancelQueries( countCacheKey );
 
-				const previousPendingSiteSubscriptions = queryClient.getQueryData<
-					PendingSiteSubscription[]
-				>( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+				const previousPendingPostSubscriptions = queryClient.getQueryData<
+					PendingPostSubscription[]
+				>( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
 
-				// remove blog from pending site subscriptions
-				if ( previousPendingSiteSubscriptions ) {
-					queryClient.setQueryData< PendingSiteSubscription[] >(
-						[ [ 'read', 'pending-site-subscriptions', isLoggedIn ] ],
-						previousPendingSiteSubscriptions.filter(
-							( pendingSiteSubscription ) => pendingSiteSubscription.id !== params.id
+				// remove post comment from pending post subscriptions
+				if ( previousPendingPostSubscriptions ) {
+					queryClient.setQueryData< PendingPostSubscription[] >(
+						[ [ 'read', 'pending-post-subscriptions', isLoggedIn ] ],
+						previousPendingPostSubscriptions.filter(
+							( pendingPostSubscription ) => pendingPostSubscription.id !== params.id
 						)
 					);
 				}
@@ -60,7 +60,7 @@ const usePendingSiteDeleteMutation = () => {
 				const previousSubscriptionsCount =
 					queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >( countCacheKey );
 
-				// decrement the blog count
+				// decrement the post comment count
 				if ( previousSubscriptionsCount ) {
 					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >( countCacheKey, {
 						...previousSubscriptionsCount,
@@ -70,13 +70,13 @@ const usePendingSiteDeleteMutation = () => {
 					} );
 				}
 
-				return { previousPendingSiteSubscriptions, previousSubscriptionsCount };
+				return { previousPendingPostSubscriptions, previousSubscriptionsCount };
 			},
 			onError: ( error, variables, context ) => {
-				if ( context?.previousPendingSiteSubscriptions ) {
-					queryClient.setQueryData< PendingSiteSubscription[] >(
-						[ 'read', 'pending-site-subscriptions', isLoggedIn ],
-						context.previousPendingSiteSubscriptions
+				if ( context?.previousPendingPostSubscriptions ) {
+					queryClient.setQueryData< PendingPostSubscription[] >(
+						[ 'read', 'pending-post-subscriptions', isLoggedIn ],
+						context.previousPendingPostSubscriptions
 					);
 				}
 				if ( context?.previousSubscriptionsCount ) {
@@ -87,11 +87,11 @@ const usePendingSiteDeleteMutation = () => {
 				}
 			},
 			onSettled: () => {
-				queryClient.invalidateQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+				queryClient.invalidateQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
 				queryClient.invalidateQueries( countCacheKey );
 			},
 		}
 	);
 };
 
-export default usePendingSiteDeleteMutation;
+export default usePendingPostDeleteMutation;


### PR DESCRIPTION
## Proposed Changes

This change adds the delete action to the pending post comment subscription list.
<img width="362" alt="Screenshot 2023-04-20 at 15 37 00" src="https://user-images.githubusercontent.com/3832570/233383468-80c52281-8279-4017-8251-31b41106a4ab.png">


## Testing Instructions

1. Apply this PR and run the application.
2. Apply this patch to your sandbox
3. Subscribe to a blog with a non-WP.com user (for example, your-email+testing@gmail.com)
4. You should receive a confirmation e-mail that contains a "Manage subscriptions" button
5. Copy the button's link & visit in an incognito window
6. Open dev tools & copy the cookie. Make sure "Show URL decoded" is checked. Copy the value from the subkey cookie.
7. Add the subkey cookie to `calypso.localhost:3000`.
8. Go to `/subscriptions/pending`.
9. Open the meatballs menu in any of your comment subscriptions and click "delete".
10. The pending subscription should be removed from the list.
