### PR TITLE
Tour: only show site title tour if there are fewer than three sites.

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -58,6 +58,7 @@ export const getTask = (
 		isBlogger,
 		isFSEActive,
 		isRtl,
+		siteCount,
 	} = {}
 ) => {
 	let taskData = {};
@@ -118,7 +119,8 @@ export const getTask = (
 					: translate( 'Give your new site a title to let people know what your site is about.' ),
 				actionText: isBlogger ? translate( 'Name your blog' ) : translate( 'Name your site' ),
 				actionUrl: `/settings/general/${ siteSlug }`,
-				tour: 'checklistSiteTitle',
+				// only show the tour for the first two sites.
+				tour: siteCount > 2 ? undefined : 'checklistSiteTitle',
 			};
 			break;
 		case CHECKLIST_KNOWN_TASKS.MOBILE_APP_INSTALLED:

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -17,6 +17,7 @@ import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/
 import { requestGuidedTour } from 'calypso/state/guided-tours/actions';
 import getChecklistTaskUrls from 'calypso/state/selectors/get-checklist-task-urls';
 import getSiteChecklist from 'calypso/state/selectors/get-site-checklist';
+import getSites from 'calypso/state/selectors/get-sites';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { useSiteOption } from 'calypso/state/sites/hooks';
 import { getSiteOption, getSiteSlug, getCustomizerUrl } from 'calypso/state/sites/selectors';
@@ -114,6 +115,7 @@ const SiteSetupList = ( {
 	tasks,
 	taskUrls,
 	userEmail,
+	siteCount,
 } ) => {
 	const [ currentTaskId, setCurrentTaskId ] = useState( null );
 	const [ currentTask, setCurrentTask ] = useState( null );
@@ -190,6 +192,7 @@ const SiteSetupList = ( {
 				isBlogger,
 				isFSEActive,
 				isRtl,
+				siteCount,
 			} );
 			setCurrentTask( newCurrentTask );
 			trackTaskDisplay( dispatch, newCurrentTask, siteId, isPodcastingSite );
@@ -210,6 +213,7 @@ const SiteSetupList = ( {
 		isBlogger,
 		isFSEActive,
 		isRtl,
+		siteCount,
 	] );
 
 	useEffect( () => {
@@ -336,7 +340,7 @@ const SiteSetupList = ( {
 
 const ConnectedSiteSetupList = connect( ( state, props ) => {
 	const { isFSEActive } = props;
-
+	const siteCount = getSites( state ).length;
 	const siteId = getSelectedSiteId( state );
 	const user = getCurrentUser( state );
 	const designType = getSiteOption( state, siteId, 'design_type' );
@@ -365,6 +369,7 @@ const ConnectedSiteSetupList = connect( ( state, props ) => {
 		tasks: taskList.getAll(),
 		taskUrls: getChecklistTaskUrls( state, siteId ),
 		userEmail: user?.email,
+		siteCount,
 	};
 } )( SiteSetupList );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* I am proposing that we remove the tour for setting the site name if the user already has two sites. It doesn't seem necessary for experienced users. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new user
* Create a site, launch it via Launchpad then go to `/home/:site`
* Click `Show site setup` and then `Name your site`
* Confirm the tour is shown which guides you through the process of naming your site and then saving
* Repeat this with a new site and confirm the tour is still shown
* Repeat with a third site and confirm the tour is not shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
