### PR TITLE
Theme Showcase Update logged out Theme Showcase header tagline UI

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -506,7 +506,7 @@ class ThemeShowcase extends Component {
 									}
 							  )
 							: translate(
-									'Beautiful and responsive WordPress.com themes. Choose from free and premium options for all types of websites. Then, install the one that is right for you.'
+									'Beautiful and responsive WordPress.com themes. Choose from free and premium options for all types of websites. Then, activate the one that is right for you.'
 							  )
 					}
 				>

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -42,8 +42,10 @@
 		}
 
 		.page-sub-header {
-			font-size: 1rem;
-			max-width: 640px;
+			font-size: $font-body-large;
+			line-height: 26px;
+			margin-bottom: 8px;
+			max-width: 680px;
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

As discussed in pdyEEc-xW-p2#comment-667 and p1681939479364529-slack-C048CUFRGFQ, update the logged out Theme Showcase header so that:

1. The word "install" changes to "activate"
2. The tagline text and line-height increase from 16px to 18px, and 24px to 26px respectively.

| Before | After |
| --- | --- |
| ![Screenshot 2023-04-21 at 10 11 52 AM](https://user-images.githubusercontent.com/797888/233524395-df9bcc84-ebe2-4205-81f2-10256dc88316.png) | ![Screenshot 2023-04-21 at 10 06 22 AM](https://user-images.githubusercontent.com/797888/233524404-497226cf-b82a-4f2b-9235-944e1cc62393.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged out Theme Showcase.
* Ensure that the updates are as described as above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?