### PR TITLE
Invites: Fix undefined query data warning

### DIFF
--- a/client/data/invites/use-get-invites-query.ts
+++ b/client/data/invites/use-get-invites-query.ts
@@ -13,6 +13,7 @@ const useGetInvitesQuery = ( siteId: number ) => {
 		if ( siteId && ! requestingInProgress ) {
 			dispatch( requestSiteInvites( siteId ) );
 		}
+		return null;
 	} );
 };
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes the following warning when visiting `/people/team/{SITE_SLUG}`:

![Screenshot 2023-04-28 at 16 25 42](https://user-images.githubusercontent.com/8436925/235160150-f13f3559-2619-40e2-b05d-0547657af737.png)

Seems to have been revealed with the v4 upgrade in #76077.

According to [the docs](https://tanstack.com/query/v4/docs/react/reference/useQuery): the `queryFn`:

> Must return a promise that will either resolve data or throw an error. The data cannot be undefined.

We [don't really utilize the data](https://github.com/Automattic/wp-calypso/blob/391f81bea18051ef155398fe2de4aba51455ebe4/client/my-sites/people/team-invites/index.tsx#L26) from this query, since the query is only used to trigger a Redux fetch of the invites. Therefore, to fix the error, we're returning a `null` to both satisfy the non-undefined requirement and still keep returning nothing from the query.

See #72674 which introduced this query.

## Testing Instructions

* Head to `/people/team/{SITE_SLUG}`
* Verify you no longer see the error message.