### PR TITLE
Staging Sites: Redirect backup page to home for staging sites

### DIFF
--- a/client/my-sites/backup/index.js
+++ b/client/my-sites/backup/index.js
@@ -15,7 +15,12 @@ import {
 	showUnavailableForMultisites,
 } from 'calypso/my-sites/backup/controller';
 import WPCOMUpsellPage from 'calypso/my-sites/backup/wpcom-backup-upsell';
-import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
+import {
+	navigation,
+	siteSelection,
+	sites,
+	stagingSiteNotSupportedRedirect,
+} from 'calypso/my-sites/controller';
 import isJetpackSectionEnabledForSite from 'calypso/state/selectors/is-jetpack-section-enabled-for-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { backupMainPath, backupRestorePath, backupDownloadPath, backupClonePath } from './paths';
@@ -37,6 +42,7 @@ export default function () {
 	page(
 		backupDownloadPath( ':site', ':rewindId' ),
 		siteSelection,
+		stagingSiteNotSupportedRedirect,
 		navigation,
 		backupDownload,
 		wrapInSiteOffsetProvider,
@@ -54,6 +60,7 @@ export default function () {
 	page(
 		backupRestorePath( ':site', ':rewindId' ),
 		siteSelection,
+		stagingSiteNotSupportedRedirect,
 		navigation,
 		backupRestore,
 		wrapInSiteOffsetProvider,
@@ -71,6 +78,7 @@ export default function () {
 	page(
 		backupClonePath( ':site' ),
 		siteSelection,
+		stagingSiteNotSupportedRedirect,
 		navigation,
 		backupClone,
 		wrapInSiteOffsetProvider,
@@ -88,6 +96,7 @@ export default function () {
 	page(
 		backupMainPath( ':site' ),
 		siteSelection,
+		stagingSiteNotSupportedRedirect,
 		navigation,
 		backups,
 		wrapInSiteOffsetProvider,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/1880

## Proposed Changes

In this diff, I propose to redirect from the Backup page to the Home for staging sites. We are disabling this link under another PR, and I would like to block direct access to the page here.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Use Calypso Live environment or local environment.

1. Access site eligible for Jetpack Backups
2. Create a staging site and stay in production site context
3. Navigate to the Jetpack Backup page and confirm it works fine
4. Use the sidebar site selector to switch to the staging site
5. Confirm that Calypso redirects to site's home

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
