### PR TITLE
Update the need atomic transformation to check if the theme is not Dotcom

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -78,9 +78,12 @@ export function useThemesThankYouData( themeSlugs: string[] ): ThankYouData {
 		[ translate ]
 	);
 
-	// DotOrg and Externay managed themes
+	// DotOrg (if not also Dotcom) and Externay managed themes
 	// needs an atomic site to be installed.
-	const hasDotOrgThemes = dotOrgThemes.some( ( theme: any ) => !! theme );
+	const hasDotOrgThemes = dotOrgThemes.some(
+		( theme: any ) =>
+			!! theme && ! dotComThemes.find( ( dotComTheme: any ) => dotComTheme?.id === theme.id )
+	);
 	const hasExternallyManagedThemes = useSelector( ( state ) =>
 		getHasExternallyManagedThemes( state, themeSlugs )
 	);

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -80,9 +80,10 @@ export function useThemesThankYouData( themeSlugs: string[] ): ThankYouData {
 
 	// DotOrg (if not also Dotcom) and Externay managed themes
 	// needs an atomic site to be installed.
+	type Theme = { id: string } | undefined;
 	const hasDotOrgThemes = dotOrgThemes.some(
-		( theme: any ) =>
-			!! theme && ! dotComThemes.find( ( dotComTheme: any ) => dotComTheme?.id === theme.id )
+		( theme: Theme ) =>
+			!! theme && ! dotComThemes.find( ( dotComTheme: Theme ) => dotComTheme?.id === theme.id )
 	);
 	const hasExternallyManagedThemes = useSelector( ( state ) =>
 		getHasExternallyManagedThemes( state, themeSlugs )


### PR DESCRIPTION
Related to p1682437829419869-slack-C02JPCHEKDY

## Proposed Changes

Check if there are DotOrg themes that **are not Dotcom** to define if a transfer to atomic is needed.

## Testing Instructions
* Select a below than Business plan. Ex: Premium or Free
* Try to activate a DotOrg theme also supported by Dotcom. Ex: Twenty Twelve
* Check if the Marketplace Thank You page is shown as the image below

| Before  | After |
| ------------- | ------------- |
|<img width="1173" alt="CleanShot 2023-04-25 at 13 37 14@2x" src="https://user-images.githubusercontent.com/5039531/234344388-caa1150d-3017-4cbd-8d04-49c963b9c6d7.png">|<img width="921" alt="CleanShot 2023-04-25 at 13 29 13@2x" src="https://user-images.githubusercontent.com/5039531/234343608-354ce004-e72a-4bc2-9ee0-51b9d2a9bcfb.png">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?