### PR TITLE
Allow users to export content from and delete expired free trial sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -304,8 +304,10 @@ function onSelectedSiteAvailable( context ) {
 				'/checkout/',
 				'/domains/',
 				'/email/',
+				'/export/',
 				'/plans/my-plan/trial-expired/',
 				'/purchases/',
+				'/settings/delete-site/',
 			];
 
 			if ( ! permittedPathPrefixes.some( ( prefix ) => context.pathname.startsWith( prefix ) ) ) {

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -86,6 +87,13 @@ const ECommerceTrialExpired = (): JSX.Element => {
 					yearlyControlProps={ yearlyControlProps }
 					showIntervalToggle={ true }
 				/>
+
+				<div className="ecommerce-trial-expired__footer">
+					<Button href={ `/settings/delete-site/${ siteSlug }` } scary icon="trash">
+						<Gridicon icon="trash" />
+						<span>{ translate( 'Delete your site permanently' ) }</span>
+					</Button>
+				</div>
 			</Main>
 		</>
 	);

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
@@ -11,6 +11,7 @@ import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { WooExpressPlans } from 'calypso/my-sites/plans/ecommerce-trial/wooexpress-plans';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -20,6 +21,7 @@ const ECommerceTrialExpired = (): JSX.Element => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
+	const siteIsAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 
 	const nonECommerceTrialPurchases = useMemo(
 		() =>
@@ -89,7 +91,13 @@ const ECommerceTrialExpired = (): JSX.Element => {
 				/>
 
 				<div className="ecommerce-trial-expired__footer">
-					<Button href={ `/settings/delete-site/${ siteSlug }` } scary icon="trash">
+					{ ! siteIsAtomic && (
+						<Button href={ `/export/${ siteSlug }` }>
+							<Gridicon icon="cloud-download" />
+							<span>{ translate( 'Export your content' ) }</span>
+						</Button>
+					) }
+					<Button href={ `/settings/delete-site/${ siteSlug }` } scary>
 						<Gridicon icon="trash" />
 						<span>{ translate( 'Delete your site permanently' ) }</span>
 					</Button>

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
@@ -41,4 +41,11 @@ body.is-section-plans.is-expired-ecommerce-trial-plan {
 			margin-top: 16px;
 		}
 	}
+
+	.ecommerce-trial-expired__footer {
+		border-top: 1px solid var(--color-border-subtle);
+		display: flex;
+		justify-content: center;
+		padding-top: 2em;
+	}
 }

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
@@ -45,7 +45,13 @@ body.is-section-plans.is-expired-ecommerce-trial-plan {
 	.ecommerce-trial-expired__footer {
 		border-top: 1px solid var(--color-border-subtle);
 		display: flex;
+		flex-direction: column;
+		gap: 2em;
 		justify-content: center;
 		padding-top: 2em;
+
+		@media ( min-width: $break-small ) {
+			flex-direction: row;
+		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76284

## Proposed Changes

* This PR has two major pieces:
   1. It allows users with expired eCommerce trial sites to access the `/settings/delete-site/` and `/export/` paths in Calypso, making it possible to export content from a site**, and delete the site permanently.
   2. It adds buttons to the bottom of the expired trial page to allow users to access these two pages directly

** _Note:_ Because the Export page only works for WPCOM Simple sites, it will only be shown for sites on the Simple architecture for now. We need to allow access to `/wp-admin/export.php` before it makes sense to run exports for Atomic sites. That will require a change in the code that redirects to the expired site page.
 
### Screenshot

<img width="1181" alt="Screenshot 2023-04-26 at 16 39 40" src="https://user-images.githubusercontent.com/3376401/234612250-fdfcfe4f-eb13-4726-996e-8062f150f648.png">

## Testing Instructions

* Find two free trial sites, one where the free trial has expired, and the site is back on WordPress.com Simple, and one where the site is still Atomic
* For the free trial site on WordPress.com Simple, navigate to `/plans/:siteSlug`
* Verify that this redirects you to the expired trial page
* Scroll to the bottom of the page, and verify that you see the _Export your content_ and _Delete your site permanently_ buttons
* Adjust the width of the page to be really narrow, and verify that the buttons respond appropriately - they should stack once the screen gets relatively narrow
* Click on the _Export your content_ button
* Verify that you're taken to the export page, and the left nav is not displayed
* Confirm that you can export your content and your media library
* Click on your browser's Back button to get back to the expired trial page
* Click on the _Delete your site permanently_ button
* Verify that you can access the delete site page
* If you _really_ want, verify that you can actually delete the site. (It doesn't redirect to any pages, so that is not strictly necessary.)
* Now test with your still-Atomic site
* Navigate to `/plans/:siteSlug`
* Verify that this redirects you to the expired trial page
* Scroll to the bottom of the page, and verify that you can only see the  _Delete your site permanently_ button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
