### PR TITLE
Pricing page: Add new Jetpack Scan FAQs in the pricing page.

### DIFF
--- a/client/my-sites/plans-features-main/components/jetpack-faq.jsx
+++ b/client/my-sites/plans-features-main/components/jetpack-faq.jsx
@@ -21,6 +21,20 @@ export const getHelpLink = ( context ) => {
 	);
 };
 
+export const getSupportLink = ( doc ) => {
+	return (
+		<a
+			className="jetpack-faq__learn-more-link"
+			href={ `https://jetpack.com/support/${ doc }` }
+			target="_blank"
+			rel="noopener noreferrer"
+			onClick={ () => {
+				recordTracksEvent( 'calypso_' + doc.replace( /(-| )/g, '_' ), { doc } );
+			} }
+		/>
+	);
+};
+
 export const getAgenciesLink = () => {
 	return (
 		<a

--- a/client/my-sites/plans/jetpack-plans/faq/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/faq/index.tsx
@@ -5,6 +5,7 @@ import FoldableFAQ from 'calypso/components/foldable-faq';
 import {
 	getAgenciesLink,
 	getHelpLink,
+	getSupportLink,
 } from 'calypso/my-sites/plans-features-main/components/jetpack-faq';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
@@ -108,10 +109,13 @@ const JetpackFAQ: FC = () => {
 							className="jetpack-faq__section"
 						>
 							{ translate(
-								'Jetpack Protect (Scan) detects and prevents attacks, but is not designed to fully clean up sites infected before it was active. If your site has malware, take immediate action to clean it up and remove the malicious code. {{br/}} To clean up your site, we suggest using a malware removal tool, or if possible restore from a backup taken before the infection. We recommend using Jetpack VaultPress Backup in conjunction with Jetpack Scan to secure your website.',
+								'Jetpack Protect (Scan) detects and prevents attacks, but is not designed to fully clean up sites infected before it was active. If your site has malware, take immediate action to clean it up and remove the malicious code. {{br/}} To clean up your site, we suggest using a malware removal tool, or if possible restore from a backup taken before the infection. We recommend using Jetpack VaultPress Backup in conjunction with Jetpack Scan to secure your website. {{br/}} {{JetpackScanLearnMoreLink}}Learn more about cleaning your site{{/JetpackScanLearnMoreLink}}.',
 								{
 									components: {
 										br: <br />,
+										JetpackScanLearnMoreLink: getSupportLink(
+											'how-to-clean-your-hacked-wordpress-site'
+										),
 									},
 								}
 							) }

--- a/client/my-sites/plans/jetpack-plans/faq/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/faq/index.tsx
@@ -100,6 +100,25 @@ const JetpackFAQ: FC = () => {
 					</li>
 					<li>
 						<FoldableFAQ
+							id="scan-infected-sites"
+							question={ translate(
+								'Can I use Jetpack Scan to fix a site that is already infected?'
+							) }
+							onToggle={ onFaqToggle }
+							className="jetpack-faq__section"
+						>
+							{ translate(
+								'Jetpack Protect (Scan) detects and prevents attacks, but is not designed to fully clean up sites infected before it was active. If your site has malware, take immediate action to clean it up and remove the malicious code. {{br/}} To clean up your site, we suggest using a malware removal tool, or if possible restore from a backup taken before the infection. We recommend using Jetpack VaultPress Backup in conjunction with Jetpack Scan to secure your website.',
+								{
+									components: {
+										br: <br />,
+									},
+								}
+							) }
+						</FoldableFAQ>
+					</li>
+					<li>
+						<FoldableFAQ
 							id="backup-storage-limits"
 							question={ translate( 'How do backup storage limits work?' ) }
 							onToggle={ onFaqToggle }

--- a/client/my-sites/plans/jetpack-plans/faq/style.scss
+++ b/client/my-sites/plans/jetpack-plans/faq/style.scss
@@ -41,3 +41,11 @@
 .jetpack-faq__section button:focus-visible {
 	outline: thin dotted;
 }
+
+a.jetpack-faq__learn-more-link {
+	display: inline-block;
+	font-size: 1rem;
+	text-decoration: underline;
+	margin-top: 0.5rem;
+	color: var(--studio-gray-60);
+}

--- a/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
+++ b/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
@@ -31,7 +31,10 @@ import {
 	getJetpackProductRecommendedFor,
 	TERM_TRIENNIALLY,
 } from '@automattic/calypso-products';
-import { getHelpLink } from 'calypso/my-sites/plans-features-main/components/jetpack-faq';
+import {
+	getHelpLink,
+	getSupportLink,
+} from 'calypso/my-sites/plans-features-main/components/jetpack-faq';
 import buildCardFeaturesFromItem from './build-card-features-from-item';
 import {
 	EXTERNAL_PRODUCTS_LIST,
@@ -167,7 +170,7 @@ function itemToSelectorProduct(
 			buttonLabel: getJetpackProductCallToAction( item ),
 			whatIsIncluded: getJetpackProductWhatIsIncluded( item ),
 			benefits: getJetpackProductBenefits( item ),
-			faqs: getJetpackProductFAQs( item.product_slug, getHelpLink ),
+			faqs: getJetpackProductFAQs( item.product_slug, getHelpLink, getSupportLink ),
 			recommendedFor: getJetpackProductRecommendedFor( item ),
 			monthlyProductSlug,
 			term: item.term,
@@ -210,7 +213,7 @@ function itemToSelectorProduct(
 				? getForCurrentCROIteration( item.getWhatIsIncluded )
 				: [],
 			benefits: item.getBenefits ? getForCurrentCROIteration( item.getBenefits ) : [],
-			faqs: getJetpackProductFAQs( productSlug, getHelpLink ),
+			faqs: getJetpackProductFAQs( productSlug, getHelpLink, getSupportLink ),
 			recommendedFor: item.getRecommendedFor
 				? getForCurrentCROIteration( item.getRecommendedFor )
 				: [],

--- a/packages/calypso-products/src/get-jetpack-product-faqs.ts
+++ b/packages/calypso-products/src/get-jetpack-product-faqs.ts
@@ -4,8 +4,9 @@ import { getJetpackProductsFAQs } from './translations';
  */
 export function getJetpackProductFAQs(
 	product_slug: string,
-	getHelpLink: ( context: unknown ) => JSX.Element
+	getHelpLink: ( context: unknown ) => JSX.Element,
+	getSupportLink: ( context: unknown ) => JSX.Element
 ) {
-	const jetpackProductsFAQsInfo = getJetpackProductsFAQs( getHelpLink );
+	const jetpackProductsFAQsInfo = getJetpackProductsFAQs( getHelpLink, getSupportLink );
 	return jetpackProductsFAQsInfo[ product_slug ];
 }

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -956,7 +956,8 @@ export const getJetpackProductsBenefits = (): Record< string, Array< TranslateRe
 };
 
 export const getJetpackProductsFAQs = (
-	getHelpLink: ( context: unknown ) => JSX.Element
+	getHelpLink: ( context: unknown ) => JSX.Element,
+	getSupportLink: ( context: unknown ) => JSX.Element
 ): Record< string, Array< FAQ > > => {
 	const cancellationPolicyFAQ = {
 		id: 'cancellation-policy',
@@ -989,10 +990,11 @@ export const getJetpackProductsFAQs = (
 			id: 'scan-infected-sites',
 			question: translate( 'Can I use Jetpack Scan to fix a site that is already infected?' ),
 			answer: translate(
-				'Jetpack Protect (Scan) detects and prevents attacks, but is not designed to fully clean up sites infected before it was active. If your site has malware, take immediate action to clean it up and remove the malicious code. {{br/}} To clean up your site, we suggest using a malware removal tool, or if possible restore from a backup taken before the infection. We recommend using Jetpack VaultPress Backup in conjunction with Jetpack Scan to secure your website.',
+				'Jetpack Protect (Scan) detects and prevents attacks, but is not designed to fully clean up sites infected before it was active. If your site has malware, take immediate action to clean it up and remove the malicious code. {{br/}} To clean up your site, we suggest using a malware removal tool, or if possible restore from a backup taken before the infection. We recommend using Jetpack VaultPress Backup in conjunction with Jetpack Scan to secure your website. {{br/}} {{JetpackScanLearnMoreLink}}Learn more about cleaning your site{{/JetpackScanLearnMoreLink}}.',
 				{
 					components: {
 						br: <br />,
+						JetpackScanLearnMoreLink: getSupportLink( 'how-to-clean-your-hacked-wordpress-site' ),
 					},
 				}
 			),

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -958,6 +958,18 @@ export const getJetpackProductsBenefits = (): Record< string, Array< TranslateRe
 export const getJetpackProductsFAQs = (
 	getHelpLink: ( context: unknown ) => JSX.Element
 ): Record< string, Array< FAQ > > => {
+	const cancellationPolicyFAQ = {
+		id: 'cancellation-policy',
+		question: translate( 'What is your cancellation policy?' ),
+		answer: translate(
+			'If you are dissatisfied for any reason, we offer full refunds within %(annualDays)d days for yearly plans, and within %(monthlyDays)d days for monthly plans. If you have a question about our paid plans, {{helpLink}}please let us know{{/helpLink}}!',
+			{
+				args: { annualDays: 14, monthlyDays: 7 },
+				components: { helpLink: getHelpLink( 'cancellation' ) },
+			}
+		),
+	};
+
 	const backupFAQs: Array< FAQ > = [
 		{
 			id: 'backup-storage-limits',
@@ -969,27 +981,36 @@ export const getJetpackProductsFAQs = (
 				}
 			),
 		},
+		cancellationPolicyFAQ,
+	];
+
+	const scanFAQs: Array< FAQ > = [
 		{
-			id: 'cancellation-policy',
-			question: translate( 'What is your cancellation policy?' ),
+			id: 'scan-infected-sites',
+			question: translate( 'Can I use Jetpack Scan to fix a site that is already infected?' ),
 			answer: translate(
-				'If you are dissatisfied for any reason, we offer full refunds within %(annualDays)d days for yearly plans, and within %(monthlyDays)d days for monthly plans. If you have a question about our paid plans, {{helpLink}}please let us know{{/helpLink}}!',
+				'Jetpack Protect (Scan) detects and prevents attacks, but is not designed to fully clean up sites infected before it was active. If your site has malware, take immediate action to clean it up and remove the malicious code. {{br/}} To clean up your site, we suggest using a malware removal tool, or if possible restore from a backup taken before the infection. We recommend using Jetpack VaultPress Backup in conjunction with Jetpack Scan to secure your website.',
 				{
-					args: { annualDays: 14, monthlyDays: 7 },
-					components: { helpLink: getHelpLink( 'cancellation' ) },
+					components: {
+						br: <br />,
+					},
 				}
 			),
 		},
+		cancellationPolicyFAQ,
 	];
+
 	return {
-		[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ]: backupFAQs,
-		[ PRODUCT_JETPACK_BACKUP_T1_MONTHLY ]: backupFAQs,
-		[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ]: backupFAQs,
-		[ PRODUCT_JETPACK_BACKUP_T2_MONTHLY ]: backupFAQs,
 		[ PLAN_JETPACK_SECURITY_T1_MONTHLY ]: backupFAQs,
 		[ PLAN_JETPACK_SECURITY_T1_YEARLY ]: backupFAQs,
 		[ PLAN_JETPACK_SECURITY_T2_MONTHLY ]: backupFAQs,
 		[ PLAN_JETPACK_SECURITY_T2_YEARLY ]: backupFAQs,
+		[ PRODUCT_JETPACK_BACKUP_T1_MONTHLY ]: backupFAQs,
+		[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ]: backupFAQs,
+		[ PRODUCT_JETPACK_BACKUP_T2_MONTHLY ]: backupFAQs,
+		[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ]: backupFAQs,
+		[ PRODUCT_JETPACK_SCAN ]: scanFAQs,
+		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: scanFAQs,
 	};
 };
 


### PR DESCRIPTION
Users who purchase a scan after their site is infected often do not realize it will not help them resolve existing issues. The goal of this PR is to make it clearer in our UI how the scan works when a site is infected to reduce churn.

<img width="1124" alt="Screen Shot 2023-04-21 at 4 57 42 PM" src="https://user-images.githubusercontent.com/56598660/233593304-8ca256a1-b8b7-4949-afab-6f21f08e3383.png">
<img width="850" alt="Screen Shot 2023-04-24 at 8 23 01 PM" src="https://user-images.githubusercontent.com/56598660/233995208-38accee1-5394-4365-b9f3-e396137c2456.png">


related to 1202858161751496-as-1203884690118153

## Proposed Changes

* Add FAQs for Jetpack Scan products in the Calypso products package.
* Display Jetpack Scan FAQ in the product lightbox and Pricing page's FAQ section.

## Testing Instructions

- Run git fetch && git checkout `add/jp-pricing-page-scan-faqs`
- Run `yarn start-jetpack-cloud`
- Go to http://jetpack.cloud.localhost:3000/pricing or use the Jetpack Cloud live link and append `/pricing`.
- Click **More about Scan** button
- Confirm that the FAQs are visible and copies are correct.
- Click **Learn more about cleaning your site** link.
- Confirm it opens a new tab to https://jetpack.com/support/scan/how-to-clean-your-hacked-wordpress-site/
- Exit the product lightbox and scrolldown to FAQs section. 
- Confirm the new Jetpack Scan FAQ is visible and copies are correct.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1204446895152930
  - 0-as-1203884690118153