### PR TITLE
Starter designs: Remove virtual theme params

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -131,7 +131,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		{
 			seed: siteSlugOrId || undefined,
 			_locale: locale,
-			include_pattern_virtual_designs: true,
 		},
 		{
 			enabled: true,

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -14,8 +14,6 @@ import type {
 interface StarterDesignsQueryParams {
 	seed?: string;
 	_locale: string;
-	include_virtual_designs?: boolean;
-	include_pattern_virtual_designs?: boolean;
 }
 
 interface Options extends QueryOptions< StarterDesignsResponse, unknown > {


### PR DESCRIPTION
Counterpart of D109046-code

## Proposed Changes

The `starter-designs` endpoint no longer needs a param to generate virtual designs – they are always included now.

## Testing Instructions

- Use the Calypso live link below.
- Go to `/setup/site-setup/designSetup?siteSlug=<SITE_DOMAIN>`.
- Make sure virtual designs are still visible.

