### PR TITLE
Launchpad: Update my home controller redirection to use launchpadChecklist API

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -4,6 +4,7 @@ import { useEffect } from '@wordpress/element';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
+import { useLaunchpadChecklist } from 'calypso/../packages/help-center/src/hooks/use-launchpad-checklist';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useLaunchpad } from 'calypso/data/sites/use-launchpad';
@@ -18,7 +19,6 @@ import { successNotice } from 'calypso/state/notices/actions';
 import { useQuery } from '../../../../hooks/use-query';
 import StepContent from './step-content';
 import { areLaunchpadTasksCompleted } from './task-helper';
-import { launchpadFlowTasks } from './tasks';
 import type { Step } from '../../types';
 import type { SiteSelect } from '@automattic/data-stores';
 
@@ -37,13 +37,17 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	const site = useSite();
 	const {
 		isError: launchpadFetchError,
-		data: { launchpad_screen: launchpadScreenOption, checklist_statuses, site_intent },
+		data: { launchpad_screen: launchpadScreenOption, site_intent: siteIntentOption },
 	} = useLaunchpad( siteSlug );
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 	const recordSignupComplete = useRecordSignupComplete( flow );
 	const dispatch = useDispatch();
 	const { saveSiteSettings } = useWPDispatch( SITE_STORE );
 	const isLoggedIn = useSelector( isUserLoggedIn );
+
+	const {
+		data: { checklist: launchpadChecklist },
+	} = useLaunchpadChecklist( siteSlug, siteIntentOption );
 
 	const fetchingSiteError = useSelect(
 		( select ) => ( select( SITE_STORE ) as SiteSelect ).getFetchingSiteError(),
@@ -65,14 +69,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		redirectToSiteHome( siteSlug, flow );
 	}
 
-	if (
-		areLaunchpadTasksCompleted(
-			site_intent,
-			launchpadFlowTasks,
-			checklist_statuses,
-			isSiteLaunched
-		)
-	) {
+	if ( areLaunchpadTasksCompleted( launchpadChecklist, isSiteLaunched ) ) {
 		saveSiteSettings( site?.ID, { launchpad_screen: 'off' } );
 		redirectToSiteHome( siteSlug, flow );
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -10,6 +10,8 @@ export interface Task {
 	warning?: boolean;
 }
 
+export type LaunchpadChecklist = Task[];
+
 export interface LaunchpadFlowTaskList {
 	[ string: string ]: string[];
 }

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,8 +1,8 @@
 import { isEcommerce } from '@automattic/calypso-products/src';
 import page from 'page';
+import { fetchLaunchpadChecklist } from 'calypso/../packages/help-center/src/hooks/use-launchpad-checklist';
 import { fetchLaunchpad } from 'calypso/data/sites/use-launchpad';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
-import { launchpadFlowTasks } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
@@ -47,21 +47,22 @@ export async function maybeRedirect( context, next ) {
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 
 	try {
-		const { launchpad_screen, checklist_statuses, site_intent } = await fetchLaunchpad( slug );
+		const { launchpad_screen: launchpadScreenOption, site_intent: siteIntentOption } =
+			await fetchLaunchpad( slug );
+		// We can remove this fetchLaunchpadChecklist call once we add the checklist data into the launchpad endpoint
+		const { checklist: launchpadChecklist } = await fetchLaunchpadChecklist(
+			slug,
+			siteIntentOption
+		);
 		if (
-			launchpad_screen === 'full' &&
-			! areLaunchpadTasksCompleted(
-				site_intent,
-				launchpadFlowTasks,
-				checklist_statuses,
-				isSiteLaunched
-			)
+			launchpadScreenOption === 'full' &&
+			! areLaunchpadTasksCompleted( launchpadChecklist, isSiteLaunched )
 		) {
 			// The new stepper launchpad onboarding flow isn't registered within the "page"
 			// client-side router, so page.redirect won't work. We need to use the
 			// traditional window.location Web API.
 			const verifiedParam = getQueryArgs()?.verified;
-			redirectToLaunchpad( slug, site_intent, verifiedParam );
+			redirectToLaunchpad( slug, siteIntentOption, verifiedParam );
 			return;
 		}
 	} catch ( error ) {}

--- a/packages/help-center/src/hooks/use-launchpad-checklist.tsx
+++ b/packages/help-center/src/hooks/use-launchpad-checklist.tsx
@@ -1,0 +1,52 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useQuery } from 'react-query';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+
+interface APIFetchOptions {
+	global: boolean;
+	path: string;
+}
+
+interface LaunchpadTask {
+	id?: string;
+	completed?: boolean;
+	disabled?: boolean;
+	title?: string;
+	subtitle?: string;
+	badgeText?: string;
+	actionDispatch?: () => void;
+	isLaunchTask?: boolean;
+	warning?: boolean;
+}
+
+interface LaunchpadTasks {
+	checklist: LaunchpadTask[];
+}
+
+export const fetchLaunchpadChecklist = (
+	siteSlug: string | null,
+	siteIntent: string
+): Promise< LaunchpadTasks > => {
+	const slug = encodeURIComponent( siteSlug as string );
+
+	return canAccessWpcomApis()
+		? wpcomRequest( {
+				path: `sites/${ slug }/launchpad/checklist?checklist_slug=${ siteIntent }`,
+				apiNamespace: 'wpcom/v2/',
+				apiVersion: '2',
+		  } )
+		: apiFetch( {
+				global: true,
+				path: `sites/${ slug }/launchpad/checklist?checklist_slug=${ siteIntent }`,
+		  } as APIFetchOptions );
+};
+
+export const useLaunchpadChecklist = ( siteSlug: string | null, siteIntent: string ) => {
+	const key = [ 'launchpad_checklist', siteSlug ];
+	return useQuery( key, () => fetchLaunchpadChecklist( siteSlug, siteIntent ), {
+		retry: 3,
+		initialData: {
+			checklist: [],
+		},
+	} );
+};

--- a/packages/help-center/src/hooks/use-launchpad-checklist.tsx
+++ b/packages/help-center/src/hooks/use-launchpad-checklist.tsx
@@ -7,10 +7,10 @@ interface APIFetchOptions {
 	path: string;
 }
 
-interface LaunchpadTask {
-	id?: string;
-	completed?: boolean;
-	disabled?: boolean;
+interface Task {
+	id: string;
+	completed: boolean;
+	disabled: boolean;
 	title?: string;
 	subtitle?: string;
 	badgeText?: string;
@@ -20,7 +20,7 @@ interface LaunchpadTask {
 }
 
 interface LaunchpadTasks {
-	checklist: LaunchpadTask[];
+	checklist: Task[];
 }
 
 export const fetchLaunchpadChecklist = (
@@ -42,11 +42,19 @@ export const fetchLaunchpadChecklist = (
 };
 
 export const useLaunchpadChecklist = ( siteSlug: string | null, siteIntent: string ) => {
-	const key = [ 'launchpad_checklist', siteSlug ];
-	return useQuery( key, () => fetchLaunchpadChecklist( siteSlug, siteIntent ), {
+	const key = [ 'launchpad-checklist', siteSlug ];
+	const queryResult = useQuery( key, () => fetchLaunchpadChecklist( siteSlug, siteIntent ), {
 		retry: 3,
 		initialData: {
 			checklist: [],
 		},
 	} );
+
+	// Typescript is returning the type "T | undefined" for useQuery,
+	// regardless of initialData or placeholderData. Because of this, we
+	// need to narrow the return type ourselves, which is why we have
+	// the ternary we do below.
+	// https://github.com/TanStack/query/discussions/1331#discussioncomment-809549
+	const data = queryResult.isSuccess ? queryResult.data : { checklist: [] };
+	return { ...queryResult, data };
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/wp-calypso/issues/75504

## Proposed Changes

* Update "My home" controller redirection to use launchpadChecklist API to determine if the user should be redirected to the launchpad screen

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Pull the latest launchpad jetpack changes and enable them on your sandbox : `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/registry-for-launchpad-checklists`
* Create a launchpad enabled site (one free site and one newsletter site)
* Verify that you redirected to the launchpad when you visit `/home`
* Complete the last task for both sites , navigate to `/home` and verify you are NOT redirected to the launchpad screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
