### PR TITLE
Use `isInitialLoading` to fix inline support links

### DIFF
--- a/client/blocks/support-article-dialog/dialog-content.jsx
+++ b/client/blocks/support-article-dialog/dialog-content.jsx
@@ -17,7 +17,7 @@ const getPostKey = ( blogId, postId ) => ( { blogId, postId } );
 
 const useSupportArticleAlternatePostKey = ( blogId, postId ) => {
 	const supportArticleAlternates = useSupportArticleAlternatesQuery( blogId, postId );
-	if ( supportArticleAlternates.isLoading ) {
+	if ( supportArticleAlternates.isInitialLoading ) {
 		return null;
 	}
 


### PR DESCRIPTION
See p1682943383723849-slack-C03N25JPCE4

Related https://github.com/Automattic/wp-calypso/pull/76077

## Proposed Changes

Switches from `isLoading` to `isInitialLoading` to ensure inline support links load properly.

## Testing Instructions

1. Navigate to General Settings and scroll down to Gift Subscriptions module.
2. Click on 'Learn more' and verify the support doc loads as expected.