### PR TITLE
add/Jetpack Zendesk Chat to partner dashboard

### DIFF
--- a/client/components/jetpack/jetpack-presales-chat-widget/index.tsx
+++ b/client/components/jetpack/jetpack-presales-chat-widget/index.tsx
@@ -13,6 +13,12 @@ type PresalesChatResponse = {
 	is_available: boolean;
 };
 
+export type KeyType = 'jpAgency' | 'jpGeneral';
+
+export interface ZendeskJetpackChatProps {
+	keyType: KeyType;
+}
+
 //the API is rate limited if we hit the limit we'll back off and retry
 async function fetchWithRetry(
 	url: string,
@@ -38,10 +44,16 @@ async function fetchWithRetry(
 	}
 }
 
-export const ZendeskJetpackChat: React.VFC = () => {
+export const ZendeskJetpackChat: React.VFC< { keyType: KeyType } > = ( { keyType } ) => {
 	const [ error, setError ] = useState( false );
 	const { data: isStaffed } = usePresalesAvailabilityQuery();
-	const zendeskChatKey = config( 'zendesk_presales_chat_key' ) as keyof ConfigData;
+	const zendeskChatKey = useMemo( () => {
+		return config(
+			keyType === 'jpAgency'
+				? 'zendesk_presales_chat_key_jp_agency_dashboard'
+				: 'zendesk_presales_chat_key'
+		) as keyof ConfigData;
+	}, [ keyType ] );
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const shouldShowZendeskPresalesChat = useMemo( () => {
 		const isEnglishLocale = ( config( 'english_locales' ) as string[] ).includes(

--- a/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar/index.tsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { localize, translate as TranslateType } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { ZendeskJetpackChat } from 'calypso/components/jetpack/jetpack-presales-chat-widget';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import Sidebar from 'calypso/layout/sidebar';
 import SidebarItem from 'calypso/layout/sidebar/item';
@@ -105,6 +106,7 @@ class PartnerPortalSidebar extends Component< Props > {
 						) }
 					</SidebarMenu>
 				</SidebarRegion>
+				<ZendeskJetpackChat keyType="jpAgency" />
 			</Sidebar>
 		);
 	}

--- a/client/my-sites/plans/jetpack-plans/product-store/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/index.tsx
@@ -74,7 +74,7 @@ const ProductStore: React.FC< ProductStoreProps > = ( {
 			{ showJetpackFree && <JetpackFree urlQueryArgs={ urlQueryArgs } siteId={ siteId } /> }
 
 			<Recommendations />
-			<ZendeskJetpackChat />
+			<ZendeskJetpackChat keyType="jpGeneral" />
 			<OpenSourceSection />
 
 			<StoreFooter />

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -36,6 +36,7 @@
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"zendesk_presales_chat_key": false,
+	"zendesk_presales_chat_key_jp_agency_dashboard": false,
 	"upwork_support_locales": [
 		"de",
 		"de-at",

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -27,6 +27,7 @@
 	],
 	"oauth_client_id": 68663,
 	"zendesk_presales_chat_key": "7c42153f-f579-49ba-a33e-246b2d27fb93",
+	"zendesk_presales_chat_key_jp_agency_dashboard": "dc0b7d60-f893-4ab4-8aa8-7d7ca45270d8",
 	"features": {
 		"activity-log/v2": true,
 		"always_use_logout_url": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -24,6 +24,7 @@
 		}
 	],
 	"zendesk_presales_chat_key": "7c42153f-f579-49ba-a33e-246b2d27fb93",
+	"zendesk_presales_chat_key_jp_agency_dashboard": "dc0b7d60-f893-4ab4-8aa8-7d7ca45270d8",
 	"features": {
 		"activity-log/v2": true,
 		"always_use_logout_url": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -25,6 +25,7 @@
 	],
 	"oauth_client_id": 69041,
 	"zendesk_presales_chat_key": "7c42153f-f579-49ba-a33e-246b2d27fb93",
+	"zendesk_presales_chat_key_jp_agency_dashboard": "dc0b7d60-f893-4ab4-8aa8-7d7ca45270d8",
 	"features": {
 		"activity-log/v2": true,
 		"ad-tracking": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -25,6 +25,7 @@
 	],
 	"oauth_client_id": 69040,
 	"zendesk_presales_chat_key": "7c42153f-f579-49ba-a33e-246b2d27fb93",
+	"zendesk_presales_chat_key_jp_agency_dashboard": "dc0b7d60-f893-4ab4-8aa8-7d7ca45270d8",
 	"features": {
 		"activity-log/v2": true,
 		"ad-tracking": false,


### PR DESCRIPTION
Related to [#](p7pQDF-8iG-p2)

## Proposed Changes

* This PR adds the Zendesk chat widget to cloud.jetpack.com/partner-portal
* The component is called from the Sidebar of the partner portal because that site has no footer, and adding one would have caused a lot of complications and delay
* Because this chat widget uses a different API key, a few changes had to be made to the existing chat widget code.
* A new property was created called keyType which expects either jpGeneral or jpAgency
* Based on which type is passed, the widget will fetch the corresponding API key
* New keys were added for the agency to the environment files

## Testing Instructions

* Use the Jetpack Cloud live link, or build this PR locally and head over to /partner-portal (note you have to be a Jetpack partner to access the portal). The process should be documented in the FG.
* Chat will behave and look as it does on the rest of Jetpack Cloud (you can also test /pricing to make sure it shows chat when appropriate)
* To verify different API keys are being used, you can use the Network tab and search for requests going to zendesk.com you should see a different API key for the agency dashboard and for general Jetpack Cloud

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?