### PR TITLE
Jetpack Pro Dashboard: fix app break during dashboard bulk edit

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
@@ -11,9 +11,10 @@ import './style.scss';
 interface Props {
 	sites: Array< SiteData >;
 	isLargeScreen?: boolean;
+	isLoading: boolean;
 }
 
-export default function EditButton( { sites, isLargeScreen }: Props ) {
+export default function EditButton( { sites, isLargeScreen, isLoading }: Props ) {
 	const translate = useTranslate();
 
 	const { setIsBulkManagementActive, setSelectedSites } = useContext( SitesOverviewContext );
@@ -33,7 +34,12 @@ export default function EditButton( { sites, isLargeScreen }: Props ) {
 
 	return (
 		<ButtonGroup>
-			<Button className="dashboard-bulk-actions__edit-button" compact onClick={ handleEditAll }>
+			<Button
+				className="dashboard-bulk-actions__edit-button"
+				compact
+				onClick={ handleEditAll }
+				disabled={ isLoading }
+			>
 				{ translate( 'Edit All', { context: 'button label' } ) }
 			</Button>
 		</ButtonGroup>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -54,8 +54,15 @@ export default function SitesOverview() {
 
 	const [ highlightTab, setHighlightTab ] = useState( false );
 
-	const { search, currentPage, filter, sort, selectedSites, setSelectedSites } =
-		useContext( SitesOverviewContext );
+	const {
+		search,
+		currentPage,
+		filter,
+		sort,
+		selectedSites,
+		setSelectedSites,
+		setIsBulkManagementActive,
+	} = useContext( SitesOverviewContext );
 
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites(
 		isPartnerOAuthTokenLoaded,
@@ -125,6 +132,7 @@ export default function SitesOverview() {
 					selected: isFavorite ? filter.showOnlyFavorites : ! filter.showOnlyFavorites,
 					path: `${ basePath }${ isFavorite ? '/favorites' : '' }${ search ? '?s=' + search : '' }`,
 					onClick: () => {
+						setIsBulkManagementActive( false );
 						dispatch(
 							recordTracksEvent( 'calypso_jetpack_agency_dashboard_tab_click', {
 								nav_item: navItem.key,
@@ -142,6 +150,7 @@ export default function SitesOverview() {
 			isMobile,
 			search,
 			translate,
+			setIsBulkManagementActive,
 		]
 	);
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -82,7 +82,7 @@ export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Pro
 			</div>
 			<DashboardBulkActions
 				selectedSites={ selectedSites }
-				monitorUserEmails={ sites[ 0 ].monitor.settings?.monitor_user_emails ?? [] }
+				monitorUserEmails={ sites?.[ 0 ]?.monitor?.settings?.monitor_user_emails ?? [] }
 				isLargeScreen={ isLargeScreen }
 			/>
 		</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 import BulkSelect from 'calypso/components/bulk-select';
 import DashboardBulkActions from '../../dashboard-bulk-actions';
 import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
@@ -18,8 +18,7 @@ export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Pro
 	const translate = useTranslate();
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, isLargeScreen );
 
-	const { selectedSites, setSelectedSites, setIsBulkManagementActive } =
-		useContext( SitesOverviewContext );
+	const { selectedSites, setSelectedSites } = useContext( SitesOverviewContext );
 
 	const selectedSiteIds = selectedSites.map( ( site ) => site.blog_id );
 
@@ -56,11 +55,6 @@ export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Pro
 		! isChecked &&
 		selectedSites.length > 0 &&
 		sites.some( ( item ) => selectedSiteIds.includes( item.site.value.blog_id ) );
-
-	useEffect( () => {
-		// If the user navigates away from the page, we want to make sure that the bulk management is deactivated.
-		return () => setIsBulkManagementActive( false );
-	}, [ setIsBulkManagementActive ] );
 
 	return (
 		<div className="site-bulk-select">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import BulkSelect from 'calypso/components/bulk-select';
 import DashboardBulkActions from '../../dashboard-bulk-actions';
 import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
@@ -18,7 +18,8 @@ export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Pro
 	const translate = useTranslate();
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, isLargeScreen );
 
-	const { selectedSites, setSelectedSites } = useContext( SitesOverviewContext );
+	const { selectedSites, setSelectedSites, setIsBulkManagementActive } =
+		useContext( SitesOverviewContext );
 
 	const selectedSiteIds = selectedSites.map( ( site ) => site.blog_id );
 
@@ -55,6 +56,11 @@ export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Pro
 		! isChecked &&
 		selectedSites.length > 0 &&
 		sites.some( ( item ) => selectedSiteIds.includes( item.site.value.blog_id ) );
+
+	useEffect( () => {
+		// If the user navigates away from the page, we want to make sure that the bulk management is deactivated.
+		return () => setIsBulkManagementActive( false );
+	}, [ setIsBulkManagementActive ] );
 
 	return (
 		<div className="site-bulk-select">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -67,7 +67,7 @@ const SiteContent = ( { data, isLoading, currentPage, isFavoritesTab }: Props, r
 								<SiteSort isSortable={ firstColumn.isSortable } columnKey={ firstColumn.key }>
 									<span className="site-content__bulk-select-label">{ firstColumn.title }</span>
 								</SiteSort>
-								<EditButton sites={ sites } />
+								<EditButton sites={ sites } isLoading={ isLoading } />
 							</>
 						) }
 					</Card>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -57,7 +57,7 @@ const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableEle
 							) ) }
 							<th colSpan={ 3 }>
 								<div className="plugin-common-table__bulk-actions">
-									<EditButton isLargeScreen sites={ items } />
+									<EditButton isLargeScreen sites={ items } isLoading={ isLoading } />
 								</div>
 							</th>
 						</>


### PR DESCRIPTION
Related to 1202619025189113-as-1204466907194896

## Proposed Changes

- Show loading for the `Edit All` button when the sites are loading since that breaks the page when clicked when the sites are loading
- Reset bulk management flag when switching to other tabs since that breaks the page when visiting `Favorite` section without closing the bulk management menu


#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/app-break-during-dashboard-bulk-edit` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Verify the `Edit All` button is disabled when the sites are loading.

<img width="299" alt="Screenshot 2023-04-25 at 1 33 24 PM" src="https://user-images.githubusercontent.com/10586875/234213601-e4eb20e1-4741-43ae-9738-4c2174303a70.png">

5. Follow the steps mentioned here - 1202619025189113-as-1204466907194896 and verify the app doesn't break

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?