### PR TITLE
Fix small issue with misalignment of x-post layout in Reader

### DIFF
--- a/client/blocks/reader-avatar/style.scss
+++ b/client/blocks/reader-avatar/style.scss
@@ -33,8 +33,6 @@
 		&.has-gravatar.has-site-icon {
 			max-height: 40px;
 			max-width: 40px;
-			min-height: 40px;
-			min-width: 40px;
 		}
 
 		&.has-site-and-author-icon {

--- a/client/blocks/reader-avatar/style.scss
+++ b/client/blocks/reader-avatar/style.scss
@@ -30,10 +30,12 @@
 			min-width: 32px;
 			min-height: 32px;
 		}
-		
+
 		&.has-gravatar.has-site-icon {
 			max-height: 40px;
 			max-width: 40px;
+			min-height: 40px;
+			min-width: 40px;
 		}
 
 		&.has-site-and-author-icon {

--- a/client/blocks/reader-avatar/style.scss
+++ b/client/blocks/reader-avatar/style.scss
@@ -30,6 +30,7 @@
 			min-width: 32px;
 			min-height: 32px;
 		}
+		
 		&.has-gravatar.has-site-icon {
 			max-height: 40px;
 			max-width: 40px;

--- a/client/blocks/reader-avatar/style.scss
+++ b/client/blocks/reader-avatar/style.scss
@@ -30,6 +30,12 @@
 			min-width: 32px;
 			min-height: 32px;
 		}
+		&.has-gravatar.has-site-icon {
+			max-height: 40px;
+			max-width: 40px;
+			min-height: 40px;
+			min-width: 40px;
+		}
 
 		&.has-site-and-author-icon {
 			.site-icon {


### PR DESCRIPTION
## Description

@bluefuton highlighted the following issue: https://github.com/Automattic/wp-calypso/issues/76110 where x-post formatting was inconsistent. I took a pass at fixing this, though I had to use http://calypso.localhost:3000/read/a8c to test it because I didn't have any x-posts in my normal following feed.

### Before
<!-- Updated the original screenshots because they revealed internal information -->
<img width="141" alt="Screenshot 2023-04-26 at 9 50 52 AM" src="https://user-images.githubusercontent.com/17325/234412305-3423a036-f168-4d86-84f6-87719517109b.png">

### After

<img width="140" alt="Screenshot 2023-04-26 at 9 50 59 AM" src="https://user-images.githubusercontent.com/17325/234412326-e74c159d-a324-492c-8267-e321e8aabd1f.png">


## Testing instructions

- Apply this PR locally
- Head to http://calypso.localhost:3000/read/ or http://calypso.localhost:3000/read/a8c if you're an Automattician and look for a x-post which spans more than 2 lines.