### PR TITLE
Stored cards: Do not return isLoading when logged-out

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
@@ -166,7 +166,7 @@ export function useStoredPaymentMethods( {
 
 	return {
 		paymentMethods,
-		isLoading,
+		isLoading: isLoggedOut ? false : isLoading,
 		isDeleting: mutation.isLoading,
 		error: errorMessage,
 		deletePaymentMethod: deletePaymentMethodAndSimilar,


### PR DESCRIPTION
## Proposed Changes

The `useStoredPaymentMethods()` hook fetches stored cards using `react-query`, but sometimes we don't want to fetch them. In that case, the consumer sets the `isLoggedOut` prop, which disables the fetching.

Recently there was an upgrade to `react-query` in https://github.com/Automattic/wp-calypso/pull/76077 and it appears that one of the side effects was that when you disable a query, it leaves `isLoading` true instead of setting it to false. The result is that when `useStoredPaymentMethods()` is disabled, it seems to load forever. This prevents checkout from loading if the user is logged-out.

## Testing Instructions

- Visit the following URL in an incognito window: `/checkout/jetpack/jetpack_security_t1_yearly?source=jetpack-plans&checkoutBackUrl=https%3A%2F%2Fcloud.jetpack.com%2Fpricing`
- Verify that checkout loads.