### PR TITLE
Checkout: Add test for rendering logged-out Jetpack checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -103,7 +103,7 @@ export default function CheckoutMain( {
 	redirectTo?: string | undefined;
 	feature?: string | undefined;
 	plan?: string | undefined;
-	purchaseId?: number | undefined;
+	purchaseId?: number | string | undefined;
 	couponCode?: string | undefined;
 	isComingFromUpsell?: boolean;
 	isLoggedOutCart?: boolean;

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -66,7 +66,7 @@ import type {
 } from '@automattic/wpcom-checkout';
 
 const { colors } = colorStudio;
-const debug = debugFactory( 'calypso:composite-checkout:composite-checkout' );
+const debug = debugFactory( 'calypso:checkout-main' );
 
 export default function CheckoutMain( {
 	siteSlug,
@@ -505,6 +505,7 @@ export default function CheckoutMain( {
 	if ( isCheckoutPageLoading ) {
 		debug( 'still loading because one of these is true', {
 			isInitialCartLoading,
+			...( allowedPaymentMethods.includes( 'card' ) ? { isLoadingStoredCards } : {} ),
 			paymentMethods: paymentMethods.length < 1,
 			arePaymentMethodsLoading: arePaymentMethodsLoading,
 			items: responseCart.products.length < 1,

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -734,7 +734,7 @@ export default function CheckoutMain( {
 }
 
 function getAnalyticsPath(
-	purchaseId: number | undefined,
+	purchaseId: number | string | undefined,
 	product: string | undefined,
 	selectedSiteSlug: string | undefined,
 	selectedFeature: string | undefined,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -67,7 +67,7 @@ export default function useCreatePaymentCompleteCallback( {
 	createUserAndSiteBeforeTransaction?: boolean;
 	productAliasFromUrl?: string | undefined;
 	redirectTo?: string | undefined;
-	purchaseId?: number | undefined;
+	purchaseId?: number | string | undefined;
 	feature?: string | undefined;
 	isInModal?: boolean;
 	isComingFromUpsell?: boolean;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
@@ -83,7 +83,7 @@ export default function useGetThankYouUrl( {
 export interface GetThankYouUrlProps {
 	siteSlug: string | undefined;
 	redirectTo?: string | undefined;
-	purchaseId?: number | undefined;
+	purchaseId?: number | string | undefined;
 	feature?: string | undefined;
 	cart: ResponseCart;
 	sitelessCheckoutType: SitelessCheckoutType;

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-autocomplete.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-autocomplete.tsx
@@ -22,6 +22,9 @@ import {
 	mockMatchMediaOnWindow,
 	mockGetVatInfoEndpoint,
 	countryList,
+	mockLogStashEndpoint,
+	mockGetSupportedCountriesEndpoint,
+	mockGetPaymentMethodsEndpoint,
 } from './util';
 import { MockCheckout } from './util/mock-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
@@ -63,11 +66,10 @@ describe( 'Checkout contact step', () => {
 	beforeEach( () => {
 		dispatch( CHECKOUT_STORE ).reset();
 		nock.cleanAll();
-		nock( 'https://public-api.wordpress.com' ).persist().post( '/rest/v1.1/logstash' ).reply( 200 );
-		nock( 'https://public-api.wordpress.com' )
-			.get( '/rest/v1.1/me/transactions/supported-countries' )
-			.reply( 200, countryList );
 		mockGetVatInfoEndpoint( {} );
+		mockGetPaymentMethodsEndpoint( [] );
+		mockLogStashEndpoint();
+		mockGetSupportedCountriesEndpoint( countryList );
 	} );
 
 	it( 'does not complete the contact step when the contact step button has not been clicked and there are no cached details', async () => {
@@ -170,12 +172,6 @@ describe( 'Checkout contact step', () => {
 				country_code: 'US',
 				email: 'test@example.com',
 			};
-			nock.cleanAll();
-			nock( 'https://public-api.wordpress.com' )
-				.persist()
-				.post( '/rest/v1.1/logstash' )
-				.reply( 200 );
-			mockGetVatInfoEndpoint( {} );
 
 			const messages = ( () => {
 				if ( valid === 'valid' ) {

--- a/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-contact-step.tsx
@@ -21,6 +21,9 @@ import {
 	mockMatchMediaOnWindow,
 	mockGetVatInfoEndpoint,
 	countryList,
+	mockGetPaymentMethodsEndpoint,
+	mockLogStashEndpoint,
+	mockGetSupportedCountriesEndpoint,
 } from './util';
 import { MockCheckout } from './util/mock-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
@@ -55,11 +58,10 @@ describe( 'Checkout contact step', () => {
 	beforeEach( () => {
 		dispatch( CHECKOUT_STORE ).reset();
 		nock.cleanAll();
-		nock( 'https://public-api.wordpress.com' ).persist().post( '/rest/v1.1/logstash' ).reply( 200 );
-		nock( 'https://public-api.wordpress.com' )
-			.get( '/rest/v1.1/me/transactions/supported-countries' )
-			.reply( 200, countryList );
 		mockGetVatInfoEndpoint( {} );
+		mockGetPaymentMethodsEndpoint( [] );
+		mockLogStashEndpoint();
+		mockGetSupportedCountriesEndpoint( countryList );
 	} );
 
 	it( 'does not render the contact step when the purchase is free', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-extra-tax-fields.tsx
@@ -24,6 +24,9 @@ import {
 	mockGetVatInfoEndpoint,
 	mockSetVatInfoEndpoint,
 	countryList,
+	mockGetPaymentMethodsEndpoint,
+	mockLogStashEndpoint,
+	mockGetSupportedCountriesEndpoint,
 } from './util';
 import { MockCheckout } from './util/mock-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
@@ -70,10 +73,9 @@ describe( 'Checkout contact step extra tax fields', () => {
 	beforeEach( () => {
 		dispatch( CHECKOUT_STORE ).reset();
 		nock.cleanAll();
-		nock( 'https://public-api.wordpress.com' ).persist().post( '/rest/v1.1/logstash' ).reply( 200 );
-		nock( 'https://public-api.wordpress.com' )
-			.get( '/rest/v1.1/me/transactions/supported-countries' )
-			.reply( 200, countryList );
+		mockGetPaymentMethodsEndpoint( [] );
+		mockLogStashEndpoint();
+		mockGetSupportedCountriesEndpoint( countryList );
 		mockGetVatInfoEndpoint( {} );
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -78,11 +78,13 @@ describe( 'CheckoutMain', () => {
 			additionalProps,
 			additionalCartProps,
 			useUndefinedCartKey,
+			useUndefinedSiteId,
 		}: {
 			cartChanges: Partial< ResponseCart >;
 			additionalProps: Partial< Parameters< typeof CheckoutMain > >;
 			additionalCartProps: Partial< Parameters< typeof ShoppingCartProvider > >;
 			useUndefinedCartKey?: boolean;
+			useUndefinedSiteId?: boolean;
 		} ) => {
 			const managerClient = createShoppingCartManagerClient( {
 				getCart: mockGetCartEndpointWith( { ...initialCart, ...( cartChanges ?? {} ) } ),
@@ -110,7 +112,7 @@ describe( 'CheckoutMain', () => {
 						>
 							<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
 								<CheckoutMain
-									siteId={ siteId }
+									siteId={ useUndefinedSiteId ? undefined : siteId }
 									siteSlug="foo.com"
 									overrideCountryList={ countryList }
 									{ ...additionalProps }
@@ -130,6 +132,27 @@ describe( 'CheckoutMain', () => {
 
 	it( 'renders the line items with prices', async () => {
 		render( <MyCheckout />, container );
+		await waitFor( () => {
+			screen
+				.getAllByLabelText( 'WordPress.com Personal' )
+				.map( ( element ) => expect( element ).toHaveTextContent( 'R$144' ) );
+		} );
+	} );
+
+	it( 'renders the line items with prices when logged-out', async () => {
+		const cartChanges = { products: [] };
+		render(
+			<MyCheckout
+				cartChanges={ cartChanges }
+				useUndefinedSiteId
+				additionalProps={ {
+					isLoggedOutCart: true,
+					productAliasFromUrl: 'personal',
+					sitelessCheckoutType: 'jetpack',
+				} }
+			/>,
+			container
+		);
 		await waitFor( () => {
 			screen
 				.getAllByLabelText( 'WordPress.com Personal' )

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -31,6 +31,7 @@ import {
 	countryList,
 	getBasicCart,
 	mockMatchMediaOnWindow,
+	mockGetPaymentMethodsEndpoint,
 } from './util';
 import type { ResponseCart } from '@automattic/shopping-cart';
 
@@ -69,6 +70,8 @@ describe( 'CheckoutMain', () => {
 			currency: initialCart.currency,
 			locale: initialCart.locale,
 		} );
+
+		mockGetPaymentMethodsEndpoint( [] );
 
 		const store = createTestReduxStore();
 		const queryClient = new QueryClient();

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -7,7 +7,6 @@ import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automatt
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, fireEvent, screen, within, waitFor, act } from '@testing-library/react';
 import { dispatch } from '@wordpress/data';
-import nock from 'nock';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { navigate } from 'calypso/lib/navigate';
@@ -32,6 +31,9 @@ import {
 	getBasicCart,
 	mockMatchMediaOnWindow,
 	mockGetPaymentMethodsEndpoint,
+	mockGetVatInfoEndpoint,
+	mockGetSupportedCountriesEndpoint,
+	mockLogStashEndpoint,
 } from './util';
 import type { ResponseCart } from '@automattic/shopping-cart';
 
@@ -97,11 +99,9 @@ describe( 'CheckoutMain', () => {
 			( useCartKey as jest.Mock ).mockImplementation( () =>
 				useUndefinedCartKey ? undefined : mainCartKey
 			);
-			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
-			nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {} );
-			nock( 'https://public-api.wordpress.com' )
-				.get( '/rest/v1.1/me/transactions/supported-countries' )
-				.reply( 200, countryList );
+			mockLogStashEndpoint();
+			mockGetVatInfoEndpoint( {} );
+			mockGetSupportedCountriesEndpoint( countryList );
 			mockMatchMediaOnWindow();
 			return (
 				<ReduxProvider store={ store }>

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -58,7 +58,6 @@ describe( 'CheckoutMain', () => {
 		( isJetpackSite as jest.Mock ).mockImplementation( () => false );
 
 		mockGetPaymentMethodsEndpoint( [] );
-
 		mockLogStashEndpoint();
 		mockGetVatInfoEndpoint( {} );
 		mockGetSupportedCountriesEndpoint( countryList );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  */
 import { GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY } from '@automattic/calypso-products';
-import { render, fireEvent, screen, within, waitFor, act } from '@testing-library/react';
+import { render, screen, within, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { dispatch } from '@wordpress/data';
 import React from 'react';
 import { navigate } from 'calypso/lib/navigate';
@@ -157,11 +158,12 @@ describe( 'CheckoutMain', () => {
 		const removeProductButton = await within( activeSection ).findByLabelText(
 			'Remove WordPress.com Personal from cart'
 		);
+		const user = userEvent.setup();
 		expect( screen.getAllByLabelText( 'WordPress.com Personal' ) ).toHaveLength( 1 );
-		fireEvent.click( removeProductButton );
+		await user.click( removeProductButton );
 		const confirmModal = await screen.findByRole( 'dialog' );
 		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
-		fireEvent.click( confirmButton );
+		await user.click( confirmButton );
 		await waitFor( async () => {
 			expect( screen.queryByLabelText( 'WordPress.com Personal' ) ).not.toBeInTheDocument();
 		} );
@@ -181,10 +183,11 @@ describe( 'CheckoutMain', () => {
 		const removeProductButton = await within( activeSection ).findByLabelText(
 			'Remove WordPress.com Personal from cart'
 		);
-		fireEvent.click( removeProductButton );
+		const user = userEvent.setup();
+		await user.click( removeProductButton );
 		const confirmModal = await screen.findByRole( 'dialog' );
 		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
-		fireEvent.click( confirmButton );
+		await user.click( confirmButton );
 		await waitFor( () => {
 			expect( navigate ).toHaveBeenCalledWith( '/plans/foo.com' );
 		} );
@@ -204,10 +207,11 @@ describe( 'CheckoutMain', () => {
 		const removeProductButton = await within( activeSection ).findByLabelText(
 			'Remove foo.cash from cart'
 		);
-		fireEvent.click( removeProductButton );
+		const user = userEvent.setup();
+		await user.click( removeProductButton );
 		const confirmModal = await screen.findByRole( 'dialog' );
 		const confirmButton = await within( confirmModal ).findByText( 'Continue' );
-		fireEvent.click( confirmButton );
+		await user.click( confirmButton );
 		await waitFor( async () => {
 			expect( navigate ).not.toHaveBeenCalledWith( '/plans/foo.com' );
 		} );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-main.tsx
@@ -2,31 +2,21 @@
  * @jest-environment jsdom
  */
 import { GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY } from '@automattic/calypso-products';
-import { StripeHookProvider } from '@automattic/calypso-stripe';
-import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, fireEvent, screen, within, waitFor, act } from '@testing-library/react';
 import { dispatch } from '@wordpress/data';
 import React from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
 import { navigate } from 'calypso/lib/navigate';
-import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import CheckoutMain from '../components/checkout-main';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
 import {
-	siteId,
 	domainProduct,
 	planWithoutDomain,
-	fetchStripeConfiguration,
 	mockSetCartEndpointWith,
-	mockGetCartEndpointWith,
 	getActivePersonalPlanDataForType,
-	createTestReduxStore,
 	countryList,
 	getBasicCart,
 	mockMatchMediaOnWindow,
@@ -35,9 +25,8 @@ import {
 	mockGetSupportedCountriesEndpoint,
 	mockLogStashEndpoint,
 } from './util';
-import type { ResponseCart } from '@automattic/shopping-cart';
-
-/* eslint-disable jest/no-conditional-expect */
+import { MockCheckout } from './util/mock-checkout';
+import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
 
 jest.mock( 'calypso/state/sites/selectors' );
 jest.mock( 'calypso/state/sites/domains/selectors' );
@@ -49,8 +38,13 @@ jest.mock( 'calypso/state/products-list/selectors/is-marketplace-product' );
 jest.mock( 'calypso/lib/navigate' );
 
 describe( 'CheckoutMain', () => {
-	let container;
-	let MyCheckout;
+	const initialCart = getBasicCart();
+	const mainCartKey = 123456;
+
+	const mockSetCartEndpoint = mockSetCartEndpointWith( {
+		currency: initialCart.currency,
+		locale: initialCart.locale,
+	} );
 
 	beforeEach( () => {
 		dispatch( CHECKOUT_STORE ).reset();
@@ -63,78 +57,22 @@ describe( 'CheckoutMain', () => {
 		( isMarketplaceProduct as jest.Mock ).mockImplementation( () => false );
 		( isJetpackSite as jest.Mock ).mockImplementation( () => false );
 
-		container = document.createElement( 'div' );
-		document.body.appendChild( container );
-
-		const initialCart = getBasicCart();
-
-		const mockSetCartEndpoint = mockSetCartEndpointWith( {
-			currency: initialCart.currency,
-			locale: initialCart.locale,
-		} );
-
 		mockGetPaymentMethodsEndpoint( [] );
 
-		const store = createTestReduxStore();
-		const queryClient = new QueryClient();
-
-		MyCheckout = ( {
-			cartChanges,
-			additionalProps,
-			additionalCartProps,
-			useUndefinedCartKey,
-			useUndefinedSiteId,
-		}: {
-			cartChanges: Partial< ResponseCart >;
-			additionalProps: Partial< Parameters< typeof CheckoutMain > >;
-			additionalCartProps: Partial< Parameters< typeof ShoppingCartProvider > >;
-			useUndefinedCartKey?: boolean;
-			useUndefinedSiteId?: boolean;
-		} ) => {
-			const managerClient = createShoppingCartManagerClient( {
-				getCart: mockGetCartEndpointWith( { ...initialCart, ...( cartChanges ?? {} ) } ),
-				setCart: mockSetCartEndpoint,
-			} );
-			const mainCartKey = 123456;
-			( useCartKey as jest.Mock ).mockImplementation( () =>
-				useUndefinedCartKey ? undefined : mainCartKey
-			);
-			mockLogStashEndpoint();
-			mockGetVatInfoEndpoint( {} );
-			mockGetSupportedCountriesEndpoint( countryList );
-			mockMatchMediaOnWindow();
-			return (
-				<ReduxProvider store={ store }>
-					<QueryClientProvider client={ queryClient }>
-						<ShoppingCartProvider
-							managerClient={ managerClient }
-							options={ {
-								defaultCartKey: useUndefinedCartKey ? undefined : mainCartKey,
-							} }
-							{ ...additionalCartProps }
-						>
-							<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
-								<CheckoutMain
-									siteId={ useUndefinedSiteId ? undefined : siteId }
-									siteSlug="foo.com"
-									overrideCountryList={ countryList }
-									{ ...additionalProps }
-								/>
-							</StripeHookProvider>
-						</ShoppingCartProvider>
-					</QueryClientProvider>
-				</ReduxProvider>
-			);
-		};
-	} );
-
-	afterEach( () => {
-		document.body.removeChild( container );
-		container = null;
+		mockLogStashEndpoint();
+		mockGetVatInfoEndpoint( {} );
+		mockGetSupportedCountriesEndpoint( countryList );
+		mockMatchMediaOnWindow();
 	} );
 
 	it( 'renders the line items with prices', async () => {
-		render( <MyCheckout />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+			/>
+		);
 		await waitFor( () => {
 			screen
 				.getAllByLabelText( 'WordPress.com Personal' )
@@ -145,7 +83,9 @@ describe( 'CheckoutMain', () => {
 	it( 'renders the line items with prices when logged-out', async () => {
 		const cartChanges = { products: [] };
 		render(
-			<MyCheckout
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
 				cartChanges={ cartChanges }
 				useUndefinedSiteId
 				additionalProps={ {
@@ -153,8 +93,7 @@ describe( 'CheckoutMain', () => {
 					productAliasFromUrl: 'personal',
 					sitelessCheckoutType: 'jetpack',
 				} }
-			/>,
-			container
+			/>
 		);
 		await waitFor( () => {
 			screen
@@ -164,7 +103,13 @@ describe( 'CheckoutMain', () => {
 	} );
 
 	it( 'renders the tax amount', async () => {
-		render( <MyCheckout />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+			/>
+		);
 		await waitFor( () => {
 			screen
 				.getAllByLabelText( 'Tax' )
@@ -173,7 +118,13 @@ describe( 'CheckoutMain', () => {
 	} );
 
 	it( 'renders the total amount', async () => {
-		render( <MyCheckout />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+			/>
+		);
 		await waitFor( () => {
 			screen
 				.getAllByLabelText( 'Total' )
@@ -182,14 +133,27 @@ describe( 'CheckoutMain', () => {
 	} );
 
 	it( 'renders the checkout summary', async () => {
-		render( <MyCheckout />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+			/>
+		);
 		expect( await screen.findByText( 'Purchase Details' ) ).toBeInTheDocument();
 		expect( navigate ).not.toHaveBeenCalled();
 	} );
 
 	it( 'removes a product from the cart after clicking to remove it', async () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
 		const activeSection = await screen.findByTestId( 'review-order-step--visible' );
 		const removeProductButton = await within( activeSection ).findByLabelText(
 			'Remove WordPress.com Personal from cart'
@@ -206,7 +170,14 @@ describe( 'CheckoutMain', () => {
 
 	it( 'redirects to the plans page if the cart is empty after removing the last product', async () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
 		const activeSection = await screen.findByTestId( 'review-order-step--visible' );
 		const removeProductButton = await within( activeSection ).findByLabelText(
 			'Remove WordPress.com Personal from cart'
@@ -222,7 +193,14 @@ describe( 'CheckoutMain', () => {
 
 	it( 'does not redirect to the plans page if the cart is empty after removing a product when it is not the last', async () => {
 		const cartChanges = { products: [ planWithoutDomain, domainProduct ] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
 		const activeSection = await screen.findByTestId( 'review-order-step--visible' );
 		const removeProductButton = await within( activeSection ).findByLabelText(
 			'Remove foo.cash from cart'
@@ -238,7 +216,14 @@ describe( 'CheckoutMain', () => {
 
 	it( 'does not redirect to the plans page if the cart is empty when it loads', async () => {
 		const cartChanges = { products: [] };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
 		await waitFor( async () => {
 			expect( navigate ).not.toHaveBeenCalledWith( '/plans/foo.com' );
 		} );
@@ -248,8 +233,13 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'personal' };
 		render(
-			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-			container
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+			/>
 		);
 		await waitFor( async () => {
 			expect( navigate ).not.toHaveBeenCalled();
@@ -260,8 +250,13 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'personal' };
 		render(
-			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-			container
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+			/>
 		);
 		await waitFor( async () => {
 			screen
@@ -277,8 +272,13 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'jetpack_scan' };
 		render(
-			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-			container
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+			/>
 		);
 		await waitFor( async () => {
 			screen
@@ -294,8 +294,13 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'jetpack_scan,jetpack_backup_daily' };
 		render(
-			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-			container
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+			/>
 		);
 		await waitFor( async () => {
 			screen
@@ -311,13 +316,18 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [] };
 		const additionalProps = {
 			productAliasFromUrl: 'ak_plus_yearly_1',
-			sitelessCheckoutType: 'akismet',
+			sitelessCheckoutType: 'akismet' as SitelessCheckoutType,
 			isNoSiteCart: true,
 		};
 
 		render(
-			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-			container
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+			/>
 		);
 
 		await waitFor( async () => {
@@ -331,13 +341,18 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [] };
 		const additionalProps = {
 			productAliasFromUrl: 'ak_plus_yearly_1,ak_plus_yearly_2',
-			sitelessCheckoutType: 'akismet',
+			sitelessCheckoutType: 'akismet' as SitelessCheckoutType,
 			isNoSiteCart: true,
 		};
 
 		render(
-			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-			container
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+			/>
 		);
 
 		await waitFor( async () => {
@@ -352,8 +367,13 @@ describe( 'CheckoutMain', () => {
 		const additionalProps = { productAliasFromUrl: 'concierge-session' };
 		await act( async () => {
 			render(
-				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-				container
+				<MockCheckout
+					mainCartKey={ mainCartKey }
+					initialCart={ initialCart }
+					setCart={ mockSetCartEndpoint }
+					cartChanges={ cartChanges }
+					additionalProps={ additionalProps }
+				/>
 			);
 		} );
 		expect( navigate ).not.toHaveBeenCalled();
@@ -363,8 +383,13 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		const additionalProps = { productAliasFromUrl: 'concierge-session' };
 		render(
-			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-			container
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+			/>
 		);
 		await waitFor( async () => {
 			screen
@@ -381,8 +406,13 @@ describe( 'CheckoutMain', () => {
 		const additionalProps = { productAliasFromUrl: 'theme:ovation' };
 		await act( async () => {
 			render(
-				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-				container
+				<MockCheckout
+					mainCartKey={ mainCartKey }
+					initialCart={ initialCart }
+					setCart={ mockSetCartEndpoint }
+					cartChanges={ cartChanges }
+					additionalProps={ additionalProps }
+				/>
 			);
 		} );
 		expect( navigate ).not.toHaveBeenCalled();
@@ -392,8 +422,13 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		const additionalProps = { productAliasFromUrl: 'theme:ovation' };
 		render(
-			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-			container
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+			/>
 		);
 		await waitFor( async () => {
 			screen
@@ -412,7 +447,14 @@ describe( 'CheckoutMain', () => {
 		const additionalProps = {
 			productAliasFromUrl: `${ productSlug }:${ domainName }:-q-${ quantity }`,
 		};
-		render( <MyCheckout additionalProps={ additionalProps } />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				additionalProps={ additionalProps }
+			/>
+		);
 		expect(
 			await screen.findByLabelText(
 				`Google Workspace for '${ domainName }' and quantity '${ quantity }'`
@@ -426,7 +468,14 @@ describe( 'CheckoutMain', () => {
 		const additionalProps = {
 			productAliasFromUrl: `${ productSlug }:-q-${ quantity }`,
 		};
-		render( <MyCheckout additionalProps={ additionalProps } />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				additionalProps={ additionalProps }
+			/>
+		);
 		expect(
 			await screen.findByLabelText( `Google Workspace for '' and quantity '${ quantity }'` )
 		).toBeInTheDocument();
@@ -437,8 +486,13 @@ describe( 'CheckoutMain', () => {
 		const additionalProps = { productAliasFromUrl: 'domain-mapping:bar.com' };
 		await act( async () => {
 			render(
-				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-				container
+				<MockCheckout
+					mainCartKey={ mainCartKey }
+					initialCart={ initialCart }
+					setCart={ mockSetCartEndpoint }
+					cartChanges={ cartChanges }
+					additionalProps={ additionalProps }
+				/>
 			);
 		} );
 		expect( navigate ).not.toHaveBeenCalled();
@@ -448,8 +502,13 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [ planWithoutDomain ] };
 		const additionalProps = { productAliasFromUrl: 'domain-mapping:bar.com' };
 		render(
-			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-			container
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+			/>
 		);
 		await waitFor( async () => {
 			screen
@@ -466,8 +525,13 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'personal-bundle', purchaseId: '12345' };
 		render(
-			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-			container
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+			/>
 		);
 		await waitFor( async () => {
 			screen
@@ -480,8 +544,13 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'domain_reg:foo.cash', purchaseId: '12345' };
 		render(
-			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-			container
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+			/>
 		);
 		await waitFor( async () => {
 			expect( screen.getAllByText( 'Domain Registration: billed annually' ) ).toHaveLength( 1 );
@@ -493,8 +562,13 @@ describe( 'CheckoutMain', () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { productAliasFromUrl: 'domain_map:bar.com', purchaseId: '12345' };
 		render(
-			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-			container
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+			/>
 		);
 		await waitFor( async () => {
 			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 1 );
@@ -509,8 +583,13 @@ describe( 'CheckoutMain', () => {
 			purchaseId: '12345,54321',
 		};
 		render(
-			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-			container
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+			/>
 		);
 		await waitFor( () => {
 			expect( screen.getAllByText( 'Domain Mapping: billed annually' ) ).toHaveLength( 1 );
@@ -527,8 +606,13 @@ describe( 'CheckoutMain', () => {
 			coupon_savings_total_display: '$R10',
 		};
 		render(
-			<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
-			container
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+			/>
 		);
 		await waitFor( () => {
 			screen
@@ -542,7 +626,13 @@ describe( 'CheckoutMain', () => {
 
 	it( 'displays loading while cart key is undefined (eg: when cart store has pending updates)', async () => {
 		await act( async () => {
-			render( <MyCheckout useUndefinedCartKey={ true } />, container );
+			render(
+				<MockCheckout
+					mainCartKey={ undefined }
+					initialCart={ initialCart }
+					setCart={ mockSetCartEndpoint }
+				/>
+			);
 		} );
 		expect( screen.getByText( 'Loading checkout' ) ).toBeInTheDocument();
 	} );

--- a/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-payment-method-list.tsx
@@ -1,31 +1,25 @@
 /**
  * @jest-environment jsdom
  */
-import { StripeHookProvider } from '@automattic/calypso-stripe';
-import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import { dispatch } from '@wordpress/data';
-import nock from 'nock';
-import { Provider as ReduxProvider } from 'react-redux';
-import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import CheckoutMain from '../components/checkout-main';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
 import {
-	siteId,
-	fetchStripeConfiguration,
 	mockSetCartEndpointWith,
-	mockGetCartEndpointWith,
 	getActivePersonalPlanDataForType,
-	createTestReduxStore,
 	countryList,
 	getBasicCart,
 	mockMatchMediaOnWindow,
+	mockGetPaymentMethodsEndpoint,
+	mockLogStashEndpoint,
+	mockGetVatInfoEndpoint,
+	mockGetSupportedCountriesEndpoint,
 } from './util';
+import { MockCheckout } from './util/mock-checkout';
 
 /* eslint-disable jest/no-conditional-expect */
 
@@ -39,8 +33,13 @@ jest.mock( 'calypso/state/products-list/selectors/is-marketplace-product' );
 jest.mock( 'calypso/lib/navigate' );
 
 describe( 'Checkout payment methods list', () => {
-	let container;
-	let MyCheckout;
+	const initialCart = getBasicCart();
+	const mainCartKey = 123456;
+
+	const mockSetCartEndpoint = mockSetCartEndpointWith( {
+		currency: initialCart.currency,
+		locale: initialCart.locale,
+	} );
 
 	beforeEach( () => {
 		dispatch( CHECKOUT_STORE ).reset();
@@ -53,69 +52,34 @@ describe( 'Checkout payment methods list', () => {
 		isMarketplaceProduct.mockImplementation( () => false );
 		isJetpackSite.mockImplementation( () => false );
 
-		container = document.createElement( 'div' );
-		document.body.appendChild( container );
-
-		const initialCart = getBasicCart();
-
-		const mockSetCartEndpoint = mockSetCartEndpointWith( {
-			currency: initialCart.currency,
-			locale: initialCart.locale,
-		} );
-
-		const store = createTestReduxStore();
-		const queryClient = new QueryClient();
-
-		MyCheckout = ( { cartChanges, additionalProps, additionalCartProps, useUndefinedCartKey } ) => {
-			const managerClient = createShoppingCartManagerClient( {
-				getCart: mockGetCartEndpointWith( { ...initialCart, ...( cartChanges ?? {} ) } ),
-				setCart: mockSetCartEndpoint,
-			} );
-			const mainCartKey = 'foo.com';
-			useCartKey.mockImplementation( () => ( useUndefinedCartKey ? undefined : mainCartKey ) );
-			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
-			nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {} );
-			mockMatchMediaOnWindow();
-			return (
-				<ReduxProvider store={ store }>
-					<QueryClientProvider client={ queryClient }>
-						<ShoppingCartProvider
-							managerClient={ managerClient }
-							options={ {
-								defaultCartKey: useUndefinedCartKey ? undefined : mainCartKey,
-							} }
-							{ ...additionalCartProps }
-						>
-							<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
-								<CheckoutMain
-									siteId={ siteId }
-									siteSlug="foo.com"
-									getStoredCards={ async () => [] }
-									overrideCountryList={ countryList }
-									{ ...additionalProps }
-								/>
-							</StripeHookProvider>
-						</ShoppingCartProvider>
-					</QueryClientProvider>
-				</ReduxProvider>
-			);
-		};
-	} );
-
-	afterEach( () => {
-		document.body.removeChild( container );
-		container = null;
+		mockGetPaymentMethodsEndpoint( [] );
+		mockLogStashEndpoint();
+		mockGetVatInfoEndpoint( {} );
+		mockGetSupportedCountriesEndpoint( countryList );
+		mockMatchMediaOnWindow();
 	} );
 
 	it( 'renders the paypal payment method option', async () => {
-		render( <MyCheckout />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+			/>
+		);
 		await waitFor( () => {
 			expect( screen.getByText( 'PayPal' ) ).toBeInTheDocument();
 		} );
 	} );
 
 	it( 'does not render the full credits payment method option when no credits are available', async () => {
-		render( <MyCheckout />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+			/>
+		);
 		await waitFor( () => {
 			expect( screen.queryByText( /WordPress.com Credits:/ ) ).not.toBeInTheDocument();
 		} );
@@ -123,7 +87,14 @@ describe( 'Checkout payment methods list', () => {
 
 	it( 'does not render the full credits payment method option when partial credits are available', async () => {
 		const cartChanges = { credits_integer: 15400, credits_display: 'R$154' };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
 		await waitFor( () => {
 			expect( screen.queryByText( /WordPress.com Credits:/ ) ).not.toBeInTheDocument();
 		} );
@@ -131,7 +102,14 @@ describe( 'Checkout payment methods list', () => {
 
 	it( 'renders the paypal payment method option when partial credits are available', async () => {
 		const cartChanges = { credits_integer: 15400, credits_display: 'R$154' };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
 		await waitFor( () => {
 			expect( screen.getByText( 'PayPal' ) ).toBeInTheDocument();
 		} );
@@ -144,7 +122,14 @@ describe( 'Checkout payment methods list', () => {
 			credits_integer: 15600,
 			credits_display: 'R$156',
 		};
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
 		await waitFor( () => {
 			expect( screen.getByText( /WordPress.com Credits:/ ) ).toBeInTheDocument();
 		} );
@@ -157,14 +142,27 @@ describe( 'Checkout payment methods list', () => {
 			credits_integer: 15600,
 			credits_display: 'R$156',
 		};
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
 		await waitFor( () => {
 			expect( screen.queryByText( 'PayPal' ) ).not.toBeInTheDocument();
 		} );
 	} );
 
 	it( 'does not render the free payment method option when the purchase is not free', async () => {
-		render( <MyCheckout />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+			/>
+		);
 		await waitFor( () => {
 			expect( screen.queryByText( 'Free Purchase' ) ).not.toBeInTheDocument();
 		} );
@@ -172,7 +170,14 @@ describe( 'Checkout payment methods list', () => {
 
 	it( 'does not render the paypal payment method option when the purchase is free', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
 		await waitFor( () => {
 			expect( screen.queryByText( 'PayPal' ) ).not.toBeInTheDocument();
 		} );
@@ -189,7 +194,14 @@ describe( 'Checkout payment methods list', () => {
 			credits_integer: 15600,
 			credits_display: 'R$156',
 		};
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
 		await waitFor( () => {
 			expect( screen.queryByText( /WordPress.com Credits:/ ) ).not.toBeInTheDocument();
 		} );
@@ -197,7 +209,14 @@ describe( 'Checkout payment methods list', () => {
 
 	it( 'renders the free payment method option when the purchase is free', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
 		await waitFor( () => {
 			expect( screen.getByText( 'Free Purchase' ) ).toBeInTheDocument();
 		} );
@@ -205,7 +224,14 @@ describe( 'Checkout payment methods list', () => {
 
 	it( 'does not render the contact step when the purchase is free', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
-		render( <MyCheckout cartChanges={ cartChanges } />, container );
+		render(
+			<MockCheckout
+				mainCartKey={ mainCartKey }
+				initialCart={ initialCart }
+				setCart={ mockSetCartEndpoint }
+				cartChanges={ cartChanges }
+			/>
+		);
 		await waitFor( () => {
 			expect(
 				screen.queryByText( /Enter your (billing|contact) information/ )

--- a/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/checkout-vat-form.tsx
@@ -23,6 +23,9 @@ import {
 	mockGetVatInfoEndpoint,
 	mockSetVatInfoEndpoint,
 	countryList,
+	mockGetPaymentMethodsEndpoint,
+	mockLogStashEndpoint,
+	mockGetSupportedCountriesEndpoint,
 } from './util';
 import { MockCheckout } from './util/mock-checkout';
 import type { CartKey } from '@automattic/shopping-cart';
@@ -69,10 +72,10 @@ describe( 'Checkout contact step VAT form', () => {
 	beforeEach( () => {
 		dispatch( CHECKOUT_STORE ).reset();
 		nock.cleanAll();
-		nock( 'https://public-api.wordpress.com' ).persist().post( '/rest/v1.1/logstash' ).reply( 200 );
-		nock( 'https://public-api.wordpress.com' )
-			.get( '/rest/v1.1/me/transactions/supported-countries' )
-			.reply( 200, countryList );
+		mockGetPaymentMethodsEndpoint( [] );
+		mockLogStashEndpoint();
+		mockGetSupportedCountriesEndpoint( countryList );
+		mockMatchMediaOnWindow();
 		mockGetVatInfoEndpoint( {} );
 	} );
 
@@ -142,6 +145,7 @@ describe( 'Checkout contact step VAT form', () => {
 
 	it( 'renders the VAT fields and checks the box on load if the VAT endpoint returns data', async () => {
 		nock.cleanAll();
+		mockGetPaymentMethodsEndpoint( [] );
 		mockCachedContactDetailsEndpoint( {
 			country_code: 'GB',
 			postal_code: '',
@@ -167,6 +171,7 @@ describe( 'Checkout contact step VAT form', () => {
 
 	it( 'renders the VAT fields pre-filled if the VAT endpoint returns data', async () => {
 		nock.cleanAll();
+		mockGetPaymentMethodsEndpoint( [] );
 		mockCachedContactDetailsEndpoint( {
 			country_code: 'GB',
 			postal_code: '',
@@ -193,6 +198,7 @@ describe( 'Checkout contact step VAT form', () => {
 
 	it( 'renders the Northern Ireland checkbox pre-filled if the VAT endpoint returns XI', async () => {
 		nock.cleanAll();
+		mockGetPaymentMethodsEndpoint( [] );
 		mockCachedContactDetailsEndpoint( {
 			country_code: 'GB',
 			postal_code: '',
@@ -217,6 +223,7 @@ describe( 'Checkout contact step VAT form', () => {
 
 	it( 'does not allow unchecking the VAT details checkbox if the VAT fields are pre-filled', async () => {
 		nock.cleanAll();
+		mockGetPaymentMethodsEndpoint( [] );
 		mockCachedContactDetailsEndpoint( {
 			country_code: 'GB',
 			postal_code: '',
@@ -393,6 +400,7 @@ describe( 'Checkout contact step VAT form', () => {
 
 	it( 'when there is a cached contact country that differs from the cached VAT country, the contact country is sent to the VAT endpoint', async () => {
 		nock.cleanAll();
+		mockGetPaymentMethodsEndpoint( [] );
 		const cachedContactCountry = 'ES';
 		mockCachedContactDetailsEndpoint( {
 			country_code: cachedContactCountry,

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker-dropdown.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker-dropdown.tsx
@@ -7,7 +7,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { dispatch } from '@wordpress/data';
-import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
@@ -30,6 +29,11 @@ import {
 	countryList,
 	mockUserAgent,
 	getPlanSubtitleTextForInterval,
+	mockGetPaymentMethodsEndpoint,
+	mockLogStashEndpoint,
+	mockGetSupportedCountriesEndpoint,
+	mockGetVatInfoEndpoint,
+	mockMatchMediaOnWindow,
 } from './util';
 
 jest.mock( 'calypso/lib/analytics/utils/refresh-country-code-cookie-gdpr' );
@@ -94,21 +98,11 @@ describe( 'CheckoutMain with a variant picker', () => {
 
 		const store = createTestReduxStore();
 		const queryClient = new QueryClient();
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
-		nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {} );
-		Object.defineProperty( window, 'matchMedia', {
-			writable: true,
-			value: jest.fn().mockImplementation( ( query ) => ( {
-				matches: false,
-				media: query,
-				onchange: null,
-				addListener: jest.fn(), // deprecated
-				removeListener: jest.fn(), // deprecated
-				addEventListener: jest.fn(),
-				removeEventListener: jest.fn(),
-				dispatchEvent: jest.fn(),
-			} ) ),
-		} );
+		mockGetPaymentMethodsEndpoint( [] );
+		mockLogStashEndpoint();
+		mockGetSupportedCountriesEndpoint( countryList );
+		mockGetVatInfoEndpoint( {} );
+		mockMatchMediaOnWindow();
 
 		MyCheckout = ( { cartChanges, additionalProps, additionalCartProps, useUndefinedCartKey } ) => {
 			const managerClient = createShoppingCartManagerClient( {
@@ -224,8 +218,6 @@ describe( 'CheckoutMain with a variant picker', () => {
 			} ) );
 			const user = userEvent.setup();
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
-			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
-			nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {} );
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
 			const openVariantPicker = await screen.findByLabelText( 'Pick a product term' );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker-radio.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-variant-picker-radio.tsx
@@ -7,7 +7,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { dispatch } from '@wordpress/data';
-import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
@@ -30,6 +29,11 @@ import {
 	countryList,
 	mockUserAgent,
 	getPlanSubtitleTextForInterval,
+	mockGetPaymentMethodsEndpoint,
+	mockLogStashEndpoint,
+	mockGetSupportedCountriesEndpoint,
+	mockGetVatInfoEndpoint,
+	mockMatchMediaOnWindow,
 } from './util';
 
 jest.mock( 'calypso/lib/analytics/utils/refresh-country-code-cookie-gdpr' );
@@ -94,21 +98,11 @@ describe( 'CheckoutMain with a variant picker', () => {
 
 		const store = createTestReduxStore();
 		const queryClient = new QueryClient();
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
-		nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {} );
-		Object.defineProperty( window, 'matchMedia', {
-			writable: true,
-			value: jest.fn().mockImplementation( ( query ) => ( {
-				matches: false,
-				media: query,
-				onchange: null,
-				addListener: jest.fn(), // deprecated
-				removeListener: jest.fn(), // deprecated
-				addEventListener: jest.fn(),
-				removeEventListener: jest.fn(),
-				dispatchEvent: jest.fn(),
-			} ) ),
-		} );
+		mockGetPaymentMethodsEndpoint( [] );
+		mockLogStashEndpoint();
+		mockGetSupportedCountriesEndpoint( countryList );
+		mockGetVatInfoEndpoint( {} );
+		mockMatchMediaOnWindow();
 
 		MyCheckout = ( { cartChanges, additionalProps, additionalCartProps, useUndefinedCartKey } ) => {
 			const managerClient = createShoppingCartManagerClient( {
@@ -217,8 +211,6 @@ describe( 'CheckoutMain with a variant picker', () => {
 				data: getActivePersonalPlanDataForType( activePlan ),
 			} ) );
 			const cartChanges = { products: [ getBusinessPlanForInterval( cartPlan ) ] };
-			nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
-			nock( 'https://public-api.wordpress.com' ).get( '/rest/v1.1/me/vat-info' ).reply( 200, {} );
 			render( <MyCheckout cartChanges={ cartChanges } /> );
 
 			await screen.findByLabelText( 'Pick a product term' );

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -24,6 +24,11 @@ import type {
 	PossiblyCompleteDomainContactDetails,
 } from '@automattic/wpcom-checkout';
 
+export const normalAllowedPaymentMethods = [
+	'WPCOM_Billing_PayPal_Express',
+	'WPCOM_Billing_Stripe_Payment_Method',
+];
+
 export const stripeConfiguration = {
 	processor_id: 'IE',
 	js_url: 'https://stripe-js-url',
@@ -383,7 +388,7 @@ export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
 		}, taxInteger );
 
 		return {
-			allowed_payment_methods: [ 'WPCOM_Billing_PayPal_Express' ],
+			allowed_payment_methods: normalAllowedPaymentMethods,
 			blog_id: 1234,
 			cart_generated_at_timestamp: 12345,
 			cart_key: 1234,
@@ -1123,7 +1128,7 @@ export function getBasicCart(): ResponseCart {
 			display_taxes: true,
 			location: {},
 		},
-		allowed_payment_methods: [ 'WPCOM_Billing_PayPal_Express' ],
+		allowed_payment_methods: normalAllowedPaymentMethods,
 		total_tax_integer: 700,
 		total_cost_integer: 15600,
 		sub_total_integer: 15600,
@@ -1152,9 +1157,7 @@ export function mockGetCartEndpointWith( initialCart: ResponseCart ) {
 			initialCart.credits_integer >= initialCart.total_cost_integer;
 		return {
 			...initialCart,
-			allowed_payment_methods: isFree
-				? [ 'WPCOM_Billing_WPCOM' ]
-				: [ 'WPCOM_Billing_PayPal_Express' ],
+			allowed_payment_methods: isFree ? [ 'WPCOM_Billing_WPCOM' ] : normalAllowedPaymentMethods,
 		};
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -1419,12 +1419,31 @@ export function createTestReduxStore() {
 	return createStore( rootReducer, applyMiddleware( thunk ) );
 }
 
+export function mockGetSupportedCountriesEndpoint( response ) {
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( '/rest/v1.1/me/transactions/supported-countries' )
+		.reply( 200, response );
+}
+
 export function mockGetVatInfoEndpoint( response ) {
 	nock( 'https://public-api.wordpress.com' )
 		.persist()
 		.get( '/rest/v1.1/me/vat-info' )
 		.optionally()
 		.reply( 200, response );
+}
+
+export function mockLogStashEndpoint() {
+	const endpoint = jest.fn();
+	endpoint.mockReturnValue( true );
+
+	nock( 'https://public-api.wordpress.com' )
+		.post( '/rest/v1.1/logstash', ( body ) => {
+			return endpoint( body );
+		} )
+		.reply( 200 );
+	return endpoint;
 }
 
 export function mockSetVatInfoEndpoint() {

--- a/client/my-sites/checkout/composite-checkout/test/util/index.ts
+++ b/client/my-sites/checkout/composite-checkout/test/util/index.ts
@@ -1456,6 +1456,12 @@ export const mockPayPalRedirectResponse = () => [
 	{ redirect_url: 'https://test-redirect-url' },
 ];
 
+export function mockGetPaymentMethodsEndpoint( endpointResponse ) {
+	nock( 'https://public-api.wordpress.com' )
+		.get( /\/rest\/v1\.2\/me\/payment-methods/ )
+		.reply( 200, endpointResponse );
+}
+
 export function mockCreateAccountEndpoint( endpointResponse ) {
 	const endpoint = jest.fn();
 	endpoint.mockReturnValue( true );

--- a/client/my-sites/checkout/composite-checkout/test/util/mock-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/test/util/mock-checkout.tsx
@@ -20,12 +20,14 @@ export function MockCheckout( {
 	cartChanges,
 	additionalProps,
 	setCart,
+	useUndefinedSiteId,
 }: {
 	initialCart: ResponseCart;
 	mainCartKey: CartKey;
 	cartChanges?: Partial< ResponseCart >;
 	additionalProps?: Partial< PropsOf< typeof CheckoutMain > >;
 	setCart?: SetCart;
+	useUndefinedSiteId?: boolean;
 } ) {
 	const reduxStore = createTestReduxStore();
 	const queryClient = new QueryClient();
@@ -49,7 +51,7 @@ export function MockCheckout( {
 				>
 					<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
 						<CheckoutMain
-							siteId={ siteId }
+							siteId={ useUndefinedSiteId ? undefined : siteId }
 							siteSlug="foo.com"
 							overrideCountryList={ countryList }
 							{ ...additionalProps }


### PR DESCRIPTION
## Proposed Changes

This PR adds a test to guard against the bug fixed by https://github.com/Automattic/wp-calypso/pull/76357. It's a simple test that just makes sure that checkout finishes loading when logged-out.

To do this required a few hoops because our checkout testing setup was only rendering the PayPal payment method, and in order to prove that the bug is fixed, we have to also allow stored card payment methods. Once that was allowed, we had to mock the `/me/payment-methods` endpoint in every checkout test.

I also took the opportunity to clean up some of the boilerplate on older checkout tests to use some newer helpers that have been added.

## Testing Instructions

Make sure tests pass.