### PR TITLE
Limited Global Styles: Show gating modal in the view canvas mode

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/store.js
@@ -1,4 +1,4 @@
-import { createRegistrySelector, registerStore } from '@wordpress/data';
+import { registerStore } from '@wordpress/data';
 
 const DEFAULT_STATE = {
 	isModalVisible: true,
@@ -24,11 +24,9 @@ registerStore( 'automattic/wpcom-global-styles', {
 	},
 
 	selectors: {
-		isModalVisible: createRegistrySelector( ( select ) => ( state ) => {
-			const currentSidebar =
-				select( 'core/interface' ).getActiveComplementaryArea( 'core/edit-site' );
-			return currentSidebar === 'edit-site/global-styles' && state.isModalVisible;
-		} ),
+		isModalVisible: ( state, currentSidebar, viewCanvasPath ) =>
+			state.isModalVisible &&
+			( currentSidebar === 'edit-site/global-styles' || viewCanvasPath === '/wp_global_styles' ),
 	},
 
 	persist: true,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2204

## Proposed Changes

Displays the Global Styles gating modal upon entering the Styles section of the view canvas mode (aka browse mode).

## Testing Instructions

- Apply these changes to your sandbox
- Create a new site and sandbox it
- Open the site editor
- While in the view canvas mode, go to Styles
- Make sure the gating modal shows up
- Enter the edit canvas mode and open the Styles sidebar
- Make sure the gating modal doesn't show up
