### PR TITLE
Created new approach to select a domain in start-write flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -80,9 +80,10 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 		isEmailVerified
 	);
 
-	const { getPlanCartItem } = useSelect(
+	const { getPlanCartItem, getDomainCartItem } = useSelect(
 		( select ) => ( {
 			getPlanCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem,
+			getDomainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem,
 		} ),
 		[]
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -389,6 +389,13 @@ export function getEnhancedTasks(
 						title: translate( 'Choose a domain' ),
 						completed: domainUpsellCompleted,
 						actionDispatch: () => {
+							const startWritingFlow = isStartWritingFlow( flow || null );
+
+							const destionaionUrlWriteFlow = addQueryArgs( `/domains/add/${ siteSlug }`, {
+								flow: flow,
+								domainAndPlanPackage: true,
+							} );
+
 							recordTaskClickTracksEvent( flow, domainUpsellCompleted, task.id );
 							const destinationUrl = domainUpsellCompleted
 								? `/domains/manage/${ siteSlug }`
@@ -397,7 +404,7 @@ export function getEnhancedTasks(
 										flowToReturnTo: flow,
 										new: site?.name,
 								  } );
-							window.location.assign( destinationUrl );
+							window.location.assign( startWritingFlow ? destionaionUrlWriteFlow : destinationUrl );
 						},
 						badgeText: domainUpsellCompleted ? '' : translate( 'Upgrade plan' ),
 					};

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -184,7 +184,6 @@ class DomainSearch extends Component {
 			const nextStepLinkWritingFlow = addQueryArgs(
 				{
 					siteSlug: this.props.selectedSiteSlug,
-					START_WRITING_FLOW: true,
 				},
 				`/setup/start-writing/plans`
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
