### PR TITLE
Enable the Unified Importer on atomic

### DIFF
--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -259,15 +259,14 @@ function getConfig(
 		weight: 0,
 	};
 
+	// TODO: remove the atomic once Jetpack 12.1 is deployed.
+	const hasUnifiedImporter = config.isEnabled( 'importer/unified' ) && !! args.isAtomic;
+
 	// For Jetpack sites, we don't support migration as destination,
 	// so we remove the override here.
-	if ( config.isEnabled( 'importer/unified' ) && args.isJetpack && ! args.isAtomic ) {
-		delete importerConfig.wordpress.overrideDestination;
-	}
-
-	// Filter out all importers except the WordPress ones for Atomic sites.
-	if ( ! config.isEnabled( 'importer/unified' ) && args.isAtomic ) {
+	if ( hasUnifiedImporter && args.isJetpack && ! args.isAtomic ) {
 		importerConfig = { wordpress: importerConfig.wordpress };
+		delete importerConfig.wordpress.overrideDestination;
 	}
 
 	return importerConfig;

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -62,7 +62,7 @@ const getImporterTypeForEngine = ( engine ) => `importer-type-${ engine }`;
 /**
  * The minimum version of the Jetpack plugin required to use the Jetpack Importer API.
  */
-const JETPACK_IMPORT_MIN_PLUGIN_VERSION = '12.0';
+const JETPACK_IMPORT_MIN_PLUGIN_VERSION = '12.1';
 
 class SectionImport extends Component {
 	static propTypes = {
@@ -293,6 +293,9 @@ class SectionImport extends Component {
 		const jetpackVersionInCompatible =
 			this.props.siteJetpackVersion < JETPACK_IMPORT_MIN_PLUGIN_VERSION;
 
+		// TODO: remove the atomic once Jetpack 12.1 is deployed.
+		const hasUnifiedImporter = isEnabled( 'importer/unified' ) && isAtomic;
+
 		return (
 			<Main>
 				<ScreenOptionsTab wpAdminPath="import.php" />
@@ -313,7 +316,7 @@ class SectionImport extends Component {
 					hasScreenOptions
 				/>
 				<EmailVerificationGate allowUnlaunched>
-					{ isJetpack && ! isAtomic && ! isEnabled( 'importer/unified' ) ? (
+					{ isJetpack && ! isAtomic && ! hasUnifiedImporter ? (
 						<JetpackImporter />
 					) : (
 						<>

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -57,7 +57,8 @@ const useSiteMenuItems = () => {
 
 	const hasSiteWithPlugins = useSelector( canAnySiteHavePlugins );
 
-	const hasUnifiedImporter = isEnabled( 'importer/unified' );
+	// TODO: remove the atomic once Jetpack 12.1 is deployed.
+	const hasUnifiedImporter = isEnabled( 'importer/unified' ) && isAtomic;
 
 	/**
 	 * When no site domain is provided, lets show only menu items that support all sites screens.

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -45,6 +45,7 @@
 		"home/layout-dev": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
+		"importer/unified": true,
 		"inline-help": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-messaging-i3": true,

--- a/config/production.json
+++ b/config/production.json
@@ -47,6 +47,7 @@
 		"help": true,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
+		"importer/unified": true,
 		"inline-help": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/api-cache": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -44,6 +44,7 @@
 		"happychat": true,
 		"help": true,
 		"i18n/empathy-mode": true,
+		"importer/unified": true,
 		"inline-help": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/api-cache": true,


### PR DESCRIPTION
This PR enables the Unified Importer on atomic.

## Proposed Changes

* Enable the config flag
* The unified importer is enabled only if the `importer/unified` flag is on and the site is atomic
* Updated the minimum required version to 12.1, the version we are waiting to be deployed

## Testing Instructions

* `/import/URL` in an atomic site: all importers.
* `/import/URL` in a Jetpack self-hosted site: "Want to import into your site?" page.
* The Tools > Import link of the left menu in a Jetpack self-hosted site should have `/import/URL` endpoint.
* `/import/URL` in a simple site: all importers.