### PR TITLE
With theme flow: Fix the with-theme theme_type queryParam

### DIFF
--- a/client/state/themes/selectors/get-theme-signup-url.js
+++ b/client/state/themes/selectors/get-theme-signup-url.js
@@ -2,6 +2,7 @@ import { doesThemeBundleSoftwareSet } from 'calypso/state/themes/selectors/does-
 import { isExternallyManagedTheme } from 'calypso/state/themes/selectors/is-externally-managed-theme';
 import { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 import 'calypso/state/themes/init';
+import { isWpcomTheme } from 'calypso/state/themes/selectors/is-wpcom-theme';
 import { isWporgTheme } from 'calypso/state/themes/selectors/is-wporg-theme';
 
 /**
@@ -57,6 +58,10 @@ function getThemeTypeUrlParameter( state, themeId ) {
 		return 'premium';
 	}
 
+	if ( isWpcomTheme( state, themeId ) && ! isThemePremium( state, themeId ) ) {
+		return 'free';
+	}
+
 	/**
 	 * Is .ORG theme.
 	 */
@@ -64,5 +69,8 @@ function getThemeTypeUrlParameter( state, themeId ) {
 		return 'dot-org';
 	}
 
+	/**
+	 * Unhandled type, fallback to free.
+	 */
 	return 'free';
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fix the theme_type query parameter for the start/with-theme flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link and go incognito
* Search for TT3
* Click on the theme details page
* Notice that the `Pick design` button has a URL with a `theme_type` queryParam with the value `free`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
