### PR TITLE
Woo Express: Fix interval toggle overflow on small mobile screens

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -9,6 +9,8 @@ import {
 	getPlans,
 	isWooExpressPlan,
 } from '@automattic/calypso-products';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useCallback, useMemo } from 'react';
@@ -46,6 +48,7 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 		yearlyControlProps,
 	} = props;
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const mediumPlanAnnual = getPlans()[ PLAN_WOOEXPRESS_MEDIUM ];
 	const mediumPlanMonthly = getPlans()[ PLAN_WOOEXPRESS_MEDIUM_MONTHLY ];
@@ -71,15 +74,28 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 				...yearlyControlProps,
 				content: (
 					<span>
-						{ translate( 'Pay Annually (Save %(percentageSavings)s%%)', {
-							args: { percentageSavings },
-						} ) }
+						{ isEnglishLocale ||
+						hasTranslation( 'Pay Annually {{span}}(Save %(percentageSavings)s%%){{/span}}' )
+							? translate( 'Pay Annually {{span}}(Save %(percentageSavings)s%%){{/span}}', {
+									args: { percentageSavings },
+									components: { span: <span className="wooexpress-plans__interval-savings" /> },
+							  } )
+							: translate( 'Pay Annually (Save %(percentageSavings)s%%)', {
+									args: { percentageSavings },
+							  } ) }
 					</span>
 				),
 				selected: interval === 'yearly',
 			},
 		];
-	}, [ interval, translate, monthlyControlProps, percentageSavings, yearlyControlProps ] );
+	}, [
+		interval,
+		translate,
+		monthlyControlProps,
+		percentageSavings,
+		yearlyControlProps,
+		isEnglishLocale,
+	] );
 
 	const smallPlan = interval === 'yearly' ? PLAN_WOOEXPRESS_SMALL : PLAN_WOOEXPRESS_SMALL_MONTHLY;
 	const mediumPlan =

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
@@ -15,6 +15,10 @@
 		@media (max-width: $break-mobile) {
 			max-width: 100%;
 			width: 100%;
+
+			.wooexpress-plans__interval-savings {
+				display: none;
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixed #75487

## Proposed Changes

On some older iPhones with small screens (like the SE), the plan interval toggle buttons overflowed the container.

![image](https://user-images.githubusercontent.com/917632/234105448-84a29da9-0be4-497a-a66d-cb962df828a4.png)

This adds a new breakpoint for tiny mobile screens and shrinks the font slightly to prevent the overflow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the calypso.live link, access the `/plans` page for a Woo Express site from either a small mobile device or use your browser's responsive display tools to view the site with a page with of 375px or less.
* Verify that the "Pay Annually" button isn't overflowing the container.
![image](https://user-images.githubusercontent.com/917632/234105816-669bbeba-4f1c-40a2-9dd8-f8f567cd8c40.png)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
