### PR TITLE
E2E: Try to stabilize Atomic likes (again)

### DIFF
--- a/packages/calypso-e2e/src/lib/components/comments-component.ts
+++ b/packages/calypso-e2e/src/lib/components/comments-component.ts
@@ -105,9 +105,8 @@ export class CommentsComponent {
 			// See the like() method for info on the following method call.
 			await waitForWPWidgetsIfNecessary( this.page );
 
-			const likeButtonFrame = this.page
-				.frameLocator( `iframe[name^="like-comment-frame"]:below(:text("${ comment }"))` )
-				.first();
+			const commentContent = this.page.locator( '.comment-content', { hasText: comment } );
+			const likeButtonFrame = commentContent.frameLocator( "iframe[name^='like-comment-frame']" );
 
 			unlikeButton = likeButtonFrame.getByRole( 'link', { name: 'Liked by you' } );
 			unlikedStatus = likeButtonFrame.getByRole( 'link', { name: 'Like' } );
@@ -119,7 +118,6 @@ export class CommentsComponent {
 		}
 
 		await this.page.getByText( comment ).scrollIntoViewIfNeeded();
-		await unlikeButton.waitFor();
 		await unlikeButton.click();
 		await unlikedStatus.waitFor();
 	}

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -795,12 +795,12 @@ export class RestAPIClient {
 
 		// Tried to like the comment, but failed to do so
 		// and the user still has not liked the comment.
-		if ( action === 'like' && ! response.success && ! response.i_like ) {
+		if ( action === 'like' && response.like_count !== 1 ) {
 			throw new Error( `Failed to like ${ commentID } on site ${ siteID }` );
 		}
 		// Tried to unlike the comment, but failed to do so
 		// and the user still likes the comment.
-		if ( action === 'unlike' && ! response.success && response.i_like ) {
+		if ( action === 'unlike' && response.like_count !== 0 ) {
 			throw new Error( `Failed to unlike ${ commentID } on site ${ siteID }` );
 		}
 

--- a/test/e2e/specs/published-content/likes__comment.ts
+++ b/test/e2e/specs/published-content/likes__comment.ts
@@ -67,7 +67,7 @@ describe( 'Likes: Comment', function () {
 		// The comment takes some time to settle. If we request the like
 		// immediately we might be getting the `unknown_comment` error. Let's do
 		// a few retries to make sure the like is getting through.
-		let likeRetryCount = 5;
+		let likeRetryCount = 10;
 		const likeRetryTimer = setInterval( async () => {
 			try {
 				await restAPIClient.commentAction(

--- a/test/e2e/specs/published-content/likes__comment.ts
+++ b/test/e2e/specs/published-content/likes__comment.ts
@@ -38,7 +38,7 @@ describe( 'Likes: Comment', function () {
 	let commentToBeUnliked: NewCommentResponse;
 	let restAPIClient: RestAPIClient;
 
-	beforeAll( async function () {
+	it( 'Setup the test', async function () {
 		page = await browser.newPage();
 
 		testAccount = new TestAccount( accountName );
@@ -64,21 +64,28 @@ describe( 'Likes: Comment', function () {
 			DataHelper.getRandomPhrase()
 		);
 
-		// For AT sites the API will respond with a HTTP 404
-		// unless time is given for the comment to "settle" in place.
-		// It could be argued that adding this arbitrary delay is
-		// "more representative" of users.
-		// @see: https://github.com/Automattic/wp-calypso/issues/75952
-		if ( envVariables.TEST_ON_ATOMIC ) {
-			await page.waitForTimeout( 5 * 1000 );
-		}
+		// The comment takes some time to settle. If we request the like
+		// immediately we might be getting the `unknown_comment` error. Let's do
+		// a few retries to make sure the like is getting through.
+		let likeRetryCount = 5;
+		const likeRetryTimer = setInterval( async () => {
+			try {
+				await restAPIClient.commentAction(
+					'like',
+					testAccount.credentials.testSites?.primary.id as number,
+					commentToBeUnliked.ID
+				);
 
-		// Establish proper state for the comment to be unliked.
-		await restAPIClient.commentAction(
-			'like',
-			testAccount.credentials.testSites?.primary.id as number,
-			commentToBeUnliked.ID
-		);
+				clearInterval( likeRetryTimer );
+			} catch ( error ) {
+				likeRetryCount--;
+
+				if ( likeRetryCount === 0 ) {
+					clearInterval( likeRetryTimer );
+					throw error;
+				}
+			}
+		}, 1000 );
 
 		await testAccount.authenticate( page );
 	} );

--- a/test/e2e/specs/published-content/likes__comment.ts
+++ b/test/e2e/specs/published-content/likes__comment.ts
@@ -67,25 +67,22 @@ describe( 'Likes: Comment', function () {
 		// The comment takes some time to settle. If we request the like
 		// immediately we might be getting the `unknown_comment` error. Let's do
 		// a few retries to make sure the like is getting through.
-		let likeRetryCount = 10;
-		const likeRetryTimer = setInterval( async () => {
+		const likeRetryCount = 10;
+		for ( let i = 0; i <= likeRetryCount; i++ ) {
 			try {
 				await restAPIClient.commentAction(
 					'like',
 					testAccount.credentials.testSites?.primary.id as number,
 					commentToBeUnliked.ID
 				);
-
-				clearInterval( likeRetryTimer );
+				break;
 			} catch ( error ) {
-				likeRetryCount--;
-
-				if ( likeRetryCount === 0 ) {
-					clearInterval( likeRetryTimer );
+				if ( i === likeRetryCount ) {
 					throw error;
 				}
+				await page.waitForTimeout( 1000 );
 			}
-		}, 1000 );
+		}
 
 		await testAccount.authenticate( page );
 	} );


### PR DESCRIPTION
Related: https://github.com/Automattic/wp-calypso/pull/75947

## Proposed Changes

When adding a comment on an Atomic site, it takes a bit until that comment is settled. Sometimes, when we send the like request immediately after creating a comment, we get an `unknown_comment` error response. To address that, let's make a couple `like` request retries before failing the test.

## Testing Instructions

```
TEST_ON_ATOMIC=true yarn workspace wp-e2e-tests test likes__comment.ts
```
