### PR TITLE
Flaky E2E: synchronize the extended timeout on `PluginsPage.visit` method.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -85,7 +85,7 @@ export class PluginsPage {
 			this.page.waitForResponse( /\/sites\/\d+\/plugins/, { timeout: 20 * 1000 } ),
 			// This is one of the last, reliable web requests to finish on this page
 			// and is a pretty good indicator the async loading is done.
-			this.page.goto( getCalypsoURL( `plugins/${ site }` ) ),
+			this.page.goto( getCalypsoURL( `plugins/${ site }` ), { timeout: 20 * 1000 } ),
 		] );
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/76012..

## Proposed Changes

This PR applies the extended timeout to the `page.goto` method within the `PluginsPage.visit` method.

In https://github.com/Automattic/wp-calypso/pull/75357, the extended timeout of 20s was applied to just the `waitForResponse` method, which is an issue as the `page.goto` navigation and the resulting `load` event waiter is still running off the default (10s) timeout.

## Testing Instructions

Passed 15 round iterations on my local machine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
