### PR TITLE
Stats Widget: Fix notice styling impacted by widget styles

### DIFF
--- a/apps/odyssey-stats/src/styles/widget-base.scss
+++ b/apps/odyssey-stats/src/styles/widget-base.scss
@@ -1,4 +1,4 @@
-// Apply dependencies styles from Calypso to Jetpack Widgets.
+// Apply partial dependencies styles from Calypso (calypso/assets/stylesheets/style.scss) to Odyssey Stats Widgets.
 
 // External Dependencies
 @import "calypso/assets/stylesheets/vendor.scss";

--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -7,7 +7,7 @@
 }
 
 // Override notice styles
-#wpbody-content > .notice {
+#wpbody-content .notice {
 	display: block;
 	width: auto;
 	background: var(--studio-white);

--- a/apps/odyssey-stats/src/widget/index.scss
+++ b/apps/odyssey-stats/src/widget/index.scss
@@ -1,4 +1,4 @@
-@import "../styles/base.scss";
+@import "../styles/widget-base.scss";
 @import "../styles/theme.scss";
 @import "../styles/wp-admin.scss";
 @import "../styles/typography.scss";


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76117 

## Proposed Changes

* Change the CSS structure to adjust the applied notice component styles shipped by the widget.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jurassic Ninja site.
* Follow `Option 2` of `PCYsg-Pp7-p2#option-2` to verify changes on the JN site.
* Ensure the JN welcome notice looks as previously.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?