### PR TITLE
localizeUrl: option to preserve trailing slash variation

### DIFF
--- a/packages/i18n-utils/CHANGELOG.md
+++ b/packages/i18n-utils/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.0
+
+Add support for preserving trailing slash variation in `localizeUrl`
+
 ## 1.1.0
 
 Add support for `https://apps.wordpress.com` URLs

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-utils",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "WordPress.com i18n utils.",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -170,14 +170,12 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 };
 
 function hasTrailingSlash( urlString: string ) {
-	let url;
 	try {
-		url = new URL( String( urlString ), INVALID_URL );
+		const url = new URL( String( urlString ), INVALID_URL );
+		return url.pathname.endsWith( '/' );
 	} catch ( e ) {
 		return false;
 	}
-
-	return url.pathname.endsWith( '/' );
 }
 
 export function localizeUrl(

--- a/packages/i18n-utils/src/localize-url.tsx
+++ b/packages/i18n-utils/src/localize-url.tsx
@@ -169,10 +169,22 @@ export const urlLocalizationMapping: UrlLocalizationMapping = {
 	},
 };
 
+function hasTrailingSlash( urlString: string ) {
+	let url;
+	try {
+		url = new URL( String( urlString ), INVALID_URL );
+	} catch ( e ) {
+		return false;
+	}
+
+	return url.pathname.endsWith( '/' );
+}
+
 export function localizeUrl(
 	fullUrl: string,
 	locale: Locale = getDefaultLocale(),
-	isLoggedIn = true
+	isLoggedIn = true,
+	preserveTrailingSlashVariation = false
 ): string {
 	let url;
 	try {
@@ -191,6 +203,10 @@ export function localizeUrl(
 
 	if ( ! url.pathname.endsWith( '.php' ) ) {
 		// Essentially a trailingslashit.
+		// We need to do this because the matching list is standardised to use
+		// trailing slashes everywhere.
+		// However, if the `preserveTrailingSlashVariation` option is enabled, we
+		// remove the trailing slash at the end again, when appropriate.
 		url.pathname = ( url.pathname + '/' ).replace( /\/+$/, '/' );
 	}
 
@@ -209,7 +225,21 @@ export function localizeUrl(
 
 	for ( let i = lookup.length - 1; i >= 0; i-- ) {
 		if ( lookup[ i ] in urlLocalizationMapping ) {
-			return urlLocalizationMapping[ lookup[ i ] ]( url, locale, isLoggedIn ).href;
+			const mapped = urlLocalizationMapping[ lookup[ i ] ]( url, locale, isLoggedIn ).href;
+
+			if ( ! preserveTrailingSlashVariation ) {
+				return mapped;
+			}
+
+			try {
+				const mappedUrl = new URL( mapped );
+				if ( ! hasTrailingSlash( fullUrl ) ) {
+					mappedUrl.pathname = mappedUrl.pathname.replace( /\/+$/, '' );
+				}
+				return mappedUrl.href;
+			} catch {
+				return mapped;
+			}
 		}
 	}
 
@@ -221,11 +251,16 @@ export function useLocalizeUrl() {
 	const providerLocale = useLocale();
 
 	return useCallback(
-		( fullUrl: string, locale?: Locale, isLoggedIn?: boolean ) => {
+		(
+			fullUrl: string,
+			locale?: Locale,
+			isLoggedIn?: boolean,
+			preserveTrailingSlashVariation?: boolean
+		) => {
 			if ( locale ) {
-				return localizeUrl( fullUrl, locale, isLoggedIn );
+				return localizeUrl( fullUrl, locale, isLoggedIn, preserveTrailingSlashVariation );
 			}
-			return localizeUrl( fullUrl, providerLocale, isLoggedIn );
+			return localizeUrl( fullUrl, providerLocale, isLoggedIn, preserveTrailingSlashVariation );
 		},
 		[ providerLocale ]
 	);

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -91,11 +91,34 @@ describe( '#localizeUrl', () => {
 	} );
 
 	test( 'trailing slash variations', () => {
-		expect( localizeUrl( 'https://automattic.com/cookies/', 'de' ) ).toEqual(
+		const loggedIn = false;
+
+		// Add trailing slashes everywhere (default).
+		expect( localizeUrl( 'https://automattic.com/cookies/', 'de', loggedIn ) ).toEqual(
 			'https://automattic.com/de/cookies/'
 		);
-		expect( localizeUrl( 'https://automattic.com/cookies', 'de' ) ).toEqual(
+		expect( localizeUrl( 'https://automattic.com/cookies', 'de', loggedIn ) ).toEqual(
 			'https://automattic.com/de/cookies/'
+		);
+		expect( localizeUrl( 'https://automattic.com/cookies?foo=bar', 'de', loggedIn ) ).toEqual(
+			'https://automattic.com/de/cookies/?foo=bar'
+		);
+		expect( localizeUrl( 'https://automattic.com/cookies#baz', 'de', loggedIn ) ).toEqual(
+			'https://automattic.com/de/cookies/#baz'
+		);
+
+		// Preserve trailing slash variation.
+		expect( localizeUrl( 'https://automattic.com/cookies/', 'de', loggedIn, true ) ).toEqual(
+			'https://automattic.com/de/cookies/'
+		);
+		expect( localizeUrl( 'https://automattic.com/cookies', 'de', loggedIn, true ) ).toEqual(
+			'https://automattic.com/de/cookies'
+		);
+		expect( localizeUrl( 'https://automattic.com/cookies?foo=bar', 'de', loggedIn, true ) ).toEqual(
+			'https://automattic.com/de/cookies?foo=bar'
+		);
+		expect( localizeUrl( 'https://automattic.com/cookies#baz', 'de', loggedIn, true ) ).toEqual(
+			'https://automattic.com/de/cookies#baz'
 		);
 	} );
 

--- a/packages/i18n-utils/src/test/localize-url.js
+++ b/packages/i18n-utils/src/test/localize-url.js
@@ -91,33 +91,33 @@ describe( '#localizeUrl', () => {
 	} );
 
 	test( 'trailing slash variations', () => {
-		const loggedIn = false;
+		const isLoggedIn = false;
 
 		// Add trailing slashes everywhere (default).
-		expect( localizeUrl( 'https://automattic.com/cookies/', 'de', loggedIn ) ).toEqual(
+		expect( localizeUrl( 'https://automattic.com/cookies/', 'de', isLoggedIn ) ).toEqual(
 			'https://automattic.com/de/cookies/'
 		);
-		expect( localizeUrl( 'https://automattic.com/cookies', 'de', loggedIn ) ).toEqual(
+		expect( localizeUrl( 'https://automattic.com/cookies', 'de', isLoggedIn ) ).toEqual(
 			'https://automattic.com/de/cookies/'
 		);
-		expect( localizeUrl( 'https://automattic.com/cookies?foo=bar', 'de', loggedIn ) ).toEqual(
+		expect( localizeUrl( 'https://automattic.com/cookies?foo=bar', 'de', isLoggedIn ) ).toEqual(
 			'https://automattic.com/de/cookies/?foo=bar'
 		);
-		expect( localizeUrl( 'https://automattic.com/cookies#baz', 'de', loggedIn ) ).toEqual(
+		expect( localizeUrl( 'https://automattic.com/cookies#baz', 'de', isLoggedIn ) ).toEqual(
 			'https://automattic.com/de/cookies/#baz'
 		);
 
 		// Preserve trailing slash variation.
-		expect( localizeUrl( 'https://automattic.com/cookies/', 'de', loggedIn, true ) ).toEqual(
+		expect( localizeUrl( 'https://automattic.com/cookies/', 'de', isLoggedIn, true ) ).toEqual(
 			'https://automattic.com/de/cookies/'
 		);
-		expect( localizeUrl( 'https://automattic.com/cookies', 'de', loggedIn, true ) ).toEqual(
+		expect( localizeUrl( 'https://automattic.com/cookies', 'de', isLoggedIn, true ) ).toEqual(
 			'https://automattic.com/de/cookies'
 		);
-		expect( localizeUrl( 'https://automattic.com/cookies?foo=bar', 'de', loggedIn, true ) ).toEqual(
-			'https://automattic.com/de/cookies?foo=bar'
-		);
-		expect( localizeUrl( 'https://automattic.com/cookies#baz', 'de', loggedIn, true ) ).toEqual(
+		expect(
+			localizeUrl( 'https://automattic.com/cookies?foo=bar', 'de', isLoggedIn, true )
+		).toEqual( 'https://automattic.com/de/cookies?foo=bar' );
+		expect( localizeUrl( 'https://automattic.com/cookies#baz', 'de', isLoggedIn, true ) ).toEqual(
 			'https://automattic.com/de/cookies#baz'
 		);
 	} );

--- a/packages/wpcom-template-parts/package.json
+++ b/packages/wpcom-template-parts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-template-parts",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "WordPress.com template parts to be used everywhere",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/wpcom-template-parts/package.json
+++ b/packages/wpcom-template-parts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-template-parts",
-	"version": "1.0.1",
+	"version": "1.0.0",
 	"description": "WordPress.com template parts to be used everywhere",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -151,7 +151,8 @@ const UniversalNavbarHeader = ( {
 															urlValue={ localizeUrl(
 																'//wordpress.com/themes',
 																locale,
-																isLoggedIn
+																isLoggedIn,
+																true
 															) }
 															type="dropdown"
 														/>
@@ -161,7 +162,8 @@ const UniversalNavbarHeader = ( {
 															urlValue={ localizeUrl(
 																'//wordpress.com/plugins',
 																locale,
-																isLoggedIn
+																isLoggedIn,
+																true
 															) }
 															type="dropdown"
 														/>
@@ -258,7 +260,7 @@ const UniversalNavbarHeader = ( {
 											className="x-nav-item x-nav-item__wide"
 											titleValue={ __( 'Log In', __i18n_text_domain__ ) }
 											content={ __( 'Log In', __i18n_text_domain__ ) }
-											urlValue={ localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn ) }
+											urlValue={ localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn, true ) }
 											type="nav"
 										/>
 									) }
@@ -334,7 +336,7 @@ const UniversalNavbarHeader = ( {
 										<ClickableItem
 											titleValue={ __( 'Log In', __i18n_text_domain__ ) }
 											content={ __( 'Log In', __i18n_text_domain__ ) }
-											urlValue={ localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn ) }
+											urlValue={ localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn, true ) }
 											type="menu"
 										/>
 									</ul>
@@ -412,13 +414,23 @@ const UniversalNavbarHeader = ( {
 											<ClickableItem
 												titleValue={ __( 'WordPress Themes', __i18n_text_domain__ ) }
 												content={ __( 'WordPress Themes', __i18n_text_domain__ ) }
-												urlValue={ localizeUrl( '//wordpress.com/themes', locale, isLoggedIn ) }
+												urlValue={ localizeUrl(
+													'//wordpress.com/themes',
+													locale,
+													isLoggedIn,
+													true
+												) }
 												type="menu"
 											/>
 											<ClickableItem
 												titleValue={ __( 'WordPress Plugins', __i18n_text_domain__ ) }
 												content={ __( 'WordPress Plugins', __i18n_text_domain__ ) }
-												urlValue={ localizeUrl( '//wordpress.com/plugins', locale, isLoggedIn ) }
+												urlValue={ localizeUrl(
+													'//wordpress.com/plugins',
+													locale,
+													isLoggedIn,
+													true
+												) }
 												type="menu"
 											/>
 											<ClickableItem


### PR DESCRIPTION
The motivation behind this PR is to fix the `Log In` link in logged-out theme pages.

<img width="1042" alt="image" src="https://user-images.githubusercontent.com/409615/235187941-0780b155-53e4-4e42-abf6-00ba43de50aa.png">

As of right now, clicking it results in the URL location changing, but nothing else happening. The bug seems to be caused by the fact that the login URL has a trailing slash, which the routing doesn't particularly like.

In order to fix this, a new option needed to be added to `localizeUrl`, so that the chosen trailing slash variation (yes/no) for a link can be preserved.

This PR adds the new option and updates `wpcom-template-parts` to use it, where appropriate.

CC @josephscott and @mreishus, who also looked at the bug. 

## Proposed Changes

* Add new `preserveTrailingSlashVariation` option to `localizeUrl` and `useLocalizeUrl`.
* Modify `wpcom-template-parts` to use the new option where appropriate
* Add unit tests for the new option

## Testing Instructions

* Ensure the old and new `i18n-utils` tests work
* Modify `packages/wpcom-template-parts/src/universal-header-navigation/index.tsx` (L263) to localise the URL `'/log-in'` instead of `'//wordpress.com/log-in'` (it needs to match the origin for the bug to manifest)
* Start a dev build
* Open a theme page while logged out (e.g. `/theme/verso`)
* Click the `Log In` link at the top
* Ensure that you get redirected to the login page

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [X] Have you checked for TypeScript, React or other console errors?
