### PR TITLE
Stats Widget: Apply 7-Day Highlights section mobile layout redesign

### DIFF
--- a/apps/odyssey-stats/src/widget/highlights.jsx
+++ b/apps/odyssey-stats/src/widget/highlights.jsx
@@ -135,7 +135,7 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 				<label>{ headingTitle }</label>
 			</div>
 			<div className="stats-widget-highlights__tabs">
-				<SegmentedControl primary className="test">
+				<SegmentedControl primary>
 					{ moduleTabs.map( ( tab ) => {
 						return (
 							<SegmentedControl.Item

--- a/apps/odyssey-stats/src/widget/highlights.jsx
+++ b/apps/odyssey-stats/src/widget/highlights.jsx
@@ -110,13 +110,12 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 		queryDate
 	);
 
+	const headingTitle = translate( '7 Day Highlights' );
+
 	return (
-		<div
-			className="stats-widget-highlights stats-widget-card"
-			aria-label={ translate( '7 Day Highlights' ) }
-		>
+		<div className="stats-widget-highlights stats-widget-card" aria-label={ headingTitle }>
 			<div className="stats-widget-highlights__header">
-				<label>{ translate( '7 Day Highlights' ) }</label>
+				<label>{ headingTitle }</label>
 			</div>
 			<div className="stats-widget-highlights__body">
 				<TopColumn

--- a/apps/odyssey-stats/src/widget/highlights.jsx
+++ b/apps/odyssey-stats/src/widget/highlights.jsx
@@ -93,27 +93,6 @@ function TopColumn( {
 
 export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } ) {
 	const translate = useTranslate();
-	const [ selectedTab, setSelectedTab ] = useState( 'topPostsAndPages' );
-
-	const queryDate = moment()
-		.utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 )
-		.format( 'YYYY-MM-DD' );
-	const viewAllPostsStatsUrl = `${ odysseyStatsBaseUrl }#!/stats/day/posts/${ siteId }?startDate=${ queryDate }&summarize=1&num=7`;
-	const viewAllReferrerStatsUrl = `${ odysseyStatsBaseUrl }#!/stats/day/referrers/${ siteId }?startDate=${ queryDate }&summarize=1&num=7`;
-
-	const { data: topPostsAndPages = [], isFetching: isFetchingPostsAndPages } = useTopPostsQuery(
-		siteId,
-		'day',
-		7,
-		queryDate
-	);
-	const { data: topReferrers = [], isFetching: isFetchingReferrers } = useReferrersQuery(
-		siteId,
-		'day',
-		7,
-		queryDate
-	);
-
 	const headingTitle = translate( '7 Day Highlights' );
 	const topPostsAndPagesTitle = translate( 'Top Posts & Pages' );
 	const topReferrersTitle = translate( 'Top Referrers' );
@@ -128,6 +107,29 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 			label: topReferrersTitle,
 		},
 	];
+
+	// Default to the first tab `topPostsAndPages`.
+	const [ selectedTab, setSelectedTab ] = useState( moduleTabs[ 0 ].value );
+
+	const queryDate = moment()
+		.utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 )
+		.format( 'YYYY-MM-DD' );
+	const viewAllPostsStatsUrl = `${ odysseyStatsBaseUrl }#!/stats/day/posts/${ siteId }?startDate=${ queryDate }&summarize=1&num=7`;
+	const viewAllReferrerStatsUrl = `${ odysseyStatsBaseUrl }#!/stats/day/referrers/${ siteId }?startDate=${ queryDate }&summarize=1&num=7`;
+
+	const { data: topPostsAndPages = [], isFetching: isFetchingPostsAndPages } = useTopPostsQuery(
+		siteId,
+		'day',
+		7,
+		queryDate
+	);
+
+	const { data: topReferrers = [], isFetching: isFetchingReferrers } = useReferrersQuery(
+		siteId,
+		'day',
+		7,
+		queryDate
+	);
 
 	return (
 		<div className="stats-widget-highlights stats-widget-card" aria-label={ headingTitle }>

--- a/apps/odyssey-stats/src/widget/highlights.jsx
+++ b/apps/odyssey-stats/src/widget/highlights.jsx
@@ -151,7 +151,9 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 			</div>
 			<div className="stats-widget-highlights__body">
 				<TopColumn
-					className="stats-widget-highlights__column"
+					className={ classNames( 'stats-widget-highlights__column', {
+						'is-mobile-show': selectedTab === 'topPostsAndPages',
+					} ) }
 					title={ topPostsAndPagesTitle }
 					viewAllUrl={ viewAllPostsStatsUrl }
 					viewAllText={ translate( 'View all posts & pages stats' ) }
@@ -162,7 +164,9 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 					isItemLink={ true }
 				/>
 				<TopColumn
-					className="stats-widget-highlights__column"
+					className={ classNames( 'stats-widget-highlights__column', {
+						'is-mobile-show': selectedTab === 'topReferrers',
+					} ) }
 					title={ topReferrersTitle }
 					viewAllUrl={ viewAllReferrerStatsUrl }
 					viewAllText={ translate( 'View all referrer stats' ) }

--- a/apps/odyssey-stats/src/widget/highlights.jsx
+++ b/apps/odyssey-stats/src/widget/highlights.jsx
@@ -152,7 +152,7 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 			<div className="stats-widget-highlights__body">
 				<TopColumn
 					className={ classNames( 'stats-widget-highlights__column', {
-						'is-mobile-show': selectedTab === 'topPostsAndPages',
+						'stats-widget-highlights__column--show-in-mobile': selectedTab === 'topPostsAndPages',
 					} ) }
 					title={ topPostsAndPagesTitle }
 					viewAllUrl={ viewAllPostsStatsUrl }
@@ -165,7 +165,7 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 				/>
 				<TopColumn
 					className={ classNames( 'stats-widget-highlights__column', {
-						'is-mobile-show': selectedTab === 'topReferrers',
+						'stats-widget-highlights__column--show-in-mobile': selectedTab === 'topReferrers',
 					} ) }
 					title={ topReferrersTitle }
 					viewAllUrl={ viewAllReferrerStatsUrl }

--- a/apps/odyssey-stats/src/widget/highlights.jsx
+++ b/apps/odyssey-stats/src/widget/highlights.jsx
@@ -3,6 +3,8 @@ import { Icon, external } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
+import { useState } from 'react';
+import SegmentedControl from 'calypso/components/segmented-control';
 import useReferrersQuery from '../hooks/use-referrers-query';
 import useTopPostsQuery from '../hooks/use-top-posts-query';
 
@@ -91,6 +93,8 @@ function TopColumn( {
 
 export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } ) {
 	const translate = useTranslate();
+	const [ selectedTab, setSelectedTab ] = useState( 'topPostsAndPages' );
+
 	const queryDate = moment()
 		.utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 )
 		.format( 'YYYY-MM-DD' );
@@ -111,16 +115,44 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 	);
 
 	const headingTitle = translate( '7 Day Highlights' );
+	const topPostsAndPagesTitle = translate( 'Top Posts & Pages' );
+	const topReferrersTitle = translate( 'Top Referrers' );
+
+	const moduleTabs = [
+		{
+			value: 'topPostsAndPages',
+			label: topPostsAndPagesTitle,
+		},
+		{
+			value: 'topReferrers',
+			label: topReferrersTitle,
+		},
+	];
 
 	return (
 		<div className="stats-widget-highlights stats-widget-card" aria-label={ headingTitle }>
 			<div className="stats-widget-highlights__header">
 				<label>{ headingTitle }</label>
 			</div>
+			<div className="stats-widget-highlights__tabs">
+				<SegmentedControl primary className="test">
+					{ moduleTabs.map( ( tab ) => {
+						return (
+							<SegmentedControl.Item
+								key={ tab.value }
+								selected={ tab.value === selectedTab }
+								onClick={ () => setSelectedTab( tab.value ) }
+							>
+								{ tab.label }
+							</SegmentedControl.Item>
+						);
+					} ) }
+				</SegmentedControl>
+			</div>
 			<div className="stats-widget-highlights__body">
 				<TopColumn
 					className="stats-widget-highlights__column"
-					title={ translate( 'Top Posts & Pages' ) }
+					title={ topPostsAndPagesTitle }
 					viewAllUrl={ viewAllPostsStatsUrl }
 					viewAllText={ translate( 'View all posts & pages stats' ) }
 					items={ topPostsAndPages }
@@ -131,7 +163,7 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 				/>
 				<TopColumn
 					className="stats-widget-highlights__column"
-					title={ translate( 'Top Referrers' ) }
+					title={ topReferrersTitle }
 					viewAllUrl={ viewAllReferrerStatsUrl }
 					viewAllText={ translate( 'View all referrer stats' ) }
 					items={ topReferrers }

--- a/apps/odyssey-stats/src/widget/highlights.jsx
+++ b/apps/odyssey-stats/src/widget/highlights.jsx
@@ -11,6 +11,9 @@ import useTopPostsQuery from '../hooks/use-top-posts-query';
 import './hightlights.scss';
 
 const HIGHLIGHT_ITEMS_LIMIT = 5;
+const HIGHLIGHT_TAB_TOP_POSTS_PAGES = 'topPostsAndPages';
+const HIGHLIGHT_TAB_TOP_REFERRERS = 'topReferrers';
+
 const postAndPageLink = ( baseUrl, siteId, postId ) => {
 	return `${ baseUrl }#!/stats/post/${ postId }/${ siteId }`;
 };
@@ -93,23 +96,24 @@ function TopColumn( {
 
 export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } ) {
 	const translate = useTranslate();
+
 	const headingTitle = translate( '7 Day Highlights' );
 	const topPostsAndPagesTitle = translate( 'Top Posts & Pages' );
 	const topReferrersTitle = translate( 'Top Referrers' );
 
 	const moduleTabs = [
 		{
-			value: 'topPostsAndPages',
+			value: HIGHLIGHT_TAB_TOP_POSTS_PAGES,
 			label: topPostsAndPagesTitle,
 		},
 		{
-			value: 'topReferrers',
+			value: HIGHLIGHT_TAB_TOP_REFERRERS,
 			label: topReferrersTitle,
 		},
 	];
 
 	// Default to the first tab `topPostsAndPages`.
-	const [ selectedTab, setSelectedTab ] = useState( moduleTabs[ 0 ].value );
+	const [ selectedTab, setSelectedTab ] = useState( HIGHLIGHT_TAB_TOP_POSTS_PAGES );
 
 	const queryDate = moment()
 		.utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 )
@@ -154,7 +158,8 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 			<div className="stats-widget-highlights__body">
 				<TopColumn
 					className={ classNames( 'stats-widget-highlights__column', {
-						'stats-widget-highlights__column--show-in-mobile': selectedTab === 'topPostsAndPages',
+						'stats-widget-highlights__column--show-in-mobile':
+							selectedTab === HIGHLIGHT_TAB_TOP_POSTS_PAGES,
 					} ) }
 					title={ topPostsAndPagesTitle }
 					viewAllUrl={ viewAllPostsStatsUrl }
@@ -167,7 +172,8 @@ export default function Highlights( { siteId, gmtOffset, odysseyStatsBaseUrl } )
 				/>
 				<TopColumn
 					className={ classNames( 'stats-widget-highlights__column', {
-						'stats-widget-highlights__column--show-in-mobile': selectedTab === 'topReferrers',
+						'stats-widget-highlights__column--show-in-mobile':
+							selectedTab === HIGHLIGHT_TAB_TOP_REFERRERS,
 					} ) }
 					title={ topReferrersTitle }
 					viewAllUrl={ viewAllReferrerStatsUrl }

--- a/apps/odyssey-stats/src/widget/hightlights.scss
+++ b/apps/odyssey-stats/src/widget/hightlights.scss
@@ -28,7 +28,7 @@ $offset-padding-hovering: 8px;
 		display: grid;
 		grid-template-columns: repeat(2, 1fr);
 		column-gap: 24px;
-		margin: 26px (-$offset-padding-hovering) 0;
+		margin: 16px (-$offset-padding-hovering) 0;
 
 		@media only screen and (max-width: $break-dashboard-mobile) {
 			grid-template-columns: none;
@@ -52,22 +52,23 @@ $offset-padding-hovering: 8px;
 	}
 
 	.stats-widget-highlights-card__title {
+		display: block;
 		font-weight: 500;
 		font-size: $font-body;
 		line-height: 26px;
-		margin-left: $offset-padding-hovering;
+		margin: 0 0 16px $offset-padding-hovering;
 	}
 
 	.stats-widget-highlights-card__empty {
 		min-height: 40px;
-		margin: 20px 0 0 $offset-padding-hovering;
+		margin: 0 0 0 $offset-padding-hovering;
 		color: var(--studio-gray-40);
 	}
 
 	.stats-widget-highlights-card__list {
 		list-style: none;
 		padding: 0;
-		margin: 12px 0 0;
+		margin: 0;
 
 		li {
 			&:not(:last-child) {

--- a/apps/odyssey-stats/src/widget/hightlights.scss
+++ b/apps/odyssey-stats/src/widget/hightlights.scss
@@ -47,9 +47,10 @@ $offset-padding-hovering: 8px;
 			@media only screen and (max-width: $break-dashboard-mobile) {
 				display: block;
 				width: 100%;
-			}
-			.stats-widget-highlights-card__title {
-				display: none;
+
+				.stats-widget-highlights-card__title {
+					display: none;
+				}
 			}
 		}
 	}

--- a/apps/odyssey-stats/src/widget/hightlights.scss
+++ b/apps/odyssey-stats/src/widget/hightlights.scss
@@ -29,11 +29,26 @@ $offset-padding-hovering: 8px;
 		grid-template-columns: repeat(2, 1fr);
 		column-gap: 24px;
 		margin: 26px (-$offset-padding-hovering) 0;
+
+		@media only screen and (max-width: $break-dashboard-mobile) {
+			grid-template-columns: none;
+		}
 	}
 
 	.stats-widget-highlights__column {
 		// Make sure the highlight section doesn't overflow the container, which makes ellipsis work.
 		min-width: 0;
+
+		@media only screen and (max-width: $break-dashboard-mobile) {
+			display: none;
+		}
+
+		&.is-mobile-show {
+			@media only screen and (max-width: $break-dashboard-mobile) {
+				display: block;
+				width: 100%;
+			}
+		}
 	}
 
 	.stats-widget-highlights-card__title {

--- a/apps/odyssey-stats/src/widget/hightlights.scss
+++ b/apps/odyssey-stats/src/widget/hightlights.scss
@@ -1,4 +1,5 @@
 @import "../styles/variables.scss";
+@import "./variables.scss";
 
 $offset-padding-hovering: 8px;
 
@@ -11,6 +12,15 @@ $offset-padding-hovering: 8px;
 			font-weight: 500;
 			font-size: $font-body-large;
 			line-height: 26px;
+		}
+	}
+
+	.stats-widget-highlights__tabs {
+		display: none;
+		margin-top: 16px;
+
+		@media only screen and (max-width: $break-dashboard-mobile) {
+			display: block;
 		}
 	}
 

--- a/apps/odyssey-stats/src/widget/hightlights.scss
+++ b/apps/odyssey-stats/src/widget/hightlights.scss
@@ -48,6 +48,9 @@ $offset-padding-hovering: 8px;
 				display: block;
 				width: 100%;
 			}
+			.stats-widget-highlights-card__title {
+				display: none;
+			}
 		}
 	}
 

--- a/apps/odyssey-stats/src/widget/hightlights.scss
+++ b/apps/odyssey-stats/src/widget/hightlights.scss
@@ -43,7 +43,7 @@ $offset-padding-hovering: 8px;
 			display: none;
 		}
 
-		&.is-mobile-show {
+		&.stats-widget-highlights__column--show-in-mobile {
 			@media only screen and (max-width: $break-dashboard-mobile) {
 				display: block;
 				width: 100%;

--- a/apps/odyssey-stats/src/widget/index.scss
+++ b/apps/odyssey-stats/src/widget/index.scss
@@ -4,6 +4,8 @@
 @import "../styles/typography.scss";
 @import "./variables.scss";
 
+$segmentedControlItemBorderRadius: 4px;
+
 .jp-stats-widget {
 	// Offset the margin and padding of the `.postbox .inside` container.
 	margin: -11px -12px -12px;
@@ -11,6 +13,51 @@
 
 .stats-widget-content {
 	font-family: $font-sf-pro-text;
+
+	// For both MiniChart and Highlights.
+	.segmented-control {
+		height: 36px;
+		min-width: 259px;
+
+		@media only screen and (max-width: $break-dashboard-mobile) {
+			width: 100%;
+		}
+
+		.segmented-control__item {
+			&:first-of-type .segmented-control__link {
+				border-top-left-radius: $segmentedControlItemBorderRadius;
+				border-bottom-left-radius: $segmentedControlItemBorderRadius;
+			}
+
+			&:last-of-type .segmented-control__link {
+				border-top-right-radius: $segmentedControlItemBorderRadius;
+				border-bottom-right-radius: $segmentedControlItemBorderRadius;
+			}
+
+			// Black segmented controls.
+			.segmented-control__link:hover {
+				background-color: var(--color-neutral-0);
+			}
+
+			&.is-selected .segmented-control__link {
+				&,
+				&:hover,
+				&:focus {
+					background-color: var(--studio-black);
+					border-color: var(--studio-black);
+				}
+			}
+
+			&.is-selected + .segmented-control__item .segmented-control__link {
+				border-left-color: var(--studio-black);
+			}
+		}
+
+		.segmented-control__link {
+			color: var(--studio-gray-70);
+			font-weight: 600;
+		}
+	}
 }
 
 .stats-widget-wrapper {

--- a/apps/odyssey-stats/src/widget/mini-chart.scss
+++ b/apps/odyssey-stats/src/widget/mini-chart.scss
@@ -1,6 +1,3 @@
-@import "./variables.scss";
-
-$segmentedControlItemBorderRadius: 4px;
 $barDarkColor: var(--color-primary-60);
 
 .stats-widget-minichart {
@@ -76,49 +73,6 @@ $barDarkColor: var(--color-primary-60);
 
 	.chart__bar-section-inner {
 		background-color: $barDarkColor;
-	}
-
-	.segmented-control {
-		&.stats-navigation__intervals {
-			height: 36px;
-			min-width: 259px;
-
-			@media only screen and (max-width: $break-dashboard-mobile) {
-				width: 100%;
-			}
-		}
-
-		.segmented-control__item {
-			&:first-of-type .segmented-control__link {
-				border-top-left-radius: $segmentedControlItemBorderRadius;
-				border-bottom-left-radius: $segmentedControlItemBorderRadius;
-			}
-
-			&:last-of-type .segmented-control__link {
-				border-top-right-radius: $segmentedControlItemBorderRadius;
-				border-bottom-right-radius: $segmentedControlItemBorderRadius;
-			}
-
-			// Black segmented controls.
-			.segmented-control__link:hover {
-				background-color: var(--color-neutral-0);
-			}
-
-			&.is-selected .segmented-control__link,
-			&.is-selected .segmented-control__link:hover {
-				background-color: var(--studio-black);
-				border-color: var(--studio-black);
-			}
-
-			&.is-selected + .segmented-control__item .segmented-control__link {
-				border-left-color: var(--studio-black);
-			}
-		}
-
-		.segmented-control__link {
-			color: var(--studio-gray-70);
-			font-weight: 600;
-		}
 	}
 
 	.stats__empty-state {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76383 

## Proposed Changes

Reference of @kangzj's thoughts: https://github.com/Automattic/wp-calypso/pull/76315#issuecomment-1526721163

Since the Jetpack Stats Widget width is not entirely correlated with the window width, I prefer to tackle the module tabs along with the single-column module card to improve the user experience on the really mobile layout (window width <= 799px) rather than the narrower PC windows which the width > 799 but the widget scope feels narrow.

* Refactor `SegmentedControl` styles to fit usages on `MiniChart` and `Highlights`.
* Add module tabs for the mobile layout to toggle single-column module card displaying.
* Align layout styling with the latest design.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open your local Jetpack site.
* Check out the branch of the Jetpack to the latest `trunk`.
* Build Jetpack if necessary: `jetpack build plugins/jetpack`.
* Run `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev` under `calypso/apps/odyssey-stats`.
* Navigate to `/wp-admin/index.php`.
* Ensure the layout of the Stats Widget aligns with the latest design.
* Ensure there are tabs for the mobile layout to toggle displaying the selected module card.

#### PC
<img width="598" alt="截圖 2023-04-28 下午10 04 35" src="https://user-images.githubusercontent.com/6869813/235169812-4df3132e-682f-4b28-86de-a0e7d18a5c1e.png">

#### Mobile
|Before|After|
|-|-|
|<img width="848" alt="截圖 2023-04-28 下午10 05 32" src="https://user-images.githubusercontent.com/6869813/235169936-d0445e02-e100-4dac-83b6-36f8745558b2.png">|<img width="849" alt="截圖 2023-04-28 下午10 04 18" src="https://user-images.githubusercontent.com/6869813/235169906-45404187-2f7d-4abe-90e9-dd5f6556000f.png">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
