### PR TITLE
Move launchpad checklist to data stores package

### DIFF
--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -17,6 +17,7 @@ export { useSiteAnalysis } from './queries/use-site-analysis';
 export { useUserSites } from './queries/use-user-sites';
 export type { AnalysisReport } from './queries/use-site-analysis';
 export { useSiteIntent } from './queries/use-site-intent';
+export { useLaunchpadChecklist, fetchLaunchpadChecklist } from './queries/use-launchpad-checklist';
 export { useSupportAvailability } from './support-queries/use-support-availability';
 export { useSubmitTicketMutation } from './support-queries/use-submit-support-ticket';
 export { useSubmitForumsMutation } from './support-queries/use-submit-forums-topic';

--- a/packages/data-stores/src/queries/use-launchpad-checklist.ts
+++ b/packages/data-stores/src/queries/use-launchpad-checklist.ts
@@ -1,0 +1,52 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useQuery } from 'react-query';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+
+interface APIFetchOptions {
+	global: boolean;
+	path: string;
+}
+
+interface LaunchpadTask {
+	id?: string;
+	completed?: boolean;
+	disabled?: boolean;
+	title?: string;
+	subtitle?: string;
+	badgeText?: string;
+	actionDispatch?: () => void;
+	isLaunchTask?: boolean;
+	warning?: boolean;
+}
+
+interface LaunchpadTasks {
+	checklist: LaunchpadTask[];
+}
+
+export const fetchLaunchpadChecklist = (
+	siteSlug: string | null,
+	siteIntent: string
+): Promise< LaunchpadTasks > => {
+	const slug = encodeURIComponent( siteSlug as string );
+
+	return canAccessWpcomApis()
+		? wpcomRequest( {
+				path: `sites/${ slug }/launchpad/checklist?checklist_slug=${ siteIntent }`,
+				apiNamespace: 'wpcom/v2/',
+				apiVersion: '2',
+		  } )
+		: apiFetch( {
+				global: true,
+				path: `sites/${ slug }/launchpad/checklist?checklist_slug=${ siteIntent }`,
+		  } as APIFetchOptions );
+};
+
+export const useLaunchpadChecklist = ( siteSlug: string | null, siteIntent: string ) => {
+	const key = [ 'launchpad_checklist', siteSlug ];
+	return useQuery( key, () => fetchLaunchpadChecklist( siteSlug, siteIntent ), {
+		retry: 3,
+		initialData: {
+			checklist: [],
+		},
+	} );
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
