### PR TITLE
Fixing pricing page agency discount amount

### DIFF
--- a/client/my-sites/plans/jetpack-plans/faq/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/faq/index.tsx
@@ -146,8 +146,9 @@ const JetpackFAQ: FC = () => {
 							className="jetpack-faq__section"
 						>
 							{ translate(
-								'Anyone with at least five websites can join our licensing platform and enjoy a 25% discount across all Jetpack products! You can learn more about our {{agenciesLink}}licensing platform and agency program here{{/agenciesLink}}.',
+								'Anyone with at least five websites can join our licensing platform and enjoy up to %(discountRate)s%% discount across all Jetpack products! You can learn more about our {{agenciesLink}}licensing platform and agency program here{{/agenciesLink}}.',
 								{
+									args: { discountRate: 60 },
 									components: { agenciesLink: getAgenciesLink() },
 								}
 							) }


### PR DESCRIPTION
This is a patch to correct the multiple-site discount amount on the pricing page FAQ. I think ideally we should retrieve that amount dynamically from somewhere; however, it is out of the scope of this pull request.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1681086009129379-slack-C01264051NE and #75465 

## Proposed Changes

*

## Testing Instructions

- ssh your sandbox
- kick off the calypso environment
- change the string
- Go to http://jetpack.cloud.localhost:3000/pricing or http://jetpack.cloud.localhost:3001/pricing to check if the string is shown correctly.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before:
<img width="1086" alt="230867490-ed05a0eb-d4fb-416e-96e7-cd2565567ae1" src="https://user-images.githubusercontent.com/82706809/234568440-4bbce537-6721-44ab-b746-a4b700594574.png">

After:
<img width="1439" alt="Screen Shot 2023-04-26 at 14 59 58" src="https://user-images.githubusercontent.com/82706809/234568560-7e134e8d-8fb4-4cc5-839e-1a65c93df488.png">


*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?