### PR TITLE
Monthly plan upsell: setup the code for the experiment

### DIFF
--- a/client/lib/user/shared-utils/filter-user-object.js
+++ b/client/lib/user/shared-utils/filter-user-object.js
@@ -32,6 +32,7 @@ const allowedKeys = [
 	'lasagna_jwt',
 	'i18n_empathy_mode',
 	'use_fallback_for_incomplete_languages',
+	'calypso_postpurchase_upsell_monthly_to_annual_plan',
 ];
 const requiredKeys = [ 'ID' ];
 const decodedKeys = [ 'display_name', 'description', 'user_URL' ];

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -44,4 +44,5 @@ export type OptionalUserData = {
 	username: string;
 	visible_site_count: number;
 	jetpack_visible_site_count?: number;
+	calypso_postpurchase_upsell_monthly_to_annual_plan?: boolean;
 };

--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -16,6 +16,7 @@ import {
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { clearPurchases } from 'calypso/state/purchases/actions';
 import { fetchReceiptCompleted } from 'calypso/state/receipts/actions';
+import { isMonthlyToAnnualPostPurchaseExperimentUser } from 'calypso/state/selectors/is-monthly-to-annual-post-purchase-experiment-user';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { requestSite } from 'calypso/state/sites/actions';
 import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
@@ -97,6 +98,9 @@ export default function useCreatePaymentCompleteCallback( {
 	);
 
 	const domains = useSiteDomains( siteId ?? undefined );
+	const monthlyToAnnualPostPurchaseExperimentUser = useSelector( ( state ) =>
+		isMonthlyToAnnualPostPurchaseExperimentUser( state )
+	);
 
 	return useCallback(
 		( { paymentMethodId, transactionLastResponse }: PaymentEventCallbackArguments ): void => {
@@ -132,6 +136,7 @@ export default function useCreatePaymentCompleteCallback( {
 				jetpackTemporarySiteId,
 				adminPageRedirect,
 				domains,
+				monthlyToAnnualPostPurchaseExperimentUser,
 			};
 
 			debug( 'getThankYouUrl called with', getThankYouPageUrlArguments );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-get-thank-you-url/index.tsx
@@ -2,6 +2,7 @@ import debugFactory from 'debug';
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/get-thank-you-page-url';
+import { isMonthlyToAnnualPostPurchaseExperimentUser } from 'calypso/state/selectors/is-monthly-to-annual-post-purchase-experiment-user';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
@@ -40,6 +41,10 @@ export default function useGetThankYouUrl( {
 }: GetThankYouUrlProps ): GetThankYouUrl {
 	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
 
+	const monthlyToAnnualPostPurchaseExperimentUser = useSelector( ( state ) =>
+		isMonthlyToAnnualPostPurchaseExperimentUser( state )
+	);
+
 	const adminUrl = selectedSiteData?.options?.admin_url;
 
 	const getThankYouUrl = useCallback( () => {
@@ -56,6 +61,7 @@ export default function useGetThankYouUrl( {
 			hideNudge,
 			isInModal,
 			domains,
+			monthlyToAnnualPostPurchaseExperimentUser,
 		};
 
 		debug( 'getThankYouUrl called with', getThankYouPageUrlArguments );
@@ -76,6 +82,7 @@ export default function useGetThankYouUrl( {
 		hideNudge,
 		sitelessCheckoutType,
 		domains,
+		monthlyToAnnualPostPurchaseExperimentUser,
 	] );
 	return getThankYouUrl;
 }

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -99,7 +99,7 @@ export interface PostCheckoutUrlArguments {
 	jetpackTemporarySiteId?: string;
 	adminPageRedirect?: string;
 	domains?: ResponseDomain[];
-	monthlyToAnnualPostPurchaseExperimentUser?: boolean;
+	monthlyToAnnualPostPurchaseExperimentUser: boolean;
 }
 
 /**
@@ -654,7 +654,7 @@ function getRedirectUrlForPostCheckoutUpsell( {
 	hideUpsell: boolean;
 	domains: ResponseDomain[] | undefined;
 	isDomainOnly?: boolean;
-	monthlyToAnnualPostPurchaseExperimentUser?: boolean;
+	monthlyToAnnualPostPurchaseExperimentUser: boolean;
 } ): string | undefined {
 	if ( hideUpsell ) {
 		return;

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -99,7 +99,7 @@ export interface PostCheckoutUrlArguments {
 	jetpackTemporarySiteId?: string;
 	adminPageRedirect?: string;
 	domains?: ResponseDomain[];
-	monthlyToAnnualPostPurchaseExperimentUser: boolean;
+	monthlyToAnnualPostPurchaseExperimentUser?: boolean;
 }
 
 /**
@@ -577,7 +577,7 @@ function getFallbackDestination( {
  */
 function getNextHigherPlanSlug(
 	cart: ResponseCart,
-	monthlyToAnnualPostPurchaseExperimentUser: boolean
+	monthlyToAnnualPostPurchaseExperimentUser?: boolean
 ): string | undefined {
 	const currentPlanSlug = cart && getAllCartItems( cart ).filter( isPlan )[ 0 ]?.product_slug;
 	if ( ! currentPlanSlug ) {
@@ -612,7 +612,7 @@ function getPlanUpgradeUpsellUrl( {
 	receiptId: ReceiptId | ReceiptIdPlaceholder;
 	cart: ResponseCart | undefined;
 	siteSlug: string | undefined;
-	monthlyToAnnualPostPurchaseExperimentUser: boolean;
+	monthlyToAnnualPostPurchaseExperimentUser?: boolean;
 } ): string | undefined {
 	if ( ! siteSlug ) {
 		return;
@@ -654,7 +654,7 @@ function getRedirectUrlForPostCheckoutUpsell( {
 	hideUpsell: boolean;
 	domains: ResponseDomain[] | undefined;
 	isDomainOnly?: boolean;
-	monthlyToAnnualPostPurchaseExperimentUser: boolean;
+	monthlyToAnnualPostPurchaseExperimentUser?: boolean;
 } ): string | undefined {
 	if ( hideUpsell ) {
 		return;

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -3,7 +3,6 @@
  *
  * @jest-environment jsdom
  */
-import config from '@automattic/calypso-config';
 import {
 	JETPACK_REDIRECT_URL,
 	GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY,
@@ -31,12 +30,6 @@ jest.mock( '@automattic/calypso-products', () => ( {
 	...( jest.requireActual( '@automattic/calypso-products' ) as object ),
 	redirectCheckoutToWpAdmin: jest.fn(),
 } ) );
-const mockConfig = config as unknown as { isEnabled: jest.Mock };
-jest.mock( '@automattic/calypso-config', () => {
-	const mock = () => '';
-	mock.isEnabled = jest.fn();
-	return mock;
-} );
 
 const samplePurchaseId = 12342424241;
 
@@ -140,9 +133,7 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/business/:receiptId' );
 	} );
 
-	it( 'redirects to premium plan annual upsell when feature upsell/monthly-to-annual is set and the cart contains the premium monthly plan', () => {
-		mockConfig.isEnabled.mockImplementation( ( flag ) => flag === 'upsell/monthly-to-annual' );
-
+	it( 'redirects to premium plan annual upsell when user belongs to calypso_postpurchase_upsell_monthly_to_annual_plan experiment and the cart contains the premium monthly plan', () => {
 		const cart = {
 			...getMockCart(),
 			products: [
@@ -156,9 +147,9 @@ describe( 'getThankYouPageUrl', () => {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
+			monthlyToAnnualPostPurchaseExperimentUser: true,
 		} );
 		expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/value_bundle/:receiptId' );
-		mockConfig.isEnabled.mockImplementation( ( flag ) => flag !== 'upsell/monthly-to-annual' );
 	} );
 
 	it( 'redirects to the thank-you page with a placeholder receiptId with a site when the cart is not empty but there is no receipt id', () => {

--- a/client/state/selectors/is-monthly-to-annual-post-purchase-experiment-user.js
+++ b/client/state/selectors/is-monthly-to-annual-post-purchase-experiment-user.js
@@ -1,0 +1,13 @@
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+
+/**
+ * Whether the user is in the Monthly To Annual Post Purchase experiment.
+ *
+ * @param state {object} Global state tree.
+ * @returns {boolean} Whether the user is in the Monthly To Annual Post Purchase experiment.
+ */
+export const isMonthlyToAnnualPostPurchaseExperimentUser = ( state ) => {
+	const currentUser = getCurrentUser( state );
+
+	return 'treatment' === currentUser?.calypso_postpurchase_upsell_monthly_to_annual_plan;
+};


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2196

## Proposed Changes

The experiment post is here: pbxNRc-2tB-p2
Experiment: `calypso_postpurchase_upsell_monthly_to_annual_plan`

#### Acceptance criteria:
- [ ] Setup the experiment code
- [ ] `treatment` should load the annual plan upsell
- [ ] `control` should see no upsell

## Testing Instructions

* Apply the diff (D109282-code)
* Change your variation to `treatment` at the experiment `calypso_postpurchase_upsell_monthly_to_annual_plan` following these tips: pb5gDS-2nD-p2#connecting-an-experiment-to-a-jitm
* Go to `/plans/monthly/:siteSlug` with an account on free plan
* Upgrade to a paid monthly plan.
* Should redirect to temporary upsell placeholder page with "THIS IS THE UPSELL" on top
* check the :plan in the URL and make sure it's the corresponding annual plan `/checkout/:siteSlug/offer-plan-upgrade/:plan/:receipt`
* Test for personal, premium, business plans
* Test around with other checkout flows to make sure nothing is affected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?