### PR TITLE
Hosting site creation flow ends on `/sites` page

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -16,13 +16,13 @@ export function generateFlows( {
 	getDestinationFromIntent = noop,
 	getDIFMSignupDestination = noop,
 	getDIFMSiteContentCollectionDestination = noop,
-	getHomeDestination = noop,
+	getSitesDestination = noop,
 } = {} ) {
 	const flows = [
 		{
 			name: HOSTING_LP_FLOW,
 			steps: [ 'plans-hosting', 'user-hosting', 'domains' ],
-			destination: getHomeDestination,
+			destination: getSitesDestination,
 			description:
 				'Create an account and a blog and give the user the option of adding a domain and plan to the cart.',
 			lastModified: '2023-02-09',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -169,8 +169,8 @@ function getDIFMSiteContentCollectionDestination( { siteSlug } ) {
 	return `/home/${ siteSlug }`;
 }
 
-function getHomeDestination( { siteSlug } ) {
-	return `/home/${ siteSlug }`;
+function getSitesDestination( { siteSlug } ) {
+	return addQueryArgs( { 'new-site': siteSlug }, '/sites' );
 }
 
 const flows = generateFlows( {
@@ -186,7 +186,7 @@ const flows = generateFlows( {
 	getDestinationFromIntent,
 	getDIFMSignupDestination,
 	getDIFMSiteContentCollectionDestination,
-	getHomeDestination,
+	getSitesDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -18,6 +18,7 @@ export interface SitesDashboardQueryParams {
 	search?: string;
 	showHidden?: boolean;
 	status?: GroupableSiteLaunchStatuses;
+	newSiteSlug?: string;
 }
 
 const FilterBar = styled.div( {

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -205,7 +205,7 @@ export function SitesDashboard( {
 				<SitesDashboardSitesList
 					sites={ allSites }
 					filtering={ { search } }
-					sorting={ sitesSorting }
+					sorting={ { ...sitesSorting, newSiteSlug } }
 					grouping={ { status, showHidden: true } }
 				>
 					{ ( { sites, statuses } ) => {

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -138,7 +138,7 @@ const ScrollButton = styled( Button, { shouldForwardProp: ( prop ) => prop !== '
 const SitesDashboardSitesList = createSitesListComponent();
 
 export function SitesDashboard( {
-	queryParams: { page = 1, perPage = 96, search, status = 'all' },
+	queryParams: { page = 1, perPage = 96, search, status = 'all', newSiteSlug },
 }: SitesDashboardProps ) {
 	const { __, _n } = useI18n();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery();
@@ -237,6 +237,7 @@ export function SitesDashboard( {
 														isLoading={ isLoading }
 														sites={ paginatedSites }
 														className={ sitesMargin }
+														newSiteSlug={ newSiteSlug }
 													/>
 												) }
 												{ displayMode === 'tile' && (
@@ -244,6 +245,7 @@ export function SitesDashboard( {
 														isLoading={ isLoading }
 														sites={ paginatedSites }
 														className={ sitesMargin }
+														newSiteSlug={ newSiteSlug }
 													/>
 												) }
 												{ ( selectedStatus.hiddenCount > 0 || sites.length > perPage ) && (

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -1,4 +1,5 @@
 import { PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { Ribbon } from '@automattic/components';
 import { useSiteLaunchStatusLabel, getSiteLaunchStatus } from '@automattic/sites';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
@@ -72,9 +73,10 @@ const ellipsis = css( {
 
 interface SitesGridItemProps {
 	site: SiteExcerptData;
+	isNewSite?: boolean;
 }
 
-export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
+export const SitesGridItem = memo( ( { site, isNewSite }: SitesGridItemProps ) => {
 	const { __ } = useI18n();
 
 	const isP2Site = site.options?.is_wpforteams_site;
@@ -100,6 +102,7 @@ export const SitesGridItem = memo( ( { site }: SitesGridItemProps ) => {
 			leading={
 				<>
 					<ThumbnailLink { ...siteDashboardUrlProps }>
+						{ isNewSite && <Ribbon>{ __( 'New' ) }</Ribbon> }
 						<SiteItemThumbnail
 							displayMode="tile"
 							className={ siteThumbnail }

--- a/client/sites-dashboard/components/sites-grid.tsx
+++ b/client/sites-dashboard/components/sites-grid.tsx
@@ -27,16 +27,19 @@ interface SitesGridProps {
 	className?: string;
 	isLoading: boolean;
 	sites: SiteExcerptData[];
+	newSiteSlug?: string;
 }
 
-export const SitesGrid = ( { sites, isLoading, className }: SitesGridProps ) => {
+export const SitesGrid = ( { sites, isLoading, className, newSiteSlug }: SitesGridProps ) => {
 	return (
 		<div className={ classnames( container, className ) }>
 			{ isLoading
 				? Array( N_LOADING_ROWS )
 						.fill( null )
 						.map( ( _, i ) => <SitesGridItemLoading key={ i } delayMS={ i * 150 } /> )
-				: sites.map( ( site ) => <SitesGridItem site={ site } key={ site.ID } /> ) }
+				: sites.map( ( site ) => (
+						<SitesGridItem site={ site } key={ site.ID } isNewSite={ site.slug === newSiteSlug } />
+				  ) ) }
 			<LinkInBioBanner displayMode="grid" />
 		</div>
 	);

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -1,4 +1,4 @@
-import { ListTile } from '@automattic/components';
+import { ListTile, Ribbon } from '@automattic/components';
 import { useSiteLaunchStatusLabel } from '@automattic/sites';
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
@@ -23,6 +23,7 @@ import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
 interface SiteTableRowProps {
 	site: SiteExcerptData;
+	isNewSite?: boolean;
 }
 
 const Row = styled.tr`
@@ -78,7 +79,7 @@ const ListTileSubtitle = styled.div`
 	align-items: center;
 `;
 
-export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
+export default memo( function SitesTableRow( { site, isNewSite }: SiteTableRowProps ) {
 	const { __ } = useI18n();
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 	const { ref, inView } = useInView( { triggerOnce: true } );
@@ -104,6 +105,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 							href={ getDashboardUrl( site.slug ) }
 							title={ __( 'Visit Dashboard' ) }
 						>
+							{ isNewSite && <Ribbon>{ __( 'New' ) }</Ribbon> }
 							<SiteItemThumbnail displayMode="list" showPlaceholder={ ! inView } site={ site } />
 						</ListTileLeading>
 					}

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -14,6 +14,7 @@ interface SitesTableProps {
 	className?: string;
 	sites: SiteExcerptData[];
 	isLoading?: boolean;
+	newSiteSlug?: string;
 }
 
 const Table = styled.table`
@@ -80,7 +81,12 @@ const StatsThInner = styled.div( {
 	gap: '6px',
 } );
 
-export function SitesTable( { className, sites, isLoading = false }: SitesTableProps ) {
+export function SitesTable( {
+	className,
+	sites,
+	isLoading = false,
+	newSiteSlug,
+}: SitesTableProps ) {
 	const { __ } = useI18n();
 
 	const headerRef = useRef< HTMLTableSectionElement >( null );
@@ -175,7 +181,11 @@ export function SitesTable( { className, sites, isLoading = false }: SitesTableP
 								/>
 							) ) }
 					{ sites.map( ( site ) => (
-						<SitesTableRow site={ site } key={ site.ID }></SitesTableRow>
+						<SitesTableRow
+							site={ site }
+							key={ site.ID }
+							isNewSite={ newSiteSlug === site.slug }
+						></SitesTableRow>
 					) ) }
 				</tbody>
 			</Table>

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -74,6 +74,7 @@ export function sitesDashboard( context: PageJSContext, next: () => void ) {
 						: undefined,
 					search: context.query.search,
 					status: context.query.status,
+					newSiteSlug: context.query[ 'new-site' ] ?? undefined,
 				} }
 			/>
 		</>

--- a/client/state/sites/hooks/use-sites-sorting.ts
+++ b/client/state/sites/hooks/use-sites-sorting.ts
@@ -29,7 +29,9 @@ export const parseSitesSorting = ( serializedSorting: SitesSorting | 'none' ) =>
 	return sorting;
 };
 
-export const stringifySitesSorting = ( sorting: Required< SitesSortOptions > ): SitesSorting => {
+export const stringifySitesSorting = (
+	sorting: Required< Omit< SitesSortOptions, 'newSiteSlug' > >
+): SitesSorting => {
 	return `${ sorting.sortKey }${ SEPARATOR }${ sorting.sortOrder }`;
 };
 
@@ -46,7 +48,7 @@ export const useSitesSorting = () => {
 	return {
 		hasSitesSortingPreferenceLoaded: sitesSorting !== 'none',
 		sitesSorting: parseSitesSorting( sitesSorting ),
-		onSitesSortingChange: ( newSorting: Required< SitesSortOptions > ) => {
+		onSitesSortingChange: ( newSorting: Required< Omit< SitesSortOptions, 'newSiteSlug' > > ) => {
 			onSitesSortingChange( stringifySitesSorting( newSorting ) );
 		},
 	};

--- a/packages/sites/tests/use-sites-list-sorting.test.ts
+++ b/packages/sites/tests/use-sites-list-sorting.test.ts
@@ -10,6 +10,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 1,
 			title: 'B',
+			slug: 'b.wordpress.com',
 			options: {
 				updated_at: '2022-05-27T07:19:20+00:00',
 			},
@@ -18,6 +19,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 2,
 			title: 'A',
+			slug: 'a.wordpress.com',
 			options: {
 				updated_at: '2022-07-13T17:17:12+00:00',
 			},
@@ -26,6 +28,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 3,
 			title: 'C',
+			slug: 'c.wordpress.com',
 			options: {
 				updated_at: '2022-06-14T13:32:34+00:00',
 			},
@@ -35,6 +38,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 1,
 			title: 'B',
+			slug: 'b.wordpress.com',
 			options: {
 				updated_at: '2022-05-27T07:19:20+00:00',
 			},
@@ -43,6 +47,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 2,
 			title: 'A',
+			slug: 'a.wordpress.com',
 			options: {
 				updated_at: '2022-07-13T17:17:12+00:00',
 			},
@@ -51,6 +56,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 3,
 			title: 'C',
+			slug: 'c.wordpress.com',
 			options: {
 				updated_at: '2022-06-14T13:32:34+00:00',
 			},
@@ -62,6 +68,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 1,
 			title: 'B',
+			slug: 'b.wordpress.com',
 			options: {
 				updated_at: '2022-05-27T07:19:20+00:00',
 			},
@@ -70,6 +77,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 2,
 			title: 'A',
+			slug: 'a.wordpress.com',
 			options: {
 				updated_at: '2022-07-13T17:17:12+00:00',
 				wpcom_staging_blog_ids: [ 3 ],
@@ -79,6 +87,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 3,
 			title: 'C',
+			slug: 'c.wordpress.com',
 			is_wpcom_staging_site: true,
 			options: {
 				updated_at: '2022-06-14T13:32:34+00:00',
@@ -89,6 +98,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 4,
 			title: 'E',
+			slug: 'e.wordpress.com',
 			options: {
 				updated_at: '2022-06-14T13:32:34+00:00',
 			},
@@ -100,6 +110,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 1,
 			title: 'B',
+			slug: 'b.wordpress.com',
 			options: {
 				updated_at: '2022-05-27T07:19:20+00:00',
 			},
@@ -108,6 +119,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 2,
 			title: 'A',
+			slug: 'a.wordpress.com',
 			options: {
 				updated_at: '2022-07-13T17:17:12+00:00',
 				wpcom_staging_blog_ids: [ 3 ],
@@ -117,6 +129,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 3,
 			title: 'C',
+			slug: 'c.wordpress.com',
 			is_wpcom_staging_site: true,
 			options: {
 				updated_at: '2022-06-14T13:32:34+00:00',
@@ -127,6 +140,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 4,
 			title: 'E',
+			slug: 'e.wordpress.com',
 			options: {
 				updated_at: '2022-06-14T13:32:34+00:00',
 			},
@@ -135,6 +149,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 5,
 			title: 'F',
+			slug: 'f.wordpress.com',
 			is_wpcom_staging_site: true,
 			options: {
 				wpcom_production_blog_id: 10,
@@ -148,6 +163,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 1,
 			title: 'B',
+			slug: 'b.wordpress.com',
 			options: {
 				updated_at: '2022-05-27T07:19:20+00:00',
 			},
@@ -156,6 +172,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 2,
 			title: 'A',
+			slug: 'a.wordpress.com',
 			options: {
 				updated_at: '2022-07-13T17:17:12+00:00',
 				wpcom_staging_blog_ids: [ 3, 11, 5 ],
@@ -165,6 +182,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 3,
 			title: 'C',
+			slug: 'c.wordpress.com',
 			is_wpcom_staging_site: true,
 			options: {
 				updated_at: '2022-06-14T13:32:34+00:00',
@@ -175,6 +193,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 4,
 			title: 'E',
+			slug: 'e.wordpress.com',
 			options: {
 				updated_at: '2022-06-14T13:32:34+00:00',
 			},
@@ -183,6 +202,7 @@ describe( 'useSitesSorting', () => {
 		{
 			ID: 5,
 			title: 'F',
+			slug: 'f.wordpress.com',
 			is_wpcom_staging_site: true,
 			options: {
 				updated_at: '2022-06-14T13:32:34+00:00',
@@ -333,6 +353,36 @@ describe( 'useSitesSorting', () => {
 		expect( result.current[ 0 ].title ).toBe( 'C' );
 		expect( result.current[ 1 ].title ).toBe( 'B' );
 		expect( result.current[ 2 ].title ).toBe( 'A' );
+	} );
+
+	test( 'should sort new site to top descending', () => {
+		const { result } = renderHook( () =>
+			useSitesListSorting( filteredSites, {
+				sortKey: 'lastInteractedWith',
+				sortOrder: 'desc',
+				newSiteSlug: 'c.wordpress.com',
+			} )
+		);
+
+		expect( result.current.length ).toBe( 3 );
+		expect( result.current[ 0 ].title ).toBe( 'C' );
+		expect( result.current[ 1 ].title ).toBe( 'A' );
+		expect( result.current[ 2 ].title ).toBe( 'B' );
+	} );
+
+	test( 'should sort new site to bottom ascending', () => {
+		const { result } = renderHook( () =>
+			useSitesListSorting( filteredSites, {
+				sortKey: 'lastInteractedWith',
+				sortOrder: 'asc',
+				newSiteSlug: 'c.wordpress.com',
+			} )
+		);
+
+		expect( result.current.length ).toBe( 3 );
+		expect( result.current[ 0 ].title ).toBe( 'B' );
+		expect( result.current[ 1 ].title ).toBe( 'A' );
+		expect( result.current[ 2 ].title ).toBe( 'C' );
 	} );
 
 	test( 'should sort sites by updatedAt descending', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2174

## Proposed Changes

As discussed in https://github.com/Automattic/dotcom-forge/issues/2174, users going through the hosting onboarding flow should land on `/sites` after their site has been created.

This PR also adds a new "new" badge to the site thumbnail which is controlled by the `?new-site` query param. This new site is also sorted to the top of the list in "magic" sort mode.
The purpose of this new badge is to prevent "change blindness" after landing on `/sites`. We want to show them the new list item they just created.

![CleanShot 2023-05-02 at 13 07 27@2x](https://user-images.githubusercontent.com/1500769/235594300-8903dcd1-beff-437b-b304-221adae2e418.png)

![CleanShot 2023-05-02 at 13 07 49@2x](https://user-images.githubusercontent.com/1500769/235594321-843728c5-8884-4f55-a914-d86fe721642b.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new user using `/start/hosting`
   * The user should land on `/sites` after their first site is created
* Create a new user using `/start` to check nothing has changed
   * The user should land on `/home` after their first site is created

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~