### PR TITLE
Add function to check if path is within Calypso scope when navigating

### DIFF
--- a/client/lib/navigate/index.ts
+++ b/client/lib/navigate/index.ts
@@ -7,23 +7,17 @@ function isSameOrigin( path: string ): boolean {
 	return new URL( path, window.location.href ).origin === window.location.origin;
 }
 
-// Check whether the section is defined as a page.js routing path or not.
-// For example, the section "/setup" is registered by react-router-dom instead of page.js
-function isPageRegistered() {
-	return !! String( page.base() );
-}
-
-// Check if the path is within Calypso's scope.
+// Check if the current path is within Calypso's scope.
 // For example, the path "/home" is within Calypso's scope.
 // The path "/setup" is not within Calypso's scope. Its part of the Stepper framework.
-function isPathOutOfScope( redirectPath: string ): boolean {
+function isCurrentPathOutOfScope( currentPath: string ): boolean {
 	const paths = [ '/setup' ];
-	return paths.some( ( path ) => redirectPath.startsWith( path ) );
+	return paths.some( ( path ) => currentPath.startsWith( path ) );
 }
 
 export function navigate( path: string ): void {
 	if ( isSameOrigin( path ) ) {
-		if ( ! isPageRegistered() && ! isPathOutOfScope( path ) ) {
+		if ( isCurrentPathOutOfScope( window.location.pathname ) ) {
 			const state = { path };
 			window.history.pushState( state, '', path );
 			dispatchEvent( new PopStateEvent( 'popstate', { state } ) );

--- a/client/lib/navigate/index.ts
+++ b/client/lib/navigate/index.ts
@@ -13,9 +13,17 @@ function isPageRegistered() {
 	return !! String( page.base() );
 }
 
+// Check if the path is within Calypso's scope.
+// For example, the path "/home" is within Calypso's scope.
+// The path "/setup" is not within Calypso's scope. Its part of the Stepper framework.
+function isPathOutOfScope( redirectPath: string ): boolean {
+	const paths = [ '/setup' ];
+	return paths.some( ( path ) => redirectPath.startsWith( path ) );
+}
+
 export function navigate( path: string ): void {
 	if ( isSameOrigin( path ) ) {
-		if ( ! isPageRegistered() ) {
+		if ( ! isPageRegistered() && ! isPathOutOfScope( path ) ) {
 			const state = { path };
 			window.history.pushState( state, '', path );
 			dispatchEvent( new PopStateEvent( 'popstate', { state } ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Test / Review Time

Test: short
Review: short

## Proposed Changes

* Currently, the "Next steps" exit link within the post editor (for launchpad enabled sites) is not displaying the correct redirection URL in the browser address bar, but the URL is not actually loaded. This PR adds a function to check if the URL is within Calypso's scope when navigating.

**Current issue:**


https://user-images.githubusercontent.com/10482592/234633125-1297721a-fb18-4b74-b12f-de3d4b73dd49.mp4




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch (or use the calypso.live link)
* Create or use an existing launchpad-enabled site. 
* Navigate to the post editor (`/post`) and click the "Next steps"
* Verify that you navigated to the launchpad screen
* Use a non-launchpad-enabled site , navigate to the post editor, click the "Dashboard" link in the sidebar and confirm you navigated to `/home`.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?