### PR TITLE
Redirect to monthly to annual upsell for eligible plans post-checkout

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -1,6 +1,5 @@
 import {
 	PLAN_BUSINESS,
-	PLAN_ECOMMERCE,
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 	isJetpackLegacyItem,
@@ -335,7 +334,6 @@ export function upsellNudge( context, next ) {
 			case PLAN_PERSONAL:
 			case PLAN_PREMIUM:
 			case PLAN_BUSINESS:
-			case PLAN_ECOMMERCE:
 				upsellType = ANNUAL_PLAN_UPGRADE_UPSELL;
 				break;
 			case 'business':

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -1,4 +1,10 @@
-import { isJetpackLegacyItem } from '@automattic/calypso-products';
+import {
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	isJetpackLegacyItem,
+} from '@automattic/calypso-products';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -39,6 +45,7 @@ import UpsellNudge, {
 	CONCIERGE_SUPPORT_SESSION,
 	CONCIERGE_QUICKSTART_SESSION,
 	PROFESSIONAL_EMAIL_UPSELL,
+	ANNUAL_PLAN_UPGRADE_UPSELL,
 } from './upsell-nudge';
 import { getProductSlugFromContext, isContextJetpackSitelessCheckout } from './utils';
 
@@ -325,6 +332,12 @@ export function upsellNudge( context, next ) {
 		upgradeItem = context.params.upgradeItem;
 
 		switch ( upgradeItem ) {
+			case PLAN_PERSONAL:
+			case PLAN_PREMIUM:
+			case PLAN_BUSINESS:
+			case PLAN_ECOMMERCE:
+				upsellType = ANNUAL_PLAN_UPGRADE_UPSELL;
+				break;
 			case 'business':
 			case 'business-2-years':
 			case 'business-3-years':

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -606,6 +606,10 @@ function getPlanUpgradeUpsellUrl( {
 	cart: ResponseCart | undefined;
 	siteSlug: string | undefined;
 } ): string | undefined {
+	if ( ! siteSlug ) {
+		return;
+	}
+
 	if ( config.isEnabled( 'upsell/monthly-to-annual' ) ) {
 		if ( cart ) {
 			const upgradeItem = getNextHigherPlanSlug( cart );

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -3,7 +3,7 @@
  *
  * @jest-environment jsdom
  */
-
+import config from '@automattic/calypso-config';
 import {
 	JETPACK_REDIRECT_URL,
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
@@ -31,6 +31,12 @@ jest.mock( '@automattic/calypso-products', () => ( {
 	...( jest.requireActual( '@automattic/calypso-products' ) as object ),
 	redirectCheckoutToWpAdmin: jest.fn(),
 } ) );
+const mockConfig = config as unknown as { isEnabled: jest.Mock };
+jest.mock( '@automattic/calypso-config', () => {
+	const mock = () => '';
+	mock.isEnabled = jest.fn();
+	return mock;
+} );
 
 const samplePurchaseId = 12342424241;
 
@@ -132,6 +138,27 @@ describe( 'getThankYouPageUrl', () => {
 			cart,
 		} );
 		expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/business/:receiptId' );
+	} );
+
+	it( 'redirects to premium plan annual upsell when feature upsell/monthly-to-annual is set and the cart contains the premium monthly plan', () => {
+		mockConfig.isEnabled.mockImplementation( ( flag ) => flag === 'upsell/monthly-to-annual' );
+
+		const cart = {
+			...getMockCart(),
+			products: [
+				{
+					...getEmptyResponseCartProduct(),
+					product_slug: 'value_bundle_monthly',
+				},
+			],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+		} );
+		expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/value_bundle/:receiptId' );
+		mockConfig.isEnabled.mockImplementation( ( flag ) => flag !== 'upsell/monthly-to-annual' );
 	} );
 
 	it( 'redirects to the thank-you page with a placeholder receiptId with a site when the cart is not empty but there is no receipt id', () => {

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -76,6 +76,7 @@ const noop = () => {};
 export const CONCIERGE_QUICKSTART_SESSION = 'concierge-quickstart-session';
 export const CONCIERGE_SUPPORT_SESSION = 'concierge-support-session';
 export const BUSINESS_PLAN_UPGRADE_UPSELL = 'business-plan-upgrade-upsell';
+export const ANNUAL_PLAN_UPGRADE_UPSELL = 'annual-plan-upgrade-upsell';
 export const PROFESSIONAL_EMAIL_UPSELL = 'professional-email-upsell';
 
 export interface UpsellNudgeManualProps {
@@ -327,7 +328,24 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 						hasSevenDayRefundPeriod={ hasSevenDayRefundPeriod }
 					/>
 				);
-
+			case ANNUAL_PLAN_UPGRADE_UPSELL:
+				return isLoading ? (
+					this.renderGenericPlaceholder()
+				) : (
+					<div>
+						<h1>THIS IS THE UPSELL</h1>
+						<BusinessPlanUpgradeUpsell
+							currencyCode={ currencyCode }
+							planRawPrice={ planRawPrice }
+							planDiscountedRawPrice={ planDiscountedRawPrice }
+							receiptId={ receiptId }
+							translate={ translate }
+							handleClickAccept={ this.handleClickAccept }
+							handleClickDecline={ this.handleClickDecline }
+							hasSevenDayRefundPeriod={ hasSevenDayRefundPeriod }
+						/>
+					</div>
+				);
 			case PROFESSIONAL_EMAIL_UPSELL:
 				return (
 					<ProfessionalEmailUpsell

--- a/packages/calypso-products/test/plan-lookups.js
+++ b/packages/calypso-products/test/plan-lookups.js
@@ -783,6 +783,20 @@ describe( 'getPlan', () => {
 
 describe( 'findSimilarPlansKeys', () => {
 	test( 'should return a proper similar plan - by term', () => {
+		expect( findSimilarPlansKeys( PLAN_PERSONAL_MONTHLY, { term: TERM_ANNUALLY } ) ).toEqual( [
+			PLAN_PERSONAL,
+		] );
+		expect( findSimilarPlansKeys( PLAN_PREMIUM_MONTHLY, { term: TERM_ANNUALLY } ) ).toEqual( [
+			PLAN_PREMIUM,
+		] );
+		expect( findSimilarPlansKeys( PLAN_BUSINESS_MONTHLY, { term: TERM_ANNUALLY } ) ).toEqual( [
+			PLAN_BUSINESS,
+		] );
+		expect( findSimilarPlansKeys( PLAN_ECOMMERCE_MONTHLY, { term: TERM_ANNUALLY } ) ).toEqual( [
+			PLAN_ECOMMERCE,
+			PLAN_WOOEXPRESS_MEDIUM,
+			PLAN_WOOEXPRESS_SMALL,
+		] );
 		expect( findSimilarPlansKeys( PLAN_BLOGGER, { term: TERM_BIENNIALLY } ) ).toEqual( [
 			PLAN_BLOGGER_2_YEARS,
 		] );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2229

## Proposed Changes

* Redirect to monthly to annual plan upsell
* The upsell page is not created yet, so using the business upsell as a placeholder
* Gated behind a feature flag

Before

https://user-images.githubusercontent.com/6586048/234275743-c88fd286-9088-4e6e-bbce-85b901a48a2f.mp4



After


https://user-images.githubusercontent.com/6586048/234275754-38ba6921-5495-4df0-a6a3-026cdc4e8589.mp4



## Testing Instructions
Known items in discussion: premium monthly -> premium annual -> business annual upsell route (pebzTe-VQ-p2#comment-1674)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* feature flag used: `upsell/monthly-to-annual`
* go to `/plans/monthly/:siteSlug?flags=upsell/monthly-to-annual` with an account on free plan
* upgrade to a paid monthly planned
* should redirect to temporary upsell placeholder page; see video above, has "THIS IS THE UPSELL" on top
* check the :plan in the URL and make sure it's the corresponding annual plan `/checkout/:siteSlug/offer-plan-upgrade/:plan/:receipt`
* test for personal, premium, business plans
* test around with other checkout flows to make sure nothing is affected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~