### PR TITLE
Revert 'Revert "Site Editor: un-iframe in all environments"'

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -260,23 +260,6 @@ export const post = ( context, next ) => {
 	return next();
 };
 
-export const siteEditor = ( context, next ) => {
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
-
-	context.primary = (
-		<CalypsoifyIframe
-			// This key is added as a precaution due to it's oberserved necessity in the above post editor.
-			// It will force the component to remount completely when the Id changes.
-			key={ siteId }
-			editorType="site"
-			completedFlow={ getSessionStorageOneTimeValue( 'wpcom_signup_completed_flow' ) }
-		/>
-	);
-
-	return next();
-};
-
 export const exitPost = ( context, next ) => {
 	const postId = getPostID( context );
 	const siteId = getSelectedSiteId( context.store.getState() );
@@ -290,16 +273,9 @@ export const exitPost = ( context, next ) => {
  * Redirects to the un-iframed Site Editor if the config is enabled.
  *
  * @param {Object} context Shared context in the route.
- * @param {Function} next  Next registered callback for the route.
  * @returns {*}            Whatever the next callback returns.
  */
-export const redirectSiteEditor = async ( context, next ) => {
-	// bail unless the config is enabled
-	if ( ! isEnabled( 'block-editor/un-iframed-site-editor' ) ) {
-		return next();
-	}
-
-	// Let's ditch that iframe!
+export const redirectSiteEditor = async ( context ) => {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -1,26 +1,10 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { siteSelection, sites } from 'calypso/my-sites/controller';
-import {
-	authenticate,
-	post,
-	redirect,
-	siteEditor,
-	exitPost,
-	redirectSiteEditor,
-} from './controller';
+import { authenticate, post, redirect, exitPost, redirectSiteEditor } from './controller';
 
 export default function () {
-	page(
-		'/site-editor/:site?',
-		siteSelection,
-		redirectSiteEditor,
-		redirect,
-		authenticate,
-		siteEditor,
-		makeLayout,
-		clientRender
-	);
+	page( '/site-editor/:site?', siteSelection, redirectSiteEditor );
 
 	page( '/post', siteSelection, sites, makeLayout, clientRender );
 	page( '/post/new', '/post' ); // redirect from beep-beep-boop

--- a/config/development.json
+++ b/config/development.json
@@ -29,7 +29,6 @@
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
 		"anchor/sunset-integration": true,
-		"block-editor/un-iframed-site-editor": false,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -17,7 +17,6 @@
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
 		"anchor/sunset-integration": false,
-		"block-editor/un-iframed-site-editor": false,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -21,14 +21,10 @@ import {
 	DimensionsSettings,
 	CookieBannerComponent,
 } from '..';
-import { getCalypsoURL } from '../../data-helper';
 import { getIdFromBlock } from '../../element-helper';
 import envVariables from '../../env-variables';
 
-const wpAdminPath = 'wp-admin/site-editor.php';
-
 const selectors = {
-	editorIframe: `iframe.is-loaded[src*="${ wpAdminPath }"]`,
 	editorRoot: 'body.block-editor-page',
 	editorCanvasIframe: 'iframe[name="editor-canvas"]',
 	editorCanvasRoot: 'body.block-editor-iframe__body',
@@ -75,11 +71,7 @@ export class FullSiteEditorPage {
 	constructor( page: Page ) {
 		this.page = page;
 
-		if ( this.shouldUseIframe() ) {
-			this.editor = page.frameLocator( selectors.editorIframe ).locator( selectors.editorRoot );
-		} else {
-			this.editor = page.locator( selectors.editorRoot );
-		}
+		this.editor = page.locator( selectors.editorRoot );
 
 		this.editorCanvas = this.editor
 			.frameLocator( selectors.editorCanvasIframe )
@@ -128,16 +120,10 @@ export class FullSiteEditorPage {
 			);
 		}
 
-		let targetHref: string;
-		if ( this.shouldUseIframe() ) {
-			targetHref = getCalypsoURL( `/site-editor/${ parsedUrl.host }` );
-		} else {
-			parsedUrl.pathname = '/wp-admin/site-editor.php';
-			parsedUrl.searchParams.set( 'calypso_origin', envVariables.CALYPSO_BASE_URL );
-			targetHref = parsedUrl.href;
-		}
+		parsedUrl.pathname = '/wp-admin/site-editor.php';
+		parsedUrl.searchParams.set( 'calypso_origin', envVariables.CALYPSO_BASE_URL );
 
-		await this.page.goto( targetHref, { timeout: 60 * 1000 } );
+		await this.page.goto( parsedUrl.href, { timeout: 60 * 1000 } );
 	}
 
 	/**
@@ -657,16 +643,6 @@ export class FullSiteEditorPage {
 		if ( ( await toastLocator.count() ) > 0 ) {
 			await toastLocator.click();
 		}
-	}
-
-	/**
-	 * TODO: Temp check -- we will delete when we un-iframe everywhere
-	 */
-	private shouldUseIframe(): boolean {
-		// The only place we are preserving the Site Editor iFrame is Simple sites on staging/production.
-		return (
-			! envVariables.TEST_ON_ATOMIC && envVariables.CALYPSO_BASE_URL === 'https://wordpress.com'
-		);
 	}
 
 	//#endregion

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -27,7 +27,6 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	let page: Page;
 	let fullSiteEditorPage: FullSiteEditorPage;
-	let testAccount: TestAccount;
 
 	const features = envToFeatureKey( envVariables );
 	const accountName = getTestAccountByFeature( { ...features, variant: 'siteEditor' } );
@@ -35,7 +34,7 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	beforeAll( async () => {
 		page = await browser.newPage();
 
-		testAccount = new TestAccount( accountName );
+		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
 	} );
 
@@ -52,7 +51,6 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	it( 'Open the Page template', async function () {
 		fullSiteEditorPage = new FullSiteEditorPage( page );
 
-		await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );
 		await fullSiteEditorPage.prepareForInteraction();
 
 		await fullSiteEditorPage.ensureNavigationTopLevel();


### PR DESCRIPTION
Reverts #76106

The CORS-issue for wpcom mapped domains was resolved in D108844-code 

Because we serve the Site Editor from the `*.wordpress.com` subdomain, we needed to add that subdomain to an `Access-Control-Allow-Origin` header for the frontend when it is mapped to a custom domain and being called with a template-resolving `?_wp-find-template=true` request.

Because the iframe was directly passing the appropriate `postId` and `postTemplate` query args to the Site Editor, it hid that longstanding issue long enough for us to forget about it.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75652

## Proposed Changes

* Un-iframe the Site Editor in all envs

## Testing Instructions

Try to visit the Site Editor with this branch running. You should be once again redirected simply to `SITE.wordpress.com/wp-admin/site-editor.php`. (`calypso_origin` args will be added outside of wordpress.com)

Ensure that you also test on a wpcom Simple site with a mapped domain.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
