### PR TITLE
Marketplace Thank You: Guarantee 3 sections on footer

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
@@ -26,14 +26,14 @@ export function useThankYouFoooter(
 	 * If only plugins are present
 	 */
 	if ( hasPlugins && ! hasThemes ) {
-		footerSteps = [ pluginExploreStep, pluginSupportStep ];
+		footerSteps = [ pluginExploreStep, pluginSupportStep, themeSupportStep ];
 	}
 
 	/**
 	 * If only themes are present
 	 */
 	if ( ! hasPlugins && hasThemes ) {
-		footerSteps = [ themeSupportStep, WordPressForumStep ];
+		footerSteps = [ themeSupportStep, WordPressForumStep, pluginExploreStep ];
 	}
 
 	const steps = useNextSteps( footerSteps, pluginSlugs, themeSlugs );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
@@ -58,6 +58,18 @@ export function useThankYouFoooter(
 					},
 			  ]
 			: [] ),
+		...( hasThemes
+			? [
+					{
+						key: 'thank_you_footer_support_guides_themes',
+						title: translate( 'Learn More' ),
+						description: translate( 'Discover everything you need to know about Themes.' ),
+						link: 'https://wordpress.com/support/themes/',
+						linkText: translate( 'Theme Support' ),
+						eventKey: 'calypso_plugin_thank_you_theme_support_click',
+					},
+			  ]
+			: [] ),
 	];
 	const steps = useNextSteps( footerSteps, pluginSlugs, themeSlugs );
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
@@ -10,67 +10,32 @@ export function useThankYouFoooter(
 	pluginSlugs: Array< string >,
 	themeSlugs: Array< string >
 ): ThankYouSectionProps {
-	const translate = useTranslate();
-	const siteSlug = useSelector( getSelectedSiteSlug );
 	const [ hasPlugins, hasThemes ] = [ pluginSlugs, themeSlugs ].map(
 		( slugs ) => slugs.length !== 0
 	);
 
-	const footerSteps: FooterStep[] = [
-		...( hasPlugins
-			? [
-					{
-						key: 'thank_you_footer_explore',
-						title: translate( 'Keep growing' ),
-						description: translate(
-							'Take your site to the next level. We have all the solutions to help you.'
-						),
-						link: `/plugins/${ siteSlug }`,
-						linkText: translate( 'Explore plugins' ),
-						eventKey: 'calypso_plugin_thank_you_explore_plugins_click',
-						blankTarget: false,
-					},
-			  ]
-			: [] ),
-		...( hasPlugins
-			? [
-					{
-						key: 'thank_you_footer_support_guides',
-						title: translate( 'Learn More' ),
-						description: translate( 'Discover everything you need to know about Plugins.' ),
-						link: 'https://wordpress.com/support/plugins/',
-						linkText: translate( 'Plugin Support' ),
-						eventKey: 'calypso_plugin_thank_you_plugin_support_click',
-					},
-			  ]
-			: [] ),
-		...( hasThemes
-			? [
-					{
-						key: 'thank_you_footer_forum',
-						title: translate( 'WordPress community' ),
-						description: translate(
-							'Have a question about this theme? Get help from the community.'
-						),
-						link: 'https://wordpress.com/forums/',
-						linkText: translate( 'Visit Forum' ),
-						eventKey: 'calypso_plugin_thank_you_forum_click',
-					},
-			  ]
-			: [] ),
-		...( hasThemes
-			? [
-					{
-						key: 'thank_you_footer_support_guides_themes',
-						title: translate( 'Learn More' ),
-						description: translate( 'Discover everything you need to know about Themes.' ),
-						link: 'https://wordpress.com/support/themes/',
-						linkText: translate( 'Theme Support' ),
-						eventKey: 'calypso_plugin_thank_you_theme_support_click',
-					},
-			  ]
-			: [] ),
-	];
+	const [ pluginExploreStep, pluginSupportStep ] = usePluginSteps();
+	const [ themeSupportStep, WordPressForumStep ] = useThemeSteps();
+
+	/**
+	 * Base case: multiple product types
+	 */
+	let footerSteps: FooterStep[] = [ pluginExploreStep, pluginSupportStep, WordPressForumStep ];
+
+	/**
+	 * If only plugins are present
+	 */
+	if ( hasPlugins && ! hasThemes ) {
+		footerSteps = [ pluginExploreStep, pluginSupportStep ];
+	}
+
+	/**
+	 * If only themes are present
+	 */
+	if ( ! hasPlugins && hasThemes ) {
+		footerSteps = [ themeSupportStep, WordPressForumStep ];
+	}
+
 	const steps = useNextSteps( footerSteps, pluginSlugs, themeSlugs );
 
 	return {
@@ -78,6 +43,56 @@ export function useThankYouFoooter(
 		nextStepsClassName: 'thank-you__footer',
 		nextSteps: steps.slice( 0, 3 ),
 	};
+}
+
+function usePluginSteps(): FooterStep[] {
+	const translate = useTranslate();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	return [
+		{
+			key: 'thank_you_footer_explore',
+			title: translate( 'Keep growing' ),
+			description: translate(
+				'Take your site to the next level. We have all the solutions to help you.'
+			),
+			link: `/plugins/${ siteSlug }`,
+			linkText: translate( 'Explore plugins' ),
+			eventKey: 'calypso_plugin_thank_you_explore_plugins_click',
+			blankTarget: false,
+		},
+		{
+			key: 'thank_you_footer_support_guides',
+			title: translate( 'Learn More' ),
+			description: translate( 'Discover everything you need to know about Plugins.' ),
+			link: 'https://wordpress.com/support/plugins/',
+			linkText: translate( 'Plugin Support' ),
+			eventKey: 'calypso_plugin_thank_you_plugin_support_click',
+		},
+	];
+}
+
+function useThemeSteps(): FooterStep[] {
+	const translate = useTranslate();
+
+	return [
+		{
+			key: 'thank_you_footer_support_guides_themes',
+			title: translate( 'Learn More' ),
+			description: translate( 'Discover everything you need to know about Themes.' ),
+			link: 'https://wordpress.com/support/themes/',
+			linkText: translate( 'Theme Support' ),
+			eventKey: 'calypso_plugin_thank_you_theme_support_click',
+		},
+		{
+			key: 'thank_you_footer_forum',
+			title: translate( 'WordPress community' ),
+			description: translate( 'Have a question about this theme? Get help from the community.' ),
+			link: 'https://wordpress.com/forums/',
+			linkText: translate( 'Visit Forum' ),
+			eventKey: 'calypso_plugin_thank_you_forum_click',
+		},
+	];
 }
 
 function useNextSteps(

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-footer.tsx
@@ -78,7 +78,7 @@ function useThemeSteps(): FooterStep[] {
 	return [
 		{
 			key: 'thank_you_footer_support_guides_themes',
-			title: translate( 'Learn More' ),
+			title: translate( 'Learn About Themes' ),
 			description: translate( 'Discover everything you need to know about Themes.' ),
 			link: 'https://wordpress.com/support/themes/',
 			linkText: translate( 'Theme Support' ),


### PR DESCRIPTION
## Proposed Changes

* Update the architecture of footer steps to allow more flexibility in the ordering of the items
* Create a theme support section
* Update all cases(only plugins, only themes, multiple types) to have 3 sections

![CleanShot 2023-04-28 at 14 42 18@2x](https://user-images.githubusercontent.com/5039531/235216965-02fe670d-d188-40ed-a66a-b69eabbc5fa2.png)


## Testing Instructions
* Install a plugin 
* Check if the Marketplace Thank You footer is similar to the image below
* Install a theme
* Check if the Marketplace Thank You footer is similar to the image below
* Purchase a plugin along with a theme
* Check if the Marketplace Thank You footer is similar to the image below

| Plugin  | Theme | Plugin + Theme|
| ------------- | ------------- |------------- |
|<img width="972" alt="CleanShot 2023-04-28 at 14 39 41@2x" src="https://user-images.githubusercontent.com/5039531/235216418-c0abe6a9-8e1e-44e9-ad33-82ed1ba661ca.png">|<img width="980" alt="CleanShot 2023-04-28 at 14 40 03@2x" src="https://user-images.githubusercontent.com/5039531/235216506-f7dcf779-00d0-4336-b29d-8d23121bb33f.png">|<img width="956" alt="CleanShot 2023-04-28 at 14 40 50@2x" src="https://user-images.githubusercontent.com/5039531/235216628-31dfe692-b481-4ad0-badf-54548da014c9.png">|

---

Related to #76429

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
