### PR TITLE
Link in Bio: fix readonly `data` error breaking the Link in Bio flow

### DIFF
--- a/packages/pattern-picker/src/use-query-patterns.ts
+++ b/packages/pattern-picker/src/use-query-patterns.ts
@@ -48,12 +48,14 @@ const useQueryPatterns = ( siteSlug: string ): UseQueryResult< Pattern[] > => {
 	);
 
 	const { data: order } = useOrder( queryResult.data?.length ?? 0 );
+	let newData = queryResult.data;
 
 	if ( queryResult.data && order ) {
-		queryResult.data = order.map( ( index ) => queryResult.data[ index ] );
+		newData = order.map( ( index ) => queryResult.data[ index ] );
 	}
 
-	return queryResult;
+	// merging this way because data is readonly
+	return { ...{ data: newData }, ...queryResult };
 };
 
 export default useQueryPatterns;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Prevent the error

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
