### PR TITLE
Jetpack Pro Dashboard: fix jumpy Backup and Scan columns

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -445,3 +445,9 @@
 		left: 4px;
 	}
 }
+
+.fixed-site-column {
+	max-width: 140px !important;
+	min-width: 140px !important;
+}
+

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -57,13 +57,13 @@ export const siteColumns: SiteColumns = [
 	{
 		key: 'backup',
 		title: translate( 'Backup' ),
-		className: 'width-fit-content',
+		className: 'fixed-site-column',
 		isExpandable: true,
 	},
 	{
 		key: 'scan',
 		title: translate( 'Scan' ),
-		className: 'width-fit-content',
+		className: 'fixed-site-column',
 	},
 	{
 		key: 'monitor',


### PR DESCRIPTION
Related to 1202619025189113-as-1204438047173015

## Proposed Changes

This PR fixes the jumpy Backup and Scan columns.

## Testing Instructions

> **_NOTE:_**  You can always use the live link URL to test these changes and https://cloud.jetpack.com/ to compare the changes

- Run `git checkout fix/fix-jumpy-columns-in-pro-dashboard` and `yarn start-jetpack-cloud`
- Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
- Select an *(+ Add)* button on Backup & Scan columns to select a license for a site. Verify both the column width is not increasing/decreasing when a license is selected/unselected.  
- Verify the same with different large screen resolutions(>1280px) using the dev tool.
- You can also test this using a different language by converting this page. 

<img width="377" alt="Screenshot 2023-04-26 at 12 44 32 PM" src="https://user-images.githubusercontent.com/10586875/234498585-66cb6477-1301-4c1f-95dc-0a696ba846fd.png">


<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>

https://user-images.githubusercontent.com/10586875/234497440-c2969c83-8b14-4507-80c9-f768c1988bb2.mov

</td>
<td>

https://user-images.githubusercontent.com/10586875/234497405-f0d21254-7377-46aa-b60e-850613570989.mov

</td>
</tr>
</table>
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?