### PR TITLE
Staging Sites: Fix staging site check that breaks user account in some cases

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -191,7 +191,7 @@ class Site extends Component {
 						{ this.props.isSiteP2 && ! this.props.isP2Hub && (
 							<span className="site__badge is-p2">P2</span>
 						) }
-						{ site.is_wpcom_staging_site && (
+						{ site?.is_wpcom_staging_site && (
 							<SitesStagingBadge className="site__badge" secondary>
 								{ translate( 'Staging' ) }
 							</SitesStagingBadge>

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -51,7 +51,7 @@ class Sites extends Component {
 
 		// Domains can be managed on Simple and Atomic sites.
 		if ( /^\/domains/.test( path ) ) {
-			if ( site.is_wpcom_staging_site ) {
+			if ( site?.is_wpcom_staging_site ) {
 				return false;
 			}
 			return ! site.jetpack || site.options.is_automated_transfer;
@@ -59,7 +59,7 @@ class Sites extends Component {
 
 		// If a site is Jetpack, plans are available only when it is upgradeable.
 		if ( /^\/plans/.test( path ) ) {
-			if ( site.is_wpcom_staging_site ) {
+			if ( site?.is_wpcom_staging_site ) {
 				return false;
 			}
 			return ! site.jetpack || site.capabilities.manage_options;

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -263,7 +263,7 @@ const SiteDropdownMenu = styled( DropdownMenu )( {
 function useSubmenuItems( site: SiteExcerptData ) {
 	const { __ } = useI18n();
 	const siteSlug = site.slug;
-	const isStagingSite = site.is_wpcom_staging_site;
+	const isStagingSite = site?.is_wpcom_staging_site;
 	const isStagingSiteEnabled = isEnabled( 'yolo/staging-sites-i1' );
 	const hasStagingSitesFeature = useSafeSiteHasFeature( site.ID, FEATURE_SITE_STAGING_SITES );
 

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -39,6 +39,7 @@ import {
 	isCustomDomain,
 	isNotAtomicJetpack,
 	isP2Site,
+	isStagingSite,
 } from '../utils';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
@@ -263,7 +264,7 @@ const SiteDropdownMenu = styled( DropdownMenu )( {
 function useSubmenuItems( site: SiteExcerptData ) {
 	const { __ } = useI18n();
 	const siteSlug = site.slug;
-	const isStagingSite = site?.is_wpcom_staging_site;
+	const isWpcomStagingSite = isStagingSite( site );
 	const isStagingSiteEnabled = isEnabled( 'yolo/staging-sites-i1' );
 	const hasStagingSitesFeature = useSafeSiteHasFeature( site.ID, FEATURE_SITE_STAGING_SITES );
 
@@ -283,7 +284,7 @@ function useSubmenuItems( site: SiteExcerptData ) {
 				sectionName: 'database_access',
 			},
 			{
-				condition: ! isStagingSite && isStagingSiteEnabled && hasStagingSitesFeature,
+				condition: ! isWpcomStagingSite && isStagingSiteEnabled && hasStagingSitesFeature,
 				label: __( 'Staging site' ),
 				href: `/hosting-config/${ siteSlug }#staging-site`,
 				sectionName: 'staging_site',
@@ -311,7 +312,7 @@ function useSubmenuItems( site: SiteExcerptData ) {
 				sectionName: 'logs',
 			},
 		].filter( ( { condition } ) => condition ?? true );
-	}, [ __, siteSlug, isStagingSite, isStagingSiteEnabled, hasStagingSitesFeature, isA12n ] );
+	}, [ __, siteSlug, isWpcomStagingSite, isStagingSiteEnabled, hasStagingSitesFeature, isA12n ] );
 }
 
 function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps ) {

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -78,7 +78,7 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 	const { __ } = useI18n();
 
 	const isP2Site = site.options?.is_wpforteams_site;
-	const isStagingSite = site.is_wpcom_staging_site;
+	const isStagingSite = site?.is_wpcom_staging_site;
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 	const isECommerceTrialSite = site.plan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -6,7 +6,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { AnchorHTMLAttributes, memo } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
-import { displaySiteUrl, getDashboardUrl } from '../utils';
+import { displaySiteUrl, getDashboardUrl, isStagingSite } from '../utils';
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
 import { SitesGridActionRenew } from './sites-grid-action-renew';
 import { SitesGridTile } from './sites-grid-tile';
@@ -78,7 +78,7 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 	const { __ } = useI18n();
 
 	const isP2Site = site.options?.is_wpforteams_site;
-	const isStagingSite = site?.is_wpcom_staging_site;
+	const isWpcomStagingSite = isStagingSite( site );
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 	const isECommerceTrialSite = site.plan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 
@@ -123,7 +123,7 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 
 					<div className={ badges }>
 						{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
-						{ isStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
+						{ isWpcomStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
 						{ getSiteLaunchStatus( site ) !== 'public' && (
 							<SitesLaunchStatusBadge>{ translatedStatus }</SitesLaunchStatusBadge>
 						) }

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -9,7 +9,7 @@ import { useSelector } from 'react-redux';
 import StatsSparkline from 'calypso/blocks/stats-sparkline';
 import TimeSince from 'calypso/components/time-since';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { displaySiteUrl, getDashboardUrl, MEDIA_QUERIES } from '../utils';
+import { displaySiteUrl, getDashboardUrl, isStagingSite, MEDIA_QUERIES } from '../utils';
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
 import SitesP2Badge from './sites-p2-badge';
 import { SiteItemThumbnail } from './sites-site-item-thumbnail';
@@ -85,7 +85,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 
 	const isP2Site = site.options?.is_wpforteams_site;
-	const isStagingSite = site?.is_wpcom_staging_site;
+	const isWpcomStagingSite = isStagingSite( site );
 
 	let siteUrl = site.URL;
 	if ( site.options?.is_redirect && site.options?.unmapped_url ) {
@@ -113,7 +113,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 								{ site.title }
 							</SiteName>
 							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }
-							{ isStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
+							{ isWpcomStagingSite && <SitesStagingBadge>{ __( 'Staging' ) }</SitesStagingBadge> }
 						</ListTileTitle>
 					}
 					subtitle={

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -85,7 +85,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 
 	const isP2Site = site.options?.is_wpforteams_site;
-	const isStagingSite = site.is_wpcom_staging_site;
+	const isStagingSite = site?.is_wpcom_staging_site;
 
 	let siteUrl = site.URL;
 	if ( site.options?.is_redirect && site.options?.unmapped_url ) {

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -45,7 +45,7 @@ export const isP2Site = ( site: SiteExcerptNetworkData ) => {
 };
 
 export const isStagingSite = ( site: SiteExcerptNetworkData ) => {
-	return site.is_wpcom_staging_site;
+	return site?.is_wpcom_staging_site;
 };
 
 export const SMALL_MEDIA_QUERY = 'screen and ( max-width: 600px )';

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -44,7 +44,7 @@ export const isP2Site = ( site: SiteExcerptNetworkData ) => {
 	return site.options?.is_wpforteams_site;
 };
 
-export const isStagingSite = ( site: SiteExcerptNetworkData ) => {
+export const isStagingSite = ( site: SiteExcerptNetworkData | undefined ) => {
 	return site?.is_wpcom_staging_site;
 };
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/76099

## Proposed Changes

In this PR, I propose to use optional chaining to avoid breaking UI if not all site data is loaded.

The issue popped out on the domain upsell block on the customer profile page via staging site check from `client/sites-dashboard/utils.ts`. To reproduce without setting upsell on the data level:

1. Run Calypso on local environment
2. Open customer profile
3. Edit the `client/my-sites/customer-home/cards/features/domain-upsell/index.jsx` file and remove three other checks from the condition that includes a check for `isStagingSite`
4. Refresh customer profile

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run Calypso on the local environment or use Calypso Live
2. Open customer profile
3. Confirm page loads without an error

Additionally, check if:

- staging site has a badge on the Sites page in both table and grid modes
- staging site has a badge in the left sidebar menu
- staging site doesn’t have a link to Staging sites on Sites page context menu

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
