### PR TITLE
Optimistic update for sites/comments did not update `totalCount`

### DIFF
--- a/packages/data-stores/src/reader/mutations/use-post-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-post-unsubscribe-mutation.ts
@@ -66,17 +66,16 @@ const usePostUnsubscribeMutation = () => {
 
 				// remove post from comment subscriptions
 				if ( previousPostSubscriptions ) {
-					previousPostSubscriptions.pages = previousPostSubscriptions.pages.map( ( page ) => ( {
-						...page,
-						comment_subscriptions: page.comment_subscriptions.filter(
-							( subscription ) => subscription.id !== params.id
-						),
-					} ) );
-
-					queryClient.setQueryData< PostSubscriptionsPages >(
-						postSubscriptionsCacheKey,
-						previousPostSubscriptions
-					);
+					queryClient.setQueryData< PostSubscriptionsPages >( postSubscriptionsCacheKey, {
+						...previousPostSubscriptions,
+						pages: previousPostSubscriptions.pages.map( ( page ) => ( {
+							...page,
+							comment_subscriptions: page.comment_subscriptions.filter(
+								( subscription ) => subscription.id !== params.id
+							),
+							total_comment_subscriptions_count: page.total_comment_subscriptions_count - 1,
+						} ) ),
+					} );
 				}
 
 				const previousSubscriptionsCount =

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -1,11 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { applyCallbackToPages, callApi } from '../helpers';
+import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn } from '../hooks';
-import {
-	PagedQueryResult,
-	SiteSubscription,
-	SubscriptionManagerSubscriptionsCount,
-} from '../types';
+import { SiteSubscription, SubscriptionManagerSubscriptionsCount } from '../types';
 
 type UnsubscribeParams = {
 	blog_id: number | string;
@@ -15,6 +11,16 @@ type UnsubscribeResponse = {
 	success: boolean;
 	subscribed: boolean;
 	subscription: null;
+};
+
+type SiteSubscriptionPage = {
+	subscriptions: SiteSubscription[];
+	total_subscriptions: number;
+};
+
+type SiteSubscriptionsPages = {
+	pageParams: [];
+	pages: SiteSubscriptionPage[];
 };
 
 const useSiteUnsubscribeMutation = () => {
@@ -53,23 +59,21 @@ const useSiteUnsubscribeMutation = () => {
 				await queryClient.cancelQueries( subscriptionsCountCacheKey );
 
 				const previousSiteSubscriptions =
-					queryClient.getQueryData< PagedQueryResult< SiteSubscription, 'subscriptions' > >(
-						siteSubscriptionsCacheKey
-					);
+					queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsCacheKey );
 				// remove blog from site subscriptions
 				if ( previousSiteSubscriptions ) {
-					const mutatedSiteSubscriptions = applyCallbackToPages<
-						'subscriptions',
-						SiteSubscription
-					>( previousSiteSubscriptions, ( page ) => {
-						return {
-							...page,
-							subscriptions: page.subscriptions.filter(
-								( siteSubscription ) => siteSubscription.blog_ID !== params.blog_id
-							),
-						};
+					queryClient.setQueryData( siteSubscriptionsCacheKey, {
+						...previousSiteSubscriptions,
+						pages: previousSiteSubscriptions.pages.map( ( page ) => {
+							return {
+								...page,
+								subscriptions: page.subscriptions.filter(
+									( siteSubscription ) => siteSubscription.blog_ID !== params.blog_id
+								),
+								total_subscriptions: page.total_subscriptions - 1,
+							};
+						} ),
 					} );
-					queryClient.setQueryData( siteSubscriptionsCacheKey, mutatedSiteSubscriptions );
 				}
 
 				const previousSubscriptionsCount =


### PR DESCRIPTION
Closes #76351

## Proposed Changes

Fixes this for both sites subscriptions & post (comment) subscriptions:

![CleanShot 2023-04-27 at 09 25 13](https://user-images.githubusercontent.com/528287/234843378-fa628624-641e-46e5-8240-e10ed038ac19.gif)

The optimistic update that happens after deleting a site or post subscription did only update the list of subscriptions, and didn't update the count returned. 

This PR also:
- simplifies the types used in `useSiteUnsubscribeMutation`.
- fixes a small bug in `usePostUnsubscribeMutation` where the `previousPostSubscriptions` object was mutated directly, which would have caused issues when the mutation would fail because then the mutated `previousPostSubscriptions` would be restored which would have the optimistic data.

## Testing Instructions

If this hasn't been merged yet, apply it to your sandbox: D108479-code (needed for site subscriptions)

- Apply this PR & make sure you have a subkey set
- Navigate to http://calypso.localhost:3000/subscriptions/sites and make sure when you delete the last site subscription you don't get the banner telling you "Sorry, no sites match %s}"
- Click on comments and verify the same

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?