### PR TITLE
Backup: Add translations to update staging flag notices

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/staging/update/index.ts
+++ b/client/state/data-layer/wpcom/sites/rewind/staging/update/index.ts
@@ -1,3 +1,4 @@
+import { translate } from 'i18n-calypso';
 import {
 	JETPACK_BACKUP_STAGING_UPDATE_REQUEST,
 	JETPACK_BACKUP_STAGING_UPDATE_REQUEST_FAILURE,
@@ -25,7 +26,7 @@ const updateStagingFlagSuccess = ( { siteId }: UpdateStagingFlagRequestActionTyp
 		type: JETPACK_BACKUP_STAGING_UPDATE_REQUEST_SUCCESS,
 		siteId,
 	},
-	successNotice( 'Site staging status has been successfully updated.', {
+	successNotice( translate( 'Site staging status has been successfully updated.' ), {
 		duration: 5000,
 		isPersistent: true,
 	} ),
@@ -40,7 +41,7 @@ const updateStagingFlagError = (
 		siteId,
 		error,
 	},
-	errorNotice( 'Updating site staging status failed.  Please, try again.', {
+	errorNotice( translate( 'Updating site staging status failed. Please, try again.' ), {
 		duration: 5000,
 		isPersistent: true,
 	} ),


### PR DESCRIPTION
## Proposed Changes

* Add translations for notices when we attempt to update the backup staging flag (success and failure notices).

## Screenshots
| Description | Screenshot |
|---|---|
| Success notice | ![image](https://user-images.githubusercontent.com/1488641/233739829-68ef0fbb-aa1b-4a63-bbaa-08f624b40d97.png) |
| Error notice | ![image](https://user-images.githubusercontent.com/1488641/233739769-cc42df28-2bc2-41f9-8c49-ddd88956efb6.png) |

## Testing Instructions

These notices are not available on the UI yet. They were introduced on #75998 and the idea of this PR is to push them for translations. No formal test is required, but you can still ensure unit tests are still passing: `yarn run test-client client/state/rewind`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
