### PR TITLE
Adjusting feature text on the Jetpack Social pricing card 

### DIFF
--- a/client/jetpack-cloud/sections/jetpack-social/promo.jsx
+++ b/client/jetpack-cloud/sections/jetpack-social/promo.jsx
@@ -32,7 +32,7 @@ export const Promo = ( { isSocialActive, adminUrl, translate } ) => {
 
 	return (
 		<Main wideLayout className="jetpack-social__promo">
-			<DocumentHead title={ titleHeader } />{ ' ' }
+			<DocumentHead title={ titleHeader } />
 			<div className="jetpack-social__promo-content">
 				<JetpackRnaActionCard
 					headerText={ titleHeader }
@@ -44,15 +44,14 @@ export const Promo = ( { isSocialActive, adminUrl, translate } ) => {
 					{ ...ctaProps }
 				>
 					<ul className="jetpack-social__features">
-						{ ' ' }
 						{ features.map( ( feature, i ) => (
 							<li className="jetpack-social__feature" key={ i }>
-								<Gridicon size={ 18 } icon="checkmark" /> { preventWidows( feature ) }{ ' ' }
+								<Gridicon size={ 18 } icon="checkmark" /> { preventWidows( feature ) }
 							</li>
-						) ) }{ ' ' }
-					</ul>{ ' ' }
-				</JetpackRnaActionCard>{ ' ' }
-			</div>{ ' ' }
+						) ) }
+					</ul>
+				</JetpackRnaActionCard>
+			</div>
 		</Main>
 	);
 };

--- a/client/jetpack-cloud/sections/jetpack-social/promo.jsx
+++ b/client/jetpack-cloud/sections/jetpack-social/promo.jsx
@@ -15,7 +15,7 @@ import './promo.scss';
 export const Promo = ( { isSocialActive, adminUrl, translate } ) => {
 	const titleHeader = translate( 'Social', { context: 'Jetpack product name' } );
 	const features = [
-		translate( 'Connect with Twitter, Facebook, LinkedIn and Tumblr' ),
+		translate( 'Connect with Facebook, LinkedIn and Tumblr' ),
 		translate( 'Select the social media to share posts while publishing' ),
 		translate( 'Publish custom messages' ),
 	];
@@ -32,7 +32,7 @@ export const Promo = ( { isSocialActive, adminUrl, translate } ) => {
 
 	return (
 		<Main wideLayout className="jetpack-social__promo">
-			<DocumentHead title={ titleHeader } />
+			<DocumentHead title={ titleHeader } />{ ' ' }
 			<div className="jetpack-social__promo-content">
 				<JetpackRnaActionCard
 					headerText={ titleHeader }
@@ -44,14 +44,15 @@ export const Promo = ( { isSocialActive, adminUrl, translate } ) => {
 					{ ...ctaProps }
 				>
 					<ul className="jetpack-social__features">
+						{ ' ' }
 						{ features.map( ( feature, i ) => (
 							<li className="jetpack-social__feature" key={ i }>
-								<Gridicon size={ 18 } icon="checkmark" /> { preventWidows( feature ) }
+								<Gridicon size={ 18 } icon="checkmark" /> { preventWidows( feature ) }{ ' ' }
 							</li>
-						) ) }
-					</ul>
-				</JetpackRnaActionCard>
-			</div>
+						) ) }{ ' ' }
+					</ul>{ ' ' }
+				</JetpackRnaActionCard>{ ' ' }
+			</div>{ ' ' }
 		</Main>
 	);
 };

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -2083,16 +2083,14 @@ export const FEATURES_LIST: FeatureList = {
 		getTitle: () => i18n.translate( 'Limited shares in social media' ),
 		getDescription: () =>
 			i18n.translate(
-				'Get 30 social shares per month to promote your posts on Facebook, Twitter, Tumblr, and more.'
+				'Get 30 social shares per month to promote your posts on Facebook, Tumblr, and more.'
 			),
 	},
 	[ FEATURE_SHARES_SOCIAL_MEDIA_JP ]: {
 		getSlug: () => FEATURE_SHARES_SOCIAL_MEDIA_JP,
 		getTitle: () => i18n.translate( 'Shares on social media' ),
 		getDescription: () =>
-			i18n.translate(
-				'Automatically share your latest post on Facebook, Twitter, Tumblr, and more.'
-			),
+			i18n.translate( 'Automatically share your latest post on Facebook, Tumblr, and more.' ),
 		getConditionalTitle: ( planSlug ) => {
 			if ( ! planSlug ) {
 				return '';

--- a/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-jetpack-product-features.ts
@@ -85,7 +85,7 @@ function getFeatureStrings(
 				translate( 'Automatically share your posts' ),
 				translate( 'Posting to multiple channels at once' ),
 				translate( 'Scheduled posts' ),
-				translate( 'Sharing to Twitter, Facebook, LinkedIn, and Tumblr' ),
+				translate( 'Sharing to Facebook, LinkedIn, and Tumblr' ),
 				translate( 'Content recycling' ),
 			];
 		case 'support':

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -175,7 +175,7 @@ export const MarketingTools: FunctionComponent = () => {
 				<MarketingToolsFeature
 					title={ translate( 'Get social, and share your blog posts where the people are' ) }
 					description={ translate(
-						"Use your site's Jetpack Social tools to connect your site and your social media accounts, and share your new posts automatically. Connect to Twitter, Facebook, LinkedIn, and more."
+						"Use your site's Jetpack Social tools to connect your site and your social media accounts, and share your new posts automatically. Connect to Facebook, LinkedIn, and more."
 					) }
 					imagePath="/calypso/images/marketing/social-media-logos.svg"
 				>

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -813,7 +813,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Post to multiple channels at once' ),
 		translate( 'Manage all of your channels from a single hub' ),
 		translate( 'Scheduled posts' ),
-		translate( 'Share to Twitter, Facebook, LinkedIn, and Tumblr' ),
+		translate( 'Share to Facebook, LinkedIn, and Tumblr' ),
 		translate( 'Recycle content' ),
 	];
 	const socialAdvancedIncludesInfo = [
@@ -821,7 +821,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Post to multiple channels at once' ),
 		translate( 'Manage all of your channels from a single hub' ),
 		translate( 'Scheduled posts' ),
-		translate( 'Share to Twitter, Facebook, LinkedIn, and Tumblr' ),
+		translate( 'Share to Facebook, LinkedIn, and Tumblr' ),
 		translate( 'Engagement Optimizer' ),
 		translate( 'Recycle content' ),
 		translate( 'Coming soon: Image generator' ),

--- a/packages/components/src/jetpack-upsell-card/index.tsx
+++ b/packages/components/src/jetpack-upsell-card/index.tsx
@@ -86,7 +86,7 @@ export default function JetpackUpsellCard( {
 			},
 			{
 				description: translate(
-					'Save time by auto-posting your content to social networks like Facebook, Twitter, and more.'
+					'Save time by auto-posting your content to social networks like Facebook, LinkedIn, and more.'
 				),
 				href: 'https://jetpack.com/social/',
 				iconUrl: SocialIcon,


### PR DESCRIPTION
We'd like to remove emphasis on certain features in the Jetpack Social pricing card

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1682361449115369-slack-C01264051NE

**Note**- We should get these ready, but shouldn't deploy them yet: p1682449748501889-slack-C04MT6AAYG3

## Proposed Changes

* Adjusting features on the Jetpack Social pricing card

## Testing Instructions
- Patch the changes
- Check if the Social pricing card reflects the changes

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before:
<img width="799" alt="Screen Shot 2023-04-25 at 16 03 45" src="https://user-images.githubusercontent.com/82706809/234285660-de6bb25e-a703-4dc1-83bf-441d5b4a9a4e.png">

After:
<img width="714" alt="Screen Shot 2023-04-25 at 16 03 18" src="https://user-images.githubusercontent.com/82706809/234285701-9cda122f-465c-4fcc-b911-d9627bccbbb5.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?