### PR TITLE
Domain upsell: Added strings for translation

### DIFF
--- a/client/my-sites/customer-home/cards/features/domain-upsell/domain-upsell-translations.js
+++ b/client/my-sites/customer-home/cards/features/domain-upsell/domain-upsell-translations.js
@@ -1,0 +1,4 @@
+import { translate } from 'i18n-calypso';
+
+translate( 'Search a domain' );
+translate( 'Get the custom domain' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2207-gh-Automattic/dotcom-forge

## Proposed Changes

Add preemptive translations for Domain Upsell new design

FYI, in the top carousel banner, the buttons are `Get this domain` and `Find other domains`

![image](https://user-images.githubusercontent.com/402286/234301360-589fc5cd-e0be-473a-9d43-87ed9addf8e3.png)


## Testing Instructions
Ensure the strings are good for the context.