### PR TITLE
Added new post and new comment columns to Sites list in Subscription Manager

### DIFF
--- a/client/landing/subscriptions/components/site-list/site-list.tsx
+++ b/client/landing/subscriptions/components/site-list/site-list.tsx
@@ -1,3 +1,4 @@
+import { SubscriptionManager } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import SiteRow from './site-row';
 import './styles.scss';
@@ -11,6 +12,7 @@ const defaultSites: SiteSubscription[] = [];
 
 export default function SiteList( { sites = defaultSites }: SiteListProps ) {
 	const translate = useTranslate();
+	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
 
 	return (
 		<ul className="subscription-manager__site-list" role="table">
@@ -21,6 +23,16 @@ export default function SiteList( { sites = defaultSites }: SiteListProps ) {
 				<span className="date" role="columnheader">
 					{ translate( 'Since' ) }
 				</span>
+				{ isLoggedIn && (
+					<span className="new-posts" role="columnheader">
+						{ translate( 'New posts' ) }
+					</span>
+				) }
+				{ isLoggedIn && (
+					<span className="new-comments" role="columnheader">
+						{ translate( 'New comments' ) }
+					</span>
+				) }
 				<span className="email-frequency" role="columnheader">
 					{ translate( 'Email frequency' ) }
 				</span>

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -39,10 +39,23 @@ export default function SiteRow( {
 		}
 		return <Gridicon className="icon" icon="globe" size={ 48 } />;
 	}, [ site_icon, name ] );
+	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
+	const translate = useTranslate();
 
 	const deliveryFrequencyValue = useMemo(
 		() => delivery_methods?.email?.post_delivery_frequency as SiteSubscriptionDeliveryFrequency,
 		[ delivery_methods?.email?.post_delivery_frequency ]
+	);
+	const newPostDelivery = useMemo( () => {
+		const emailDelivery = delivery_methods?.email?.send_posts ? translate( 'Email' ) : null;
+		const notificationDelivery = delivery_methods?.notification?.send_posts
+			? translate( 'Notifications' )
+			: null;
+		return [ emailDelivery, notificationDelivery ].filter( Boolean ).join( ', ' );
+	}, [ delivery_methods?.email?.send_posts, delivery_methods?.notification?.send_posts ] );
+	const newCommentDelivery = useMemo(
+		() => delivery_methods?.email?.send_comments,
+		[ delivery_methods?.email?.send_comments ]
 	);
 	const deliveryFrequencyLabel = useDeliveryFrequencyLabel( deliveryFrequencyValue );
 
@@ -65,6 +78,20 @@ export default function SiteRow( {
 			<span className="date" role="cell">
 				<TimeSince date={ date_subscribed.toISOString?.() ?? date_subscribed } />
 			</span>
+			{ isLoggedIn && (
+				<span className="new-posts" role="cell">
+					{ newPostDelivery }
+				</span>
+			) }
+			{ isLoggedIn && (
+				<span className="new-comments" role="cell">
+					{ newCommentDelivery ? (
+						<Gridicon icon="checkmark" size={ 16 } className="green" />
+					) : (
+						<Gridicon icon="cross" size={ 16 } className="red" />
+					) }
+				</span>
+			) }
 			<span className="email-frequency" role="cell">
 				{ deliveryFrequencyLabel }
 			</span>

--- a/client/landing/subscriptions/components/site-list/styles.scss
+++ b/client/landing/subscriptions/components/site-list/styles.scss
@@ -90,12 +90,27 @@ $max-list-width: 1300px;
 
 		.title-box,
 		.email-frequency,
-		.date {
+		.date,
+		.new-posts,
+		.new-comments {
 			font-weight: 400;
 			font-size: $font-body-small;
 			line-height: 20px;
 			letter-spacing: -0.15px;
 			color: $studio-gray-60;
+		}
+
+		.new-posts,
+		.new-comments {
+			.green {
+				fill: var(--color-success);
+				vertical-align: text-bottom;
+			}
+
+			.red {
+				fill: var(--color-error);
+				vertical-align: text-bottom;
+			}
 		}
 
 		.actions {
@@ -109,6 +124,18 @@ $max-list-width: 1300px;
 
 		&:last-child {
 			border-bottom: none;
+		}
+	}
+
+	@media (max-width: $break-xlarge) {
+		.new-comments {
+			display: none;
+		}
+	}
+
+	@media (max-width: $break-large) {
+		.new-posts {
+			display: none;
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/76398

## Proposed Changes

This PR adds the 2 missing columns in the Sites view for Subscription Manager: new posts and new comments. 

<img width="1408" alt="Screenshot 2023-04-28 at 17 29 46" src="https://user-images.githubusercontent.com/3832570/235190255-d96650f7-695a-46e5-ab06-a984d4495dae.png">

These two columns will only be visible for the logged-in users.

## Testing Instructions

1. Follow these instructions to run Calypso with your user logged in: PCYsg-5YE-p2
2. Apply this PR and run the application.
3. Go to `http://calypso.localhost:3000/subscriptions/sites`. You should see the new columns like the image above.
4. Now, in incognito, go to `https://wordpress.com/email-subscriptions/` and log in with an external user.
5. You should receive a confirmation e-mail that contains a "Manage subscriptions" button
6. Copy the button's link & visit in an incognito window
7. Open dev tools & copy the cookie. Make sure "Show URL decoded" is checked. Copy the value from the subkey cookie.
8. Add the subkey cookie to calypso.localhost:3000.
9. Go to `http://calypso.localhost:3000/subscriptions/sites`. You should not be able to see the new columns as it's only available for internal users.


