### PR TITLE
Signup Stepper: Only add products to cart if a site slug exists

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/domain-upsell.ts
@@ -70,16 +70,16 @@ const domainUpsell: Flow = {
 						const planCartItem = getPlanCartItem();
 						const domainCartItem = getDomainCartItem();
 						if ( planCartItem ) {
-							await addPlanToCart( siteSlug as string, flowName as string, true, '', planCartItem );
+							await addPlanToCart( siteSlug, flowName, true, '', planCartItem );
 						}
 
 						if ( domainCartItem ) {
-							await addProductsToCart( siteSlug as string, flowName as string, [ domainCartItem ] );
+							await addProductsToCart( siteSlug, flowName, [ domainCartItem ] );
 						}
 
 						return window.location.assign(
 							`/checkout/${ encodeURIComponent(
-								( siteSlug as string ) ?? ''
+								siteSlug ?? ''
 							) }?redirect_to=${ encodedReturnUrl }`
 						);
 					}

--- a/client/landing/stepper/declarative-flow/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/domain-upsell.ts
@@ -40,7 +40,7 @@ const domainUpsell: Flow = {
 		);
 		const { setHideFreePlan } = useDispatch( ONBOARD_STORE );
 
-		const returnUrl = `/setup/${ flowName }/launchpad?siteSlug=${ siteSlug }`;
+		const returnUrl = `/setup/${ flowName ?? 'free' }/launchpad?siteSlug=${ siteSlug }`;
 		const encodedReturnUrl = encodeURIComponent( returnUrl );
 
 		const exitFlow = ( location = '/sites' ) => {
@@ -69,11 +69,11 @@ const domainUpsell: Flow = {
 					if ( providedDependencies?.goToCheckout ) {
 						const planCartItem = getPlanCartItem();
 						const domainCartItem = getDomainCartItem();
-						if ( planCartItem ) {
+						if ( planCartItem && siteSlug && flowName ) {
 							await addPlanToCart( siteSlug, flowName, true, '', planCartItem );
 						}
 
-						if ( domainCartItem ) {
+						if ( domainCartItem && siteSlug && flowName ) {
 							await addProductsToCart( siteSlug, flowName, [ domainCartItem ] );
 						}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/index.tsx
@@ -21,6 +21,7 @@ import { useCreateSenseiSite } from './create-sensei-site';
 import { useBusinessPlanPricing, useSenseiProPricing } from './sensei-plan-products';
 import type { Step } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { PlanBillingPeriod } from 'calypso/../packages/data-stores';
 
 import 'calypso/../packages/plans-grid/src/plans-table/style.scss';
@@ -48,10 +49,9 @@ const SenseiPlan: Step = ( { flow, navigation: { submit } } ) => {
 
 	const createCheckoutCart = useCallback(
 		async ( site ) => {
-			const cartKey = await cartManagerClient.getCartKeyForSiteSlug( site?.site_slug as string );
+			const cartKey = await cartManagerClient.getCartKeyForSiteSlug( site?.site_slug );
 
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const productsToAdd: any[] = [
+			const productsToAdd: MinimalRequestCartProduct[] = [
 				{
 					product_slug: businessPlan.productSlug,
 					extra: {
@@ -69,7 +69,7 @@ const SenseiPlan: Step = ( { flow, navigation: { submit } } ) => {
 			if ( domain && domain.product_slug ) {
 				const registration = domainRegistration( {
 					domain: domain.domain_name,
-					productSlug: domain.product_slug as string,
+					productSlug: domain.product_slug,
 					extra: { privacy_available: domain.supports_privacy },
 				} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -42,6 +42,13 @@ const DEFAULT_WOOEXPRESS_FLOW = 'pub/twentytwentytwo';
 const DEFAULT_NEWSLETTER_THEME = 'pub/lettre';
 const DEFAULT_START_WRITING_THEME = 'pub/livro';
 
+function hasSourceSlug( data: unknown ): data is { sourceSlug: string } {
+	if ( data && ( data as { sourceSlug: string } ).sourceSlug ) {
+		return true;
+	}
+	return false;
+}
+
 const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, data } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
@@ -121,8 +128,9 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			};
 		}
 
+		const sourceSlug = hasSourceSlug( data ) ? data.sourceSlug : undefined;
 		const site = await createSiteWithCart(
-			flow as string,
+			flow,
 			true,
 			isPaidDomainItem,
 			theme,
@@ -132,20 +140,20 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			true,
 			username,
 			domainCartItem,
-			data?.sourceSlug as string
+			sourceSlug
 		);
 
-		if ( planCartItem ) {
-			await addPlanToCart( site?.siteSlug as string, flow as string, true, theme, planCartItem );
+		if ( planCartItem && site?.siteSlug ) {
+			await addPlanToCart( site.siteSlug, flow, true, theme, planCartItem );
 		}
 
-		if ( productCartItems?.length ) {
-			await addProductsToCart( site?.siteSlug as string, flow as string, productCartItems );
+		if ( productCartItems?.length && site?.siteSlug ) {
+			await addProductsToCart( site.siteSlug, flow, productCartItems );
 		}
 
-		if ( isMigrationFlow( flow ) ) {
+		if ( isMigrationFlow( flow ) && site?.siteSlug && siteData?.ID ) {
 			// Store temporary target blog id to source site option
-			addTempSiteToSourceOption( site?.siteId as number, siteData?.ID as number );
+			addTempSiteToSourceOption( site.siteId, siteData.ID );
 		}
 
 		return {


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/68722 and https://github.com/Automattic/wp-calypso/pull/74313 the domains and plans steps were added to the Stepper framework of signup. Those steps were configured to add products and plans to the shopping cart. However, they use `as string` to override TypeScript's protections when calling the `addPlanToCart()`, `addProductsToCart()`, and `addTempSiteToSourceOption()` helper functions. This defeats the purpose of TypeScript and could result in any number of hard-to-find bugs like those fixed in https://github.com/Automattic/wp-calypso/pull/76157. 

I followed the code in those helper functions to see what would happen if the data was _not_ a string (as could happen in production without these changes) and it would cause failed network calls to `/sites/undefined/themes/mine` and `/migrations/from-source/undefined`. Assuming no fatal errors, the cart items would then be added to the user's `no-site` cart. It's likely that these issues are not happening because the data in question actually _does_ always exist in practice, but we can confirm that without opting-out of TypeScript's guards by just using JavaScript `if` statements.

## Proposed Changes

In this diff we modify the `createSite()` function inside `SiteCreationStep` to remove the `as string` type casting. The result is that in order to safely call the helper methods, we must also add guards to prevent calling them if `site.siteSlug` (and in one case `siteData.ID`) does not exist.

We also modify `submit()` inside `useStepNavigation()` in the `domainUpsell` flow to prevent calling those same helpers when a site slug or flow name does not exist.

## Testing Instructions

The biggest risk here is that the type casting could be hiding incorrect types on the helper functions; that is, if `addPlanToCart()`, etc. are intended to actually work without a site slug, then this PR would break that functionality. So the first thing to verify is: are these flows intended to work without a `siteSlug`? I'm hoping that's not the case since those types have existed for longer than the code this PR touches.

I'm not familiar with this section of the codebase but we can probably use the testing instructions from the original diffs:

- Go to `http://calypso.localhost:3000/setup?flow=link-in-bio`
- Try the flow: free/paid domains, free/paid plans, `decide later`, filter domains, ...

And:

* Create a new launchpad-enabled site (http://calypso.localhost:3000/setup/free) 
* Click the "Choose a domain" task
* Verify the "use your own domain link" adds the correct domain and plan to your cart on the checkout screen. Empty the cart without completing the purchase and return to the domain upsell flow through the launchpad screen. (You can use any valid domain like tinyurl.com)
* Complete the flow (select domain and any plan) and ensure the domain/plan has been purchased successfully.
* Verify the Launchpad "Choose a domain" task is marked as completed after upgrading to a paid plan
* Verify existing usage of the domains component isn't affected by these changes (`/setup/newsletter` and `/setup/link-in-bio use this component)
* Verify the "Choose a domain" task redirects to `/domains/manage` if the user is on a paid plan