### PR TITLE
i18n: Localize link to privacy settings on Sharing Buttons screen

### DIFF
--- a/client/my-sites/marketing/buttons/tray.jsx
+++ b/client/my-sites/marketing/buttons/tray.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
+import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { filter, find } from 'lodash';
@@ -166,7 +167,7 @@ class SharingButtonsTray extends Component {
 						) }
 					</em>
 					<a
-						href="https://wordpress.com/support/settings/privacy-settings/"
+						href={ localizeUrl( 'https://wordpress.com/support/settings/privacy-settings/' ) }
 						target="_blank"
 						rel="noreferrer"
 					>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 607-gh-Automattic/i18n-issues

## Proposed Changes

* Localize link to Privacy Settings support document on Share Buttons screen.

![CleanShot 2023-04-25 at 18 18 09](https://user-images.githubusercontent.com/2722412/234325879-753e1190-e899-4108-a0c6-fbf693b2ce2b.png)

## Testing Instructions

* Use calypso.live image or boot locally.
* Change UI language to a Mag-16 locale.
* Go to `/marketing/sharing-buttons` and select a private site.
* Click on `Add sharing buttons` or `Add “More” button` button.
* Confirm the link to the support document is properly localized.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
