### PR TITLE
VideoPress: Fix sites not launching

### DIFF
--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -212,9 +212,6 @@ const videopress: Flow = {
 			case 'chooseADomain':
 				stepValidateSiteTitle();
 				break;
-			case 'processing':
-				addVideoPressPendingAction();
-				break;
 		}
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
@@ -239,6 +236,7 @@ const videopress: Flow = {
 				}
 
 				case 'chooseADomain': {
+					addVideoPressPendingAction();
 					return navigate( 'processing' );
 				}
 

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -212,6 +212,11 @@ const videopress: Flow = {
 			case 'chooseADomain':
 				stepValidateSiteTitle();
 				break;
+			case 'processing':
+				if ( ! _siteSlug ) {
+					addVideoPressPendingAction();
+				}
+				break;
 		}
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
@@ -236,13 +241,12 @@ const videopress: Flow = {
 				}
 
 				case 'chooseADomain': {
-					addVideoPressPendingAction();
 					return navigate( 'processing' );
 				}
 
 				case 'launchpad': {
 					clearOnboardingSiteOptions();
-					return navigate( 'processing' );
+					return navigate( `processing?siteSlug=${ _siteSlug }` );
 				}
 			}
 			return providedDependencies;


### PR DESCRIPTION
### Proposed Changes

Resolves: https://github.com/Automattic/wp-calypso/issues/75846
Related to: https://github.com/Automattic/wp-calypso/pull/75682

Before this PR if you start a site via the VideoPress flow, arrive at Launchpad, and try to launch your site, it will not launch. You will be redirected to a checkout screen (even though you already checked out with a paid plan earlier in the flow). 

After investigation, this occurs because the `addVideoPressPendingAction()` was invoked [every time a user entered the processing screen](https://github.com/Automattic/wp-calypso/blob/336f7b84d07eb675ce98e56e6b1a2b6d85762a33/client/landing/stepper/declarative-flow/videopress.ts#L216). That methods sets a pendingAction for the processing screen that redirects to checkout. This is what we want for the first processing screen, after the choose a domain step. 

But it is not what we want during the second processing screen when a user click the Launch button. We do set up a proper pendingAction in the the actionDispatch for the videopress_launched task in task-helpers.ts [here](https://github.com/Automattic/wp-calypso/blob/336f7b84d07eb675ce98e56e6b1a2b6d85762a33/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts#L321). However, that pending action is overridden by the one above, so launch does not happen and instead we re-do the checkout. 

To fix, I've simply move the  `addVideoPressPendingAction()` down so that it fires upon submit from the Choose Domain screen. That ensure it fires only once, when it should. And it allows the launch task's pendingAction to fire when expected. 


*Here's a video of the issue. Not this is cropped awkwardly to exclude domain name and other personal info.*
https://user-images.githubusercontent.com/21228350/234368058-afade41f-fc16-420f-8787-0fca29efadeb.mp4



### Testing Instructions

Review time: Short
Testing time: Short

1. Check out this branch and run yarn and yarn start if needed. 
2. Start a VideoPress site at http://calypso.localhost:3000/setup/videopress. Go through to Launchpad. Do the Upload Video action as that is required before launch. Return to launchpad. 
3. Update root domain if needed: When you return to Launchpad, if you click the Next Steps button, you're root domain may be reset from calypso localhost to wordpress.com, so you'll need to manually update. 
4. TEST: Click the launch button and confirm a) the site is launched and b) you a redirected to my home. (Before this PR, you'd end up on the checkout screen). 