### PR TITLE
Fix the alignment of the SectionHeader/SectionSubHeader for RTL

### DIFF
--- a/client/components/section/index.tsx
+++ b/client/components/section/index.tsx
@@ -39,14 +39,24 @@ export const SectionHeader = styled.div< SectionHeaderProps >`
 	font-weight: 400;
 	letter-spacing: -0.4px;
 	line-height: 1.2;
-	text-align: left;
+	html[dir='ltr'] & {
+		text-align: left;
+	}
+	html[dir='rtl'] & {
+		text-align: right;
+	}
 	font-size: var( --scss-font-title-large );
 `;
 
 const SectionSubHeader = styled.div< SectionHeaderProps >`
 	color: var( --${ ( props ) => ( props.dark ? 'color-text-inverted' : 'color-text' ) } );
 	font-weight: 400;
-	text-align: left;
+	html[dir='ltr'] & {
+		text-align: left;
+	}
+	html[dir='rtl'] & {
+		text-align: right;
+	}
 	font-size: var( --scss-font-body-small );
 `;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 606-gh-Automattic/i18n-issues

## Proposed Changes

* Fix the text alignment of sections on the /plugins page to be right-aligned for RTL locales

Before:
<img width="717" alt="Screenshot 2023-04-25 at 00 17 42" src="https://user-images.githubusercontent.com/7847633/234128695-f72c7d84-7eb3-4cfe-b7e1-3d6ceeee4d80.png">

After:
<img width="717" alt="Screenshot 2023-04-25 at 00 18 28" src="https://user-images.githubusercontent.com/7847633/234128682-4e3cc727-03cf-497e-be8a-d96739a0ad66.png">

## Testing Instructions

* Use calypso.live or your local instance with the PR branch.
* Navigate to https://wordpress.com/he/plugins or https://wordpress.com/ar/plugins in incognito mode to test the logged-out Plugins page.
* Switch your user locale to Arabic or Hebrew and check https://wordpress.com/plugins while being logged-in.
* Test with an LTR locale to check for any regression issues.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
