### PR TITLE
Stepper: Connect Domain flow

### DIFF
--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -1,5 +1,5 @@
 import { useLocale } from '@automattic/i18n-utils';
-import { useFlowProgress, CONNECT_DOMAIN_FLOW } from '@automattic/onboarding';
+import { CONNECT_DOMAIN_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
@@ -26,7 +26,7 @@ import type { UserSelect } from '@automattic/data-stores';
 const connectDomain: Flow = {
 	name: CONNECT_DOMAIN_FLOW,
 	get title() {
-		return translate( 'Connect Domain' );
+		return translate( 'Connect your domain' );
 	},
 	useAssertConditions: () => {
 		const { domain, provider } = useDomainParams();
@@ -88,10 +88,7 @@ const connectDomain: Flow = {
 	},
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const flowName = this.name;
-		const { setStepProgress } = useDispatch( ONBOARD_STORE );
-		const flowProgress = useFlowProgress( { stepName: _currentStepSlug, flowName } );
 		const { domain, provider } = useDomainParams();
-		setStepProgress( flowProgress );
 
 		// trigger guides on step movement, we don't care about failures or response
 		wpcom.req.post(

--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -1,0 +1,145 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useFlowProgress, CONNECT_DOMAIN_FLOW } from '@automattic/onboarding';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { domainMapping } from 'calypso/lib/cart-values/cart-items';
+import wpcom from 'calypso/lib/wp';
+import {
+	clearSignupDestinationCookie,
+	setSignupCompleteSlug,
+	persistSignupDestination,
+	setSignupCompleteFlowName,
+} from 'calypso/signup/storageUtils';
+import { useDomainParams } from '../hooks/use-domain-params';
+import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { redirect } from './internals/steps-repository/import/util';
+import {
+	AssertConditionResult,
+	AssertConditionState,
+	Flow,
+	ProvidedDependencies,
+} from './internals/types';
+import type { UserSelect } from '@automattic/data-stores';
+
+const connectDomain: Flow = {
+	name: CONNECT_DOMAIN_FLOW,
+	get title() {
+		return translate( 'Connect Domain' );
+	},
+	useAssertConditions: () => {
+		const { domain, provider } = useDomainParams();
+		const flowName = CONNECT_DOMAIN_FLOW;
+		const locale = useLocale();
+		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
+		const userIsLoggedIn = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+			[]
+		);
+
+		if ( ! domain ) {
+			redirect( ` /setup/${ CONNECT_DOMAIN_FLOW }` ); //TODO
+			result = {
+				state: AssertConditionState.FAILURE,
+				message: 'connect-domain requires a domain query parameter',
+			};
+		}
+
+		const redirectTo = `/setup/${ flowName }/plans?domain=${ domain }&provider=${ provider }}`;
+		const logInUrl =
+			locale && locale !== 'en'
+				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Connect%20your%20Domain&redirect_to=${ redirectTo }`
+				: `/start/account/user?variationName=${ flowName }&pageTitle=Connect%20your%20Domain&redirect_to=${ redirectTo }`;
+
+		if ( ! userIsLoggedIn ) {
+			window.location.assign( logInUrl );
+			return {
+				state: AssertConditionState.FAILURE,
+			};
+		}
+
+		return result;
+	},
+	useSideEffect() {
+		const { domain } = useDomainParams();
+		const { setHideFreePlan, setDomainCartItem } = useDispatch( ONBOARD_STORE );
+
+		useEffect( () => {
+			if ( domain ) {
+				setHideFreePlan( true );
+				const domainCartItem = domainMapping( { domain } );
+				setDomainCartItem( domainCartItem );
+			}
+		}, [] );
+	},
+	useSteps() {
+		return [
+			{ slug: 'plans', asyncComponent: () => import( './internals/steps-repository/plans' ) },
+			{
+				slug: 'siteCreationStep',
+				asyncComponent: () => import( './internals/steps-repository/site-creation-step' ),
+			},
+			{
+				slug: 'processing',
+				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
+			},
+		];
+	},
+	useStepNavigation( _currentStepSlug, navigate ) {
+		const flowName = this.name;
+		const { setStepProgress } = useDispatch( ONBOARD_STORE );
+		const flowProgress = useFlowProgress( { stepName: _currentStepSlug, flowName } );
+		const { domain, provider } = useDomainParams();
+		setStepProgress( flowProgress );
+
+		// trigger guides on step movement, we don't care about failures or response
+		wpcom.req.post(
+			'guides/trigger',
+			{
+				apiNamespace: 'wpcom/v2/',
+			},
+			{
+				flow: flowName,
+				step: _currentStepSlug,
+			}
+		);
+
+		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
+			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug, undefined, {
+				provider,
+				domain,
+			} );
+
+			switch ( _currentStepSlug ) {
+				case 'plans':
+					clearSignupDestinationCookie();
+					return navigate( 'siteCreationStep' );
+
+				case 'siteCreationStep':
+					return navigate( 'processing' );
+
+				case 'processing': {
+					const destination = `/domains/mapping/${ providedDependencies.siteSlug }/setup/${ domain }?firstVisit=true`;
+					persistSignupDestination( destination );
+					setSignupCompleteSlug( providedDependencies?.siteSlug );
+					setSignupCompleteFlowName( flowName );
+					const returnUrl = encodeURIComponent( destination );
+
+					return window.location.assign(
+						`/checkout/${ encodeURIComponent(
+							( providedDependencies?.siteSlug as string ) ?? ''
+						) }?redirect_to=${ returnUrl }&signup=1`
+					);
+				}
+			}
+			return providedDependencies;
+		};
+
+		return {
+			submit,
+		};
+	},
+};
+
+export default connectDomain;

--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -46,7 +46,9 @@ const connectDomain: Flow = {
 			};
 		}
 
-		const redirectTo = `/setup/${ flowName }/plans?domain=${ domain }&provider=${ provider }}`;
+		const redirectTo = encodeURIComponent(
+			`/setup/${ flowName }/plans?domain=${ domain }&provider=${ provider }}`
+		);
 		const logInUrl =
 			locale && locale !== 'en'
 				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Connect%20your%20Domain&redirect_to=${ redirectTo }`

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -1,5 +1,5 @@
 import { ProgressBar } from '@automattic/components';
-import { SITE_SETUP_FLOW } from '@automattic/onboarding';
+import { CONNECT_DOMAIN_FLOW, SITE_SETUP_FLOW } from '@automattic/onboarding';
 import classnames from 'classnames';
 import kebabCase from 'calypso/landing/stepper/utils/kebabCase';
 import SignupHeader from 'calypso/signup/signup-header';
@@ -22,14 +22,15 @@ const StepRoute = ( {
 	progressBarExtraStyle,
 	showWooLogo,
 	renderStep,
-}: StepRouteProps ) => (
-	<div
-		className={ classnames( flow.name, flow.variantSlug, flow.classnames, kebabCase( step.slug ) ) }
-	>
-		{ 'videopress' === flow.name && 'intro' === step.slug && <VideoPressIntroBackground /> }
-		{ flow.name !== SITE_SETUP_FLOW && (
-			// The progress bar is removed from the site-setup due to its fragility.
-			// See https://github.com/Automattic/wp-calypso/pull/73653
+}: StepRouteProps ) => {
+	const renderProgressBar = () => {
+		// The progress bar is removed from the site-setup due to its fragility.
+		// See https://github.com/Automattic/wp-calypso/pull/73653
+		if ( [ SITE_SETUP_FLOW, CONNECT_DOMAIN_FLOW ].includes( flow.name ) ) {
+			return null;
+		}
+
+		return (
 			<ProgressBar
 				// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 				className="flow-progress"
@@ -37,10 +38,24 @@ const StepRoute = ( {
 				total={ 100 }
 				style={ progressBarExtraStyle }
 			/>
-		) }
-		<SignupHeader pageTitle={ flow.title } showWooLogo={ showWooLogo } />
-		{ renderStep( step ) }
-	</div>
-);
+		);
+	};
+
+	return (
+		<div
+			className={ classnames(
+				flow.name,
+				flow.variantSlug,
+				flow.classnames,
+				kebabCase( step.slug )
+			) }
+		>
+			{ 'videopress' === flow.name && 'intro' === step.slug && <VideoPressIntroBackground /> }
+			{ renderProgressBar() }
+			<SignupHeader pageTitle={ flow.title } showWooLogo={ showWooLogo } />
+			{ renderStep( step ) }
+		</div>
+	);
+};
 
 export default StepRoute;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -2,7 +2,7 @@
 import { getPlan, PLAN_FREE, is2023PricingGridActivePage } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
-import { DOMAIN_UPSELL_FLOW, NEWSLETTER_FLOW } from '@automattic/onboarding';
+import { DOMAIN_UPSELL_FLOW, isLinkInBioFlow, isNewsletterFlow } from '@automattic/onboarding';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -137,7 +137,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			return __( 'Choose your flavor of WordPress' );
 		}
 
-		if ( flowName === NEWSLETTER_FLOW ) {
+		if ( isNewsletterFlow( flowName ) ) {
 			return __( `There's a plan for you.` );
 		}
 
@@ -155,7 +155,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			<Button onClick={ handleFreePlanButtonClick } className="is-borderless" />
 		);
 
-		if ( flowName === NEWSLETTER_FLOW ) {
+		if ( isNewsletterFlow( flowName ) ) {
 			return hideFreePlan
 				? __( 'Unlock a powerful bundle of features for your Newsletter.' )
 				: translate(
@@ -164,16 +164,27 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 				  );
 		}
 
+		if ( isLinkInBioFlow( flowName ) ) {
+			return hideFreePlan
+				? __( 'Unlock a powerful bundle of features for your Link in Bio.' )
+				: translate(
+						`Unlock a powerful bundle of features for your Link in Bio. Or {{link}}start with a free plan{{/link}}.`,
+						{ components: { link: freePlanButton } }
+				  );
+		}
+
 		if ( flowName === DOMAIN_UPSELL_FLOW ) {
 			return;
 		}
 
-		return hideFreePlan
-			? __( 'Unlock a powerful bundle of features for your Link in Bio.' )
-			: translate(
-					`Unlock a powerful bundle of features for your Link in Bio. Or {{link}}start with a free plan{{/link}}.`,
-					{ components: { link: freePlanButton } }
-			  );
+		if ( ! hideFreePlan ) {
+			return translate(
+				`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
+				{ components: { link: freePlanButton } }
+			);
+		}
+
+		return;
 	};
 	const is2023PricingGridVisible = is2023PricingGridActivePage( window );
 

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -1,4 +1,8 @@
-import { LINK_IN_BIO_DOMAIN_FLOW, START_WRITING_FLOW } from '@automattic/onboarding';
+import {
+	LINK_IN_BIO_DOMAIN_FLOW,
+	START_WRITING_FLOW,
+	CONNECT_DOMAIN_FLOW,
+} from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
 const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
@@ -74,6 +78,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	[ START_WRITING_FLOW ]: () =>
 		import( /* webpackChunkName: "start-writing-flow" */ './start-writing' ),
+
+	[ CONNECT_DOMAIN_FLOW ]: () =>
+		import( /* webpackChunkName: "connect-domain" */ '../declarative-flow/connect-domain' ),
 };
 
 availableFlows[ 'plugin-bundle' ] = () =>

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -5,6 +5,7 @@ export const LINK_IN_BIO_FLOW = 'link-in-bio';
 export const LINK_IN_BIO_DOMAIN_FLOW = 'link-in-bio-domain';
 export const LINK_IN_BIO_TLD_FLOW = 'link-in-bio-tld';
 export const LINK_IN_BIO_POST_SETUP_FLOW = 'link-in-bio-post-setup';
+export const CONNECT_DOMAIN_FLOW = 'connect-domain';
 export const VIDEOPRESS_FLOW = 'videopress';
 export const IMPORT_FOCUSED_FLOW = 'import-focused';
 export const SENSEI_FLOW = 'sensei';


### PR DESCRIPTION
## What

This PR creates a new flow in Stepper: `Connect Domain` .
This flow would allow a user to create a regular site with a domain that they already own.

**The new flow is open to customisation regarding name and titles/subtitles of the steps.**


## Testing
1. Live Link
2. Visit the flow: [Live Link]/setup/connect-domain?domain=[your test domain]&provider=[your test provider]
3. Test the flow in incognito and go through login
4. Check that the flow works.


Related to https://github.com/Automattic/wp-calypso/issues/75048