### PR TITLE
Plan notices should not be shown in signup

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -40,7 +40,7 @@ export default function PlanNotice( {
 
 	const handleDismissNotice = () => setIsNoticeDismissed( true );
 
-	if ( isNoticeDismissed ) {
+	if ( isNoticeDismissed || isInSignup ) {
 		return null;
 	} else if ( ! canUserPurchasePlan ) {
 		return (
@@ -73,7 +73,7 @@ export default function PlanNotice( {
 				{ activeDiscount.plansPageNoticeText }
 			</Notice>
 		);
-	} else if ( isPlanUpgradeCreditEligible && ! isInSignup ) {
+	} else if ( isPlanUpgradeCreditEligible ) {
 		return (
 			<Notice
 				className="plan-features__notice-credits"

--- a/client/my-sites/plans-features-main/components/test/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/test/plan-notice.tsx
@@ -146,7 +146,7 @@ describe( '<PlanNotice /> Tests', () => {
 		);
 	} );
 
-	test( 'A marketing message <PlanNotice /> when no other notices are available and marketing messages are available', () => {
+	test( 'A marketing message <PlanNotice /> when no other notices are available and marketing messages are available and the user is not in signup', () => {
 		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => true );
 		mIsCurrentPlanPaid.mockImplementation( () => true );
 		mGetDiscountByName.mockImplementation( () => false );
@@ -169,5 +169,30 @@ describe( '<PlanNotice /> Tests', () => {
 			/>
 		);
 		expect( screen.getByRole( 'status' ).textContent ).toBe( 'An important marketing message' );
+	} );
+
+	test( 'No <PlanNotice /> should be shown when in signup', () => {
+		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => true );
+		mIsCurrentPlanPaid.mockImplementation( () => true );
+		mGetDiscountByName.mockImplementation( () => false );
+		mUsePlanUpgradeCreditsDisplay.mockImplementation( () => ( {
+			creditsValue: 0,
+			isPlanUpgradeCreditEligible: false,
+		} ) );
+		mUseMarketingMessage.mockImplementation( () => [
+			false,
+			[ { id: '12121', text: 'An important marketing message' } ],
+			() => ( {} ),
+		] );
+		//
+		renderWithProvider(
+			<PlanNotice
+				discountInformation={ { withDiscount: 'test', discountEndDate: new Date() } }
+				visiblePlans={ plansList }
+				isInSignup={ true }
+				siteId={ 32234 }
+			/>
+		);
+		expect( screen.queryByRole( 'status' ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
Related to #76100

## Proposed Changes

* The change in #76100 needs to not show any notices in signup, however when you activate marketing notices and visit signup you can still see the marketing banner tight above the plans grid.

![image](https://user-images.githubusercontent.com/3422709/235272304-2356ba40-59c5-4455-9b88-a25d3cad9b49.png)

## Testing Instructions
- Enable marketing notices as shown in 2efed-pb
- Go to `/start`
- In the plans step make sure marketing messages are not visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
