### PR TITLE
Jetpack Pro Dashboard: Add a feature flag for the multiple email recipients for the downtime monitoring project

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
@@ -1,0 +1,8 @@
+export default function ConfigureEmailNotification() {
+	return (
+		<>
+			<br />
+			Coming Soon
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { Modal, ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -10,6 +11,7 @@ import {
 	getSiteCountText,
 	mobileAppLink,
 } from '../../sites-overview/utils';
+import ConfigureEmailNotification from '../configure-email-notification';
 import type { MonitorSettings, Site } from '../../sites-overview/types';
 
 import './style.scss';
@@ -99,6 +101,10 @@ export default function NotificationSettings( {
 		}
 	}, [ isComplete, onClose ] );
 
+	const isMultipleEmailEnabled = isEnabled(
+		'jetpack/pro-dashboard-monitor-multiple-email-recipients'
+	);
+
 	return (
 		<Modal
 			open={ true }
@@ -186,11 +192,20 @@ export default function NotificationSettings( {
 						</div>
 						<div className="notification-settings__toggle-content">
 							<div className="notification-settings__content-heading">{ translate( 'Email' ) }</div>
-							<div className="notification-settings__content-sub-heading">
-								{ translate( 'Receive email notifications with your account email address %s.', {
-									args: addedEmailAddresses,
-								} ) }
-							</div>
+							{ isMultipleEmailEnabled ? (
+								<>
+									<div className="notification-settings__content-sub-heading">
+										{ translate( 'Receive email notifications with one or more recipients.' ) }
+									</div>
+									{ enableEmailNotification && <ConfigureEmailNotification /> }
+								</>
+							) : (
+								<div className="notification-settings__content-sub-heading">
+									{ translate( 'Receive email notifications with your account email address %s.', {
+										args: addedEmailAddresses,
+									} ) }
+								</div>
+							) }
 						</div>
 					</div>
 				</div>

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -50,6 +50,7 @@
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": true,
+		"jetpack/pro-dashboard-monitor-multiple-email-recipients": true,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -44,6 +44,7 @@
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": false,
+		"jetpack/pro-dashboard-monitor-multiple-email-recipients": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -47,6 +47,7 @@
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": false,
+		"jetpack/pro-dashboard-monitor-multiple-email-recipients": false,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -47,6 +47,7 @@
 		"jetpack/pricing-page": true,
 		"jetpack/pricing-page-annual-only": true,
 		"jetpack/pro-dashboard-jetpack-boost": false,
+		"jetpack/pro-dashboard-monitor-multiple-email-recipients": false,
 		"jetpack/search-product": true,
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,


### PR DESCRIPTION
Related to 1204408201748644-as-1204493271132971

## Proposed Changes

The PR adds a feature flag for the multiple email recipients for the downtime monitoring project.

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/monitor-multiple-email-feature-flag` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Verify that you can see the `Coming Soon` text as shown below.

<img width="448" alt="Screenshot 2023-04-28 at 1 09 36 PM" src="https://user-images.githubusercontent.com/10586875/235087558-3c9808ce-b63f-4c89-9a34-c51ef5a69d2e.png">

6. Open the config/jetpack-cloud-development.json file and verify that the `jetpack/pro-dashboard-monitor-multiple-email-recipients` flag is set to true
7. Open the following files and verify that the value for the `jetpack/pro-dashboard-monitor-multiple-email-recipients` flag is set to false:
- config/jetpack-cloud-horizon.json
- config/jetpack-cloud-production.json
- config/jetpack-cloud-stage.json


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?