### PR TITLE
Staging Sites: Use 'Switch to production site' as button text

### DIFF
--- a/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
@@ -82,7 +82,7 @@ function StagingSiteProductionCard( { disabled, siteId }: CardProps ) {
 						href={ `/hosting-config/${ urlToSlug( productionSite.url ) }` }
 						disabled={ disabled }
 					>
-						<span>{ __( 'Go back to production' ) }</span>
+						<span>{ __( 'Switch to production site' ) }</span>
 					</Button>
 				</ActionButtons>
 			</>


### PR DESCRIPTION
From pdtkmj-1pr-p2#comment-2603

## Proposed Changes

Switches the back button to 'Switch to production site':

<img width="774" alt="image" src="https://user-images.githubusercontent.com/36432/234429954-fe011e60-4839-4b4b-a1ef-088214e3cb26.png">

## Testing Instructions

1. Create a Business site and take it Atomic.
2. Navigate to Hosting Configuration.
3. Create a staging site.
4. Click on 'Manage staging site'
5. On the staging site's Hosting Configuration, verify the button appears as expected.