### PR TITLE
Add E2E tests for theme switching

### DIFF
--- a/test/e2e/specs/onboarding/theme-switch.ts
+++ b/test/e2e/specs/onboarding/theme-switch.ts
@@ -12,13 +12,14 @@ jest.setTimeout( TIMEOUT_1_HOUR );
 
 describe( DataHelper.createSuiteTitle( 'Theme Switch' ), () => {
 	// twentyeleven
-	const FROM = 'hemingway-rewritten';
+	// const FROM = 'hemingway-rewritten';
 	// const FROM = 'appleton';
-	// const FROM = 'pendant';
+	const FROM = 'pendant';
 
 	// const TO = 'hemingway-rewritten';
 	// const TO = 'pendant';
-	const TO = 'appleton';
+	const TO = 'business';
+	// const TO = 'appleton';
 
 	let page: Page;
 	let selectedDomain: string;
@@ -82,15 +83,18 @@ describe( DataHelper.createSuiteTitle( 'Theme Switch' ), () => {
 		} );
 
 		it( 'Switch the theme', async function () {
-			await page.goto( DataHelper.getCalypsoURL( `/themes/${ TO }/${ selectedDomain }` ) );
+			await page.goto( DataHelper.getCalypsoURL( `/theme/${ TO }/${ selectedDomain }` ) );
 			await page.getByText( 'Activate this design' ).click();
 
 			const themeSwitchModal = '.themes__auto-loading-homepage-modal';
-			await page.locator( themeSwitchModal );
-			await page.waitForTimeout( 2 * 1000 );
-			await page.screenshot( { path: `results/from ${ FROM }/to ${ TO }/0-switch-modal.png` } );
+			if ( await page.locator( themeSwitchModal ).isVisible() ) {
+				await page.waitForTimeout( TIMEOUT_1_HOUR );
+				await page.waitForTimeout( 2 * 1000 );
+				await page.screenshot( { path: `results/from ${ FROM }/to ${ TO }/0-switch-modal.png` } );
 
-			await page.locator( `[data-e2e-button="activeTheme"]` ).click();
+				await page.locator( `[data-e2e-button="activeTheme"]` ).click();
+			}
+
 			await page.waitForTimeout( 1 * 1000 );
 			await page.screenshot( { path: `results/from ${ FROM }/to ${ TO }/1-activated.png` } );
 		} );

--- a/test/e2e/specs/onboarding/theme-switch.ts
+++ b/test/e2e/specs/onboarding/theme-switch.ts
@@ -1,0 +1,134 @@
+/**
+ * @group quarantined
+ */
+
+import { DataHelper, TestAccount } from '@automattic/calypso-e2e';
+import { Browser, Page } from 'playwright';
+
+declare const browser: Browser;
+
+const TIMEOUT_1_HOUR = 60 * 60 * 1000;
+jest.setTimeout( TIMEOUT_1_HOUR );
+
+describe( DataHelper.createSuiteTitle( 'Theme Switch' ), () => {
+	// twentyeleven
+	const FROM = 'hemingway-rewritten';
+	// const FROM = 'appleton';
+	// const FROM = 'pendant';
+
+	// const TO = 'hemingway-rewritten';
+	// const TO = 'pendant';
+	const TO = 'appleton';
+
+	let page: Page;
+	let selectedDomain: string;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+	} );
+
+	describe( `Switch from the ${ FROM } theme to the ${ TO } theme (preserve)`, function () {
+		it( 'Login', async function () {
+			const testAccount = new TestAccount( 'defaultUser' );
+			await testAccount.authenticate( page );
+		} );
+
+		it( 'Select the FROM theme', async function () {
+			await page.goto(
+				DataHelper.getCalypsoURL( '/start/with-theme/user', {
+					theme: FROM,
+					theme_type: 'free',
+				} )
+			);
+		} );
+
+		it( 'Select domain', async function () {
+			await page.fill( 'input[type="search"]', 'test' );
+			const targetItem = await page.waitForSelector(
+				`.domain-suggestion__content:has-text("${ '.wordpress.com' }")`
+			);
+			selectedDomain = await targetItem.waitForSelector( 'h3' ).then( ( el ) => el.innerText() );
+			await targetItem.click();
+			await page.getByText( 'start with a free site' ).click();
+			await page.waitForNavigation( { timeout: 60 * 1000 } );
+		} );
+
+		it( 'Go to the FROM site', async function () {
+			await page.goto( `https://${ selectedDomain }` );
+			await page.waitForTimeout( 1 * 1000 );
+			await page.screenshot( { path: `results/from ${ FROM }/0-site.png`, fullPage: true } );
+
+			await page.goto( DataHelper.getCalypsoURL( `/posts/${ selectedDomain }` ) );
+			await page.waitForTimeout( 1 * 1000 );
+			await page.screenshot( { path: `results/from ${ FROM }/1-posts.png` } );
+
+			await page.goto( DataHelper.getCalypsoURL( `/pages/${ selectedDomain }` ) );
+			await page.waitForTimeout( 1 * 1000 );
+			await page.screenshot( { path: `results/from ${ FROM }/2-pages.png` } );
+			const homepageAsPage = page.locator( '.page__main', {
+				has: page.locator( '.page-card-info__badge-text', { hasText: 'Homepage' } ),
+			} );
+			if ( await homepageAsPage.isVisible() ) {
+				await homepageAsPage.locator( '.page__title' ).click();
+				await page.waitForTimeout( 5 * 1000 );
+				await page.screenshot( {
+					path: `results/from ${ FROM }/to ${ TO }/3-homepage-as-page.png`,
+				} );
+			}
+
+			await page.goto( DataHelper.getCalypsoURL( `/settings/reading/${ selectedDomain }` ) );
+			await page.waitForTimeout( 1 * 1000 );
+			await page.screenshot( { path: `results/from ${ FROM }/4-reading-setting.png` } );
+		} );
+
+		it( 'Switch the theme', async function () {
+			await page.goto( DataHelper.getCalypsoURL( `/themes/${ TO }/${ selectedDomain }` ) );
+			await page.getByText( 'Activate this design' ).click();
+
+			const themeSwitchModal = '.themes__auto-loading-homepage-modal';
+			await page.locator( themeSwitchModal );
+			await page.waitForTimeout( 2 * 1000 );
+			await page.screenshot( { path: `results/from ${ FROM }/to ${ TO }/0-switch-modal.png` } );
+
+			await page.locator( `[data-e2e-button="activeTheme"]` ).click();
+			await page.waitForTimeout( 1 * 1000 );
+			await page.screenshot( { path: `results/from ${ FROM }/to ${ TO }/1-activated.png` } );
+		} );
+
+		it( 'Go to the TO site', async function () {
+			await page.goto( `https://${ selectedDomain }` );
+			await page.waitForTimeout( 1 * 1000 );
+			await page.screenshot( {
+				path: `results/from ${ FROM }/to ${ TO }/2-site.png`,
+				fullPage: true,
+			} );
+
+			await page.goto( DataHelper.getCalypsoURL( `/posts/${ selectedDomain }` ) );
+			await page.waitForTimeout( 1 * 1000 );
+			await page.screenshot( { path: `results/from ${ FROM }/to ${ TO }/3-posts.png` } );
+
+			await page.goto( DataHelper.getCalypsoURL( `/pages/${ selectedDomain }` ) );
+			await page.waitForTimeout( 1 * 1000 );
+			await page.screenshot( { path: `results/from ${ FROM }/to ${ TO }/4-pages.png` } );
+			const homepageAsPage = page.locator( '.page__main', {
+				has: page.locator( '.page-card-info__badge-text', { hasText: 'Homepage' } ),
+			} );
+			if ( await homepageAsPage.isVisible() ) {
+				await homepageAsPage.locator( '.page__title' ).click();
+				// await page.locator( '.edit-post-sidebar' ).isVisible();
+				await page.waitForTimeout( 5 * 1000 );
+				await page.screenshot( {
+					path: `results/from ${ FROM }/to ${ TO }/5-homepage-as-page.png`,
+				} );
+			}
+
+			await page.goto( DataHelper.getCalypsoURL( `/settings/reading/${ selectedDomain }` ) );
+			await page.waitForTimeout( 1 * 1000 );
+			await page.screenshot( { path: `results/from ${ FROM }/to ${ TO }/6-reading-setting.png` } );
+		} );
+
+		it( 'Wait for debug', async function () {
+			await page.waitForTimeout( TIMEOUT_1_HOUR );
+		} );
+	} );
+} );

--- a/test/e2e/specs/onboarding/theme-switch.ts
+++ b/test/e2e/specs/onboarding/theme-switch.ts
@@ -12,14 +12,22 @@ jest.setTimeout( TIMEOUT_1_HOUR );
 
 describe( DataHelper.createSuiteTitle( 'Theme Switch' ), () => {
 	// twentyeleven
-	// const FROM = 'hemingway-rewritten';
-	// const FROM = 'appleton';
-	const FROM = 'pendant';
 
+	// const FROM = 'ames';
+	// const FROM = 'appleton';
+	// const FROM = 'business';
+	// const FROM = 'hemingway-rewritten';
+	const FROM = 'pendant';
+	// const FROM = 'zoologist';
+
+	// const TO = 'ames';
+	// const TO = 'appleton';
+	// const TO = 'business';
 	// const TO = 'hemingway-rewritten';
 	// const TO = 'pendant';
-	const TO = 'business';
-	// const TO = 'appleton';
+	const TO = 'zoologist';
+
+	const preserveMyHomepageContent = false;
 
 	let page: Page;
 	let selectedDomain: string;
@@ -28,7 +36,7 @@ describe( DataHelper.createSuiteTitle( 'Theme Switch' ), () => {
 		page = await browser.newPage();
 	} );
 
-	describe( `Switch from the ${ FROM } theme to the ${ TO } theme (preserve)`, function () {
+	describe( `Switch from the ${ FROM } theme to the ${ TO } theme (preserve my homepage content ${ preserveMyHomepageContent })`, function () {
 		it( 'Login', async function () {
 			const testAccount = new TestAccount( 'defaultUser' );
 			await testAccount.authenticate( page );
@@ -88,7 +96,10 @@ describe( DataHelper.createSuiteTitle( 'Theme Switch' ), () => {
 
 			const themeSwitchModal = '.themes__auto-loading-homepage-modal';
 			if ( await page.locator( themeSwitchModal ).isVisible() ) {
-				await page.waitForTimeout( TIMEOUT_1_HOUR );
+				if ( ! preserveMyHomepageContent ) {
+					await page.getByText( /Replace my homepage content with/ ).click();
+				}
+
 				await page.waitForTimeout( 2 * 1000 );
 				await page.screenshot( { path: `results/from ${ FROM }/to ${ TO }/0-switch-modal.png` } );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This is to test permutations for the Live Preview spike.

Just by running the E2E test, it automatically performs a theme switch and saves a screenshot of the screen we want to confirm instead of manually performing a theme switch every time.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- `yarn workspace wp-e2e-tests build`
- `NODE_ENV=test yarn workspace wp-e2e-tests test -- test/e2e/specs/onboarding/theme-switch.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
