### PR TITLE
Remove extra space in plugins management update test

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/test/update-plugin.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/update-plugin.test.tsx
@@ -57,7 +57,7 @@ describe( '<UpdatePlugin>', () => {
 		).toEqual( plugin.version );
 
 		const [ updateButton ] = container.getElementsByClassName( 'update-plugin__new-version' );
-		expect( updateButton.textContent ).toEqual( `Update to  ${ plugin.update.new_version }` );
+		expect( updateButton.textContent ).toEqual( `Update to ${ plugin.update.new_version }` );
 
 		await userEvent.click( updateButton );
 		expect( props.updatePlugin ).toHaveBeenCalledTimes( 1 );

--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -141,7 +141,7 @@ export default function UpdatePlugin( { plugin, selectedSite, className, updateP
 					borderless
 					compact
 				>
-					{ translate( '{{span}}Update to {{/span}} %s', {
+					{ translate( '{{span}}Update to {{/span}}%s', {
 						components: {
 							span: <span />,
 						},


### PR DESCRIPTION
Remove the extra space in the plugins management "Update to" text and fix the test case.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Removes extra space in the plugins management page between the `Update to` and plugins version text

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR
* Ensure that you have a test site connected to Jetpack and a plugin that needs updating. The Jetpack Beta Tester plugin can be used to manage Jetpack plugin versions and temporarily activate an older Jetpack plugin version.
* run `yarn start-jetpack-cloud`
* Visit `http://jetpack.cloud.localhost:3000/dashboard` and click on the link in the dashboard row that shows `x Available` in the plugins column.
* Inspect the element and ensure that the plugin version no longer has a leading space before it.  
<img width="943" alt="Screenshot 2023-04-21 at 9 49 29 AM" src="https://user-images.githubusercontent.com/1273880/233680096-a14cacdd-320b-4af3-aeb4-1123f95dcecd.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
