### PR TITLE
Fix correct prop type to fix warning

### DIFF
--- a/client/blocks/reader-post-card/tag-link.jsx
+++ b/client/blocks/reader-post-card/tag-link.jsx
@@ -6,7 +6,7 @@ const noop = () => {};
 
 class TagLink extends Component {
 	static propTypes = {
-		tag: PropTypes.string.isRequired,
+		tag: PropTypes.object.isRequired,
 		post: PropTypes.object,
 		onClick: PropTypes.func,
 	};


### PR DESCRIPTION
Fixes bug with incorrect prop type. The tag is an object, not a string. This throws error in console.