### PR TITLE
Plugin Selectors: Guard against nulls in preparation for using TypeScript plugin selectors

### DIFF
--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
@@ -30,8 +30,8 @@ export const JetpackPluginUpdatesTour = makeTour(
 		{ ...meta }
 		when={ ( state: AppState ) => {
 			const site = getSelectedSite( state );
-			const isRequestingPlugins = isRequesting( state, site?.ID );
-			const sitePlugin = getPluginOnSite( state, site?.ID, 'jetpack' );
+			const isRequestingPlugins = site ? isRequesting( state, site.ID ) : false;
+			const sitePlugin = site ? getPluginOnSite( state, site.ID, 'jetpack' ) : undefined;
 			const res = ! isRequestingPlugins && !! sitePlugin;
 			return res;
 		} }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -32,7 +32,9 @@ const MarketplaceThankYou = ( {
 } ) => {
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
-	const isRequestingPlugins = useSelector( ( state ) => isRequesting( state, siteId ) );
+	const isRequestingPlugins = useSelector( ( state ) =>
+		siteId ? isRequesting( state, siteId ) : false
+	);
 
 	const defaultThankYouFooter = useThankYouFoooter( pluginSlugs, themeSlugs );
 

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -19,7 +19,7 @@ interface Props {
 	plugins: Array< PluginComponentProps >;
 	isLoading: boolean;
 	requestError: boolean;
-	selectedSite: SiteDetails;
+	selectedSite?: SiteDetails;
 	searchTerm: string;
 	isBulkManagementActive: boolean;
 	toggleBulkManagement: () => void;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-card/index.tsx
@@ -11,7 +11,7 @@ import './style.scss';
 
 interface Props {
 	item: any;
-	selectedSite: SiteDetails;
+	selectedSite?: SiteDetails;
 	rowFormatter: ( args: RowFormatterArgs ) => ReactNode;
 	columns: Columns;
 	renderActions?: ( args: any ) => ReactElement;

--- a/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-common/plugin-common-list/index.tsx
@@ -10,7 +10,7 @@ import type { ReactElement, ReactNode } from 'react';
 import './style.scss';
 
 interface Props {
-	selectedSite: SiteDetails;
+	selectedSite?: SiteDetails;
 	items: Array< any >;
 	isLoading: boolean;
 	columns: Columns;

--- a/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugins-list/index.tsx
@@ -11,7 +11,7 @@ import type { SiteDetails } from '@automattic/data-stores';
 import '../style.scss';
 
 interface Props {
-	selectedSite: SiteDetails;
+	selectedSite?: SiteDetails;
 	items: Array< PluginComponentProps >;
 	isLoading: boolean;
 	columns: Columns;

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -43,7 +43,7 @@ const getConfirmationText = ( sites, selectedPlugins, actionText ) => {
 
 		Object.keys( plugin.sites ).forEach( ( siteId ) => {
 			const site = sites.find( ( s ) => s.ID === parseInt( siteId ) );
-			if ( site.canUpdateFiles ) {
+			if ( site && site.canUpdateFiles ) {
 				sitesList[ site.ID ] = true;
 				siteName = site.title;
 			}

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -15,6 +15,7 @@ export function getVisibleSites( sites ) {
 
 export function useLocalizedPlugins() {
 	const isLoggedIn = useSelector( isUserLoggedIn );
+	// eslint-disable-next-line wpcalypso/i18n-translate-identifier
 	const { localeSlug } = useTranslate();
 
 	const localizePath = useCallback(

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -15,16 +15,16 @@ export function getVisibleSites( sites ) {
 
 export function useLocalizedPlugins() {
 	const isLoggedIn = useSelector( isUserLoggedIn );
-	const { localeSlug: locale } = useTranslate();
+	const { localeSlug } = useTranslate();
 
 	const localizePath = useCallback(
 		( path ) => {
 			const shouldPrefix =
-				! isLoggedIn && isMagnificentLocale( locale ) && path.startsWith( '/plugins' );
+				! isLoggedIn && isMagnificentLocale( localeSlug ) && path.startsWith( '/plugins' );
 
-			return shouldPrefix ? `/${ locale }${ path }` : path;
+			return shouldPrefix ? `/${ localeSlug }${ path }` : path;
 		},
-		[ isLoggedIn, locale ]
+		[ isLoggedIn, localeSlug ]
 	);
 
 	return { localizePath };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

As part of splitting https://github.com/Automattic/wp-calypso/pull/72363 into multiple files, this PR adds a lot of small changes which check for nulls. These changes will eventually be necessary when the TypeScript versions of the plugin selectors are used, but for now they just serve to reduce ambiguity and avoid a few possible null reference errors.

I also removed the renaming of `localSlug` to `locale` in `client/my-sites/plugins/utils.js` due to a linting error in `i18n-translate-identifier` which tries to prevent the renaming of translation variables. However this code still does not pass the linter, so I opened https://github.com/Automattic/wp-calypso/issues/76339.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For this PR it is best to review the code visually to ensure that it is either functionally equivalent to what existed before or avoids a null reference error.

If you want to do functional testing, just run a flow that loads each component and look for errors in the console.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
