### PR TITLE
Revert "Happy-Blocks: Implement Global Header i2"

### DIFF
--- a/apps/happy-blocks/block-library/universal-header/index.php
+++ b/apps/happy-blocks/block-library/universal-header/index.php
@@ -29,7 +29,6 @@ $happy_blocks_tabs = array(
 )
 ?>
 
-<?php if ( ! is_user_logged_in() ) : ?>
 <div id="lpc-header-nav" class="lpc lpc-header-nav">
 	<div class="x-root lpc-header-nav-wrapper">
 		<div class="lpc-header-nav-container">
@@ -381,25 +380,21 @@ $happy_blocks_tabs = array(
 		</div>
 	</div>
 </div>
-<?php endif; ?>
 <div class="happy-blocks-mini-search">
 	<div class="happy-blocks-search-container">
-		<div class="happy-blocks-global-header__top">
-			<div class="happy-blocks-global-header__tabs-wrapper">
+			<div class="happy-blocks-global-header__top">
 				<div class="happy-blocks-global-header__tabs">
 					<?php foreach ( $happy_blocks_tabs as $key => $happy_blocks_tab ) { ?>
 							<a href="<?php echo esc_attr( $happy_blocks_tab['url'] ); ?>" class="happy-blocks-global-header__tab<?php echo $happy_blocks_current_tab === $key ? ' active' : ''; ?>"><?php echo esc_html( $happy_blocks_tab['title'] ); ?></a>
 					<?php } ?>
 				</div>
-			</div>
-			<div class="happy-blocks-global-header__title-wrapper">
-				<?php if ( $args['include_site_title'] ) : ?>
-					<div class="happy-blocks-global-header-site__title">
-						<h1><?php echo esc_html( $args['site_title'] ); ?></h1>
-						<p><?php echo esc_html( $args['site_tagline'] ); ?></p>
-					</div>
-				<?php endif; ?>
 				<form role="search" method="get" action=""><label for="wp-block-search__input-1" class="screen-reader-text"><?php echo esc_html( $args['search_placeholder'] ); ?></label><div class="happy-blocks-search__inside-wrapper"><input type="search" id="wp-block-search__input-1" name="s" value="" placeholder="<?php echo esc_html( $args['search_placeholder'] ); ?>"></div></form>
 			</div>
+			<?php if ( $args['include_site_title'] ) : ?>
+			<div class="happy-blocks-global-header-site__title">
+				<h1><?php echo esc_html( $args['site_title'] ); ?></h1>
+				<p><?php echo esc_html( $args['site_tagline'] ); ?></p>
+			</div>
+			<?php endif; ?>
 	</div>
 </div>

--- a/apps/happy-blocks/block-library/universal-header/style.scss
+++ b/apps/happy-blocks/block-library/universal-header/style.scss
@@ -601,41 +601,10 @@ body.logged-in .x-dropdown {
 	padding: 0;
 }
 
-.happy-blocks-global-header__tabs-wrapper {
-	border-bottom: 1px solid var(--color-neutral-5);
-}
-
-.happy-blocks-global-header__title-wrapper {
+.happy-blocks-global-header__top {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	max-width: var(--wp--style--global--wide-size, 1224px);
-	margin: 0 auto;
-	gap: 20px;
-
-	form {
-		margin-top: 32px;
-	}
-
-
-	@media only screen and ( max-width: $breakpoint-mobile ) {
-		flex-direction: column-reverse;
-
-		form {
-			width: 100%;
-		}
-
-		.happy-blocks-global-header-site__title {
-			width: 100%;
-
-			h1 {
-				margin-top: 0;
-			}
-		}
-	}
-}
-
-.happy-blocks-global-header__top {
 	margin-top: 37px;
 	margin-bottom: 32px;
 
@@ -647,8 +616,6 @@ body.logged-in .x-dropdown {
 .happy-blocks-global-header__tabs {
 	display: flex;
 	width: 100%;
-	max-width: var(--wp--style--global--wide-size, 1224px);
-	margin: 0 auto;
 }
 
 .happy-blocks-global-header__tab {
@@ -660,7 +627,7 @@ body.logged-in .x-dropdown {
 	color: var(--color-neutral-100);
 
 	&.active {
-		border-bottom: 2px solid var(--color-neutral-70);
+		border-bottom: 2px solid #0675c4;
 	}
 
 	&:hover,
@@ -678,8 +645,8 @@ body.logged-in .x-dropdown {
 	margin-bottom: 45px;
 	// This applies to all search bars
 	.happy-blocks-search__inside-wrapper {
-		// width is 1/3 of the grid width minus 30px / 2 for the grid gap (gap is 30px, we need 2/3 of it)
-		width: calc(var(--wp--style--global--wide-size, 1224px) / 3 - 30px / 2);
+		// width is 1/3 of the grid width minus 30px * 2 / 3 for the grid gap (gap is 30px, we need 2/3 of it)
+		width: calc(var(--wp--style--global--wide-size, 1224px) / 3 - 30px * 2 / 3);
 		height: 50px;
 		max-width: 100%;
 		position: relative;
@@ -729,6 +696,13 @@ body.logged-in .x-dropdown {
 	}
 
 	.happy-blocks-search-container {
+		margin: 0 auto;
+		max-width: var(--wp--style--global--wide-size, 1224px);
+
+		form {
+			width: 100%;
+		}
+
 		@media ( max-width: $breakpoint-desktop ) {
 			padding: 0 24px;
 		}


### PR DESCRIPTION
Reverts Automattic/wp-calypso#76041

I decided to revert this because the page is just way bland now. I'll re-check with Vini and see what he thinks.

![wordpress com_support_ (7)](https://user-images.githubusercontent.com/17054134/234077726-0c3ed58c-44ff-4e4b-806f-6da99f50d402.png)
