### PR TITLE
Enable public tags page in production config

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -103,7 +103,7 @@
 		"purchases/new-payment-methods": true,
 		"reader": true,
 		"reader/list-management": true,
-		"reader/public-tag-pages": false,
+		"reader/public-tag-pages": true,
 		"reader/subscription-management": false,
 		"redirect-fallback-browsers": true,
 		"safari-idb-mitigation": true,

--- a/config/production.json
+++ b/config/production.json
@@ -120,7 +120,7 @@
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/list-management": true,
-		"reader/public-tag-pages": false,
+		"reader/public-tag-pages": true,
 		"reader/subscription-management": false,
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,


### PR DESCRIPTION
This enables the public tags page in production config.

Currently, even after this is released, the old php/atlas `/tags` page will still be used on wpcom because that's how the production routing is configured.

But this is required before we can switch the route over :)