### PR TITLE
Accommodated changes in the backend response for post comments

### DIFF
--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -20,7 +20,7 @@ const CommentRow = ( {
 	site_title,
 	site_icon,
 	site_url,
-	subscription_date,
+	date_subscribed,
 	forwardedRef,
 	style,
 }: CommentRowProps ) => {
@@ -54,7 +54,7 @@ const CommentRow = ( {
 					</span>
 				</a>
 				<span className="date" role="cell">
-					<TimeSince date={ subscription_date.toISOString?.() ?? subscription_date } />
+					<TimeSince date={ date_subscribed.toISOString?.() ?? date_subscribed } />
 				</span>
 				<span className="actions" role="cell">
 					<CommentSettings

--- a/client/landing/subscriptions/components/pending-list/pending-post-list/pending-post-row.tsx
+++ b/client/landing/subscriptions/components/pending-list/pending-post-list/pending-post-row.tsx
@@ -7,7 +7,7 @@ import type { PendingPostSubscription } from '@automattic/data-stores/src/reader
 
 export default function PendingPostRow( {
 	id,
-	subscription_date,
+	date_subscribed,
 	site_icon,
 	post_title,
 	post_url,
@@ -49,7 +49,7 @@ export default function PendingPostRow( {
 					</span>
 				</a>
 				<span className="date" role="cell">
-					<TimeSince date={ subscription_date.toISOString?.() ?? subscription_date } />
+					<TimeSince date={ date_subscribed.toISOString?.() ?? date_subscribed } />
 				</span>
 				<span className="actions" role="cell">
 					<PendingPostSettings

--- a/packages/data-stores/src/reader/queries/use-pending-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-pending-post-subscriptions-query.ts
@@ -27,7 +27,7 @@ const callPendingBlogSubscriptionsEndpoint =
 			pendingPosts.push(
 				...incoming.comment_subscriptions.map( ( pendingSubscription ) => ( {
 					...pendingSubscription,
-					subscription_date: new Date( pendingSubscription.subscription_date ),
+					date_subscribed: new Date( pendingSubscription.date_subscribed ),
 				} ) )
 			);
 		}

--- a/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
@@ -26,7 +26,7 @@ const sortByPostName = ( a: PostSubscription, b: PostSubscription ) =>
 	a.post_title.localeCompare( b.post_title );
 
 const sortByRecentlySubscribed = ( a: PostSubscription, b: PostSubscription ) =>
-	b.subscription_date.getTime() - a.subscription_date.getTime();
+	b.date_subscribed.getTime() - a.date_subscribed.getTime();
 
 const getSortFunction = ( sortTerm: PostSubscriptionsSortBy ) => {
 	switch ( sortTerm ) {
@@ -83,7 +83,7 @@ const usePostSubscriptionsQuery = ( {
 		// Transform the dates into Date objects
 		const transformedData = flattenedData?.map( ( comment_subscription ) => ( {
 			...comment_subscription,
-			subscription_date: new Date( comment_subscription.subscription_date ),
+			date_subscribed: new Date( comment_subscription.date_subscribed ),
 		} ) );
 
 		const searchTermLowerCase = searchTerm.toLowerCase();

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -72,7 +72,7 @@ export type SiteSubscriptionDeliveryFrequency = 'instantly' | 'daily' | 'weekly'
 export type PostSubscription = {
 	id: string;
 	blog_id: string;
-	subscription_date: Date;
+	date_subscribed: Date;
 	site_id: string;
 	site_title: string;
 	site_icon: string;
@@ -98,7 +98,7 @@ export type PendingSiteSubscription = {
 export type PendingPostSubscription = {
 	id: string;
 	blog_id: string;
-	subscription_date: Date;
+	date_subscribed: Date;
 	site_id: string;
 	site_title: string;
 	site_icon: string;


### PR DESCRIPTION
**Note:** Don't merge this PR until this patch is deployed to production: D109023-code

## Proposed Changes

The backend response for the Post Comments list changed its field for subscription date. This PR accommodates Calypso to those changes.

## Testing Instructions

1. Apply this PR and run the application.
2. Subscribe to a blog with a non-WP.com user (for example, `your-email+testing@gmail.com`)
3. You should receive a confirmation e-mail that contains a "Manage subscriptions" button
4. Copy the button's link & visit in an incognito window
5. Open dev tools & copy the cookie. Make sure "Show URL decoded" is checked. Copy the value from the subkey cookie.
6. Add the subkey cookie to calypso.localhost:3000.
7. Go to `http://calypso.localhost:3000/subscriptions/comments`. You should see the list ordered by default. Click on the different options in the `Sort` dropdown. You should see the list changing its order accordingly.

