### PR TITLE
Update posts and recommended posts on reader search page

### DIFF
--- a/client/reader/search-stream/post-results.jsx
+++ b/client/reader/search-stream/post-results.jsx
@@ -34,7 +34,6 @@ class PostResults extends Component {
 			! query || query === ''
 				? ( postKey ) => ( { ...postKey, isRecommendation: true } )
 				: defaultTransform;
-
 		return (
 			<Stream
 				{ ...this.props }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -109,7 +109,6 @@
 	box-sizing: border-box;
 	border-bottom: 1px solid var(--color-neutral-10);
 	display: flex;
-	//flex-basis: calc(50% - 15px);
 	margin: 0 0 0 15px;
 	padding: 20px 0;
 
@@ -123,18 +122,6 @@
 
 	@include breakpoint-deprecated( "<480px" ) {
 		margin: 0 5px 0 0;
-	}
-
-	&:nth-child(2n) {
-		//margin: 0 15px 0 0;
-
-		@include breakpoint-deprecated( "<960px" ) {
-			margin: 0;
-		}
-
-		@include breakpoint-deprecated( "<660px" ) {
-			margin: 0 5px 0 0;
-		}
 	}
 
 	.reader-related-card__post {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -109,7 +109,7 @@
 	box-sizing: border-box;
 	border-bottom: 1px solid var(--color-neutral-10);
 	display: flex;
-	flex-basis: calc(50% - 15px);
+	//flex-basis: calc(50% - 15px);
 	margin: 0 0 0 15px;
 	padding: 20px 0;
 
@@ -126,7 +126,7 @@
 	}
 
 	&:nth-child(2n) {
-		margin: 0 15px 0 0;
+		//margin: 0 15px 0 0;
 
 		@include breakpoint-deprecated( "<960px" ) {
 			margin: 0;

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -29,13 +29,11 @@ const exported = {
 		const { sort = 'relevance', q, show = SEARCH_TYPES.POSTS } = context.query;
 		const searchSlug = q;
 
-		let streamKey;
+		let streamKey = 'custom_recs_sites_with_images';
 		let isQuerySuggestion = false;
 		if ( searchSlug ) {
 			streamKey = 'search:' + JSON.stringify( { sort, q } );
 			isQuerySuggestion = context.query.isSuggestion === '1';
-		} else {
-			streamKey = 'custom_recs_sites_with_images';
 		}
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );

--- a/client/reader/search/controller.js
+++ b/client/reader/search/controller.js
@@ -35,7 +35,7 @@ const exported = {
 			streamKey = 'search:' + JSON.stringify( { sort, q } );
 			isQuerySuggestion = context.query.isSuggestion === '1';
 		} else {
-			streamKey = 'custom_recs_posts_with_images';
+			streamKey = 'custom_recs_sites_with_images';
 		}
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );

--- a/client/reader/stream/empty-search-recommended-site.jsx
+++ b/client/reader/stream/empty-search-recommended-site.jsx
@@ -1,0 +1,34 @@
+import { RelatedPostCard } from 'calypso/blocks/reader-related-card';
+import { EMPTY_SEARCH_RECOMMENDATIONS } from 'calypso/reader/follow-sources';
+import { recordTrackForPost, recordAction } from 'calypso/reader/stats';
+
+export default function EmptySearchRecommendedSite( { post } ) {
+	function handlePostClick() {
+		recordTrackForPost( 'calypso_reader_recommended_site_clicked', post, {
+			recommendation_source: 'empty-search-site',
+		} );
+		recordAction( 'search_page_rec_post_click' );
+	}
+
+	function handleSiteClick() {
+		recordTrackForPost( 'calypso_reader_recommended_site_clicked', post, {
+			recommendation_source: 'empty-search-site',
+		} );
+		recordAction( 'search_page_rec_site_click' );
+	}
+
+	const site = { title: post && post.site_name };
+
+	/* eslint-disable  wpcalypso/jsx-classname-namespace */
+	return (
+		<div className="search-stream__recommendation-list-item" key={ post && post.global_ID }>
+			<RelatedPostCard
+				post={ post }
+				site={ site }
+				onSiteClick={ handleSiteClick }
+				onPostClick={ handlePostClick }
+				followSource={ EMPTY_SEARCH_RECOMMENDATIONS }
+			/>
+		</div>
+	);
+}

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -18,6 +18,7 @@ import withDimensions from 'calypso/lib/with-dimensions';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { shouldShowLikes } from 'calypso/reader/like-helper';
 import { keysAreEqual, keyToString } from 'calypso/reader/post-key';
+import ReaderSearchSidebar from 'calypso/reader/stream/reader-search-sidebar';
 import ReaderTagSidebar from 'calypso/reader/stream/reader-tag-sidebar';
 import UpdateNotice from 'calypso/reader/update-notice';
 import { showSelectedPost, getStreamType } from 'calypso/reader/utils';
@@ -63,7 +64,6 @@ const excludesSidebar = [
 	'feed',
 	'likes',
 	'search',
-	'custom_recs_posts_with_images',
 	'list',
 	'p2',
 ];
@@ -475,6 +475,7 @@ class ReaderStream extends Component {
 
 		const path = window.location.pathname;
 		const isTagPage = path.startsWith( '/tag/' );
+		const isSearchPage = path.startsWith( '/read/search' );
 		const streamType = getStreamType( streamKey );
 
 		let baseClassnames = classnames( 'following', this.props.className );
@@ -503,13 +504,17 @@ class ReaderStream extends Component {
 				/>
 			);
 
-			const sidebarContent = isTagPage ? (
-				<ReaderTagSidebar tag={ tag } />
-			) : (
-				<ReaderListFollowedSites path={ path } />
-			);
+			let sidebarContent = null;
+			let tabTitle = translate( 'Sites' );
 
-			const tabTitle = isTagPage ? translate( 'Related' ) : translate( 'Sites' );
+			if ( isTagPage ) {
+				sidebarContent = <ReaderTagSidebar tag={ tag } />;
+				tabTitle = translate( 'Related' );
+			} else if ( isSearchPage ) {
+				sidebarContent = <ReaderSearchSidebar items={ items } />;
+			} else {
+				sidebarContent = <ReaderListFollowedSites path={ path } />;
+			}
 
 			if ( excludesSidebar.includes( streamType ) ) {
 				body = bodyContent;

--- a/client/reader/stream/reader-list-followed-sites/item.jsx
+++ b/client/reader/stream/reader-list-followed-sites/item.jsx
@@ -35,6 +35,8 @@ const ReaderListFollowingItem = ( props ) => {
 		return null;
 	}
 
+	const urlForDisplay = formatUrlForDisplay( site.URL );
+
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<li
@@ -52,12 +54,18 @@ const ReaderListFollowingItem = ( props ) => {
 					<Favicon site={ site } size={ 32 } />
 				</span>
 				<span className="reader-sidebar-site_sitename">
-					<span className="reader-sidebar-site_nameurl">
-						{ site.name || formatUrlForDisplay( site.URL ) }
-					</span>
-					<span className="reader-sidebar-site_updated">
-						{ site.last_updated > 0 && moment( new Date( site.last_updated ) ).fromNow() }
-					</span>
+					<span className="reader-sidebar-site_nameurl">{ site.name || urlForDisplay }</span>
+					{ site.last_updated > 0 && (
+						<span className="reader-sidebar-site_updated">
+							{ moment( new Date( site.last_updated ) ).fromNow() }
+						</span>
+					) }
+					{ site.description?.length > 0 && (
+						<span className="reader-sidebar-site_description">{ site.description }</span>
+					) }
+					{ urlForDisplay.length > 0 && (
+						<span className="reader-sidebar-site_url">{ urlForDisplay }</span>
+					) }
 				</span>
 				{ isUnseen && site.unseen_count > 0 && <Count count={ site.unseen_count } compact /> }
 			</a>

--- a/client/reader/stream/reader-search-sidebar/index.jsx
+++ b/client/reader/stream/reader-search-sidebar/index.jsx
@@ -30,18 +30,18 @@ const ReaderSearchSidebar = ( { items } ) => {
 		.map( ( item ) => getSiteFromItem( item ) )
 		.filter( ( site ) => site !== null );
 
-	const recommendedSitesLinks = sites.map( ( site ) => (
+	const popularSitesLinks = sites.map( ( site ) => (
 		<ReaderListFollowingItem key={ site.feed_ID } site={ site } path="/" />
 	) );
 
-	if ( ! recommendedSitesLinks.length ) {
+	if ( ! popularSitesLinks.length ) {
 		return null;
 	}
 
 	return (
 		<div className="reader-tag-sidebar-recommended-sites">
-			<h2>{ translate( 'Recommended Sites' ) }</h2>
-			{ recommendedSitesLinks }
+			<h2>{ translate( 'Popular Sites' ) }</h2>
+			{ popularSitesLinks }
 		</div>
 	);
 };

--- a/client/reader/stream/reader-search-sidebar/index.jsx
+++ b/client/reader/stream/reader-search-sidebar/index.jsx
@@ -1,0 +1,46 @@
+import { useTranslate } from 'i18n-calypso';
+import ReaderListFollowingItem from 'calypso/reader/stream/reader-list-followed-sites/item';
+import '../style.scss';
+
+function unescape( str ) {
+	return str.replace( /&#(\d+);/g, ( match, entity ) => String.fromCharCode( entity ) );
+}
+
+// create function to transform item into a site object
+const getSiteFromItem = ( item ) => {
+	console.log( 'item', item );
+	return {
+		feed_ID: item.feed_ID,
+		blog_ID: item.blogId,
+		URL: item.feed_URL ?? item.url,
+		name: unescape( item.site_name ),
+		site_icon: item.site_icon ?? null,
+		description: unescape( item.site_description ),
+		last_updated: 0,
+		unseen_count: 0,
+	};
+};
+
+const ReaderSearchSidebar = ( { items } ) => {
+	const translate = useTranslate();
+
+	const sites = items.map( ( item ) => getSiteFromItem( item ) );
+	console.log( 'sites', sites );
+
+	const recommendedSitesLinks = sites.map( ( site ) => (
+		<ReaderListFollowingItem key={ site.feed_ID } site={ site } path="/" />
+	) );
+
+	if ( ! recommendedSitesLinks.length ) {
+		return null;
+	}
+
+	return (
+		<div className="reader-tag-sidebar-recommended-sites">
+			<h2>{ translate( 'Recommended Sites' ) }</h2>
+			{ recommendedSitesLinks }
+		</div>
+	);
+};
+
+export default ReaderSearchSidebar;

--- a/client/reader/stream/reader-search-sidebar/index.jsx
+++ b/client/reader/stream/reader-search-sidebar/index.jsx
@@ -8,14 +8,16 @@ function unescape( str ) {
 
 // create function to transform item into a site object
 const getSiteFromItem = ( item ) => {
-	console.log( 'item', item );
+	if ( item.site_name === undefined ) {
+		return null;
+	}
 	return {
 		feed_ID: item.feed_ID,
 		blog_ID: item.blogId,
 		URL: item.feed_URL ?? item.url,
-		name: unescape( item.site_name ),
+		name: unescape( item?.site_name ),
 		site_icon: item.site_icon ?? null,
-		description: unescape( item.site_description ),
+		description: unescape( item?.site_description ),
 		last_updated: 0,
 		unseen_count: 0,
 	};
@@ -24,8 +26,9 @@ const getSiteFromItem = ( item ) => {
 const ReaderSearchSidebar = ( { items } ) => {
 	const translate = useTranslate();
 
-	const sites = items.map( ( item ) => getSiteFromItem( item ) );
-	console.log( 'sites', sites );
+	const sites = items
+		.map( ( item ) => getSiteFromItem( item ) )
+		.filter( ( site ) => site !== null );
 
 	const recommendedSitesLinks = sites.map( ( site ) => (
 		<ReaderListFollowingItem key={ site.feed_ID } site={ site } path="/" />

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -614,6 +614,7 @@
 	.reader-sidebar-site_siteicon {
 		height: 32px;
 		width: 32px;
+		min-width: 32px;
 	}
 
 	.reader-sidebar-site_sitename {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -568,6 +568,19 @@
 	}
 }
 
+.search-stream__results {
+	.stream__two-column {
+		.stream__right-column {
+			.reader-sidebar-site_url {
+				display: block;
+			}
+			.reader-sidebar-site_description {
+				display: -webkit-box;
+			}
+		}
+	}
+}
+
 .stream__two-column {
 	align-items: flex-start;
 	display: flex;
@@ -710,6 +723,26 @@
 				font-size: $font-body-extra-small;
 				color: var(--color-text-subtle);
 			}
+		}
+
+		.reader-sidebar-site_url {
+			display: none;
+			color: var(--color-text-subtle);
+			font-weight: 400;
+			font-size: $font-body-extra-small;
+			line-height: 18px;
+		}
+
+		.reader-sidebar-site_description {
+			display: none;
+			color: var(--color-neutral-70);
+			font-weight: 600;
+			font-size: $font-body-extra-small;
+			line-height: 18px;
+			overflow: hidden;
+			width: auto;
+			-webkit-line-clamp: 2;
+			-webkit-box-orient: vertical;
 		}
 	}
 

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -594,7 +594,7 @@
 	}
 
 	.reader-sidebar-site_link {
-		align-items: center;
+		align-items: flex-start;
 		display: flex;
 		flex-wrap: nowrap;
 		gap: 11px;
@@ -742,7 +742,7 @@
 			line-height: 18px;
 			overflow: hidden;
 			width: auto;
-			-webkit-line-clamp: 2;
+			-webkit-line-clamp: 1;
 			-webkit-box-orient: vertical;
 		}
 	}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -826,7 +826,6 @@
 	clear: both;
 	display: flex;
 	flex-direction: column;
-	flex-basis: calc(50% - 15px);
 	margin: 6px 0 0 0;
 
 	@include breakpoint-deprecated(">660px") {
@@ -835,10 +834,6 @@
 
 	@include breakpoint-deprecated( ">960px" ) {
 		margin: 6px 0 0 15px;
-
-		&:nth-child(2n) {
-			margin: 6px 15px 0 0;
-		}
 	}
 
 	.blogging-prompt__menu {

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -13,7 +13,8 @@
 
 .is-reader-page .recommended-for-you.main,
 .is-reader-page .following.main,
-.is-reader-page .tag-stream__main.main {
+.is-reader-page .tag-stream__main.main,
+.is-reader-page .search-stream__with-sites.main {
 	margin: 30px auto;
 	@include breakpoint-deprecated( "<660px" ) {
 		margin: 30px;

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -161,9 +161,8 @@ const streamApis = {
 		query: ( extras ) =>
 			getQueryString( {
 				...extras,
-				seed,
-				alg_prefix: 'read:recommendations:sites',
-				posts_per_site: 1,
+				algorithm: 'read:recommendations:sites/es/2',
+				number: 10,
 			} ),
 	},
 	tag: {

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -9,7 +9,6 @@ import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { READER_STREAMS_PAGE_REQUEST } from 'calypso/state/reader/action-types';
 import { receivePosts } from 'calypso/state/reader/posts/actions';
 import { receivePage, receiveUpdates } from 'calypso/state/reader/streams/actions';
-import { getFeedByFeedUrl } from 'calypso/state/reader/feeds/selectors';
 
 const noop = () => {};
 
@@ -36,17 +35,17 @@ function streamKeySuffix( streamKey ) {
 }
 
 const analyticsAlgoMap = new Map();
-function analyticsForStream( { streamKey, algorithm, posts } ) {
-	if ( ! streamKey || ! algorithm || ! posts ) {
+function analyticsForStream( { streamKey, algorithm, items } ) {
+	if ( ! streamKey || ! algorithm || ! items ) {
 		return [];
 	}
 
 	analyticsAlgoMap.set( streamKey, algorithm );
 
 	const eventName = 'calypso_traintracks_render';
-	const analyticsActions = posts
-		.filter( ( post ) => !! post.railcar )
-		.map( ( post ) => recordTracksEvent( eventName, post.railcar ) );
+	const analyticsActions = items
+		.filter( ( item ) => !! item.railcar )
+		.map( ( item ) => recordTracksEvent( eventName, item.railcar ) );
 	return analyticsActions;
 }
 const getAlgorithmForStream = ( streamKey ) => analyticsAlgoMap.get( streamKey );
@@ -156,6 +155,16 @@ const streamApis = {
 				alg_prefix: 'read:recommendations:posts',
 			} ),
 	},
+	custom_recs_sites_with_images: {
+		path: () => '/read/recommendations/sites',
+		dateProperty: 'date',
+		query: ( extras ) =>
+			getQueryString( {
+				...extras,
+				seed,
+				alg_prefix: 'read:recommendations:sites',
+			} ),
+	},
 	tag: {
 		path: ( { streamKey } ) => `/read/tags/${ streamKeySuffix( streamKey ) }/posts`,
 		dateProperty: 'date',
@@ -214,7 +223,7 @@ export function requestPage( action ) {
 }
 
 export function handlePage( action, data ) {
-	const { posts, date_range, meta, next_page } = data;
+	const { posts, date_range, meta, next_page, sites } = data;
 	const { streamKey, query, isPoll, gap, streamType } = action.payload;
 	const { dateProperty } = streamApis[ streamType ];
 	let pageHandle = {};
@@ -233,27 +242,56 @@ export function handlePage( action, data ) {
 		pageHandle = { before: after };
 	}
 
-	const actions = analyticsForStream( { streamKey, algorithm: data.algorithm, posts } );
+	if ( streamType === 'custom_recs_sites_with_images' ) {
+		pageHandle = { page_handle: next_page || meta.next_page };
+	}
 
-	console.log( 'posts', posts );
+	const actions = analyticsForStream( {
+		streamKey,
+		algorithm: data.algorithm,
+		items: posts || sites,
+	} );
 
-	const streamItems = posts.map( ( post ) => ( {
-		...keyForPost( post ),
-		date: post[ dateProperty ],
-		...( post.comments && { comments: map( post.comments, 'ID' ).reverse() } ), // include comments for conversations
-		url: post.URL,
-		site_icon: post.site_icon?.ico,
-		site_description: post.description,
-		site_name: post.site_name,
-		feed_URL: post.feed_URL,
-		feed_ID: post.feed_ID,
-		xPostMetadata: XPostHelper.getXPostMetadata( post ),
-	} ) );
+	let streamItems = [];
+	let streamPosts = posts;
+
+	if ( posts ) {
+		streamItems = posts.map( ( post ) => ( {
+			...keyForPost( post ),
+			date: post[ dateProperty ],
+			...( post.comments && { comments: map( post.comments, 'ID' ).reverse() } ), // include comments for conversations
+			url: post.URL,
+			site_icon: post.site_icon?.ico,
+			site_description: post.description,
+			site_name: post.site_name,
+			feed_URL: post.feed_URL,
+			feed_ID: post.feed_ID,
+			xPostMetadata: XPostHelper.getXPostMetadata( post ),
+		} ) );
+	} else if ( sites ) {
+		streamItems = sites.map( ( site ) => {
+			const post = site.posts[ 0 ];
+			return {
+				...keyForPost( post ),
+				date: post[ dateProperty ],
+				...( post.comments && { comments: map( post.comments, 'ID' ).reverse() } ), // include comments for conversations
+				url: post.URL,
+				site_icon: site.icon?.ico,
+				site_description: site.description,
+				site_name: site.name,
+				feed_URL: post.feed_URL,
+				feed_ID: post.feed_ID,
+				xPostMetadata: XPostHelper.getXPostMetadata( post ),
+			};
+		} );
+		// get array of posts from sites object
+		streamPosts = sites.map( ( site ) => site.posts[ 0 ] );
+	}
 
 	if ( isPoll ) {
 		actions.push( receiveUpdates( { streamKey, streamItems, query } ) );
 	} else {
-		actions.push( receivePosts( posts ) );
+		actions.push( receivePosts( streamPosts ) );
 		actions.push( receivePage( { streamKey, query, streamItems, pageHandle, gap } ) );
 	}
 

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -163,6 +163,7 @@ const streamApis = {
 				...extras,
 				seed,
 				alg_prefix: 'read:recommendations:sites',
+				posts_per_site: 1,
 			} ),
 	},
 	tag: {

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -9,6 +9,7 @@ import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
 import { READER_STREAMS_PAGE_REQUEST } from 'calypso/state/reader/action-types';
 import { receivePosts } from 'calypso/state/reader/posts/actions';
 import { receivePage, receiveUpdates } from 'calypso/state/reader/streams/actions';
+import { getFeedByFeedUrl } from 'calypso/state/reader/feeds/selectors';
 
 const noop = () => {};
 
@@ -234,11 +235,18 @@ export function handlePage( action, data ) {
 
 	const actions = analyticsForStream( { streamKey, algorithm: data.algorithm, posts } );
 
+	console.log( 'posts', posts );
+
 	const streamItems = posts.map( ( post ) => ( {
 		...keyForPost( post ),
 		date: post[ dateProperty ],
 		...( post.comments && { comments: map( post.comments, 'ID' ).reverse() } ), // include comments for conversations
 		url: post.URL,
+		site_icon: post.site_icon?.ico,
+		site_description: post.description,
+		site_name: post.site_name,
+		feed_URL: post.feed_URL,
+		feed_ID: post.feed_ID,
 		xPostMetadata: XPostHelper.getXPostMetadata( post ),
 	} ) );
 


### PR DESCRIPTION
This PR plans to update the default listing of posts/sites on the search page to recommended posts.

This is part of the project - pe7F0s-Le-p2

**Design**
![preview](https://user-images.githubusercontent.com/5560595/234336490-9f830d60-d10a-47f2-9152-37af67740b63.png)

At the moment, search already falls back to showing related/recommended posts if no search query is entered.
I have updated this to use the recommended sites API endpoint instead and pulled out the most recently liked post from that site.

This PR uses a new algorithm that will lookup a list of popular sites based on views and based on those results, return a list of recommended sites posts in 1 column and include a sidebar with the recommended sites list.

### Testing

* Needs patch; D109829-code
* Sandbox public-api.wordpress.com
* Go to Reader search and confirm it loads with recommended posts/sites based on popular sites - http://calypso.localhost:3000/read/search

