### PR TITLE
Fix QueryActiveTheme error in theme page

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1332,7 +1332,11 @@ class ThemeSheet extends Component {
 					properties={ { is_logged_in: isLoggedIn } }
 				/>
 				<AsyncLoad require="calypso/components/global-notices" placeholder={ null } id="notices" />
-				<QueryActiveTheme siteId={ siteId } />
+				{
+					siteId && (
+						<QueryActiveTheme siteId={ siteId } />
+					) /* TODO: Make QueryActiveTheme handle falsey siteId */
+				}
 				<ThanksModal source="details" themeId={ this.props.themeId } />
 				<AutoLoadingHomepageModal source="details" />
 				<div className="theme__sheet-action-bar-container">


### PR DESCRIPTION
When visiting a theme page while logged out in dev mode, a prop type error is shown for `QueryActiveTheme`.

<img width="1402" alt="image" src="https://user-images.githubusercontent.com/409615/235135192-6a7c2cf9-d961-4735-853e-81bdc5aef989.png">

This PR works around the issue with the same approach that was used for `QuerySitePurchases`.

## Proposed Changes

* Fix prop type error with `QueryActiveTheme` in the theme page

## Testing Instructions

* Start a dev build
* Open a theme page while logged out (e.g. `/theme/verso`)
* Verify that the above error no longer shows

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] Have you checked for TypeScript, React or other console errors?
