### PR TITLE
Tracks Tracking Debug Test

### DIFF
--- a/client/server/lib/analytics/index.js
+++ b/client/server/lib/analytics/index.js
@@ -42,6 +42,7 @@ function getUserFromRequest( request ) {
 const analytics = {
 	tracks: {
 		createPixel: function ( data ) {
+			console.log( 'createPixel', data );
 			data._rt = new Date().getTime();
 			data._ = '_';
 			const pixelUrl = URL.format( {

--- a/config/development.json
+++ b/config/development.json
@@ -26,7 +26,7 @@
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"features": {
-		"ad-tracking": false,
+		"ad-tracking": true,
 		"akismet/siteless-checkout": true,
 		"anchor/sunset-integration": true,
 		"calypso/help-center": true,
@@ -62,7 +62,7 @@
 		"external-media/openverse": true,
 		"full-site-editing/beta-opt-in": true,
 		"fullstory": true,
-		"cookie-banner": false,
+		"cookie-banner": true,
 		"google-drive": true,
 		"google-my-business": true,
 		"gutenboarding/alpha-templates": false,

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -39,6 +39,7 @@ let _superProps: any; // Added to all Tracks events.
 let _loadTracksResult = Promise.resolve(); // default value for non-BOM environments.
 
 if ( typeof document !== 'undefined' ) {
+	debug( 'Loading Tracks script: stats.wp.com/w.js?63' );
 	_loadTracksResult = loadScript( '//stats.wp.com/w.js?63' );
 }
 
@@ -113,6 +114,7 @@ export function getTracksLoadPromise() {
 }
 
 export function pushEventToTracksQueue( args: Array< any > ) {
+	console.log( 'pushEventToTracksQueue', args );
 	if ( typeof window !== 'undefined' ) {
 		window._tkq = window._tkq || [];
 		window._tkq.push( args );


### PR DESCRIPTION
This is just a test to help this other PR: #76277

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
