### PR TITLE
Jetpack Pro Dashboard: Mix user and partner licenses on the licensing screen

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/index.ts
+++ b/client/jetpack-cloud/sections/partner-portal/index.ts
@@ -29,7 +29,7 @@ export default function () {
 
 	// List licenses.
 	page(
-		`/partner-portal/licenses/:filter(unassigned|assigned|revoked)?`,
+		`/partner-portal/licenses/:filter(unassigned|assigned|revoked|standard)?`,
 		controller.requireAccessContext,
 		controller.requireTermsOfServiceConsentContext,
 		controller.requireSelectedPartnerKeyContext,

--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -52,10 +52,10 @@ export default function LicenseDetailsActions( {
 		<div className="license-details__actions">
 			{ licenseState === LicenseState.Attached && siteUrl && (
 				<>
-					<Button external compact href={ siteUrl }>
+					<Button compact href={ siteUrl } target="_blank" rel="noopener noreferrer">
 						{ translate( 'View site' ) }
 					</Button>
-					<Button external compact href={ debugUrl }>
+					<Button compact href={ debugUrl } target="_blank" rel="noopener noreferrer">
 						{ translate( 'Debug site' ) }
 					</Button>
 				</>

--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -5,16 +5,12 @@ import { useDispatch } from 'react-redux';
 import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
 import { LicenseState, LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import UnassignLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/unassign-license-dialog';
-import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
-import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 interface Props {
 	licenseKey: string;
 	product: string;
 	siteUrl: string | null;
-	attachedAt: string | null;
-	revokedAt: string | null;
 	licenseState: LicenseState;
 	licenseType: LicenseType;
 }
@@ -23,8 +19,6 @@ export default function LicenseDetailsActions( {
 	licenseKey,
 	product,
 	siteUrl,
-	attachedAt,
-	revokedAt,
 	licenseState,
 	licenseType,
 }: Props ) {
@@ -78,7 +72,7 @@ export default function LicenseDetailsActions( {
 				</>
 			) }
 
-			{ licenseState == LicenseState.Detached && licenseType === LicenseType.Partner && (
+			{ licenseState === LicenseState.Detached && licenseType === LicenseType.Partner && (
 				<Button compact onClick={ openRevokeDialog } scary>
 					{ translate( 'Revoke' ) }
 				</Button>

--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -52,14 +52,15 @@ export default function LicenseDetailsActions( {
 	return (
 		<div className="license-details__actions">
 			{ licenseState === LicenseState.Attached && siteUrl && (
-				<>
-					<Button compact href={ siteUrl } target="_blank" rel="noopener noreferrer">
-						{ translate( 'View site' ) }
-					</Button>
-					<Button compact href={ debugUrl } target="_blank" rel="noopener noreferrer">
-						{ translate( 'Debug site' ) }
-					</Button>
-				</>
+				<Button compact href={ siteUrl } target="_blank" rel="noopener noreferrer">
+					{ translate( 'View site' ) }
+				</Button>
+			) }
+
+			{ licenseState === LicenseState.Attached && debugUrl && (
+				<Button compact href={ debugUrl } target="_blank" rel="noopener noreferrer">
+					{ translate( 'Debug site' ) }
+				</Button>
 			) }
 
 			{ licenseState === LicenseState.Attached && licenseType === LicenseType.Partner && (

--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -5,6 +5,7 @@ import { useDispatch } from 'react-redux';
 import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
 import { LicenseState, LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import UnassignLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/unassign-license-dialog';
+import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 interface Props {
@@ -75,6 +76,17 @@ export default function LicenseDetailsActions( {
 			{ licenseState === LicenseState.Detached && licenseType === LicenseType.Partner && (
 				<Button compact onClick={ openRevokeDialog } scary>
 					{ translate( 'Revoke' ) }
+				</Button>
+			) }
+
+			{ licenseState === LicenseState.Detached && (
+				<Button
+					compact
+					primary
+					className="license-details__assign-button"
+					href={ addQueryArgs( { key: licenseKey }, '/partner-portal/assign-license' ) }
+				>
+					{ translate( 'Assign License' ) }
 				</Button>
 			) }
 

--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
-import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { LicenseState, LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import UnassignLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/unassign-license-dialog';
 import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -15,6 +15,8 @@ interface Props {
 	siteUrl: string | null;
 	attachedAt: string | null;
 	revokedAt: string | null;
+	licenseState: LicenseState;
+	licenseType: LicenseType;
 }
 
 export default function LicenseDetailsActions( {
@@ -23,12 +25,14 @@ export default function LicenseDetailsActions( {
 	siteUrl,
 	attachedAt,
 	revokedAt,
+	licenseState,
+	licenseType,
 }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const [ revokeDialog, setRevokeDialog ] = useState( false );
 	const [ unassignDialog, setUnassignDialog ] = useState( false );
+	const debugUrl = siteUrl ? `https://jptools.wordpress.com/debug/?url=${ siteUrl }` : null;
 
 	const openRevokeDialog = useCallback( () => {
 		setRevokeDialog( true );
@@ -52,23 +56,32 @@ export default function LicenseDetailsActions( {
 
 	return (
 		<div className="license-details__actions">
-			{ licenseState !== LicenseState.Revoked && (
-				<Button onClick={ openRevokeDialog } scary>
-					{ translate( 'Revoke License' ) }
-				</Button>
+			{ licenseState === LicenseState.Attached && siteUrl && (
+				<>
+					<Button external compact href={ siteUrl }>
+						{ translate( 'View site' ) }
+					</Button>
+					<Button external compact href={ debugUrl }>
+						{ translate( 'Debug site' ) }
+					</Button>
+				</>
 			) }
 
-			{ licenseState === LicenseState.Detached && (
-				<Button
-					className="license-details__assign-button"
-					href={ addQueryArgs( { key: licenseKey }, '/partner-portal/assign-license' ) }
-				>
-					{ translate( 'Assign License' ) }
-				</Button>
+			{ licenseState === LicenseState.Attached && licenseType === LicenseType.Partner && (
+				<>
+					<Button compact onClick={ openUnassignDialog }>
+						{ translate( 'Unassign' ) }
+					</Button>
+					<Button compact onClick={ openRevokeDialog } scary>
+						{ translate( 'Revoke' ) }
+					</Button>
+				</>
 			) }
 
-			{ licenseState === LicenseState.Attached && (
-				<Button onClick={ openUnassignDialog }>{ translate( 'Unassign License' ) }</Button>
+			{ licenseState == LicenseState.Detached && licenseType === LicenseType.Partner && (
+				<Button compact onClick={ openRevokeDialog } scary>
+					{ translate( 'Revoke' ) }
+				</Button>
 			) }
 
 			{ revokeDialog && (

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import FormattedDate from 'calypso/components/formatted-date';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import LicenseDetailsActions from 'calypso/jetpack-cloud/sections/partner-portal/license-details/actions';
-import { LicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { LicenseState, LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { getLicenseState, noop } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import './style.scss';
 
@@ -17,6 +17,7 @@ interface Props {
 	attachedAt: string | null;
 	revokedAt: string | null;
 	onCopyLicense?: () => void;
+	licenseType: LicenseType;
 }
 
 const DETAILS_DATE_FORMAT = 'YYYY-MM-DD h:mm:ss A';
@@ -31,15 +32,15 @@ export default function LicenseDetails( {
 	attachedAt,
 	revokedAt,
 	onCopyLicense = noop,
+	licenseType,
 }: Props ) {
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
-	const debugUrl = siteUrl ? `https://jptools.wordpress.com/debug/?url=${ siteUrl }` : null;
 
 	return (
 		<Card className="license-details">
 			<ul className="license-details__list">
-				<li className="license-details__list-item license-details__list-item--wide">
+				<li className="license-details__list-item">
 					<h4 className="license-details__label">{ translate( 'License code' ) }</h4>
 
 					<div className="license-details__license-key-row">
@@ -58,43 +59,14 @@ export default function LicenseDetails( {
 				</li>
 
 				<li className="license-details__list-item">
-					<h4 className="license-details__label">{ translate( 'Blog URL' ) }</h4>
-					{ siteUrl ? (
-						<a href={ siteUrl } target="_blank" rel="noopener noreferrer">
-							{ siteUrl }
-						</a>
-					) : (
-						<Gridicon icon="minus" />
-					) }
-				</li>
-
-				<li className="license-details__list-item">
-					<h4 className="license-details__label">{ translate( 'Jetpack Debugger' ) }</h4>
-					{ debugUrl ? (
-						<a href={ debugUrl } target="_blank" rel="noopener noreferrer">
-							{ debugUrl }
-						</a>
-					) : (
-						<Gridicon icon="minus" />
-					) }
-				</li>
-
-				<li className="license-details__list-item">
-					<h4 className="license-details__label">{ translate( 'Issued on' ) }</h4>
-					<FormattedDate date={ issuedAt } format={ DETAILS_DATE_FORMAT } />
+					<h4 className="license-details__label">{ translate( "Owner's User ID" ) }</h4>
+					{ username ? <span>{ username }</span> : <Gridicon icon="minus" /> }
 				</li>
 
 				{ licenseState === LicenseState.Attached && (
 					<li className="license-details__list-item">
-						<h4 className="license-details__label">{ translate( 'Assigned on' ) }</h4>
-						<FormattedDate date={ attachedAt } format={ DETAILS_DATE_FORMAT } />
-					</li>
-				) }
-
-				{ licenseState === LicenseState.Detached && (
-					<li className="license-details__list-item">
-						<h4 className="license-details__label">{ translate( 'Assigned on' ) }</h4>
-						<Gridicon icon="minus" />
+						<h4 className="license-details__label">{ translate( 'Site ID' ) }</h4>
+						{ blogId ? <span>{ blogId }</span> : <Gridicon icon="minus" /> }
 					</li>
 				) }
 
@@ -104,16 +76,6 @@ export default function LicenseDetails( {
 						<FormattedDate date={ revokedAt } format={ DETAILS_DATE_FORMAT } />
 					</li>
 				) }
-
-				<li className="license-details__list-item">
-					<h4 className="license-details__label">{ translate( "Owner's User ID" ) }</h4>
-					{ username ? <span>{ username }</span> : <Gridicon icon="minus" /> }
-				</li>
-
-				<li className="license-details__list-item">
-					<h4 className="license-details__label">{ translate( 'Blog ID' ) }</h4>
-					{ blogId ? <span>{ blogId }</span> : <Gridicon icon="minus" /> }
-				</li>
 			</ul>
 
 			<LicenseDetailsActions
@@ -122,6 +84,8 @@ export default function LicenseDetails( {
 				siteUrl={ siteUrl }
 				attachedAt={ attachedAt }
 				revokedAt={ revokedAt }
+				licenseState={ licenseState }
+				licenseType={ licenseType }
 			/>
 		</Card>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -21,6 +21,7 @@ interface Props {
 }
 
 const DETAILS_DATE_FORMAT = 'YYYY-MM-DD h:mm:ss A';
+const DETAILS_DATE_FORMAT_SHORT = 'YYYY-MM-DD';
 
 export default function LicenseDetails( {
 	licenseKey,
@@ -57,6 +58,18 @@ export default function LicenseDetails( {
 						</ClipboardButton>
 					</div>
 				</li>
+
+				<li className="license-details__list-item-small">
+					<h4 className="license-details__label">{ translate( 'Issued on' ) }</h4>
+					<FormattedDate date={ issuedAt } format={ DETAILS_DATE_FORMAT_SHORT } />
+				</li>
+
+				{ licenseState === LicenseState.Attached && (
+					<li className="license-details__list-item-small">
+						<h4 className="license-details__label">{ translate( 'Assigned on' ) }</h4>
+						<FormattedDate date={ attachedAt } format={ DETAILS_DATE_FORMAT_SHORT } />
+					</li>
+				) }
 
 				<li className="license-details__list-item">
 					<h4 className="license-details__label">{ translate( "Owner's User ID" ) }</h4>

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -95,8 +95,6 @@ export default function LicenseDetails( {
 				licenseKey={ licenseKey }
 				product={ product }
 				siteUrl={ siteUrl }
-				attachedAt={ attachedAt }
-				revokedAt={ revokedAt }
 				licenseState={ licenseState }
 				licenseType={ licenseType }
 			/>

--- a/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
@@ -73,14 +73,34 @@
 	&__actions {
 		margin-top: 1rem;
 		display: flex;
+		flex-wrap: wrap;
+
+		@include break-xlarge {
+			flex-wrap: nowrap;
+		}
 
 		.button {
-			margin-right: 1rem;
+			flex: 0 0 100%;
+		}
+
+		.button:not(:last-child) {
+			margin-bottom: 0.5rem;
+		}
+
+		@include break-large {
+			.button {
+				flex: 0 0 auto;
+			}
+
+			.button:not(:last-child) {
+				margin-right: 1rem;
+				margin-bottom: 0;
+			}
 		}
 	}
 
 	&__assign-button {
-		@include break-xlarge {
+		@include break-large {
 			display: none;
 		}
 	}

--- a/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
@@ -21,13 +21,20 @@
 		}
 	}
 
-	&__list-item {
+	&__list-item,
+	&__list-item-small {
 		font-size: 1rem;
 
 		&--wide {
 			@include break-xlarge() {
 				grid-column-start: span 2;
 			}
+		}
+	}
+
+	&__list-item-small {
+		@include break-xlarge() {
+			display: none;
 		}
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
@@ -15,7 +15,7 @@
 		list-style-type: none;
 
 		@include break-xlarge() {
-			grid-template-columns: repeat(2, 1fr);
+			grid-template-columns: 3fr 1fr 1fr;
 			grid-column-gap: 32px;
 			grid-row-gap: 32px;
 		}
@@ -64,10 +64,12 @@
 	}
 
 	&__actions {
-		margin-top: 42px;
+		margin-top: 1rem;
 		display: flex;
-		flex-direction: row-reverse;
-		justify-content: space-between;
+
+		.button {
+			margin-right: 1rem;
+		}
 	}
 
 	&__assign-button {

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -1,12 +1,12 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-$column-domain: 1;
-$column-actions: 4;
-$column-toggle: 5;
+$column-domain: 2;
+$column-actions: 5;
+$column-toggle: 6;
 
-$grid-xlarge: 1fr 114px 114px 128px 30px;
-$grid-wide: 1fr 128px 128px 128px 36px;
+$grid-xlarge: 0.5fr 0.5fr 114px 114px 128px 30px;
+$grid-wide: 0.5fr 0.5fr 128px 128px 128px 36px;
 
 .license-list-item {
 	display: grid;
@@ -47,7 +47,6 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 			margin-left: 0;
 			padding-right: 7px;
 			padding-left: 7px;
-			text-align: center;
 		}
 
 		> *:last-child {
@@ -99,7 +98,6 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 
 		h2,
 		h2 button {
-			justify-self: center;
 			font-size: 0.875rem;
 			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			line-height: 1.25rem;
@@ -135,5 +133,27 @@ $grid-wide: 1fr 128px 128px 128px 36px;
 		&.is-sort-asc {
 			transform: rotateZ(180deg);
 		}
+	}
+
+	.badge {
+		font-size: 0.65rem;
+		padding: 0 10px;
+		font-weight: 400;
+		border-radius: 0;
+	}
+
+	.badge--success {
+		background: var(--studio-green-5);
+		color: var(--studio-green-50);
+	}
+
+	.badge--warning {
+		background: var(--studio-yellow-5);
+		color: var(--studio-yellow-70);
+	}
+
+	.badge--error {
+		background: var(--studio-red-5);
+		color: var(--studio-red-70);
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -1,6 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+$column-product: 1;
 $column-domain: 2;
 $column-actions: 5;
 $column-toggle: 6;
@@ -64,6 +65,10 @@ $grid-wide: 0.5fr 0.5fr 128px 128px 128px 36px;
 		> *:nth-child(#{$column-toggle}) {
 			grid-column-end: auto;
 		}
+
+		.license-preview__product-small {
+			display: none;
+		}
 	}
 
 	@include break-wide() {
@@ -71,6 +76,10 @@ $grid-wide: 0.5fr 0.5fr 128px 128px 128px 36px;
 
 		> *:last-child {
 			margin-left: 12px;
+		}
+
+		.license-preview__product-small {
+			display: none;
 		}
 	}
 
@@ -136,7 +145,7 @@ $grid-wide: 0.5fr 0.5fr 128px 128px 128px 36px;
 	}
 
 	.badge {
-		font-size: 0.65rem;
+		font-size: 0.65rem; /* stylelint-disable-line */
 		padding: 0 10px;
 		font-weight: 400;
 		border-radius: 0;
@@ -155,5 +164,9 @@ $grid-wide: 0.5fr 0.5fr 128px 128px 128px 36px;
 	.badge--error {
 		background: var(--studio-red-5);
 		color: var(--studio-red-70);
+	}
+
+	.license-preview__product-small {
+		font-size: 1rem;
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
@@ -21,6 +21,7 @@ export default function LicenseListEmpty( { filter }: Props ) {
 		[ LicenseFilter.Attached ]: translate( 'No assigned licenses.' ),
 		[ LicenseFilter.Detached ]: translate( 'No unassigned licenses.' ),
 		[ LicenseFilter.Revoked ]: translate( 'No revoked licenses.' ),
+		[ LicenseFilter.Standard ]: translate( 'No standard licenses.' ),
 	};
 
 	const licenseFilterStatusTitle = licenseFilterStatusTitleMap[ filter ] as string;

--- a/client/jetpack-cloud/sections/partner-portal/license-list/header.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/header.tsx
@@ -82,7 +82,7 @@ export default function LicenseListHeader() {
 
 	return (
 		<LicenseListItem header className="license-list__header">
-			<h2>{ translate( 'License state' ) }</h2>
+			<h2>{ translate( 'Product' ) }</h2>
 
 			<h2>{ translate( 'Site' ) }</h2>
 

--- a/client/jetpack-cloud/sections/partner-portal/license-list/header.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/header.tsx
@@ -84,6 +84,8 @@ export default function LicenseListHeader() {
 		<LicenseListItem header className="license-list__header">
 			<h2>{ translate( 'License state' ) }</h2>
 
+			<h2>{ translate( 'Site' ) }</h2>
+
 			<SortButton
 				sortField={ LicenseSortField.IssuedAt }
 				currentSortField={ sortField }

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -91,6 +91,7 @@ export default function LicenseList() {
 								attachedAt={ license.attachedAt }
 								revokedAt={ license.revokedAt }
 								filter={ filter }
+								licenseType={ license.ownerType }
 							/>
 						</LicenseTransition>
 					) ) }

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -11,6 +11,7 @@ import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/li
 import LicensePreview, {
 	LicensePreviewPlaceholder,
 } from 'calypso/jetpack-cloud/sections/partner-portal/license-preview';
+import { LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { addQueryArgs } from 'calypso/lib/route';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constants';
@@ -91,7 +92,11 @@ export default function LicenseList() {
 								attachedAt={ license.attachedAt }
 								revokedAt={ license.revokedAt }
 								filter={ filter }
-								licenseType={ license.ownerType }
+								licenseType={
+									license.ownerType === LicenseType.Standard
+										? LicenseType.Standard
+										: LicenseType.Partner
+								}
 							/>
 						</LicenseTransition>
 					) ) }

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -3,10 +3,10 @@ import { Button, Gridicon } from '@automattic/components';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import moment from 'moment';
 import page from 'page';
 import { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import Badge from 'calypso/components/badge';
 import FormattedDate from 'calypso/components/formatted-date';
 import LicenseDetails from 'calypso/jetpack-cloud/sections/partner-portal/license-details';
 import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
@@ -20,7 +20,6 @@ import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { infoNotice, errorNotice } from 'calypso/state/notices/actions';
 import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
-import Badge from 'calypso/components/badge';
 import './style.scss';
 
 interface Props {
@@ -55,14 +54,6 @@ export default function LicensePreview( {
 	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 	const domain = siteUrl ? getUrlParts( siteUrl ).hostname || siteUrl : '';
-	const showDomain =
-		domain && [ LicenseState.Attached, LicenseState.Revoked ].indexOf( licenseState ) !== -1;
-
-	const oneMinuteAgo = moment.utc().subtract( 1, 'minute' );
-
-	const justIssued = moment.utc( issuedAt, 'YYYY-MM-DD HH:mm:ss' ) > oneMinuteAgo;
-
-	const justAssigned = moment.utc( attachedAt, 'YYYY-MM-DD HH:mm:ss' ) > oneMinuteAgo;
 
 	const open = useCallback( () => {
 		setOpen( ! isOpen );
@@ -128,6 +119,7 @@ export default function LicensePreview( {
 				</div>
 
 				<div>
+					<div className="license-preview__product-small">{ product }</div>
 					{ domain }
 					{ ! domain && licenseState === LicenseState.Detached && (
 						<span>

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -10,12 +10,17 @@ import { useDispatch, useSelector } from 'react-redux';
 import FormattedDate from 'calypso/components/formatted-date';
 import LicenseDetails from 'calypso/jetpack-cloud/sections/partner-portal/license-details';
 import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
-import { LicenseState, LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import {
+	LicenseState,
+	LicenseFilter,
+	LicenseType,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { getLicenseState } from 'calypso/jetpack-cloud/sections/partner-portal/utils';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { infoNotice, errorNotice } from 'calypso/state/notices/actions';
 import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
+import Badge from 'calypso/components/badge';
 import './style.scss';
 
 interface Props {
@@ -28,6 +33,7 @@ interface Props {
 	attachedAt: string | null;
 	revokedAt: string | null;
 	filter: LicenseFilter;
+	licenseType: LicenseType;
 }
 
 export default function LicensePreview( {
@@ -40,6 +46,7 @@ export default function LicensePreview( {
 	attachedAt,
 	revokedAt,
 	filter,
+	licenseType,
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -117,42 +124,29 @@ export default function LicensePreview( {
 				} ) }
 			>
 				<div>
-					<h3 className="license-preview__domain">
-						{ showDomain && <span>{ domain }</span> }
+					<span className="license-preview__product">{ product }</span>
+				</div>
 
-						{ licenseState === LicenseState.Detached && (
-							<span className="license-preview__tag license-preview__tag--is-detached">
-								<Gridicon icon="info-outline" size={ 18 } />
-								{ translate( 'Unassigned' ) }
-							</span>
-						) }
-
-						{ licenseState === LicenseState.Revoked && (
-							<span className="license-preview__tag license-preview__tag--is-revoked">
-								<Gridicon icon="block" size={ 18 } />
-								{ translate( 'Revoked' ) }
-							</span>
-						) }
-
-						{ justIssued && ! justAssigned && (
-							<span className="license-preview__tag license-preview__tag--is-just-issued">
-								<Gridicon icon="checkmark-circle" size={ 18 } />
-								{ translate( 'Just issued' ) }
-							</span>
-						) }
-
-						{ justAssigned && (
-							<span className="license-preview__tag license-preview__tag--is-assigned">
-								<Gridicon icon="checkmark-circle" size={ 18 } />
-								{ translate( 'Successfully assigned' ) }
-							</span>
-						) }
-					</h3>
-
-					<span className="license-preview__product">
-						<span>{ translate( 'Product:' ) } </span>
-						{ product }
-					</span>
+				<div>
+					{ domain }
+					{ ! domain && licenseState === LicenseState.Detached && (
+						<span>
+							<Badge type="warning">{ translate( 'Unassigned' ) }</Badge>
+							<Button
+								className="license-preview__assign-button"
+								borderless
+								compact
+								onClick={ assign }
+							>
+								{ translate( 'Assign' ) }
+							</Button>
+						</span>
+					) }
+					{ revokedAt && (
+						<span>
+							<Badge type="error">{ translate( 'Revoked' ) }</Badge>
+						</span>
+					) }
 				</div>
 
 				<div>
@@ -188,10 +182,8 @@ export default function LicensePreview( {
 				) }
 
 				<div>
-					{ licenseState === LicenseState.Detached && (
-						<Button compact onClick={ assign }>
-							{ translate( 'Assign License' ) }
-						</Button>
+					{ LicenseType.Standard === licenseType && (
+						<Badge type="success">{ translate( 'Standard license' ) }</Badge>
 					) }
 				</div>
 
@@ -213,6 +205,7 @@ export default function LicensePreview( {
 					attachedAt={ attachedAt }
 					revokedAt={ revokedAt }
 					onCopyLicense={ onCopyLicense }
+					licenseType={ licenseType }
 				/>
 			) }
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -31,14 +31,6 @@
 				padding-left: 21px;
 			}
 		}
-
-		&--is-detached.card.is-compact {
-			border-left: 3px solid var(--studio-orange-40);
-		}
-
-		&--is-revoked.card.is-compact {
-			border-left: 3px solid var(--studio-red-60);
-		}
 	}
 
 	&__no-value {
@@ -136,6 +128,13 @@
 	&--placeholder &__label + div,
 	&--placeholder &__copy-license-key {
 		@include placeholder( --color-neutral-10 );
+	}
+
+	&__assign-button {
+		font-size: 0.65rem;
+		font-weight: 400;
+		text-decoration: underline;
+		margin-left: 10px;
 	}
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -131,7 +131,7 @@
 	}
 
 	&__assign-button {
-		font-size: 0.65rem;
+		font-size: 0.75rem;
 		font-weight: 400;
 		text-decoration: underline;
 		margin-left: 10px;

--- a/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-state-filter/index.tsx
@@ -43,6 +43,10 @@ function LicenseStateFilter( { doSearch }: Props ) {
 			key: LicenseFilter.Revoked,
 			label: translate( 'Revoked' ),
 		},
+		{
+			key: LicenseFilter.Standard,
+			label: translate( 'Standard licenses' ),
+		},
 	].map( ( navItem ) => ( {
 		...navItem,
 		count: counts[ navItem.key ] || 0,

--- a/client/jetpack-cloud/sections/partner-portal/types.ts
+++ b/client/jetpack-cloud/sections/partner-portal/types.ts
@@ -11,6 +11,7 @@ export enum LicenseFilter {
 	Detached = 'detached',
 	Attached = 'attached',
 	Revoked = 'revoked',
+	Standard = 'standard',
 }
 
 export enum LicenseSortField {
@@ -22,6 +23,11 @@ export enum LicenseSortField {
 export enum LicenseSortDirection {
 	Ascending = 'asc',
 	Descending = 'desc',
+}
+
+export enum LicenseType {
+	Standard = 'user',
+	Partner = 'jetpack_partner_key',
 }
 
 export interface AssignLicenceProps {

--- a/client/state/partner-portal/licenses/handlers.ts
+++ b/client/state/partner-portal/licenses/handlers.ts
@@ -35,6 +35,7 @@ interface APILicense {
 	issued_at: string;
 	attached_at: string | null;
 	revoked_at: string | null;
+	owner_type: string | null;
 }
 
 interface APIPaginatedItems< T > {
@@ -107,6 +108,7 @@ function formatLicenses( items: APILicense[] ): License[] {
 		issuedAt: item.issued_at,
 		attachedAt: item.attached_at,
 		revokedAt: item.revoked_at,
+		ownerType: item.owner_type,
 	} ) );
 }
 

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -223,6 +223,7 @@ export interface LicenseCounts {
 	revoked: number;
 	not_revoked: number;
 	all: number;
+	standard: number;
 }
 
 export interface LicensesStore {

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -214,6 +214,7 @@ export interface License {
 	issuedAt: string;
 	attachedAt: string | null;
 	revokedAt: string | null;
+	ownerType: string | null;
 }
 
 export interface LicenseCounts {


### PR DESCRIPTION
## Proposed Changes

* Uses updated API responses to mix user and partner licenses on the licensing page in the Jetpack Pro Dashboard.
* Updates the design based on i1 designs for the license mixing project.

## Testing Instructions

* Test in combination with and based on instructions in D105642.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
