### PR TITLE
Plans: Fix interval toggle margins

### DIFF
--- a/client/my-sites/plan-features-2023-grid/_media-queries.scss
+++ b/client/my-sites/plan-features-2023-grid/_media-queries.scss
@@ -155,7 +155,7 @@ $minWidthToGridWidthMap: (
  */
 @mixin plans-section-custom-mobile-breakpoint() {
 	.is-section-plans & {
-		@media ( min-width: $custom-mobile-breakpoint ) {
+		@media ( min-width: $plans-2023-small-breakpoint ) {
 			@content;
 		}
 	}

--- a/client/my-sites/plan-features-2023-grid/style.scss
+++ b/client/my-sites/plan-features-2023-grid/style.scss
@@ -687,7 +687,7 @@ body.is-section-signup.is-white-signup,
 body.is-section-signup.is-white-signup .is-onboarding-2023-pricing-grid .signup__step .segmented-control.price-toggle,
 #primary .is-pricing-grid-2023-plans-features-main .segmented-control.price-toggle {
 	background-color: #f2f2f2;
-	width: 414px; // width of mobile plans grid
+	width: 100%;
 	margin: 0 auto;
 
 	@include plans-2023-break-small {

--- a/client/my-sites/plans-features-main/components/plan-type-selector.tsx
+++ b/client/my-sites/plans-features-main/components/plan-type-selector.tsx
@@ -323,6 +323,7 @@ const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSig
 	display: ${ ( { isInSignup } ) => ( isInSignup ? 'flex' : 'block' ) };
 	align-content: space-between;
 	justify-content: center;
+	margin: 0 20px;
 
 	> .segmented-control.is-compact:not( .is-signup ) {
 		margin: 8px auto 16px;

--- a/client/my-sites/plans/modernized-layout.tsx
+++ b/client/my-sites/plans/modernized-layout.tsx
@@ -21,7 +21,7 @@ const ModernizedLayout: React.FunctionComponent< { dropShadowOnHeader?: boolean 
 	// from @automattic/components/src/highlight-cards/variables.scss:
 	// ----------------------------------------------
 	// If changed, also change @plans-section-custom-mobile-breakpoint in client/my-sites/plan-features-2023-grid/_media-queries.scss
-	const customBreakpointSmall = '660px';
+	const customBreakpointSmall = '780px';
 	const verticalMargin = '32px';
 	// ----------------------------------------------
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #75033 

## Proposed Changes

* Fixes the styling of the interval type toggle on mobile screens.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start` on mobile. Confirm that the interval toggle has the appropriate margins:
<img width="195" alt="image" src="https://user-images.githubusercontent.com/5436027/234808947-d99b0240-787c-46a8-bda5-ac6ac6d67a88.png">

* Go to `/plans/<site slug>` and confirm the same:
<img width="197" alt="image" src="https://user-images.githubusercontent.com/5436027/234814574-7566eb1c-49d8-48ec-820e-135eb47ba81b.png">

* Known issue: On certain resolutions (tablets?), on the /plans page, the toggle is not aligned with the plans grid. This PR does not fix this issue. (No change from production)
<img width="417" alt="image" src="https://user-images.githubusercontent.com/5436027/234815348-58cfab8e-67ba-4197-8f4f-2b037e5a9b64.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
