### PR TITLE
Site Logs: The correct log entry stays expanded after logs are refreshed

### DIFF
--- a/client/my-sites/site-logs/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/index.tsx
@@ -23,11 +23,15 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 	const columns = useSiteColumns( logs );
 	const siteGmtOffset = useCurrentSiteGmtOffset();
 
-	if ( isLoading && ! logs?.length ) {
+	const logsWithKeys = useMemo( () => {
+		return generateRowKeys( logs );
+	}, [ logs ] );
+
+	if ( isLoading && ! logsWithKeys.length ) {
 		return <Skeleton />;
 	}
 
-	if ( ! isLoading && ! logs?.length ) {
+	if ( ! isLoading && ! logsWithKeys.length ) {
 		return <>{ __( 'No log entries within this time range.' ) }</>;
 	}
 
@@ -42,11 +46,9 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 				</tr>
 			</thead>
 			<tbody>
-				{ logs?.map( ( log, index ) => (
-					// An index key is ok in this case because it's just as unique to the log entry as a
-					// time stamp.
+				{ logsWithKeys.map( ( [ log, key ] ) => (
 					<SiteLogsTableRow
-						key={ index }
+						key={ key }
 						columns={ columns }
 						log={ log }
 						siteGmtOffset={ siteGmtOffset }
@@ -56,6 +58,41 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 		</table>
 	);
 } );
+
+/**
+ * Generates a unique key for each row in the table. The timestamp alone isn't unique enough (the
+ * PHP logs have a resolution of 1 second, so multiple entries can have the same timestamp), so we
+ * also include the order the logs appear as part of the key.
+ *
+ * If we're unlucky there's a chance that logs with the same timestamp appear across multiple fetches,
+ * in which case our keys will be wrong. But this is the best I think we can come up with without
+ * the logging API returning a proper ID for each log entry.
+ */
+function generateRowKeys( logs: SiteLogs = [] ): [ SiteLogs[ 0 ], React.Key ][] {
+	let previousKey: React.Key;
+	let count = 0;
+	return logs.map( ( log, index ) => {
+		const key = generateRowKey( log, index );
+		if ( previousKey !== key ) {
+			count = 0;
+		}
+		count++;
+		previousKey = key;
+		return [ log, `${ key }${ count }` ];
+	} );
+}
+
+function generateRowKey( log: SiteLogs[ 0 ], index: number ): React.Key {
+	if ( typeof log[ 'date' ] === 'string' || typeof log[ 'date' ] === 'number' ) {
+		return log[ 'date' ];
+	}
+	if ( typeof log[ 'timestamp' ] === 'string' || typeof log[ 'timestamp' ] === 'number' ) {
+		return log[ 'timestamp' ];
+	}
+
+	// We don't recognise this log format, but we need to fallback to something.
+	return index;
+}
 
 function useSiteColumns( logs: SiteLogs | undefined ) {
 	return useMemo( () => {

--- a/client/my-sites/site-logs/components/site-logs-table/site-logs-table-row.tsx
+++ b/client/my-sites/site-logs/components/site-logs-table/site-logs-table-row.tsx
@@ -1,7 +1,9 @@
 import { Button } from '@automattic/components';
 import { Icon, chevronDown, chevronRight } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import moment from 'moment';
-import { Fragment, useState } from 'react';
+import { Fragment, useRef, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { SiteLogsData } from 'calypso/data/hosting/use-site-logs-query';
 import SiteLogsExpandedContent from './site-logs-expanded-content';
@@ -14,12 +16,22 @@ interface Props {
 }
 
 export default function SiteLogsTableRow( { columns, log, siteGmtOffset }: Props ) {
+	const { __ } = useI18n();
 	const [ isExpanded, setIsExpanded ] = useState( false );
+	const expandedId = useRef( uuidv4() ).current;
+
 	return (
 		<Fragment>
 			<tr>
 				<td>
-					<Button borderless onClick={ () => setIsExpanded( ! isExpanded ) } compact>
+					<Button
+						borderless
+						onClick={ () => setIsExpanded( ! isExpanded ) }
+						compact
+						aria-label={ __( 'Expand row' ) }
+						aria-expanded={ isExpanded }
+						aria-controls={ expandedId }
+					>
 						<Icon icon={ isExpanded ? chevronDown : chevronRight } />
 					</Button>
 				</td>
@@ -29,7 +41,7 @@ export default function SiteLogsTableRow( { columns, log, siteGmtOffset }: Props
 			</tr>
 
 			{ isExpanded && (
-				<tr className="site-logs-table__table-row-expanded">
+				<tr className="site-logs-table__table-row-expanded" id={ expandedId }>
 					<td colSpan={ Object.keys( log ).length + 1 }>
 						<SiteLogsExpandedContent log={ log } />
 					</td>

--- a/client/my-sites/site-logs/test/main.tsx
+++ b/client/my-sites/site-logs/test/main.tsx
@@ -16,7 +16,7 @@ import { SiteLogs } from '../main';
 // Mock it for now to avoid the error.
 jest.mock( 'page' );
 
-// Mock matchMedia in DateRange component
+// Mock matchMedia, used in Gutenberg components
 Object.defineProperty( window, 'matchMedia', {
 	value: jest.fn( () => {
 		return {

--- a/client/my-sites/site-logs/test/site-logs-table.tsx
+++ b/client/my-sites/site-logs/test/site-logs-table.tsx
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import siteSettings from 'calypso/state/site-settings/reducer';
+import { reducer as ui } from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { SiteLogsTable } from '../components/site-logs-table';
+
+const render = ( el, options = {} ) =>
+	renderWithProvider( el, { ...options, reducers: { ui, siteSettings } } );
+
+test( `each row is expandable independently`, async () => {
+	const logs = [
+		{ message: 'one', date: '2023-03-24T04:36:04.238Z' },
+		{ message: 'two', date: '2023-03-24T04:36:04.123Z' },
+	];
+
+	const { container } = render( <SiteLogsTable logs={ logs } isLoading={ false } /> );
+
+	const expandButtons = await waitFor( () =>
+		screen.getAllByRole( 'button', { expanded: false, name: 'Expand row' } )
+	);
+
+	expect( container.querySelector( '.site-logs-table__expanded-content' ) ).not.toBeInTheDocument();
+
+	await userEvent.click( expandButtons[ 0 ] );
+
+	await ( () => {
+		expect( expandButtons[ 0 ] ).toHaveAttribute( 'aria-expanded', 'true' );
+		expect( expandButtons[ 1 ] ).toHaveAttribute( 'aria-expanded', 'false' );
+		expect(
+			container.querySelector( 'tr:first-child .site-logs-table__expanded-content' )
+		).toBeInTheDocument();
+		expect(
+			container.querySelector( 'tr:last-child .site-logs-table__expanded-content' )
+		).not.toBeInTheDocument();
+	} );
+
+	await userEvent.click( expandButtons[ 1 ] );
+
+	await ( () => {
+		expect( expandButtons[ 0 ] ).toHaveAttribute( 'aria-expanded', 'true' );
+		expect( expandButtons[ 1 ] ).toHaveAttribute( 'aria-expanded', 'true' );
+		expect(
+			container.querySelector( 'tr:first-child .site-logs-table__expanded-content' )
+		).toBeInTheDocument();
+		expect(
+			container.querySelector( 'tr:last-child .site-logs-table__expanded-content' )
+		).toBeInTheDocument();
+	} );
+
+	await userEvent.click( expandButtons[ 0 ] );
+
+	await ( () => {
+		expect( expandButtons[ 0 ] ).toHaveAttribute( 'aria-expanded', 'false' );
+		expect( expandButtons[ 1 ] ).toHaveAttribute( 'aria-expanded', 'true' );
+		expect(
+			container.querySelector( 'tr:first-child .site-logs-table__expanded-content' )
+		).not.toBeInTheDocument();
+		expect(
+			container.querySelector( 'tr:last-child .site-logs-table__expanded-content' )
+		).toBeInTheDocument();
+	} );
+} );
+
+test( `rows keep their expanded state after logs are updated`, async () => {
+	const logs = [
+		// Note: these two entries have the same timestamp
+		{ message: 'one', date: '2023-03-24T04:36:04.238Z' },
+		{ message: 'two', date: '2023-03-24T04:36:04.238Z' },
+	];
+
+	const { rerender } = render( <SiteLogsTable logs={ logs } isLoading={ false } /> );
+
+	await userEvent.click( screen.getAllByRole( 'button', { name: 'Expand row' } )[ 0 ] );
+
+	const updatedLogs = [ { message: 'latest', date: '2023-03-24T04:37:00.000Z' }, ...logs ];
+
+	rerender( <SiteLogsTable logs={ updatedLogs } isLoading={ false } /> );
+
+	const expandButtons = await waitFor( () =>
+		screen.getAllByRole( 'button', { name: 'Expand row' } )
+	);
+
+	expect( expandButtons ).toHaveLength( 3 );
+	expect( expandButtons[ 0 ] ).toHaveAttribute( 'aria-expanded', 'false' );
+	expect( expandButtons[ 1 ] ).toHaveAttribute( 'aria-expanded', 'true' );
+	expect( expandButtons[ 2 ] ).toHaveAttribute( 'aria-expanded', 'false' );
+} );

--- a/client/my-sites/site-logs/test/site-logs-table.tsx
+++ b/client/my-sites/site-logs/test/site-logs-table.tsx
@@ -4,7 +4,6 @@
 
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import siteSettings from 'calypso/state/site-settings/reducer';
 import { reducer as ui } from 'calypso/state/ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

**Note to translators**: the **Expand row** text is the accessible label given to this button
![CleanShot 2023-05-01 at 11 12 02@2x](https://user-images.githubusercontent.com/1500769/235380374-13454b8e-3c64-4b20-8263-ee79abd289dd.png)


## Proposed Changes

The site logs table currently uses a simple index as the React key. This worked fine when the table was one giant component. But now that each row is its own component with its own state (which we changed when introducing the expand button) it means we need a proper key.

That's because it creates this issue:
- expand the first row
- do something that causes other logs to be recorded
- wait for the site logs to auto refresh
- see that the _new_ first row is expanded and the previously expanded log entry has been collapsed

The timestamp would do a good job as a unique ID, except that for the PHP logs it only goes down to the nearest second, and so there are usually multiple log entries with an identical timestamp. So the new key takes the order of logs with identical timestamps into account too.

Here's what the fixed table looks like.

https://user-images.githubusercontent.com/1500769/235061023-cfc710b4-748b-4b6d-95a9-6fafaa684c5e.mov



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- expand the first row
- do something that causes other logs to be recorded
- wait for the site logs to auto refresh
- see that the new rows are collapsed and the previously expanded log entries are still expanded
