### PR TITLE
Global Styles: Fix tracking for menu selections

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-global-styles-menu-selected.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-global-styles-menu-selected.js
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import tracksRecordEvent from './track-record-event';
 
-function trackGlobalStylesMenuSelected( { path } ) {
+function trackGlobalStylesMenuSelected( event, target ) {
 	// Gutenberg 12.5.0 changes the selector for the preview at the top level to have the '*__iframe' suffix.
 	const isAtTopLevel = document.querySelector(
 		'.edit-site-global-styles-sidebar .edit-site-global-styles-preview, .edit-site-global-styles-sidebar .edit-site-global-styles-preview__iframe'
@@ -11,7 +11,7 @@ function trackGlobalStylesMenuSelected( { path } ) {
 		return;
 	}
 
-	const buttonText = path.find( ( node ) => node.nodeName === 'BUTTON' )?.innerText;
+	const buttonText = target.innerText;
 
 	if ( buttonText === __( 'Typography' ) ) {
 		tracksRecordEvent( 'wpcom_block_editor_global_styles_menu_selected', {

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-global-styles-menu-selected.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-global-styles-menu-selected.js
@@ -29,6 +29,10 @@ function trackGlobalStylesMenuSelected( event, target ) {
 		tracksRecordEvent( 'wpcom_block_editor_global_styles_menu_selected', {
 			menu: 'layout',
 		} );
+	} else if ( buttonText === __( 'Browse styles' ) ) {
+		tracksRecordEvent( 'wpcom_block_editor_global_styles_menu_selected', {
+			menu: 'styles',
+		} );
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/75798

## Proposed Changes

The tracking of the `wpcom_block_editor_global_styles_menu_selected` event was relying on a deprecated and non-standard [`event.path` property](https://github.com/Automattic/wp-calypso/blob/79c1b10c2fca1e6d29b0a625729b286e07d158cd/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-global-styles-menu-selected.js#L4) to track this event and such property was [fully removed in January 2023](https://bugs.chromium.org/p/chromium/issues/detail?id=1277431), effectively breaking our ability to track menu selections on the Global Styles sidebar.

This PR fixes that by changing the logic to use the `target` param instead of `event.path`.

## Testing Instructions

- Apply these changes to your sandbox: `install-plugin.sh wpcom-block-editor fix/track-tlobal-styles-menu-selected`.
- Sandbox `widgets.wp.com`.
- Open the site editor.
- Open the Networks tab on your browser devtools.
- Observe the `t.gif` requests.
- Open the Global Styles sidebar and select any of the sections (Typography, Color, Blocks, etc).
- Make sure a `wpcom_block_editor_global_styles_menu_selected` event is tracked properly.