### PR TITLE
Marketplace Thank You: Centralize footer

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -67,7 +67,7 @@
 			display: flex;
 			flex-direction: column;
 			flex-wrap: wrap;
-			min-width: 280px;
+			min-width: 260px;
 			border-top: none;
 
 			@media ( max-width: 740px ) {
@@ -92,6 +92,7 @@
 				font-size: $font-body-small;
 				color: var(--studio-gray-60);
 				margin-bottom: 16px;
+				padding-right: 0;
 			}
 		}
 


### PR DESCRIPTION
## Proposed Changes

Remove lateral padding and update width to make the footer items to be centralized

## Testing Instructions
* Install a plugin or a theme (or both)
* On the Marketplace Thank You page check if the footer items are centralized

| Before  | After |
| ------------- | ------------- |
|<img width="1138" alt="CleanShot 2023-04-28 at 15 26 10@2x" src="https://user-images.githubusercontent.com/5039531/235225715-b7d1c88a-f2a7-45a4-8183-452a9047451d.png">|<img width="897" alt="CleanShot 2023-04-28 at 15 27 56@2x" src="https://user-images.githubusercontent.com/5039531/235225736-3b9eb485-6995-41ac-8ab2-d3e0b03250bf.png">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
