### PR TITLE
Remove business plan upsell for premium monthly purchases

### DIFF
--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -588,8 +588,9 @@ function getNextHigherPlanSlug( cart: ResponseCart ): string | undefined {
 		}
 	}
 
-	// Only upsell to Business plan when not a monthly plan.
-	if ( isWpComPremiumPlan( currentPlanSlug ) ) {
+	// Don't show the business plan upsell if the current plan is a premium monthly plan.
+	// For the experiment: calypso_postpurchase_upsell_monthly_to_annual_plan
+	if ( isWpComPremiumPlan( currentPlanSlug ) && currentPlan?.term !== TERM_MONTHLY ) {
 		const planKey = findFirstSimilarPlanKey( PLAN_BUSINESS, { term: currentPlan?.term } );
 		return planKey ? getPlan( planKey )?.getPathSlug?.() : undefined;
 	}

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1042,8 +1042,8 @@ describe( 'getThankYouPageUrl', () => {
 
 	// NOTE: as part of the calypso_postpurchase_upsell_monthly_to_annual_plan experiment
 	// we're disabling the monthly premium to monthly business plan upsell
+	// https://github.com/Automattic/wp-calypso/pull/76260
 	it( 'redirects to thank you page if jetpack is not in the cart, and premium monthly is in the cart', () => {
-		// it( 'redirects to business monthly upgrade nudge if jetpack is not in the cart, and premium monthly is in the cart', () => {
 		const cart = {
 			...getMockCart(),
 			products: [
@@ -1060,10 +1060,7 @@ describe( 'getThankYouPageUrl', () => {
 			cart,
 			receiptId: samplePurchaseId,
 		} );
-		expect( url ).toBe(
-			`/checkout/thank-you/foo.bar/${ samplePurchaseId }`
-			// `/checkout/foo.bar/offer-plan-upgrade/business-monthly/${ samplePurchaseId }`
-		);
+		expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
 	} );
 
 	it( 'redirects to the business upgrade nudge with a placeholder when jetpack is not in the cart and premium is in the cart but there is no receipt', () => {
@@ -1622,7 +1619,7 @@ describe( 'getThankYouPageUrl', () => {
 
 		// NOTE: as part of the calypso_postpurchase_upsell_monthly_to_annual_plan experiment
 		// we're disabling the monthly premium to monthly business plan upsell
-		// it( 'offers discounted monthly business plan upgrade when monthly premium plan is purchased.', () => {
+		// https://github.com/Automattic/wp-calypso/pull/76260
 		it( 'shows thank you page for monthly premium plan purchases', () => {
 			const cart = {
 				...getMockCart(),
@@ -1640,10 +1637,7 @@ describe( 'getThankYouPageUrl', () => {
 				receiptId: samplePurchaseId,
 				cart,
 			} );
-			expect( url ).toBe(
-				`/checkout/thank-you/foo.bar/${ samplePurchaseId }`
-				// `/checkout/foo.bar/offer-plan-upgrade/business-monthly/${ samplePurchaseId }`
-			);
+			expect( url ).toBe( `/checkout/thank-you/foo.bar/${ samplePurchaseId }` );
 		} );
 
 		it( 'Does not offers discounted annual business plan upgrade when annual premium plan and DIFM light is purchased together.', () => {

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1040,7 +1040,10 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( `/checkout/foo.bar/offer-plan-upgrade/business/${ samplePurchaseId }` );
 	} );
 
-	it( 'redirects to business monthly upgrade nudge if jetpack is not in the cart, and premium monthly is in the cart', () => {
+	// NOTE: as part of the calypso_postpurchase_upsell_monthly_to_annual_plan experiment
+	// we're disabling the monthly premium to monthly business plan upsell
+	it( 'redirects to thank you page if jetpack is not in the cart, and premium monthly is in the cart', () => {
+		// it( 'redirects to business monthly upgrade nudge if jetpack is not in the cart, and premium monthly is in the cart', () => {
 		const cart = {
 			...getMockCart(),
 			products: [
@@ -1058,7 +1061,8 @@ describe( 'getThankYouPageUrl', () => {
 			receiptId: samplePurchaseId,
 		} );
 		expect( url ).toBe(
-			`/checkout/foo.bar/offer-plan-upgrade/business-monthly/${ samplePurchaseId }`
+			`/checkout/thank-you/foo.bar/${ samplePurchaseId }`
+			// `/checkout/foo.bar/offer-plan-upgrade/business-monthly/${ samplePurchaseId }`
 		);
 	} );
 
@@ -1616,7 +1620,10 @@ describe( 'getThankYouPageUrl', () => {
 			);
 		} );
 
-		it( 'offers discounted monthly business plan upgrade when monthly premium plan is purchased.', () => {
+		// NOTE: as part of the calypso_postpurchase_upsell_monthly_to_annual_plan experiment
+		// we're disabling the monthly premium to monthly business plan upsell
+		// it( 'offers discounted monthly business plan upgrade when monthly premium plan is purchased.', () => {
+		it( 'shows thank you page for monthly premium plan purchases', () => {
 			const cart = {
 				...getMockCart(),
 				products: [
@@ -1634,7 +1641,8 @@ describe( 'getThankYouPageUrl', () => {
 				cart,
 			} );
 			expect( url ).toBe(
-				`/checkout/foo.bar/offer-plan-upgrade/business-monthly/${ samplePurchaseId }`
+				`/checkout/thank-you/foo.bar/${ samplePurchaseId }`
+				// `/checkout/foo.bar/offer-plan-upgrade/business-monthly/${ samplePurchaseId }`
 			);
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/2195

For the experiment, when purchasing monthly plans for personal/premium/business plans
* control: no upsell
* treatment: with annual upsell
* this has been discussed in pbxNRc-2tB-p2#comment-4248

## Proposed Changes

* Remove business plan upsell for premium monthly purchases

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before


https://user-images.githubusercontent.com/6586048/234462616-9d26892d-e9e0-42d5-9f67-fa2a1d653f91.mp4



After


https://user-images.githubusercontent.com/6586048/234462346-439f8826-4264-4f88-814c-7ed877171aa8.mp4



* have a test account on a free/personal plan
* go to `/plans/monthly/:siteSlug`
* select the premium plan
* should see the after thank you page and not the upsell in before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~