### PR TITLE
Odyssey Stats: avoid using configData directly

### DIFF
--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -24,9 +24,9 @@ const QUERY_VALUES = {
 };
 
 export default function JetpackUpsellSection() {
-	// NOTE: This will only work within Odyssey Stats.
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
 
+	// NOTE: This will only work within Odyssey Stats.
 	const { purchasedProducts, error, isLoading } = usePurchasedProducts();
 
 	// Exit early if we don't have and can't get the site purchase data.

--- a/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
@@ -15,13 +15,6 @@ import wpcom from 'calypso/lib/wp';
 // It also requires the existence of ${api_root}/jetpack/v4/site/purchases!
 //
 
-// Include data from stats-admin initialization for making resource requests.
-const fetchPurchases = ( resource: string, options = {} ) =>
-	wpcom.req
-		.get( { path: resource, apiNamespace: 'jetpack/v4' }, options )
-		.then( ( res ) => res.json() )
-		.then( ( json ) => JSON.parse( json.data ) );
-
 const KEY_SLUG_MAP = new Map( [
 	[ 'backup', [ ...JETPACK_BACKUP_PRODUCTS, ...JETPACK_SECURITY_PLANS ] as readonly string[] ],
 	[ 'boost', JETPACK_BOOST_PRODUCTS as readonly string[] ],
@@ -51,7 +44,9 @@ export default function usePurchasedProducts() {
 	const [ error, setError ] = useState();
 
 	useEffect( () => {
-		fetchPurchases( '/site/purchases' )
+		wpcom.req
+			.get( { path: '/site/purchases', apiNamespace: 'jetpack/v4' } )
+			.then( ( res ) => JSON.parse( res.data ) )
 			.then( ( purchases ) => {
 				setIsLoading( false );
 				setPurchasedProducts( formatResponse( purchases ) );

--- a/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
@@ -41,17 +41,17 @@ function formatResponse( responseData?: Record< string, string >[] ) {
 export default function usePurchasedProducts() {
 	const [ purchasedProducts, setPurchasedProducts ] = useState( [] as string[] );
 	const [ isLoading, setIsLoading ] = useState( true );
-	const [ error, setError ] = useState();
+	const [ error, setError ] = useState< object >();
 
 	useEffect( () => {
 		wpcom.req
 			.get( { path: '/site/purchases', apiNamespace: 'jetpack/v4' } )
-			.then( ( res ) => JSON.parse( res.data ) )
-			.then( ( purchases ) => {
+			.then( ( res: { data: string } ) => JSON.parse( res.data ) )
+			.then( ( purchases: Record< string, string >[] ) => {
 				setIsLoading( false );
 				setPurchasedProducts( formatResponse( purchases ) );
 			} )
-			.catch( ( error ) => setError( error ) );
+			.catch( ( error: Error ) => setError( error ) );
 	}, [] );
 
 	return {

--- a/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
@@ -7,6 +7,7 @@ import {
 	JETPACK_VIDEOPRESS_PRODUCTS,
 } from '@automattic/calypso-products';
 import { useEffect, useState } from 'react';
+import wpcom from 'calypso/lib/wp';
 
 //
 // WARNING: This hook will only work within Odyssey Stats!
@@ -16,13 +17,8 @@ import { useEffect, useState } from 'react';
 
 // Include data from stats-admin initialization for making resource requests.
 const fetchPurchases = ( resource: string, options = {} ) =>
-	// Prefix resource with api_root for the site.
-	fetch( window.configData?.api_root + resource, {
-		...options,
-		credentials: 'include',
-		// Attach WordPress nonce to request.
-		headers: { 'X-WP-Nonce': window.configData?.nonce },
-	} )
+	wpcom.req
+		.get( { path: resource, apiNamespace: 'jetpack/v4' }, options )
 		.then( ( res ) => res.json() )
 		.then( ( json ) => JSON.parse( json.data ) );
 
@@ -55,7 +51,7 @@ export default function usePurchasedProducts() {
 	const [ error, setError ] = useState();
 
 	useEffect( () => {
-		fetchPurchases( 'jetpack/v4/site/purchases' )
+		fetchPurchases( '/site/purchases' )
 			.then( ( purchases ) => {
 				setIsLoading( false );
 				setPurchasedProducts( formatResponse( purchases ) );

--- a/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
@@ -41,7 +41,7 @@ function formatResponse( responseData?: Record< string, string >[] ) {
 export default function usePurchasedProducts() {
 	const [ purchasedProducts, setPurchasedProducts ] = useState( [] as string[] );
 	const [ isLoading, setIsLoading ] = useState( true );
-	const [ error, setError ] = useState< object >();
+	const [ error, setError ] = useState< Error | null >( null );
 
 	useEffect( () => {
 		wpcom.req

--- a/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/use-purchased-products.tsx
@@ -11,7 +11,6 @@ import wpcom from 'calypso/lib/wp';
 
 //
 // WARNING: This hook will only work within Odyssey Stats!
-// It depends on api_root and nonce from window.configData!
 // It also requires the existence of ${api_root}/jetpack/v4/site/purchases!
 //
 


### PR DESCRIPTION

## Proposed Changes

We refactored to use a different configData name in https://github.com/Automattic/jetpack/pull/30147, so we need to avoid use `configData` directly. Also we shouldn't have used that, instead of `configData.xxx`, we could just `config('xxx')`.

The PR proposes to use `wpcom`, which automatically sends the requests to Jetpack sites.

## Testing Instructions

* Open your local Jetpack site.
* Enable Odyssey Stats if you disabled it.
* Check out the branch of the Jetpack to the branch in https://github.com/Automattic/jetpack/pull/30147.
* Build Jetpack if necessary: `jetpack build plugins/jetpack`.
* Run `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev` under `calypso/apps/odyssey-stats`.
* Open `/wp-admin/admin.php?page=stats#!/stats/day/jasper1.au.ngrok.io`
* Open Network tab in dev tools
* Ensure `/wp-json/jetpack/v4/site/purchases` succeeds.
* Ensure the upsell section shows okay

![image](https://user-images.githubusercontent.com/1425433/233873181-f426c572-52c5-4a29-9467-1ace36876823.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
