### PR TITLE
Revert "Revert "Woo Express: Fix interval toggle overflow on small mobile screens""

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -9,6 +9,8 @@ import {
 	getPlans,
 	isWooExpressPlan,
 } from '@automattic/calypso-products';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useCallback, useMemo } from 'react';
@@ -46,6 +48,7 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 		yearlyControlProps,
 	} = props;
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const mediumPlanAnnual = getPlans()[ PLAN_WOOEXPRESS_MEDIUM ];
 	const mediumPlanMonthly = getPlans()[ PLAN_WOOEXPRESS_MEDIUM_MONTHLY ];
@@ -71,15 +74,28 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 				...yearlyControlProps,
 				content: (
 					<span>
-						{ translate( 'Pay Annually (Save %(percentageSavings)s%%)', {
-							args: { percentageSavings },
-						} ) }
+						{ isEnglishLocale ||
+						hasTranslation( 'Pay Annually {{span}}(Save %(percentageSavings)s%%){{/span}}' )
+							? translate( 'Pay Annually {{span}}(Save %(percentageSavings)s%%){{/span}}', {
+									args: { percentageSavings },
+									components: { span: <span className="wooexpress-plans__interval-savings" /> },
+							  } )
+							: translate( 'Pay Annually (Save %(percentageSavings)s%%)', {
+									args: { percentageSavings },
+							  } ) }
 					</span>
 				),
 				selected: interval === 'yearly',
 			},
 		];
-	}, [ interval, translate, monthlyControlProps, percentageSavings, yearlyControlProps ] );
+	}, [
+		interval,
+		translate,
+		monthlyControlProps,
+		percentageSavings,
+		yearlyControlProps,
+		isEnglishLocale,
+	] );
 
 	const smallPlan = interval === 'yearly' ? PLAN_WOOEXPRESS_SMALL : PLAN_WOOEXPRESS_SMALL_MONTHLY;
 	const mediumPlan =

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/style.scss
@@ -15,6 +15,10 @@
 		@media (max-width: $break-mobile) {
 			max-width: 100%;
 			width: 100%;
+
+			.wooexpress-plans__interval-savings {
+				display: none;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#76241

Restoring the changes from #76156. We had to revert to clean up a deploy issue from another PR. Our original PR was fine.