### PR TITLE
Newsletter: update "Lettre" colour to "Allegro Blue"

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/accent-color-control/index.tsx
@@ -44,7 +44,7 @@ export type AccentColor = {
 };
 
 enum COLORS {
-	Lettre = '#113AF5',
+	AllegroBlue = '#113AF5',
 	Black = '#000000',
 	VividRed = '#CF2E2E',
 	VividPurple = '#9B51E0',
@@ -65,9 +65,9 @@ const AccentColorControl = ( {
 	const getColorOptions = useCallback(
 		(): ColorOption[] => [
 			{
-				label: __( 'Lettre' ),
-				value: COLORS.Lettre,
-				icon: <ColorSwatch color={ COLORS.Lettre } />,
+				label: __( 'Allegro Blue' ),
+				value: COLORS.AllegroBlue,
+				icon: <ColorSwatch color={ COLORS.AllegroBlue } />,
 				isPremium: false,
 			},
 			{


### PR DESCRIPTION
## Proposed Changes

* Updating colour "Lettre" to "Allegro Blue"; Lettre is the theme name but as colour name during onboarding its out of context to customers.

## Testing Instructions

* Open `/setup/newsletter` at localhost or calypso live
* At setup step note the colour dropdown

<img width="679" alt="Screenshot 2023-04-24 at 14 47 49" src="https://user-images.githubusercontent.com/87168/233987507-ea038df1-d1b5-4d18-a03a-e5719536f937.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
