### PR TITLE
i18n: Add context to the Jetpack 'Complete' plan

### DIFF
--- a/client/jetpack-cloud/sections/comparison/table/useProductsToCompare.ts
+++ b/client/jetpack-cloud/sections/comparison/table/useProductsToCompare.ts
@@ -30,7 +30,7 @@ export const useProductsToCompare = () => {
 			},
 			{
 				id: 'COMPLETE',
-				name: translate( 'Complete' ),
+				name: translate( 'Complete', { context: 'Jetpack plan name' } ),
 				productSlug: PLAN_JETPACK_COMPLETE,
 			},
 		],

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -143,7 +143,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 			label: translate( 'Bundles' ),
 			items: [
 				{
-					label: translate( 'Complete' ),
+					label: translate( 'Complete', { context: 'Jetpack plan name' } ),
 					tagline: translate( 'The ultimate toolkit' ),
 					href: `${ JETPACK_COM_BASE_URL }/complete/`,
 				},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/i18n-issues/issues/595

## Proposed Changes

Add a context for Jetpack 'Complete' plan name to separate it from the word 'Complete'. 
This is a continuation of 7a33e5a94c2fbffddd2f2c1891a3f6d90fc817f8, and reuses the existing `Jetpack plan name` context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Review changes.
- Inspect `calypso-strings.pot` build artifact and confirm the updated 'Complete' string with context are included.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
