### PR TITLE
Subscription Management: Add support to sort posts on Comments tab

### DIFF
--- a/client/landing/subscriptions/components/sort-controls/sort-controls.tsx
+++ b/client/landing/subscriptions/components/sort-controls/sort-controls.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect, ChangeEvent, ReactElement } from 'react';
+import { ChangeEvent, ReactElement } from 'react';
 import './styles.scss';
 
 export type Option = {
@@ -19,11 +19,6 @@ const SortControls: < T extends string >( props: SortControlsProps< T > ) => Rea
 	onChange,
 } ) => {
 	const translate = useTranslate();
-	const [ selected, setSelected ] = useState( value );
-
-	useEffect( () => {
-		setSelected( value );
-	}, [ value ] );
 
 	const handleSelectChange = ( event: ChangeEvent< HTMLSelectElement > ) => {
 		onChange( event?.target.value as typeof value );
@@ -37,7 +32,7 @@ const SortControls: < T extends string >( props: SortControlsProps< T > ) => Rea
 					id="subscription-manager-sort-controls__select"
 					className="subscription-manager-sort-controls__select"
 					onChange={ handleSelectChange }
-					value={ selected }
+					value={ value }
 				>
 					{ options.map( ( option ) => (
 						<option key={ `${ option.value }.${ option.label }` } value={ option.value }>

--- a/client/landing/subscriptions/components/tab-views/comments/comments.tsx
+++ b/client/landing/subscriptions/components/tab-views/comments/comments.tsx
@@ -2,23 +2,38 @@ import config from '@automattic/calypso-config';
 import { SubscriptionManager } from '@automattic/data-stores';
 import SearchInput from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import { CommentList } from 'calypso/landing/subscriptions/components/comment-list';
 import { SearchIcon } from 'calypso/landing/subscriptions/components/icons';
 import { Notice } from 'calypso/landing/subscriptions/components/notice';
+import { SortControls, Option } from 'calypso/landing/subscriptions/components/sort-controls';
 import useSearch from 'calypso/landing/subscriptions/hooks/use-search';
 import TabView from '../tab-view';
+
+const SortBy = SubscriptionManager.PostSubscriptionsSortBy;
+
+const useSortOptions = (): Option[] => {
+	const translate = useTranslate();
+
+	return [
+		{ value: SortBy.PostName, label: translate( 'Post name' ) },
+		{ value: SortBy.RecentlySubscribed, label: translate( 'Recently subscribed' ) },
+	];
+};
 
 const isListControlsEnabled = config.isEnabled( 'subscription-management/comments-list-controls' );
 
 const Comments = () => {
 	const translate = useTranslate();
+	const [ sortTerm, setSortTerm ] = useState( SortBy.RecentlyCommented );
 	const { searchTerm, handleSearch } = useSearch();
+	const sortOptions = useSortOptions();
 
 	const {
 		data: { posts, totalCount },
 		isLoading,
 		error,
-	} = SubscriptionManager.usePostSubscriptionsQuery( { searchTerm } );
+	} = SubscriptionManager.usePostSubscriptionsQuery( { searchTerm, sortTerm } );
 
 	// todo: translate when we have agreed on the error message
 	const errorMessage = error ? 'An error occurred while fetching your subscriptions.' : '';
@@ -39,6 +54,7 @@ const Comments = () => {
 						searchIcon={ <SearchIcon size={ 18 } /> }
 						onSearch={ handleSearch }
 					/>
+					<SortControls options={ sortOptions } value={ sortTerm } onChange={ setSortTerm } />
 				</div>
 			) }
 

--- a/client/landing/subscriptions/components/tab-views/comments/comments.tsx
+++ b/client/landing/subscriptions/components/tab-views/comments/comments.tsx
@@ -16,8 +16,8 @@ const useSortOptions = (): Option[] => {
 	const translate = useTranslate();
 
 	return [
-		{ value: SortBy.PostName, label: translate( 'Post name' ) },
 		{ value: SortBy.RecentlySubscribed, label: translate( 'Recently subscribed' ) },
+		{ value: SortBy.PostName, label: translate( 'Post name' ) },
 	];
 };
 

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -10,6 +10,7 @@ import {
 	usePendingPostDeleteMutation,
 } from './mutations';
 import {
+	PostSubscriptionsSortBy,
 	SiteSubscriptionsSortBy,
 	useSiteSubscriptionsQuery,
 	usePostSubscriptionsQuery,
@@ -20,6 +21,7 @@ import {
 } from './queries';
 
 export const SubscriptionManager = {
+	PostSubscriptionsSortBy,
 	SiteSubscriptionsSortBy,
 	usePostUnfollowMutation,
 	useSiteDeliveryFrequencyMutation,

--- a/packages/data-stores/src/reader/queries/index.ts
+++ b/packages/data-stores/src/reader/queries/index.ts
@@ -4,6 +4,9 @@ export {
 	default as useSiteSubscriptionsQuery,
 	SiteSubscriptionsSortBy,
 } from './use-site-subscriptions-query';
-export { default as usePostSubscriptionsQuery } from './use-post-subscriptions-query';
+export {
+	default as usePostSubscriptionsQuery,
+	PostSubscriptionsSortBy,
+} from './use-post-subscriptions-query';
 export { default as usePendingSiteSubscriptionsQuery } from './use-pending-site-subscriptions-query';
 export { default as usePendingPostSubscriptionsQuery } from './use-pending-post-subscriptions-query';

--- a/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
@@ -4,6 +4,12 @@ import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn, useIsQueryEnabled } from '../hooks';
 import type { PostSubscription } from '../types';
 
+export enum PostSubscriptionsSortBy {
+	PostName = 'post_name',
+	RecentlyCommented = 'recently_commented',
+	RecentlySubscribed = 'recently_subscribed',
+}
+
 type SubscriptionManagerPostSubscriptions = {
 	comment_subscriptions: PostSubscription[];
 	total_comment_subscriptions_count: number;
@@ -12,17 +18,32 @@ type SubscriptionManagerPostSubscriptions = {
 type SubscriptionManagerPostSubscriptionsQueryProps = {
 	searchTerm?: string;
 	filter?: ( item?: PostSubscription ) => boolean;
-	sort?: ( a?: PostSubscription, b?: PostSubscription ) => number;
+	sortTerm?: PostSubscriptionsSortBy;
 	number?: number;
 };
 
+const sortByPostName = ( a: PostSubscription, b: PostSubscription ) =>
+	a.post_title.localeCompare( b.post_title );
+
+const sortByRecentlySubscribed = ( a: PostSubscription, b: PostSubscription ) =>
+	b.subscription_date.getTime() - a.subscription_date.getTime();
+
+const getSortFunction = ( sortTerm: PostSubscriptionsSortBy ) => {
+	switch ( sortTerm ) {
+		case PostSubscriptionsSortBy.PostName:
+			return sortByPostName;
+		default:
+		case PostSubscriptionsSortBy.RecentlySubscribed:
+			return sortByRecentlySubscribed;
+	}
+};
+
 const defaultFilter = () => true;
-const defaultSort = () => 0;
 
 const usePostSubscriptionsQuery = ( {
 	searchTerm = '',
 	filter = defaultFilter,
-	sort = defaultSort,
+	sortTerm = PostSubscriptionsSortBy.RecentlySubscribed,
 	number = 500,
 }: SubscriptionManagerPostSubscriptionsQueryProps = {} ) => {
 	const { isLoggedIn } = useIsLoggedIn();
@@ -74,6 +95,7 @@ const usePostSubscriptionsQuery = ( {
 				  item.post_url.includes( searchTermLowerCase ) ||
 				  item.site_title.toLocaleLowerCase().includes( searchTermLowerCase )
 				: true;
+		const sort = getSortFunction( sortTerm );
 
 		return {
 			posts: transformedData
@@ -81,7 +103,7 @@ const usePostSubscriptionsQuery = ( {
 				.sort( sort ),
 			totalCount: data?.pages?.[ 0 ]?.total_comment_subscriptions_count ?? 0,
 		};
-	}, [ data?.pages, filter, searchTerm, sort ] );
+	}, [ data?.pages, filter, searchTerm, sortTerm ] );
 
 	return {
 		data: outputData,


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/75893

## Proposed Changes

* Adds support to sort posts on Comments tab
* Updates `usePostSubscriptionsQuery` to enable sorting

> **TODOs**
> - Missing the "Recently commented" option: https://github.com/Automattic/wp-calypso/issues/76067
> - Missing the new Sort menu layout (based on wordpress.com/sites) https://github.com/Automattic/wp-calypso/issues/76068

## Testing Instructions

* Run this PR on your local env
* Go to http://calypso.localhost:3000/subscriptions/comments
* Try sorting your subscribed posts by name and recently subscribed

<img width="863" alt="Screenshot 2023-04-20 at 22 17 03" src="https://user-images.githubusercontent.com/3113712/233518965-94dc746f-306e-487d-bfe6-086cb2e42145.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
