### PR TITLE
Avoid having Leave Site message while redirecting user

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -16,7 +16,7 @@ export function redirectOnboardingUserAfterPublishingPost() {
 		const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
 		const getCurrentPostRevisionsCount = select( 'core/editor' ).getCurrentPostRevisionsCount();
 
-		if ( false === isSavingPost && isCurrentPostPublished && getCurrentPostRevisionsCount === 1 ) {
+		if ( ! isSavingPost && isCurrentPostPublished && getCurrentPostRevisionsCount === 1 ) {
 			unsubscribe();
 
 			window.location.href =

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -4,7 +4,6 @@ import { getQueryArg } from '@wordpress/url';
 
 export function redirectOnboardingUserAfterPublishingPost() {
 	const showLaunchpad = getQueryArg( window.location.search, 'showLaunchpad' );
-
 	if ( 'true' !== showLaunchpad ) {
 		return false;
 	}
@@ -13,10 +12,11 @@ export function redirectOnboardingUserAfterPublishingPost() {
 	const siteSlug = window.location.hostname;
 
 	const unsubscribe = subscribe( () => {
+		const isSavingPost = select( 'core/editor' ).isSavingPost();
 		const isCurrentPostPublished = select( 'core/editor' ).isCurrentPostPublished();
 		const getCurrentPostRevisionsCount = select( 'core/editor' ).getCurrentPostRevisionsCount();
 
-		if ( isCurrentPostPublished && getCurrentPostRevisionsCount === 1 ) {
+		if ( false === isSavingPost && isCurrentPostPublished && getCurrentPostRevisionsCount === 1 ) {
 			unsubscribe();
 
 			window.location.href =

--- a/apps/wpcom-block-editor/src/wpcom/features/test/redirect-onboarding-user-after-publishing-post.test.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/test/redirect-onboarding-user-after-publishing-post.test.js
@@ -7,6 +7,7 @@ beforeAll( () => {} );
 
 const mockUnSubscribe = jest.fn();
 let mockSubscribeFunction = null;
+let mockIsSaving = false;
 
 jest.mock( '@wordpress/data', () => ( {
 	subscribe: ( userFunction ) => {
@@ -17,6 +18,7 @@ jest.mock( '@wordpress/data', () => ( {
 	select: ( item ) => {
 		if ( item === 'core/editor' ) {
 			return {
+				isSavingPost: () => mockIsSaving,
 				isCurrentPostPublished: () => true,
 				getCurrentPostRevisionsCount: () => 1,
 			};
@@ -39,7 +41,26 @@ describe( 'redirectOnboardingUserAfterPublishingPost', () => {
 		expect( global.window.location.href ).toBe( undefined );
 	} );
 
+	it( 'should NOT redirect while saving the POST', () => {
+		mockIsSaving = true;
+		delete global.window;
+		global.window = {
+			location: {
+				search: '?showLaunchpad=true&origin=https://calypso.localhost:3000',
+				hostname: 'wordpress.com',
+			},
+		};
+
+		redirectOnboardingUserAfterPublishingPost();
+		expect( mockSubscribeFunction ).not.toBe( null );
+		mockSubscribeFunction();
+
+		expect( mockUnSubscribe ).toBeCalledTimes( 0 );
+		expect( global.window.location.href ).toBe( undefined );
+	} );
+
 	it( 'should redirect the user to the launchpad when a post is published and the showLaunchpad query parameter is present', () => {
+		mockIsSaving = false;
 		delete global.window;
 		global.window = {
 			location: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2198-gh-Automattic/dotcom-forge

## Proposed Changes

* Avoid the `Leave Site` message while redirecting the user outside the edition 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch on your local Calypso
* Make sure `widgets.wp.com` is sandboxed.
* Follow the [wpcom-block-editor sync flow](https://github.com/Automattic/wp-calypso/tree/trunk/apps/wpcom-block-editor#dev-workflow). In summary: 
  - cd apps/wpcom-block-editor/src 
  - yarn dev --sync

* Create a new post using the onboarding flag: http://calypso.localhost:3000/post/{domain}?showLaunchpad=true
* Inspect the page and open the iFrame URL in a new tab
* After publishing a post, you should get redirected to the Launchpad instead of seeing the `Leave Site` message

* Run test with this command: `yarn run jest apps/wpcom-block-editor/src/wpcom/features/test/redirect-onboarding-user-after-publishing-post.test.js`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?