### PR TITLE
Added P2 label to the list of sites in Subscription Manager

### DIFF
--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -81,7 +81,7 @@ export default function SiteRow( {
 					<span className="title-column">
 						<span className="name">
 							{ name }
-							{ organization_id && <span className="p2-label">P2</span> }
+							{ !! organization_id && <span className="p2-label">P2</span> }
 						</span>
 						<span className="url">{ hostname }</span>
 					</span>

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -41,7 +41,7 @@ export default function SiteRow( {
 	URL: url,
 	date_subscribed,
 	delivery_methods,
-	organization_id,
+	is_wpforteams_site,
 }: SiteSubscription ) {
 	const hostname = useMemo( () => {
 		try {
@@ -81,7 +81,7 @@ export default function SiteRow( {
 					<span className="title-column">
 						<span className="name">
 							{ name }
-							{ !! organization_id && <span className="p2-label">P2</span> }
+							{ !! is_wpforteams_site && <span className="p2-label">P2</span> }
 						</span>
 						<span className="url">{ hostname }</span>
 					</span>

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -41,6 +41,7 @@ export default function SiteRow( {
 	URL: url,
 	date_subscribed,
 	delivery_methods,
+	organization_id,
 }: SiteSubscription ) {
 	const hostname = useMemo( () => {
 		try {
@@ -78,7 +79,10 @@ export default function SiteRow( {
 				<span className="title-box" role="cell">
 					<SiteIcon iconUrl={ site_icon } size={ 48 } siteName={ name } />
 					<span className="title-column">
-						<span className="name">{ name }</span>
+						<span className="name">
+							{ name }
+							{ organization_id && <span className="p2-label">P2</span> }
+						</span>
 						<span className="url">{ hostname }</span>
 					</span>
 				</span>

--- a/client/landing/subscriptions/components/site-list/styles.scss
+++ b/client/landing/subscriptions/components/site-list/styles.scss
@@ -1,8 +1,7 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
-@import "client/assets/stylesheets/style";
-@import "../../styles";
+@import "client/assets/stylesheets/p2-vars";
 
 .subscription-manager__site-list {
 

--- a/client/landing/subscriptions/components/site-list/styles.scss
+++ b/client/landing/subscriptions/components/site-list/styles.scss
@@ -83,6 +83,19 @@
 					}
 				}
 			}
+
+			.p2-label {
+				display: inline-block;
+				text-align: center;
+				width: 36px;
+				height: 20px;
+				background: #2a6aee;
+				color: $studio-green-0;
+				font-size: 12;
+				border-radius: 4px;
+				margin-left: 8px;
+				line-height: 20px;
+			}
 		}
 
 		.title-box,

--- a/client/landing/subscriptions/components/site-list/styles.scss
+++ b/client/landing/subscriptions/components/site-list/styles.scss
@@ -1,6 +1,8 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
+@import "client/assets/stylesheets/style";
+@import "../../styles";
 
 .subscription-manager__site-list {
 
@@ -82,19 +84,6 @@
 						text-decoration: underline;
 					}
 				}
-			}
-
-			.p2-label {
-				display: inline-block;
-				text-align: center;
-				width: 36px;
-				height: 20px;
-				background: #2a6aee;
-				color: $studio-green-0;
-				font-size: 12;
-				border-radius: 4px;
-				margin-left: 8px;
-				line-height: 20px;
 			}
 		}
 

--- a/client/landing/subscriptions/styles/styles.scss
+++ b/client/landing/subscriptions/styles/styles.scss
@@ -100,4 +100,17 @@ body {
 		border: none;
 		border-top: 1px solid $studio-gray-5;
 	}
+
+	.p2-label {
+		display: inline-block;
+		text-align: center;
+		width: 36px;
+		height: 20px;
+		background: var(--p2-color-link);
+		color: $studio-green-0;
+		font-size: $font-body-extra-small;
+		border-radius: 4px;
+		margin-left: 8px;
+		line-height: 20px;
+	}
 }

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -67,6 +67,7 @@ export type SiteSubscription = {
 	site_icon: string;
 	is_owner: boolean;
 	meta: SiteSubscriptionMeta;
+	is_wpforteams_site: boolean;
 };
 
 export type SiteSubscriptionPage = {


### PR DESCRIPTION
⚠️ Please do not merge until the D109848-code patch is merged and deployed. ⚠️ 

Fixes https://github.com/Automattic/wp-calypso/issues/75078

## Proposed Changes

This PR adds the P2 label to the list of sites in the new Subscription Manager, as seen in the Figma file: inDLaEQV8jJ21O4WXawIsJ-fi-712_18319
<img width="1292" alt="Screenshot 2023-05-23 at 19 25 24" src="https://github.com/Automattic/wp-calypso/assets/3832570/ab146568-4feb-4ead-ba11-315f8f1c18f7">


## Testing Instructions

1. Apply this PR.
2. Go to this file `client/server/pages/index.js` and change the call back in `app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res, next ) {` to it ends up like this:
```js
	app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res, next ) {
		return next();
	} );
```
3. Log in to your Calypso local and go to `http://calypso.localhost:3000/subscriptions/sites`.
4. If your user has P2 and non-P2 site subscriptions, you should see the P2 tag beside the site's name accordingly.
