### PR TITLE
Data Stores: Add new Launchpad endpoint

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -1,3 +1,4 @@
+import { useLaunchpad } from '@automattic/data-stores';
 import { StepContainer, START_WRITING_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch as useWPDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -7,7 +8,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useLaunchpadChecklist } from 'calypso/../packages/help-center/src/hooks/use-launchpad-checklist';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { useLaunchpad } from 'calypso/data/sites/use-launchpad';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useRecordSignupComplete } from 'calypso/landing/stepper/hooks/use-record-signup-complete';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
@@ -37,7 +37,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	const site = useSite();
 	const {
 		isError: launchpadFetchError,
-		data: { launchpad_screen: launchpadScreenOption, site_intent: siteIntentOption },
+		data: { launchpad_screen: launchpadScreenOption, site_intent: siteIntentOption } = {},
 	} = useLaunchpad( siteSlug );
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 	const recordSignupComplete = useRecordSignupComplete( flow );
@@ -47,7 +47,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 
 	const {
 		data: { checklist: launchpadChecklist },
-	} = useLaunchpadChecklist( siteSlug, siteIntentOption );
+	} = useLaunchpadChecklist( siteSlug, siteIntentOption || null );
 
 	const fetchingSiteError = useSelect(
 		( select ) => ( select( SITE_STORE ) as SiteSelect ).getFetchingSiteError(),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -47,7 +47,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 
 	const {
 		data: { checklist: launchpadChecklist },
-	} = useLaunchpadChecklist( siteSlug, siteIntentOption || null );
+	} = useLaunchpadChecklist( siteSlug, siteIntentOption );
 
 	const fetchingSiteError = useSelect(
 		( select ) => ( select( SITE_STORE ) as SiteSelect ).getFetchingSiteError(),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,5 +1,5 @@
 import { Gridicon, CircularProgressBar } from '@automattic/components';
-import { OnboardSelect } from '@automattic/data-stores';
+import { OnboardSelect, useLaunchpad } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
 import { useRef, useState } from '@wordpress/element';
 import { Icon, copy } from '@wordpress/icons';
@@ -9,7 +9,6 @@ import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
 import Badge from 'calypso/components/badge';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import Tooltip from 'calypso/components/tooltip';
-import { useLaunchpad } from 'calypso/data/sites/use-launchpad';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
@@ -66,9 +65,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 
 	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles( site?.ID );
-	const {
-		data: { checklist_statuses },
-	} = useLaunchpad( siteSlug );
+	const { data: { checklist_statuses } = {} } = useLaunchpad( siteSlug );
 
 	const isEmailVerified = useSelector( isCurrentUserEmailVerified );
 

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -28,6 +28,7 @@ export * from './onboard/types';
 export * from './domain-suggestions/types';
 export * from './plans/types';
 export * from './user/types';
+export * from './queries/use-launchpad';
 
 const { SubscriptionManager } = Reader;
 

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -1,0 +1,98 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useQuery } from 'react-query';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+
+interface APIFetchOptions {
+	global: boolean;
+	path: string;
+}
+
+interface Task {
+	id?: string;
+	completed?: boolean;
+	disabled?: boolean;
+	title?: string;
+	subtitle?: string;
+	badgeText?: string;
+	actionDispatch?: () => void;
+	isLaunchTask?: boolean;
+	warning?: boolean;
+}
+
+interface ChecklistStatuses {
+	links_edited?: boolean;
+	site_edited?: boolean;
+	site_launched?: boolean;
+	first_post_published?: boolean;
+	video_uploaded?: boolean;
+	publish_first_course?: boolean;
+	plan_completed?: boolean;
+	domain_upsell_deferred?: boolean;
+}
+
+interface LaunchpadResponse {
+	site_intent?: string | null;
+	launchpad_screen?: string | boolean | null | undefined;
+	checklist?: Task[] | null;
+	checklist_statuses?: ChecklistStatuses;
+}
+
+type LaunchpadUpdateSettings = {
+	checklist_statuses?: Record< string, boolean >;
+};
+
+export const fetchLaunchpad = (
+	siteSlug: string | null,
+	checklist_slug?: string | null
+): Promise< LaunchpadResponse > => {
+	const slug = encodeURIComponent( siteSlug as string );
+	const requestUrl = checklist_slug
+		? `/sites/${ slug }/launchpad?checklist_slug=${ checklist_slug }`
+		: `/sites/${ slug }/launchpad`;
+
+	return canAccessWpcomApis()
+		? wpcomRequest( {
+				path: requestUrl,
+				apiNamespace: 'wpcom/v2',
+				apiVersion: '2',
+		  } )
+		: apiFetch( {
+				global: true,
+				path: `/wpcom/v2${ requestUrl }`,
+		  } as APIFetchOptions );
+};
+
+export const useLaunchpad = ( siteSlug: string | null, checklist_slug?: string | null ) => {
+	const key = [ 'launchpad', siteSlug, checklist_slug ];
+	return useQuery( key, () => fetchLaunchpad( siteSlug, checklist_slug ), {
+		retry: 3,
+		initialData: {
+			site_intent: '',
+			launchpad_screen: undefined,
+			checklist_statuses: {},
+			checklist: null,
+		},
+	} );
+};
+
+export const updateLaunchpadSettings = (
+	siteSlug: string | null,
+	settings: LaunchpadUpdateSettings = {}
+) => {
+	const slug = encodeURIComponent( siteSlug as string );
+	const requestUrl = `/sites/${ slug }/launchpad`;
+
+	return canAccessWpcomApis()
+		? wpcomRequest( {
+				path: requestUrl,
+				apiNamespace: 'wpcom/v2',
+				method: 'PUT',
+				body: { settings },
+		  } )
+		: apiFetch( {
+				global: true,
+				path: `/wpcom/v2${ requestUrl }`,
+				method: 'PUT',
+				data: { settings },
+		  } as APIFetchOptions );
+};

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -8,10 +8,10 @@ interface APIFetchOptions {
 }
 
 interface Task {
-	id?: string;
-	completed?: boolean;
-	disabled?: boolean;
-	title?: string;
+	id: string;
+	completed: boolean;
+	disabled: boolean;
+	title: string;
 	subtitle?: string;
 	badgeText?: string;
 	actionDispatch?: () => void;

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -1,5 +1,5 @@
+import { useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
-import { useQuery } from 'react-query';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 
 interface APIFetchOptions {

--- a/packages/help-center/src/hooks/use-launchpad-checklist.tsx
+++ b/packages/help-center/src/hooks/use-launchpad-checklist.tsx
@@ -25,7 +25,7 @@ interface LaunchpadTasks {
 
 export const fetchLaunchpadChecklist = (
 	siteSlug: string | null,
-	siteIntent: string
+	siteIntent: string | null
 ): Promise< LaunchpadTasks > => {
 	const slug = encodeURIComponent( siteSlug as string );
 
@@ -41,7 +41,7 @@ export const fetchLaunchpadChecklist = (
 		  } as APIFetchOptions );
 };
 
-export const useLaunchpadChecklist = ( siteSlug: string | null, siteIntent: string ) => {
+export const useLaunchpadChecklist = ( siteSlug: string | null, siteIntent: string | null ) => {
 	const key = [ 'launchpad-checklist', siteSlug ];
 	const queryResult = useQuery( key, () => fetchLaunchpadChecklist( siteSlug, siteIntent ), {
 		retry: 3,

--- a/packages/help-center/src/hooks/use-launchpad-checklist.tsx
+++ b/packages/help-center/src/hooks/use-launchpad-checklist.tsx
@@ -25,7 +25,7 @@ interface LaunchpadTasks {
 
 export const fetchLaunchpadChecklist = (
 	siteSlug: string | null,
-	siteIntent: string | null | undefined
+	siteIntent: string | null
 ): Promise< LaunchpadTasks > => {
 	const slug = encodeURIComponent( siteSlug as string );
 
@@ -43,7 +43,7 @@ export const fetchLaunchpadChecklist = (
 
 export const useLaunchpadChecklist = (
 	siteSlug: string | null,
-	siteIntent: string | null | undefined
+	siteIntent: string | null = null
 ) => {
 	const key = [ 'launchpad-checklist', siteSlug ];
 	const queryResult = useQuery( key, () => fetchLaunchpadChecklist( siteSlug, siteIntent ), {

--- a/packages/help-center/src/hooks/use-launchpad-checklist.tsx
+++ b/packages/help-center/src/hooks/use-launchpad-checklist.tsx
@@ -25,7 +25,7 @@ interface LaunchpadTasks {
 
 export const fetchLaunchpadChecklist = (
 	siteSlug: string | null,
-	siteIntent: string | null
+	siteIntent: string | null | undefined
 ): Promise< LaunchpadTasks > => {
 	const slug = encodeURIComponent( siteSlug as string );
 
@@ -41,7 +41,10 @@ export const fetchLaunchpadChecklist = (
 		  } as APIFetchOptions );
 };
 
-export const useLaunchpadChecklist = ( siteSlug: string | null, siteIntent: string | null ) => {
+export const useLaunchpadChecklist = (
+	siteSlug: string | null,
+	siteIntent: string | null | undefined
+) => {
 	const key = [ 'launchpad-checklist', siteSlug ];
 	const queryResult = useQuery( key, () => fetchLaunchpadChecklist( siteSlug, siteIntent ), {
 		retry: 3,


### PR DESCRIPTION
### Proposed Changes

This moves our useLaunchpad / fetchLaunchpad / updateLaunchpadSettings methods/hooks to the data-stores package, and also makes some changes to them. This will allow us to delete some duplicated hooks/methods, and ensures the new hooks are universally available to any packages, apps, or core calypso code. 

**Details:**
   - Move useLaunchpad hook, the underlying fetchLaunchpad method, and the updateLaunchpadSettings hook from  [calypso/data](https://github.com/Automattic/wp-calypso/blob/trunk/client/data/sites/use-launchpad.ts) to the data-stores package. . 
   - To ensure our hook is viable on both simple and atomic sites, we conditionally use wpcomRequest and apiFetch in both useLaunchpad and updateLaunchpadSettings (see this slack thread for more: p1681177419999259-slack-CHN6J22MP)
   - Note that for useLaunchpad, we've updated the query key to include the checklist_slug
   - This PR also anticipates that we'll consolidate to a single Launchpad endpoint, so the hook allows you to fetch our new backend checklist by providing a checklist slug. If no checklist_slug is provided, it will return the same info as the original useLaunchpad hook, along with 'null' for the checklist. The ability to fetch a checklist will depend on deploying this PR: https://github.com/Automattic/jetpack/pull/30227

**Anticipated follow ups:**
  - Update My Home controller to use this new endpoint [here](https://github.com/Automattic/wp-calypso/blob/f541a5c6cc184fb3e6ccb70646de7979351cdcf5/client/my-sites/customer-home/controller.jsx#L50). 
  - Remove near-duplicate hook from [packages/help-center](https://github.com/Automattic/wp-calypso/blob/trunk/packages/help-center/src/hooks/use-launchpad.tsx), and update Help Center logic to use this new hook.
  - Once all logic is using the new hook, we can also delete the existing useLaunchpad file from [calypso/data](https://github.com/Automattic/wp-calypso/blob/trunk/client/data/sites/use-launchpad.ts) 

### Testing Instructions

Ultimately, the user-facing, front-end behavior of Launchpad should be exactly the same before and after this PR. So really, we are testing to confirm there are no regressive breakages. 

1. Check out this branch locally and run `yarn` and `yarn start` if needed. 
2. Note: The new code is in a package. While packages should be rebuild during yarn start, depending on your local environment conditions, you may need to rebuild packages using the `yarn build-packages` command.
3. Start any new launchpad-enabled site, such as a free site at http://calypso.localhost:3000/setup/free/intro
4. Continue through to Launchpad and confirm the Launchpad screen and checklist loads as expected. 
5. Complete each task, and confirm that checklist statuses update as expected. 
6. Consider duplicating steps 2-3 for another flow. 
