### PR TITLE
Jetpack Pro Dashboard: fix unnecessary re-rendering of the component while scrolling

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -14,7 +14,6 @@ import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
-import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { resetSite } from 'calypso/state/jetpack-agency-dashboard/actions';
 import {
@@ -27,14 +26,13 @@ import OnboardingWidget from '../../partner-portal/primary/onboarding-widget';
 import SitesOverviewContext from './context';
 import SiteAddLicenseNotification from './site-add-license-notification';
 import SiteContent from './site-content';
+import SiteContentHeader from './site-content-header';
 import SiteSearchFilterContainer from './site-search-filter-container/SiteSearchFilterContainer';
 import SiteWelcomeBanner from './site-welcome-banner';
 import { getProductSlugFromProductType } from './utils';
 import type { Site } from '../sites-overview/types';
 
 import './style.scss';
-
-const CALYPSO_MASTERBAR_HEIGHT = 47;
 
 export default function SitesOverview() {
 	const translate = useTranslate();
@@ -182,10 +180,6 @@ export default function SitesOverview() {
 		} );
 	}, [ selectedLicensesSiteId, selectedLicenses ] );
 
-	const [ divRef, hasCrossed ] = useDetectWindowBoundary( CALYPSO_MASTERBAR_HEIGHT );
-
-	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
-
 	const renderIssueLicenseButton = () => {
 		return (
 			<div className="sites-overview__licenses-buttons">
@@ -236,22 +230,11 @@ export default function SitesOverview() {
 					<div className="sites-overview__content-wrapper">
 						<SiteWelcomeBanner isDashboardView />
 						{ data?.sites && <SiteAddLicenseNotification /> }
-						<div className="sites-overview__viewport" { ...outerDivProps }>
-							<div
-								className={ classNames( 'sites-overview__page-title-container', {
-									'is-sticky': showIssueLicenseButtonsLargeScreen && hasCrossed,
-								} ) }
-							>
-								<div className="sites-overview__page-heading">
-									<h2 className="sites-overview__page-title">{ pageTitle }</h2>
-									<div className="sites-overview__page-subtitle">
-										{ translate( 'Manage all your Jetpack sites from one location' ) }
-									</div>
-								</div>
-
-								{ showIssueLicenseButtonsLargeScreen && renderIssueLicenseButton() }
-							</div>
-						</div>
+						<SiteContentHeader
+							content={ renderIssueLicenseButton() }
+							pageTitle={ pageTitle }
+							showStickyContent={ !! showIssueLicenseButtonsLargeScreen }
+						/>
 						<SectionNav
 							applyUpdatedStyles
 							selectedText={

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
@@ -1,0 +1,38 @@
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
+import type { ReactChild } from 'react';
+
+const CALYPSO_MASTERBAR_HEIGHT = 47;
+
+interface Props {
+	pageTitle: string;
+	showStickyContent: boolean;
+	content: ReactChild;
+}
+
+export default function SiteContentHeader( { content, pageTitle, showStickyContent }: Props ) {
+	const [ divRef, hasCrossed ] = useDetectWindowBoundary( CALYPSO_MASTERBAR_HEIGHT );
+
+	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
+
+	const translate = useTranslate();
+	return (
+		<div className="sites-overview__viewport" { ...outerDivProps }>
+			<div
+				className={ classNames( 'sites-overview__page-title-container', {
+					'is-sticky': showStickyContent && hasCrossed,
+				} ) }
+			>
+				<div className="sites-overview__page-heading">
+					<h2 className="sites-overview__page-title">{ pageTitle }</h2>
+					<div className="sites-overview__page-subtitle">
+						{ translate( 'Manage all your Jetpack sites from one location' ) }
+					</div>
+				</div>
+
+				{ showStickyContent && content }
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
Related to 1202619025189113-as-1204471700391083

## Proposed Changes

This PR fixes the unnecessary re-rendering of the component while scrolling by moving the piece of code that requires detecting the scroll position to show the sticky content into to new child component. By doing this, it prevents the parent component where a lot of content is displayed won't re-render, which will improve the performance. 

## Testing Instructions

- Run `git checkout fix/re-rendering-while-scrolling` and `yarn start-jetpack-cloud`
- Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
- Add the line `console.log( 'RENDERING SITES OVERVIEW' );` anywhere in the `client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx` file and keep the `Console` tab in the dev tool open. 
- Scroll up and down continuously and verify that added `console.log` is not getting printed again & again.
- Select any license by clicking `+Add` on `Backup` or `Scan`. Make sure you have not added any of these licenses before to this site.
- Verify the sticky content still appears on scrolling below the site table headers and added `console.log` is not getting printed when scrolling up/down.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>

https://user-images.githubusercontent.com/10586875/234771075-435d6b29-d75b-45b3-9f30-be9af65725ba.mov


</td>
<td>

https://user-images.githubusercontent.com/10586875/234771258-9bba4b68-e798-4e06-b137-bb596d3d1975.mov

</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?