### PR TITLE
Subscription Management: Update SortControls design to match sorting on wordpress.com/sites

### DIFF
--- a/client/landing/subscriptions/components/sort-controls/sort-controls.tsx
+++ b/client/landing/subscriptions/components/sort-controls/sort-controls.tsx
@@ -1,5 +1,7 @@
+import { Gridicon } from '@automattic/components';
+import { Button, Dropdown, MenuItemsChoice, NavigableMenu } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, ReactElement } from 'react';
+import { ReactElement, useMemo } from 'react';
 import './styles.scss';
 
 export type Option = {
@@ -19,29 +21,48 @@ const SortControls: < T extends string >( props: SortControlsProps< T > ) => Rea
 	onChange,
 } ) => {
 	const translate = useTranslate();
-
-	const handleSelectChange = ( event: ChangeEvent< HTMLSelectElement > ) => {
-		onChange( event?.target.value as typeof value );
-	};
+	const sortingLabel = useMemo(
+		() => options.find( ( option ) => option.value === value )?.label,
+		[ options, value ]
+	);
 
 	return (
-		<div className="subscription-manager-sort-controls">
-			<label htmlFor="subscription-manager-sort-controls__select">
-				{ translate( 'Sort by:' ) }
-				<select
-					id="subscription-manager-sort-controls__select"
-					className="subscription-manager-sort-controls__select"
-					onChange={ handleSelectChange }
-					value={ value }
+		<Dropdown
+			className="subscription-manager-sort-controls"
+			position="bottom left"
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<Button
+					className="subscription-manager-sort-controls__button"
+					icon={ <Gridicon icon={ isOpen ? 'chevron-up' : 'chevron-down' } /> }
+					iconSize={ 16 }
+					onClick={ onToggle }
+					aria-expanded={ isOpen }
+					onKeyDown={ ( event: React.KeyboardEvent ) => {
+						if ( ! isOpen && event.code === 'ArrowDown' ) {
+							event.preventDefault();
+							onToggle();
+						}
+					} }
 				>
-					{ options.map( ( option ) => (
-						<option key={ `${ option.value }.${ option.label }` } value={ option.value }>
-							{ option.label }
-						</option>
-					) ) }
-				</select>
-			</label>
-		</div>
+					{
+						// translators: %s is the current sorting mode.
+						translate( 'Sort: %(sortingLabel)s', { args: { sortingLabel } } )
+					}
+				</Button>
+			) }
+			renderContent={ ( { onClose } ) => (
+				<NavigableMenu cycle={ false }>
+					<MenuItemsChoice
+						value={ value }
+						onSelect={ ( selectedValue: string ) => {
+							onChange( selectedValue as typeof value );
+							onClose();
+						} }
+						choices={ options }
+					/>
+				</NavigableMenu>
+			) }
+		/>
 	);
 };
 

--- a/client/landing/subscriptions/components/sort-controls/styles.scss
+++ b/client/landing/subscriptions/components/sort-controls/styles.scss
@@ -3,25 +3,13 @@
 @import "@automattic/color-studio/dist/color-variables";
 
 .subscription-manager-sort-controls {
-	select,
-	label {
+	.subscription-manager-sort-controls__button {
+		align-self: stretch;
+		flex-direction: row-reverse;
+		gap: 8px;
+		white-space: nowrap;
 		font-weight: 500;
-		color: $studio-gray-60;
-		line-height: $font-title-small;
 		font-size: $font-body-small;
-	}
-
-	select {
-		border: none;
-
-		&:focus {
-			border-color: var(--color-primary);
-			border-radius: 2px;
-			box-shadow: 0 0 0 1px var(--color-primary), 0 0 0 4px var(--color-primary-10);
-		}
-
-		&:focus-visible {
-			outline: none;
-		}
+		line-height: $font-title-small;
 	}
 }

--- a/client/landing/subscriptions/components/tab-views/comments/comments.tsx
+++ b/client/landing/subscriptions/components/tab-views/comments/comments.tsx
@@ -25,7 +25,7 @@ const isListControlsEnabled = config.isEnabled( 'subscription-management/comment
 
 const Comments = () => {
 	const translate = useTranslate();
-	const [ sortTerm, setSortTerm ] = useState( SortBy.RecentlyCommented );
+	const [ sortTerm, setSortTerm ] = useState( SortBy.RecentlySubscribed );
 	const { searchTerm, handleSearch } = useSearch();
 	const sortOptions = useSortOptions();
 

--- a/client/landing/subscriptions/styles.scss
+++ b/client/landing/subscriptions/styles.scss
@@ -49,6 +49,7 @@ body {
 			display: flex;
 			justify-content: space-between;
 			align-items: center;
+			gap: 8px;
 
 			.subscription-manager__sort-controls {
 				margin-left: auto;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/76068

## Proposed Changes

* Updates `SortControls` design to match sorting on https://wordpress.com/sites
* Fix default sorting option on Comments tab

## Testing Instructions

* Run this PR on your local env
* Go to http://calypso.localhost:3000/subscriptions/sites
* Verify if the SortControls is rendered as expected
* Check if the sorting is working as expected
* Go to Comments tab and check if sorting is working as expected

<img width="324" alt="Screenshot 2023-04-24 at 17 42 57" src="https://user-images.githubusercontent.com/3113712/234113595-1467d2cb-73f4-401e-b7c8-adc64ccd5722.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
