### PR TITLE
Checkout: Render loading info and support link if loading is slow

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/checkout-loading-placeholder.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-loading-placeholder.tsx
@@ -9,7 +9,7 @@ export function CheckoutLoadingPlaceholder( {
 }: {
 	checkoutLoadingConditions: Array< { name: string; isLoading: boolean } >;
 } ) {
-	const showLoadingInfoThresholdMs = 1000;
+	const showLoadingInfoThresholdMs = 5000;
 	const [ shouldShowLoadingInfo, setShowLoadingInfo ] = useState( false );
 	useEffect( () => {
 		const timer = setTimeout( () => {

--- a/client/my-sites/checkout/composite-checkout/components/checkout-loading-placeholder.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-loading-placeholder.tsx
@@ -21,12 +21,12 @@ export function CheckoutLoadingPlaceholder( {
 	}, [] );
 
 	return (
-		<div>
+		<>
 			{ shouldShowLoadingInfo && (
 				<CheckoutLoadingInfo checkoutLoadingConditions={ checkoutLoadingConditions } />
 			) }
 			<LoadingContent />
-		</div>
+		</>
 	);
 }
 

--- a/client/my-sites/checkout/composite-checkout/components/checkout-loading-placeholder.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-loading-placeholder.tsx
@@ -1,0 +1,63 @@
+import { LoadingContent } from '@automattic/composite-checkout';
+import { styled } from '@automattic/wpcom-checkout';
+import { useTranslate } from 'i18n-calypso';
+import { useRef } from 'react';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+
+export function CheckoutLoadingPlaceholder( {
+	checkoutLoadingConditions,
+}: {
+	checkoutLoadingConditions: Array< { name: string; isLoading: boolean } >;
+} ) {
+	const initialRenderTime = useRef( Date.now() );
+	const showLoadingInfoThresholdMs = 1000;
+	const shouldShowLoadingInfo = Date.now() - initialRenderTime.current > showLoadingInfoThresholdMs;
+	return (
+		<div>
+			{ shouldShowLoadingInfo && (
+				<CheckoutLoadingInfo checkoutLoadingConditions={ checkoutLoadingConditions } />
+			) }
+			<LoadingContent />
+		</div>
+	);
+}
+
+const CheckoutLoadingInfoDiv = styled.div`
+	text-align: center;
+	margin-bottom: 1em;
+
+	h2 {
+		font-size: 1.5em;
+	}
+`;
+
+function CheckoutLoadingInfo( {
+	checkoutLoadingConditions,
+}: {
+	checkoutLoadingConditions: Array< { name: string; isLoading: boolean } >;
+} ) {
+	const translate = useTranslate();
+	const firstActiveLoadingCondition = checkoutLoadingConditions.find(
+		( condition ) => condition.isLoading === true
+	);
+	if ( ! firstActiveLoadingCondition ) {
+		return null;
+	}
+
+	return (
+		<CheckoutLoadingInfoDiv>
+			<div>{ firstActiveLoadingCondition.name }</div>{ ' ' }
+			<h2>{ translate( 'Hm… This is taking a while…' ) }</h2>
+			<div>
+				{ translate(
+					'If this page does not load, {{contactSupportLink}}please contact support{{/contactSupportLink}}.',
+					{
+						components: {
+							contactSupportLink: <a target="_blank" href={ CALYPSO_CONTACT } rel="noreferrer" />,
+						},
+					}
+				) }
+			</div>
+		</CheckoutLoadingInfoDiv>
+	);
+}

--- a/client/my-sites/checkout/composite-checkout/components/checkout-loading-placeholder.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-loading-placeholder.tsx
@@ -1,7 +1,7 @@
 import { LoadingContent } from '@automattic/composite-checkout';
 import { styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
-import { useRef } from 'react';
+import { useEffect, useState } from 'react';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 
 export function CheckoutLoadingPlaceholder( {
@@ -9,9 +9,17 @@ export function CheckoutLoadingPlaceholder( {
 }: {
 	checkoutLoadingConditions: Array< { name: string; isLoading: boolean } >;
 } ) {
-	const initialRenderTime = useRef( Date.now() );
 	const showLoadingInfoThresholdMs = 1000;
-	const shouldShowLoadingInfo = Date.now() - initialRenderTime.current > showLoadingInfoThresholdMs;
+	const [ shouldShowLoadingInfo, setShowLoadingInfo ] = useState( false );
+	useEffect( () => {
+		const timer = setTimeout( () => {
+			setShowLoadingInfo( true );
+		}, showLoadingInfoThresholdMs );
+		return () => {
+			clearTimeout( timer );
+		};
+	}, [] );
+
 	return (
 		<div>
 			{ shouldShowLoadingInfo && (

--- a/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-main.tsx
@@ -55,6 +55,7 @@ import { translateResponseCartToWPCOMCart } from '../lib/translate-cart';
 import weChatProcessor from '../lib/we-chat-processor';
 import webPayProcessor from '../lib/web-pay-processor';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
+import { CheckoutLoadingPlaceholder } from './checkout-loading-placeholder';
 import WPCheckout from './wp-checkout';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
@@ -491,26 +492,34 @@ export default function CheckoutMain( {
 	const theme = { ...checkoutTheme, colors: { ...checkoutTheme.colors, ...jetpackColors } };
 
 	// This variable determines if we see the loading page or if checkout can
-	// render its steps. Note that this does not prevent everything inside
-	// `CheckoutProvider` from rendering, only everything inside
-	// `CheckoutStepGroup`. This is because this variable is used to set the
-	// `FormStatus` to `FormStatus::LOADING`. Be careful what you add to this
-	// variable because it will slow down checkout's load time.
-	const isCheckoutPageLoading: boolean =
-		isInitialCartLoading ||
-		arePaymentMethodsLoading ||
-		paymentMethods.length < 1 ||
-		responseCart.products.length < 1 ||
-		countriesList.length < 1;
+	// render its steps.
+	//
+	// Note that this does not prevent everything inside `CheckoutProvider` from
+	// rendering, only everything inside `CheckoutStepGroup`. This is because
+	// this variable is used to set the `FormStatus` to `FormStatus::LOADING`.
+	//
+	// These conditions do not need to be true if the cart is empty. The empty
+	// cart page will show itself based on `shouldShowEmptyCartPage()` which has
+	// its own set of conditions and is not affected by this list.
+	//
+	// Be careful what you add to this variable because it will slow down
+	// checkout's apparent load time. If something can be loaded async inside
+	// checkout, do that instead.
+	const checkoutLoadingConditions: Array< { name: string; isLoading: boolean } > = [
+		{ name: translate( 'Loading cart' ), isLoading: isInitialCartLoading },
+		{ name: translate( 'Loading saved payment methods' ), isLoading: arePaymentMethodsLoading },
+		{ name: translate( 'Initializing payment methods' ), isLoading: paymentMethods.length < 1 },
+		{
+			name: translate( 'Preparing products for cart' ),
+			isLoading: responseCart.products.length < 1,
+		},
+		{ name: translate( 'Loading countries list' ), isLoading: countriesList.length < 1 },
+	];
+	const isCheckoutPageLoading: boolean = checkoutLoadingConditions.some(
+		( condition ) => condition.isLoading
+	);
 	if ( isCheckoutPageLoading ) {
-		debug( 'still loading because one of these is true', {
-			isInitialCartLoading,
-			...( allowedPaymentMethods.includes( 'card' ) ? { isLoadingStoredCards } : {} ),
-			paymentMethods: paymentMethods.length < 1,
-			arePaymentMethodsLoading: arePaymentMethodsLoading,
-			items: responseCart.products.length < 1,
-			countriesList: countriesList.length < 1,
-		} );
+		debug( 'still loading because one of these is true', checkoutLoadingConditions );
 	} else {
 		debug( 'no longer loading' );
 	}
@@ -711,6 +720,9 @@ export default function CheckoutMain( {
 				selectFirstAvailablePaymentMethod
 			>
 				<WPCheckout
+					loadingContent={
+						<CheckoutLoadingPlaceholder checkoutLoadingConditions={ checkoutLoadingConditions } />
+					}
 					useVariantPickerRadioButtons={ useVariantPickerRadioButtons }
 					customizedPreviousPath={ customizedPreviousPath }
 					isRemovingProductFromCart={ isRemovingProductFromCart }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.tsx
@@ -72,6 +72,7 @@ import type { OnChangeItemVariant } from './item-variation-picker';
 import type { CheckoutPageErrorCallback } from '@automattic/composite-checkout';
 import type { RemoveProductFromCart, MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { CountryListItem } from '@automattic/wpcom-checkout';
+import type { ReactNode } from 'react';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 
@@ -151,6 +152,7 @@ export default function WPCheckout( {
 	isInitialCartLoading,
 	customizedPreviousPath,
 	useVariantPickerRadioButtons,
+	loadingContent,
 }: {
 	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
 	changePlanLength: OnChangeItemVariant;
@@ -169,6 +171,7 @@ export default function WPCheckout( {
 	customizedPreviousPath?: string;
 	// This is just for unit tests.
 	useVariantPickerRadioButtons?: boolean;
+	loadingContent: ReactNode;
 } ) {
 	const cartKey = useCartKey();
 	const {
@@ -314,6 +317,7 @@ export default function WPCheckout( {
 
 	return (
 		<CheckoutStepGroup
+			loadingContent={ loadingContent }
 			stepAreaHeader={
 				<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
 					<CheckoutErrorBoundary

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -126,7 +126,7 @@ It has the following props.
 - `onPaymentMethodChanged?: (method: string) => void`. A function to call when the active payment method is changed. The argument will be the method's id.
 - `paymentMethods: object[]`. An array of [Payment Method objects](#payment-methods). Can be disabled by [useTogglePaymentMethod](#useTogglePaymentMethod).
 - `paymentProcessors: object`. A key-value map of payment processor functions (see [Payment Methods](#payment-methods)).
-- `isLoading?: boolean`. If set and true, the form will be replaced with a loading placeholder and the form status will be set to [`.LOADING`](#FormStatus) (see [useFormStatus](#useFormStatus)).
+- `isLoading?: boolean`. If set and true, the form will be replaced with a [loading placeholder](#LoadingContent) and the form status will be set to [`.LOADING`](#FormStatus) (see [useFormStatus](#useFormStatus)).
 - `isValidating?: boolean`. If set and true, the form status will be set to [`.VALIDATING`](#FormStatus) (see [useFormStatus](#useFormStatus)).
 - `redirectToUrl?: (url: string) => void`. Will be used by [useTransactionStatus](#useTransactionStatus) if it needs to redirect. If not set, it will change `window.location.href`.
 - `initiallySelectedPaymentMethodId?: string | null`. If set, is used to preselect a payment method on first load or when the `paymentMethods` array changes. Default is `null`, which yields no initial selection. To change the selection in code, see the [`usePaymentMethodId`](#usePaymentMethodId) hook. If a disabled payment method is chosen, it will appear that no payment method is selected.
@@ -205,6 +205,7 @@ Available props:
 
 - `areStepsActive?: boolean`. A boolean you can set to explicitly disable all the steps in the group.
 - `stepAreaHeader?: ReactNode`. A slot for additional components that can be injected at the top of the step group.
+- `loadingContent: ReactNode`. A component that will be displayed while checkout is loading. The default is [LoadingContent](#LoadingContent).
 - `store?: CheckoutStepGroupStore`. A way to inject a data store for the step group created by [createCheckoutStepGroupStore](#createCheckoutStepGroupStore). If not provided, a store will be created automatically.
 
 ### CheckoutSubmitButton
@@ -237,6 +238,10 @@ An enum that holds the values of the [form status](#useFormStatus).
 - `.SUBMITTING`
 - `.VALIDATING`
 - `.COMPLETE`
+
+### LoadingContent
+
+A placeholder used while checkout is initially loading (when [FormStatus](#FormStatus) is `LOADING`). Can be replaced using the `loadingContent` prop of [CheckoutStepGroup](#CheckoutStepGroup).
 
 ### MainContentWrapper
 

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -340,9 +340,11 @@ interface CheckoutStepsProps {
 function CheckoutStepGroupWrapper( {
 	children,
 	className,
+	loadingContent,
 	store,
 }: PropsWithChildren< {
 	className?: string;
+	loadingContent?: ReactNode;
 	store: CheckoutStepGroupStore;
 } > ) {
 	const { isRTL } = useI18n();
@@ -384,7 +386,7 @@ function CheckoutStepGroupWrapper( {
 		return (
 			<CheckoutWrapper className={ classNames }>
 				<MainContentWrapper className={ joinClasses( [ className, 'checkout__content' ] ) }>
-					<LoadingContent />
+					{ loadingContent ? loadingContent : <LoadingContent /> }
 				</MainContentWrapper>
 			</CheckoutWrapper>
 		);
@@ -1146,14 +1148,16 @@ export function CheckoutStepGroup( {
 	areStepsActive,
 	stepAreaHeader,
 	store,
+	loadingContent,
 }: PropsWithChildren< {
 	areStepsActive?: boolean;
 	stepAreaHeader?: ReactNode;
 	store?: CheckoutStepGroupStore;
+	loadingContent?: ReactNode;
 } > ) {
 	const stepGroupStore = useMemo( () => store || createCheckoutStepGroupStore(), [ store ] );
 	return (
-		<CheckoutStepGroupWrapper store={ stepGroupStore }>
+		<CheckoutStepGroupWrapper store={ stepGroupStore } loadingContent={ loadingContent }>
 			{ stepAreaHeader }
 			<CheckoutStepArea>
 				<CheckoutStepGroupInner areStepsActive={ areStepsActive }>

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -202,6 +202,7 @@ const CheckoutWrapper = styled.div`
 export const MainContentWrapper = styled.div`
 	display: flex;
 	flex-direction: column;
+	flex-wrap: wrap;
 	width: 100%;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -30,6 +30,7 @@ import {
 	getDefaultPaymentMethodStep,
 	getDefaultOrderReviewStep,
 } from './components/default-steps';
+import LoadingContent from './components/loading-content';
 import {
 	OrderReviewLineItems,
 	OrderReviewTotal,
@@ -82,6 +83,7 @@ export {
 	CheckoutSummaryArea,
 	CheckoutSummaryCard,
 	InvalidPaymentProcessorResponseError,
+	LoadingContent,
 	MainContentWrapper,
 	OrderReviewLineItems,
 	OrderReviewSection,


### PR DESCRIPTION
## Proposed Changes

This PR modifies the checkout loading page so that if it takes longer than a certain amount of time, the user will see additional text appear. This text will include a description of the current loading step and a link to contact support.

<img width="892" alt="Screenshot 2023-04-27 at 5 48 37 PM" src="https://user-images.githubusercontent.com/2036909/235000251-dff2c002-bcad-4eb7-89e7-26677564c85e.png">

<img width="970" alt="Screenshot 2023-04-28 at 2 31 01 PM" src="https://user-images.githubusercontent.com/2036909/235226085-1042084b-0b2c-431a-b5b6-932b60be1d2b.png">


## Testing Instructions

It's easiest to see this by breaking checkout loading. One way to do that is to apply the following diff and then visiting `/checkout` in calypso on this branch.

```diff
--- a/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods.tsx
@@ -166,7 +166,7 @@ export function useStoredPaymentMethods( {

        return {
                paymentMethods,
-               isLoading: isLoggedOut ? false : isLoading,
+               isLoading: true,
                isDeleting: mutation.isLoading,
                error: errorMessage,
                deletePaymentMethod: deletePaymentMethodAndSimilar,
```