### PR TITLE
Use tag stats to display post and site count totals

### DIFF
--- a/client/data/reader/use-related-meta-by-tag.ts
+++ b/client/data/reader/use-related-meta-by-tag.ts
@@ -111,7 +111,9 @@ export const useRelatedMetaByTag = ( tag: string ): UseQueryResult< RelatedMetaB
 		[ 'related-meta-by-tag-' + tag_recs_per_card + '-' + site_recs_per_card, tag ],
 		() =>
 			wp.req.get( {
-				path: `/read/tags/${ tag }/cards?tag_recs_per_card=${ tag_recs_per_card }&site_recs_per_card=${ site_recs_per_card }`,
+				path: `/read/tags/${ encodeURIComponent(
+					tag
+				) }/cards?tag_recs_per_card=${ tag_recs_per_card }&site_recs_per_card=${ site_recs_per_card }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
 		{

--- a/client/data/reader/use-tag-stats.ts
+++ b/client/data/reader/use-tag-stats.ts
@@ -1,0 +1,25 @@
+import { useQuery, UseQueryResult } from 'react-query';
+import wp from 'calypso/lib/wp';
+
+export interface TagStats {
+	total_posts: number; // Number of posts in the time period.
+	total_sites: number; // Number of sites that posted in the time period.
+	posts_per_day: number; // Average number of posts per day in the time period.
+	last_post_date_gmt: string; //(ISO 8601 datetime) Datetime for the most recent post in the time period.
+}
+
+const select = ( response: TagStats ): TagStats | null => response;
+
+export const useTagStats = ( tag: string ): UseQueryResult< TagStats | null > =>
+	useQuery(
+		[ 'tag-stats', tag ],
+		() =>
+			wp.req.get( {
+				path: `/read/topics/${ tag }/stats`,
+				apiNamespace: 'wpcom/v1.3',
+			} ),
+		{
+			staleTime: 3600000, // 1 hour
+			select: select,
+		}
+	);

--- a/client/data/reader/use-tag-stats.ts
+++ b/client/data/reader/use-tag-stats.ts
@@ -8,32 +8,15 @@ export interface TagStats {
 	last_post_date_gmt: string; //(ISO 8601 datetime) Datetime for the most recent post in the time period.
 }
 
-const selectFromResponse = ( response: {
-	total_posts: number;
-	total_sites: number;
-	posts_per_day: number;
-	last_post_date_gmt: string;
-} ): TagStats | null => {
-	console.log( 'response', response );
-	return {
-		total_posts: response.total_posts,
-		total_sites: response.total_sites,
-		posts_per_day: response.posts_per_day,
-		last_post_date_gmt: response.last_post_date_gmt,
-	};
-};
-
 export const useTagStats = ( tag: string ): UseQueryResult< TagStats | null > =>
 	useQuery(
 		[ 'tag-stats', tag ],
 		() =>
-			wp.req.get( {
-				path: `/read/topics/${ tag }/stats`,
-				apiNamespace: 'rest/v1.3',
+			wp.req.get( `/read/topics/${ encodeURIComponent( tag ) }/stats`, {
+				apiVersion: '1.3',
 			} ),
 		{
 			staleTime: 86400000, // 1 day
-			select: selectFromResponse,
 			refetchOnMount: 'always',
 		}
 	);

--- a/client/data/reader/use-tag-stats.ts
+++ b/client/data/reader/use-tag-stats.ts
@@ -8,7 +8,20 @@ export interface TagStats {
 	last_post_date_gmt: string; //(ISO 8601 datetime) Datetime for the most recent post in the time period.
 }
 
-const select = ( response: TagStats ): TagStats | null => response;
+const selectFromResponse = ( response: {
+	total_posts: number;
+	total_sites: number;
+	posts_per_day: number;
+	last_post_date_gmt: string;
+} ): TagStats | null => {
+	console.log( 'response', response );
+	return {
+		total_posts: response.total_posts,
+		total_sites: response.total_sites,
+		posts_per_day: response.posts_per_day,
+		last_post_date_gmt: response.last_post_date_gmt,
+	};
+};
 
 export const useTagStats = ( tag: string ): UseQueryResult< TagStats | null > =>
 	useQuery(
@@ -16,10 +29,11 @@ export const useTagStats = ( tag: string ): UseQueryResult< TagStats | null > =>
 		() =>
 			wp.req.get( {
 				path: `/read/topics/${ tag }/stats`,
-				apiNamespace: 'wpcom/v1.3',
+				apiNamespace: 'rest/v1.3',
 			} ),
 		{
-			staleTime: 3600000, // 1 hour
-			select: select,
+			staleTime: 86400000, // 1 day
+			select: selectFromResponse,
+			refetchOnMount: 'always',
 		}
 	);

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -10,7 +10,6 @@ const ReaderTagSidebar = ( { tag } ) => {
 	const translate = useTranslate();
 	const relatedMetaByTag = useRelatedMetaByTag( tag );
 	const tagStats = useTagStats( tag );
-	console.log( 'tagStats', tagStats.data );
 	if ( relatedMetaByTag === undefined ) {
 		return null;
 	}
@@ -28,13 +27,13 @@ const ReaderTagSidebar = ( { tag } ) => {
 				<div className="reader-tag-sidebar-stats">
 					<div className="reader-tag-sidebar-stats__item">
 						<span className="reader-tag-sidebar-stats__count">
-							{ formatNumberCompact( tagStats?.total_posts ) }
+							{ formatNumberCompact( tagStats?.data?.total_posts ) }
 						</span>
 						<span className="reader-tag-sidebar-stats__title">{ translate( 'Posts' ) }</span>
 					</div>
 					<div className="reader-tag-sidebar-stats__item">
 						<span className="reader-tag-sidebar-stats__count">
-							{ formatNumberCompact( tagStats?.total_sites ) }
+							{ formatNumberCompact( tagStats?.data?.total_sites ) }
 						</span>
 						<span className="reader-tag-sidebar-stats__title">{ translate( 'Sites' ) }</span>
 					</div>

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -10,6 +10,7 @@ const ReaderTagSidebar = ( { tag } ) => {
 	const translate = useTranslate();
 	const relatedMetaByTag = useRelatedMetaByTag( tag );
 	const tagStats = useTagStats( tag );
+	console.log( 'tagStats', tagStats.data );
 	if ( relatedMetaByTag === undefined ) {
 		return null;
 	}

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -1,12 +1,14 @@
 import { useTranslate } from 'i18n-calypso';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
 import { useRelatedMetaByTag } from 'calypso/data/reader/use-related-meta-by-tag';
+import { useTagStats } from 'calypso/data/reader/use-tag-stats';
 import ReaderListFollowingItem from 'calypso/reader/stream/reader-list-followed-sites/item';
 import '../style.scss';
 
 const ReaderTagSidebar = ( { tag } ) => {
 	const translate = useTranslate();
 	const relatedMetaByTag = useRelatedMetaByTag( tag );
+	const tagStats = useTagStats( tag );
 	if ( relatedMetaByTag === undefined ) {
 		return null;
 	}

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -2,6 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
 import { useRelatedMetaByTag } from 'calypso/data/reader/use-related-meta-by-tag';
 import { useTagStats } from 'calypso/data/reader/use-tag-stats';
+import formatNumberCompact from 'calypso/lib/format-number-compact';
 import ReaderListFollowingItem from 'calypso/reader/stream/reader-list-followed-sites/item';
 import '../style.scss';
 
@@ -22,6 +23,22 @@ const ReaderTagSidebar = ( { tag } ) => {
 
 	return (
 		<>
+			{ tagStats && (
+				<div className="reader-tag-sidebar-stats">
+					<div className="reader-tag-sidebar-stats__item">
+						<span className="reader-tag-sidebar-stats__count">
+							{ formatNumberCompact( tagStats?.total_posts ) }
+						</span>
+						<span className="reader-tag-sidebar-stats__title">{ translate( 'Posts' ) }</span>
+					</div>
+					<div className="reader-tag-sidebar-stats__item">
+						<span className="reader-tag-sidebar-stats__count">
+							{ formatNumberCompact( tagStats?.total_sites ) }
+						</span>
+						<span className="reader-tag-sidebar-stats__title">{ translate( 'Sites' ) }</span>
+					</div>
+				</div>
+			) }
 			{ tagLinks && (
 				<div className="reader-tag-sidebar-related-tags">
 					<h2>{ translate( 'Related Tags' ) }</h2>

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -688,6 +688,28 @@
 				margin-bottom: 14px;
 			}
 		}
+
+		.reader-tag-sidebar-stats {
+			display: flex;
+			flex-direction: row;
+			gap: 20px;
+			margin-bottom: 32px;
+
+			.reader-tag-sidebar-stats__item {
+				display: flex;
+				flex-direction: column;
+			}
+
+			.reader-tag-sidebar-stats__count {
+				font-size: $font-title-small;
+				font-weight: bold;
+			}
+
+			.reader-tag-sidebar-stats__title {
+				font-size: $font-body-extra-small;
+				color: var(--color-text-subtle);
+			}
+		}
 	}
 
 	.reader-post-card__tag-link {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -703,6 +703,7 @@
 			.reader-tag-sidebar-stats__count {
 				font-size: $font-title-small;
 				font-weight: bold;
+				width: 90px;
 			}
 
 			.reader-tag-sidebar-stats__title {


### PR DESCRIPTION
There is a WPCOM REST API endpoint available to get the stats for a tag.

For a request like;
```
https://public-api.wordpress.com/rest/v1.3/read/topics/creativity/stats?_envelope=1
```

We should get a JSON response like;

```
{"total_posts":71395,"posts_per_day":195.6027397260274,"total_sites":37076,"last_post_date_gmt":"2023-04-20T23:50:35+0000"}
```

This PR will call this endpoint and display the `total_posts` and the `total_sites` tallies on the tag page sidebar similar to the mockup below;

<img width="1676" alt="screenshot-2023-03-16-at-3 26 14-pm" src="https://user-images.githubusercontent.com/5560595/231879571-814556cf-1e49-4d4f-99dd-b9bd7eef77cc.png">