### PR TITLE
Blog onboarding: Create a new Launchpad for "Start writing flow v1"

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -6,6 +6,7 @@ import {
 	BUILD_FLOW,
 	WRITE_FLOW,
 	isNewsletterFlow,
+	START_WRITING_FLOW,
 } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -87,6 +88,8 @@ const LaunchpadSitePreview = ( {
 			case BUILD_FLOW:
 				return DEVICE_TYPES.COMPUTER;
 			case WRITE_FLOW:
+				return DEVICE_TYPES.COMPUTER;
+			case START_WRITING_FLOW:
 				return DEVICE_TYPES.COMPUTER;
 			default:
 				return DEVICE_TYPES.PHONE;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -1,4 +1,4 @@
-import { LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
+import { LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW, START_WRITING_FLOW } from '@automattic/onboarding';
 import { LaunchpadFlowTaskList, Task } from './types';
 
 export const DOMAIN_UPSELL = 'domain_upsell';
@@ -136,4 +136,11 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 	],
 	write: [ 'setup_write', 'design_selected', 'first_post_published', 'site_launched' ],
 	videopress: [ 'videopress_setup', 'plan_selected', 'videopress_upload', 'videopress_launched' ],
+	[ START_WRITING_FLOW ]: [
+		'first_post_published',
+		'setup_free',
+		DOMAIN_UPSELL,
+		'plan_selected',
+		'site_launched',
+	],
 };

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -79,8 +79,8 @@ const startWriting: Flow = {
 				message: `${ flowName } requires a logged in user`,
 			};
 		} else if ( userAlreadyHasSites && ! isLaunchpad ) {
-		    // Redirect users with existing sites out of the flow as we create a new site as the first step in this flow.
-			// This prevents a bunch of sites being created accidentally
+			// Redirect users with existing sites out of the flow as we create a new site as the first step in this flow.
+			// This prevents a bunch of sites being created accidentally.
 			redirect( `/post?${ START_WRITING_FLOW }=true` );
 			result = {
 				state: AssertConditionState.CHECKING,

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -79,6 +79,8 @@ const startWriting: Flow = {
 				message: `${ flowName } requires a logged in user`,
 			};
 		} else if ( userAlreadyHasSites && ! isLaunchpad ) {
+		    // Redirect users with existing sites out of the flow as we create a new site as the first step in this flow.
+			// This prevents a bunch of sites being created accidentally
 			redirect( `/post?${ START_WRITING_FLOW }=true` );
 			result = {
 				state: AssertConditionState.CHECKING,

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -24,6 +24,10 @@ const startWriting: Flow = {
 				slug: 'processing',
 				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
 			},
+			{
+				slug: 'launchpad',
+				asyncComponent: () => import( './internals/steps-repository/launchpad' ),
+			},
 		];
 	},
 
@@ -57,6 +61,9 @@ const startWriting: Flow = {
 		const isLoggedIn = useSelector( isUserLoggedIn );
 		const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
 		const locale = useLocale();
+		const currentPath = window.location.pathname;
+		const isLaunchpad = currentPath.includes( 'setup/start-writing/launchpad' );
+		const userAlreadyHasSites = currentUserSiteCount && currentUserSiteCount > 0;
 
 		const logInUrl =
 			locale && locale !== 'en'
@@ -71,7 +78,7 @@ const startWriting: Flow = {
 				state: AssertConditionState.CHECKING,
 				message: `${ flowName } requires a logged in user`,
 			};
-		} else if ( currentUserSiteCount && currentUserSiteCount > 0 ) {
+		} else if ( userAlreadyHasSites && ! isLaunchpad ) {
 			redirect( `/post?${ START_WRITING_FLOW }=true` );
 			result = {
 				state: AssertConditionState.CHECKING,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2214

## Proposed Changes

* This PR creates a new `/setup/start-writing/launchpad` step that we can customize for the "Start writing v1" flow.
* This page, though "live" is not linked from anywhere, but we can use this to start iterating on the "Start writing v1" Launchpad "tasks."

![start-writing-launchpad](https://user-images.githubusercontent.com/140841/234106504-4c21148b-5ea0-4d5b-bc6d-cdbfb79fd88b.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure this PR does not introduce any regressions
* You can view `/setup/start-writing/launchpad?siteSlug={site-slug}&start-writing=true`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
