### PR TITLE
Newsletter: switch few setup step label names

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
@@ -29,9 +29,11 @@ const NewsletterPostSetup: Step = ( { navigation } ) => {
 	const fetchedAccentColor = useAccentColor();
 	const saveAccentColor = useSaveAccentColor();
 	const newsletterFormText = {
+		titleLabel: translate( 'Give your newsletter a name' ),
 		titlePlaceholder: translate( 'Open Me Carefully' ),
 		titleMissing: translate( `Oops. Looks like your newsletter doesn't have a name yet.` ),
-		taglinePlaceholder: translate( 'Describe your Newsletter in a line or two' ),
+		taglineLabel: translate( 'Add a brief description' ),
+		taglinePlaceholder: translate( `Letters from Emily Dickinson's garden` ),
 		iconPlaceholder: translate( 'Add a site icon' ),
 		colorLabel: translate( 'Choose an accent color' ),
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-post-setup/index.tsx
@@ -29,10 +29,11 @@ const NewsletterPostSetup: Step = ( { navigation } ) => {
 	const fetchedAccentColor = useAccentColor();
 	const saveAccentColor = useSaveAccentColor();
 	const newsletterFormText = {
-		titlePlaceholder: translate( 'My newsletter' ),
-		titleMissing: translate( `Oops. Looks like your Newsletter doesn't have a name yet.` ),
+		titlePlaceholder: translate( 'Open Me Carefully' ),
+		titleMissing: translate( `Oops. Looks like your newsletter doesn't have a name yet.` ),
 		taglinePlaceholder: translate( 'Describe your Newsletter in a line or two' ),
 		iconPlaceholder: translate( 'Add a site icon' ),
+		colorLabel: translate( 'Choose an accent color' ),
 	};
 
 	const [ invalidSiteTitle, setInvalidSiteTitle ] = useState( false );
@@ -124,7 +125,11 @@ const NewsletterPostSetup: Step = ( { navigation } ) => {
 					isLoading={ isLoading }
 					isSubmitError={ isSubmitError }
 				>
-					<AccentColorControl accentColor={ accentColor } setAccentColor={ setAccentColor } />
+					<AccentColorControl
+						accentColor={ accentColor }
+						setAccentColor={ setAccentColor }
+						labelText={ newsletterFormText?.colorLabel }
+					/>
 				</SetupForm>
 			}
 			recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -36,7 +36,7 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 		taglineLabel: translate( 'Add a brief description' ),
 		taglinePlaceholder: translate( `Letters from Emily Dickinson's garden` ),
 		iconPlaceholder: translate( 'Add a site icon' ),
-		colorLabel: translate( 'Favorite color' ),
+		colorLabel: translate( 'Choose an accent color' ),
 		buttonText: translate( 'Save and continue' ),
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/index.tsx
@@ -30,9 +30,9 @@ const NewsletterSetup: Step = ( { navigation } ) => {
 	const site = useSite();
 
 	const newsletterFormText = {
-		titleLabel: translate( 'Give your blog a name' ),
+		titleLabel: translate( 'Give your newsletter a name' ),
 		titlePlaceholder: translate( 'Open Me Carefully' ),
-		titleMissing: translate( `Oops. Looks like your Newsletter doesn't have a name yet.` ),
+		titleMissing: translate( `Oops. Looks like your newsletter doesn't have a name yet.` ),
 		taglineLabel: translate( 'Add a brief description' ),
 		taglinePlaceholder: translate( `Letters from Emily Dickinson's garden` ),
 		iconPlaceholder: translate( 'Add a site icon' ),


### PR DESCRIPTION
Texts discussed on Slack (p1682513643463089-slack-C052XEUUBL4) and partly addresses https://github.com/Automattic/wp-calypso/issues/76448

## Proposed Changes

* Update "Give your blog a name" to "Give your newsletter a name"
* Change Title case "Newsletter" to lowercase in missing title warning
* Change "Favorite color" to "Choose an accent color" be more consistent with other labels, and for clarity
* Updates some texts at "post setup" step to make them same as "setup" step

<img width="1116" alt="Screenshot 2023-04-26 at 16 16 06" src="https://user-images.githubusercontent.com/87168/234587043-95ee833c-95a9-46ad-bc99-75b1eb6ec74a.png">


## Testing Instructions

* Go `/setup/newsletter`
* Go to setup step
* Submit without entering site title, note warning and new labels

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?