### PR TITLE
Site: Return early if title is not defined to avoid breaking site

### DIFF
--- a/packages/sites/src/use-sites-list-sorting.tsx
+++ b/packages/sites/src/use-sites-list-sorting.tsx
@@ -242,6 +242,10 @@ function sortAlphabetically< T extends SiteDetailsForSorting >(
 	b: T,
 	sortOrder: SitesSortOrder
 ) {
+	if ( ! a?.title || ! b?.title ) {
+		return 0;
+	}
+
 	const normalizedA = a.title.toLocaleLowerCase();
 	const normalizedB = b.title.toLocaleLowerCase();
 

--- a/packages/sites/tests/use-sites-list-sorting.test.ts
+++ b/packages/sites/tests/use-sites-list-sorting.test.ts
@@ -191,6 +191,28 @@ describe( 'useSitesSorting', () => {
 			user_interactions: [ '2022-09-16', '2022-09-13', '2022-09-09' ],
 		},
 	];
+	const sitesWithEmptyTitle = [
+		{
+			ID: 1,
+			options: {
+				updated_at: '2022-05-27T07:19:20+00:00',
+			},
+			user_interactions: [ '2022-09-13' ],
+		},
+		{
+			ID: 2,
+			options: {
+				updated_at: '2022-07-13T17:17:12+00:00',
+			},
+			user_interactions: [ '2022-09-14' ],
+		},
+		{
+			ID: 3,
+			options: {
+				updated_at: '2022-06-14T13:32:34+00:00',
+			},
+		},
+	];
 
 	test( 'should not sort sites if unsupported sortKey is provided', () => {
 		const { result } = renderHook( () =>
@@ -232,6 +254,20 @@ describe( 'useSitesSorting', () => {
 		expect( result.current[ 0 ].title ).toBe( 'C' );
 		expect( result.current[ 1 ].title ).toBe( 'B' );
 		expect( result.current[ 2 ].title ).toBe( 'A' );
+	} );
+
+	test( 'should not break when sort sites without title', () => {
+		const { result } = renderHook( () =>
+			useSitesListSorting( sitesWithEmptyTitle, {
+				sortKey: 'alphabetically',
+				sortOrder: 'asc',
+			} )
+		);
+
+		expect( result.current.length ).toBe( 3 );
+		expect( result.current[ 0 ].ID ).toBe( 1 );
+		expect( result.current[ 1 ].ID ).toBe( 2 );
+		expect( result.current[ 2 ].ID ).toBe( 3 );
 	} );
 
 	test( 'should sort sites by last interaction descending', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/76353

## Proposed Changes

In this diff, I propose to modify the sorting function to return early if any of the items don't have a title defined.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run Calypso on local
2. Add a line in the function https://github.com/Automattic/wp-calypso/blob/db4978db551eb0011c05fb80a6271ec07da5164b/packages/sites/src/use-sites-list-sorting.tsx#L279

```
delete sites[0].title;
```

3. Confirm page still loads fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?