### PR TITLE
Subscriptions Management: Create the "Notify me of new posts" toggle for the Sites page (logged-in user)

### DIFF
--- a/client/landing/subscriptions/components/settings-popover/site-settings/notify-me-of-new-posts-toggle.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/notify-me-of-new-posts-toggle.tsx
@@ -1,6 +1,12 @@
-import { ToggleControl } from '@wordpress/components';
+import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+
+const ToggleControl = OriginalToggleControl as React.ComponentType<
+	OriginalToggleControl.Props & {
+		disabled?: boolean;
+	}
+>;
 
 type NotifyMeOfNewPostsToggleProps = {
 	value: boolean;

--- a/client/landing/subscriptions/components/settings-popover/site-settings/notify-me-of-new-posts-toggle.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/notify-me-of-new-posts-toggle.tsx
@@ -2,6 +2,8 @@ import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 
+// This is a fix to get around the fact that the original ToggleControl component doesn't support the disabled prop.
+// TODO: Remove this when the original ToggleControl component supports the disabled prop.
 const ToggleControl = OriginalToggleControl as React.ComponentType<
 	OriginalToggleControl.Props & {
 		disabled?: boolean;

--- a/client/landing/subscriptions/components/settings-popover/site-settings/notify-me-of-new-posts-toggle.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/notify-me-of-new-posts-toggle.tsx
@@ -16,7 +16,11 @@ const NotifyMeOfNewPostsToggle = ( {
 	const translate = useTranslate();
 
 	return (
-		<PopoverMenuItem itemComponent="div" className="settings-popover__notify-me-of-new-posts-item">
+		<PopoverMenuItem
+			itemComponent="div"
+			focusOnHover={ false }
+			className="settings-popover__notify-me-of-new-posts-item"
+		>
 			<ToggleControl
 				className="settings-popover__notify-me-of-new-posts-toggle"
 				label={ translate( 'Notify me of new posts' ) }

--- a/client/landing/subscriptions/components/settings-popover/site-settings/notify-me-of-new-posts-toggle.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/notify-me-of-new-posts-toggle.tsx
@@ -16,7 +16,7 @@ const NotifyMeOfNewPostsToggle = ( {
 	const translate = useTranslate();
 
 	return (
-		<PopoverMenuItem itemComponent="div">
+		<PopoverMenuItem itemComponent="div" className="settings-popover__notify-me-of-new-posts-item">
 			<ToggleControl
 				className="settings-popover__notify-me-of-new-posts-toggle"
 				label={ translate( 'Notify me of new posts' ) }

--- a/client/landing/subscriptions/components/settings-popover/site-settings/notify-me-of-new-posts-toggle.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/notify-me-of-new-posts-toggle.tsx
@@ -1,0 +1,32 @@
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+
+type NotifyMeOfNewPostsToggleProps = {
+	value: boolean;
+	isUpdating: boolean;
+};
+
+const NotifyMeOfNewPostsToggle = ( {
+	value = false,
+	isUpdating = false,
+}: NotifyMeOfNewPostsToggleProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<PopoverMenuItem itemComponent="div">
+			<ToggleControl
+				className="settings-popover__notify-me-of-new-posts-toggle"
+				label={ translate( 'Notify me of new posts' ) }
+				onChange={ () => null }
+				checked={ value }
+				disabled={ isUpdating }
+			/>
+			<p className="settings-popover__popout-hint">
+				{ translate( 'Receive web and mobile notifications for new posts from this site.' ) }
+			</p>
+		</PopoverMenuItem>
+	);
+};
+
+export default NotifyMeOfNewPostsToggle;

--- a/client/landing/subscriptions/components/settings-popover/site-settings/notify-me-of-new-posts-toggle.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/notify-me-of-new-posts-toggle.tsx
@@ -5,11 +5,13 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 type NotifyMeOfNewPostsToggleProps = {
 	value: boolean;
 	isUpdating: boolean;
+	onChange: ( value: boolean ) => void;
 };
 
 const NotifyMeOfNewPostsToggle = ( {
 	value = false,
 	isUpdating = false,
+	onChange,
 }: NotifyMeOfNewPostsToggleProps ) => {
 	const translate = useTranslate();
 
@@ -18,7 +20,7 @@ const NotifyMeOfNewPostsToggle = ( {
 			<ToggleControl
 				className="settings-popover__notify-me-of-new-posts-toggle"
 				label={ translate( 'Notify me of new posts' ) }
-				onChange={ () => null }
+				onChange={ () => onChange( ! value ) }
 				checked={ value }
 				disabled={ isUpdating }
 			/>

--- a/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
@@ -41,7 +41,7 @@ const SiteSettings = ( {
 					isUpdating={ updatingNotifyMeOfNewPosts }
 				/>
 			) }
-			<PopoverMenuItem itemComponent="div">
+			<PopoverMenuItem itemComponent="div" className="settings-popover__delivery-frequency-item">
 				<p className="settings-popover__item-label">{ translate( 'Email me new posts' ) }</p>
 				<DeliveryFrequencyInput
 					value={ deliveryFrequency }

--- a/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
@@ -9,6 +9,7 @@ import type { SiteSubscriptionDeliveryFrequency } from '@automattic/data-stores/
 
 type SiteSettingsProps = {
 	notifyMeOfNewPosts: boolean;
+	onNotifyMeOfNewPostsChange: ( value: boolean ) => void;
 	deliveryFrequency: SiteSubscriptionDeliveryFrequency;
 	onDeliveryFrequencyChange: ( value: SiteSubscriptionDeliveryFrequency ) => void;
 	onUnsubscribe: () => void;
@@ -18,6 +19,7 @@ type SiteSettingsProps = {
 
 const SiteSettings = ( {
 	notifyMeOfNewPosts,
+	onNotifyMeOfNewPostsChange,
 	deliveryFrequency,
 	onDeliveryFrequencyChange,
 	onUnsubscribe,
@@ -28,7 +30,11 @@ const SiteSettings = ( {
 
 	return (
 		<SettingsPopover>
-			<NotifyMeOfNewPostsToggle value={ notifyMeOfNewPosts } isUpdating={ false } />
+			<NotifyMeOfNewPostsToggle
+				value={ notifyMeOfNewPosts }
+				onChange={ onNotifyMeOfNewPostsChange }
+				isUpdating={ false }
+			/>
 			<PopoverMenuItem itemComponent="div">
 				<p className="settings-popover__item-label">{ translate( 'Email me new posts' ) }</p>
 				<DeliveryFrequencyInput

--- a/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
@@ -3,10 +3,12 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import Separator from 'calypso/components/popover-menu/separator';
 import SettingsPopover from '../settings-popover';
 import DeliveryFrequencyInput from './delivery-frequency-input';
+import NotifyMeOfNewPostsToggle from './notify-me-of-new-posts-toggle';
 import UnsubscribeSiteButton from './unsubscribe-site-button';
 import type { SiteSubscriptionDeliveryFrequency } from '@automattic/data-stores/src/reader/types';
 
 type SiteSettingsProps = {
+	notifyMeOfNewPosts: boolean;
 	deliveryFrequency: SiteSubscriptionDeliveryFrequency;
 	onDeliveryFrequencyChange: ( value: SiteSubscriptionDeliveryFrequency ) => void;
 	onUnsubscribe: () => void;
@@ -15,6 +17,7 @@ type SiteSettingsProps = {
 };
 
 const SiteSettings = ( {
+	notifyMeOfNewPosts,
 	deliveryFrequency,
 	onDeliveryFrequencyChange,
 	onUnsubscribe,
@@ -25,6 +28,7 @@ const SiteSettings = ( {
 
 	return (
 		<SettingsPopover>
+			<NotifyMeOfNewPostsToggle value={ notifyMeOfNewPosts } isUpdating={ false } />
 			<PopoverMenuItem itemComponent="div">
 				<p className="settings-popover__item-label">{ translate( 'Email me new posts' ) }</p>
 				<DeliveryFrequencyInput

--- a/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
@@ -10,7 +10,7 @@ import type { SiteSubscriptionDeliveryFrequency } from '@automattic/data-stores/
 type SiteSettingsProps = {
 	notifyMeOfNewPosts: boolean;
 	onNotifyMeOfNewPostsChange: ( value: boolean ) => void;
-	updatingNotifyMyOfNewPosts: boolean;
+	updatingNotifyMeOfNewPosts: boolean;
 	deliveryFrequency: SiteSubscriptionDeliveryFrequency;
 	onDeliveryFrequencyChange: ( value: SiteSubscriptionDeliveryFrequency ) => void;
 	onUnsubscribe: () => void;
@@ -21,7 +21,7 @@ type SiteSettingsProps = {
 const SiteSettings = ( {
 	notifyMeOfNewPosts,
 	onNotifyMeOfNewPostsChange,
-	updatingNotifyMyOfNewPosts,
+	updatingNotifyMeOfNewPosts,
 	deliveryFrequency,
 	onDeliveryFrequencyChange,
 	onUnsubscribe,
@@ -35,7 +35,7 @@ const SiteSettings = ( {
 			<NotifyMeOfNewPostsToggle
 				value={ notifyMeOfNewPosts }
 				onChange={ onNotifyMeOfNewPostsChange }
-				isUpdating={ updatingNotifyMyOfNewPosts }
+				isUpdating={ updatingNotifyMeOfNewPosts }
 			/>
 			<PopoverMenuItem itemComponent="div">
 				<p className="settings-popover__item-label">{ translate( 'Email me new posts' ) }</p>

--- a/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
@@ -10,6 +10,7 @@ import type { SiteSubscriptionDeliveryFrequency } from '@automattic/data-stores/
 type SiteSettingsProps = {
 	notifyMeOfNewPosts: boolean;
 	onNotifyMeOfNewPostsChange: ( value: boolean ) => void;
+	updatingNotifyMyOfNewPosts: boolean;
 	deliveryFrequency: SiteSubscriptionDeliveryFrequency;
 	onDeliveryFrequencyChange: ( value: SiteSubscriptionDeliveryFrequency ) => void;
 	onUnsubscribe: () => void;
@@ -20,6 +21,7 @@ type SiteSettingsProps = {
 const SiteSettings = ( {
 	notifyMeOfNewPosts,
 	onNotifyMeOfNewPostsChange,
+	updatingNotifyMyOfNewPosts,
 	deliveryFrequency,
 	onDeliveryFrequencyChange,
 	onUnsubscribe,
@@ -33,7 +35,7 @@ const SiteSettings = ( {
 			<NotifyMeOfNewPostsToggle
 				value={ notifyMeOfNewPosts }
 				onChange={ onNotifyMeOfNewPostsChange }
-				isUpdating={ false }
+				isUpdating={ updatingNotifyMyOfNewPosts }
 			/>
 			<PopoverMenuItem itemComponent="div">
 				<p className="settings-popover__item-label">{ translate( 'Email me new posts' ) }</p>

--- a/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
@@ -1,3 +1,4 @@
+import { SubscriptionManager } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import Separator from 'calypso/components/popover-menu/separator';
@@ -29,14 +30,17 @@ const SiteSettings = ( {
 	updatingFrequency,
 }: SiteSettingsProps ) => {
 	const translate = useTranslate();
+	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
 
 	return (
 		<SettingsPopover>
-			<NotifyMeOfNewPostsToggle
-				value={ notifyMeOfNewPosts }
-				onChange={ onNotifyMeOfNewPostsChange }
-				isUpdating={ updatingNotifyMeOfNewPosts }
-			/>
+			{ isLoggedIn && (
+				<NotifyMeOfNewPostsToggle
+					value={ notifyMeOfNewPosts }
+					onChange={ onNotifyMeOfNewPostsChange }
+					isUpdating={ updatingNotifyMeOfNewPosts }
+				/>
+			) }
 			<PopoverMenuItem itemComponent="div">
 				<p className="settings-popover__item-label">{ translate( 'Email me new posts' ) }</p>
 				<DeliveryFrequencyInput

--- a/client/landing/subscriptions/components/settings-popover/styles.scss
+++ b/client/landing/subscriptions/components/settings-popover/styles.scss
@@ -90,10 +90,6 @@
 	.settings-popover__notify-me-of-new-posts-toggle {
 		font-size: $font-body-small;
 		margin-bottom: 16px;
-
-		.is-checked .components-form-toggle__track {
-			background-color: $studio-black;
-		}
 	}
 
 	.settings-popover__popout-hint {

--- a/client/landing/subscriptions/components/settings-popover/styles.scss
+++ b/client/landing/subscriptions/components/settings-popover/styles.scss
@@ -90,6 +90,11 @@
 	.settings-popover__notify-me-of-new-posts-toggle {
 		font-size: $font-body-small;
 		margin-bottom: 16px;
+
+		.components-form-toggle {
+			display: flex;
+			align-items: center;
+		}
 	}
 
 	.settings-popover__popout-hint {

--- a/client/landing/subscriptions/components/settings-popover/styles.scss
+++ b/client/landing/subscriptions/components/settings-popover/styles.scss
@@ -31,6 +31,10 @@
 		width: calc(100% - 42px);
 	}
 
+	.settings-popover__delivery-frequency-item {
+		padding-top: 0;
+	}
+
 	.settings-popover__delivery-frequency-control,
 	.settings-popover__item-button {
 		&.is-loading {
@@ -78,6 +82,11 @@
 		line-height: $font-body;
 	}
 
+	.settings-popover__notify-me-of-new-posts-item {
+		padding-bottom: 0;
+		margin-bottom: 16px;
+	}
+
 	.settings-popover__notify-me-of-new-posts-toggle {
 		font-size: $font-body-small;
 		margin-bottom: 16px;
@@ -92,7 +101,6 @@
 		font-size: $font-body-extra-small;
 		text-align: left;
 		width: 212px;
-		//margin-top: 16px;
 	}
 }
 

--- a/client/landing/subscriptions/components/settings-popover/styles.scss
+++ b/client/landing/subscriptions/components/settings-popover/styles.scss
@@ -31,10 +31,6 @@
 		width: calc(100% - 42px);
 	}
 
-	.settings-popover__delivery-frequency-item {
-		padding-top: 0;
-	}
-
 	.settings-popover__delivery-frequency-control,
 	.settings-popover__item-button {
 		&.is-loading {

--- a/client/landing/subscriptions/components/settings-popover/styles.scss
+++ b/client/landing/subscriptions/components/settings-popover/styles.scss
@@ -77,6 +77,23 @@
 		padding-bottom: 10px;
 		line-height: $font-body;
 	}
+
+	.settings-popover__notify-me-of-new-posts-toggle {
+		font-size: $font-body-small;
+		margin-bottom: 16px;
+
+		.is-checked .components-form-toggle__track {
+			background-color: $studio-black;
+		}
+	}
+
+	.settings-popover__popout-hint {
+		color: $studio-gray-50;
+		font-size: $font-body-extra-small;
+		text-align: left;
+		width: 212px;
+		//margin-top: 16px;
+	}
 }
 
 .settings-popover__container {

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -55,7 +55,7 @@ export default function SiteRow( {
 		SubscriptionManager.useSiteDeliveryFrequencyMutation();
 	const { mutate: unsubscribe, isLoading: unsubscribing } =
 		SubscriptionManager.useSiteUnsubscribeMutation();
-	const { mutate: updateNotifyMeOfNewPosts } =
+	const { mutate: updateNotifyMeOfNewPosts, isLoading: updatingNotifyMyOfNewPosts } =
 		SubscriptionManager.useSiteNotifyMeOfNewPostsMutation();
 
 	return (
@@ -81,6 +81,7 @@ export default function SiteRow( {
 					onNotifyMeOfNewPostsChange={ ( send_posts ) =>
 						updateNotifyMeOfNewPosts( { blog_id: blog_ID, send_posts } )
 					}
+					updatingNotifyMeOfNewPosts={ updatingNotifyMyOfNewPosts }
 					deliveryFrequency={ deliveryFrequencyValue }
 					onDeliveryFrequencyChange={ ( delivery_frequency ) =>
 						updateDeliveryFrequency( { blog_id: blog_ID, delivery_frequency } )

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -55,6 +55,8 @@ export default function SiteRow( {
 		SubscriptionManager.useSiteDeliveryFrequencyMutation();
 	const { mutate: unsubscribe, isLoading: unsubscribing } =
 		SubscriptionManager.useSiteUnsubscribeMutation();
+	const { mutate: updateNotifyMeOfNewPosts } =
+		SubscriptionManager.useSiteNotifyMeOfNewPostsMutation();
 
 	return (
 		<li className="row" role="row">
@@ -76,6 +78,9 @@ export default function SiteRow( {
 			<span className="actions" role="cell">
 				<SiteSettings
 					notifyMeOfNewPosts={ notifyMeOfNewPosts }
+					onNotifyMeOfNewPostsChange={ ( send_posts ) =>
+						updateNotifyMeOfNewPosts( { blog_id: blog_ID, send_posts } )
+					}
 					deliveryFrequency={ deliveryFrequencyValue }
 					onDeliveryFrequencyChange={ ( delivery_frequency ) =>
 						updateDeliveryFrequency( { blog_id: blog_ID, delivery_frequency } )

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -55,7 +55,7 @@ export default function SiteRow( {
 		SubscriptionManager.useSiteDeliveryFrequencyMutation();
 	const { mutate: unsubscribe, isLoading: unsubscribing } =
 		SubscriptionManager.useSiteUnsubscribeMutation();
-	const { mutate: updateNotifyMeOfNewPosts, isLoading: updatingNotifyMyOfNewPosts } =
+	const { mutate: updateNotifyMeOfNewPosts, isLoading: updatingNotifyMeOfNewPosts } =
 		SubscriptionManager.useSiteNotifyMeOfNewPostsMutation();
 
 	return (
@@ -81,7 +81,7 @@ export default function SiteRow( {
 					onNotifyMeOfNewPostsChange={ ( send_posts ) =>
 						updateNotifyMeOfNewPosts( { blog_id: blog_ID, send_posts } )
 					}
-					updatingNotifyMeOfNewPosts={ updatingNotifyMyOfNewPosts }
+					updatingNotifyMeOfNewPosts={ updatingNotifyMeOfNewPosts }
 					deliveryFrequency={ deliveryFrequencyValue }
 					onDeliveryFrequencyChange={ ( delivery_frequency ) =>
 						updateDeliveryFrequency( { blog_id: blog_ID, delivery_frequency } )

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -46,6 +46,11 @@ export default function SiteRow( {
 	);
 	const deliveryFrequencyLabel = useDeliveryFrequencyLabel( deliveryFrequencyValue );
 
+	const notifyMeOfNewPosts = useMemo(
+		() => delivery_methods?.notification?.send_posts,
+		[ delivery_methods?.notification?.send_posts ]
+	);
+
 	const { mutate: updateDeliveryFrequency, isLoading: updatingFrequency } =
 		SubscriptionManager.useSiteDeliveryFrequencyMutation();
 	const { mutate: unsubscribe, isLoading: unsubscribing } =
@@ -70,6 +75,7 @@ export default function SiteRow( {
 			</span>
 			<span className="actions" role="cell">
 				<SiteSettings
+					notifyMeOfNewPosts={ notifyMeOfNewPosts }
 					deliveryFrequency={ deliveryFrequencyValue }
 					onDeliveryFrequencyChange={ ( delivery_frequency ) =>
 						updateDeliveryFrequency( { blog_id: blog_ID, delivery_frequency } )

--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -2,6 +2,7 @@ import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
 import wpcomRequest from 'wpcom-proxy-request';
 
 type callApiParams = {
+	apiNamespace?: string;
 	path: string;
 	method?: 'GET' | 'POST';
 	body?: object;
@@ -16,6 +17,7 @@ const getSubkey = () => {
 
 // Helper function for fetching from subkey authenticated API. Subkey authentication process is only applied in case of logged-out users.
 async function callApi< ReturnType >( {
+	apiNamespace = '',
 	path,
 	method = 'GET',
 	body,
@@ -24,6 +26,7 @@ async function callApi< ReturnType >( {
 }: callApiParams ): Promise< ReturnType > {
 	if ( isLoggedIn ) {
 		const res = await wpcomRequest( {
+			apiNamespace,
 			path,
 			apiVersion,
 			method,

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -8,6 +8,7 @@ import {
 	usePendingSiteDeleteMutation,
 	usePendingPostConfirmMutation,
 	usePendingPostDeleteMutation,
+	useSiteNotifyMeOfNewPostsMutation,
 } from './mutations';
 import {
 	PostSubscriptionsSortBy,
@@ -38,6 +39,7 @@ export const SubscriptionManager = {
 	usePendingSiteDeleteMutation,
 	usePendingPostConfirmMutation,
 	usePendingPostDeleteMutation,
+	useSiteNotifyMeOfNewPostsMutation,
 	useIsLoggedIn,
 };
 

--- a/packages/data-stores/src/reader/mutations/index.ts
+++ b/packages/data-stores/src/reader/mutations/index.ts
@@ -6,3 +6,4 @@ export { default as usePendingSiteConfirmMutation } from './use-pending-site-con
 export { default as usePendingSiteDeleteMutation } from './use-pending-site-delete-mutation';
 export { default as usePendingPostConfirmMutation } from './use-pending-post-confirm-mutation';
 export { default as usePendingPostDeleteMutation } from './use-pending-post-delete-mutation';
+export { default as useSiteNotifyMeOfNewPostsMutation } from './use-site-notify-me-of-new-posts-mutation';

--- a/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
@@ -31,7 +31,7 @@ const useSiteNotifyMeOfNewPostsMutation = () => {
 
 	return useMutation(
 		async ( params: SiteSubscriptionNotifyMeOfNewPostsParams ) => {
-			if ( ! params.blog_id || typeof params.send_posts === 'undefined' ) {
+			if ( ! params.blog_id || typeof params.send_posts !== 'boolean' ) {
 				throw new Error(
 					// reminder: translate this string when we add it to the UI
 					'Something went wrong while changing the "Notify me of new posts" setting.'

--- a/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
@@ -1,0 +1,108 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { callApi } from '../helpers';
+import { useCacheKey, useIsLoggedIn } from '../hooks';
+import type { SiteSubscription } from '../types';
+
+type SiteSubscriptionNotifyMeOfNewPostsParams = {
+	send_posts: boolean;
+	blog_id: number | string;
+};
+
+type SiteSubscriptionNotifyMeOfNewPostsResponse = {
+	success: boolean;
+	subscribed: boolean;
+};
+
+type SiteSubscriptionPage = {
+	subscriptions: SiteSubscription[];
+	total_subscriptions: number;
+};
+
+type SiteSubscriptionsPages = {
+	pageParams: [];
+	pages: SiteSubscriptionPage[];
+};
+
+const useSiteNotifyMeOfNewPostsMutation = () => {
+	const { isLoggedIn } = useIsLoggedIn();
+	const queryClient = useQueryClient();
+
+	const siteSubscriptionsCacheKey = useCacheKey( [ 'read', 'site-subscriptions' ] );
+
+	return useMutation(
+		async ( params: SiteSubscriptionNotifyMeOfNewPostsParams ) => {
+			if ( ! params.blog_id || typeof params.send_posts === 'undefined' ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while changing the "Notify me of new posts" setting.'
+				);
+			}
+
+			const action = params.send_posts ? 'new' : 'delete';
+
+			const response = await callApi< SiteSubscriptionNotifyMeOfNewPostsResponse >( {
+				apiNamespace: 'wpcom/v2',
+				path: `/read/sites/${ params.blog_id }/notification-subscriptions/${ action }`,
+				method: 'POST',
+				body: {},
+				isLoggedIn,
+				apiVersion: '2',
+			} );
+			if ( ! response.success ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while changing the "Notify me of new posts" setting.'
+				);
+			}
+
+			return response;
+		},
+		{
+			onMutate: async ( params ) => {
+				await queryClient.cancelQueries( siteSubscriptionsCacheKey );
+
+				const previousSiteSubscriptions =
+					queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsCacheKey );
+
+				if ( previousSiteSubscriptions ) {
+					queryClient.setQueryData( siteSubscriptionsCacheKey, {
+						...previousSiteSubscriptions,
+						pages: previousSiteSubscriptions.pages.map( ( page ) => {
+							return {
+								...page,
+								subscriptions: page.subscriptions.map( ( siteSubscription ) => {
+									if ( siteSubscription.blog_ID === params.blog_id ) {
+										return {
+											...siteSubscription,
+											delivery_methods: {
+												...siteSubscription.delivery_methods,
+												notification: {
+													...siteSubscription.delivery_methods?.notification,
+													send_posts: params.send_posts,
+												},
+											},
+										};
+									}
+									return siteSubscription;
+								} ),
+							};
+						} ),
+					} );
+				}
+				return { previousSiteSubscriptions };
+			},
+
+			onError: ( err, params, context ) => {
+				if ( context?.previousSiteSubscriptions ) {
+					queryClient.setQueryData( siteSubscriptionsCacheKey, context.previousSiteSubscriptions );
+				}
+			},
+			onSettled: () => {
+				// pass in a more minimal key, everything to the right will be invalidated
+				queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
+			},
+		}
+	);
+};
+
+export default useSiteNotifyMeOfNewPostsMutation;

--- a/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
@@ -88,7 +88,6 @@ const useSiteNotifyMeOfNewPostsMutation = () => {
 				}
 			},
 			onSettled: () => {
-				// pass in a more minimal key, everything to the right will be invalidated
 				queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
 			},
 		}

--- a/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn } from '../hooks';
-import type { SiteSubscription } from '../types';
+import type { SiteSubscriptionsPages } from '../types';
 
 type SiteSubscriptionNotifyMeOfNewPostsParams = {
 	send_posts: boolean;
@@ -11,16 +11,6 @@ type SiteSubscriptionNotifyMeOfNewPostsParams = {
 type SiteSubscriptionNotifyMeOfNewPostsResponse = {
 	success: boolean;
 	subscribed: boolean;
-};
-
-type SiteSubscriptionPage = {
-	subscriptions: SiteSubscription[];
-	total_subscriptions: number;
-};
-
-type SiteSubscriptionsPages = {
-	pageParams: [];
-	pages: SiteSubscriptionPage[];
 };
 
 const useSiteNotifyMeOfNewPostsMutation = () => {

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { callApi } from '../helpers';
 import { useCacheKey, useIsLoggedIn } from '../hooks';
-import { SiteSubscription, SubscriptionManagerSubscriptionsCount } from '../types';
+import { SiteSubscriptionsPages, SubscriptionManagerSubscriptionsCount } from '../types';
 
 type UnsubscribeParams = {
 	blog_id: number | string;
@@ -11,16 +11,6 @@ type UnsubscribeResponse = {
 	success: boolean;
 	subscribed: boolean;
 	subscription: null;
-};
-
-type SiteSubscriptionPage = {
-	subscriptions: SiteSubscription[];
-	total_subscriptions: number;
-};
-
-type SiteSubscriptionsPages = {
-	pageParams: [];
-	pages: SiteSubscriptionPage[];
 };
 
 const useSiteUnsubscribeMutation = () => {

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -67,6 +67,16 @@ export type SiteSubscription = {
 	meta: SiteSubscriptionMeta;
 };
 
+export type SiteSubscriptionPage = {
+	subscriptions: SiteSubscription[];
+	total_subscriptions: number;
+};
+
+export type SiteSubscriptionsPages = {
+	pageParams: [];
+	pages: SiteSubscriptionPage[];
+};
+
 export type SiteSubscriptionDeliveryFrequency = 'instantly' | 'daily' | 'weekly';
 
 export type PostSubscription = {


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/76393.

## Proposed Changes

The proposed changes create and add the "Notify me of new posts" toggle to the Sites page and make it work:

![Markup on 2023-05-02 at 11:25:45](https://user-images.githubusercontent.com/25105483/235629962-7e98fb5b-09e8-4f48-afe1-e80cf88ef9eb.png)

Specific changes in bulletpoints:

* create `NotifyMeOfNewPostsToggle` component
* create `useSiteNotifyMeOfNewPostsMutation`
* allow `callApi` to accept and use `apiNamespace`
* move `SiteSubscriptionPage` and `SiteSubscriptionsPages` types into `packages/data-stores/src/reader/types/index.ts`

Design: inDLaEQV8jJ21O4WXawIsJ-fi-712_13475

ℹ️  The color of the toggle is blue (not black as in the design). The reason for this is that the toggle should respect user's color profile which our Subscriptions app doesn't support yet. I have created a separate task to address that issue: https://github.com/Automattic/wp-calypso/issues/76490.

## Testing Instructions

1. Check out the PR.
2. Navigate to `client/server/pages/index.js` and temporarily add `return next();` to the line `833`:

![Markup on 2023-04-28 at 17:50:44](https://user-images.githubusercontent.com/25105483/235195033-4902bb9d-db57-43a4-b295-2d90feb6731f.png)

3. Build the app.
4. Log in to a test WordPress.com account that has some Site subscriptions.
5. Navigate to http://calypso.localhost:3000/subscriptions/sites.
6. When you click on the settings menu on any of the sites, you should be able to switch the "Notify me of new posts" toggle.
7. The change should reflect to the same setting of the same site in the Reader at https://wordpress.com/following/manage.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?