### PR TITLE
Staging Sites: Link to support doc from the Hosting Config card

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -83,6 +83,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/sftp/',
 		post_id: 159771,
 	},
+	'hosting-staging-site': {
+		link: 'https://wordpress.com/support/how-to-create-a-staging-site/',
+		post_id: 239448,
+	},
 	'hosting-clear-cache': {
 		link: 'https://wordpress.com/support/clear-your-sites-cache/',
 		post_id: 164969,

--- a/client/my-sites/hosting/cache-card/index.js
+++ b/client/my-sites/hosting/cache-card/index.js
@@ -26,7 +26,7 @@ const CacheCard = ( {
 			<div>
 				<p>
 					{ translate(
-						'Be careful, clearing the cache may make your site unresponsive while it is being rebuilt. {{a}}Learn more about clearing your site’s cache{{/a}}.',
+						'Be careful, clearing the cache may make your site unresponsive while it is being rebuilt. {{a}}Learn more{{/a}}.',
 						{
 							components: {
 								a: <InlineSupportLink supportContext="hosting-clear-cache" showIcon={ false } />,

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -8,6 +8,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import SiteIcon from 'calypso/blocks/site-icon';
 import CardHeading from 'calypso/components/card-heading';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import Notice from 'calypso/components/notice';
 import { USE_SITE_EXCERPTS_QUERY_KEY } from 'calypso/data/sites/use-site-excerpts-query';
@@ -174,7 +175,12 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 			<>
 				<p>
 					{ translate(
-						'A staging site is a test version of your website you can use to preview and troubleshoot changes before applying them to your production site.'
+						'A staging site is a test version of your website you can use to preview and troubleshoot changes before applying them to your production site. {{a}}Learn more{{/a}}.',
+						{
+							components: {
+								a: <InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />,
+							},
+						}
 					) }
 				</p>
 				<Button


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/1964

## Proposed Changes

Links to the Staging Sites support doc from the Hosting Config card:

<img width="778" alt="image" src="https://user-images.githubusercontent.com/36432/235451122-2fee90a0-987d-4188-9ed3-ea52af3c9c4d.png">


## Testing Instructions

1. Navigate to Hosting Configuration.
2. Click on the 'Learn more' and verify the support doc loads as expected.