### PR TITLE
Add newsletter status to posts page

### DIFF
--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -198,13 +198,13 @@ class PostRelativeTime extends PureComponent {
 		let extraStatusClassName;
 
 		if ( status === 'everybody' ) {
-			extraStatusClassName = 'is-everybody';
+			extraStatusClassName = 'is-newsletter-everybody';
 			statusText = this.props.translate( 'Everybody' );
 		} else if ( status === 'subscribers' ) {
-			extraStatusClassName = 'is-subscribers';
+			extraStatusClassName = 'is-newsletter-subscribers';
 			statusText = this.props.translate( 'Subscribers' );
 		} else if ( status === 'paid_subscribers' ) {
-			extraStatusClassName = 'is-paid-subcribers';
+			extraStatusClassName = 'is-newsletter-paid-subcribers';
 			statusText = this.props.translate( 'Paid Subscribers' );
 		}
 

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -185,6 +185,34 @@ class PostRelativeTime extends PureComponent {
 	}
 
 	/**
+	 * Get Newsletter status label
+	 *
+	 * @param {string} status Newsletter tatus
+	 */
+	getNewsletterStatus( status ) {
+		if ( ! status ) {
+			return;
+		}
+
+		let statusText;
+		let extraStatusClassName;
+
+		if ( status === 'everybody' ) {
+			extraStatusClassName = 'is-everybody';
+			statusText = this.props.translate( 'Everbody' );
+		} else if ( status === 'future' ) {
+			extraStatusClassName = 'is-subscribers';
+			statusText = this.props.translate( 'Subscribers' );
+		} else if ( status === 'new' ) {
+			extraStatusClassName = 'is-paid-subcribers';
+			statusText = this.props.translate( 'Paid Subscribers' );
+		}
+
+		const statusIcon = 'mail';
+		return this.getLabel( statusText, extraStatusClassName, statusIcon );
+	}
+
+	/**
 	 * Get "private" label
 	 */
 	getPrivateLabel() {
@@ -231,6 +259,8 @@ class PostRelativeTime extends PureComponent {
 		let innerText = (
 			<>
 				{ showPublishedStatus ? this.getStatus() : timeText }
+				{ /* TODO: Figure out why the Jetpack newsletter status is not available */ }
+				{ this.getNewsletterStatus( 'everybody' ) }
 				{ post.status === 'pending' && this.getPendingLabel() }
 				{ post.status === 'private' && this.getPrivateLabel() }
 				{ post.sticky && this.getStickyLabel() }

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -200,10 +200,10 @@ class PostRelativeTime extends PureComponent {
 		if ( status === 'everybody' ) {
 			extraStatusClassName = 'is-everybody';
 			statusText = this.props.translate( 'Everbody' );
-		} else if ( status === 'future' ) {
+		} else if ( status === 'subscribers' ) {
 			extraStatusClassName = 'is-subscribers';
 			statusText = this.props.translate( 'Subscribers' );
-		} else if ( status === 'new' ) {
+		} else if ( status === 'paid_subscribers' ) {
 			extraStatusClassName = 'is-paid-subcribers';
 			statusText = this.props.translate( 'Paid Subscribers' );
 		}
@@ -256,11 +256,15 @@ class PostRelativeTime extends PureComponent {
 	render() {
 		const { showPublishedStatus, post } = this.props;
 		const timeText = this.getTimeText();
+
+		const newletterStatus = post?.metadata?.find(
+			( { key } ) => key === '_jetpack_newsletter_access'
+		)?.value;
+
 		let innerText = (
 			<>
 				{ showPublishedStatus ? this.getStatus() : timeText }
-				{ /* TODO: Figure out why the Jetpack newsletter status is not available */ }
-				{ this.getNewsletterStatus( 'everybody' ) }
+				{ this.getNewsletterStatus( newletterStatus ) }
 				{ post.status === 'pending' && this.getPendingLabel() }
 				{ post.status === 'private' && this.getPrivateLabel() }
 				{ post.sticky && this.getStickyLabel() }

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -199,7 +199,7 @@ class PostRelativeTime extends PureComponent {
 
 		if ( status === 'everybody' ) {
 			extraStatusClassName = 'is-everybody';
-			statusText = this.props.translate( 'Everbody' );
+			statusText = this.props.translate( 'Everybody' );
 		} else if ( status === 'subscribers' ) {
 			extraStatusClassName = 'is-subscribers';
 			statusText = this.props.translate( 'Subscribers' );

--- a/client/my-sites/post-relative-time-status/style.scss
+++ b/client/my-sites/post-relative-time-status/style.scss
@@ -23,9 +23,9 @@
 		color: var(--color-error);
 	}
 	.is-private,
-	.is-everybody,
-	.is-subscribers,
-	.is-paid-subcribers {
+	.is-newsletter-everybody,
+	.is-newsletter-subscribers,
+	.is-newsletter-paid-subcribers {
 		color: var(--color-primary-dark);
 	}
 }

--- a/client/my-sites/post-relative-time-status/style.scss
+++ b/client/my-sites/post-relative-time-status/style.scss
@@ -22,7 +22,10 @@
 	.is-trash {
 		color: var(--color-error);
 	}
-	.is-private {
+	.is-private,
+	.is-everybody,
+	.is-subscribers,
+	.is-paid-subcribers {
 		color: var(--color-primary-dark);
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Relates to https://github.com/Automattic/wp-calypso/issues/75788
Relates to https://github.com/Automattic/jetpack/pull/30172
Relates to https://github.com/Automattic/jetpack/pull/30372

## Proposed Changes

Add newsletter status to post manage page

<img width="1120" alt="Screenshot 2023-05-01 at 10 28 51 AM" src="https://user-images.githubusercontent.com/7076981/235477600-efc02157-eef1-4b8c-9b7b-b4b9188d79ce.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync chances to https://github.com/Automattic/jetpack/pull/30372 to WPCOM
* Sandbox `public-api`
* Go to the post manage page of a blog with newsletter enabled. That is: `http://calypso.localhost:3000/posts/{WPCOM_URL}`
* Notice the newsletter status is displayed next to the post timestamp

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
