### PR TITLE
Updated the copy in the sorting options in the Sites screen on Subscription Manager

### DIFF
--- a/client/landing/subscriptions/components/tab-views/sites/sites.tsx
+++ b/client/landing/subscriptions/components/tab-views/sites/sites.tsx
@@ -15,11 +15,9 @@ const SortBy = SubscriptionManager.SiteSubscriptionsSortBy;
 const isListControlsEnabled = config.isEnabled( 'subscription-management/sites-list-controls' );
 
 const getSortOptions = ( translate: ReturnType< typeof useTranslate > ): Option[] => [
-	{ value: SortBy.LastUpdated, label: translate( 'Last updated' ) },
-	// todo: translate when we have agreed on the label
-	{ value: SortBy.DateSubscribed, label: 'Date subscribed' },
-	// todo: translate when we have agreed on the label
-	{ value: SortBy.SiteName, label: 'Site name' },
+	{ value: SortBy.LastUpdated, label: translate( 'Recently updated' ) },
+	{ value: SortBy.DateSubscribed, label: translate( 'Recently subscribed' ) },
+	{ value: SortBy.SiteName, label: translate( 'Site name' ) },
 ];
 
 const useSortOptions = ( translate: ReturnType< typeof useTranslate > ): Option[] =>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/76201

## Proposed Changes

This PR updates the sorting options copy of the Sites screen in the new Subscription Manager:

<img width="868" alt="Screenshot 2023-04-26 at 10 22 04" src="https://user-images.githubusercontent.com/3832570/234517185-a021540a-96cd-4524-a398-04d57889b316.png">


## Testing Instructions

1. Apply this PR and run the application.
2. Apply this patch to your sandbox
3. Subscribe to a blog with a non-WP.com user (for example, `your-email+testing@gmail.com`)
4. You should receive a confirmation e-mail that contains a "Manage subscriptions" button
5. Copy the button's link & visit in an incognito window
6. Open dev tools & copy the cookie. Make sure "Show URL decoded" is checked. Copy the value from the subkey cookie.
7. Add the subkey cookie to calypso.localhost:3000.
8. Go to `http://calypso.localhost:3000/subscriptions/sites` and click the `Sort` dropdown. You should see the options like in the image above.

