### PR TITLE
Plans: Show current plan price correctly

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/header-price.tsx
@@ -3,8 +3,8 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import PlanPrice from 'calypso/my-sites/plan-price';
-import usePlanPrices from 'calypso/my-sites/plans/hooks/use-plan-prices';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
+import { usePlanPricesDisplay } from '../hooks/use-plan-prices-display';
 import type { PlanProperties } from '../types';
 
 interface PlanFeatures2023GridHeaderPriceProps {
@@ -12,6 +12,8 @@ interface PlanFeatures2023GridHeaderPriceProps {
 	is2023OnboardingPricingGrid: boolean;
 	isLargeCurrency: boolean;
 	isPlanUpgradeCreditEligible: boolean;
+	currentSitePlanSlug?: string;
+	siteId?: number | null;
 }
 
 const PricesGroup = styled.div< { isLargeCurrency: boolean } >`
@@ -127,17 +129,19 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	is2023OnboardingPricingGrid,
 	isLargeCurrency,
 	isPlanUpgradeCreditEligible,
+	currentSitePlanSlug,
+	siteId,
 }: PlanFeatures2023GridHeaderPriceProps ) => {
 	const translate = useTranslate();
 	const { planName, showMonthlyPrice } = planProperties;
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const planPrices = usePlanPrices( {
+	const planPrices = usePlanPricesDisplay( {
 		planSlug: planName as PlanSlug,
 		returnMonthly: showMonthlyPrice,
+		currentSitePlanSlug,
+		siteId,
 	} );
-	const shouldShowDiscountedPrice = Boolean(
-		planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice
-	);
+	const shouldShowDiscountedPrice = Boolean( planPrices.discountedPrice );
 
 	if ( isWpcomEnterpriseGridPlan( planName ) ) {
 		return null;
@@ -155,7 +159,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 					<PricesGroup isLargeCurrency={ isLargeCurrency }>
 						<PlanPrice
 							currencyCode={ currencyCode }
-							rawPrice={ planPrices.rawPrice }
+							rawPrice={ planPrices.originalPrice }
 							displayPerMonthNotation={ false }
 							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 							isLargeCurrency={ isLargeCurrency }
@@ -163,7 +167,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
-							rawPrice={ planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice }
+							rawPrice={ planPrices.discountedPrice }
 							displayPerMonthNotation={ false }
 							is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 							isLargeCurrency={ isLargeCurrency }
@@ -175,7 +179,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 			{ ! shouldShowDiscountedPrice && (
 				<PlanPrice
 					currencyCode={ currencyCode }
-					rawPrice={ planPrices.rawPrice }
+					rawPrice={ planPrices.originalPrice }
 					displayPerMonthNotation={ false }
 					is2023OnboardingPricingGrid={ is2023OnboardingPricingGrid }
 					isLargeCurrency={ isLargeCurrency }

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -375,6 +375,7 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 	planActionOverrides,
 	isPlanUpgradeCreditEligible,
 	selectedPlan,
+	siteId,
 } ) => {
 	const { planName, planConstantObj, availableForPurchase, current, ...planPropertiesObj } =
 		planProperties;
@@ -448,6 +449,8 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 				planProperties={ planProperties }
 				is2023OnboardingPricingGrid={ true }
 				isLargeCurrency={ isLargeCurrency }
+				currentSitePlanSlug={ currentSitePlanSlug }
+				siteId={ siteId }
 			/>
 			<div className="plan-comparison-grid__billing-info">
 				<PlanFeatures2023GridBillingTimeframe
@@ -455,6 +458,8 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 					isMonthlyPlan={ planPropertiesObj.isMonthlyPlan }
 					billingTimeframe={ planConstantObj.getBillingTimeFrame() }
 					billingPeriod={ planPropertiesObj.billingPeriod }
+					currentSitePlanSlug={ currentSitePlanSlug }
+					siteId={ siteId }
 				/>
 			</div>
 			<PlanFeatures2023GridActions
@@ -535,6 +540,7 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 					isLargeCurrency={ isLargeCurrency }
 					planActionOverrides={ planActionOverrides }
 					selectedPlan={ selectedPlan }
+					siteId={ siteId }
 				/>
 			) ) }
 		</PlanRow>

--- a/client/my-sites/plan-features-2023-grid/components/test/billing-timeframe.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/test/billing-timeframe.tsx
@@ -14,7 +14,7 @@ jest.mock( 'react-redux', () => ( {
 	...jest.requireActual( 'react-redux' ),
 	useSelector: jest.fn( ( selector ) => selector() ),
 } ) );
-jest.mock( 'calypso/my-sites/plans/hooks/use-plan-prices', () => jest.fn() );
+jest.mock( '../../hooks/use-plan-prices-display', () => ( { usePlanPricesDisplay: jest.fn() } ) );
 
 import {
 	PLAN_ANNUAL_PERIOD,
@@ -27,10 +27,11 @@ import {
 import { formatCurrency } from '@automattic/format-currency';
 import { render } from '@testing-library/react';
 import React from 'react';
-import usePlanPrices from 'calypso/my-sites/plans/hooks/use-plan-prices';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import { PlanPrices } from 'calypso/state/plans/types';
+import { usePlanPricesDisplay } from '../../hooks/use-plan-prices-display';
 import PlanFeatures2023GridBillingTimeframe from '../billing-timeframe';
+
+type PlanPricesDisplay = ReturnType< typeof usePlanPricesDisplay >;
 
 describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 	const defaultProps = {
@@ -43,18 +44,16 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 	} );
 
 	test( `should show savings with yearly when plan is monthly`, () => {
-		const planMonthlyPrices: PlanPrices = {
-			planDiscountedRawPrice: 100,
-			discountedRawPrice: 150,
-			rawPrice: 200,
+		const planMonthlyPrices: PlanPricesDisplay = {
+			discountedPrice: 150,
+			originalPrice: 200,
 		};
-		const planYearlyPrices: PlanPrices = {
-			planDiscountedRawPrice: 50,
-			discountedRawPrice: 100,
-			rawPrice: 150,
+		const planYearlyPrices: PlanPricesDisplay = {
+			discountedPrice: 100,
+			originalPrice: 150,
 		};
 
-		usePlanPrices.mockImplementation(
+		usePlanPricesDisplay.mockImplementation(
 			jest.fn( ( { planSlug } ) => {
 				if ( planSlug === PLAN_BUSINESS_MONTHLY ) {
 					return planMonthlyPrices;
@@ -66,29 +65,30 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		const { container } = render(
 			<PlanFeatures2023GridBillingTimeframe
 				{ ...defaultProps }
+				currentSitePlanSlug=""
 				planName={ PLAN_BUSINESS_MONTHLY }
 				isMonthlyPlan={ true }
 				billingPeriod={ PLAN_MONTHLY_PERIOD }
 			/>
 		);
 		const savings =
-			( 100 * ( planMonthlyPrices.rawPrice - planYearlyPrices.discountedRawPrice ) ) /
-			planMonthlyPrices.rawPrice;
+			( 100 * ( planMonthlyPrices.originalPrice - planYearlyPrices.discountedPrice ) ) /
+			planMonthlyPrices.originalPrice;
 
 		expect( container ).toHaveTextContent( `Save ${ savings }%` );
 	} );
 
 	test( 'should show full-term discounted price when plan is yearly', () => {
-		const planPrices: PlanPrices = {
-			planDiscountedRawPrice: 100,
-			discountedRawPrice: 150,
-			rawPrice: 200,
+		const planPrices: PlanPricesDisplay = {
+			discountedPrice: 150,
+			originalPrice: 200,
 		};
 
-		usePlanPrices.mockImplementation( jest.fn( () => planPrices ) );
+		usePlanPricesDisplay.mockImplementation( jest.fn( () => planPrices ) );
 
 		const { container } = render(
 			<PlanFeatures2023GridBillingTimeframe
+				currentSitePlanSlug=""
 				{ ...defaultProps }
 				planName={ PLAN_BUSINESS }
 				isMonthlyPlan={ false }
@@ -96,30 +96,30 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 			/>
 		);
 
-		const discountedPrice = formatCurrency( planPrices.planDiscountedRawPrice, 'INR', {
+		const discountedPrice = formatCurrency( planPrices.discountedPrice, 'INR', {
 			stripZeros: true,
 		} );
 		expect( container ).toHaveTextContent( `per month, ${ discountedPrice } for the first year` );
 	} );
 
 	test( 'should show full-term discounted price when plan is 2-yearly', () => {
-		const planPrices: PlanPrices = {
-			planDiscountedRawPrice: 100,
-			discountedRawPrice: 150,
-			rawPrice: 200,
+		const planPrices: PlanPricesDisplay = {
+			discountedPrice: 150,
+			originalPrice: 200,
 		};
 
-		usePlanPrices.mockImplementation( jest.fn( () => planPrices ) );
+		usePlanPricesDisplay.mockImplementation( jest.fn( () => planPrices ) );
 
 		const { container } = render(
 			<PlanFeatures2023GridBillingTimeframe
+				currentSitePlanSlug=""
 				{ ...defaultProps }
 				planName={ PLAN_BUSINESS_2_YEARS }
 				isMonthlyPlan={ false }
 				billingPeriod={ PLAN_BIENNIAL_PERIOD }
 			/>
 		);
-		const discountedPrice = formatCurrency( planPrices.planDiscountedRawPrice, 'INR', {
+		const discountedPrice = formatCurrency( planPrices.discountedPrice, 'INR', {
 			stripZeros: true,
 		} );
 		expect( container ).toHaveTextContent( `per month, ${ discountedPrice } for the first year` );

--- a/client/my-sites/plan-features-2023-grid/components/test/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/test/header-price.tsx
@@ -15,14 +15,15 @@ jest.mock( 'react-redux', () => ( {
 	...jest.requireActual( 'react-redux' ),
 	useSelector: jest.fn(),
 } ) );
-jest.mock( 'calypso/my-sites/plans/hooks/use-plan-prices', () => jest.fn() );
+jest.mock( '../../hooks/use-plan-prices-display', () => ( { usePlanPricesDisplay: jest.fn() } ) );
 
 import { render } from '@testing-library/react';
 import React from 'react';
-import usePlanPrices from 'calypso/my-sites/plans/hooks/use-plan-prices';
+import { usePlanPricesDisplay } from '../../hooks/use-plan-prices-display';
 import PlanFeatures2023GridHeaderPrice from '../header-price';
 import type { PlanProperties } from '../../types';
-import type { PlanPrices } from 'calypso/state/plans/selectors/get-plan-prices';
+
+type PlanPricesDisplay = ReturnType< typeof usePlanPricesDisplay >;
 
 describe( 'PlanFeatures2023GridHeaderPrice', () => {
 	const planProperties = {
@@ -40,30 +41,19 @@ describe( 'PlanFeatures2023GridHeaderPrice', () => {
 	} );
 
 	test( 'should render raw and discounted prices when discount exists', () => {
-		const planPrices: PlanPrices = {
-			planDiscountedRawPrice: 0,
-			discountedRawPrice: 50,
-			rawPrice: 100,
+		const planPrices: PlanPricesDisplay = {
+			discountedPrice: 50,
+			originalPrice: 100,
 		};
-		usePlanPrices.mockImplementation( () => planPrices );
+		usePlanPricesDisplay.mockImplementation( () => planPrices );
 
-		const { container } = render( <PlanFeatures2023GridHeaderPrice { ...defaultProps } /> );
-		const rawPrice = container.querySelector( '.plan-price.is-original' );
-		const discountedPrice = container.querySelector( '.plan-price.is-discounted' );
-
-		expect( rawPrice ).toHaveTextContent( '100' );
-		expect( discountedPrice ).toHaveTextContent( '50' );
-	} );
-
-	test( 'should render raw and plan-discounted prices when discount exists', () => {
-		const planPrices: PlanPrices = {
-			planDiscountedRawPrice: 50,
-			discountedRawPrice: 10,
-			rawPrice: 100,
-		};
-		usePlanPrices.mockImplementation( () => planPrices );
-
-		const { container } = render( <PlanFeatures2023GridHeaderPrice { ...defaultProps } /> );
+		const { container } = render(
+			<PlanFeatures2023GridHeaderPrice
+				isPlanUpgradeCreditEligible={ false }
+				currentSitePlanSlug=""
+				{ ...defaultProps }
+			/>
+		);
 		const rawPrice = container.querySelector( '.plan-price.is-original' );
 		const discountedPrice = container.querySelector( '.plan-price.is-discounted' );
 
@@ -72,14 +62,19 @@ describe( 'PlanFeatures2023GridHeaderPrice', () => {
 	} );
 
 	test( 'should render just the raw price when no discount exists', () => {
-		const planPrices: PlanPrices = {
-			planDiscountedRawPrice: 0,
-			discountedRawPrice: 0,
-			rawPrice: 100,
+		const planPrices: PlanPricesDisplay = {
+			discountedPrice: 0,
+			originalPrice: 100,
 		};
-		usePlanPrices.mockImplementation( () => planPrices );
+		usePlanPricesDisplay.mockImplementation( () => planPrices );
 
-		const { container } = render( <PlanFeatures2023GridHeaderPrice { ...defaultProps } /> );
+		const { container } = render(
+			<PlanFeatures2023GridHeaderPrice
+				isPlanUpgradeCreditEligible={ false }
+				currentSitePlanSlug=""
+				{ ...defaultProps }
+			/>
+		);
 		const rawPrice = container.querySelector( '.plan-price' );
 		const discountedPrice = container.querySelector( '.plan-price.is-discounted' );
 

--- a/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-prices-display.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/test/use-plan-prices-display.ts
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Default mock implementations
+ */
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useSelector: ( selector ) => selector(),
+} ) );
+jest.mock( 'calypso/state/plans/selectors', () => ( {
+	getPlanPrices: jest.fn(),
+} ) );
+jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
+	getSitePlanRawPrice: jest.fn(),
+	isPlanAvailableForPurchase: jest.fn(),
+} ) );
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSiteId: jest.fn( () => 1 ),
+} ) );
+import { PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
+import { getPlanPrices } from 'calypso/state/plans/selectors';
+import {
+	getSitePlanRawPrice,
+	isPlanAvailableForPurchase,
+} from 'calypso/state/sites/plans/selectors';
+import { usePlanPricesDisplay } from '../use-plan-prices-display';
+
+describe( 'usePlanPricesDisplay', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should return the original price as the site plan price and discounted price as 0 for the current plan', () => {
+		getPlanPrices.mockImplementation( () => null );
+		getSitePlanRawPrice.mockImplementation( () => 300 );
+		isPlanAvailableForPurchase.mockImplementation( () => false );
+
+		const planPrices = usePlanPricesDisplay( {
+			siteId: 100,
+			planSlug: PLAN_PREMIUM,
+			currentSitePlanSlug: PLAN_PREMIUM,
+			returnMonthly: true,
+			withoutProRatedCredits: false,
+		} );
+
+		expect( planPrices ).toEqual( {
+			originalPrice: 300,
+			discountedPrice: 0,
+		} );
+	} );
+
+	it( 'should return the original price as the site plan price and discounted price as 0 for plans not available for purchase', () => {
+		getPlanPrices.mockImplementation( () => ( {
+			rawPrice: 300,
+			discountedRawPrice: 200,
+			planDiscountedRawPrice: 100,
+		} ) );
+		getSitePlanRawPrice.mockImplementation( () => null );
+		isPlanAvailableForPurchase.mockImplementation( () => false );
+
+		const planPrices = usePlanPricesDisplay( {
+			siteId: 100,
+			planSlug: PLAN_PERSONAL,
+			currentSitePlanSlug: PLAN_PREMIUM,
+			returnMonthly: true,
+			withoutProRatedCredits: false,
+		} );
+
+		expect( planPrices ).toEqual( {
+			originalPrice: 300,
+			discountedPrice: 0,
+		} );
+	} );
+
+	it( 'should return the original price and discounted price without pro-rated credits when withoutProRatedCredits is true', () => {
+		getPlanPrices.mockImplementation( () => ( {
+			rawPrice: 300,
+			discountedRawPrice: 200,
+			planDiscountedRawPrice: 100,
+		} ) );
+		getSitePlanRawPrice.mockImplementation( () => null );
+		isPlanAvailableForPurchase.mockImplementation( () => true );
+
+		const planPrices = usePlanPricesDisplay( {
+			siteId: 100,
+			planSlug: PLAN_PERSONAL,
+			currentSitePlanSlug: PLAN_PREMIUM,
+			returnMonthly: true,
+			withoutProRatedCredits: true,
+		} );
+
+		expect( planPrices ).toEqual( {
+			originalPrice: 300,
+			discountedPrice: 200,
+		} );
+	} );
+
+	it( 'should return the original price and discounted price with pro-rated credits when withoutProRatedCredits is false', () => {
+		getPlanPrices.mockImplementation( () => ( {
+			rawPrice: 300,
+			discountedRawPrice: 200,
+			planDiscountedRawPrice: 100,
+		} ) );
+		getSitePlanRawPrice.mockImplementation( () => null );
+		isPlanAvailableForPurchase.mockImplementation( () => true );
+
+		const planPrices = usePlanPricesDisplay( {
+			siteId: 100,
+			planSlug: PLAN_PERSONAL,
+			currentSitePlanSlug: PLAN_PREMIUM,
+			returnMonthly: true,
+			withoutProRatedCredits: false,
+		} );
+
+		expect( planPrices ).toEqual( {
+			originalPrice: 300,
+			discountedPrice: 100,
+		} );
+	} );
+} );

--- a/client/my-sites/plan-features-2023-grid/hooks/use-plan-prices-display.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-plan-prices-display.ts
@@ -1,0 +1,68 @@
+import { useSelector } from 'react-redux';
+import { getPlanPrices } from 'calypso/state/plans/selectors';
+import {
+	getSitePlanRawPrice,
+	isPlanAvailableForPurchase,
+} from 'calypso/state/sites/plans/selectors';
+import type { PlanSlug } from '@automattic/calypso-products';
+
+interface Props {
+	planSlug: PlanSlug;
+	returnMonthly: boolean; // defaults to true
+	siteId?: number | null;
+	currentSitePlanSlug?: string | null;
+	withoutProRatedCredits?: boolean;
+}
+
+/**
+ * Returns the original and discounted prices to be displayed for a particular plan slug.
+ * If the planSlug is the current plan or if the planSlug is not available for purchase,
+ * we will always show the original price.
+ */
+export function usePlanPricesDisplay( {
+	planSlug,
+	returnMonthly,
+	siteId,
+	currentSitePlanSlug,
+	withoutProRatedCredits,
+}: Props ): {
+	originalPrice: number;
+	discountedPrice: number;
+} {
+	const planPrices = useSelector( ( state ) =>
+		getPlanPrices( state, { planSlug, siteId: siteId || null, returnMonthly } )
+	);
+	const sitePlanRawPrice = useSelector( ( state ) => {
+		if ( ! siteId ) {
+			return 0;
+		}
+		return getSitePlanRawPrice( state, siteId, planSlug, { returnMonthly } ) || 0;
+	} );
+	const availableForPurchase = useSelector(
+		( state ) =>
+			! currentSitePlanSlug || ( siteId && isPlanAvailableForPurchase( state, siteId, planSlug ) )
+	);
+
+	if ( currentSitePlanSlug === planSlug ) {
+		return {
+			originalPrice: sitePlanRawPrice,
+			discountedPrice: 0,
+		};
+	}
+
+	if ( ! availableForPurchase ) {
+		return {
+			originalPrice: planPrices.rawPrice,
+			discountedPrice: 0,
+		};
+	}
+
+	const discountedPrice = withoutProRatedCredits
+		? planPrices.discountedRawPrice
+		: planPrices.planDiscountedRawPrice || planPrices.discountedRawPrice;
+
+	return {
+		originalPrice: planPrices.rawPrice,
+		discountedPrice,
+	};
+}

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -497,7 +497,14 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderPlanPrice( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
-		const { isReskinned, isLargeCurrency, translate, isPlanUpgradeCreditEligible } = this.props;
+		const {
+			isReskinned,
+			isLargeCurrency,
+			translate,
+			isPlanUpgradeCreditEligible,
+			currentSitePlanSlug,
+			siteId,
+		} = this.props;
 
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
@@ -522,6 +529,8 @@ export class PlanFeatures2023Grid extends Component<
 								planProperties={ properties }
 								is2023OnboardingPricingGrid={ true }
 								isLargeCurrency={ isLargeCurrency }
+								currentSitePlanSlug={ currentSitePlanSlug }
+								siteId={ siteId }
 							/>
 						) }
 						{ isWooExpressPlus && (
@@ -535,6 +544,7 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderBillingTimeframe( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
+		const { currentSitePlanSlug, siteId } = this.props;
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
 			.map( ( properties ) => {
@@ -552,6 +562,8 @@ export class PlanFeatures2023Grid extends Component<
 							planName={ planName }
 							billingTimeframe={ planConstantObj.getBillingTimeFrame() }
 							billingPeriod={ billingPeriod }
+							currentSitePlanSlug={ currentSitePlanSlug }
+							siteId={ siteId }
 						/>
 					</Container>
 				);

--- a/client/state/sites/plans/selectors/index.js
+++ b/client/state/sites/plans/selectors/index.js
@@ -9,6 +9,7 @@ export { default as getECommerceTrialDaysLeft } from './get-ecommerce-trial-days
 export { default as getECommerceTrialExpiration } from './get-ecommerce-trial-expiration';
 export { getSitePlan } from 'calypso/state/sites/plans/selectors/get-site-plan';
 export { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors/get-site-plan-raw-price';
+export { default as isPlanAvailableForPurchase } from 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase';
 export { getSitePlanSlug } from 'calypso/state/sites/plans/selectors/get-site-plan-slug';
 export { hasDomainCredit } from 'calypso/state/sites/plans/selectors/has-domain-credit';
 export { isCurrentPlanExpiring } from 'calypso/state/sites/plans/selectors/is-current-plan-expiring';


### PR DESCRIPTION
Fixes Automattic/martech#1695

## Proposed Changes

* If a currency-specific discount is active, and if a plan has been upgraded using pro-rated credits, the price shown on the /plans page is currently the discounted price. This is incorrect and gives the impression that the user was charged for more than the price shown on this page. This PR shows the current plan price without any discounts.
* Added a new hook, `usePlanPricesDisplay`, in the `client/my-sites/plan-features-2023-grid/hooks` directory. This returns the original and discounted prices to be displayed for a particular plan slug. This works according to the following rules:
  * If the passed plan slug is the current plan slug, it returns the "site plan raw price".
  * If the passed plan slug is not available for purchase,  it returns the raw price of the plan.
  * If the `withoutProRatedCredits` arg is false (false by default), the discounted price is either the "plan discounted raw price" (discounted price after applying pro-rated credits) or the "discounted raw price" (discounted price if there is a first-year currency specific discount).
  * If the `withoutProRatedCredits` arg is true (false by default), the discounted price is the "discounted raw price" (discounted price if there is a first-year currency-specific discount).
* The [`header-price`](https://github.com/Automattic/wp-calypso/blob/98c3ad52a21fa8d3fdea2e6711249d2f06621438/client/my-sites/plan-features-2023-grid/components/header-price.tsx) and [`billing-timeframe`](https://github.com/Automattic/wp-calypso/blob/98c3ad52a21fa8d3fdea2e6711249d2f06621438/client/my-sites/plan-features-2023-grid/components/billing-timeframe.tsx) components should not be concerned with which prices to display and should be focused on only how to display the original and discounted prices.

Screenshots: (Current plan is the Business plan)

| Production  | This branch |
|--------|--------|
|<img width="1259" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/3cccdcc6-982a-4ee8-a6a4-a67035608193">|<img width="1233" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/b2c7642c-b080-458d-9677-02fcd4a9e0fd">| 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the test instructions in Automattic/martech#1695.
* The price should be displayed correctly.
* Also confirm that the prices for the plans lower than the current plan are displayed without any discount.

#### Testing for regressions:
Confirm that the prices are displayed correctly (same as production) in the following flows:
* `/start/plans`
* `/plans/<slug>` where `<slug>` is the site slug of a site on the free plan.
* `/setup/newsletter/plans`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
