### PR TITLE
Tags page responsive tweaks

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -743,7 +743,7 @@ $font-size: rem(14px);
 			min-height: initial;
 		}
 
-		.focus-content .layout__content:not('.has-no-sidebar') {
+		.focus-content:not(.has-no-sidebar) .layout__content {
 			padding: 47px 0 0;
 		}
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -743,7 +743,7 @@ $font-size: rem(14px);
 			min-height: initial;
 		}
 
-		.focus-content .layout__content {
+		.focus-content .layout__content:not('.has-no-sidebar') {
 			padding: 47px 0 0;
 		}
 

--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, createRef } from 'react';
 import titlecase from 'to-title-case';
 import StickyPanel from 'calypso/components/sticky-panel';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -90,21 +90,22 @@ const scrollToLetter = ( letter: string ) => {
 export default function AlphabeticTags( { alphabeticTags }: AlphabeticTagsProps ) {
 	const translate = useTranslate();
 	const [ isSticky, setIsSticky ] = useState( false );
+	const tagsTableRef = createRef< HTMLDivElement >();
 
 	useEffect( () => {
 		const handleScroll = () => {
-			const tableA = document.getElementById( 'alphabetic-tags-table-A' );
-			if ( tableA ) {
-				const tableATop = tableA.getBoundingClientRect().top;
-				setIsSticky( tableATop < 0 );
+			if ( ! tagsTableRef.current ) {
+				return;
 			}
+			const tableATop = tagsTableRef.current.getBoundingClientRect().top;
+			setIsSticky( tableATop < 0 );
 		};
 
 		window.addEventListener( 'scroll', handleScroll );
 		return () => {
 			window.removeEventListener( 'scroll', handleScroll );
 		};
-	}, [] );
+	}, [ tagsTableRef, setIsSticky ] );
 
 	if ( ! alphabeticTags ) {
 		return null;
@@ -140,19 +141,21 @@ export default function AlphabeticTags( { alphabeticTags }: AlphabeticTagsProps 
 					</div>
 				</StickyPanel>
 			</div>
-			{ Object.keys( tagTables ).map( ( letter: string ) => (
-				<div className="alphabetic-tags__table" key={ 'alphabetic-tags-table-' + letter }>
-					{ /* eslint-disable jsx-a11y/no-noninteractive-tabindex */ }
-					<h3
-						tabIndex={ 0 }
-						className="alphabetic-tags__letter-title"
-						id={ 'alphabetic-tags-table-' + letter }
-					>
-						{ letter }
-					</h3>
-					<TagsTable tags={ tagTables[ letter ] } />
-				</div>
-			) ) }
+			<div ref={ tagsTableRef }>
+				{ Object.keys( tagTables ).map( ( letter: string ) => (
+					<div className="alphabetic-tags__table" key={ 'alphabetic-tags-table-' + letter }>
+						{ /* eslint-disable jsx-a11y/no-noninteractive-tabindex */ }
+						<h3
+							tabIndex={ 0 }
+							className="alphabetic-tags__letter-title"
+							id={ 'alphabetic-tags-table-' + letter }
+						>
+							{ letter }
+						</h3>
+						<TagsTable tags={ tagTables[ letter ] } />
+					</div>
+				) ) }
+			</div>
 		</>
 	);
 }

--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -42,12 +42,13 @@ const TagsColumn = ( props: TagsColProps ) => (
 
 const TagsRow = ( props: TagsRowProps ) => (
 	<div className="alphabetic-tags__row">
-		{ props.tags.map( ( tag: Tag | undefined, index ) => (
-			<div className="alphabetic-tags__col" key={ 'alphabetic-tags-col-' + index }>
-				{ tag && <TagsColumn slug={ tag.slug } title={ tag.title } /> }
-				{ ! tag && <TagsColumn slug="" title="" /> }
-			</div>
-		) ) }
+		{ props.tags.map( ( tag: Tag | undefined, index ) =>
+			tag ? (
+				<div className="alphabetic-tags__col" key={ 'alphabetic-tags-col-' + index }>
+					<TagsColumn slug={ tag.slug } title={ tag.title } />
+				</div>
+			) : null
+		) }
 	</div>
 );
 

--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useState, useEffect } from 'react';
 import titlecase from 'to-title-case';
 import StickyPanel from 'calypso/components/sticky-panel';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -88,6 +89,23 @@ const scrollToLetter = ( letter: string ) => {
 
 export default function AlphabeticTags( { alphabeticTags }: AlphabeticTagsProps ) {
 	const translate = useTranslate();
+	const [ isSticky, setIsSticky ] = useState( false );
+
+	useEffect( () => {
+		const handleScroll = () => {
+			const tableA = document.getElementById( 'alphabetic-tags-table-A' );
+			if ( tableA ) {
+				const tableATop = tableA.getBoundingClientRect().top;
+				setIsSticky( tableATop < 0 );
+			}
+		};
+
+		window.addEventListener( 'scroll', handleScroll );
+		return () => {
+			window.removeEventListener( 'scroll', handleScroll );
+		};
+	}, [] );
+
 	if ( ! alphabeticTags ) {
 		return null;
 	}
@@ -104,22 +122,24 @@ export default function AlphabeticTags( { alphabeticTags }: AlphabeticTagsProps 
 
 	return (
 		<>
-			<StickyPanel>
-				<div className="alphabetic-tags__header">
-					<h2>{ translate( 'Tags from A — Z' ) }</h2>
-					<div className="alphabetic-tags__tag-links">
-						{ Object.keys( tagTables ).map( ( letter: string ) => (
-							<Button
-								isLink
-								key={ 'alphabetic-tags-link-' + letter }
-								onClick={ () => scrollToLetter( letter ) }
-							>
-								{ letter }
-							</Button>
-						) ) }
+			<div className="sticky-container">
+				<StickyPanel className={ isSticky ? 'sticky-panel-fixed' : 'sticky-panel-absolute' }>
+					<div className="alphabetic-tags__header">
+						<h2>{ translate( 'Tags from A — Z' ) }</h2>
+						<div className="alphabetic-tags__tag-links">
+							{ Object.keys( tagTables ).map( ( letter: string ) => (
+								<Button
+									isLink
+									key={ 'alphabetic-tags-link-' + letter }
+									onClick={ () => scrollToLetter( letter ) }
+								>
+									{ letter }
+								</Button>
+							) ) }
+						</div>
 					</div>
-				</div>
-			</StickyPanel>
+				</StickyPanel>
+			</div>
 			{ Object.keys( tagTables ).map( ( letter: string ) => (
 				<div className="alphabetic-tags__table" key={ 'alphabetic-tags-table-' + letter }>
 					{ /* eslint-disable jsx-a11y/no-noninteractive-tabindex */ }

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -24,6 +24,12 @@
 		font-size: 60px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		font-weight: 400;
 		margin-bottom: 4px;
+
+		@media ( max-width: $break-medium ) {
+			font-size: $font-headline-small;
+			font-weight: 400;
+			line-height: 40px;
+		}
 	}
 	p {
 		font-weight: 400;

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -171,6 +171,37 @@
 	}
 }
 
+@media ( max-width: $break-small ) {
+	.alphabetic-tags__header {
+		border: none;
+		margin: 0;
+		padding: 0;
+
+		.alphabetic-tags__tag-links {
+			align-items: center;
+			flex-direction: column;
+		}
+		h2 {
+			display: none;
+		}
+	}
+	.sticky-container {
+		position: relative;
+	}
+	.sticky-panel {
+		top: 24px;
+		position: absolute;
+		right: -12px;
+	}
+	.sticky-panel-absolute {
+		position: absolute;
+	}
+	.sticky-panel-fixed {
+		position: fixed;
+		right: 12px;
+	}
+}
+
 .alphabetic-tags__table {
 	padding-bottom: 26px;
 	border-bottom: 1px solid var(--studio-gray-5);

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -92,11 +92,16 @@
 			outline-offset: 4px;
 		}
 		.trending-tags__title {
-			font-size: 36px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: $font-headline-small;
 			font-weight: 600;
 			color: var(--studio-black);
 			margin-right: 12px;
 			padding-right: 2px;
+
+			@media ( max-width: $break-medium ) {
+				font-size: 28px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				line-height: 32px;
+			}
 		}
 		.trending-tags__count {
 			font-size: 16px; /* stylelint-disable-line declaration-property-unit-allowed-list */


### PR DESCRIPTION
## Description

@ollierozdarz brought up in our Slack channel that the responsive mobile version of the newly renovated tags page still had some issues.

### Before

- under some of the letter sections there’s a large gap (K for example)
- H1 doesn’t look like it’s pulling a mobile style
- Top tags styles were off
- The A-Z should be mobile specific (position fixed, vertical) to the mobile design of the page.

### After

https://user-images.githubusercontent.com/5634774/234612308-748f6564-3fa2-4bbb-889b-992be9f8624e.mp4
