### PR TITLE
Block Renderer: Support custom scripts

### DIFF
--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -8,6 +8,7 @@ import { useResizeObserver, useRefEffect } from '@wordpress/compose';
 import React, { useMemo, useState, useContext } from 'react';
 import { BLOCK_MAX_HEIGHT } from '../constants';
 import useParsedAssets from '../hooks/use-parsed-assets';
+import loadScripts from '../utils/load-scripts';
 import loadStyles from '../utils/load-styles';
 import BlockRendererContext from './block-renderer-context';
 import type { RenderedStyle } from '../types';
@@ -16,6 +17,7 @@ import './block-renderer-container.scss';
 interface BlockRendererContainerProps {
 	children: React.ReactChild;
 	styles?: RenderedStyle[];
+	scripts?: string;
 	inlineCss?: string;
 	viewportWidth?: number;
 	viewportHeight?: number;
@@ -32,6 +34,7 @@ interface ScaledBlockRendererContainerProps extends BlockRendererContainerProps 
 const ScaledBlockRendererContainer = ( {
 	children,
 	styles: customStyles,
+	scripts: customScripts,
 	inlineCss = '',
 	viewportWidth = 1200,
 	viewportHeight,
@@ -65,6 +68,12 @@ const ScaledBlockRendererContainer = ( {
 		return [ ...mergedStyles, { css: inlineCss } ];
 	}, [ styles, customStyles, inlineCss ] );
 
+	const scripts = useMemo( () => {
+		return [ assets?.scripts, customScripts ].filter( Boolean ).join( '' );
+	}, [ assets?.scripts, customScripts ] );
+
+	const scriptAssets = useParsedAssets( scripts );
+
 	const svgFilters = useMemo( () => {
 		return [ ...( duotone?.default ?? [] ), ...( duotone?.theme ?? [] ) ];
 	}, [ duotone ] );
@@ -82,9 +91,11 @@ const ScaledBlockRendererContainer = ( {
 		bodyElement.style.position = 'absolute';
 		bodyElement.style.width = '100%';
 
-		// Load styles manually to avoid a flash of unstyled content.
-		// Gutenberg fixed this issue via https://github.com/WordPress/gutenberg/pull/46706 but it requires `@wordpress/block-editor: ^11.2.0`
-		loadStyles( bodyElement, styleAssets ).then( () => setIsLoaded( true ) );
+		// Load scripts and styles manually to avoid a flash of unstyled content.
+		Promise.all( [
+			loadStyles( bodyElement, styleAssets ),
+			loadScripts( bodyElement, scriptAssets ),
+		] ).then( () => setIsLoaded( true ) );
 	}, [] );
 
 	const scale = containerWidth / viewportWidth;
@@ -120,7 +131,6 @@ const ScaledBlockRendererContainer = ( {
 		>
 			<Iframe
 				head={ <EditorStyles styles={ editorStyles } /> }
-				assets={ { scripts: assets?.scripts } }
 				contentRef={ contentRef }
 				aria-hidden
 				tabIndex={ -1 }

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -94,7 +94,7 @@ const ScaledBlockRendererContainer = ( {
 		// Load scripts and styles manually to avoid a flash of unstyled content.
 		Promise.all( [
 			loadStyles( bodyElement, styleAssets ),
-			loadScripts( bodyElement, scriptAssets ),
+			loadScripts( bodyElement, scriptAssets as HTMLScriptElement[] ),
 		] ).then( () => setIsLoaded( true ) );
 	}, [] );
 

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -26,6 +26,7 @@ const PatternRenderer = ( {
 	return (
 		<BlockRendererContainer
 			styles={ pattern?.styles ?? [] }
+			scripts={ pattern?.scripts ?? '' }
 			viewportWidth={ viewportWidth }
 			viewportHeight={ viewportHeight }
 			maxHeight={ maxHeight }

--- a/packages/block-renderer/src/types.ts
+++ b/packages/block-renderer/src/types.ts
@@ -13,6 +13,7 @@ export type RenderedPattern = {
 	title: string;
 	html: string;
 	styles: RenderedStyle[];
+	scripts: string;
 };
 
 export type RenderedPatterns = {

--- a/packages/block-renderer/src/utils/load-scripts.ts
+++ b/packages/block-renderer/src/utils/load-scripts.ts
@@ -1,0 +1,25 @@
+const loadScript = async ( element: HTMLElement, { id, src, textContent }: HTMLScriptElement ) => {
+	return new Promise( ( resolve, reject ) => {
+		const script = element.ownerDocument.createElement( 'script' ) as HTMLScriptElement;
+		script.id = id;
+		if ( src ) {
+			script.src = src;
+			script.onload = () => resolve( script );
+			script.onerror = () => reject();
+		} else {
+			script.textContent = textContent;
+			resolve();
+		}
+
+		element.appendChild( script );
+	} );
+};
+
+const loadScripts = async ( element: HTMLElement, scripts: HTMLScriptElement[] ) => {
+	return scripts.reduce(
+		( promise, script ): Promise< any > => promise.then( () => loadScript( element, script ) ),
+		Promise.resolve()
+	);
+};
+
+export default loadScripts;

--- a/packages/block-renderer/src/utils/load-scripts.ts
+++ b/packages/block-renderer/src/utils/load-scripts.ts
@@ -8,7 +8,7 @@ const loadScript = async ( element: HTMLElement, { id, src, textContent }: HTMLS
 			script.onerror = () => reject();
 		} else {
 			script.textContent = textContent;
-			resolve();
+			resolve( script );
 		}
 
 		element.appendChild( script );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/76343

## Proposed Changes

* Support scripts that are required by patterns so we're able to display the pattern correctly. For example, the `jetpack/map` pattern needs its script to load the `mapbox-gl` module to render the map.

| Contact info with Map | Contact | Contact |
| - | - | - |
| ![image](https://user-images.githubusercontent.com/13596067/235168615-8fa01ccc-ced3-4dfe-8d9e-0b91ee96c2da.png) | ![image](https://user-images.githubusercontent.com/13596067/235168683-f0b3fe51-30d3-4671-85e8-a5283a2bcf6d.png) | ![image](https://user-images.githubusercontent.com/13596067/235168840-0c0c6a3f-7da5-442c-b802-08936811cd6c.png) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D109333-code
* Go to /setup/site-setup?siteSlug=<your_free_site>
* Continue until you land on the Design Picker
* On the Design Picker screen, scroll down to the bottom and select BCPA CTA
* On the Pattern Assembler screen
  * Select `Sections > Add patterns > Contact`
  * Ensure the patterns with the map are rendered correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?