### PR TITLE
Fix `planTypes` prop of the PlansFeaturesMain component and some accompanied refactoring.

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -384,7 +384,7 @@ export class PlansFeaturesMain extends Component {
 			return plan ? [ ...accum, plan ] : accum;
 		}, [] );
 
-		return this.props.showTreatmentPlansReorderTest ? plans.reverse() : plans;
+		return plans;
 	}
 
 	isPersonalCustomerTypePlanVisible() {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -228,7 +228,7 @@ export class PlansFeaturesMain extends Component {
 		);
 	}
 
-	renderPlanFeatures() {
+	renderPlanFeatures( plans, visiblePlans ) {
 		const {
 			basePlansPath,
 			currentPurchaseIsInAppPurchase,
@@ -257,8 +257,6 @@ export class PlansFeaturesMain extends Component {
 			isPlansInsideStepper,
 		} = this.props;
 
-		const plans = this.getPlansForPlanFeatures();
-		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
 		const legacyText =
 			locale === 'en' ||
 			hasTranslation(
@@ -310,7 +308,7 @@ export class PlansFeaturesMain extends Component {
 					isLandingPage={ isLandingPage }
 					isLaunchPage={ isLaunchPage }
 					onUpgradeClick={ onUpgradeClick }
-					plans={ visiblePlans }
+					plans={ plans }
 					redirectTo={ redirectTo }
 					visiblePlans={ visiblePlans }
 					selectedFeature={ selectedFeature }
@@ -571,7 +569,7 @@ export class PlansFeaturesMain extends Component {
 			return this.show2023OnboardingPricingGrid( plans, visiblePlans );
 		}
 
-		return this.renderPlanFeatures( plans );
+		return this.renderPlanFeatures( plans, visiblePlans );
 	}
 
 	render() {
@@ -586,7 +584,6 @@ export class PlansFeaturesMain extends Component {
 		/*
 		 * We need to pass all the plans in order to show the correct features in the plan comparison table.
 		 * Pleas use the getVisiblePlansForPlanFeatures selector to filter out the plans that should not be visible.
-		 * Also, note that the old pricing gird only needs the visible plans. Thus, when it's the old pricing grid,
 		 * we pass `visiblePlans` to its `plans` prop.
 		 */
 		const plans = this.getPlansForPlanFeatures();

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -362,19 +362,8 @@ export class PlansFeaturesMain extends Component {
 		].filter( ( el ) => el );
 	}
 
-	getPlansForPlanFeatures() {
-		const { intervalType, selectedPlan, showTreatmentPlansReorderTest } = this.props;
-
-		const term = this.getPlanBillingPeriod( intervalType, getPlan( selectedPlan )?.term );
-		const plans = this.getPlansFromProps( GROUP_WPCOM, term );
-
-		return showTreatmentPlansReorderTest ? plans.reverse() : plans;
-	}
-
-	getPlansFromProps( group, term ) {
-		const planTypes = this.props.planTypes || this.getDefaultPlanTypes();
-
-		return planTypes.reduce( ( accum, type ) => {
+	getPlansFromTypes( planTypes, group, term ) {
+		const plans = planTypes.reduce( ( accum, type ) => {
 			// the Free plan and the Enterprise plan don't have a term.
 			// We may consider to move this logic into the underlying `planMatches` function, but that would have wider implication so it's TBD
 			const planQuery =
@@ -391,6 +380,8 @@ export class PlansFeaturesMain extends Component {
 
 			return plan ? [ ...accum, plan ] : accum;
 		}, [] );
+
+		return this.props.showTreatmentPlansReorderTest ? plans.reverse() : plans;
 	}
 
 	isPersonalCustomerTypePlanVisible() {
@@ -579,6 +570,8 @@ export class PlansFeaturesMain extends Component {
 			hidePlanTypeSelector,
 			is2023PricingGridVisible,
 			planTypeSelectorProps,
+			intervalType,
+			selectedPlan,
 		} = this.props;
 
 		/*
@@ -586,7 +579,9 @@ export class PlansFeaturesMain extends Component {
 		 * Pleas use the getVisiblePlansForPlanFeatures selector to filter out the plans that should not be visible.
 		 * we pass `visiblePlans` to its `plans` prop.
 		 */
-		const plans = this.getPlansForPlanFeatures();
+		const term = this.getPlanBillingPeriod( intervalType, getPlan( selectedPlan )?.term );
+		const planTypes = this.props.planTypes || this.getDefaultPlanTypes();
+		const plans = this.getPlansFromTypes( planTypes, GROUP_WPCOM, term );
 		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
 		const kindOfPlanTypeSelector = this.getKindOfPlanTypeSelector( this.props );
 

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -423,7 +423,13 @@ export class PlansFeaturesMain extends Component {
 		const planTypes = this.props.planTypes || this.getDefaultPlanTypes();
 
 		return planTypes.reduce( ( accum, type ) => {
-			const plan = findPlansKeys( { group, term, type } )[ 0 ];
+			// the Free plan and the Enterprise plan don't have a term.
+			// We may consider to move this logic into the underlying `planMatches` function, but that would have wider implication so it's TBD
+			const planQuery =
+				type === TYPE_FREE || type === TYPE_ENTERPRISE_GRID_WPCOM
+					? { group, type }
+					: { group, type, term };
+			const plan = findPlansKeys( planQuery )[ 0 ];
 
 			if ( ! plan ) {
 				warn(

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -348,7 +348,10 @@ export class PlansFeaturesMain extends Component {
 
 		const isBloggerAvailable = isBloggerPlan( selectedPlan ) || isBloggerPlan( sitePlanSlug );
 
+		// TODO:
 		// this should fall into the processing function for the visible plans
+		// however, the Enterprise plan isn't a real plan and lack of some required support
+		// from the utility functions right now.
 		const isEnterpriseAvailable = is2023PricingGridVisible && ! hideEnterprisePlan;
 
 		return [

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -348,6 +348,25 @@ export class PlansFeaturesMain extends Component {
 		return plans[ intervalType ] || defaultValue || TERM_ANNUALLY;
 	}
 
+	getDefaultPlanTypes() {
+		const { selectedPlan, sitePlanSlug, hideEnterprisePlan, is2023PricingGridVisible } = this.props;
+
+		const isBloggerAvailable = isBloggerPlan( selectedPlan ) || isBloggerPlan( sitePlanSlug );
+
+		// this should fall into the processing function for the visible plans
+		const isEnterpriseAvailable = is2023PricingGridVisible && ! hideEnterprisePlan;
+
+		return [
+			TYPE_FREE,
+			isBloggerAvailable && TYPE_BLOGGER,
+			TYPE_PERSONAL,
+			TYPE_PREMIUM,
+			TYPE_BUSINESS,
+			TYPE_ECOMMERCE,
+			isEnterpriseAvailable && TYPE_ENTERPRISE_GRID_WPCOM,
+		].filter( ( el ) => el );
+	}
+
 	getPlansForPlanFeatures() {
 		const {
 			intervalType,
@@ -356,35 +375,13 @@ export class PlansFeaturesMain extends Component {
 			hidePersonalPlan,
 			hidePremiumPlan,
 			hideEcommercePlan,
-			hideEnterprisePlan,
-			sitePlanSlug,
 			showTreatmentPlansReorderTest,
 			flowName,
 			is2023PricingGridVisible,
 		} = this.props;
 
-		const hideBloggerPlan = ! isBloggerPlan( selectedPlan ) && ! isBloggerPlan( sitePlanSlug );
 		const term = this.getPlanBillingPeriod( intervalType, getPlan( selectedPlan )?.term );
-		const plansFromProps = this.getPlansFromProps( GROUP_WPCOM, term );
-
-		let plans;
-		if ( plansFromProps.length ) {
-			plans = plansFromProps;
-		} else {
-			const isBloggerPlanVisible = hideBloggerPlan === true ? false : true;
-			const isEnterprisePlanVisible = is2023PricingGridVisible && ! hideEnterprisePlan;
-			plans = [
-				findPlansKeys( { group: GROUP_WPCOM, type: TYPE_FREE } )[ 0 ],
-				isBloggerPlanVisible &&
-					findPlansKeys( { group: GROUP_WPCOM, term, type: TYPE_BLOGGER } )?.[ 0 ],
-				findPlansKeys( { group: GROUP_WPCOM, term, type: TYPE_PERSONAL } )[ 0 ],
-				findPlansKeys( { group: GROUP_WPCOM, term, type: TYPE_PREMIUM } )[ 0 ],
-				findPlansKeys( { group: GROUP_WPCOM, term, type: TYPE_BUSINESS } )[ 0 ],
-				findPlansKeys( { group: GROUP_WPCOM, term, type: TYPE_ECOMMERCE } )[ 0 ],
-				isEnterprisePlanVisible &&
-					findPlansKeys( { group: GROUP_WPCOM, type: TYPE_ENTERPRISE_GRID_WPCOM } )[ 0 ],
-			].filter( ( el ) => el );
-		}
+		let plans = this.getPlansFromProps( GROUP_WPCOM, term );
 
 		if ( is2023PricingGridVisible ) {
 			/*
@@ -423,7 +420,7 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	getPlansFromProps( group, term ) {
-		const planTypes = this.props.planTypes || [];
+		const planTypes = this.props.planTypes || this.getDefaultPlanTypes();
 
 		return planTypes.reduce( ( accum, type ) => {
 			const plan = findPlansKeys( { group, term, type } )[ 0 ];

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -365,24 +365,12 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	getPlansForPlanFeatures() {
-		const { intervalType, selectedPlan, showTreatmentPlansReorderTest, is2023PricingGridVisible } =
-			this.props;
+		const { intervalType, selectedPlan, showTreatmentPlansReorderTest } = this.props;
 
 		const term = this.getPlanBillingPeriod( intervalType, getPlan( selectedPlan )?.term );
 		const plans = this.getPlansFromProps( GROUP_WPCOM, term );
 
-		if ( is2023PricingGridVisible ) {
-			/*
-			 * We need to pass all the plans in order to show the correct features in the plan comparison table.
-			 * Pleas use the getVisiblePlansForPlanFeatures selector to filter out the plans that should not be visible.
-			 */
-			return plans;
-		}
-
-		if ( showTreatmentPlansReorderTest ) {
-			return plans.reverse();
-		}
-		return plans;
+		return showTreatmentPlansReorderTest ? plans.reverse() : plans;
 	}
 
 	getPlansFromProps( group, term ) {
@@ -595,6 +583,12 @@ export class PlansFeaturesMain extends Component {
 			planTypeSelectorProps,
 		} = this.props;
 
+		/*
+		 * We need to pass all the plans in order to show the correct features in the plan comparison table.
+		 * Pleas use the getVisiblePlansForPlanFeatures selector to filter out the plans that should not be visible.
+		 * Also, note that the old pricing gird only needs the visible plans. Thus, when it's the old pricing grid,
+		 * we pass `visiblePlans` to its `plans` prop.
+		 */
 		const plans = this.getPlansForPlanFeatures();
 		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
 		const kindOfPlanTypeSelector = this.getKindOfPlanTypeSelector( this.props );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -101,7 +101,7 @@ export class PlansFeaturesMain extends Component {
 		}
 	}
 
-	show2023OnboardingPricingGrid( plans, visiblePlans ) {
+	render2023OnboardingPricingGrid( plans, visiblePlans ) {
 		const {
 			basePlansPath,
 			customerType,
@@ -120,69 +120,47 @@ export class PlansFeaturesMain extends Component {
 			siteId,
 			plansWithScroll,
 			isReskinned,
-			isFAQCondensedExperiment,
 			isPlansInsideStepper,
-			is2023PricingGridVisible,
 			intervalType,
 			planTypeSelectorProps,
-			busyOnUpgradeClick,
 			hidePlansFeatureComparison,
 		} = this.props;
 
-		if ( is2023PricingGridVisible ) {
-			const asyncProps = {
-				basePlansPath,
-				domainName,
-				isInSignup,
-				isLandingPage,
-				isLaunchPage,
-				onUpgradeClick,
-				plans,
+		const asyncProps = {
+			basePlansPath,
+			domainName,
+			isInSignup,
+			isLandingPage,
+			isLaunchPage,
+			onUpgradeClick,
+			plans,
+			flowName,
+			redirectTo,
+			visiblePlans,
+			selectedFeature,
+			selectedPlan,
+			withDiscount,
+			discountEndDate,
+			withScroll: plansWithScroll,
+			popularPlanSpec: getPopularPlanSpec( {
 				flowName,
-				redirectTo,
-				visiblePlans,
-				selectedFeature,
-				selectedPlan,
-				withDiscount,
-				discountEndDate,
-				withScroll: plansWithScroll,
-				popularPlanSpec: getPopularPlanSpec( {
-					flowName,
-					customerType,
-					isJetpack,
-					availablePlans: visiblePlans,
-				} ),
-				siteId,
-				isReskinned,
-				isPlansInsideStepper,
-				intervalType,
-				hidePlansFeatureComparison,
-			};
-			const asyncPlanFeatures2023Grid = (
-				<AsyncLoad
-					require="calypso/my-sites/plan-features-2023-grid"
-					{ ...asyncProps }
-					planTypeSelectorProps={ planTypeSelectorProps }
-				/>
-			);
-
-			return (
-				<div
-					className={ classNames(
-						'plans-features-main__group',
-						'is-wpcom',
-						`is-customer-${ customerType }`,
-						'is-2023-pricing-grid',
-						{
-							'is-scrollable': plansWithScroll,
-						}
-					) }
-					data-e2e-plans="wpcom"
-				>
-					{ asyncPlanFeatures2023Grid }
-				</div>
-			);
-		}
+				customerType,
+				isJetpack,
+				availablePlans: visiblePlans,
+			} ),
+			siteId,
+			isReskinned,
+			isPlansInsideStepper,
+			intervalType,
+			hidePlansFeatureComparison,
+		};
+		const asyncPlanFeatures2023Grid = (
+			<AsyncLoad
+				require="calypso/my-sites/plan-features-2023-grid"
+				{ ...asyncProps }
+				planTypeSelectorProps={ planTypeSelectorProps }
+			/>
+		);
 
 		return (
 			<div
@@ -190,47 +168,24 @@ export class PlansFeaturesMain extends Component {
 					'plans-features-main__group',
 					'is-wpcom',
 					`is-customer-${ customerType }`,
+					'is-2023-pricing-grid',
 					{
 						'is-scrollable': plansWithScroll,
 					}
 				) }
 				data-e2e-plans="wpcom"
 			>
-				<PlanFeaturesComparison
-					basePlansPath={ basePlansPath }
-					domainName={ domainName }
-					isInSignup={ isInSignup }
-					isLandingPage={ isLandingPage }
-					isLaunchPage={ isLaunchPage }
-					onUpgradeClick={ onUpgradeClick }
-					plans={ plans }
-					flowName={ flowName }
-					redirectTo={ redirectTo }
-					visiblePlans={ visiblePlans }
-					selectedFeature={ selectedFeature }
-					selectedPlan={ selectedPlan }
-					withDiscount={ withDiscount }
-					discountEndDate={ discountEndDate }
-					withScroll={ plansWithScroll }
-					popularPlanSpec={ getPopularPlanSpec( {
-						flowName,
-						customerType,
-						isJetpack,
-						availablePlans: visiblePlans,
-					} ) }
-					siteId={ siteId }
-					isReskinned={ isReskinned }
-					isFAQCondensedExperiment={ isFAQCondensedExperiment }
-					isPlansInsideStepper={ isPlansInsideStepper }
-					busyOnUpgradeClick={ busyOnUpgradeClick }
-				/>
+				{ asyncPlanFeatures2023Grid }
 			</div>
 		);
 	}
 
-	renderPlanFeatures( plans, visiblePlans ) {
+	// TODO:
+	// These legacy components should also be loaded in async.
+	renderLegacyPricingGrid( plans, visiblePlans ) {
 		const {
 			basePlansPath,
+			busyOnUpgradeClick,
 			currentPurchaseIsInAppPurchase,
 			customerType,
 			disableBloggerPlanWithNonBlogDomain,
@@ -240,9 +195,12 @@ export class PlansFeaturesMain extends Component {
 			isLandingPage,
 			isLaunchPage,
 			isCurrentPlanRetired,
+			isFAQCondensedExperiment,
+			isReskinned,
 			onUpgradeClick,
 			selectedFeature,
 			selectedPlan,
+			shouldShowPlansFeatureComparison,
 			withDiscount,
 			discountEndDate,
 			redirectTo,
@@ -272,6 +230,52 @@ export class PlansFeaturesMain extends Component {
 							'Please keep in mind that switching plans will be irreversible.'
 				  )
 				: null;
+
+		if ( shouldShowPlansFeatureComparison ) {
+			return (
+				<div
+					className={ classNames(
+						'plans-features-main__group',
+						'is-wpcom',
+						`is-customer-${ customerType }`,
+						{
+							'is-scrollable': plansWithScroll,
+						}
+					) }
+					data-e2e-plans="wpcom"
+				>
+					<PlanFeaturesComparison
+						basePlansPath={ basePlansPath }
+						domainName={ domainName }
+						isInSignup={ isInSignup }
+						isLandingPage={ isLandingPage }
+						isLaunchPage={ isLaunchPage }
+						onUpgradeClick={ onUpgradeClick }
+						plans={ plans }
+						flowName={ flowName }
+						redirectTo={ redirectTo }
+						visiblePlans={ visiblePlans }
+						selectedFeature={ selectedFeature }
+						selectedPlan={ selectedPlan }
+						withDiscount={ withDiscount }
+						discountEndDate={ discountEndDate }
+						withScroll={ plansWithScroll }
+						popularPlanSpec={ getPopularPlanSpec( {
+							flowName,
+							customerType,
+							isJetpack,
+							availablePlans: visiblePlans,
+						} ) }
+						siteId={ siteId }
+						isReskinned={ isReskinned }
+						isFAQCondensedExperiment={ isFAQCondensedExperiment }
+						isPlansInsideStepper={ isPlansInsideStepper }
+						busyOnUpgradeClick={ busyOnUpgradeClick }
+					/>
+				</div>
+			);
+		}
+
 		return (
 			<div
 				className={ classNames(
@@ -556,14 +560,9 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	renderPlansGrid( plans, visiblePlans ) {
-		const { shouldShowPlansFeatureComparison, is2023PricingGridVisible } = this.props;
-
-		// TODO: need to figure out if we can deprecate `shouldShowPlansFeatureComparison`
-		if ( is2023PricingGridVisible || shouldShowPlansFeatureComparison ) {
-			return this.show2023OnboardingPricingGrid( plans, visiblePlans );
-		}
-
-		return this.renderPlanFeatures( plans, visiblePlans );
+		return this.props.is2023PricingGridVisible
+			? this.render2023OnboardingPricingGrid( plans, visiblePlans )
+			: this.renderLegacyPricingGrid( plans, visiblePlans );
 	}
 
 	render() {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -232,7 +232,7 @@ export class PlansFeaturesMain extends Component {
 		);
 	}
 
-	getPlanFeatures() {
+	renderPlanFeatures() {
 		const {
 			basePlansPath,
 			currentPurchaseIsInAppPurchase,
@@ -611,7 +611,7 @@ export class PlansFeaturesMain extends Component {
 
 		return shouldShowPlansFeatureComparison
 			? this.show2023OnboardingPricingGrid()
-			: this.getPlanFeatures();
+			: this.renderPlanFeatures();
 	}
 
 	render() {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	chooseDefaultCustomerType,
 	findPlansKeys,
@@ -415,10 +414,6 @@ export class PlansFeaturesMain extends Component {
 			plans = plans.filter(
 				( planSlug ) => ! isBusinessPlan( planSlug ) && ! isEcommercePlan( planSlug )
 			);
-		}
-
-		if ( ! isEnabled( 'plans/personal-plan' ) ) {
-			plans.splice( plans.indexOf( plans.filter( ( p ) => p === PLAN_PERSONAL )[ 0 ] ), 1 );
 		}
 
 		if ( showTreatmentPlansReorderTest ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
## Proposed Changes

This PR is primarily for fixing up the `plansTypes` prop so the new pricing grid can accept a list of plan types to show like in the case of https://github.com/Automattic/wp-calypso/pull/75174/. Before this PR, by doing so the Free plan and the Enterprise plan would disappear when toggling to the monthly term. It is because the Free plan and the Enterprise plan don't really have a term, and they only have a placeholder-like annual term in their data definition. This PR fixes it by adding special cases for them in the function for converting plan types into actual plans.

Although that part is a smaller fix, what's happening underneath is actually a series of data processing flow of:

1. Given a list of "plan types".
2. Derive "plans" data from the given types and the term.
3. Derive "visible plans" data from the plans data, given related props like `hidePersonalPlan`, `hidePersonalPlan`, `flowName`, etc.

I feel the current code doesn't outline this processing pipeline clearly, so I've done some refactoring here aiming at clarifying it from the code level. A side effect is that the whole processing will now run only once per render; currently it is run multiple times per render since `getPlansForPlanFeatures` and `getVisiblePlansForPlanFeatures` are called at multiple places per rendering.

Some other misc tweaks:

* `getPlanFeatures()` is now `renderPlanFeatures()` to match its meaning better.
* `isEnabled( 'plans/personal-plan' )` check is removed since we've enabled it everywhere for ages already.

Lastly, I chose to not updating the `plansTypes` prop name as discussed in https://github.com/Automattic/wp-calypso/pull/75174#discussion_r1171167577 to limit the scope of this PR. That name will be up for iterations for sure :) 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Confirm the plans page the same as in production for the following flows. Both the new pricing grid and the legacy one should work as it is.

* /start/ 
* /start/domain/ 
* /start/onboarding-pm/ 
* /setup/newsletter/
* /setup/link-in-bio/
* /plans while being logged-in

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
