### PR TITLE
Plans 2023: Partial list of TODOs for NPM migration

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -61,7 +61,7 @@ const DummyDisabledButton = styled.div`
 `;
 
 // @todo npm-migration
-// billing period from plans data store
+// getPlanBillPeriod from plans data store
 // pass domainFromHomeUpsellFlow as prop
 // pass ExternalLinkWithTracking as prop
 

--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -60,6 +60,11 @@ const DummyDisabledButton = styled.div`
 	text-align: center;
 `;
 
+// @todo npm-migration
+// billing period from plans data store
+// pass domainFromHomeUpsellFlow as prop
+// pass ExternalLinkWithTracking as prop
+
 const SignupFlowPlanFeatureActionButton = ( {
 	freePlan,
 	isPlaceholder,
@@ -343,6 +348,9 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 		if ( isPlaceholder ) {
 			return;
 		}
+
+		// @todo npm-migration
+		// pass onPlanUpgrade( isFreePlan, upgradingTo ) callback
 
 		if ( ! freePlan ) {
 			recordTracksEvent( 'calypso_plan_features_upgrade_click', {

--- a/client/my-sites/plan-features-2023-grid/components/header-price.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/header-price.tsx
@@ -102,6 +102,10 @@ const HeaderPriceContainer = styled.div`
 	}
 `;
 
+// @todo npm-migration
+// migrate PlanPrice to @automattic/components
+// get currency code from plan
+
 const PlanFeatures2023GridHeaderPrice = ( {
 	planProperties,
 	is2023OnboardingPricingGrid,

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -38,7 +38,7 @@ import { Plans2023Tooltip } from './plans-2023-tooltip';
 import PopularBadge from './popular-badge';
 
 // @todo npm-migration
-// pass JetPackLogo as prop
+// pass JetPackLogo as prop (or grab from @automattic/components or hook in a data store)
 // pass PlanTypeSelector or migrate it to @automattic/components
 // (not for now) feature objects are to migrate to data store
 

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -37,6 +37,11 @@ import PlanFeatures2023GridHeaderPrice from './header-price';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import PopularBadge from './popular-badge';
 
+// @todo npm-migration
+// pass JetPackLogo as prop
+// pass PlanTypeSelector or migrate it to @automattic/components
+// (not for now) feature objects are to migrate to data store
+
 function DropdownIcon() {
 	return (
 		<svg xmlns="http://www.w3.org/2000/svg" width="26" height="24" fill="none" viewBox="0 -5 26 24">

--- a/client/my-sites/plan-features-2023-grid/components/plans-2023-tooltip.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plans-2023-tooltip.tsx
@@ -22,6 +22,9 @@ const StyledTooltip = styled( Tooltip )`
 	}
 `;
 
+// @todo npm-migration
+// migrate Tooltip to @wordpress/components
+
 export const Plans2023Tooltip = ( props: PropsWithChildren< { text?: TranslateResult } > ) => {
 	const [ isVisible, setIsVisible ] = useState( false );
 	const tooltipRef = useRef< HTMLDivElement >( null );

--- a/client/my-sites/plan-features-2023-grid/components/popular-badge.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/popular-badge.tsx
@@ -3,6 +3,10 @@ import classNames from 'classnames';
 import PlanPill from 'calypso/components/plans/plan-pill';
 import useHighlightLabel from '../hooks/use-highlight-label';
 
+// @todo npm-migration
+// migrate PlanPill to @automattic/components
+// is getPlanClass needed? then migrate to data store
+
 const PopularBadge: React.FunctionComponent< {
 	isInSignup: boolean;
 	planName: string;

--- a/client/my-sites/plan-features-2023-grid/hooks/use-highlight-adjacency-matrix.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-highlight-adjacency-matrix.ts
@@ -12,6 +12,9 @@ interface HighlightAdjacencyMatrix {
 	};
 }
 
+// @todo npm-migration
+// pass currentPlanSlug as prop
+
 const useHighlightIndices = ( visiblePlans: PlanProperties[] ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const currentPlan = useSelector( ( state ) => getCurrentPlan( state, selectedSiteId ) );

--- a/client/my-sites/plan-features-2023-grid/hooks/use-highlight-label.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-highlight-label.ts
@@ -5,13 +5,12 @@ import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isPopularPlan } from '../lib/is-popular-plan';
 
-// @todo npm-migration
-// pass currentPlanSlug as prop
-
 const useHighlightLabel = ( planName: string ) => {
 	const translate = useTranslate();
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const currentPlan = useSelector( ( state ) => getCurrentPlan( state, selectedSiteId ) );
+	// @todo npm-migration
+	// pass currentPlanSlug as prop instead
 	const isCurrentPlan = currentPlan?.productSlug === planName;
 
 	if ( isCurrentPlan ) {

--- a/client/my-sites/plan-features-2023-grid/hooks/use-highlight-label.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-highlight-label.ts
@@ -5,6 +5,9 @@ import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isPopularPlan } from '../lib/is-popular-plan';
 
+// @todo npm-migration
+// pass currentPlanSlug as prop
+
 const useHighlightLabel = ( planName: string ) => {
 	const translate = useTranslate();
 	const selectedSiteId = useSelector( getSelectedSiteId );

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -91,7 +91,6 @@ import './style.scss';
 // @todo npm-migration
 // migrate *Logo to @automattic/components or behind a hook in a "logos" (or some other) data store
 // ^ preferred, but can also pass as props
-// pass canUserPurchasePlan as prop
 
 type PlanRowOptions = {
 	isMobile?: boolean;
@@ -910,6 +909,8 @@ const withIsLargeCurrency = ( Component: LocalizedComponent< typeof PlanFeatures
 const ConnectedPlanFeatures2023Grid = connect(
 	( state: IAppState, ownProps: PlanFeatures2023GridProps ) => {
 		const { placeholder, plans, isLandingPage, visiblePlans, isInSignup, siteId } = ownProps;
+		// @todo npm-migration
+		// pass canUserPurchasePlan as prop
 		const canUserPurchasePlan =
 			! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId );
 		const purchaseId = getCurrentPlanPurchaseId( state, siteId );

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -89,9 +89,9 @@ import type { IAppState } from 'calypso/state/types';
 import './style.scss';
 
 // @todo npm-migration
-// pass *Logo as props
+// migrate *Logo to @automattic/components or behind a hook in a "logos" (or some other) data store
+// ^ preferred, but can also pass as props
 // pass canUserPurchasePlan as prop
-//
 
 type PlanRowOptions = {
 	isMobile?: boolean;
@@ -253,7 +253,7 @@ export class PlanFeatures2023Grid extends Component<
 
 	componentDidMount() {
 		// @todo npm-migration
-		// pass onLoad callback
+		// pass onGridLoad callback as prop
 		// ^ removes depdency on recordTracksEvent and retargetViewPlans
 		this.props.recordTracksEvent( 'calypso_wp_plans_test_view' );
 		retargetViewPlans();
@@ -996,7 +996,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 			// pass usePlanAvailability( siteId, plan-slug ) as prop
 			const availableForPurchase = isInSignup || isPlanAvailableForPurchase( state, siteId, plan );
 			// @todo npm-migration
-			// pass currentSitePlanSlug and compare with plan-slug
+			// pass currentSitePlanSlug as prop (and update to compare with plan-slug))
 			const isCurrentPlan = isCurrentSitePlan( state, siteId, planProductId ) ?? false;
 			const isVisible = visiblePlans?.indexOf( plan ) !== -1;
 

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -88,6 +88,11 @@ import type { IAppState } from 'calypso/state/types';
 
 import './style.scss';
 
+// @todo npm-migration
+// pass *Logo as props
+// pass canUserPurchasePlan as prop
+//
+
 type PlanRowOptions = {
 	isMobile?: boolean;
 	previousProductNameShort?: string;
@@ -247,6 +252,9 @@ export class PlanFeatures2023Grid extends Component<
 	plansComparisonGridContainerRef = createRef< HTMLDivElement >();
 
 	componentDidMount() {
+		// @todo npm-migration
+		// pass onLoad callback
+		// ^ removes depdency on recordTracksEvent and retargetViewPlans
 		this.props.recordTracksEvent( 'calypso_wp_plans_test_view' );
 		retargetViewPlans();
 	}
@@ -984,13 +992,19 @@ const ConnectedPlanFeatures2023Grid = connect(
 				( planConstantObj.get2023PricingGridSignupStorageOptions &&
 					planConstantObj.get2023PricingGridSignupStorageOptions() ) ||
 				[];
+			// @todo npm-migration
+			// pass usePlanAvailability( siteId, plan-slug ) as prop
 			const availableForPurchase = isInSignup || isPlanAvailableForPurchase( state, siteId, plan );
+			// @todo npm-migration
+			// pass currentSitePlanSlug and compare with plan-slug
 			const isCurrentPlan = isCurrentSitePlan( state, siteId, planProductId ) ?? false;
 			const isVisible = visiblePlans?.indexOf( plan ) !== -1;
 
 			return {
 				availableForPurchase,
 				cartItemForPlan: getCartItemForPlan( getPlanSlug( state, planProductId ) ?? '' ),
+				// @todo npm-migration
+				// get currency code from plan
 				currencyCode: getCurrentUserCurrencyCode( state ),
 				current: isCurrentPlan,
 				features: planFeaturesTransformed,
@@ -1013,6 +1027,12 @@ const ConnectedPlanFeatures2023Grid = connect(
 				showMonthlyPrice,
 			};
 		} );
+
+		// @todo npm-migration
+		// pass manageHref as prop
+		// ^ removes a couple of dependencies
+		// pass selectedSiteSlug as prop
+		// pass currentSitePlanSlug as prop (if different?)
 
 		const manageHref =
 			purchaseId && selectedSiteSlug

--- a/client/my-sites/plans/hooks/use-is-large-currency.ts
+++ b/client/my-sites/plans/hooks/use-is-large-currency.ts
@@ -6,9 +6,9 @@ import type { PlanSlug } from '@automattic/calypso-products';
 
 const LARGE_CURRENCY_CHAR_THRESHOLD = 5;
 
-// @todo clk
+// @todo npm-migration
 // move under grid 2023
-// pass sideId
+// pass sideId as prop
 
 /**
  * Hook that returns true if the string representation of any price (discounted/undiscounted)

--- a/client/my-sites/plans/hooks/use-is-large-currency.ts
+++ b/client/my-sites/plans/hooks/use-is-large-currency.ts
@@ -6,6 +6,10 @@ import type { PlanSlug } from '@automattic/calypso-products';
 
 const LARGE_CURRENCY_CHAR_THRESHOLD = 5;
 
+// @todo clk
+// move under grid 2023
+// pass sideId
+
 /**
  * Hook that returns true if the string representation of any price (discounted/undiscounted)
  * of any of the plan slugs exceeds 5 characters.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Code TODOs. Not for merging.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
