### PR TITLE
Woo Express: Hide unavailable features

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/features.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/features.tsx
@@ -9,10 +9,15 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	features: Array< TransformedFeatureObject >;
 	planName: string;
 	domainName: string;
-} > = ( { features, planName, domainName } ) => {
+	hideUnavailableFeatures: boolean;
+} > = ( { features, planName, domainName, hideUnavailableFeatures } ) => {
 	return (
 		<>
 			{ features.map( ( currentFeature, featureIndex ) => {
+				if ( hideUnavailableFeatures && ! currentFeature.availableForCurrentPlan ) {
+					return null;
+				}
+
 				const divClasses = classNames( '', getPlanClass( planName ), {
 					'is-last-feature': featureIndex + 1 === features.length,
 				} );

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -136,6 +136,7 @@ type PlanFeatures2023GridProps = {
 	withDiscount: boolean;
 	discountEndDate: Date;
 	hidePlansFeatureComparison: boolean;
+	hideUnavailableFeatures: boolean;
 };
 
 type PlanFeatures2023GridConnectedProps = {
@@ -790,7 +791,7 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderPlanFeaturesList( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
-		const { domainName, translate } = this.props;
+		const { domainName, translate, hideUnavailableFeatures } = this.props;
 		const planProperties = planPropertiesObj.filter(
 			( properties ) =>
 				! isWpcomEnterpriseGridPlan( properties.planName ) &&
@@ -811,6 +812,7 @@ export class PlanFeatures2023Grid extends Component<
 							features={ features }
 							planName={ planName }
 							domainName={ domainName }
+							hideUnavailableFeatures={ hideUnavailableFeatures }
 						/>
 						{ jpFeatures.length !== 0 && (
 							<div className="plan-features-2023-grid__jp-logo" key="jp-logo">
@@ -827,6 +829,7 @@ export class PlanFeatures2023Grid extends Component<
 							features={ jpFeatures }
 							planName={ planName }
 							domainName={ domainName }
+							hideUnavailableFeatures={ hideUnavailableFeatures }
 						/>
 					</Container>
 				);

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -105,6 +105,7 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 	const plansTableProps = {
 		plans: [ smallPlan, mediumPlan, PLAN_WOOEXPRESS_PLUS ],
 		hidePlansFeatureComparison: false,
+		hideUnavailableFeatures: true,
 		siteId,
 		onUpgradeClick,
 	};


### PR DESCRIPTION
Previously, we displayed unavailable features with a strike-through. The new design calls for them to be hidden instead.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #75298

## Proposed Changes

Previously, unavailable features were displayed with strikethrough text.
![image](https://user-images.githubusercontent.com/917632/234270363-42a7d3de-c8df-4b99-94f7-db39009b08f3.png)

Now we hide unavailable features entirely.
![image](https://user-images.githubusercontent.com/917632/234270421-8ed07482-b55c-4a9f-b79f-cf306b5d4e2b.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch and run calypso locally or use the calypso.live link.
* Go to the plans page for a Woo Express site (Trial or otherwise).
* Make sure the "Pay Monthly" toggle is selected.
* Verify that the "Free domain for a year" feature is not visible for Essential
![image](https://user-images.githubusercontent.com/917632/234270723-b6791fd7-600f-4564-bb63-2df5f46c5724.png)
* Now switch to "Pay Annually and verify that "Free domain for a year" is displayed.
![image](https://user-images.githubusercontent.com/917632/234270815-8a0150bc-2a73-4a7a-8d96-2bc7639c125e.png)
* Then visit `/start` and verify (once you get to the plan selection step) that unavailable monthly features are still strike-through. 
![image](https://user-images.githubusercontent.com/917632/234348748-7a8e24db-b142-4c29-9f0d-133167b1209e.png)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
