### PR TITLE
Performance tracking: fix hydration mismatch

### DIFF
--- a/client/lib/performance-tracking/index.node.js
+++ b/client/lib/performance-tracking/index.node.js
@@ -1,7 +1,5 @@
-import EmptyComponent from 'calypso/components/empty-component';
-
 export const performanceTrackerStart = () => null;
 export const usePerformanceTrackerStop = () => null;
 export const withPerformanceTrackerStop = ( component ) => component;
 export const withStopPerformanceTrackingProp = ( component ) => component;
-export const PerformanceTrackerStop = EmptyComponent;
+export const PerformanceTrackerStop = () => null;


### PR DESCRIPTION
When visiting a theme page while logged out in dev mode, a hydration error is shown:

<img width="1402" alt="image" src="https://user-images.githubusercontent.com/409615/235138160-eaae4e94-644f-4091-8be6-337bacf57464.png">

Despite the laughably useless error message (thanks, React), I was able to track this down to the `PerformanceTrackerStop` component, which currently renders an empty `div` on the server, while rendering `null` on the client.

This PR fixes that by rendering `null` on the server as well. 

## Proposed Changes

* Change `PerformanceTrackerStop` to render `null` on the server

## Testing Instructions

* Start a dev build
* Open a theme page while logged out (e.g. `/theme/verso`)
* Verify that the above error no longer shows

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] Have you checked for TypeScript, React or other console errors?
