### PR TITLE
Redesign ready to blaze Posts - Attempt no. 2

### DIFF
--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -13,11 +13,13 @@ class PostRelativeTime extends PureComponent {
 		link: PropTypes.string,
 		target: PropTypes.string,
 		gridiconSize: PropTypes.number,
+		showGridIcon: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		link: null,
 		target: null,
+		showGridIcon: true,
 	};
 
 	/**
@@ -83,7 +85,9 @@ class PostRelativeTime extends PureComponent {
 			<span className="post-relative-time-status__time">
 				{ time && (
 					<>
-						<Gridicon icon="time" size={ this.props.gridiconSize || 18 } />
+						{ this.props.showGridIcon && (
+							<Gridicon icon="time" size={ this.props.gridiconSize || 18 } />
+						) }
 						<time className="post-relative-time-status__time-text" dateTime={ time }>
 							{ this.getDisplayedTimeForLabel() }
 						</time>

--- a/client/my-sites/promote-post-i2/components/campaigns-table/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/index.tsx
@@ -14,18 +14,18 @@ export default function CampaignsTable( props: Props ) {
 			<table className="promote-post__table">
 				<thead>
 					<tr>
-						<th>Campaign</th>
-						<th>User</th>
-						<th>Status</th>
-						<th>Ends</th>
-						<th>Budget</th>
-						<th>Impressions</th>
-						<th>Clicks</th>
+						<th key="campaign">Campaign</th>
+						<th key="user">User</th>
+						<th key="status">Status</th>
+						<th key="ends">Ends</th>
+						<th key="budget">Budget</th>
+						<th key="impressions">Impressions</th>
+						<th key="clicks">Clicks</th>
 					</tr>
 				</thead>
 				<tbody>
 					{ campaigns.map( ( campaign ) => {
-						return <CampaignItem campaign={ campaign } />;
+						return <CampaignItem key={ `item-${ campaign.campaign_id }` } campaign={ campaign } />;
 					} ) }
 				</tbody>
 			</table>

--- a/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaigns-table/style.scss
@@ -1,14 +1,33 @@
 @import "@automattic/typography/styles/variables";
+@import "@automattic/color-studio/dist/color-variables";
 
 $font-sf-pro-display: "SF Pro Display", $sans;
 $font-sf-pro-text: "SF Pro Text", $sans;
+
+.main.promote-post {
+	.search {
+		height: 44px;
+	}
+
+	.segmented-control {
+		background-color: transparent;
+		margin-left: 16px;
+
+		.segmented-control__link {
+			align-items: center;
+			display: flex;
+			height: 34px;
+			justify-content: center;
+		}
+	}
+}
 
 .promote-post__table {
 	th {
 		font-family: $font-sf-pro-text;
 		font-style: normal;
 		font-weight: 400;
-		font-size: 1rem;
+		font-size: 0.875rem;
 		line-height: 20px;
 		letter-spacing: -0.15px;
 		color: #50575e;
@@ -24,20 +43,25 @@ $font-sf-pro-text: "SF Pro Text", $sans;
 	}
 
 	td {
+		color: $studio-gray-60;
 		padding-top: 16px;
 		padding-bottom: 12px;
 		border-top: 1px solid #d8d8d8; /* #EEEEEE if bg is white */
-		font-size: 1rem;
+		font-size: 0.875rem;
 		vertical-align: middle;
+		line-height: 1.43;
+		letter-spacing: -0.15px;
 	}
 
-
 	.promote-post__campaign-item-wrapper {
+		color: $studio-gray-100;
 		display: flex;
 		align-items: center;
+		font-weight: 500;
 	}
 
 	.campaign-item__header-image img {
+		border: 1px solid #eee;
 		border-radius: 4px;
 		width: 108px;
 		height: 78px;
@@ -46,7 +70,9 @@ $font-sf-pro-text: "SF Pro Text", $sans;
 
 	.badge {
 		border-radius: 4px;
-		font-size: 0.875rem;
+		font-size: 0.75rem;
+		line-height: 1.666666666666667;
+		white-space: nowrap;
 
 		&.badge--error {
 			background-color: #facfd2;

--- a/client/my-sites/promote-post-i2/components/post-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/post-item/index.tsx
@@ -1,0 +1,120 @@
+import { safeImageUrl } from '@automattic/calypso-url';
+import './style.scss';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { recordDSPEntryPoint } from 'calypso/lib/promote-post';
+import resizeImageUrl from 'calypso/lib/resize-image-url';
+import { useRouteModal } from 'calypso/lib/route-modal';
+import PostRelativeTimeStatus from 'calypso/my-sites/post-relative-time-status';
+import { getPostType } from 'calypso/my-sites/promote-post/utils';
+
+type Discussion = {
+	comment_count: number;
+};
+
+export type Post = {
+	ID: number;
+	global_ID: string;
+	featured_image: string;
+	title: string;
+	date: string;
+	modified: string;
+	excerpt: string;
+	content: string;
+	site_ID: number;
+	slug: string;
+	status: string;
+	type: string; // post, page
+	URL: string;
+	like_count: number;
+	discussion: Discussion;
+	views: number;
+};
+
+type Props = {
+	post: Post;
+};
+
+export default function PostItem( { post }: Props ) {
+	const [ loading ] = useState( false );
+	const dispatch = useDispatch();
+	const keyValue = 'post-' + post.ID;
+	const { openModal } = useRouteModal( 'blazepress-widget', keyValue );
+
+	const onClickPromote = async () => {
+		openModal();
+		dispatch( recordDSPEntryPoint( 'promoted_posts-post_item' ) );
+	};
+
+	const safeUrl = safeImageUrl( post.featured_image );
+	const featuredImage = safeUrl && resizeImageUrl( safeUrl, { h: 80 }, 0 );
+
+	return (
+		<tr className="post-item__row">
+			<td className="post-item__post-data">
+				{ featuredImage && (
+					<div
+						className="post-item__post-thumbnail-wrapper"
+						style={ { backgroundImage: `url(${ featuredImage })` } }
+					/>
+				) }
+				{ ! featuredImage && (
+					<div className="post-item__post-thumbnail-wrapper post-item__post-thumbnail-wrapper_no-image">
+						<svg // "No image found" icon
+							width="20"
+							height="20"
+							viewBox="0 0 20 20"
+							fill="none"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<path
+								fill-rule="evenodd"
+								clip-rule="evenodd"
+								d="M17.5576 5.4415L16.4996 4.38344L15.4415 5.4415L14.5576 4.55762L15.6157 3.49956L14.5576 2.4415L15.4415 1.55762L16.4996
+								2.61568L17.5576 1.55762L18.4415 2.4415L17.3834 3.49956L18.4415 4.55762L17.5576 5.4415ZM17.5 15.8333V6.85506C17.1831 6.94936 16.8475 7 16.5 7C16.4159 7 16.3326 6.99704
+								16.25 6.99121V11.1306L13.769 8.71854C13.5264 8.48271 13.1402 8.48271 12.8976 8.71854L9.92167 11.6119L7.48278 10.0311C7.26548 9.89025 6.98384 9.89799 6.77461 10.0506L3.75
+								12.256L3.75 4.16667C3.75 3.93655 3.93655 3.75 4.16667 3.75L13.0088 3.75C13.003 3.66742 13 3.58406 13 3.5C13 3.15251 13.0506 2.81685 13.1449 2.5L4.16667 2.5C3.24619 2.5 2.5
+								3.24619 2.5 4.16667L2.5 15.8333C2.5 16.7538 3.24619 17.5 4.16667 17.5H15.8333C16.7538 17.5 17.5 16.7538 17.5 15.8333ZM3.75 13.803V15.8333C3.75 16.0635 3.93655 16.25
+								4.16667 16.25H15.8333C16.0635 16.25 16.25 16.0635 16.25 15.8333V12.836L16.231 12.8555L13.3333 10.0384L10.4357 12.8555C10.2266 13.0588 9.90474 13.0905 9.66005
+								12.9319L7.16369 11.3139L3.75 13.803Z"
+								fill="#8C8F94"
+							/>
+						</svg>
+					</div>
+				) }
+				<div className="post-item__post-title">{ post?.title || __( 'Untitled' ) }</div>
+			</td>
+
+			<td className="post-item__post-type">{ getPostType( post.type ) }</td>
+			<td className="post-item__post-publish-date">
+				<PostRelativeTimeStatus // TODO: adjust publish date according to Figma
+					showPublishedStatus={ false }
+					post={ post }
+					showGridIcon={ false }
+				/>
+			</td>
+
+			{ /* TODO: put the number of visitors and likes */ }
+			<td className="post-item__post-views">{ post?.views ?? 0 }</td>
+			<td className="post-item__post-likes">{ post?.like_count }</td>
+			<td className="post-item__post-comments">{ post.discussion.comment_count }</td>
+			<td className="post-item__post-link">
+				<a href={ post.URL } className="post-item__title-view">
+					{ __( 'View' ) }
+				</a>
+			</td>
+			<td className="post-item__post-promote">
+				<Button
+					className="post-item__post-promote-button"
+					isBusy={ loading }
+					disabled={ loading }
+					onClick={ onClickPromote }
+				>
+					{ __( 'Promote' ) }
+				</Button>
+			</td>
+		</tr>
+	);
+}

--- a/client/my-sites/promote-post-i2/components/post-item/style.scss
+++ b/client/my-sites/promote-post-i2/components/post-item/style.scss
@@ -1,0 +1,112 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "../../style.scss";
+
+$post-item-background-color: var(--color-surface);
+body {
+	background-color: $post-item-background-color;
+}
+
+.promote-post {
+	@include promote-post-i2-font;
+
+	.posts-list__header-column {
+		border-bottom: 1px solid #eee;
+		font-weight: normal;
+		padding-bottom: 8px;
+	}
+
+	.post-item__row {
+		width: 100%;
+	}
+
+	.post-item__post {
+		&-data,
+		&-type,
+		&-publish-date,
+		&-views,
+		&-likes,
+		&-comments,
+		&-link,
+		&-promote {
+			border-bottom: 1px solid #eee;
+			vertical-align: middle;
+		}
+
+		&-type {
+			font-size: 0.875rem;
+			width: 7.4%;
+		}
+
+		&-publish-date {
+			width: 12.8%;
+		}
+
+		&-visitors {
+			width: 9.2%;
+		}
+
+		&-likes {
+			width: 9.2%;
+		}
+
+		&-comments {
+			width: 9.2%;
+		}
+
+		&-link {
+			text-decoration-line: underline;
+			width: 7%;
+		}
+
+		&-promote {
+			color: $studio-simplenote-blue-50;
+			text-decoration-line: underline;
+			width: 5.4%;
+		}
+	}
+
+	.post-item {
+		&__row .post-item__post-data {
+			align-items: center;
+			display: flex;
+			font-weight: 500;
+		}
+
+		&__post-promote-button {
+			color: var(--studio-simplenote-blue-50);
+			text-decoration: none;
+
+			&:hover:not(:disabled) {
+				color: var(--studio-simplenote-blue-50);
+			}
+		}
+	}
+
+	.post-item__post-title {
+		color: $studio-gray-100;
+		margin-left: 16px;
+	}
+
+	.post-item__post-thumbnail-wrapper {
+		display: block;
+		position: relative;
+		height: 78px;
+		width: 108px;
+		align-self: stretch;
+		border: 1px solid #eee;
+		border-radius: 4px;
+		overflow: hidden;
+		margin: 16px 0;
+
+		&_no-image {
+			align-items: center;
+			background: $studio-gray-0;
+			border-radius: 4px;
+			display: flex;
+			justify-content: center;
+		}
+	}
+
+
+}

--- a/client/my-sites/promote-post-i2/components/posts-list/header.tsx
+++ b/client/my-sites/promote-post-i2/components/posts-list/header.tsx
@@ -1,0 +1,58 @@
+import { translate } from 'i18n-calypso';
+
+type PostsListHeaderColumn = {
+	id: string;
+	title: string | null;
+};
+
+export default function PostsListHeader() {
+	const columns: Array< PostsListHeaderColumn > = [
+		{
+			id: 'data',
+			title: translate( 'Post' ),
+		},
+		{
+			id: 'type',
+			title: translate( 'Type' ),
+		},
+		{
+			id: 'publish-date',
+			title: translate( 'Publish date' ),
+		},
+		{
+			id: 'views',
+			title: translate( 'Views' ),
+		},
+		{
+			id: 'likes',
+			title: translate( 'Likes' ),
+		},
+		{
+			id: 'comments',
+			title: translate( 'Comments' ),
+		},
+		{
+			id: 'view',
+			title: null,
+		},
+		{
+			id: 'promote',
+			title: null,
+		},
+	];
+
+	return (
+		<thead className="posts-list__header">
+			<tr>
+				{ columns.map( ( item ) => (
+					<th
+						key={ item.id }
+						className={ `posts-list__header-column post-item__post-${ item.id }` }
+					>
+						{ item.title }
+					</th>
+				) ) }
+			</tr>
+		</thead>
+	);
+}

--- a/client/my-sites/promote-post-i2/components/posts-list/index.tsx
+++ b/client/my-sites/promote-post-i2/components/posts-list/index.tsx
@@ -1,0 +1,66 @@
+import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import SitePlaceholder from 'calypso/blocks/site/placeholder';
+import BlazePressWidget from 'calypso/components/blazepress-widget';
+import EmptyContent from 'calypso/components/empty-content';
+import usePromoteParams from 'calypso/data/promote-post/use-promote-params';
+import PostItem, { Post } from 'calypso/my-sites/promote-post-i2/components/post-item';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import './style.scss';
+import SearchBar from '../search-bar';
+import PostsListHeader from './header';
+
+interface Props {
+	content: Post[];
+	isLoading: boolean;
+}
+
+export default function PostsList( { content, isLoading }: Props ) {
+	const { isModalOpen, selectedSiteId, selectedPostId, keyValue } = usePromoteParams();
+	const currentQuery = useSelector( getCurrentQueryArguments );
+	const sourceQuery = currentQuery?.[ 'source' ];
+	const source = sourceQuery ? sourceQuery.toString() : undefined;
+
+	const isEmpty = ! content || ! content.length;
+	return (
+		<>
+			<SearchBar mode="posts" />
+
+			{ isLoading && (
+				<div className="posts-list__loading-container">
+					<SitePlaceholder />
+				</div>
+			) }
+			{ ! isLoading && isEmpty && (
+				<EmptyContent
+					className="promote-post__empty-content"
+					title={ translate( 'You have no posts or pages.' ) }
+					line={ translate(
+						"Start by creating a post or a page and start promoting it once it's ready"
+					) }
+					illustration={ null }
+				/>
+			) }
+			{ ! isLoading && ! isEmpty && (
+				<table>
+					<PostsListHeader />
+					<tbody>
+						{ content.map( function ( post: Post ) {
+							return <PostItem key={ post.ID } post={ post } />;
+						} ) }
+					</tbody>
+				</table>
+			) }
+
+			{ selectedSiteId && selectedPostId && keyValue && (
+				<BlazePressWidget
+					isVisible={ isModalOpen }
+					siteId={ selectedSiteId }
+					postId={ selectedPostId }
+					keyValue={ keyValue }
+					source={ source }
+				/>
+			) }
+		</>
+	);
+}

--- a/client/my-sites/promote-post-i2/components/posts-list/style.scss
+++ b/client/my-sites/promote-post-i2/components/posts-list/style.scss
@@ -1,0 +1,27 @@
+@import "../../style.scss";
+
+.main.promote-post .search {
+	height: 42px;
+}
+
+.promote-post {
+	@include promote-post-i2-font;
+
+	.campaigns-list__loading-container {
+		display: flex;
+		justify-content: center;
+	}
+
+	&__search-bar-wrapper &__search-bar-dropdown .select-dropdown__header {
+		height: 44px;
+	}
+
+	&__search-bar-wrapper &__search-bar-dropdown.select-dropdown {
+		height: 44px;
+		margin-left: 16px;
+
+		.select-dropdown__header-text {
+			@include promote-post-i2-font;
+		}
+	}
+}

--- a/client/my-sites/promote-post-i2/components/promoted-post-filter/index.tsx
+++ b/client/my-sites/promote-post-i2/components/promoted-post-filter/index.tsx
@@ -1,0 +1,37 @@
+import { isMobile } from '@automattic/viewport';
+import { useSelector } from 'react-redux';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import { TabType } from 'calypso/my-sites/promote-post/main';
+import { TabOption } from 'calypso/my-sites/promote-post-i2/main';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+type Props = {
+	tabs: TabOption[];
+	selectedTab: TabType;
+};
+
+export default function PromotePostTabBar( { tabs, selectedTab }: Props ) {
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+
+	const sectionNavProps = isMobile() ? { allowDropdown: false, className: 'is-open' } : {};
+
+	return (
+		<SectionNav { ...sectionNavProps }>
+			<NavTabs>
+				{ tabs.map( ( { id, name, itemCount } ) => {
+					return (
+						<NavItem
+							key={ id }
+							path={ `/advertising/${ selectedSiteSlug }/${ id }` }
+							selected={ selectedTab === id }
+							children={ name }
+							count={ itemCount }
+						/>
+					);
+				} ) }
+			</NavTabs>
+		</SectionNav>
+	);
+}

--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -1,4 +1,5 @@
-import { useTranslate } from 'i18n-calypso';
+import { sprintf } from '@wordpress/i18n';
+import { translate } from 'i18n-calypso';
 import React from 'react';
 import './style.scss';
 import Gridicon from 'calypso/../packages/components/src/gridicon';
@@ -10,18 +11,52 @@ interface Props {
 	mode: 'campaigns' | 'posts';
 }
 
-const sortOptions = [
-	{
-		label: 'Last published',
-		value: 'last_published',
-	},
-];
+type SortOption = {
+	label: string;
+	value: string;
+};
+
+const SORT_OPTIONS_BY_TITLE = 'by_title';
+const SORT_OPTIONS_LAST_PUBLISHED = 'last_published';
+const SORT_OPTIONS_RECENTLY_UPDATED = 'recently_updated';
+const SORT_OPTIONS_MOST_LIKED = 'most_liked';
+const SORT_OPTIONS_MOST_COMMENTED = 'most_commented';
+const SORT_OPTIONS_MOST_VIEWED = 'most_viewed';
+
+const SORT_OPTIONS_DEFAULT = SORT_OPTIONS_RECENTLY_UPDATED;
+
 export default function SearchBar( props: Props ) {
 	const { mode } = props;
 
-	const translate = useTranslate();
+	const sortOptions: Array< SortOption > = [
+		{
+			label: translate( 'By title' ),
+			value: SORT_OPTIONS_BY_TITLE,
+		},
+		{
+			label: translate( 'Last published' ),
+			value: SORT_OPTIONS_LAST_PUBLISHED,
+		},
+		{
+			label: translate( 'Recently updated' ),
+			value: SORT_OPTIONS_RECENTLY_UPDATED,
+		},
+		{
+			label: translate( 'Most liked' ),
+			value: SORT_OPTIONS_MOST_LIKED,
+		},
+		{
+			label: translate( 'Most commented' ),
+			value: SORT_OPTIONS_MOST_COMMENTED,
+		},
+		{
+			label: translate( 'Most viewed' ),
+			value: SORT_OPTIONS_MOST_VIEWED,
+		},
+	];
+
 	const [ searchInput, setSearchInput ] = React.useState( '' );
-	const [ currentSortOption, setSortOption ] = React.useState( sortOptions[ 0 ].value );
+	const [ currentSortOption, setSortOption ] = React.useState( SORT_OPTIONS_DEFAULT );
 
 	const onSearch = () => {
 		return;
@@ -32,8 +67,22 @@ export default function SearchBar( props: Props ) {
 	};
 
 	const onChangeFilter = () => {
-		setSearchInput( '' );
+		setSearchInput( '' ); // TODO: Filter by status: All | Active | In Moderation | Rejected.
 	};
+
+	function getSelectedSortOption( value: string ) {
+		if ( ! value ) {
+			return null;
+		}
+
+		const index = sortOptions.findIndex( ( item ) => item.value === value );
+		if ( index > -1 ) {
+			// translators: %s is a sort option like "Last Published"
+			return sprintf( translate( 'Sort: %s' ), sortOptions[ index ].label );
+		}
+
+		return null;
+	}
 
 	return (
 		<div className="promote-post__search-bar-wrapper">
@@ -66,21 +115,10 @@ export default function SearchBar( props: Props ) {
 			{ mode === 'posts' && (
 				<SelectDropdown
 					className="promote-post__search-bar-dropdown"
-					selectedText=""
-					/*
-				selectedIcon={ <Gridicon size={ 18 } icon={ selectedDevice.icon } /> }
-*/
-				>
-					{ sortOptions.map( ( sortOption ) => (
-						<SelectDropdown.Item
-							key={ sortOption.value }
-							selected={ sortOption.value === currentSortOption }
-							onClick={ () => setSortOption( sortOption.value ) }
-						>
-							{ sortOption.label }
-						</SelectDropdown.Item>
-					) ) }
-				</SelectDropdown>
+					onSelect={ ( option: SortOption ) => setSortOption( option.value ) }
+					options={ sortOptions }
+					selectedText={ getSelectedSortOption( currentSortOption ) }
+				/>
 			) }
 
 			{ mode === 'campaigns' && (

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -17,10 +17,10 @@ import useCampaignsStatsQuery from 'calypso/data/promote-post/use-promote-post-c
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import memoizeLast from 'calypso/lib/memoize-last';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
-import PostsList from 'calypso/my-sites/promote-post/components/posts-list';
 import PostsListBanner from 'calypso/my-sites/promote-post/components/posts-list-banner';
-import PromotePostTabBar from 'calypso/my-sites/promote-post/components/promoted-post-filter';
 import CampaignsList from 'calypso/my-sites/promote-post-i2/components/campaigns-list';
+import PostsList from 'calypso/my-sites/promote-post-i2/components/posts-list';
+import PromotePostTabBar from 'calypso/my-sites/promote-post-i2/components/promoted-post-filter';
 import {
 	getSitePost,
 	getPostsForQuery,
@@ -38,6 +38,7 @@ export type TabType = 'posts' | 'campaigns';
 export type TabOption = {
 	id: TabType;
 	name: string;
+	itemCount: number;
 };
 
 interface Props {
@@ -138,9 +139,37 @@ export default function PromotedPosts( { tab }: Props ) {
 
 	const translate = useTranslate();
 
+	const content = [
+		...( postAndPagesByIDs || [] ),
+		...( mostPopularPostAndPages || [] ),
+		...( postAndPagesByComments || [] ),
+		...( products || [] ),
+	];
+
+	/**
+	 * Some of the posts/pages may be duplicated as we load them by popularity and sometimes by comments.
+	 */
+	const contentWithoutDuplicatedIds = content.filter(
+		( obj, index ) => content.findIndex( ( item ) => item.ID === obj.ID ) === index
+	);
+
+	/**
+	 * Maybe populate the number of views into posts
+	 */
+	for ( const obj of mostPopularPostAndPages ) {
+		const index = contentWithoutDuplicatedIds.findIndex( ( item ) => item.ID === obj.ID );
+		if ( index > -1 && obj?.views ) {
+			contentWithoutDuplicatedIds[ index ].views = obj.views;
+		}
+	}
+
 	const tabs: TabOption[] = [
-		{ id: 'posts', name: translate( 'Ready to Blaze' ) },
-		{ id: 'campaigns', name: translate( 'Campaigns' ) },
+		{
+			id: 'posts',
+			name: translate( 'Ready to promote' ),
+			itemCount: contentWithoutDuplicatedIds.length,
+		},
+		{ id: 'campaigns', name: translate( 'Campaigns' ), itemCount: ( campaignsFull || [] ).length },
 	];
 
 	const topViewedPostAndPagesIds = topViewedPostAndPages?.map( ( post: any ) => post.id );
@@ -225,20 +254,6 @@ export default function PromotedPosts( { tab }: Props ) {
 			/>
 		);
 	}
-
-	const content = [
-		...( postAndPagesByIDs || [] ),
-		...( mostPopularPostAndPages || [] ),
-		...( postAndPagesByComments || [] ),
-		...( products || [] ),
-	];
-
-	/**
-	 * Some of the posts/pages may be duplicated as we load them by popularity and sometimes by comments.
-	 */
-	const contentWithoutDuplicatedIds = content.filter(
-		( obj, index ) => content.findIndex( ( item ) => item.ID === obj.ID ) === index
-	);
 
 	const isLoading =
 		isLoadingByCommentsQuery ||

--- a/client/my-sites/promote-post-i2/style.scss
+++ b/client/my-sites/promote-post-i2/style.scss
@@ -1,3 +1,80 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/components/src/styles/typography";
+
+@mixin promote-post-i2-font {
+	color: $studio-gray-60;
+	font-family: $font-sf-pro-text;
+	font-weight: 400;
+	font-size: 0.875rem;
+	font-style: normal;
+	letter-spacing: -0.15px;
+	line-height: 1.43;
+}
+
+.notouch .promote-post .section-nav-tab__link:hover {
+	background-color: transparent;
+}
+
+.promote-post {
+	@media (min-width: 481px) {
+		.section-nav-tab {
+			margin-right: 16px;
+
+			&__link {
+				padding: 16px 0;
+
+				.section-nav-tab__text {
+					@include promote-post-i2-font;
+					color: $studio-gray-100;
+
+					.count {
+						background: $studio-gray-0;
+						border: none;
+						border-radius: 2px;
+						color: $studio-gray-80;
+						font-family: $font-sf-pro-text;
+						font-weight: 500;
+						font-size: 0.875rem;
+						line-height: 1.67;
+						padding: 0 8px;
+					}
+				}
+			}
+		}
+	}
+
+	.section-nav {
+		box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.05);
+	}
+
+	.search {
+		border: 1px solid #ddd;
+		border-radius: 4px;
+
+		&.is-open .search__open-icon {
+			fill: $studio-gray-30;
+		}
+	}
+
+	&__search-bar-wrapper {
+		.form-text-input.search__input {
+			@include promote-post-i2-font;
+			// border-radius: 4px;
+			height: calc(100% - 4px) !important;
+			margin: 2px 2px 2px 0;
+		}
+
+		.search__icon-navigation {
+			margin: 2px 0 2px 2px;
+		}
+	}
+
+	.select-dropdown__header {
+		border-color: $studio-gray-30 !important;
+		border-radius: 4px;
+	}
+}
+
 .promote-post__loading-container {
 	text-align: center;
 }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#76242

Original PR is https://github.com/Automattic/wp-calypso/pull/75959.

## Screenshots for translators

### Posts tab
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/115007291/233160240-e3feb673-1595-4b17-90f3-b45cc3bf4697.png">

### Campaigns tab
<img width="1102" alt="image" src="https://user-images.githubusercontent.com/115007291/233161217-4a639dec-d0de-4a55-8d28-4bef5ec591d6.png">

### Post sorting order dropdown options
<img width="1020" alt="Screenshot 2023-05-04 at 16 23 37" src="https://user-images.githubusercontent.com/115007291/236217958-bee8547f-7295-4261-977d-836a61781e72.png">
