### PR TITLE
Fix /themes/mine being called twice for writer flow

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -35,7 +35,8 @@ if ( typeof MainDashboardButton !== 'undefined' ) {
 				// eslint-disable-next-line react-hooks/exhaustive-deps
 			}, [] );
 
-			const isStartWritingFlow = getQueryArg( window.location.search, START_WRITING_FLOW );
+			const isStartWritingFlow =
+				getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
 			const [ clickGuardRoot ] = useState( () => document.createElement( 'div' ) );
 			useEffect( () => {
 				document.body.appendChild( clickGuardRoot );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/tour-launch.tsx
@@ -49,7 +49,7 @@ function LaunchWpcomWelcomeTour() {
 	const { siteIntent, siteIntentFetched } = useSiteIntent();
 	const localeSlug = useLocale();
 	const editorType = getEditorType();
-	const isStartWritingFlow = getQueryArg( window.location.search, START_WRITING_FLOW );
+	const isStartWritingFlow = getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
 
 	// Preload first card image (others preloaded after open state confirmed)
 	usePrefetchTourAssets( [ getTourSteps( localeSlug, false, false, null, siteIntent )[ 0 ] ] );

--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -5,8 +5,9 @@ import { getQueryArg } from '@wordpress/url';
 const START_WRITING_FLOW = 'start-writing';
 
 export function redirectOnboardingUserAfterPublishingPost() {
-	const isStartWritingFlow = getQueryArg( window.location.search, START_WRITING_FLOW );
-	if ( 'true' !== isStartWritingFlow ) {
+	const isStartWritingFlow = getQueryArg( window.location.search, START_WRITING_FLOW ) === 'true';
+
+	if ( ! isStartWritingFlow ) {
 		return false;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -40,6 +40,7 @@ const DEFAULT_WP_SITE_THEME = 'pub/zoologist';
 const DEFAULT_LINK_IN_BIO_THEME = 'pub/lynx';
 const DEFAULT_WOOEXPRESS_FLOW = 'pub/twentytwentytwo';
 const DEFAULT_NEWSLETTER_THEME = 'pub/lettre';
+const DEFAULT_START_WRITING_THEME = 'pub/livro';
 
 const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, data } ) {
 	const { submit } = navigation;
@@ -70,6 +71,8 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 		theme = DEFAULT_WP_SITE_THEME;
 	} else if ( isWooExpressFlow( flow ) ) {
 		theme = DEFAULT_WOOEXPRESS_FLOW;
+	} else if ( isStartWritingFlow( flow ) ) {
+		theme = DEFAULT_START_WRITING_THEME;
 	} else {
 		theme = isLinkInBioFlow( flow ) ? DEFAULT_LINK_IN_BIO_THEME : DEFAULT_NEWSLETTER_THEME;
 	}

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -10,7 +10,6 @@ import {
 	Flow,
 	ProvidedDependencies,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
-import { setDesignOnSite } from 'calypso/lib/signup/step-actions';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const startWriting: Flow = {
@@ -41,21 +40,10 @@ const startWriting: Flow = {
 							checklist_statuses: { first_post_published: true },
 						} );
 
-						const defaultFlowThemeSlug = 'livro';
 						const siteOrigin = window.location.origin;
 
-						setDesignOnSite(
-							() => {
-								redirect(
-									`https://${ providedDependencies?.siteSlug }/wp-admin/post-new.php?${ START_WRITING_FLOW }=true&origin=${ siteOrigin }`
-								);
-							},
-							{
-								siteSlug: providedDependencies?.siteSlug,
-								selectedDesign: {
-									theme: defaultFlowThemeSlug,
-								},
-							}
+						return redirect(
+							`https://${ providedDependencies?.siteSlug }/wp-admin/post-new.php?${ START_WRITING_FLOW }=true&origin=${ siteOrigin }`
 						);
 					}
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Please merge after https://github.com/Automattic/wp-calypso/pull/76074, since we're using `start-writing` in this PR for the redirection.

Fixes https://github.com/Automattic/dotcom-forge/issues/2201

## Proposed Changes

* Set the default theme by utilizing code [here](https://github.com/Automattic/wp-calypso/blob/7e0fa287f0b6c5a7f9e4c4bb67a5142b0577eeaa/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx#L68) 


https://user-images.githubusercontent.com/6586048/233604266-26115016-00e3-4a2b-84c4-d92cc540a83d.mp4



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Setup a new user with `/setup/start-writing`
* Make sure the API is called only once
* The theme is set to livro

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~
