### PR TITLE
Update style for search input

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -144,6 +144,7 @@
 
 	.search__open-icon {
 		color: var(--color-neutral-60);
+		opacity: 0.3;
 	}
 
 	.search__close-icon {

--- a/client/reader/components/reader-blank-suggestions/index.js
+++ b/client/reader/components/reader-blank-suggestions/index.js
@@ -6,7 +6,7 @@ function BlankSuggestions( props ) {
 	return (
 		<div className="reader-blank-suggestions">
 			{ props.suggestions &&
-				props.translate( 'Suggestions: {{suggestions /}}.', {
+				props.translate( 'Suggestions: {{suggestions /}}', {
 					components: {
 						suggestions: props.suggestions,
 					},

--- a/client/reader/components/reader-blank-suggestions/style.scss
+++ b/client/reader/components/reader-blank-suggestions/style.scss
@@ -7,7 +7,7 @@
 
 	a,
 	a:visited {
-		font-weight: bold;
+		font-weight: 500;
 		color: var(--color-neutral-60);
 	}
 

--- a/client/reader/components/reader-blank-suggestions/style.scss
+++ b/client/reader/components/reader-blank-suggestions/style.scss
@@ -7,11 +7,12 @@
 
 	a,
 	a:visited {
-		color: var(--color-primary);
+		font-weight: bold;
+		color: var(--color-neutral-60);
 	}
 
 	a:hover {
-		color: var(--color-primary-light);
+		color: var(--color-neutral-60);
 	}
 
 	@include breakpoint-deprecated( "<660px" ) {

--- a/client/reader/components/reader-blank-suggestions/style.scss
+++ b/client/reader/components/reader-blank-suggestions/style.scss
@@ -1,6 +1,5 @@
 // Search term suggestions
 .reader-blank-suggestions {
-	border-bottom: 1px solid var(--color-neutral-10);
 	font-size: $font-body-small;
 	color: var(--color-text-subtle);
 	padding: 16px 0;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -53,6 +53,8 @@
 
 .search-stream .search-stream__input-card.card {
 	margin-bottom: 0;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 6px;
 }
 
 .search-stream__input-card.card {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -14,9 +14,10 @@
 	border-radius: 6px;
 	.search__icon-navigation {
 		/* stylelint-disable-next-line scales/radii */
-		border-bottom-left-radius: 6px;
-		/* stylelint-disable-next-line scales/radii */
-		border-top-left-radius: 6px;
+		border-radius: 6px;
+		@include breakpoint-deprecated( "<660px" ) {
+			border-radius: 0;
+		}
 	}
 	.search__input.form-text-input[type="search"],
 	.search__close-icon {
@@ -55,6 +56,9 @@
 	margin-bottom: 0;
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 6px;
+	@include breakpoint-deprecated( "<660px" ) {
+		border-radius: 0;
+	}
 }
 
 .search-stream__input-card.card {

--- a/client/reader/search/utils.js
+++ b/client/reader/search/utils.js
@@ -1,5 +1,5 @@
 import i18n from 'i18n-calypso';
 
 export function getSearchPlaceholderText() {
-	return i18n.translate( 'Search' );
+	return i18n.translate( 'Search Reader' );
 }


### PR DESCRIPTION
This PR is part of the Reader search refresh project (link below).

This PR updates the search input to match Ollie's designs.

**Before** 
<img width="1160" alt="187492580-c9e5d19a-0bcc-426c-9b42-a7acfb4e9254" src="https://user-images.githubusercontent.com/5560595/234336431-e9ce0d6f-04ca-4348-8cd6-66bdf0af72c7.png">

**Updated**
<img width="940" alt="Screenshot 2023-04-25 at 17 19 44" src="https://user-images.githubusercontent.com/5560595/234340179-75c36418-ab31-4b21-a197-f67fbf4ca817.png">

**Design**
![preview](https://user-images.githubusercontent.com/5560595/234336490-9f830d60-d10a-47f2-9152-37af67740b63.png)

One thing I noticed while looking into this, is the design appears to show the `Relevance` and `Date` sort options even when no search text has not been entered yet. The current behaviour is to show this after text has been entered. I don't think it makes sense to change this behaviour.

Ref: pe7F0s-Le-p2