### PR TITLE
Change showLaunchpad attribute to start-writing for writer flow

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -1,3 +1,4 @@
+import { START_WRITING_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/edit-post';
 import { useEffect, createPortal, useState } from '@wordpress/element';
@@ -34,7 +35,7 @@ if ( typeof MainDashboardButton !== 'undefined' ) {
 				// eslint-disable-next-line react-hooks/exhaustive-deps
 			}, [] );
 
-			const showLaunchpad = getQueryArg( window.location.search, 'showLaunchpad' );
+			const isStartWritingFlow = getQueryArg( window.location.search, START_WRITING_FLOW );
 			const [ clickGuardRoot ] = useState( () => document.createElement( 'div' ) );
 			useEffect( () => {
 				document.body.appendChild( clickGuardRoot );
@@ -55,7 +56,7 @@ if ( typeof MainDashboardButton !== 'undefined' ) {
 				[]
 			);
 
-			if ( showLaunchpad ) {
+			if ( isStartWritingFlow ) {
 				return <MainDashboardButton></MainDashboardButton>;
 			}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useLocale } from '@automattic/i18n-utils';
+import { START_WRITING_FLOW } from '@automattic/onboarding';
 import { WpcomTourKit, usePrefetchTourAssets } from '@automattic/tour-kit';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { useDispatch, useSelect, dispatch } from '@wordpress/data';
@@ -48,13 +49,13 @@ function LaunchWpcomWelcomeTour() {
 	const { siteIntent, siteIntentFetched } = useSiteIntent();
 	const localeSlug = useLocale();
 	const editorType = getEditorType();
-	const showLaunchpad = getQueryArg( window.location.search, 'showLaunchpad' );
+	const isStartWritingFlow = getQueryArg( window.location.search, START_WRITING_FLOW );
 
 	// Preload first card image (others preloaded after open state confirmed)
 	usePrefetchTourAssets( [ getTourSteps( localeSlug, false, false, null, siteIntent )[ 0 ] ] );
 
 	useEffect( () => {
-		if ( showLaunchpad ) {
+		if ( isStartWritingFlow ) {
 			return;
 		}
 		if ( ! show && ! isNewPageLayoutModalOpen ) {
@@ -79,10 +80,10 @@ function LaunchWpcomWelcomeTour() {
 		siteIntent,
 		siteIntentFetched,
 		editorType,
-		showLaunchpad,
+		isStartWritingFlow,
 	] );
 
-	if ( ! show || isNewPageLayoutModalOpen || showLaunchpad ) {
+	if ( ! show || isNewPageLayoutModalOpen || isStartWritingFlow ) {
 		return null;
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -2,9 +2,11 @@ import { dispatch, select, subscribe } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
 import { getQueryArg } from '@wordpress/url';
 
+const START_WRITING_FLOW = 'start-writing';
+
 export function redirectOnboardingUserAfterPublishingPost() {
-	const showLaunchpad = getQueryArg( window.location.search, 'showLaunchpad' );
-	if ( 'true' !== showLaunchpad ) {
+	const isStartWritingFlow = getQueryArg( window.location.search, START_WRITING_FLOW );
+	if ( 'true' !== isStartWritingFlow ) {
 		return false;
 	}
 
@@ -22,8 +24,7 @@ export function redirectOnboardingUserAfterPublishingPost() {
 			unsubscribe();
 
 			dispatch( 'core/edit-post' ).closePublishSidebar();
-			window.location.href =
-				siteOrigin + '/setup/write/launchpad?siteSlug=' + siteSlug + '&showLaunchpad=true';
+			window.location.href = `${ siteOrigin }/setup/write/launchpad?siteSlug=${ siteSlug }&${ START_WRITING_FLOW }=true`;
 		}
 	} );
 }

--- a/apps/wpcom-block-editor/src/wpcom/features/test/redirect-onboarding-user-after-publishing-post.test.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/test/redirect-onboarding-user-after-publishing-post.test.js
@@ -39,7 +39,7 @@ jest.mock( '@wordpress/data', () => ( {
 } ) );
 
 describe( 'redirectOnboardingUserAfterPublishingPost', () => {
-	it( 'should NOT redirect the user to the launchpad if showLaunchpad query parameter is NOT present', () => {
+	it( 'should NOT redirect the user to the launchpad if start-writing query parameter is NOT present', () => {
 		delete global.window;
 		global.window = {
 			location: {
@@ -60,7 +60,7 @@ describe( 'redirectOnboardingUserAfterPublishingPost', () => {
 		delete global.window;
 		global.window = {
 			location: {
-				search: '?showLaunchpad=true&origin=https://calypso.localhost:3000',
+				search: '?start-writing=true&origin=https://calypso.localhost:3000',
 				hostname: 'wordpress.com',
 			},
 		};
@@ -76,13 +76,13 @@ describe( 'redirectOnboardingUserAfterPublishingPost', () => {
 		expect( global.window.location.href ).toBe( undefined );
 	} );
 
-	it( 'should redirect the user to the launchpad when a post is published and the showLaunchpad query parameter is present', () => {
+	it( 'should redirect the user to the launchpad when a post is published and the start-writing query parameter is present', () => {
 		jest.clearAllMocks();
 		mockIsSaving = false;
 		delete global.window;
 		global.window = {
 			location: {
-				search: '?showLaunchpad=true&origin=https://calypso.localhost:3000',
+				search: '?start-writing=true&origin=https://calypso.localhost:3000',
 				hostname: 'wordpress.com',
 			},
 		};
@@ -95,7 +95,7 @@ describe( 'redirectOnboardingUserAfterPublishingPost', () => {
 		expect( mockUnSubscribe ).toBeCalledTimes( 1 );
 		expect( mockClosePublishSidebar ).toBeCalledTimes( 1 );
 		expect( global.window.location.href ).toBe(
-			'https://calypso.localhost:3000/setup/write/launchpad?siteSlug=wordpress.com&showLaunchpad=true'
+			'https://calypso.localhost:3000/setup/write/launchpad?siteSlug=wordpress.com&start-writing=true'
 		);
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -1,4 +1,4 @@
-import { StepContainer } from '@automattic/onboarding';
+import { StepContainer, START_WRITING_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch as useWPDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { getQueryArg } from '@wordpress/url';
@@ -55,7 +55,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	}
 
 	// This is temporary until we can use the launchpad inside the editor.
-	const newWriterFlow = 'true' === getQueryArg( window.location.search, 'showLaunchpad' );
+	const newWriterFlow = 'true' === getQueryArg( window.location.search, START_WRITING_FLOW );
 
 	if (
 		! isLoggedIn ||

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -47,7 +47,7 @@ const startWriting: Flow = {
 						setDesignOnSite(
 							() => {
 								redirect(
-									`https://${ providedDependencies?.siteSlug }/wp-admin/post-new.php?showLaunchpad=true&origin=${ siteOrigin }`
+									`https://${ providedDependencies?.siteSlug }/wp-admin/post-new.php?${ START_WRITING_FLOW }=true&origin=${ siteOrigin }`
 								);
 							},
 							{
@@ -84,7 +84,7 @@ const startWriting: Flow = {
 				message: `${ flowName } requires a logged in user`,
 			};
 		} else if ( currentUserSiteCount && currentUserSiteCount > 0 ) {
-			redirect( '/post?showLaunchpad=true' );
+			redirect( `/post?${ START_WRITING_FLOW }=true` );
 			result = {
 				state: AssertConditionState.CHECKING,
 				message: `${ flowName } requires no preexisting sites`,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2199

## Proposed Changes

* Change `showLaunchpad` to use `start-writing` for other writer flow

Should observe URLs such as `/wp-admin/post-new.php?start-writing=true&origin=http%3A%2F%2Fcalypso.localhost%3A3000`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Please check out the thread (p1682066698014159-slack-CKZHG0QCR) since I was having trouble testing the code.

* Sandbox including widgets.wp.com
* Go to `apps/editing-toolkit` and run `yarn dev --sync`
* Go to `apps/wpcom-block-editor` and run `yarn dev --sync`
* Create a new user using /setup/start-writing/ and check if everything is working as before
* If you want to test things when getting to the post editor such as hide welcome tour, sandbox the site itself `yoursite.wordpress.com` and go to `http://calypso.localhost:3000/post/{domain}?start-writing=true`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?