### PR TITLE
Site Editor: remove unneeded Site Editor link

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
@@ -23,7 +23,6 @@ class WPCOM_Block_Editor_Nav_Sidebar {
 	 */
 	public function __construct() {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_script_and_style' ), 100 );
-		add_filter( 'block_editor_settings_all', array( $this, 'add_wpcom_dashboard_link' ) );
 	}
 
 	/**
@@ -86,18 +85,6 @@ class WPCOM_Block_Editor_Nav_Sidebar {
 			array(),
 			filemtime( plugin_dir_path( __FILE__ ) . $style_path )
 		);
-	}
-
-	/**
-	 * Point the dashboard link to wordpress.com in the editor sidebar for Gutenberg 14.5 compat
-	 *
-	 * @param array $settings Editor settings.
-	 * @return array Updated Editor settings.
-	 */
-	public function add_wpcom_dashboard_link( $settings ) {
-		$site_slug                               = preg_replace( '|^https?:\/\/|', '', home_url() );
-		$settings['__experimentalDashboardLink'] = 'https://wordpress.com/home/' . $site_slug;
-		return $settings;
 	}
 
 	/**


### PR DESCRIPTION
Introduced in #69929
Replaced by https://github.com/Automattic/jetpack/pull/27601

## Proposed Changes

* Remove duplicated code (lives in Jetpack)

## Testing Instructions

With this applied on your wpcom sandbox, does the back button in the Site Editor still take you to wpcom home?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
