### PR TITLE
Theme Showcase: Fix the logic of when to show the community badge

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -27,6 +27,7 @@ import {
 	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
 	isThemePremium as getIsThemePremium,
 	isThemePurchased,
+	isWpcomTheme as getIsWpcomTheme,
 	isWporgTheme as getIsWporgTheme,
 } from 'calypso/state/themes/selectors';
 import { setThemesBookmark } from 'calypso/state/themes/themes-ui/actions';
@@ -303,7 +304,7 @@ export class Theme extends Component {
 			isSiteEligibleForBundledSoftware,
 			isExternallyManagedTheme,
 			isSiteEligibleForManagedExternalThemes,
-			isWporgTheme,
+			isWporgOnlyTheme,
 			themeSubscriptionPrices,
 		} = this.props;
 
@@ -374,7 +375,7 @@ export class Theme extends Component {
 					Link: <LinkButton isLink onClick={ () => this.goToCheckout( 'business' ) } />,
 				}
 			);
-		} else if ( isWporgTheme ) {
+		} else if ( isWporgOnlyTheme ) {
 			return createInterpolateElement(
 				translate(
 					'This community theme can only be installed if you have the <Link>Business plan</Link> or higher on your site.'
@@ -402,10 +403,10 @@ export class Theme extends Component {
 	};
 
 	getUpsellHeader = () => {
-		const { doesThemeBundleSoftwareSet, isExternallyManagedTheme, isWporgTheme, translate } =
+		const { doesThemeBundleSoftwareSet, isExternallyManagedTheme, isWporgOnlyTheme, translate } =
 			this.props;
 
-		if ( isWporgTheme ) {
+		if ( isWporgOnlyTheme ) {
 			return translate( 'Community theme', {
 				context: 'This theme is developed and supported by a community',
 				textOnly: true,
@@ -443,7 +444,7 @@ export class Theme extends Component {
 	};
 
 	getPremiumThemeBadge = () => {
-		const { doesThemeBundleSoftwareSet, isExternallyManagedTheme, isWporgTheme, translate } =
+		const { doesThemeBundleSoftwareSet, isExternallyManagedTheme, isWporgOnlyTheme, translate } =
 			this.props;
 
 		const commonProps = {
@@ -453,7 +454,7 @@ export class Theme extends Component {
 			tooltipPosition: 'top',
 		};
 
-		if ( isWporgTheme ) {
+		if ( isWporgOnlyTheme ) {
 			return (
 				<PremiumBadge
 					{ ...commonProps }
@@ -502,13 +503,13 @@ export class Theme extends Component {
 	};
 
 	renderPricingBadge = () => {
-		const { active, isExternallyManagedTheme, isPremiumTheme, isWporgTheme, translate } =
+		const { active, isExternallyManagedTheme, isPremiumTheme, isWporgOnlyTheme, translate } =
 			this.props;
 		if ( active ) {
 			return null;
 		}
 
-		if ( isExternallyManagedTheme || isPremiumTheme || isWporgTheme ) {
+		if ( isExternallyManagedTheme || isPremiumTheme || isWporgOnlyTheme ) {
 			return this.renderUpsell();
 		}
 
@@ -588,7 +589,7 @@ export default connect(
 			isUpdating: themesUpdating && themesUpdating.indexOf( theme.id ) > -1,
 			isUpdated: themesUpdated && themesUpdated.indexOf( theme.id ) > -1,
 			isPremiumTheme: getIsThemePremium( state, theme.id ),
-			isWporgTheme: getIsWporgTheme( state, theme.id ),
+			isWporgOnlyTheme: ! getIsWpcomTheme( state, theme.id ) && getIsWporgTheme( state, theme.id ),
 			hasPremiumThemesFeature:
 				hasPremiumThemesFeature?.() ||
 				siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),


### PR DESCRIPTION
## Proposed Changes

This PR fixes the issue where the Community badge would be display for some of our first-party themes. The issue is cause due to themes can be both first-party and third-party (submitted to dotorg). Thus, we add a check to only show the Community badge if the theme is not also first-party.

| Before | After |
| --- | --- |
| ![Screenshot 2023-04-28 at 6 09 17 PM](https://user-images.githubusercontent.com/797888/235119933-15c776c9-ecb1-4b16-a2f1-618b596d51d6.png)| ![Screenshot 2023-04-28 at 6 08 43 PM](https://user-images.githubusercontent.com/797888/235119871-f96ab249-61f1-4643-9ff1-bae753acccfb.png)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Theme Showcase.
* Ensure that only third-party themes, such as Astra or Oaknut, have the Community badge.
* Also check that first-party themes with dotorg counterparts, such as Hey or CTLG (see more here: https://wordpress.org/themes/browse/new/) are labelled as Free. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
