### PR TITLE
Editor: Learn more link of Page Break block

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
@@ -195,4 +195,11 @@ export const blockLinksWithVariations: {
 	},
 };
 
+export const childrenBlockLinksWithDifferentUrl: { [ key: string ]: string } = {
+	/**
+	 * Core Blocks
+	 */
+	'core/nextpage': 'https://wordpress.com/support/wordpress-editor/blocks/page-break-block/',
+};
+
 export default blockLinks;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.tsx
@@ -58,20 +58,16 @@ const addBlockSupportLinks = (
 
 	processedBlocks[ name ] = true;
 
+	const additonalDesc = childrenBlockLinksWithDifferentUrl[ name ] || blockLinks[ blockName ];
+
 	/**
 	 * Some elements are children, but have their own url for Learn More, and we want to show those.
 	 */
-	if ( childrenBlockLinksWithDifferentUrl[ name ] ) {
+	if ( additonalDesc ) {
 		settings.description = createLocalizedDescriptionWithLearnMore(
 			String( settings.title ),
 			settings.description,
-			childrenBlockLinksWithDifferentUrl[ name ]
-		);
-	} else if ( blockLinks[ blockName ] ) {
-		settings.description = createLocalizedDescriptionWithLearnMore(
-			String( settings.title ),
-			settings.description,
-			blockLinks[ blockName ]
+			additonalDesc
 		);
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.tsx
@@ -2,7 +2,10 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { JSXElementConstructor, ReactElement } from 'react';
-import blockLinks, { blockLinksWithVariations } from './block-links-map';
+import blockLinks, {
+	blockLinksWithVariations,
+	childrenBlockLinksWithDifferentUrl,
+} from './block-links-map';
 import DescriptionSupportLink from './inline-support-link';
 
 declare global {
@@ -17,7 +20,6 @@ const createLocalizedDescriptionWithLearnMore = (
 	url: string
 ) => {
 	const localizedUrl = localizeUrl( url, window.wpcomBlockDescriptionLinksLocale );
-
 	return createInterpolateElement( '<InlineSupportLink />', {
 		InlineSupportLink: (
 			<DescriptionSupportLink title={ String( title ) } url={ localizedUrl }>
@@ -56,13 +58,16 @@ const addBlockSupportLinks = (
 
 	processedBlocks[ name ] = true;
 
-	if ( blockLinks[ blockName ] ) {
-		settings.description = createLocalizedDescriptionWithLearnMore(
-			String( settings.title ),
-			settings.description,
-			blockLinks[ blockName ]
-		);
-	}
+	/**
+	 * Some elements are children, but have their own url for Learn More, and we want to show those.
+	 */
+	settings.description = createLocalizedDescriptionWithLearnMore(
+		String( settings.title ),
+		settings.description,
+		childrenBlockLinksWithDifferentUrl[ name ]
+			? childrenBlockLinksWithDifferentUrl[ name ]
+			: blockLinks[ blockName ]
+	);
 
 	if (
 		blockLinksWithVariations[ name ] &&

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.tsx
@@ -61,13 +61,19 @@ const addBlockSupportLinks = (
 	/**
 	 * Some elements are children, but have their own url for Learn More, and we want to show those.
 	 */
-	settings.description = createLocalizedDescriptionWithLearnMore(
-		String( settings.title ),
-		settings.description,
-		childrenBlockLinksWithDifferentUrl[ name ]
-			? childrenBlockLinksWithDifferentUrl[ name ]
-			: blockLinks[ blockName ]
-	);
+	if ( childrenBlockLinksWithDifferentUrl[ name ] ) {
+		settings.description = createLocalizedDescriptionWithLearnMore(
+			String( settings.title ),
+			settings.description,
+			childrenBlockLinksWithDifferentUrl[ name ]
+		);
+	} else if ( blockLinks[ blockName ] ) {
+		settings.description = createLocalizedDescriptionWithLearnMore(
+			String( settings.title ),
+			settings.description,
+			blockLinks[ blockName ]
+		);
+	}
 
 	if (
 		blockLinksWithVariations[ name ] &&


### PR DESCRIPTION
## What

The Page Break block has a block description with a Learn More Link, but the link is to the wrong page.
Current link: https://wordpress.com/support/site-editing/theme-blocks/post-content-block/
Correct link: https://wordpress.com/support/wordpress-editor/blocks/page-break-block/
<img width="629" alt="image" src="https://user-images.githubusercontent.com/52076348/234874738-5ea8f742-2bf0-4342-8a73-70ae8367d634.png">

## Testing

1. Checkout the branch
2. `cd apps/editing-toolkit` and `yarn dev --sync`
3. Open the editor
4. Insert a page break block
5. Open the sidebar settings
6. Click 'Learn more', it should bring you to the correct url.


Fixes https://github.com/Automattic/wp-calypso/issues/75758