### PR TITLE
Learn: Mobile fixes for content footer CTA and resources

### DIFF
--- a/apps/happy-blocks/block-library/support-content-footer/index.php
+++ b/apps/happy-blocks/block-library/support-content-footer/index.php
@@ -24,12 +24,9 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 				<?php esc_html_e( 'Our professional website-building service can create the site of your dreams, no matter the scope of your project - from small websites and personal blogs to large-scale custom development and migrations.', 'happy-blocks' ); ?>
 			</p>
 			<div class="resource-link">
-				<p>
-					<a href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/webinars/' ) ); ?>">
-						<?php esc_html_e( 'Get Started', 'happy-blocks' ); ?>
-						<figure><img src="<?php echo esc_url( $image_dir . ( is_rtl() ? '/arrow-left.svg' : '/arrow-right.svg' ) ); ?>" alt="" width="15" height="11"/></figure>
-					</a>
-				</p>
+				<a href="<?php echo esc_url( 'https://wordpress.com/built-by/?ref=banner-learn' ); ?>">
+					<?php esc_html_e( 'Get Started', 'happy-blocks' ); ?>
+				</a>
 			</div>
 		</div>
 
@@ -46,14 +43,9 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 			<?php esc_html_e( 'Unlock tools, expert help, and community for your brand\'s growth and success.', 'happy-blocks' ); ?>
 			</p>
 			<div class="resource-link">
-				<p>
-					<a href="https://www.youtube.com/wordpressdotcom">
-						<?php esc_html_e( 'Upgrade your plan', 'happy-blocks' ); ?>
-						<figure>
-							<img src="<?php echo esc_url( $image_dir . ( is_rtl() ? '/arrow-left.svg' : '/arrow-right.svg' ) ); ?>" alt="" width="15" height="11"/>
-						</figure>
-					</a>
-				</p>
+				<a href="https://www.youtube.com/wordpressdotcom">
+					<?php esc_html_e( 'Upgrade your plan', 'happy-blocks' ); ?>
+				</a>
 			</div>
 		</div>
 		<div class="support-content-resource">
@@ -64,12 +56,9 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 				<?php esc_html_e( 'Connect with other WordPress customers around the world.', 'happy-blocks' ); ?>
 			</p>
 			<div class="resource-link">
-				<p>
-					<a href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/forums/' ) ); ?>">
-						<?php esc_html_e( 'Ask the Community', 'happy-blocks' ); ?>
-						<figure><img src="<?php echo esc_url( $image_dir . ( is_rtl() ? '/arrow-left.svg' : '/arrow-right.svg' ) ); ?>" alt="" width="15" height="11"/></figure>
-					</a>
-				</p>
+				<a href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/forums/' ) ); ?>">
+					<?php esc_html_e( 'Ask the Community', 'happy-blocks' ); ?>
+				</a>
 			</div>
 		</div>
 		<div class="support-content-resource">
@@ -80,12 +69,9 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 				<?php esc_html_e( 'Find the answer to the questions you know you have about WordPress.com.', 'happy-blocks' ); ?>
 			</p>
 			<div class="resource-link">
-				<p>
-					<a href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/support/' ) ); ?>">
-						<?php esc_html_e( 'Subscribe now', 'happy-blocks' ); ?>
-						<figure><img src="<?php echo esc_url( $image_dir . ( is_rtl() ? '/arrow-left.svg' : '/arrow-right.svg' ) ); ?>" alt="" width="15" height="11"/></figure>
-					</a>
-				</p>
+				<a href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/support/' ) ); ?>">
+					<?php esc_html_e( 'Subscribe now', 'happy-blocks' ); ?>
+				</a>
 			</div>
 		</div>
 	</div>

--- a/apps/happy-blocks/block-library/support-content-footer/index.php
+++ b/apps/happy-blocks/block-library/support-content-footer/index.php
@@ -36,7 +36,7 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 	</div>
 	<div class="support-content-resources alignwide" style="border-radius:0px; margin-bottom:0px">
 		<div class="support-content-resource">
-			<h4 class="support-content-resource__title has-recoleta-font-family">
+			<h4 class="support-content-resource__title">
 				<?php esc_html_e( 'Upgrade now', 'happy-blocks' ); ?>
 			</h4>
 			<p>
@@ -49,7 +49,7 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 			</div>
 		</div>
 		<div class="support-content-resource">
-			<h4 class="support-content-resource__title has-recoleta-font-family">
+			<h4 class="support-content-resource__title">
 				<?php esc_html_e( 'Forums', 'happy-blocks' ); ?>
 			</h4>
 			<p>
@@ -62,7 +62,7 @@ $image_dir = 'https://wordpress.com/wp-content/a8c-plugins/happy-blocks/block-li
 			</div>
 		</div>
 		<div class="support-content-resource">
-			<h4 class="support-content-resource__title has-recoleta-font-family">
+			<h4 class="support-content-resource__title">
 				<?php esc_html_e( 'Support Guides', 'happy-blocks' ); ?>
 			</h4>
 			<p>

--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -89,11 +89,11 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 	.support-content-resource__title {
 		margin-top: 0;
-		font-family: var(--wp--preset--font-family--system-font) !important;
+		font-family: var(--wp--preset--font-family--system-font);
 	}
 
 	@media (max-width: $breakpoint-mobile) {
-		padding: 40px 24px !important;
+		padding: 12px 24px !important;
 
 		h4 {
 			font-size: 1.25rem;
@@ -111,7 +111,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 			margin-bottom: 0;
 
 			.support-content-cta-left {
-				padding: 16px 48px 16px 0;
+				padding: 0 48px 16px 0;
 			}
 
 			.support-content-cta-right {

--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -4,7 +4,6 @@ $breakpoint-mobile: 782px; //Mobile size.
 $breakpoint-tablet: 1224px; //Large tablet size.
 $breakpoint-desktop: 1440px; //Desktop size.
 $search-icon: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"%3E%3Cpath d="M9.16667 15.8333C12.8486 15.8333 15.8333 12.8486 15.8333 9.16667C15.8333 5.48477 12.8486 2.5 9.16667 2.5C5.48477 2.5 2.5 5.48477 2.5 9.16667C2.5 12.8486 5.48477 15.8333 9.16667 15.8333Z" stroke="%238C8F94" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/%3E%3Cpath d="M17.5 17.5L13.875 13.875" stroke="%238C8F94" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/%3E%3C/svg%3E';
-$recoleta-font-family: "Recoleta", sans-serif;
 $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI", "Roboto",
 	"Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
 
@@ -75,8 +74,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 			overflow-wrap: break-word;
 			word-break: break-word;
 			border-bottom: 1px solid var(--studio-gray-5);
-			padding: 20px;
-			padding-left: 0;
+			padding: 32px 16px 32px 0;
 			font-size: 1.25rem;
 		}
 
@@ -91,19 +89,47 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 	.support-content-resource__title {
 		margin-top: 0;
-		font-family: var(--wp--preset--font-family--recoleta) !important;
+		font-family: var(--wp--preset--font-family--system-font) !important;
 	}
 
 	@media (max-width: $breakpoint-mobile) {
 		padding: 40px 24px !important;
 
+		h4 {
+			font-size: 1.25rem;
+			line-height: 26px;
+		}
+
+		p {
+			font-size: 0.875rem;
+			margin-top: 4px;
+			margin-bottom: 8px;
+			line-height: 20px;
+		}
+
+		.support-content-cta {
+			margin-bottom: 0;
+
+			.support-content-cta-left {
+				padding: 16px 48px 16px 0;
+			}
+
+			.support-content-cta-right {
+				display: none;
+			}
+		}
+
 		.support-content-resources {
-			flex-wrap: nowrap !important;
-			gap: 10px;
-			overflow: auto;
+			flex-direction: column;
+			gap: 8px;
 
 			.support-content-resource {
 				min-width: 317px;
+				padding: 16px 48px 16px 0;
+
+				.resource-link {
+					line-height: 20px;
+				}
 			}
 		}
 


### PR DESCRIPTION
## What
Styling changes to the `support-content-footer` in happy-blocks, for the mobile version of the Learn website.
This PR handles the first parte of the content footer (the one in the screenshot) on mobile, from `Let us build your website`:

![image](https://user-images.githubusercontent.com/52076348/235453529-a1f3f412-15d2-4674-889d-674133b29623.png)

### Before 
Before it was broken
![image](https://user-images.githubusercontent.com/52076348/235453431-f1e961a7-530a-42b6-8a38-d06a4e7fb766.png)



### After
![image](https://user-images.githubusercontent.com/52076348/235453180-31ff17ef-0bd5-41f7-a8b7-c8701dad1131.png)

## Testing
1. Checkout branch, `cd apps/happy-blocks`and `yarn dev --sync`
2. Sandbox `learncft.wordpress.com` and visit the site
3. Switch to mobile and check the result