### PR TITLE
Site Assembler: Fix site editor with edit mode and assembler welcome tour

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-steps.tsx
@@ -67,14 +67,13 @@ function getTourSteps(
 	themeName: string | null = null,
 	siteIntent: string | undefined = undefined
 ): WpcomStep[] {
-	const completedFlow = getQueryArg( window.location.href, 'completedFlow' );
 	const isVideoMaker = 'videomaker' === ( themeName ?? '' );
-	const isPatternAssemblerFlow = 'pattern_assembler' === completedFlow;
+	const isPatternAssembler = !! getQueryArg( window.location.href, 'assembler' );
 	const siteEditorCourseUrl = `https://wordpress.com/home/${ window.location.hostname }?courseSlug=site-editor-quick-start`;
 	const editorType = getEditorType();
 	const onSiteEditorCourseLinkClick = () => {
 		recordTracksEvent( 'calypso_editor_wpcom_tour_site_editor_course_link_click', {
-			is_pattern_assembler: isPatternAssemblerFlow,
+			is_pattern_assembler: isPatternAssembler,
 			intent: siteIntent,
 			editor_type: editorType,
 		} );
@@ -84,12 +83,12 @@ function getTourSteps(
 		{
 			slug: 'welcome',
 			meta: {
-				heading: isPatternAssemblerFlow
+				heading: isPatternAssembler
 					? __( 'Nice job! Your new page is set up.', 'full-site-editing' )
 					: __( 'Welcome to WordPress!', 'full-site-editing' ),
 				descriptions: {
 					desktop: ( () => {
-						if ( isPatternAssemblerFlow ) {
+						if ( isPatternAssembler ) {
 							return createInterpolateElement(
 								__(
 									'This is the Site Editor, where you can change everything about your site, including adding content to your homepage. <link_to_site_editor_course>Watch these short videos</link_to_site_editor_course> and take this tour to get started.',
@@ -119,7 +118,7 @@ function getTourSteps(
 					mobile: null,
 				},
 				imgSrc: getTourAssets( isVideoMaker ? 'videomakerWelcome' : 'welcome' ),
-				imgLink: isPatternAssemblerFlow
+				imgLink: isPatternAssembler
 					? {
 							href: siteEditorCourseUrl,
 							playable: true,

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -80,7 +80,6 @@ interface Props {
 	stripeConnectSuccess: 'gutenberg' | null;
 	showDraftPostModal: boolean;
 	blockEditorSettings: BlockEditorSettings;
-	completedFlow?: string;
 }
 
 interface CheckoutModalOptions extends RequestCart {
@@ -797,7 +796,6 @@ const mapStateToProps = (
 		showDraftPostModal,
 		pressThisData,
 		blockEditorSettings,
-		completedFlow,
 	}: Props
 ) => {
 	const siteId = getSelectedSiteId( state );
@@ -824,7 +822,7 @@ const mapStateToProps = (
 		showDraftPostModal,
 		...pressThisData,
 		answer_prompt: getQueryArg( window.location.href, 'answer_prompt' ),
-		completedFlow,
+		assembler: getQueryArg( window.location.href, 'assembler' ), // Customize the first slide of Welcome Tour in the site editor
 		canvas: getQueryArg( window.location.href, 'canvas' ), // Site editor can initially load with or without nav sidebar (Gutenberg v15.0.0)
 	} );
 

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -279,7 +279,7 @@ export const redirectSiteEditor = async ( context ) => {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 
-	const queryArgs = {};
+	const queryArgs = context.query || {};
 	// Only add the origin if it's not wordpress.com.
 	if ( location.origin !== 'https://wordpress.com' ) {
 		queryArgs.calypso_origin = location.origin;

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -290,8 +290,12 @@ const siteSetupFlow: Flow = {
 
 					// End of Pattern Assembler flow
 					if ( isBlankCanvasDesign( selectedDesign ) ) {
-						window.sessionStorage.setItem( 'wpcom_signup_completed_flow', 'pattern_assembler' );
-						return exitFlow( `/site-editor/${ siteSlug }?canvas=edit` );
+						const params = new URLSearchParams( {
+							canvas: 'edit',
+							assembler: '1',
+						} );
+
+						return exitFlow( `/site-editor/${ siteSlug }?${ params }` );
 					}
 
 					// If the user skips starting point, redirect them to the post editor

--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -63,9 +63,14 @@ const withThemeAssemblerFlow: Flow = {
 			recordSubmitStep( providedDependencies, intent, flowName, _currentStep );
 
 			switch ( _currentStep ) {
-				case 'processing':
-					window.sessionStorage.setItem( 'wpcom_signup_completed_flow', 'pattern_assembler' );
-					return exitFlow( `/site-editor/${ siteSlug }?canvas=edit` );
+				case 'processing': {
+					const params = new URLSearchParams( {
+						canvas: 'edit',
+						assembler: '1',
+					} );
+
+					return exitFlow( `/site-editor/${ siteSlug }?${ params }` );
+				}
 
 				case 'patternAssembler': {
 					return navigate( 'processing' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/75652

## Proposed Changes

We were working on removing the iframe from the site editor but it led to some features aren't working as expected since we didn't carry on the query args. So, this PR is focusing on
* Carry on the query args when we redirect users to the un-iframed Site Editor
* Introduce new query arg called `assembler` to allow us to customize the Welcome Tour if the user was going through the Pattern Assembler screen.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox your site domain
* cd `apps/editing-toolkit` and run `yarn dev --sync`
* Run your calypso locally
* Go to /setup/site-setup?siteSlug=<your_free_site>
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Select any layout and styles
  * Continue
  * When you land on the site editor, verify it's in the edit mode directly
  * Also, verify the first slide of the Welcome Tour is for the assembler. Note that you have to remove `showLaunchpad` [here](https://github.com/Automattic/wp-calypso/blob/9a4894f73c79f932bf97b0590a588b652f6eb8d2/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx#L85) to see the Welcome Tour
    ![image](https://user-images.githubusercontent.com/13596067/233543110-5be0bd1d-3632-42c2-b283-a2b9d2a4b1d2.png)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
