### PR TITLE
Add stats to reader tags

### DIFF
--- a/client/blocks/reader-post-card/tag-link.jsx
+++ b/client/blocks/reader-post-card/tag-link.jsx
@@ -1,7 +1,21 @@
+import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
 
+const noop = () => {};
+
 class TagLink extends Component {
+	static propTypes = {
+		tag: PropTypes.string.isRequired,
+		post: PropTypes.object,
+		onClick: PropTypes.func,
+	};
+
+	static defaultProps = {
+		tag: '',
+		onClick: noop,
+	};
+
 	recordSingleTagClick = () => {
 		const { tag, post } = this.props;
 		recordAction( 'click_tag' );
@@ -11,6 +25,7 @@ class TagLink extends Component {
 				tag: tag.slug,
 			} );
 		}
+		this.props.onClick();
 	};
 
 	render() {

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -1,9 +1,12 @@
 import { useTranslate } from 'i18n-calypso';
+import { connect } from 'react-redux';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
 import { useRelatedMetaByTag } from 'calypso/data/reader/use-related-meta-by-tag';
 import { useTagStats } from 'calypso/data/reader/use-tag-stats';
 import formatNumberCompact from 'calypso/lib/format-number-compact';
+import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import ReaderListFollowingItem from 'calypso/reader/stream/reader-list-followed-sites/item';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import '../style.scss';
 
 const ReaderTagSidebar = ( { tag } ) => {
@@ -14,8 +17,16 @@ const ReaderTagSidebar = ( { tag } ) => {
 		return null;
 	}
 
+	const handleTagSidebarClick = () => {
+		recordAction( 'clicked_reader_sidebar_tag' );
+		recordGaEvent( 'Clicked Reader Sidebar Tag' );
+		recordReaderTracksEvent( 'calypso_reader_sidebar_tag_clicked', {
+			tag: decodeURIComponent( tag ),
+		} );
+	};
+
 	const tagLinks = relatedMetaByTag.data?.related_tags?.map( ( relatedTag ) => (
-		<TagLink tag={ relatedTag } key={ relatedTag.slug } />
+		<TagLink tag={ relatedTag } key={ relatedTag.slug } onClick={ handleTagSidebarClick } />
 	) );
 	const relatedSitesLinks = relatedMetaByTag.data?.related_sites?.map( ( relatedSite ) => (
 		<ReaderListFollowingItem key={ relatedSite.feed_ID } site={ relatedSite } path="/" />
@@ -55,4 +66,4 @@ const ReaderTagSidebar = ( { tag } ) => {
 	);
 };
 
-export default ReaderTagSidebar;
+export default connect( null, { recordReaderTracksEvent } )( ReaderTagSidebar );


### PR DESCRIPTION
This PR adds stats to tag click events when they occur from the sidebar.

There are some stats already tracking when the tag is clicked but we don't have a way to know where that tag was rendered.

This PR adds a onClick prop to the TagList component to allow us to extend what is tracked when the tag link is clicked.
