### PR TITLE
i18n: Use `useI18n` hook for sensei-plan features constant

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/constants.ts
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import type { Props as PlanItemProps } from 'calypso/../packages/plans-grid/src/plans-table/plan-item';
 
 export enum Status {
@@ -7,37 +7,41 @@ export enum Status {
 	Error,
 }
 
-export const features: PlanItemProps[ 'features' ] = [
-	{
-		name: __( 'Priority live chat support' ),
-		requiresAnnuallyBilledPlan: true,
-	},
-	{
-		name: __( 'Unlimited courses and students' ),
-		requiresAnnuallyBilledPlan: false,
-	},
-	{
-		name: __( 'Interactive videos and lessons' ),
-		requiresAnnuallyBilledPlan: false,
-	},
-	{
-		name: __( 'Quizzes and certificates' ),
-		requiresAnnuallyBilledPlan: false,
-	},
-	{
-		name: __( 'Sell courses and subscriptions' ),
-		requiresAnnuallyBilledPlan: false,
-	},
-	{
-		name: __( '200GB file and video storage' ),
-		requiresAnnuallyBilledPlan: false,
-	},
-	{
-		name: __( 'Best-in-class hosting' ),
-		requiresAnnuallyBilledPlan: false,
-	},
-	{
-		name: __( 'Advanced Jetpack features' ),
-		requiresAnnuallyBilledPlan: false,
-	},
-];
+export function useFeatures(): PlanItemProps[ 'features' ] {
+	const { __ } = useI18n();
+
+	return [
+		{
+			name: __( 'Priority live chat support' ),
+			requiresAnnuallyBilledPlan: true,
+		},
+		{
+			name: __( 'Unlimited courses and students' ),
+			requiresAnnuallyBilledPlan: false,
+		},
+		{
+			name: __( 'Interactive videos and lessons' ),
+			requiresAnnuallyBilledPlan: false,
+		},
+		{
+			name: __( 'Quizzes and certificates' ),
+			requiresAnnuallyBilledPlan: false,
+		},
+		{
+			name: __( 'Sell courses and subscriptions' ),
+			requiresAnnuallyBilledPlan: false,
+		},
+		{
+			name: __( '200GB file and video storage' ),
+			requiresAnnuallyBilledPlan: false,
+		},
+		{
+			name: __( 'Best-in-class hosting' ),
+			requiresAnnuallyBilledPlan: false,
+		},
+		{
+			name: __( 'Advanced Jetpack features' ),
+			requiresAnnuallyBilledPlan: false,
+		},
+	];
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/create-sensei-site.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/create-sensei-site.ts
@@ -2,7 +2,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { SENSEI_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
 import { useNewSiteVisibility } from 'calypso/landing/stepper/hooks/use-selected-plan';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
 import wpcom from 'calypso/lib/wp';
@@ -58,6 +58,7 @@ export const useCreateSenseiSite = () => {
 		title: '',
 	} );
 
+	const { __ } = useI18n();
 	const locale = useLocale();
 	const visibility = useNewSiteVisibility();
 
@@ -118,6 +119,7 @@ export const useCreateSenseiSite = () => {
 
 		return { site: newSite };
 	}, [
+		__,
 		createSenseiSite,
 		currentUser?.username,
 		getNewSite,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/index.tsx
@@ -2,7 +2,7 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import formatCurrency from 'calypso/../packages/format-currency/src';
@@ -16,7 +16,7 @@ import { SenseiStepContainer } from '../components/sensei-step-container';
 import { SenseiStepError } from '../components/sensei-step-error';
 import { SenseiStepProgress } from '../components/sensei-step-progress';
 import { PlansIntervalToggle } from './components';
-import { features, Status } from './constants';
+import { useFeatures, Status } from './constants';
 import { useCreateSenseiSite } from './create-sensei-site';
 import { useBusinessPlanPricing, useSenseiProPricing } from './sensei-plan-products';
 import type { Step } from '../../types';
@@ -30,7 +30,8 @@ const SenseiPlan: Step = ( { flow, navigation: { submit } } ) => {
 	const [ billingPeriod, setBillingPeriod ] = useState< PlanBillingPeriod >( 'ANNUALLY' );
 	const [ status, setStatus ] = useState< Status >( Status.Initial );
 	const locale = useLocale();
-	const { hasTranslation } = useI18n();
+	const { __, hasTranslation } = useI18n();
+	const features = useFeatures();
 
 	const domain = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 597-gh-Automattic/i18n-issues

## Proposed Changes

* Convert `features` constants to `useFeatures` hook, using the `useI18n` hook.
* Replace static `__()` functions  from `@wordpress/i18n` with `useI18n` React bindings from `@wordpress/react-i18n` in sensei-plan module.

**Before:**
![CleanShot 2023-04-26 at 11 17 00](https://user-images.githubusercontent.com/2722412/234514111-0e9d3aab-d21d-4ee7-b00b-936cc46b2a6f.png)

**After:**
![CleanShot 2023-04-26 at 11 16 48](https://user-images.githubusercontent.com/2722412/234514084-4554d816-b9ac-4589-8cee-b533d53b1649.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change UI language to any Mag-16 locale.
* Use calypso.live or boot locally.
* Go through the process of creating site with Sensei from `/setup/sensei/senseiPlan?ref=create-a-course`.
* Confirm plan features appear translated as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
