### PR TITLE
[gutenberg-on-dotcom][e2e][at] Change the AT E2E builds to notify results to `#gutenberg-on-dotcom`

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -43,8 +43,8 @@ object WPComTests : Project({
 	buildType(gutenbergPlaywrightBuildType("desktop", "c341e9b9-1118-48e9-a569-325100f5fd9" , atomic=true, edge=false));
 	buildType(gutenbergPlaywrightBuildType("mobile", "e0f7e412-ae6c-41d3-9eec-c57c94dd8385", atomic=true, edge=false));
 	// Gutenberg Atomic Edge
-	buildType(gutenbergPlaywrightBuildType("desktop", "4c66d90d-99c6-4ecb-9507-18bc2f44b551" , atomic=true, edge=true));
-	buildType(gutenbergPlaywrightBuildType("mobile", "ba0f925b-497b-4156-977e-5bfbe94f5744", atomic=true, edge=true));
+	buildType(gutenbergPlaywrightBuildType("desktop", "4c66d90d-99c6-4ecb-9507-18bc2f44b551" , atomic=true, edge=true, slackChannel="#gutenberg-on-dotcom"));
+	buildType(gutenbergPlaywrightBuildType("mobile", "ba0f925b-497b-4156-977e-5bfbe94f5744", atomic=true, edge=true, slackChannel="#gutenberg-on-dotcom"));
 
 	// Editor Tracking
 	buildType(editorTrackingBuildType("desktop", "bd15ed14-e77d-11ec-8fea-0242ac120002", atomic=false, edge=false));
@@ -67,7 +67,7 @@ object WPComTests : Project({
 	buildType(P2E2ETests)
 })
 
-fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomic: Boolean = false, edge: Boolean = false ): E2EBuildType {
+fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomic: Boolean = false, edge: Boolean = false, slackChannel: String = "#gutenberg-e2e" ): E2EBuildType {
 	var siteType = if (atomic) "atomic" else "simple";
 	var edgeType = if (edge) "edge" else "production";
 
@@ -110,7 +110,7 @@ fun gutenbergPlaywrightBuildType( targetDevice: String, buildUuid: String, atomi
 			notifications {
 				notifierSettings = slackNotifier {
 					connection = "PROJECT_EXT_11"
-					sendTo = "#gutenberg-e2e"
+					sendTo = slackChannel
 					messageFormat = verboseMessageFormat {
 						addBranch = true
 						addStatusText = true


### PR DESCRIPTION
## Proposed Changes

Related to PT: p4TIVU-apL-p2#comment-11696 and D107859-code, D109415-code.


After D107859-code is merged and setup to run via `jcron`, the idea is to have the AT tests to be sent to `#gutenberg-on-dotcom` (currently they're all sent to `#gutenberg-e2e`, but this channel is not actively monitored and serves more as a reference of past test runs for all GB-related builds in Calypso). We'll then be monitoring those and if they pass, we'll post the AT upgrade request for that specific GB version. This will effectively detach the upgrade of GB on AT from the simple upgrade (right now, AT is upgraded as part of the simple upgrade and AFTER the simple upgrade is done). That should allow for a faster turnaround for AT deploys and it's totally fine to upgrade AT first, and actually less risky than the current approach, as currently, there's a small window of time when AT has a < version than simple and any simple sites that upgrade during this window of time, run the risk of bugs due to a practical GB "downgrade", this won't be the case anymore.

Once D107859-code and this PR are shipped, we'll need to modify the `gutenbot` scripts to:
* not upgrade the AT testing site + trigger AT E2E builds anymore as part of the `gbtrack` for a simple site release;
* not post the AT upgrade request anymore as part of the `gbtrack` for a simple site release.

There should be a new option in `gbtrack` to announce an AT release, that will post it the upgrade request to the AT P2. This will later be replaced by a slack message that will be posted if all AT builds passed, but for now, we'll manually be posting the AT P2 using `gbtrack`.

## Testing Instructions

* Verify syntax looks alright, scan code for anything abnormal;
* Results from the GB on dotcom AT E2E builds should go to the #gutenberg-on-dotcom Slack channel. AFAIK, this can only be tested once this is merged to `trunk`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?