### PR TITLE
Pending subscriptions tab visible for EN non-wp users only

### DIFF
--- a/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
+++ b/client/landing/subscriptions/components/tabs-switcher/tabs-switcher.tsx
@@ -60,7 +60,7 @@ const TabsSwitcher = () => {
 						{ translate( 'Comments' ) }
 					</NavItem>
 
-					{ shouldEnablePendingTab && ( counts?.pending || pathname.includes( 'pending' ) ) ? (
+					{ counts?.pending || pathname.includes( 'pending' ) ? (
 						<NavItem
 							onClick={ () => {
 								shouldEnablePendingTab

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -130,6 +130,7 @@
 		"subscription-gifting": true,
 		"subscription-management": true,
 		"subscription-management-comments-view": true,
+		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,

--- a/config/production.json
+++ b/config/production.json
@@ -151,6 +151,7 @@
 		"subscription-gifting": true,
 		"subscription-management": true,
 		"subscription-management-comments-view": true,
+		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -146,6 +146,7 @@
 		"subscription-gifting": true,
 		"subscription-management": true,
 		"subscription-management-comments-view": true,
+		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -157,6 +157,7 @@
 		"subscription-gifting": true,
 		"subscription-management": true,
 		"subscription-management-comments-view": true,
+		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
 		"themes/atomic-homepage-replace": true,


### PR DESCRIPTION
## Proposed Changes

The pending subscriptions screen in the Subscription Manager will be visible only for external users with 'en' locale.
<img width="967" alt="Screenshot 2023-04-21 at 11 02 46" src="https://user-images.githubusercontent.com/3832570/233594907-8fcf7333-7044-4e5c-8cb3-bbf55b7a18cc.png">


## Testing Instructions


1. Build this PR locally.
2. Navigate to http://calypso.localhost:3000/subscriptions/settings?locale=pt-br (or specify some other non-EN locale). → When you click on the "Pending" tab, you should be directed to https://wordpress.com/email-subscriptions/?option=pending.
3. Navigate to http://calypso.localhost:3000/subscriptions/settings?locale=en (English locale) → When you click on the "Pending" link now, you should end up on the new "Pending" view in Calypso.


