### PR TITLE
Theme showcase: Fix upgrade link for Premium themes in the tooltip

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -261,6 +261,8 @@ export class Theme extends Component {
 	goToCheckout = ( plan = 'premium' ) => {
 		const { siteSlug } = this.props;
 
+		this.props.recordTracksEvent( 'calypso_theme_tooltip_upgrade_nudge_click', { plan } );
+
 		if ( siteSlug ) {
 			const params = new URLSearchParams();
 			params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );
@@ -331,7 +333,7 @@ export class Theme extends Component {
 					'You have a subscription for this theme, but it will only be usable if you have the <link>Business plan</link> on your site.'
 				),
 				{
-					link: <LinkButton isLink onClic={ () => this.goToCheckout( 'business' ) } />,
+					link: <LinkButton isLink onClick={ () => this.goToCheckout( 'business' ) } />,
 				}
 			);
 		} else if ( isExternallyManagedTheme && ! isSiteEligibleForManagedExternalThemes ) {
@@ -396,7 +398,7 @@ export class Theme extends Component {
 				}
 			),
 			{
-				Link: <LinkButton isLink onClick={ this.goToCheckout } />,
+				Link: <LinkButton isLink onClick={ () => this.goToCheckout( 'premium' ) } />,
 			}
 		);
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Fix the upgrade link for Premium themes in Themeshowcase, in the tooltip we display on each theme 
* Add a new event that tracks the number of clicks on this link.

## Out-of-scope
Currently, this issue is reproducing on the logged-out page too. In this scenario, we'll need a bit more effort since we'll need to change the path to /start/with-theme.

For this, we'll need a separate PR. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link
* Go to Themes
* Search for a Premium theme
* Move the cursor on top of a "Premium" label
* Open devTools
* A tooltip should appear
* Click on the "Premium" link
* You should be redirected to checkout with a Premium subscription added
* You should notice that we trigger a new event called `calypso_theme_tooltip_upgrade_nudge_click` that has a `plan` prop

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
