### PR TITLE
Stats Widget: Adjust notice styles hierarchy for overriding correctly

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -6,8 +6,9 @@
 	}
 }
 
-// Override notice styles
-#wpbody-content .notice {
+// Since styles of the component Notice should be imported before this file,
+// we can override the styles without more hierarchy for higher specificity.
+.notice {
 	display: block;
 	width: auto;
 	background: var(--studio-white);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/76196#issuecomment-1522506320.

## Proposed Changes

* Adjust overriding Notice styles hierarchy to avoid breaking existing `.notice` additional styles.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Jurassic Ninja site.
* Follow `Option 2` of `PCYsg-Pp7-p2#option-2` to verify changes on the JN site.
* Ensure the JN welcome notice looks as previously.
* Ensure the dashboard widget `WordPress Events and News` looks reasonable.

|Before|After|
|-|-|
|<img width="596" alt="截圖 2023-04-27 上午12 53 46" src="https://user-images.githubusercontent.com/6869813/234647921-b5f927bf-660c-4bb0-9b90-d9160f71dd32.png">|<img width="588" alt="截圖 2023-04-27 上午12 54 41" src="https://user-images.githubusercontent.com/6869813/234647953-892291dc-2831-4aa7-abc2-f8ab5c34b8d1.png">|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
