### PR TITLE
Fix the color of nav items in ETK sidebar for RTL locales

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/style.scss
@@ -20,7 +20,7 @@ $nav-item-untitled-text-color: #b5bcc2; // former $light-gray-800
 
 	&:hover,
 	&:not([aria-disabled="true"]):active {
-		color: $white;
+		color: $white !important;
 	}
 
 	&:focus {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -117,7 +117,7 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 	width: 100%;
 	border: none !important;
 	box-shadow: none !important;
-	color: $white;
+	color: $white !important;
 	flex-shrink: 0;
 	padding: 8px 11px !important;
 	margin: 12px 0;
@@ -164,7 +164,7 @@ $sidebar-button-text-color: #a2aab2; // former $light-gray-900
 	}
 
 	.is-selected {
-		color: $white;
+		color: $white !important;
 	}
 	/*
 	@TODO Work out how we're going to handle overflow


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 524-gh-Automattic/i18n-issues

## Proposed Changes

* For RTL locales the CSS styles are not being concatenated, which means that the `.components-button` styles are overriding the ones from `.wpcom-block-editor-nav-...` and the colors for navigation items in the ETK sidebar are different for RTL locales. The easiest way to resolve this is to add `!important` to the styles to force the correct color to be used.

| Before  | After |
| ------------- | ------------- |
| <img width="268" alt="Screenshot 2023-04-25 at 22 19 37" src="https://user-images.githubusercontent.com/7847633/234395544-0dbdac51-5414-43c4-8e47-6c6f9e76395d.png"> | <img width="268" alt="Screenshot 2023-04-25 at 22 21 39" src="https://user-images.githubusercontent.com/7847633/234395550-795288bd-d3e3-4ba7-a461-4120b70c3347.png"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* To reproduce the issue, set your WordPress.com locale to Arabic or Hebrew, navigate to a post on an Atomic site with an installed plugin (.wpcomstaging.com) and click on the WordPress logo in the top right corner to open the navigation sidebar.
* Disable `WordPress.com Editing Toolkit` on your Atomic site.
* Open the details for `Editing ToolKit (WPCom Plugins)` TeamCity build in this PR
* Go to `Artifacts`, download `editing-toolkit.zip` and install it.
* Test the post sidebar again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
