### PR TITLE
Jetpack Pro Dashboard: scroll top when visiting plugin details page from all plugins page

### DIFF
--- a/client/jetpack-cloud/sections/plugin-management/index.ts
+++ b/client/jetpack-cloud/sections/plugin-management/index.ts
@@ -1,6 +1,7 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
+import { scrollTopIfNoHash } from 'calypso/my-sites/plugins/controller';
 import { pluginManagementContext, pluginDetailsContext } from './controller';
 
 export default function (): void {
@@ -19,9 +20,10 @@ export default function (): void {
 		makeLayout,
 		clientRender
 	);
-	page( '/plugins/:plugin', pluginDetailsContext, makeLayout, clientRender );
+	page( '/plugins/:plugin', scrollTopIfNoHash, pluginDetailsContext, makeLayout, clientRender );
 	page(
 		'/plugins/:plugin/:site',
+		scrollTopIfNoHash,
 		siteSelection,
 		navigation,
 		pluginDetailsContext,


### PR DESCRIPTION
Related to 1202619025189113-as-1204424574580690

Resolves https://github.com/Automattic/wp-calypso/issues/75885

## Proposed Changes

The PR fixes the issue which keeps the scroll position of the previous page when visiting a plugin details page.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout fix/plugin-details-scroll-top` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Click on the `Plugins` tab and scroll to the bottom of the plugin list(make sure you have a large no of plugins installed)
4. Click on any plugin and verify that the scroll position is at the top instead of the current scroll position at the `Plugins` page.
5. Visit any individual site and click on `Plugins` and verify the step 4 here.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>

https://user-images.githubusercontent.com/426388/232761518-9a076fad-b109-4e05-abbd-e6bb2a05e9ca.mov

</td>
<td>

https://user-images.githubusercontent.com/10586875/234286391-9332fdb5-b402-48f2-be5b-c8eeb4ab42d5.mov

</td>
</tr>
</table>


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?