### PR TITLE
Connection Services: Allow services to be disabled

### DIFF
--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -564,7 +564,7 @@ export class SharingService extends Component {
 					<FoldableCard disabled header={ header } compact className={ classNames } />
 					<Notice isCompact status="is-error" className="sharing-service__unsupported">
 						{ this.props.translate(
-							'This service is no longer supported. {{a}}Learn more about this.{{/a}}',
+							'Twitter is no longer supported. {{a}}Learn more about this.{{/a}}',
 							{
 								components: {
 									a: (
@@ -572,7 +572,7 @@ export class SharingService extends Component {
 											href={ localizeUrl(
 												this.props.isJetpack
 													? 'https://jetpack.com/support/unsupported-service'
-													: 'https://wordpress.com/support/unsupported-service'
+													: 'https://wordpress.com/blog/2023/04/29/why-twitter-auto-sharing-is-coming-to-an-end/'
 											) }
 										/>
 									),

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -571,7 +571,7 @@ export class SharingService extends Component {
 										<a
 											href={ localizeUrl(
 												this.props.isJetpack
-													? 'https://jetpack.com/support/unsupported-service'
+													? 'https://jetpack.com/redirect/?source=publicize-connection-not-supported'
 													: 'https://wordpress.com/blog/2023/04/29/why-twitter-auto-sharing-is-coming-to-an-end/'
 											) }
 										/>

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -575,7 +575,7 @@ export class SharingService extends Component {
 											iconSize={ 14 }
 											href={ localizeUrl(
 												this.props.isJetpack
-													? 'https://jetpack.com/redirect/?source=publicize-connection-not-supported'
+													? 'https://jetpack.com/2023/04/29/the-end-of-twitter-auto-sharing/'
 													: 'https://wordpress.com/blog/2023/04/29/why-twitter-auto-sharing-is-coming-to-an-end/'
 											) }
 										/>

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -7,6 +7,7 @@ import { isEqual, find, some, get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, cloneElement } from 'react';
 import { connect } from 'react-redux';
+import ExternalLink from 'calypso/components/external-link';
 import FoldableCard from 'calypso/components/foldable-card';
 import Notice from 'calypso/components/notice';
 import SocialLogo from 'calypso/components/social-logo';
@@ -564,11 +565,14 @@ export class SharingService extends Component {
 					<FoldableCard disabled header={ header } compact className={ classNames } />
 					<Notice isCompact status="is-error" className="sharing-service__unsupported">
 						{ this.props.translate(
-							'Twitter is no longer supported. {{a}}Learn more about this.{{/a}}',
+							'Twitter is no longer supported. {{a}}Learn more about this{{/a}}',
 							{
 								components: {
 									a: (
-										<a
+										<ExternalLink
+											target="_blank"
+											icon={ true }
+											iconSize={ 14 }
 											href={ localizeUrl(
 												this.props.isJetpack
 													? 'https://jetpack.com/redirect/?source=publicize-connection-not-supported'

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { localizeUrl } from '@automattic/i18n-utils';
 import requestExternalAccess from '@automattic/request-external-access';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -527,6 +528,7 @@ export class SharingService extends Component {
 		const accounts = this.state.isSelectingAccount ? this.props.availableExternalAccounts : [];
 		const showLinkedInNotice =
 			'linkedin' === this.props.service.ID && some( connections, { status: 'must_reauth' } );
+		const serviceStatus = this.props.service.status ?? 'ok';
 
 		const header = (
 			<div>
@@ -552,6 +554,28 @@ export class SharingService extends Component {
 				) }
 			</div>
 		);
+
+		if ( 'ok' !== serviceStatus ) {
+			return (
+				<li>
+					<FoldableCard disabled header={ header } compact className={ classNames } />
+					<Notice isCompact status="is-error" className="sharing-service__unsupported">
+						{ this.props.translate(
+							'This service is no longer supported. {{a}}Learn more about this.{{/a}}',
+							{
+								components: {
+									a: (
+										<a
+											href={ localizeUrl( 'https://wordpress.com/support/unsupported-service' ) }
+										/>
+									),
+								},
+							}
+						) }
+					</Notice>
+				</li>
+			);
+		}
 
 		const action = (
 			<ServiceAction

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -37,6 +37,7 @@ import {
 	isFetchingConnections,
 } from 'calypso/state/sharing/publicize/selectors';
 import { getAvailableExternalAccounts, isServiceExpanded } from 'calypso/state/sharing/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import AccountDialog from './account-dialog';
 import Connection from './connection';
@@ -78,6 +79,7 @@ export class SharingService extends Component {
 		updateSiteConnection: PropTypes.func,
 		warningNotice: PropTypes.func,
 		isP2HubSite: PropTypes.bool,
+		isJetpack: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -98,6 +100,7 @@ export class SharingService extends Component {
 		updateSiteConnection: () => {},
 		warningNotice: () => {},
 		isP2HubSite: false,
+		isJetpack: false,
 	};
 
 	/**
@@ -566,7 +569,11 @@ export class SharingService extends Component {
 								components: {
 									a: (
 										<a
-											href={ localizeUrl( 'https://wordpress.com/support/unsupported-service' ) }
+											href={ localizeUrl(
+												this.props.isJetpack
+													? 'https://jetpack.com/support/unsupported-service'
+													: 'https://wordpress.com/support/unsupported-service'
+											) }
 										/>
 									),
 								},
@@ -692,6 +699,7 @@ export function connectFor( sharingService, mapStateToProps, mapDispatchToProps 
 				userId,
 				isExpanded: isServiceExpanded( state, service ),
 				isP2HubSite: isSiteP2Hub( state, siteId ),
+				isJetpack: isJetpackSite( state, siteId ),
 			};
 			return typeof mapStateToProps === 'function' ? mapStateToProps( state, props ) : props;
 		},

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -82,6 +82,10 @@
 	}
 }
 
+.sharing-services-group__services .notice.sharing-service__unsupported {
+	width: 100%;
+}
+
 .buttons__sharing-settings,
 .connections__sharing-settings {
 	// labels, checkboxes, radio


### PR DESCRIPTION
We'd like to be able to mark services as disabled.

## Proposed Changes

This change works in conjunction with D109406-code.

If a service has an `unsupported` status then it will be shown as disabled with a notice linking to a support document. For now this is a placeholder.

## Testing Instructions

- Apply D109406-code and sandbox the API
- Add the blog sticker mentioned in the patch to a site
- Head to /marketing/connections/<site with the blog sticker>
- Check that a service is shown disabled with a notice linking to a support document

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
