### PR TITLE
Newsletter onboarding placeholders colors to --studio-gray-30

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -16,7 +16,7 @@
 		input,
 		form-textarea {
 			&::placeholder {
-				color: var(--studio-gray-50);
+				color: var(--studio-gray-30);
 			}
 		}
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/style.scss
@@ -35,7 +35,7 @@
 		.add-subscriber__form--container {
 			input {
 				&::placeholder {
-					color: var(--studio-gray-50);
+					color: var(--studio-gray-30);
 				}
 			}
 		}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/75683

## Proposed Changes

![image](https://user-images.githubusercontent.com/104869/233700413-43c80823-38d9-4673-9a42-2789bdbf438d.png)

Fixes https://github.com/Automattic/wp-calypso/issues/75683

## Testing Instructions

- Checkout branch and yarn start OR visit the Live Link
- Reach /setup/newslettter/newsletterSetup
- Check the placeholder colors
