### PR TITLE
Odyssey Widget: fix broken chart when expanding widget

### DIFF
--- a/apps/odyssey-stats/src/widget/mini-chart.jsx
+++ b/apps/odyssey-stats/src/widget/mini-chart.jsx
@@ -1,9 +1,10 @@
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import Chart from 'calypso/components/chart';
 import Legend from 'calypso/components/chart/legend';
+import { rectIsEqual, rectIsZero } from 'calypso/lib/track-element-size';
 import { buildChartData } from 'calypso/my-sites/stats/stats-chart-tabs/utility';
 import StatsEmptyState from 'calypso/my-sites/stats/stats-empty-state';
 import StatsModulePlaceholder from 'calypso/my-sites/stats/stats-module/placeholder';
@@ -45,8 +46,33 @@ const MiniChart = ( { siteId, quantity = 7, gmtOffset, odysseyStatsBaseUrl } ) =
 		queryDate
 	);
 
+	const chartWrapperRef = useRef( null );
+	const lastRect = useRef( null );
+	useEffect( () => {
+		if ( ! chartWrapperRef?.current ) {
+			return;
+		}
+		const observer = new ResizeObserver( () => {
+			const rect = chartWrapperRef.current ? chartWrapperRef.current.getBoundingClientRect() : null;
+			if ( ! rectIsEqual( lastRect.current, rect ) && ! rectIsZero( rect ) ) {
+				lastRect.current = rect;
+				// Trigger a resize event to force the chart to redraw.
+				window?.dispatchEvent( new Event( 'resize' ) );
+			}
+		} );
+
+		observer.observe( chartWrapperRef.current );
+
+		return () => observer.disconnect();
+	} );
+
 	return (
-		<div id="stats-widget-minichart" className="stats-widget-minichart" aria-hidden="true">
+		<div
+			ref={ chartWrapperRef }
+			id="stats-widget-minichart"
+			className="stats-widget-minichart"
+			aria-hidden="true"
+		>
 			<div className="stats-widget-minichart__chart-head">
 				<Intervals selected={ period } compact={ false } onChange={ setPeriod } />
 				<Legend

--- a/client/lib/track-element-size/index.ts
+++ b/client/lib/track-element-size/index.ts
@@ -6,11 +6,6 @@ type NullableDOMRect = ClientRect | DOMRect | null;
 type NullableElement = Element | null;
 
 export const THROTTLE_RATE = 200;
-const FLOATING_POINT_TOLERANCE = 1e-4;
-
-function floatIsEqual( a: number, b: number ) {
-	return Math.abs( a - b ) < FLOATING_POINT_TOLERANCE;
-}
 
 export function rectIsEqual( prevRect: NullableDOMRect, nextRect: NullableDOMRect ) {
 	if ( prevRect === null ) {
@@ -22,11 +17,12 @@ export function rectIsEqual( prevRect: NullableDOMRect, nextRect: NullableDOMRec
 	}
 
 	return (
-		floatIsEqual( prevRect.bottom, nextRect.bottom ) &&
-		floatIsEqual( prevRect.left, nextRect.left ) &&
-		floatIsEqual( prevRect.right, nextRect.right ) &&
-		floatIsEqual( prevRect.width, nextRect.width ) &&
-		floatIsEqual( prevRect.height, nextRect.height )
+		prevRect.bottom === nextRect.bottom &&
+		prevRect.left === nextRect.left &&
+		prevRect.right === nextRect.right &&
+		prevRect.top === nextRect.top &&
+		prevRect.width === nextRect.width &&
+		prevRect.height === nextRect.height
 	);
 }
 

--- a/client/lib/track-element-size/index.ts
+++ b/client/lib/track-element-size/index.ts
@@ -6,8 +6,13 @@ type NullableDOMRect = ClientRect | DOMRect | null;
 type NullableElement = Element | null;
 
 export const THROTTLE_RATE = 200;
+const FLOATING_POINT_TOLERANCE = 1e-4;
 
-function rectIsEqual( prevRect: NullableDOMRect, nextRect: NullableDOMRect ) {
+function floatIsEqual( a: number, b: number ) {
+	return Math.abs( a - b ) < FLOATING_POINT_TOLERANCE;
+}
+
+export function rectIsEqual( prevRect: NullableDOMRect, nextRect: NullableDOMRect ) {
 	if ( prevRect === null ) {
 		return nextRect === null;
 	}
@@ -17,16 +22,15 @@ function rectIsEqual( prevRect: NullableDOMRect, nextRect: NullableDOMRect ) {
 	}
 
 	return (
-		prevRect.bottom === nextRect.bottom &&
-		prevRect.left === nextRect.left &&
-		prevRect.right === nextRect.right &&
-		prevRect.top === nextRect.top &&
-		prevRect.width === nextRect.width &&
-		prevRect.height === nextRect.height
+		floatIsEqual( prevRect.bottom, nextRect.bottom ) &&
+		floatIsEqual( prevRect.left, nextRect.left ) &&
+		floatIsEqual( prevRect.right, nextRect.right ) &&
+		floatIsEqual( prevRect.width, nextRect.width ) &&
+		floatIsEqual( prevRect.height, nextRect.height )
 	);
 }
 
-function rectIsZero( rect: NullableDOMRect ) {
+export function rectIsZero( rect: NullableDOMRect ) {
 	if ( rect === null ) {
 		return null;
 	}


### PR DESCRIPTION
Related to #76259 

## Proposed Changes

Add listener to the chart wrapper and trigger `resize` event for the chart to redraw.

## Testing Instructions


* Build Jetpack if necessary: `jetpack build plugins/jetpack`.
* Run `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev` under `calypso/apps/odyssey-stats`.
- Open `/wp-admin/index.php` on a site with Jetpack bleeding edge
- Fold Jetpack Stats Widget
- Refresh
- Expand Jetpack Stats Widget
- Ensure the chart is properly rendered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
