### PR TITLE
Theme Showcase: Fix style variation preview not displaying the correct font

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -470,7 +470,12 @@ class ThemeSheet extends Component {
 	}
 
 	renderWebPreview = () => {
-		const { locale, stylesheet, themeId } = this.props;
+		const { locale, stylesheet, styleVariations, themeId } = this.props;
+		const baseStyleVariation = styleVariations.find(
+			( style ) => style.slug === DEFAULT_VARIATION_SLUG
+		);
+		const baseStyleVariationInlineCss = baseStyleVariation?.inline_css || '';
+		const selectedStyleVariationInlineCss = this.getSelectedStyleVariation()?.inline_css || '';
 		const url = getDesignPreviewUrl(
 			{ slug: themeId, recipe: { stylesheet } },
 			{ language: locale }
@@ -481,7 +486,7 @@ class ThemeSheet extends Component {
 				<div className="theme__sheet-web-preview">
 					<ThemeWebPreview
 						url={ url }
-						inlineCss={ this.getSelectedStyleVariation()?.inline_css }
+						inlineCss={ baseStyleVariationInlineCss + selectedStyleVariationInlineCss }
 						isShowFrameBorder={ false }
 						isShowDeviceSwitcher={ false }
 					/>

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -770,28 +770,30 @@ $theme-sheet-content-max-width: 1462px;
 	display: none;
 }
 
-.banner.theme__page-upsell-banner {
-	background-color: #f0f7fc;
-	border: 0;
-	border-radius: 4px;
-	box-shadow: none;
-	margin-bottom: 24px;
-	padding: 24px 30px;
-	width: 100%;
+.banner.card {
+	&.theme__page-upsell-banner {
+		background-color: #f0f7fc;
+		border: 0;
+		border-radius: 4px;
+		box-shadow: none;
+		margin-bottom: 24px;
+		padding: 24px 30px;
+		width: 100%;
 
-	.banner__icon-circle {
-		background-color: var(--studio-blue-50);
+		.banner__icon-circle {
+			background-color: var(--studio-blue-50);
+		}
 	}
-}
 
-.banner.theme__page-upsell-disabled {
-	pointer-events: none;
-	opacity: 0.5;
-}
+	&.theme__page-upsell-disabled {
+		pointer-events: none;
+		opacity: 0.5;
+	}
 
-.banner.theme__preview-upsell-banner {
-	@include banner-dark();
-	width: 100%;
-	margin: 0;
-	text-decoration: none;
+	&.theme__preview-upsell-banner {
+		@include banner-dark();
+		width: 100%;
+		margin: 0;
+		text-decoration: none;
+	}
 }

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -39,10 +39,13 @@ const GlobalStylesVariation = ( {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const { base } = useContext( GlobalStylesContext );
 	const context = useMemo( () => {
+		const { inline_css: globalStylesVariationInlineCss = '' } = globalStylesVariation;
+		const baseInlineCss = base.inline_css || '';
 		return {
 			user: globalStylesVariation,
 			base,
 			merged: mergeBaseAndUserConfigs( base, globalStylesVariation ),
+			inline_css: baseInlineCss + globalStylesVariationInlineCss,
 		};
 	}, [ globalStylesVariation, base ] );
 
@@ -77,7 +80,7 @@ const GlobalStylesVariation = ( {
 				<GlobalStylesContext.Provider value={ context }>
 					<GlobalStylesVariationPreview
 						title={ globalStylesVariation.title }
-						inlineCss={ globalStylesVariation.inline_css }
+						inlineCss={ context.inline_css }
 						isFocused={ isFocused || showOnlyHoverView }
 						onFocusOut={ () => setIsFocused( false ) }
 					/>


### PR DESCRIPTION
## Proposed Changes

This PR fixes an issue where the style variation/theme preview doesn't display the correct font. The issue is fixed by also including the font-face definitions from the default global styles.

| Before | After |
| --- | --- |
| ![Screenshot 2023-04-24 at 5 52 04 PM](https://user-images.githubusercontent.com/797888/233962880-b7e89bbc-80d3-490b-ade8-941d6d214973.png) | ![Screenshot 2023-04-24 at 5 52 10 PM](https://user-images.githubusercontent.com/797888/233962919-dca456fc-9d45-48e5-b11e-f12453452241.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Click a theme with style variations, such as Storia.
* Ensure that the correct fonts are rendering in both the style variation and theme preview. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
