### PR TITLE
Staging Sites: Disable plugin CTA and add a notice on staging sites

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -16,6 +16,7 @@ import BillingIntervalSwitcher from 'calypso/my-sites/marketplace/components/bil
 import { ManageSitePluginsDialog } from 'calypso/my-sites/plugins/manage-site-plugins-dialog';
 import PluginAutoupdateToggle from 'calypso/my-sites/plugins/plugin-autoupdate-toggle';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
+import StagingSiteNotice from 'calypso/my-sites/plugins/plugin-details-CTA/staging-site-notice';
 import { siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getEligibility } from 'calypso/state/automated-transfer/selectors';
@@ -31,6 +32,7 @@ import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/st
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import getSelectedOrAllSitesWithPlugins from 'calypso/state/selectors/get-selected-or-all-sites-with-plugins';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSectionName } from 'calypso/state/ui/selectors';
@@ -66,6 +68,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
+	const isWpcomStaging = useSelector( ( state ) => isSiteWpcomStaging( state, selectedSite?.ID ) );
 	const pluginFeature = isMarketplaceProduct
 		? WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS
 		: FEATURE_INSTALL_PLUGINS;
@@ -310,18 +313,21 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 						plugin={ plugin }
 					/>
 				) }
-				<div className="plugin-details-cta__install">
-					<PrimaryButton
-						isLoggedIn={ isLoggedIn }
-						shouldUpgrade={ shouldUpgrade }
-						hasEligibilityMessages={ hasEligibilityMessages }
-						incompatiblePlugin={ incompatiblePlugin }
-						userCantManageTheSite={ userCantManageTheSite }
-						translate={ translate }
-						plugin={ plugin }
-						saasRedirectHRef={ saasRedirectHRef }
-					/>
-				</div>
+				{ ! isWpcomStaging && (
+					<div className="plugin-details-cta__install">
+						<PrimaryButton
+							isLoggedIn={ isLoggedIn }
+							shouldUpgrade={ shouldUpgrade }
+							hasEligibilityMessages={ hasEligibilityMessages }
+							incompatiblePlugin={ incompatiblePlugin }
+							userCantManageTheSite={ userCantManageTheSite }
+							translate={ translate }
+							plugin={ plugin }
+							saasRedirectHRef={ saasRedirectHRef }
+						/>
+					</div>
+				) }
+				{ isWpcomStaging && <StagingSiteNotice plugin={ plugin } /> }
 				{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
 					<div className="plugin-details-cta__t-and-c">
 						{ translate(

--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -313,20 +313,19 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 						plugin={ plugin }
 					/>
 				) }
-				{ ! isWpcomStaging && (
-					<div className="plugin-details-cta__install">
-						<PrimaryButton
-							isLoggedIn={ isLoggedIn }
-							shouldUpgrade={ shouldUpgrade }
-							hasEligibilityMessages={ hasEligibilityMessages }
-							incompatiblePlugin={ incompatiblePlugin }
-							userCantManageTheSite={ userCantManageTheSite }
-							translate={ translate }
-							plugin={ plugin }
-							saasRedirectHRef={ saasRedirectHRef }
-						/>
-					</div>
-				) }
+				<div className="plugin-details-cta__install">
+					<PrimaryButton
+						isLoggedIn={ isLoggedIn }
+						shouldUpgrade={ shouldUpgrade }
+						hasEligibilityMessages={ hasEligibilityMessages }
+						incompatiblePlugin={ incompatiblePlugin }
+						userCantManageTheSite={ userCantManageTheSite }
+						translate={ translate }
+						plugin={ plugin }
+						saasRedirectHRef={ saasRedirectHRef }
+						isWpcomStaging={ isWpcomStaging }
+					/>
+				</div>
 				{ isWpcomStaging && <StagingSiteNotice plugin={ plugin } /> }
 				{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
 					<div className="plugin-details-cta__t-and-c">
@@ -383,6 +382,7 @@ function PrimaryButton( {
 	translate,
 	plugin,
 	saasRedirectHRef,
+	isWpcomStaging,
 } ) {
 	const dispatch = useDispatch();
 	const sectionName = useSelector( getSectionName );
@@ -434,7 +434,7 @@ function PrimaryButton( {
 		<CTAButton
 			plugin={ plugin }
 			hasEligibilityMessages={ hasEligibilityMessages }
-			disabled={ incompatiblePlugin || userCantManageTheSite }
+			disabled={ incompatiblePlugin || userCantManageTheSite || isWpcomStaging }
 		/>
 	);
 }

--- a/client/my-sites/plugins/plugin-details-CTA/staging-site-notice.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/staging-site-notice.jsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import Banner from 'calypso/components/banner';
-import productionSiteForWpcomStaging from 'calypso/state/selectors/get-production-site-for-wpcom-staging';
+import getProductionSiteForWpcomStaging from 'calypso/state/selectors/get-production-site-for-wpcom-staging';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -9,7 +9,9 @@ export default function StagingSiteNotice( { plugin } ) {
 	const translate = useTranslate();
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const productionSite = useSelector( ( state ) => productionSiteForWpcomStaging( state, siteId ) );
+	const productionSite = useSelector( ( state ) =>
+		getProductionSiteForWpcomStaging( state, siteId )
+	);
 	const productionSiteSlug = useSelector( ( state ) => getSiteSlug( state, productionSite?.ID ) );
 
 	let url = '';
@@ -23,7 +25,7 @@ export default function StagingSiteNotice( { plugin } ) {
 				disableHref={ url === '' }
 				icon="notice"
 				href={ url }
-				title={ translate( 'Paid plugins cannot be purchased on staging sites' ) }
+				title={ translate( 'Plugins cannot be purchased on staging sites' ) }
 				description={ translate( 'Subscribe to this plugin on your production site.' ) }
 			/>
 		</>

--- a/client/my-sites/plugins/plugin-details-CTA/staging-site-notice.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/staging-site-notice.jsx
@@ -23,8 +23,8 @@ export default function StagingSiteNotice( { plugin } ) {
 				disableHref={ url === '' }
 				icon="notice"
 				href={ url }
-				title={ translate( 'Plugins are not available' ) }
-				description={ translate( 'Plugins are only available for production sites.' ) }
+				title={ translate( 'Paid plugins cannot be purchased on staging sites' ) }
+				description={ translate( 'Subscribe to this plugin on your production site.' ) }
 			/>
 		</>
 	);

--- a/client/my-sites/plugins/plugin-details-CTA/staging-site-notice.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/staging-site-notice.jsx
@@ -1,0 +1,31 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import Banner from 'calypso/components/banner';
+import productionSiteForWpcomStaging from 'calypso/state/selectors/get-production-site-for-wpcom-staging';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export default function StagingSiteNotice( { plugin } ) {
+	const translate = useTranslate();
+
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const productionSite = useSelector( ( state ) => productionSiteForWpcomStaging( state, siteId ) );
+	const productionSiteSlug = useSelector( ( state ) => getSiteSlug( state, productionSite?.ID ) );
+
+	let url = '';
+	if ( productionSiteSlug ) {
+		url = `/plugins/${ plugin?.slug }/${ productionSiteSlug }`;
+	}
+
+	return (
+		<>
+			<Banner
+				disableHref={ url === '' }
+				icon="notice"
+				href={ url }
+				title={ translate( 'Plugins are not available' ) }
+				description={ translate( 'Plugins are only available for production sites.' ) }
+			/>
+		</>
+	);
+}

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -53,7 +53,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { isUserPaid } from 'calypso/state/purchases/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
-import productionSiteForWpcomStaging from 'calypso/state/selectors/get-production-site-for-wpcom-staging';
+import getProductionSiteForWpcomStaging from 'calypso/state/selectors/get-production-site-for-wpcom-staging';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -1476,7 +1476,7 @@ export default connect(
 
 		const isAtomic = isSiteAutomatedTransfer( state, siteId );
 		const isWpcomStaging = isSiteWpcomStaging( state, siteId );
-		const productionSite = productionSiteForWpcomStaging( state, siteId );
+		const productionSite = getProductionSiteForWpcomStaging( state, siteId );
 		const productionSiteSlug = getSiteSlug( state, productionSite?.ID );
 		const isJetpack = isJetpackSite( state, siteId );
 		const isStandaloneJetpack = isJetpack && ! isAtomic;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2042

## Proposed Changes

In this PR, I propose to disable the plugin CTA on staging sites and an informative notice explaining why it's disabled.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use Calypso Live environment to create a staging site
2. Navigate to the staging site
3. Navigate to Plugins
4. Click on a paid plugin
5. Confirm that message appears below the disabled CTA

![Screenshot 2023-04-26 at 13 39 24](https://user-images.githubusercontent.com/727413/234563888-0b4e50b8-d223-4980-a7f4-29b441745298.png)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
