### PR TITLE
Marketplace: Rotate search term suggestions

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -34,6 +34,8 @@ import PluginsSearchResultPage from '../plugins-search-results-page';
 
 import './style.scss';
 
+const searchTerms = [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ];
+
 const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews, isLoggedIn } ) => {
 	const analyticsPageTitle = 'Plugin Browser' + category ? ` > ${ category }` : '';
 	let analyticsPath = category ? `/plugins/browse/${ category }` : '/plugins';
@@ -169,7 +171,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 						) ) &&
 					__( 'Add new functionality and integrations to your site with thousands of plugins.' )
 				}
-				searchTerms={ [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ] }
+				searchTerms={ searchTerms }
 				renderTitleInH1={ ! category }
 			/>
 

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -34,15 +34,7 @@ import PluginsSearchResultPage from '../plugins-search-results-page';
 
 import './style.scss';
 
-const searchTerms = [
-	'woocommerce',
-	'seo',
-	'reset',
-	'file manager',
-	'jetpack',
-	'ecommerce',
-	'form',
-];
+const searchTerms = [ 'woocommerce', 'seo', 'file manager', 'jetpack', 'ecommerce', 'form' ];
 
 const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews, isLoggedIn } ) => {
 	const analyticsPageTitle = 'Plugin Browser' + category ? ` > ${ category }` : '';

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -34,7 +34,15 @@ import PluginsSearchResultPage from '../plugins-search-results-page';
 
 import './style.scss';
 
-const searchTerms = [ 'seo', 'pay', 'booking', 'ecommerce', 'newsletter' ];
+const searchTerms = [
+	'woocommerce',
+	'seo',
+	'reset',
+	'file manager',
+	'jetpack',
+	'ecommerce',
+	'form',
+];
 
 const PageViewTrackerWrapper = ( { category, selectedSiteId, trackPageViews, isLoggedIn } ) => {
 	const analyticsPageTitle = 'Plugin Browser' + category ? ` > ${ category }` : '';

--- a/client/my-sites/plugins/search-box-header/index.jsx
+++ b/client/my-sites/plugins/search-box-header/index.jsx
@@ -6,11 +6,21 @@ import { useDispatch } from 'react-redux';
 import { setQueryArgs } from 'calypso/lib/query-args';
 import scrollTo from 'calypso/lib/scroll-to';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { useTermsSuggestions } from './useTermsSuggestions';
 import './style.scss';
 
-const SearchBox = ( { isMobile, searchTerm, searchBoxRef, categoriesRef, isSearching } ) => {
+const SearchBox = ( {
+	isMobile,
+	searchTerm,
+	searchBoxRef,
+	categoriesRef,
+	isSearching,
+	searchTerms,
+} ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+
+	const searchTermSuggestion = useTermsSuggestions( searchTerms ) || 'ecommerce';
 
 	const pageToSearch = useCallback(
 		( s ) => {
@@ -40,7 +50,9 @@ const SearchBox = ( { isMobile, searchTerm, searchBoxRef, categoriesRef, isSearc
 				onSearch={ pageToSearch }
 				defaultValue={ searchTerm }
 				searchMode="on-enter"
-				placeholder={ translate( 'Try searching "ecommerce"' ) }
+				placeholder={ translate( 'Try searching "%(searchTermSuggestion)s"', {
+					args: { searchTermSuggestion },
+				} ) }
 				delaySearch={ false }
 				recordEvent={ recordSearchEvent }
 				searching={ isSearching }
@@ -60,6 +72,7 @@ const SearchBoxHeader = ( props ) => {
 		searchRef,
 		categoriesRef,
 		renderTitleInH1,
+		searchTerms,
 	} = props;
 
 	// Clear the keyword in search box on PluginsBrowser load if required.
@@ -89,6 +102,7 @@ const SearchBoxHeader = ( props ) => {
 					searchBoxRef={ searchRef }
 					isSearching={ isSearching }
 					categoriesRef={ categoriesRef }
+					searchTerms={ searchTerms }
 				/>
 			</div>
 			<div className="search-box-header__sticky-ref" ref={ stickySearchBoxRef }></div>

--- a/client/my-sites/plugins/search-box-header/useTermsSuggestions.js
+++ b/client/my-sites/plugins/search-box-header/useTermsSuggestions.js
@@ -13,18 +13,19 @@ function applyTermAnimation( term, characterIndex, callback ) {
 }
 
 // This function adds an interval which will run every 'interval' seconds
-// It will then grab a random term from the 'termSuggestions' array and apply the animation
+// It will then loop through the terms from the 'termSuggestions' array and apply the animation
 // The interval will be cleared when the user scrolls down the page, and then re-added when
 // the user scrolls back up
-
+let previousIndex = 0;
 export function useTermsSuggestions( termSuggestions = [], interval = INTERVAL_BETWEEN_TERMS ) {
 	const [ termSuggestion, setTermSuggestion ] = useState( termSuggestions[ 0 ] );
 
 	useEffect( () => {
 		function addInterval() {
 			return setInterval( () => {
-				const randomIndex = Math.floor( Math.random() * termSuggestions.length );
-				applyTermAnimation( termSuggestions[ randomIndex ], 0, setTermSuggestion );
+				const currentIndex = previousIndex % termSuggestions.length;
+				previousIndex++;
+				applyTermAnimation( termSuggestions[ currentIndex ], 0, setTermSuggestion );
 			}, interval );
 		}
 		let intervalId = addInterval();

--- a/client/my-sites/plugins/search-box-header/useTermsSuggestions.js
+++ b/client/my-sites/plugins/search-box-header/useTermsSuggestions.js
@@ -1,15 +1,51 @@
 import { useState, useEffect } from 'react';
 
-const INTERVAL = 20000;
+const INTERVAL_BETWEEN_TERMS = 5000;
+const INTERVAL_ANIMATION = 50;
 
-export function useTermsSuggestions( termSuggestions = [], interval = INTERVAL ) {
+function applyTermAnimation( term, characterIndex, callback ) {
+	callback( term.substring( 0, characterIndex + 1 ) );
+	setTimeout( () => {
+		if ( characterIndex < term.length ) {
+			applyTermAnimation( term, characterIndex + 1, callback );
+		}
+	}, INTERVAL_ANIMATION );
+}
+
+// This function adds an interval which will run every 'interval' seconds
+// It will then grab a random term from the 'termSuggestions' array and apply the animation
+// The interval will be cleared when the user scrolls down the page, and then re-added when
+// the user scrolls back up
+
+export function useTermsSuggestions( termSuggestions = [], interval = INTERVAL_BETWEEN_TERMS ) {
 	const [ termSuggestion, setTermSuggestion ] = useState( termSuggestions[ 0 ] );
+
 	useEffect( () => {
-		const intervalId = setInterval( () => {
-			const randomIndex = Math.floor( Math.random() * termSuggestions.length );
-			setTermSuggestion( termSuggestions[ randomIndex ] );
-		}, interval );
-		return () => clearInterval( intervalId );
+		function addInterval() {
+			return setInterval( () => {
+				const randomIndex = Math.floor( Math.random() * termSuggestions.length );
+				applyTermAnimation( termSuggestions[ randomIndex ], 0, setTermSuggestion );
+			}, interval );
+		}
+		let intervalId = addInterval();
+
+		addEventListener( 'scroll', onScroll );
+		let intervalActive = true;
+		function onScroll() {
+			if ( intervalActive ) {
+				clearInterval( intervalId );
+				intervalActive = false;
+			}
+
+			if ( window.scrollY < 100 ) {
+				intervalId = addInterval();
+				intervalActive = true;
+			}
+		}
+		return () => {
+			clearInterval( intervalId );
+			removeEventListener( 'scroll', onScroll );
+		};
 	}, [ termSuggestions, interval ] );
 
 	return termSuggestion;

--- a/client/my-sites/plugins/search-box-header/useTermsSuggestions.js
+++ b/client/my-sites/plugins/search-box-header/useTermsSuggestions.js
@@ -1,0 +1,16 @@
+import { useState, useEffect } from 'react';
+
+const INTERVAL = 20000;
+
+export function useTermsSuggestions( termSuggestions = [], interval = INTERVAL ) {
+	const [ termSuggestion, setTermSuggestion ] = useState( termSuggestions[ 0 ] );
+	useEffect( () => {
+		const intervalId = setInterval( () => {
+			const randomIndex = Math.floor( Math.random() * termSuggestions.length );
+			setTermSuggestion( termSuggestions[ randomIndex ] );
+		}, interval );
+		return () => clearInterval( intervalId );
+	}, [ termSuggestions, interval ] );
+
+	return termSuggestion;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #[67926](https://github.com/Automattic/wp-calypso/issues/67926)

## Proposed Changes

* Creates a hook that returns a list of passed terms every 5 seconds by default
* The term is animated, returning character by character separated by 50 milliseconds 
* Uses that hook, and it passes a list of terms based on the most popular search terms

https://user-images.githubusercontent.com/3519124/234599079-7afe127c-825c-4412-8346-9d00624c51b3.mp4




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch
* Navigate to `/plugins` and check the search box
* Verify that the search suggestions displayed rotate every 20 seconds with the following message:
* `Try searching "<search term>"` being <search term> in the list configured [in this constant](https://github.com/Automattic/wp-calypso/blob/update/search-terms-suggestions/client/my-sites/plugins/plugins-browser/index.jsx#L37) or in the diff view [this constant](https://github.com/Automattic/wp-calypso/pull/76236/commits/ef3bef13afcbeefb416a635e2c9a5e5207d354b7#diff-6750c272a1df0c496a26adc7ae59a20a6f9a7f1ca37f751b869ee40714e355f6R37)
* Check that the `<search term>` is populated using an animation
* Scroll down so the search box is sticked to the top
* Check that the `<search term>` animation is not happening anymore, the whole placeholder message does not change
* Scroll up to the original position
* Check that the `<search term>` animation is back again and the placeholder message changes every 5 seconds with an animation


## Screenshot

The original message was `Try searching "ecommerce"` and now it has changed to `Try searching "%(searchTermSuggestion)s"` being `searchTermSuggestion` one of the following `[ 'woocommerce', 'seo', 'file manager', 'jetpack', 'ecommerce', 'form' ]`

![CleanShot 2023-04-27 at 20 45 17@2x](https://user-images.githubusercontent.com/3519124/234961969-c19f94ff-07e9-465c-a48e-108de0a2cf8f.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
