### PR TITLE
Remove siteless domain url from Calypso purchases history and receipt.

### DIFF
--- a/client/me/purchases/billing-history/billing-history-list.tsx
+++ b/client/me/purchases/billing-history/billing-history-list.tsx
@@ -98,11 +98,13 @@ class BillingHistoryList extends Component<
 	serviceNameDescription = ( transaction: BillingTransactionItem ) => {
 		const plan = capitalPDangit( transaction.variation );
 		if ( transaction.domain ) {
+			const isSitelessHoldingSite =
+				/^siteless\.(jetpack|akismet)\.com/.test( transaction.domain ) ?? false;
 			const termLabel = getTransactionTermLabel( transaction, this.props.translate );
 			return (
 				<div>
 					<strong>{ plan }</strong>
-					<small>{ transaction.domain }</small>
+					{ ! isSitelessHoldingSite && <small>{ transaction.domain }</small> }
 					{ termLabel ? <small>{ termLabel }</small> : null }
 					{ transaction.licensed_quantity && (
 						<small>{ renderTransactionQuantitySummary( transaction, this.props.translate ) }</small>

--- a/client/me/purchases/billing-history/billing-history-list.tsx
+++ b/client/me/purchases/billing-history/billing-history-list.tsx
@@ -97,25 +97,16 @@ class BillingHistoryList extends Component<
 
 	serviceNameDescription = ( transaction: BillingTransactionItem ) => {
 		const plan = capitalPDangit( transaction.variation );
-		if ( transaction.domain ) {
-			const isSitelessHoldingSite =
-				/^siteless\.(jetpack|akismet)\.com/.test( transaction.domain ) ?? false;
-			const termLabel = getTransactionTermLabel( transaction, this.props.translate );
-			return (
-				<div>
-					<strong>{ plan }</strong>
-					{ ! isSitelessHoldingSite && <small>{ transaction.domain }</small> }
-					{ termLabel ? <small>{ termLabel }</small> : null }
-					{ transaction.licensed_quantity && (
-						<small>{ renderTransactionQuantitySummary( transaction, this.props.translate ) }</small>
-					) }
-				</div>
-			);
-		}
+		const termLabel = getTransactionTermLabel( transaction, this.props.translate );
 		return (
-			<strong>
-				{ transaction.product } { plan }
-			</strong>
+			<div>
+				<strong>{ plan }</strong>
+				{ transaction.domain && <small>{ transaction.domain }</small> }
+				{ termLabel && <small>{ termLabel }</small> }
+				{ transaction.licensed_quantity && (
+					<small>{ renderTransactionQuantitySummary( transaction, this.props.translate ) }</small>
+				) }
+			</div>
 		);
 	};
 

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -306,15 +306,14 @@ function ReceiptLineItems( { transaction }: { transaction: BillingTransaction } 
 
 	const items = groupedTransactionItems.map( ( item ) => {
 		const termLabel = getTransactionTermLabel( item, translate );
-		const isSitelessHoldingSite = /^siteless\.(jetpack|akismet)\.com/.test( item.domain ) ?? false;
 		return (
 			<tr key={ item.id }>
 				<td className="billing-history__receipt-item-name">
 					<span>{ item.variation }</span>
 					<small>({ item.type_localized })</small>
-					{ termLabel ? <em>{ termLabel }</em> : null }
+					{ termLabel && <em>{ termLabel }</em> }
 					<br />
-					{ ! isSitelessHoldingSite && <em>{ item.domain }</em> }
+					{ item.domain && <em>{ item.domain }</em> }
 					{ item.licensed_quantity && (
 						<em>{ renderTransactionQuantitySummary( item, translate ) }</em>
 					) }

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -306,6 +306,7 @@ function ReceiptLineItems( { transaction }: { transaction: BillingTransaction } 
 
 	const items = groupedTransactionItems.map( ( item ) => {
 		const termLabel = getTransactionTermLabel( item, translate );
+		const isSitelessHoldingSite = /^siteless\.(jetpack|akismet)\.com/.test( item.domain ) ?? false;
 		return (
 			<tr key={ item.id }>
 				<td className="billing-history__receipt-item-name">
@@ -313,7 +314,7 @@ function ReceiptLineItems( { transaction }: { transaction: BillingTransaction } 
 					<small>({ item.type_localized })</small>
 					{ termLabel ? <em>{ termLabel }</em> : null }
 					<br />
-					<em>{ item.domain }</em>
+					{ ! isSitelessHoldingSite && <em>{ item.domain }</em> }
 					{ item.licensed_quantity && (
 						<em>{ renderTransactionQuantitySummary( item, translate ) }</em>
 					) }


### PR DESCRIPTION
This PR remove the siteless.akismet.com (and siteless.jetpack.com licensed-based purchases) domain url from the Calypso purchases billing history and receipt views.
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Asana Task: 1201210512993648-as-1204443245857226/f

## Testing Instructions

**Prerequisites:** 
1. Apply patch D109092-code and sandbox `public-api.wordpress.com`.
2. You should use the store sandbox. (Add `define( 'USE_STORE_SANDBOX', true );` to the `wp-content/mu-plugins/0-sandbox.php` file).
3.  A purchased Akismet plan.  If you do not have a purchased akismet plan for your wordpress.com account, go to https://wordpress.com/checkout/akismet/ak_plus_yearly_1 and complete Akismet purchase.


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch, `git fetch && git checkout fix/remove-siteless-domain-from-purchases-history-and-receipt`
- `yarn start`
- Visit http://calypso.localhost:3000/me/purchases
- Click on the Akismet purchase to view the purchase detail page.
- Click the "Billing history" tab. 
- Verify any/all Akismet purchases do not show the domain `siteles.akismet.com/{random hash} in the purchase item details.
- Click the "View receipt" link. Verify the receipt item details do not show the domain `siteles.akismet.com/{random hash} in the receipt item details.
- Bonus: Check that the `siteless.jetpack.com/{random hash} is not showing for non-activated Jetpack licensed-based purchases also.

#### Screenshots

**Billing History page:**

**BEFORE:**
![Markup 2023-04-24 at 13 39 22](https://user-images.githubusercontent.com/11078128/234075485-9d1f0486-66ad-4588-9316-aafe59521d34.png)


**AFTER:**
![Markup 2023-04-24 at 13 40 48](https://user-images.githubusercontent.com/11078128/234075514-73d66b3b-52d2-4607-a94b-65864b0d8d86.png)

**View Receipt page:**

**BEFORE:**

![Markup 2023-04-24 at 13 42 32](https://user-images.githubusercontent.com/11078128/234075576-f5adf48b-e30d-4a15-9880-3aa432c951e8.png)

**AFTER:**

![Markup 2023-04-24 at 13 43 28](https://user-images.githubusercontent.com/11078128/234075605-9ffe30cc-8e50-47fb-b6c2-0a9d02c7e998.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?