### PR TITLE
Subscriptions Management: Update Sites page sort default value and fix "Route path" warning

### DIFF
--- a/client/landing/subscriptions/components/tab-views/sites/sites.tsx
+++ b/client/landing/subscriptions/components/tab-views/sites/sites.tsx
@@ -26,7 +26,7 @@ const useSortOptions = ( translate: ReturnType< typeof useTranslate > ): Option[
 const Sites = () => {
 	const translate = useTranslate();
 	const { searchTerm, handleSearch } = useSearch();
-	const [ sortTerm, setSortTerm ] = useState( SortBy.LastUpdated );
+	const [ sortTerm, setSortTerm ] = useState( SortBy.DateSubscribed );
 	const { data, isLoading, error } = SubscriptionManager.useSiteSubscriptionsQuery( {
 		searchTerm,
 		sortTerm,

--- a/client/landing/subscriptions/index.tsx
+++ b/client/landing/subscriptions/index.tsx
@@ -58,7 +58,7 @@ window.AppBoot = async () => {
 						<WindowLocaleEffectManager />
 						<BrowserRouter>
 							<Routes>
-								<Route path="/subscriptions*" element={ <SubscriptionManagerPage /> } />
+								<Route path="/subscriptions/*" element={ <SubscriptionManagerPage /> } />
 							</Routes>
 						</BrowserRouter>
 					</MomentProvider>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/76210.

## Proposed Changes

* update Sites page sort default value to `Recently subscribed`:

![Markup on 2023-04-27 at 09:57:49](https://user-images.githubusercontent.com/25105483/234797848-c734c541-0b89-4df9-bc38-379aa440a6ef.png)

* fix the following warning:

```
Route path "/subscriptions*" will be treated as if it were "/subscriptions/*" because the `*` character must always follow a `/` in the pattern. To get rid of this warning, please change the route path to "/subscriptions/*".
```

## Testing Instructions

1. Check out and build the PR locally.
2. Apply the correct `subkey` cookie value to your `calypso.localhost:3000` host.
3. Make sure the related user has existing site and comment subscriptions.
4. Navigate to http://calypso.localhost:3000/subscriptions/sites. The default sorting value should be set to `Recently subscribed`. You can test the sorting drop-down toggle as well.
5. Open the browser console. There should be no warning displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
