### PR TITLE
Fix legacy Akismet plans showing duplicated "Akismet" in the name

### DIFF
--- a/client/me/purchases/billing-history/billing-history-list.tsx
+++ b/client/me/purchases/billing-history/billing-history-list.tsx
@@ -112,7 +112,9 @@ class BillingHistoryList extends Component<
 		}
 		return (
 			<strong>
-				{ transaction.product } { plan }
+				{ /* This fix prevents duplicated "Akismet" in the name for legact Akismet plans, just until the
+				Akismet legacy plans migration to WPCOM takes place. This fix can be undone after migration. */ }
+				{ transaction.product !== 'Akismet' && transaction.product } { plan }
 			</strong>
 		);
 	};


### PR DESCRIPTION
This PR fixes **legacy** Akismet plans showing duplicated "Akismet" in the name in the Calypso purchases Billing History page.

Once legacy Akismet plans are migrated to WPCOM, this fix won't make any difference and could/should be removed.

Slack Thread: p1681810930078149-slack-C04B0GD9LQ6

Asana Task: 1204136657007202-as-1204411461446962/f
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Testing Instructions

TBD... Coming soon..

Prerequisites:
You need a legacy Akismet plan to test this and verify that the product name in the Calypso Billing History page is not duplicated, for example, "Akismet Akismet Pro".

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?