### PR TITLE
CODEOWNERS: Remove frameworks team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,13 +82,6 @@
 /client/lib/explat @Automattic/experimentation-platform
 /packages/explat-* @Automattic/experimentation-platform
 
-# Framework
-/client/boot @Automattic/team-calypso-frameworks
-/client/controller @Automattic/team-calypso-frameworks
-/client/layout @Automattic/team-calypso-frameworks
-/client/server @Automattic/team-calypso-frameworks
-/packages/js-utils @Automattic/team-calypso-frameworks
-
 # Jetpack Search
 /client/my-sites/jetpack-search @Automattic/jetpack-search
 


### PR DESCRIPTION
## Proposed Changes

I'm suggesting removing the @Automattic/team-calypso-frameworks team from CODEOWNERS because:
* The current list of directories is far from complete and provides the assumption that we care only about these directories when we actually care about the entire repository. 
* I've seen multiple cases of PRs when the automated review request gets removed immediately by the PR author. That means that this creates some unnecessary friction. We're staying reactive to PR review requests, but we'd like to help when intentionally called for, and not in all unintentional ping situations.
* We are not necessarily interested in all changes in those directories. Often there are minor changes, unrelated to our area of interest, and that can create unnecessary noise. 

## Testing Instructions

Not needed. 