### PR TITLE
i18n: Use getters for sensei-purpose labels

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/purposes.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/purposes.ts
@@ -22,27 +22,37 @@ type Purpose = {
 export const purposes: Purpose[] = [
 	{
 		id: 'sell_courses',
-		label: __( 'Sell courses and generate income' ),
+		get label() {
+			return __( 'Sell courses and generate income' );
+		},
 		plugins: [],
 	},
 	{
 		id: 'provide_certification',
-		label: __( 'Provide certification' ),
+		get label() {
+			return __( 'Provide certification' );
+		},
 		plugins: [
 			{
 				slug: 'sensei-certificates',
 				id: 'sensei-certificates/woothemes-sensei-certificates',
 			},
 		],
-		description: __( 'Sensei LMS Certificates will be installed for free.' ),
+		get description() {
+			return __( 'Sensei LMS Certificates will be installed for free.' );
+		},
 	},
 	{
 		id: 'educate_students',
-		label: __( 'Educate students' ),
+		get label() {
+			return __( 'Educate students' );
+		},
 	},
 	{
 		id: 'train_employees',
-		label: __( 'Train employees' ),
+		get label() {
+			return __( 'Train employees' );
+		},
 	},
 ];
 const STORAGE_KEY = 'sensei-site-purpose';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 598-gh-Automattic/i18n-issues

## Proposed Changes

* Implement getters for `label` and `description` properties of the `purposes` array, so that the gettext `__()` functions are called at the moment accessing the property, rather than just at the moment of defining the constant.
* This change is required as the translation data loaded asynchronously and is not available when the constant is being defined, but is expected to be loaded when the component renders. 

**Before:**
![CleanShot 2023-04-25 at 17 02 12](https://user-images.githubusercontent.com/2722412/234301324-eb38f964-ece4-4499-a314-e76c21bdb231.png)

**After:** 
![CleanShot 2023-04-25 at 17 01 47](https://user-images.githubusercontent.com/2722412/234301356-edcc9f5a-f69e-459f-b627-4d5bf9694c20.png)


## Testing Instructions

* Change UI language to any Mag-16 locale.
* Use calypso.live link or boot locally with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=wpcom-user-bootstrap,use-translation-chunks yarn start`.
* Create a new course from `/setup/sensei/?ref=create-a-course`.
* Complete all steps.
* Confirm purpose options on the `/setup/sensei/senseiPurpose` screen are translated as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
