### PR TITLE
Experiment: Use nextDomainIsFree to correctly show messages about included domains in checkout for tailored signup flows

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.tsx
@@ -178,7 +178,12 @@ function CheckoutSummaryFeaturesWrapper( props: {
 	}
 
 	if ( signupFlowName && shouldUseFlowFeatureList ) {
-		return <CheckoutSummaryFlowFeaturesList flowName={ signupFlowName } />;
+		return (
+			<CheckoutSummaryFlowFeaturesList
+				flowName={ signupFlowName }
+				nextDomainIsFree={ nextDomainIsFree }
+			/>
+		);
 	}
 
 	return <CheckoutSummaryFeaturesList siteId={ siteId } nextDomainIsFree={ nextDomainIsFree } />;
@@ -379,14 +384,34 @@ function CheckoutSummaryFeaturesList( props: {
 	);
 }
 
-function CheckoutSummaryFlowFeaturesList( { flowName }: { flowName: string } ) {
+function CheckoutSummaryFlowFeaturesList( props: { flowName: string; nextDomainIsFree: boolean } ) {
+	const { flowName, nextDomainIsFree } = props;
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const planInCart = responseCart.products.find( ( product ) => isPlan( product ) );
-	const planFeatures = getFlowPlanFeatures( flowName, planInCart );
+	const hasDomainsInCart = responseCart.products.some(
+		( product ) => isDomainProduct( product ) || isDomainTransfer( product )
+	);
+	const domains = responseCart.products.filter(
+		( product ) => isDomainProduct( product ) || isDomainTransfer( product )
+	);
+	const hasRenewalInCart = responseCart.products.some(
+		( product ) => product.extra.purchaseType === 'renewal'
+	);
+	const planFeatures = getFlowPlanFeatures(
+		flowName,
+		planInCart,
+		hasDomainsInCart,
+		hasRenewalInCart,
+		nextDomainIsFree
+	);
 
 	return (
 		<CheckoutSummaryFeaturesListWrapper>
+			{ hasDomainsInCart &&
+				domains.map( ( domain ) => {
+					return <CheckoutSummaryFeaturesListDomainItem domain={ domain } key={ domain.uuid } />;
+				} ) }
 			{ planFeatures.map( ( feature ) => {
 				return (
 					<CheckoutSummaryFeaturesListItem key={ `feature-list-${ feature.getSlug() }` }>

--- a/client/my-sites/checkout/composite-checkout/lib/get-flow-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-flow-plan-features.ts
@@ -1,4 +1,4 @@
-import { getPlan } from '@automattic/calypso-products';
+import { getPlan, FEATURE_CUSTOM_DOMAIN } from '@automattic/calypso-products';
 import { ResponseCartProduct } from '@automattic/shopping-cart';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import {

--- a/client/my-sites/checkout/composite-checkout/lib/get-flow-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-flow-plan-features.ts
@@ -39,7 +39,7 @@ export default function getFlowPlanFeatures(
 	const showFreeDomainFeature = ! hasDomainsInCart && ! hasRenewalInCart && nextDomainIsFree;
 	return getPlanFeaturesObject( featureAccessor() )
 		.filter( ( feature ) => {
-			return showFreeDomainFeature || feature.get_slug() !== FEATURE_CUSTOM_DOMAIN;
+			return showFreeDomainFeature || feature.getSlug() !== FEATURE_CUSTOM_DOMAIN;
 		} )
 		.map( ( feature ) => {
 			return {

--- a/client/my-sites/checkout/composite-checkout/lib/get-flow-plan-features.ts
+++ b/client/my-sites/checkout/composite-checkout/lib/get-flow-plan-features.ts
@@ -8,7 +8,10 @@ import {
 
 export default function getFlowPlanFeatures(
 	flowName: string,
-	plan: ResponseCartProduct | undefined
+	plan: ResponseCartProduct | undefined,
+	hasDomainsInCart: boolean,
+	hasRenewalInCart: boolean,
+	nextDomainIsFree: boolean
 ) {
 	const productSlug = plan?.product_slug;
 
@@ -33,10 +36,15 @@ export default function getFlowPlanFeatures(
 	}
 
 	const highlightedFeatures = getHighlightedFeatures( flowName, planConstantObj );
-	return getPlanFeaturesObject( featureAccessor() ).map( ( feature ) => {
-		return {
-			...feature,
-			isHighlightedFeature: highlightedFeatures.includes( feature.getSlug() ),
-		};
-	} );
+	const showFreeDomainFeature = ! hasDomainsInCart && ! hasRenewalInCart && nextDomainIsFree;
+	return getPlanFeaturesObject( featureAccessor() )
+		.filter( ( feature ) => {
+			return showFreeDomainFeature || feature.get_slug() !== FEATURE_CUSTOM_DOMAIN;
+		} )
+		.map( ( feature ) => {
+			return {
+				...feature,
+				isHighlightedFeature: highlightedFeatures.includes( feature.getSlug() ),
+			};
+		} );
 }


### PR DESCRIPTION
This is an experiment to try some code (which could be added on to https://github.com/Automattic/wp-calypso/pull/75777) that specifically handles correctly showing the message about included domains in tailored signup flows.

It uses `nextDomainIsFree` (which ultimately comes from the server) as the source of truth about whether the domain is free, and borrows other code from the main signup flow to make it work correctly also.

I suspect this should be merged into https://github.com/Automattic/wp-calypso/pull/75777 rather than deployed on its own, but it can be tested on its own for now.

## Testing Instructions

This can be tested by starting at `/setup/link-in-bio` (it's possible to test the other flows too, I guess).

There are four different combinations to try during signup:
- Monthly plan and a custom domain
- Monthly plan and no custom domain
- Yearly plan and a custom domain
- Yearly plan and no custom domain

In each case, the top of the "Included with your purchase" section of checkout should make sense for the particular scenario (especially the fact that monthly plans don't come with a free domain for the first year but yearly plans do).

**Screenshots of the behavior with this pull request:**

(Note that without this pull request, all scenarios incorrectly look like the "Yearly plan and no custom domain" case.)

- Monthly plan and a custom domain

![monthly-with-domain](https://user-images.githubusercontent.com/235183/235069350-5f680f42-6883-44a6-a229-9e98a0597939.png)

- Monthly plan and no custom domain

![monthly-no-domain](https://user-images.githubusercontent.com/235183/235069386-b3522cab-1b3e-4be4-be52-4a3498b62ceb.png)

- Yearly plan and a custom domain

![yearly-with-domain](https://user-images.githubusercontent.com/235183/235069420-dcd27547-1fe2-47e2-bfb1-0f1f8c90d2da.png)

- Yearly plan and no custom domain

![yearly-no-domain](https://user-images.githubusercontent.com/235183/235069439-81e0f013-36b6-47ab-a75d-8a6690b02665.png)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
