### PR TITLE
VideoPress Onboarding: Do not add cart item if missing site, cart key, or product

### DIFF
--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -192,11 +192,11 @@ const videopress: Flow = {
 					.then( () => {
 						setProgress( 1.0 );
 						const redirectTo = encodeURIComponent(
-							`/setup/videopress/launchpad?siteSlug=${ newSite?.site_slug }&siteId=${ newSite?.blogid }`
+							`/setup/videopress/launchpad?siteSlug=${ newSite.site_slug }&siteId=${ newSite.blogid }`
 						);
 
 						window.location.replace(
-							`/checkout/${ newSite?.site_slug }?signup=1&redirect_to=${ redirectTo }`
+							`/checkout/${ newSite.site_slug }?signup=1&redirect_to=${ redirectTo }`
 						);
 					} );
 			} );

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -18,6 +18,7 @@ import SiteOptions from './internals/steps-repository/site-options';
 import VideomakerSetup from './internals/steps-repository/videomaker-setup';
 import type { Flow, ProvidedDependencies } from './internals/types';
 import type { OnboardSelect, UserSelect } from '@automattic/data-stores';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const videopress: Flow = {
 	name: VIDEOPRESS_FLOW,
@@ -136,9 +137,13 @@ const videopress: Flow = {
 				setProgress( 0.5 );
 
 				const newSite = getNewSite();
-				setSelectedSite( newSite?.blogid );
-				setIntentOnSite( newSite?.site_slug as string, VIDEOPRESS_FLOW as string );
-				saveSiteSettings( newSite?.blogid as number, {
+				if ( ! newSite ) {
+					return;
+				}
+
+				setSelectedSite( newSite.blogid );
+				setIntentOnSite( newSite.site_slug, VIDEOPRESS_FLOW );
+				saveSiteSettings( newSite.blogid, {
 					launchpad_screen: 'full',
 					blogdescription: siteDescription,
 				} );
@@ -150,24 +155,29 @@ const videopress: Flow = {
 
 				const planProductObject = getPlanProduct( planObject?.periodAgnosticSlug, 'MONTHLY' );
 
-				const cartKey = await cartManagerClient.getCartKeyForSiteSlug(
-					newSite?.site_slug as string
-				);
+				const cartKey = newSite.site_slug
+					? await cartManagerClient.getCartKeyForSiteSlug( newSite.site_slug )
+					: null;
 
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				const productsToAdd: any[] = [
-					{
-						product_slug: planProductObject?.storeSlug,
-						extra: {
-							signup_flow: VIDEOPRESS_FLOW,
-						},
-					},
-				];
+				if ( ! cartKey ) {
+					return;
+				}
+
+				const productsToAdd: MinimalRequestCartProduct[] = planProductObject
+					? [
+							{
+								product_slug: planProductObject.storeSlug,
+								extra: {
+									signup_flow: VIDEOPRESS_FLOW,
+								},
+							},
+					  ]
+					: [];
 
 				if ( selectedDomain && selectedDomain.product_slug ) {
 					const registration = domainRegistration( {
 						domain: selectedDomain.domain_name,
-						productSlug: selectedDomain.product_slug as string,
+						productSlug: selectedDomain.product_slug,
 						extra: { privacy_available: selectedDomain.supports_privacy },
 					} );
 
@@ -223,8 +233,8 @@ const videopress: Flow = {
 
 				case 'options': {
 					const { siteTitle, tagline } = providedDependencies;
-					setSiteTitle( siteTitle as string );
-					setSiteDescription( tagline as string );
+					setSiteTitle( siteTitle );
+					setSiteDescription( tagline );
 					return navigate( 'chooseADomain' );
 				}
 


### PR DESCRIPTION
Originally added in https://github.com/Automattic/wp-calypso/pull/67539 and updated in https://github.com/Automattic/wp-calypso/pull/75682, the VideoPress onboarding code tries to add invalid products to the cart (specifically, cart items without a product slug). This happens if the newly created site does not exist, no cart key can be determined, or if the product itself cannot be found.

An example of this error can be found here: https://a8c.sentry.io/issues/4122116103/?project=6313676

Interestingly, TypeScript is set up to guard against all of these situations, but in both the above-mentioned PRs the code uses `as` and `any` to ignore these guards, allowing the bugs into the codebase and causing fatal errors.

## Proposed Changes

In this PR, we remove all unnecessary uses of `as` and `any`, instead bailing out of the function if `getNewSite()` fails, if the returned site data is missing its `site_slug` property, or if the `getPlanProduct()` fails to find a product.

**NOTE:** I chose to bail out silently as this was already done by the `try/catch` around `createVideoPressSite()` in the same function, but if you can think of a better UX, please suggest it. I'm not familiar with this area of the codebase so I'm not sure what the user should see when this happens.

## Testing Instructions

I'm not certain, but here's the test instructions for https://github.com/Automattic/wp-calypso/pull/75682

- Go to `/setup/videopress`
- Follow the steps
- You should get redirected to the checkout page with a premium plan, no plan page should be displayed during the flow.