### PR TITLE
update/move and rename ZendeskPresalesChat component

### DIFF
--- a/client/components/jetpack/jetpack-presales-chat-widget/index.tsx
+++ b/client/components/jetpack/jetpack-presales-chat-widget/index.tsx
@@ -38,7 +38,7 @@ async function fetchWithRetry(
 	}
 }
 
-export const ZendeskPreSalesChat: React.VFC = () => {
+export const ZendeskJetpackChat: React.VFC = () => {
 	const [ error, setError ] = useState( false );
 	const { data: isStaffed } = usePresalesAvailabilityQuery();
 	const zendeskChatKey = config( 'zendesk_presales_chat_key' ) as keyof ConfigData;

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from '@wordpress/element';
 import { useSelector } from 'react-redux';
 import StoreFooter from 'calypso/jetpack-connect/store-footer';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { ZendeskJetpackChat } from '../../../../components/jetpack/jetpack-presales-chat-widget';
 import OpenSourceSection from '../open-source';
 import PlanUpgradeSection from '../plan-upgrade';
 import StoreItemInfoContext from './context/store-item-info-context';
@@ -13,7 +14,6 @@ import { NeedMoreInfo } from './need-more-info';
 import { PricingBanner } from './pricing-banner';
 import { Recommendations } from './recommendations';
 import { UserLicensesDialog } from './user-licenses-dialog';
-import { ZendeskPreSalesChat } from './zendesk-presales-chat-widget';
 import type { ProductStoreProps } from './types';
 
 import './wpcom-styles.scss';
@@ -74,7 +74,7 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 			{ showJetpackFree && <JetpackFree urlQueryArgs={ urlQueryArgs } siteId={ siteId } /> }
 
 			<Recommendations />
-			<ZendeskPreSalesChat />
+			<ZendeskJetpackChat />
 			<OpenSourceSection />
 
 			<StoreFooter />


### PR DESCRIPTION

## Proposed Changes

* The code for the Jetpack Presales chat widget will be reused to add chat to more areas of jetpack cloud.  Following best practices, this component was moved into client/components/jetpack.
* In addition, the name of the component was a little ambiguous since this is a jetpack-specific implementation.  The component was renamed for more clarity.

## Testing Instructions

* Hit the calypso.live link and go to /pricing
* The chat widget should act as it always has, showing when chat's staffed and hidden when it's not.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
