### PR TITLE
Odyssey Stats: Disable WPCOM minifier for chunks

### DIFF
--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -60,7 +60,7 @@ module.exports = {
 	output: {
 		path: outputPath,
 		filename: '[name].min.js',
-		chunkFilename: '[name]-[contenthash].js',
+		chunkFilename: '[name]-[contenthash].js?minify=false',
 	},
 	optimization: {
 		minimize: ! isDevelopment,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76158.

## Proposed Changes

* Appends `?minify=false` to Webpack chunk file requests, which should disable WPCOM's broken JS minifier.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Wait for the Odyssey Stats build to complete for this PR.
* Apply this PR's artifacts to your WPCOM sandbox. Also, sandbox `widgets.wp.com`.
* Spin up a fresh Jurassic Ninja site on the bleeding edge version of the Jetpack plugin.
* Connect the site to your WPCOM account.
* Navigate to `/wp-admin/index.php?odyssey_widget=1`.
* Ensure that the new Jetpack Stats Widget (aka "Odyssey Stats Widget" internally) loads and works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
