### PR TITLE
Revert "Woo Express: Fix interval toggle overflow on small mobile screens"

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -9,8 +9,6 @@ import {
 	getPlans,
 	isWooExpressPlan,
 } from '@automattic/calypso-products';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useCallback, useMemo } from 'react';
@@ -48,7 +46,6 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 		yearlyControlProps,
 	} = props;
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 
 	const mediumPlanAnnual = getPlans()[ PLAN_WOOEXPRESS_MEDIUM ];
 	const mediumPlanMonthly = getPlans()[ PLAN_WOOEXPRESS_MEDIUM_MONTHLY ];
@@ -74,28 +71,15 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 				...yearlyControlProps,
 				content: (
 					<span>
-						{ isEnglishLocale ||
-						hasTranslation( 'Pay Annually {{span}}(Save %(percentageSavings)s%%){{/span}}' )
-							? translate( 'Pay Annually {{span}}(Save %(percentageSavings)s%%){{/span}}', {
-									args: { percentageSavings },
-									components: { span: <span className="wooexpress-plans__interval-savings" /> },
-							  } )
-							: translate( 'Pay Annually (Save %(percentageSavings)s%%)', {
-									args: { percentageSavings },
-							  } ) }
+						{ translate( 'Pay Annually (Save %(percentageSavings)s%%)', {
+							args: { percentageSavings },
+						} ) }
 					</span>
 				),
 				selected: interval === 'yearly',
 			},
 		];
-	}, [
-		interval,
-		translate,
-		monthlyControlProps,
-		percentageSavings,
-		yearlyControlProps,
-		isEnglishLocale,
-	] );
+	}, [ interval, translate, monthlyControlProps, percentageSavings, yearlyControlProps ] );
 
 	const smallPlan = interval === 'yearly' ? PLAN_WOOEXPRESS_SMALL : PLAN_WOOEXPRESS_SMALL_MONTHLY;
 	const mediumPlan =

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
@@ -15,10 +15,6 @@
 		@media (max-width: $break-mobile) {
 			max-width: 100%;
 			width: 100%;
-
-			.wooexpress-plans__interval-savings {
-				display: none;
-			}
 		}
 	}
 }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#76156

Reverting to clean up some stacked deploy blockage. We'll redeploy once that's sorted out.