### PR TITLE
Subscriptions Management: Display Search input on mobile and adjust related styles

### DIFF
--- a/client/landing/subscriptions/components/comment-list/comment-list.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-list.tsx
@@ -13,7 +13,7 @@ const CommentList = ( { posts }: CommentListProps ) => {
 
 	return (
 		<div className="subscription-manager__comment-list" role="table">
-			<div className="row-wrapper">
+			<div className="row-wrapper header">
 				<div className="row header" role="row">
 					<span className="post" role="columnheader">
 						{ translate( 'Subscribed post' ) }

--- a/client/landing/subscriptions/components/comment-list/styles.scss
+++ b/client/landing/subscriptions/components/comment-list/styles.scss
@@ -16,6 +16,12 @@ $max-list-width: 1300px;
 
 	.row-wrapper {
 		border-bottom: 1px solid var(--color-border-subtle);
+
+		&.header {
+			@media (max-width: $break-small) {
+				display: none;
+			}
+		}
 	}
 
 	.row {

--- a/client/landing/subscriptions/components/site-list/styles.scss
+++ b/client/landing/subscriptions/components/site-list/styles.scss
@@ -22,6 +22,10 @@ $max-list-width: 1300px;
 		&.header {
 			padding-bottom: $font-code;
 			padding-top: 0;
+
+			@media (max-width: $break-small) {
+				display: none;
+			}
 		}
 
 		.title-box {

--- a/client/landing/subscriptions/components/site-list/styles.scss
+++ b/client/landing/subscriptions/components/site-list/styles.scss
@@ -8,7 +8,7 @@ $max-list-width: 1300px;
 	max-width: $max-list-width;
 
 	.row {
-		border-bottom: 1px solid var(--color-border-subtle);
+		border-block-end: 1px solid rgb(238, 238, 238);
 		display: flex;
 		align-items: center;
 		flex-direction: row;

--- a/client/landing/subscriptions/components/site-list/styles.scss
+++ b/client/landing/subscriptions/components/site-list/styles.scss
@@ -40,6 +40,10 @@ $max-list-width: 1300px;
 				height: 40px;
 				flex: none;
 				border-radius: 50%;
+
+				@media (max-width: $break-small) {
+					display: none;
+				}
 			}
 
 			.title-column {
@@ -47,6 +51,10 @@ $max-list-width: 1300px;
 				flex-direction: column;
 				min-width: 0;
 				padding-left: 12px;
+
+				@media (max-width: $break-small) {
+					padding-left: 0;
+				}
 
 				.name {
 					font-weight: 600;

--- a/client/landing/subscriptions/styles.scss
+++ b/client/landing/subscriptions/styles.scss
@@ -55,6 +55,22 @@ body {
 				margin-left: auto;
 			}
 		}
+
+		@media (max-width: $break-small) {
+			&__list-actions-bar {
+				flex-direction: column;
+				align-items: stretch;
+				gap: 0;
+
+				.subscription-manager-sort-controls {
+					margin-top: 30.5px;
+
+					&__button {
+						padding: 0;
+					}
+				}
+			}
+		}
 	}
 
 	.search-component {
@@ -72,7 +88,6 @@ body {
 
 		input.search-component__input[type="search"]::placeholder {
 			color: $studio-gray-50;
-
 		}
 	}
 }

--- a/client/landing/subscriptions/styles.scss
+++ b/client/landing/subscriptions/styles.scss
@@ -58,6 +58,7 @@ body {
 
 		@media (max-width: $break-small) {
 			&__list-actions-bar {
+				margin-bottom: 38.5px;
 				flex-direction: column;
 				align-items: stretch;
 				gap: 0;

--- a/client/landing/subscriptions/styles.scss
+++ b/client/landing/subscriptions/styles.scss
@@ -65,10 +65,6 @@ body {
 		border: 1px solid $studio-gray-10;
 		border-radius: 2px;
 
-		@media (max-width: $break-small) {
-			display: none;
-		}
-
 		.subscriptions-manager__search-icon {
 			margin-left: 18.5px;
 			margin-right: 14px;


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/76215.

## Proposed Changes

**Sites and Comments pages:**
* display Search input on mobile
* adjust related margins / paddings on mobile
* hide list headers on mobile

**Sites page:**
* hide Site icon on mobile
* remove left-padding related to the Site title on mobile
* fix divider color

**Misc:**
* remove accidental line-break in code

| Sites | Comments |
|--------|--------|
| ![Markup on 2023-04-26 at 11:13:55](https://user-images.githubusercontent.com/25105483/234529681-37d2ad83-8ca9-48bd-a062-f8a076b77a50.png) | ![Markup on 2023-04-26 at 11:14:18](https://user-images.githubusercontent.com/25105483/234529691-39d2e6c2-7789-4693-8fa8-807a08d604ca.png) | 

## Testing Instructions

1. Check out and build the PR locally.
2. Apply the correct `subkey` cookie value to your `calypso.localhost:3000 host`.
3. Make sure the related user has existing site and comment subscriptions.
4. Navigate to http://calypso.localhost:3000/subscriptions/sites and http://calypso.localhost:3000/subscriptions/comments.
5. Check the desktop and mobile view on both pages. The design should match Figma: inDLaEQV8jJ21O4WXawIsJ-fi-712_13475.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?