### PR TITLE
Subscriptions Management: Create "Email me new comments" toggle

### DIFF
--- a/client/landing/subscriptions/components/settings-popover/comment-settings/comment-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/comment-settings/comment-settings.tsx
@@ -1,3 +1,6 @@
+import config from '@automattic/calypso-config';
+import { useIsLoggedIn } from '@automattic/data-stores/src/reader/hooks';
+import { useLocale } from '@automattic/i18n-utils';
 import Separator from 'calypso/components/popover-menu/separator';
 import SettingsPopover from '../settings-popover';
 import EmailMeNewCommentsToggle from './email-me-new-comments-toggle';
@@ -8,12 +11,23 @@ type CommentSettingsProps = {
 	unsubscribing: boolean;
 };
 
-const CommentSettings = ( { onUnsubscribe, unsubscribing }: CommentSettingsProps ) => (
-	<SettingsPopover>
-		<EmailMeNewCommentsToggle isUpdating={ false } />
-		<Separator />
-		<UnsubscribeCommentsButton unsubscribing={ unsubscribing } onUnsubscribe={ onUnsubscribe } />
-	</SettingsPopover>
-);
+const CommentSettings = ( { onUnsubscribe, unsubscribing }: CommentSettingsProps ) => {
+	const { isLoggedIn } = useIsLoggedIn();
+	const locale = useLocale();
+	const shouldEnableCommentToggles =
+		config.isEnabled( 'subscription-management/comments-list-toggles' ) && locale === 'en';
+
+	return (
+		<SettingsPopover>
+			{ shouldEnableCommentToggles && isLoggedIn && (
+				<>
+					<EmailMeNewCommentsToggle isUpdating={ false } />
+					<Separator />
+				</>
+			) }
+			<UnsubscribeCommentsButton unsubscribing={ unsubscribing } onUnsubscribe={ onUnsubscribe } />
+		</SettingsPopover>
+	);
+};
 
 export default CommentSettings;

--- a/client/landing/subscriptions/components/settings-popover/comment-settings/comment-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/comment-settings/comment-settings.tsx
@@ -1,4 +1,6 @@
+import Separator from 'calypso/components/popover-menu/separator';
 import SettingsPopover from '../settings-popover';
+import EmailMeNewCommentsToggle from './email-me-new-comments-toggle';
 import UnsubscribeCommentsButton from './unsubscribe-comments-button';
 
 type CommentSettingsProps = {
@@ -8,6 +10,8 @@ type CommentSettingsProps = {
 
 const CommentSettings = ( { onUnsubscribe, unsubscribing }: CommentSettingsProps ) => (
 	<SettingsPopover>
+		<EmailMeNewCommentsToggle isUpdating={ false } />
+		<Separator />
 		<UnsubscribeCommentsButton unsubscribing={ unsubscribing } onUnsubscribe={ onUnsubscribe } />
 	</SettingsPopover>
 );

--- a/client/landing/subscriptions/components/settings-popover/comment-settings/email-me-new-comments-toggle.tsx
+++ b/client/landing/subscriptions/components/settings-popover/comment-settings/email-me-new-comments-toggle.tsx
@@ -1,0 +1,25 @@
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+
+type EmailMeNewCommentsToggleProps = {
+	isUpdating: boolean;
+};
+
+const EmailMeNewCommentsToggle = ( { isUpdating = false }: EmailMeNewCommentsToggleProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<PopoverMenuItem itemComponent="div">
+			<ToggleControl
+				className="settings-popover__email-me-new-comments-toggle"
+				label={ translate( 'Email me new comments' ) }
+				onChange={ () => null }
+				checked={ false }
+				disabled={ isUpdating }
+			/>
+		</PopoverMenuItem>
+	);
+};
+
+export default EmailMeNewCommentsToggle;

--- a/client/landing/subscriptions/components/settings-popover/styles.scss
+++ b/client/landing/subscriptions/components/settings-popover/styles.scss
@@ -77,6 +77,15 @@
 		padding-bottom: 10px;
 		line-height: $font-body;
 	}
+
+	.settings-popover__email-me-new-comments-toggle {
+		font-size: $font-body-small;
+		margin-bottom: 0;
+
+		.is-checked .components-form-toggle__track {
+			background-color: $studio-black;
+		}
+	}
 }
 
 .settings-popover__container {

--- a/config/development.json
+++ b/config/development.json
@@ -189,6 +189,7 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
 		"subscription-management/sites-list-controls": true,
+		"subscription-management/comments-list-toggles": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/display-thank-you-page": true,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -133,6 +133,7 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
+		"subscription-management/comments-list-toggles": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/display-thank-you-page": true,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/production.json
+++ b/config/production.json
@@ -154,6 +154,7 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
+		"subscription-management/comments-list-toggles": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/display-thank-you-page": true,
 		"themes/display-thank-you-page-for-woo": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -149,6 +149,7 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
+		"subscription-management/comments-list-toggles": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/display-thank-you-page": true,
 		"themes/display-thank-you-page-for-woo": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -161,6 +161,7 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": false,
 		"subscription-management/sites-list-controls": false,
+		"subscription-management/comments-list-toggles": false,
 		"themes/atomic-homepage-replace": true,
 		"themes/display-thank-you-page": true,
 		"themes/display-thank-you-page-for-woo": true,


### PR DESCRIPTION
🚧 Work in progress. Not ready for review yet. 🚧 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
