### PR TITLE
i18n: Add context for "Expired" domain status

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -176,7 +176,7 @@ export function resolveDomainStatus(
 
 		case domainTypes.REGISTERED:
 			if ( domain.aftermarketAuction ) {
-				const statusMessage = translate( 'Expired', { context: 'domain' } );
+				const statusMessage = translate( 'Expired', { context: 'domain status' } );
 				return {
 					statusText: statusMessage,
 					statusClass: 'status-warning',
@@ -360,7 +360,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
-					status: translate( 'Expired', { context: 'domain' } ),
+					status: translate( 'Expired', { context: 'domain status' } ),
 					icon: 'info',
 					noticeText,
 					listStatusWeight: 1000,

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -176,7 +176,7 @@ export function resolveDomainStatus(
 
 		case domainTypes.REGISTERED:
 			if ( domain.aftermarketAuction ) {
-				const statusMessage = translate( 'Expired' );
+				const statusMessage = translate( 'Expired', { context: 'domain' } );
 				return {
 					statusText: statusMessage,
 					statusClass: 'status-warning',
@@ -360,7 +360,7 @@ export function resolveDomainStatus(
 				return {
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
-					status: translate( 'Expired' ),
+					status: translate( 'Expired', { context: 'domain' } ),
 					icon: 'info',
 					noticeText,
 					listStatusWeight: 1000,

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -170,7 +170,7 @@ class DomainRow extends PureComponent {
 					args: { expiryDate: expiryDate.format( 'LL' ) },
 				} );
 			} else {
-				extraInfo = translate( 'Expired', { context: 'domain' } );
+				extraInfo = translate( 'Expired', { context: 'domain status' } );
 			}
 		} else if ( domain.isAutoRenewing && domain.autoRenewalDate ) {
 			extraInfo = translate( 'Renews on %(renewalDate)s', {

--- a/client/my-sites/domains/domain-management/list/domain-row.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-row.jsx
@@ -170,7 +170,7 @@ class DomainRow extends PureComponent {
 					args: { expiryDate: expiryDate.format( 'LL' ) },
 				} );
 			} else {
-				extraInfo = translate( 'Expired' );
+				extraInfo = translate( 'Expired', { context: 'domain' } );
 			}
 		} else if ( domain.isAutoRenewing && domain.autoRenewalDate ) {
 			extraInfo = translate( 'Renews on %(renewalDate)s', {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 604-gh-Automattic/i18n-issues

## Proposed Changes

* Add context `domain` to `Expired` domain status string.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
