### PR TITLE
Blog onboarding: Add plans task to Start writing v1 Launchpad

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,10 +1,10 @@
 import { Gridicon, CircularProgressBar } from '@automattic/components';
+import { OnboardSelect } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
 import { useRef, useState } from '@wordpress/element';
 import { Icon, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import { OnboardSelect } from 'calypso/../packages/data-stores/src';
 import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
 import Badge from 'calypso/components/badge';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,8 +1,10 @@
 import { Gridicon, CircularProgressBar } from '@automattic/components';
+import { useSelect } from '@wordpress/data';
 import { useRef, useState } from '@wordpress/element';
 import { Icon, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import { OnboardSelect } from 'calypso/../packages/data-stores/src';
 import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
 import Badge from 'calypso/components/badge';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
@@ -10,6 +12,7 @@ import Tooltip from 'calypso/components/tooltip';
 import { useLaunchpad } from 'calypso/data/sites/use-launchpad';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
@@ -77,6 +80,13 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 		isEmailVerified
 	);
 
+	const { getPlanCartItem } = useSelect(
+		( select ) => ( {
+			getPlanCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem,
+		} ),
+		[]
+	);
+
 	const enhancedTasks: Task[] | null =
 		site &&
 		getEnhancedTasks(
@@ -88,7 +98,8 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 			goToStep,
 			flow,
 			isEmailVerified,
-			checklist_statuses
+			checklist_statuses,
+			getPlanCartItem()?.product_slug ?? null
 		);
 
 	const currentTask = getTasksProgress( enhancedTasks );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -141,7 +141,7 @@
 }
 
 // Launchpad - Sidebar heading text
-
+.start-writing,
 .newsletter,
 .link-in-bio.launchpad,
 .link-in-bio-tld:not(.domains),
@@ -260,6 +260,10 @@
 		background: var(--studio-blue-10);
 	}
 
+}
+
+.start-writing .launchpad__sidebar-admin-link {
+	display: none;
 }
 
 .launchpad__sidebar-admin-link {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -169,7 +169,7 @@ export function getEnhancedTasks(
 										: FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
 								} ),
 							} );
-							if ( isStartWritingFlow( flow || null ) ) {
+							if ( isStartWritingFlow( flow || null ) && site?.plan?.is_free ) {
 								plansUrl = addQueryArgs( `/setup/${ START_WRITING_FLOW }/plans`, {
 									...{ siteSlug: siteSlug, 'start-writing': true },
 								} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -42,10 +42,14 @@ export function getEnhancedTasks(
 	goToStep?: NavigationControls[ 'goToStep' ],
 	flow?: string | null,
 	isEmailVerified = false,
-	checklistStatuses: LaunchpadStatuses = {}
+	checklistStatuses: LaunchpadStatuses = {},
+	planCartProductSlug?: string | null
 ) {
 	const enhancedTaskList: Task[] = [];
-	const productSlug = site?.plan?.product_slug;
+
+	const productSlug =
+		( flow === START_WRITING_FLOW ? planCartProductSlug : null ) ?? site?.plan?.product_slug;
+
 	const translatedPlanName = productSlug ? PLANS_LIST[ productSlug ].getTitle() : '';
 
 	const linkInBioLinksEditCompleted = checklistStatuses?.links_edited || false;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -40,7 +40,7 @@ export function getEnhancedTasks(
 	submit: NavigationControls[ 'submit' ],
 	displayGlobalStylesWarning: boolean,
 	goToStep?: NavigationControls[ 'goToStep' ],
-	flow?: string | null,
+	flow: string | null = '',
 	isEmailVerified = false,
 	checklistStatuses: LaunchpadStatuses = {},
 	planCartProductSlug?: string | null
@@ -48,7 +48,7 @@ export function getEnhancedTasks(
 	const enhancedTaskList: Task[] = [];
 
 	const productSlug =
-		( flow === START_WRITING_FLOW ? planCartProductSlug : null ) ?? site?.plan?.product_slug;
+		( isStartWritingFlow( flow ) ? planCartProductSlug : null ) ?? site?.plan?.product_slug;
 
 	const translatedPlanName = productSlug ? PLANS_LIST[ productSlug ].getTitle() : '';
 
@@ -60,7 +60,7 @@ export function getEnhancedTasks(
 
 	const firstPostPublishedCompleted = checklistStatuses?.first_post_published || false;
 
-	const planCompleted = checklistStatuses?.plan_selected || ! isStartWritingFlow( flow || null );
+	const planCompleted = checklistStatuses?.plan_selected || ! isStartWritingFlow( flow );
 
 	const videoPressUploadCompleted = checklistStatuses?.video_uploaded || false;
 
@@ -169,7 +169,7 @@ export function getEnhancedTasks(
 										: FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
 								} ),
 							} );
-							if ( isStartWritingFlow( flow || null ) && site?.plan?.is_free ) {
+							if ( isStartWritingFlow( flow ) && site?.plan?.is_free ) {
 								plansUrl = addQueryArgs( `/setup/${ START_WRITING_FLOW }/plans`, {
 									...{ siteSlug: siteSlug, 'start-writing': true },
 								} );
@@ -179,7 +179,7 @@ export function getEnhancedTasks(
 						},
 						badgeText:
 							isVideoPressFlowWithUnsupportedPlan ||
-							( isStartWritingFlow( flow || null ) && ! planCompleted )
+							( isStartWritingFlow( flow ) && ! planCompleted )
 								? null
 								: translatedPlanName,
 						completed: ( planCompleted ?? task.completed ) && ! shouldDisplayWarning,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -60,7 +60,7 @@ export function getEnhancedTasks(
 
 	const firstPostPublishedCompleted = checklistStatuses?.first_post_published || false;
 
-	const planCompleted = checklistStatuses?.plan_selected;
+	const planCompleted = checklistStatuses?.plan_selected || ! isStartWritingFlow( flow || null );
 
 	const videoPressUploadCompleted = checklistStatuses?.video_uploaded || false;
 
@@ -299,6 +299,31 @@ export function getEnhancedTasks(
 
 								setPendingAction( async () => {
 									setProgressTitle( __( 'Launching website' ) );
+									await launchSite( site.ID );
+
+									// Waits for half a second so that the loading screen doesn't flash away too quickly
+									await new Promise( ( res ) => setTimeout( res, 500 ) );
+									recordTaskClickTracksEvent( flow, siteLaunchCompleted, task.id );
+									return { goToHome: true, siteSlug };
+								} );
+
+								submit?.();
+							}
+						},
+					};
+					break;
+				case 'blog_launched':
+					taskData = {
+						title: translate( 'Launch your blog' ),
+						completed: siteLaunchCompleted,
+						isLaunchTask: true,
+						actionDispatch: () => {
+							if ( site?.ID ) {
+								const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE );
+								const { launchSite } = dispatch( SITE_STORE );
+
+								setPendingAction( async () => {
+									setProgressTitle( __( 'Launching blog' ) );
 									await launchSite( site.ID );
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -177,7 +177,11 @@ export function getEnhancedTasks(
 
 							window.location.assign( plansUrl );
 						},
-						badgeText: isVideoPressFlowWithUnsupportedPlan ? null : translatedPlanName,
+						badgeText:
+							isVideoPressFlowWithUnsupportedPlan ||
+							( isStartWritingFlow( flow || null ) && ! planCompleted )
+								? null
+								: translatedPlanName,
 						completed: ( planCompleted ?? task.completed ) && ! shouldDisplayWarning,
 						warning: shouldDisplayWarning,
 					};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -329,7 +329,7 @@ export function getEnhancedTasks(
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );
 									recordTaskClickTracksEvent( flow, siteLaunchCompleted, task.id );
-									return { goToHome: true, siteSlug };
+									return { blogLaunched: true, siteSlug };
 								} );
 
 								submit?.();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -4,7 +4,14 @@ import {
 	PLAN_PREMIUM,
 	FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
 } from '@automattic/calypso-products';
-import { isFreeFlow, isBuildFlow, isWriteFlow, isNewsletterFlow } from '@automattic/onboarding';
+import {
+	isFreeFlow,
+	isBuildFlow,
+	isWriteFlow,
+	isNewsletterFlow,
+	isStartWritingFlow,
+	START_WRITING_FLOW,
+} from '@automattic/onboarding';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -48,6 +55,8 @@ export function getEnhancedTasks(
 	const siteLaunchCompleted = checklistStatuses?.site_launched || false;
 
 	const firstPostPublishedCompleted = checklistStatuses?.first_post_published || false;
+
+	const planCompleted = checklistStatuses?.plan_selected;
 
 	const videoPressUploadCompleted = checklistStatuses?.video_uploaded || false;
 
@@ -148,7 +157,7 @@ export function getEnhancedTasks(
 									'calypso_launchpad_global_styles_gating_plan_selected_task_clicked'
 								);
 							}
-							const plansUrl = addQueryArgs( `/plans/${ siteSlug }`, {
+							let plansUrl = addQueryArgs( `/plans/${ siteSlug }`, {
 								...( shouldDisplayWarning && {
 									plan: PLAN_PREMIUM,
 									feature: isVideoPressFlowWithUnsupportedPlan
@@ -156,10 +165,16 @@ export function getEnhancedTasks(
 										: FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
 								} ),
 							} );
+							if ( isStartWritingFlow( flow || null ) ) {
+								plansUrl = addQueryArgs( `/setup/${ START_WRITING_FLOW }/plans`, {
+									...{ siteSlug: siteSlug, 'start-writing': true },
+								} );
+							}
+
 							window.location.assign( plansUrl );
 						},
 						badgeText: isVideoPressFlowWithUnsupportedPlan ? null : translatedPlanName,
-						completed: task.completed && ! shouldDisplayWarning,
+						completed: ( planCompleted ?? task.completed ) && ! shouldDisplayWarning,
 						warning: shouldDisplayWarning,
 					};
 					break;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tasks.tsx
@@ -85,6 +85,11 @@ export const tasks: Task[] = [
 		disabled: false,
 	},
 	{
+		id: 'blog_launched',
+		completed: false,
+		disabled: false,
+	},
+	{
 		id: 'setup_write',
 		completed: true,
 		disabled: true,
@@ -141,6 +146,6 @@ export const launchpadFlowTasks: LaunchpadFlowTaskList = {
 		'setup_free',
 		DOMAIN_UPSELL,
 		'plan_selected',
-		'site_launched',
+		'blog_launched',
 	],
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { NEWSLETTER_FLOW } from '@automattic/onboarding';
+import { NEWSLETTER_FLOW, START_WRITING_FLOW } from '@automattic/onboarding';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import nock from 'nock';
@@ -139,6 +139,39 @@ describe( 'StepContent', () => {
 
 		it( 'renders web preview section', () => {
 			renderStepContent( false, NEWSLETTER_FLOW );
+
+			expect( screen.getByTitle( 'Preview' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'when flow is Start writing', () => {
+		it( 'renders correct sidebar header content', () => {
+			renderStepContent( false, START_WRITING_FLOW );
+
+			expect( screen.getByText( "Your blog's almost ready!" ) ).toBeInTheDocument();
+			expect(
+				screen.getByText( 'Keep up the momentum with these final steps.' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'renders correct sidebar tasks', () => {
+			renderStepContent( false, START_WRITING_FLOW );
+
+			expect( screen.getByText( 'Write your first post' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Choose a domain' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Choose a plan' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Launch your blog' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders correct status for each task', () => {
+			renderStepContent( false, START_WRITING_FLOW );
+
+			const choosePlanListItem = screen.getByText( 'Choose a plan' ).closest( 'li' );
+			expect( choosePlanListItem ).toHaveClass( 'pending' );
+		} );
+
+		it( 'renders web preview section', () => {
+			renderStepContent( false, START_WRITING_FLOW );
 
 			expect( screen.getByTitle( 'Preview' ) ).toBeInTheDocument();
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/translations.tsx
@@ -6,6 +6,7 @@ import {
 	FREE_FLOW,
 	WRITE_FLOW,
 	BUILD_FLOW,
+	START_WRITING_FLOW,
 } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
 import { TranslatedLaunchpadStrings } from './types';
@@ -42,6 +43,11 @@ export function getLaunchpadTranslations( flow: string | null ): TranslatedLaunc
 			translatedStrings.flowName = translate( 'Video' );
 			translatedStrings.title = translate( 'Your site is almost ready!' );
 			translatedStrings.launchTitle = translate( 'Your site is almost ready!' );
+			break;
+		case START_WRITING_FLOW:
+			translatedStrings.flowName = translate( 'Blog' );
+			translatedStrings.title = translate( "Your blog's almost ready!" );
+			translatedStrings.launchTitle = translate( "Your blog's almost ready!" );
 			break;
 		case WRITE_FLOW:
 		case BUILD_FLOW:

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -30,7 +30,7 @@ export interface LaunchpadStatuses {
 	first_post_published?: boolean;
 	video_uploaded?: boolean;
 	publish_first_course?: boolean;
-	plan_completed?: boolean;
+	plan_selected?: boolean;
 	domain_upsell_deferred?: boolean;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -1,5 +1,5 @@
 import { is2023PricingGridActivePage } from '@automattic/calypso-products';
-import { DOMAIN_UPSELL_FLOW, StepContainer } from '@automattic/onboarding';
+import { DOMAIN_UPSELL_FLOW, START_WRITING_FLOW, StepContainer } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import PlansWrapper from './plans-wrapper';
@@ -12,7 +12,7 @@ const plans: Step = function Plans( { navigation, flow } ) {
 	const handleSubmit = () => {
 		const providedDependencies: ProvidedDependencies = {};
 
-		if ( flow === DOMAIN_UPSELL_FLOW ) {
+		if ( flow === DOMAIN_UPSELL_FLOW || flow === START_WRITING_FLOW ) {
 			providedDependencies.goToCheckout = true;
 		}
 

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -1,6 +1,7 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { START_WRITING_FLOW } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { useSelector } from 'react-redux';
 import { OnboardSelect } from 'calypso/../packages/data-stores/src';
 import { addPlanToCart, addProductsToCart } from 'calypso/../packages/onboarding/src';
@@ -47,8 +48,6 @@ const startWriting: Flow = {
 			} ),
 			[]
 		);
-		const returnUrl = `/setup/${ flowName }/launchpad?siteSlug=${ siteSlug }`;
-		const encodedReturnUrl = encodeURIComponent( returnUrl );
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, currentStep );
@@ -89,12 +88,19 @@ const startWriting: Flow = {
 					return navigate( 'launchpad' );
 				case 'launchpad':
 					if ( getPlanCartItem() || getDomainCartItem() ) {
+						const returnUrl = addQueryArgs( `/home/${ siteSlug }`, {
+							celebrateLaunch: true,
+							launchpadComplete: true,
+						} );
+						const encodedReturnUrl = encodeURIComponent( returnUrl );
+
 						return window.location.assign(
 							`/checkout/${ encodeURIComponent(
 								( siteSlug as string ) ?? ''
 							) }?redirect_to=${ encodedReturnUrl }`
 						);
 					}
+					break;
 			}
 		}
 		return { submit };

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -24,6 +24,7 @@ const startWriting: Flow = {
 				slug: 'processing',
 				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
 			},
+			{ slug: 'plans', asyncComponent: () => import( './internals/steps-repository/plans' ) },
 			{
 				slug: 'launchpad',
 				asyncComponent: () => import( './internals/steps-repository/launchpad' ),
@@ -41,7 +42,7 @@ const startWriting: Flow = {
 				case 'processing': {
 					if ( providedDependencies?.siteSlug ) {
 						await updateLaunchpadSettings( String( providedDependencies?.siteSlug ), {
-							checklist_statuses: { first_post_published: true },
+							checklist_statuses: { first_post_published: true, plan_selected: false },
 						} );
 
 						const siteOrigin = window.location.origin;
@@ -50,7 +51,10 @@ const startWriting: Flow = {
 							`https://${ providedDependencies?.siteSlug }/wp-admin/post-new.php?${ START_WRITING_FLOW }=true&origin=${ siteOrigin }`
 						);
 					}
+					break;
 				}
+				case 'plans':
+					return navigate( 'launchpad' );
 			}
 		}
 		return { submit };
@@ -62,7 +66,9 @@ const startWriting: Flow = {
 		const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
 		const locale = useLocale();
 		const currentPath = window.location.pathname;
-		const isLaunchpad = currentPath.includes( 'setup/start-writing/launchpad' );
+		const isLaunchpad =
+			currentPath.includes( 'setup/start-writing/launchpad' ) ||
+			currentPath.includes( 'setup/start-writing/plans' );
 		const userAlreadyHasSites = currentUserSiteCount && currentUserSiteCount > 0;
 
 		const logInUrl =

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -88,7 +88,7 @@ const startWriting: Flow = {
 						}
 						return window.location.replace( returnUrl );
 					}
-					break;
+					return navigate( 'launchpad' );
 				}
 				case 'plans':
 					if ( siteSlug ) {

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -1,10 +1,9 @@
+import { OnboardSelect } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
-import { START_WRITING_FLOW } from '@automattic/onboarding';
+import { START_WRITING_FLOW, addPlanToCart } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useSelector } from 'react-redux';
-import { OnboardSelect } from 'calypso/../packages/data-stores/src';
-import { addPlanToCart } from 'calypso/../packages/onboarding/src';
 import { updateLaunchpadSettings } from 'calypso/data/sites/use-launchpad';
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
 import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -10,6 +10,7 @@ import {
 	Flow,
 	ProvidedDependencies,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 const startWriting: Flow = {
@@ -34,6 +35,7 @@ const startWriting: Flow = {
 
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
+		const siteSlug = useSiteSlug();
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, currentStep );
 			switch ( currentStep ) {
@@ -54,6 +56,11 @@ const startWriting: Flow = {
 					break;
 				}
 				case 'plans':
+					if ( siteSlug ) {
+						await updateLaunchpadSettings( siteSlug, {
+							checklist_statuses: { plan_selected: true },
+						} );
+					}
 					return navigate( 'launchpad' );
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2219

## Proposed Changes

* This PR adds a functional "Choose a plan" task to /setup/start-writing/launchpad
* You can select a plan.
* When you launch your site, you will be asked to checkout.

Note: This PR only relates to the "Choose a plan" task. The other tasks are outside the scope of this PR and are works in progress / place holders, for the moment.

<img src="https://user-images.githubusercontent.com/140841/234651724-36211ca2-b23f-4c18-8fa3-7716201bc9fe.png" width="300" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a new account with 1 or 0 unlaunched sites with no existing subscriptions.
* Go to calypso.localhost:3000/setup/start-writing/launchpad?siteSlug={siteSlug}&start-writing=true
* Select "Choose a plan"
* Try launching your site (you will need to give your site credits using Store Admin to purchase a plan)
* Try breaking this "task"

Note: this PR only affects the "Choose a plan" task. The other tasks should not be tested for this PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
