### PR TITLE
Revert "Site Editor: un-iframe in all environments (#75652)"

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -260,6 +260,23 @@ export const post = ( context, next ) => {
 	return next();
 };
 
+export const siteEditor = ( context, next ) => {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+
+	context.primary = (
+		<CalypsoifyIframe
+			// This key is added as a precaution due to it's oberserved necessity in the above post editor.
+			// It will force the component to remount completely when the Id changes.
+			key={ siteId }
+			editorType="site"
+			completedFlow={ getSessionStorageOneTimeValue( 'wpcom_signup_completed_flow' ) }
+		/>
+	);
+
+	return next();
+};
+
 export const exitPost = ( context, next ) => {
 	const postId = getPostID( context );
 	const siteId = getSelectedSiteId( context.store.getState() );
@@ -273,9 +290,16 @@ export const exitPost = ( context, next ) => {
  * Redirects to the un-iframed Site Editor if the config is enabled.
  *
  * @param {Object} context Shared context in the route.
+ * @param {Function} next  Next registered callback for the route.
  * @returns {*}            Whatever the next callback returns.
  */
-export const redirectSiteEditor = async ( context ) => {
+export const redirectSiteEditor = async ( context, next ) => {
+	// bail unless the config is enabled
+	if ( ! isEnabled( 'block-editor/un-iframed-site-editor' ) ) {
+		return next();
+	}
+
+	// Let's ditch that iframe!
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -1,10 +1,26 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { siteSelection, sites } from 'calypso/my-sites/controller';
-import { authenticate, post, redirect, exitPost, redirectSiteEditor } from './controller';
+import {
+	authenticate,
+	post,
+	redirect,
+	siteEditor,
+	exitPost,
+	redirectSiteEditor,
+} from './controller';
 
 export default function () {
-	page( '/site-editor/:site?', siteSelection, redirectSiteEditor );
+	page(
+		'/site-editor/:site?',
+		siteSelection,
+		redirectSiteEditor,
+		redirect,
+		authenticate,
+		siteEditor,
+		makeLayout,
+		clientRender
+	);
 
 	page( '/post', siteSelection, sites, makeLayout, clientRender );
 	page( '/post/new', '/post' ); // redirect from beep-beep-boop

--- a/config/development.json
+++ b/config/development.json
@@ -29,6 +29,7 @@
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
 		"anchor/sunset-integration": true,
+		"block-editor/un-iframed-site-editor": false,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -17,6 +17,7 @@
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
 		"anchor/sunset-integration": false,
+		"block-editor/un-iframed-site-editor": false,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -21,10 +21,14 @@ import {
 	DimensionsSettings,
 	CookieBannerComponent,
 } from '..';
+import { getCalypsoURL } from '../../data-helper';
 import { getIdFromBlock } from '../../element-helper';
 import envVariables from '../../env-variables';
 
+const wpAdminPath = 'wp-admin/site-editor.php';
+
 const selectors = {
+	editorIframe: `iframe.is-loaded[src*="${ wpAdminPath }"]`,
 	editorRoot: 'body.block-editor-page',
 	editorCanvasIframe: 'iframe[name="editor-canvas"]',
 	editorCanvasRoot: 'body.block-editor-iframe__body',
@@ -71,7 +75,11 @@ export class FullSiteEditorPage {
 	constructor( page: Page ) {
 		this.page = page;
 
-		this.editor = page.locator( selectors.editorRoot );
+		if ( this.shouldUseIframe() ) {
+			this.editor = page.frameLocator( selectors.editorIframe ).locator( selectors.editorRoot );
+		} else {
+			this.editor = page.locator( selectors.editorRoot );
+		}
 
 		this.editorCanvas = this.editor
 			.frameLocator( selectors.editorCanvasIframe )
@@ -120,10 +128,16 @@ export class FullSiteEditorPage {
 			);
 		}
 
-		parsedUrl.pathname = '/wp-admin/site-editor.php';
-		parsedUrl.searchParams.set( 'calypso_origin', envVariables.CALYPSO_BASE_URL );
+		let targetHref: string;
+		if ( this.shouldUseIframe() ) {
+			targetHref = getCalypsoURL( `/site-editor/${ parsedUrl.host }` );
+		} else {
+			parsedUrl.pathname = '/wp-admin/site-editor.php';
+			parsedUrl.searchParams.set( 'calypso_origin', envVariables.CALYPSO_BASE_URL );
+			targetHref = parsedUrl.href;
+		}
 
-		await this.page.goto( parsedUrl.href, { timeout: 60 * 1000 } );
+		await this.page.goto( targetHref, { timeout: 60 * 1000 } );
 	}
 
 	/**
@@ -643,6 +657,16 @@ export class FullSiteEditorPage {
 		if ( ( await toastLocator.count() ) > 0 ) {
 			await toastLocator.click();
 		}
+	}
+
+	/**
+	 * TODO: Temp check -- we will delete when we un-iframe everywhere
+	 */
+	private shouldUseIframe(): boolean {
+		// The only place we are preserving the Site Editor iFrame is Simple sites on staging/production.
+		return (
+			! envVariables.TEST_ON_ATOMIC && envVariables.CALYPSO_BASE_URL === 'https://wordpress.com'
+		);
 	}
 
 	//#endregion

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -27,6 +27,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	let page: Page;
 	let fullSiteEditorPage: FullSiteEditorPage;
+	let testAccount: TestAccount;
 
 	const features = envToFeatureKey( envVariables );
 	const accountName = getTestAccountByFeature( { ...features, variant: 'siteEditor' } );
@@ -34,7 +35,7 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	beforeAll( async () => {
 		page = await browser.newPage();
 
-		const testAccount = new TestAccount( accountName );
+		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
 	} );
 
@@ -51,6 +52,7 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	it( 'Open the Page template', async function () {
 		fullSiteEditorPage = new FullSiteEditorPage( page );
 
+		await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 		await fullSiteEditorPage.prepareForInteraction();
 
 		await fullSiteEditorPage.ensureNavigationTopLevel();


### PR DESCRIPTION
This reverts commit 7a460612883eb016007568b194184306fd1e027b.

Reverts #75652.

See p1682186205979559-slack-C02FMH4G8 for escalation.

In summary, there are some CORS-related issues that make the site editor somewhat unusable, at least on first load.

## Proposed Changes

* Reverts change where we started to un-iframe site editor. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout PR
* Create a site that has a mapped domain (something like `*.w.link` or `*.hello.blog`) will work
* Ensure that Settings > Reading uses the default as the Home page.
* Click Appearance > Editor in sidebar
* Ensure that you land in a Calypso URL and not wp-admin
* Ensure that a preview loads

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
