### PR TITLE
Site Assembler - Large patterns like LIB are cut-off in the large preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -52,6 +52,7 @@ const PatternLargePreview = ( {
 	const frameRef = useRef< HTMLDivElement | null >( null );
 	const listRef = useRef< HTMLUListElement | null >( null );
 	const [ viewportHeight, setViewportHeight ] = useState< number | undefined >( 0 );
+	const [ device, setDevice ] = useState< string >( 'desktop' );
 	const [ blockGap ] = useStyle( 'spacing.blockGap' );
 	const [ backgroundColor ] = useStyle( 'color.background' );
 	const [ patternLargePreviewStyle, setPatternLargePreviewStyle ] = useState( {
@@ -123,6 +124,7 @@ const PatternLargePreview = ( {
 				) }
 			>
 				<PatternRenderer
+					key={ device }
 					patternId={ encodePatternId( pattern.ID ) }
 					viewportHeight={ viewportHeight || frameRef.current?.clientHeight }
 					// Disable default max-height
@@ -197,7 +199,10 @@ const PatternLargePreview = ( {
 			onDeviceChange={ ( device ) => {
 				recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PREVIEW_DEVICE_CLICK, { device } );
 				// Wait for the animation to end in 200ms
-				window.setTimeout( updateViewportHeight, 205 );
+				window.setTimeout( () => {
+					setDevice( device );
+					updateViewportHeight();
+				}, 205 );
 			} }
 		>
 			{ hasSelectedPattern ? (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -29,7 +29,7 @@ interface PatternListRendererProps {
 }
 
 const PLACEHOLDER_HEIGHT = 100;
-const MAX_HEIGHT_FOR_100VH = 500;
+const MIN_HEIGHT_FOR_100VH = 500;
 
 const PatternListItem = ( {
 	pattern,
@@ -80,7 +80,7 @@ const PatternListItem = ( {
 						patternId={ encodePatternId( pattern.ID ) }
 						viewportWidth={ 1060 }
 						minHeight={ PLACEHOLDER_HEIGHT }
-						maxHeightFor100vh={ MAX_HEIGHT_FOR_100VH }
+						minHeightFor100vh={ MIN_HEIGHT_FOR_100VH }
 					/>
 				) : (
 					<div key={ pattern.ID } style={ { height: PLACEHOLDER_HEIGHT } } />

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -88,7 +88,7 @@ const ScaledBlockRendererContainer = ( {
 	}, [] );
 
 	const scale = containerWidth / viewportWidth;
-	const maxHeightFor100vh = Math.max(
+	const heightFor100vh = Math.max(
 		contentHeight || 0,
 		viewportHeight || 0,
 		minHeightFor100vh || 0
@@ -97,13 +97,13 @@ const ScaledBlockRendererContainer = ( {
 	let scaledHeight = ( contentHeight as number ) * scale || minHeight;
 	if ( isMinHeight100vh ) {
 		// Handling container height of patterns with height 100vh
-		scaledHeight = maxHeightFor100vh * scale;
+		scaledHeight = heightFor100vh * scale;
 	}
 
 	let iframeHeight = contentHeight as number;
 	if ( isMinHeight100vh ) {
 		// Handling iframe height of patterns with height 100vh
-		iframeHeight = maxHeightFor100vh;
+		iframeHeight = heightFor100vh;
 	}
 
 	return (

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -22,7 +22,7 @@ interface BlockRendererContainerProps {
 	maxHeight?: 'none' | number;
 	minHeight?: number;
 	isMinHeight100vh?: boolean;
-	maxHeightFor100vh?: number;
+	minHeightFor100vh?: number;
 }
 
 interface ScaledBlockRendererContainerProps extends BlockRendererContainerProps {
@@ -39,7 +39,7 @@ const ScaledBlockRendererContainer = ( {
 	maxHeight = BLOCK_MAX_HEIGHT,
 	minHeight,
 	isMinHeight100vh,
-	maxHeightFor100vh,
+	minHeightFor100vh,
 }: ScaledBlockRendererContainerProps ) => {
 	const [ isLoaded, setIsLoaded ] = useState( false );
 	const [ contentResizeListener, { height: contentHeight } ] = useResizeObserver();
@@ -88,19 +88,22 @@ const ScaledBlockRendererContainer = ( {
 	}, [] );
 
 	const scale = containerWidth / viewportWidth;
+	const maxHeightFor100vh = Math.max(
+		contentHeight || 0,
+		viewportHeight || 0,
+		minHeightFor100vh || 0
+	);
 
 	let scaledHeight = ( contentHeight as number ) * scale || minHeight;
-	if ( isMinHeight100vh && maxHeightFor100vh && ! viewportHeight ) {
+	if ( isMinHeight100vh ) {
+		// Handling container height of patterns with height 100vh
 		scaledHeight = maxHeightFor100vh * scale;
 	}
 
 	let iframeHeight = contentHeight as number;
 	if ( isMinHeight100vh ) {
-		if ( viewportHeight ) {
-			iframeHeight = viewportHeight;
-		} else if ( maxHeightFor100vh ) {
-			iframeHeight = maxHeightFor100vh;
-		}
+		// Handling iframe height of patterns with height 100vh
+		iframeHeight = maxHeightFor100vh;
 	}
 
 	return (

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -8,7 +8,7 @@ interface Props {
 	viewportHeight?: number;
 	minHeight?: number;
 	maxHeight?: 'none' | number;
-	maxHeightFor100vh?: number;
+	minHeightFor100vh?: number;
 	placeholder?: JSX.Element;
 }
 
@@ -18,7 +18,7 @@ const PatternRenderer = ( {
 	viewportHeight,
 	minHeight,
 	maxHeight,
-	maxHeightFor100vh,
+	minHeightFor100vh,
 }: Props ) => {
 	const renderedPatterns = usePatternsRendererContext();
 	const pattern = renderedPatterns[ patternId ];
@@ -31,7 +31,7 @@ const PatternRenderer = ( {
 			maxHeight={ maxHeight }
 			minHeight={ minHeight }
 			isMinHeight100vh={ pattern?.html?.includes( 'min-height:100vh' ) }
-			maxHeightFor100vh={ maxHeightFor100vh }
+			minHeightFor100vh={ minHeightFor100vh }
 		>
 			<div
 				// eslint-disable-next-line react/no-danger


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Closes #76129
Related #76039 #72321

## Proposed Changes

* Fix pattern thumbnail preview of patterns with `min-height: 100vh`
* Fix also the large preview for all device viewports

### Before

https://user-images.githubusercontent.com/1881481/233988424-4ad1fd28-90cf-4367-af3d-8f9f19084c25.mov 

### After 

https://user-images.githubusercontent.com/1881481/233988658-c4ab5b36-a25c-4d45-834d-ba436f004f97.mov


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to /setup?siteSlug=<your_site>
- Click the `Continue` button until you land on the Design Picker step
- Scroll to the bottom and click on `Start Designing`
- Click `Sections` and select any pattern from the category `Link In Bio`
- Click to switch devices
- Resize the window
- Make sure the pattern height is always at least 100% of the viewport height
- You will have to scroll to see the pattern content when the device is mobile or tablet
- Make sure the pattern is never cut off and you see all the pattern content when scrolling

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
