### PR TITLE
Domain Upsell: Rollback to old design on certain sites only

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/index.jsx
@@ -19,6 +19,7 @@ import { getCurrentUser, isCurrentUserEmailVerified } from 'calypso/state/curren
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
+import isSiteChecklistComplete from 'calypso/state/selectors/is-site-checklist-complete';
 import { getDomainsBySite } from 'calypso/state/sites/domains/selectors';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
@@ -56,6 +57,10 @@ export default function DomainUpsell( { context } ) {
 	const hasPreferences = useSelector( hasReceivedRemotePreferences );
 	const isDismissed = useSelector( ( state ) => getPreference( state, dismissPreference ) );
 
+	const isSiteSetupComplete = useSelector( ( state ) =>
+		isSiteChecklistComplete( state, site?.ID )
+	);
+
 	const shouldNotShowUpselDismissed = ! hasPreferences || isDismissed;
 
 	const shouldNotShowProfileUpsell =
@@ -67,7 +72,8 @@ export default function DomainUpsell( { context } ) {
 			isP2Site( primarySite ) ||
 			isNotAtomicJetpack( primarySite ) );
 
-	const shouldNotShowMyHomeUpsell = ! isProfileUpsell && ( siteDomainsLength || ! isEmailVerified );
+	const shouldNotShowMyHomeUpsell =
+		! isProfileUpsell && ( siteDomainsLength || ! isEmailVerified || isSiteSetupComplete );
 
 	if (
 		shouldNotShowUpselDismissed ||

--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -71,6 +71,7 @@ jest.mock( '@automattic/domain-picker/src', () => {
 
 let pageLink = '';
 jest.mock( 'page', () => ( link ) => ( pageLink = link ) );
+jest.mock( 'calypso/state/checklist/actions' );
 
 const domainUpsellHeadingFreePlan = 'Own your online identity with a custom domain';
 const domainUpsellHeadingPaidPlan = 'Make your mark online with a memorable domain name';

--- a/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/test/index.jsx
@@ -3,6 +3,8 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import DomainUpsell from '../';
@@ -67,9 +69,216 @@ jest.mock( '@automattic/domain-picker/src', () => {
 	};
 } );
 
+let pageLink = '';
+jest.mock( 'page', () => ( link ) => ( pageLink = link ) );
+
 const domainUpsellHeadingFreePlan = 'Own your online identity with a custom domain';
+const domainUpsellHeadingPaidPlan = 'Make your mark online with a memorable domain name';
+const buyThisDomainCta = 'Buy this domain';
+const searchForDomainCta = 'Search for another domain';
 
 describe( 'index', () => {
+	test( 'Should show H3 content for the Home domain upsell and test search domain button link', async () => {
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+
+		render(
+			<Provider store={ store }>
+				<DomainUpsell />
+			</Provider>
+		);
+
+		expect(
+			screen.getByRole( 'heading', { name: domainUpsellHeadingFreePlan } )
+		).toBeInTheDocument();
+
+		const searchLink = screen.getByRole( 'link', { name: searchForDomainCta } );
+		expect( searchLink ).toBeInTheDocument();
+		expect(
+			searchLink.href.endsWith(
+				'/domains/add/example.wordpress.com?domainAndPlanPackage=true&domain=true'
+			)
+		).toBeTruthy();
+	} );
+
+	test( 'Should test the purchase button link on Free and Monthly plans', async () => {
+		nock.cleanAll();
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.post( '/rest/v1.1/me/shopping-cart/1' )
+			.reply( 200 );
+
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+
+		render(
+			<Provider store={ store }>
+				<DomainUpsell />
+			</Provider>
+		);
+
+		const user = userEvent.setup();
+		await user.click( screen.getByRole( 'button', { name: buyThisDomainCta } ) );
+		expect( pageLink ).toBe(
+			'/plans/yearly/example.wordpress.com?domain=true&domainAndPlanPackage=true'
+		);
+	} );
+
+	test( 'Should test the purchase button link on Yearly plans', async () => {
+		nock.cleanAll();
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.post( '/rest/v1.1/me/shopping-cart/1' )
+			.reply( 200 );
+
+		const newInitialState = {
+			...initialState,
+			sites: {
+				...initialState.sites,
+				items: {
+					1: {
+						...initialState.sites.items[ 1 ],
+						plan: {
+							product_slug: 'business-bundle',
+						},
+					},
+				},
+				plans: {
+					1: {
+						product_slug: 'business-bundle',
+					},
+				},
+			},
+		};
+
+		const mockStore = configureStore();
+		const store = mockStore( newInitialState );
+
+		render(
+			<Provider store={ store }>
+				<DomainUpsell />
+			</Provider>
+		);
+
+		const user = userEvent.setup();
+		await user.click( screen.getByRole( 'button', { name: buyThisDomainCta } ) );
+		expect( pageLink ).toBe( '/checkout/example.wordpress.com' );
+	} );
+
+	test( 'Should show H3 content for the Home domain upsell if paid plan with no domains', async () => {
+		const newInitialState = {
+			...initialState,
+			sites: {
+				...initialState.sites,
+				items: {
+					1: {
+						...initialState.sites.items[ 1 ],
+						plan: {
+							product_slug: 'business-bundle',
+						},
+					},
+				},
+				plans: {
+					1: {
+						product_slug: 'business-bundle',
+					},
+				},
+			},
+		};
+
+		const mockStore = configureStore();
+		const store = mockStore( newInitialState );
+
+		render(
+			<Provider store={ store }>
+				<DomainUpsell />
+			</Provider>
+		);
+
+		expect(
+			screen.getByRole( 'heading', { name: domainUpsellHeadingPaidPlan } )
+		).toBeInTheDocument();
+
+		const searchLink = screen.getByRole( 'link', { name: searchForDomainCta } );
+		expect( searchLink ).toBeInTheDocument();
+		expect(
+			searchLink.href.endsWith(
+				'/domains/add/example.wordpress.com?domainAndPlanPackage=true&domain=true'
+			)
+		).toBeTruthy();
+	} );
+
+	test( 'Should NOT show Home domain upsell if paid plan with > 0 custom domains', async () => {
+		const newInitialState = {
+			...initialState,
+			sites: {
+				...initialState.sites,
+				items: {
+					1: {
+						...initialState.sites.items[ 1 ],
+						plan: {
+							product_slug: 'business-bundle',
+						},
+					},
+				},
+				domains: {
+					items: {
+						...initialState.sites.domains.items,
+						1: [
+							...initialState.sites.domains.items[ 1 ],
+							{
+								domain: 'example.com',
+								isWPCOMDomain: false,
+							},
+						],
+					},
+				},
+				plans: {
+					1: {
+						product_slug: 'business-bundle',
+					},
+				},
+			},
+		};
+
+		const mockStore = configureStore();
+		const store = mockStore( newInitialState );
+
+		render(
+			<Provider store={ store }>
+				<DomainUpsell />
+			</Provider>
+		);
+
+		expect(
+			screen.queryByRole( 'heading', { name: domainUpsellHeadingPaidPlan } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'Should not show Home domain upsell if was dismissed', async () => {
+		const newInitialState = {
+			...initialState,
+			preferences: {
+				remoteValues: {
+					'calypso_my_home_domain_upsell_dismiss-1': true,
+				},
+			},
+		};
+
+		const mockStore = configureStore();
+		const store = mockStore( newInitialState );
+
+		render(
+			<Provider store={ store }>
+				<DomainUpsell />
+			</Provider>
+		);
+
+		expect(
+			screen.queryByRole( 'heading', { name: domainUpsellHeadingFreePlan } )
+		).not.toBeInTheDocument();
+	} );
+
 	test( 'Should show the domain upsell in the context of the profile page', async () => {
 		const mockStore = configureStore();
 		const store = mockStore( initialState );

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -1,16 +1,19 @@
 import { createElement } from 'react';
 import BloggingPrompt from 'calypso/components/blogging-prompt-card';
 import {
+	FEATURE_DOMAIN_UPSELL,
 	FEATURE_STATS,
 	SECTION_LEARN_GROW,
 	FEATURE_SUPPORT,
 	SECTION_BLOGGING_PROMPT,
 } from 'calypso/my-sites/customer-home/cards/constants';
+import DomainUpsell from 'calypso/my-sites/customer-home/cards/features/domain-upsell';
 import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
 import Stats from 'calypso/my-sites/customer-home/cards/features/stats';
 import LearnGrow from './learn-grow';
 
 const cardComponents = {
+	[ FEATURE_DOMAIN_UPSELL ]: DomainUpsell,
 	[ FEATURE_STATS ]: Stats,
 	[ SECTION_LEARN_GROW ]: LearnGrow,
 	[ SECTION_BLOGGING_PROMPT ]: BloggingPrompt,

--- a/test/e2e/specs/domain-upsell/domain-upsell__my-home.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__my-home.ts
@@ -1,0 +1,76 @@
+/**
+ * @group calypso-pr
+ */
+
+import {
+	DataHelper,
+	PlansPage,
+	CartCheckoutPage,
+	TestAccount,
+	BrowserManager,
+	SecretsManager,
+	RestAPIClient,
+	MyHomePage,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'My Home: Domain upsell' ), function () {
+	let cartCheckoutPage: CartCheckoutPage;
+	let plansPage: PlansPage;
+	let myHomePage: MyHomePage;
+	let selectedDomain: string;
+	let page: Page;
+	const credentials = SecretsManager.secrets.testAccounts.simpleSiteFreePlanUser;
+
+	beforeAll( async function () {
+		const restAPIClient = new RestAPIClient( credentials );
+		await restAPIClient.clearShoppingCart( credentials.testSites?.primary?.id as number );
+
+		page = await browser.newPage();
+
+		await BrowserManager.setStoreCookie( page );
+
+		const testAccount = new TestAccount( 'simpleSiteFreePlanUser' );
+		await testAccount.authenticate( page, { url: /home/ } );
+	} );
+
+	it( 'Navigate to my home page', async function () {
+		myHomePage = new MyHomePage( page );
+	} );
+
+	it( 'Check Domain Upsell Exists', async function () {
+		await myHomePage.validateDomainUpsell();
+	} );
+
+	it( 'Get available domain', async function () {
+		selectedDomain = await myHomePage.suggestedDomainName();
+	} );
+
+	it( 'Buy suggested domain', async function () {
+		await myHomePage.clickBuySuggestedDomain( 'Buy this domain' );
+	} );
+
+	it( 'View available plans', async function () {
+		plansPage = new PlansPage( page );
+	} );
+
+	it( 'Click button to skip plan', async function () {
+		await plansPage.clickSkipPlanActionButton( 'Or continue with the free plan.' );
+	} );
+
+	it( 'Continue to checkout without a plan', async function () {
+		await plansPage.clickSkipPlanConfirmButton( 'That works for me' );
+	} );
+
+	it( 'Check only one item on checkout', async function () {
+		cartCheckoutPage = new CartCheckoutPage( page );
+		await cartCheckoutPage.validateCartItemsCount( 1 );
+	} );
+
+	it( 'Domain is added to the cart', async function () {
+		cartCheckoutPage = new CartCheckoutPage( page );
+		await cartCheckoutPage.validateCartItem( selectedDomain );
+	} );
+} );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2206

## Proposed Changes

We add (rollback) the Domain Upsell to My home when the site is not launched.

It should match these conditions:
- Email verified.
- Site without a custom domain.
- Site setup not completed.

## Screenshot
![image](https://user-images.githubusercontent.com/402286/234318766-45c32c6d-b205-4f40-965a-7b7a8b4a24e1.png)

## Testing Instructions

* You should apply this diff (D108879-code)
* Go to /home/:siteSlug 
* With a site matching the conditions, you should see the Domain Upsell (email-verified + site without a custom domain + site setup not completed)
* Check with a site that doesn't match the conditions.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~