### PR TITLE
Subscriptions Management: Fix `usePostUnfollowMutation`

### DIFF
--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -11,6 +11,7 @@ type CommentRowProps = PostSubscription & {
 };
 
 const CommentRow = ( {
+	id,
 	post_id,
 	post_title,
 	post_excerpt,
@@ -57,7 +58,7 @@ const CommentRow = ( {
 				</span>
 				<span className="actions" role="cell">
 					<CommentSettings
-						onUnfollow={ () => unFollow( { post_id, blog_id } ) }
+						onUnfollow={ () => unFollow( { post_id, blog_id, id } ) }
 						unfollowing={ unfollowing }
 					/>
 				</span>

--- a/packages/data-stores/src/reader/mutations/use-post-unfollow-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-post-unfollow-mutation.ts
@@ -102,15 +102,15 @@ const usePostUnfollowMutation = () => {
 				return { previousPostSubscriptions, previousSubscriptionsCount };
 			},
 			onError: ( error, variables, context ) => {
-				// if ( context?.previousPostSubscriptions ) {
-				// 	queryClient.setQueryData< PostSubscription[] >(
-				// 		postSubscriptionsCacheKey,
-				// 		context.previousPostSubscriptions
-				// 	);
-				// }
+				if ( context?.previousPostSubscriptions ) {
+					queryClient.setQueryData< SubscriptionManagerPostSubscriptionsPages >(
+						postSubscriptionsCacheKey,
+						context.previousPostSubscriptions
+					);
+				}
 				if ( context?.previousSubscriptionsCount ) {
 					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
-						[ 'read', 'subscriptions-count', isLoggedIn ],
+						subscriptionsCountCacheKey,
 						context.previousSubscriptionsCount
 					);
 				}

--- a/packages/data-stores/src/reader/mutations/use-post-unfollow-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-post-unfollow-mutation.ts
@@ -4,6 +4,7 @@ import { useCacheKey, useIsLoggedIn } from '../hooks';
 import { PostSubscription, SubscriptionManagerSubscriptionsCount } from '../types';
 
 type PostSubscriptionUnfollowParams = {
+	id: number | string;
 	blog_id: number | string;
 	post_id: number | string;
 };
@@ -28,6 +29,7 @@ const usePostUnfollowMutation = () => {
 	const { isLoggedIn } = useIsLoggedIn();
 	const queryClient = useQueryClient();
 	const postSubscriptionsCacheKey = useCacheKey( [ 'read', 'post-subscriptions' ] );
+	const subscriptionsCountCacheKey = useCacheKey( [ 'read', 'subscriptions-count' ] );
 
 	return useMutation(
 		async ( params: PostSubscriptionUnfollowParams ) => {
@@ -66,13 +68,12 @@ const usePostUnfollowMutation = () => {
 
 				// remove post from comment subscriptions
 				if ( previousPostSubscriptions ) {
-					previousPostSubscriptions.pages = previousPostSubscriptions?.pages.filter(
-						( page ) =>
-							( page.comment_subscriptions = page.comment_subscriptions.filter(
-								( subscription ) =>
-									subscription.post_id !== params.post_id && subscription.blog_id !== params.blog_id
-							) )
-					);
+					previousPostSubscriptions.pages = previousPostSubscriptions.pages.map( ( page ) => ( {
+						...page,
+						comment_subscriptions: page.comment_subscriptions.filter(
+							( subscription ) => subscription.id !== params.id
+						),
+					} ) );
 
 					queryClient.setQueryData< SubscriptionManagerPostSubscriptionsPages >(
 						postSubscriptionsCacheKey,
@@ -82,13 +83,13 @@ const usePostUnfollowMutation = () => {
 
 				const previousSubscriptionsCount =
 					queryClient.getQueryData< SubscriptionManagerSubscriptionsCount >(
-						postSubscriptionsCacheKey
+						subscriptionsCountCacheKey
 					);
 
 				// decrement the comments count
 				if ( previousSubscriptionsCount ) {
 					queryClient.setQueryData< SubscriptionManagerSubscriptionsCount >(
-						[ 'read', 'subscriptions-count', isLoggedIn ],
+						subscriptionsCountCacheKey,
 						{
 							...previousSubscriptionsCount,
 							comments: previousSubscriptionsCount?.comments
@@ -116,7 +117,7 @@ const usePostUnfollowMutation = () => {
 			},
 			onSettled: () => {
 				queryClient.invalidateQueries( postSubscriptionsCacheKey );
-				queryClient.invalidateQueries( [ 'read', 'subscriptions-count', isLoggedIn ] );
+				queryClient.invalidateQueries( subscriptionsCountCacheKey );
 			},
 		}
 	);

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -70,6 +70,7 @@ export type SiteSubscription = {
 export type SiteSubscriptionDeliveryFrequency = 'instantly' | 'daily' | 'weekly';
 
 export type PostSubscription = {
+	id: string;
 	blog_id: string;
 	subscription_date: Date;
 	site_id: string;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/76122.

## Proposed Changes

Fix `usePostUnfollowMutation` by:

- using subscription `id` instead for determining which row should be removed from the list of comment subscriptions - instead of using `post_id` and `blog_id`
- using correct React Query cache keys for the subscriptions and also their count (with the help of `useCacheKey`)

## Testing Instructions

1. Check out and build the PR locally.
2. Apply the correct `subkey` cookie value to your `calypso.localhost:3000` host.
3. Make sure the related user has existing comment subscriptions.
4. Navigate to http://calypso.localhost:3000/subscriptions/comments.
5. Try to unsubscribe from one or more subscriptions. → The unsubscribed subscription should get removed from the list and the count number in the tab should decrement.

Please note there's still the following bug: https://github.com/Automattic/wp-calypso/issues/76123 (probably related to the virtualized list).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
