### PR TITLE
Site Editor: un-iframe, again. Revert the revert.

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -260,23 +260,6 @@ export const post = ( context, next ) => {
 	return next();
 };
 
-export const siteEditor = ( context, next ) => {
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
-
-	context.primary = (
-		<CalypsoifyIframe
-			// This key is added as a precaution due to it's oberserved necessity in the above post editor.
-			// It will force the component to remount completely when the Id changes.
-			key={ siteId }
-			editorType="site"
-			completedFlow={ getSessionStorageOneTimeValue( 'wpcom_signup_completed_flow' ) }
-		/>
-	);
-
-	return next();
-};
-
 export const exitPost = ( context, next ) => {
 	const postId = getPostID( context );
 	const siteId = getSelectedSiteId( context.store.getState() );
@@ -287,18 +270,12 @@ export const exitPost = ( context, next ) => {
 };
 
 /**
- * Redirects to the un-iframed Site Editor if the config is enabled.
+ * Redirects to the un-iframed Site Editor. Good bye, iframe!
  *
  * @param {Object} context Shared context in the route.
- * @param {Function} next  Next registered callback for the route.
  * @returns {*}            Whatever the next callback returns.
  */
-export const redirectSiteEditor = async ( context, next ) => {
-	// bail unless the config is enabled
-	if ( ! isEnabled( 'block-editor/un-iframed-site-editor' ) ) {
-		return next();
-	}
-
+export const redirectSiteEditor = async ( context ) => {
 	// Let's ditch that iframe!
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -1,26 +1,10 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { siteSelection, sites } from 'calypso/my-sites/controller';
-import {
-	authenticate,
-	post,
-	redirect,
-	siteEditor,
-	exitPost,
-	redirectSiteEditor,
-} from './controller';
+import { authenticate, post, redirect, exitPost, redirectSiteEditor } from './controller';
 
 export default function () {
-	page(
-		'/site-editor/:site?',
-		siteSelection,
-		redirectSiteEditor,
-		redirect,
-		authenticate,
-		siteEditor,
-		makeLayout,
-		clientRender
-	);
+	page( '/site-editor/:site?', siteSelection, redirectSiteEditor );
 
 	page( '/post', siteSelection, sites, makeLayout, clientRender );
 	page( '/post/new', '/post' ); // redirect from beep-beep-boop

--- a/config/development.json
+++ b/config/development.json
@@ -29,7 +29,6 @@
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
 		"anchor/sunset-integration": true,
-		"block-editor/un-iframed-site-editor": false,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -17,7 +17,6 @@
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
 		"anchor/sunset-integration": false,
-		"block-editor/un-iframed-site-editor": false,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,


### PR DESCRIPTION
Reverts #76106

The CORS-issue for wpcom mapped domains was resolved in D108844-code 

Because we serve the Site Editor from the `*.wordpress.com` subdomain, we needed to add that subdomain to an `Access-Control-Allow-Origin` header for the frontend when it is mapped to a custom domain and being called with a template-resolving `?_wp-find-template=true` request.

Because the iframe was directly passing the appropriate `postId` and `postTemplate` query args to the Site Editor, it hid that longstanding issue long enough for us to forget about it.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75652

## Proposed Changes

* Un-iframe the Site Editor in all envs

## Testing Instructions

Try to visit the Site Editor with this branch running. You should be once again redirected simply to `SITE.wordpress.com/wp-admin/site-editor.php`. (`calypso_origin` args will be added outside of wordpress.com)

Ensure that you also test on a wpcom Simple site with a mapped domain.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
