### PR TITLE
Monthly plan upsell: Added strings for translation

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/annual-upsell/upsell-translations.js
+++ b/client/my-sites/checkout/upsell-nudge/annual-upsell/upsell-translations.js
@@ -1,0 +1,19 @@
+import { translate } from 'i18n-calypso';
+
+translate( 'Switch to an Annual Plan and Save %(savingsValue)', {
+	args: {
+		savingsValue: '30%',
+	},
+} );
+translate(
+	'When choosing annual billing, you’ll save on your WordPress.com subscription and get a custom domain name free for the first year.'
+);
+translate( 'That’s a total savings of %(savingsValue)!', {
+	args: {
+		savingsValue: '30%',
+	},
+} );
+translate( 'Ready to start saving? Click {{strong}}Add to cart{{/strong}} below to get started.' );
+
+translate( 'Add to cart' );
+translate( 'Consider later' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2194-gh-Automattic/dotcom-forge

## Proposed Changes

* Added strings for early translation:

![image](https://user-images.githubusercontent.com/1044309/234007807-c2502579-b989-4236-898a-803b91434eb2.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure strings are good to be used
* I have changed the string `When you choose annual billing` to `When choosing annual billing` does it look better?
* Make sure Calypso load well
