### PR TITLE
Staging Sites: Clear 'Staging site added' notice upon delete, etc.

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -26,7 +26,10 @@ import { DeleteStagingSite } from './delete-staging-site';
 import { useDeleteStagingSite } from './use-delete-staging-site';
 import { useHasSiteAccess } from './use-has-site-access';
 
+const stagingSiteAddSuccessNoticeId = 'staging-site-add-success';
 const stagingSiteAddFailureNoticeId = 'staging-site-add-failure';
+const stagingSiteDeleteSuccessNoticeId = 'staging-site-remove-success';
+const stagingSiteDeleteFailureNoticeId = 'staging-site-remove-failure';
 
 const StyledLoadingBar = styled( LoadingBar )( {
 	marginBottom: '1em',
@@ -53,12 +56,20 @@ const SiteInfo = styled.div( {
 	flexDirection: 'column',
 	marginLeft: 10,
 } );
+
 export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId, translate } ) => {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
 	const [ loadingError, setLoadingError ] = useState( false );
 	const [ isErrorValidQuota, setIsErrorValidQuota ] = useState( false );
+
+	const removeAllNotices = () => {
+		dispatch( removeNotice( stagingSiteAddSuccessNoticeId ) );
+		dispatch( removeNotice( stagingSiteAddFailureNoticeId ) );
+		dispatch( removeNotice( stagingSiteDeleteSuccessNoticeId ) );
+		dispatch( removeNotice( stagingSiteDeleteFailureNoticeId ) );
+	};
 
 	const { data: hasValidQuota, isLoading: isLoadingQuotaValidation } = useHasValidQuotaQuery(
 		siteId,
@@ -99,8 +110,29 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 		siteId,
 		stagingSiteId: stagingSite.id,
 		transferStatus,
+		onMutate: () => {
+			removeAllNotices();
+		},
+		onError: ( error ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_hosting_configuration_staging_site_delete_failure', {
+					code: error.code,
+				} )
+			);
+			dispatch(
+				errorNotice(
+					// translators: "reason" is why deleting the staging site failed.
+					sprintf( __( 'Failed to delete staging site: %(reason)s' ), { reason: error.message } ),
+					{
+						id: stagingSiteDeleteFailureNoticeId,
+					}
+				)
+			);
+		},
 		onSuccess: useCallback( () => {
-			dispatch( successNotice( __( 'Staging site deleted.' ) ) );
+			dispatch(
+				successNotice( __( 'Staging site deleted.' ), { id: stagingSiteDeleteSuccessNoticeId } )
+			);
 		}, [ dispatch, __ ] ),
 	} );
 	const isStagingSiteTransferComplete = transferStatus === transferStates.COMPLETE;
@@ -112,7 +144,9 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 	useEffect( () => {
 		if ( wasCreating && isStagingSiteTransferComplete ) {
 			queryClient.invalidateQueries( [ USE_SITE_EXCERPTS_QUERY_KEY ] );
-			dispatch( successNotice( __( 'Staging site added.' ) ) );
+			dispatch(
+				successNotice( __( 'Staging site added.' ), { id: stagingSiteAddSuccessNoticeId } )
+			);
 		}
 	}, [ dispatch, queryClient, __, isStagingSiteTransferComplete, wasCreating ] );
 
@@ -137,7 +171,7 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 
 	const { addStagingSite, isLoading: addingStagingSite } = useAddStagingSiteMutation( siteId, {
 		onMutate: () => {
-			dispatch( removeNotice( stagingSiteAddFailureNoticeId ) );
+			removeAllNotices();
 		},
 		onError: ( error ) => {
 			dispatch(

--- a/client/my-sites/hosting/staging-site-card/use-delete-staging-site.ts
+++ b/client/my-sites/hosting/staging-site-card/use-delete-staging-site.ts
@@ -12,12 +12,13 @@ interface UseDeleteStagingSiteOptions {
 	siteId: SiteId;
 	stagingSiteId: SiteId;
 	transferStatus: TransferStates | null;
+	onMutate?: () => void;
 	onSuccess?: () => void;
 	onError?: () => void;
 }
 
 export const useDeleteStagingSite = ( options: UseDeleteStagingSiteOptions ) => {
-	const { siteId, stagingSiteId, transferStatus, onSuccess, onError } = options;
+	const { siteId, stagingSiteId, transferStatus, onMutate, onSuccess, onError } = options;
 	const queryClient = useQueryClient();
 	const dispatch = useDispatch();
 	const [ isDeletingInitiated, setIsDeletingInitiated ] = useState( false );
@@ -54,6 +55,9 @@ export const useDeleteStagingSite = ( options: UseDeleteStagingSiteOptions ) => 
 			} );
 		},
 		{
+			onMutate: () => {
+				onMutate?.();
+			},
 			onSuccess: async () => {
 				// Wait for the staging site async job to start
 				setTimeout( () => {

--- a/client/my-sites/hosting/staging-site-card/use-delete-staging-site.ts
+++ b/client/my-sites/hosting/staging-site-card/use-delete-staging-site.ts
@@ -14,7 +14,12 @@ interface UseDeleteStagingSiteOptions {
 	transferStatus: TransferStates | null;
 	onMutate?: () => void;
 	onSuccess?: () => void;
-	onError?: () => void;
+	onError?: ( error: MutationError ) => void;
+}
+
+interface MutationError {
+	code: string;
+	message: string;
 }
 
 export const useDeleteStagingSite = ( options: UseDeleteStagingSiteOptions ) => {
@@ -64,9 +69,9 @@ export const useDeleteStagingSite = ( options: UseDeleteStagingSiteOptions ) => 
 					dispatch( fetchAutomatedTransferStatus( stagingSiteId ) );
 				}, 3000 );
 			},
-			onError: () => {
+			onError: ( error: MutationError ) => {
 				setIsDeletingInitiated( false );
-				onError?.();
+				onError?.( error );
 			},
 		}
 	);


### PR DESCRIPTION
## Proposed Changes

Prevents a bunch of notices from being stacked up by clearing the 'Staging site added' notice when the user clicks 'Delete staging site', and clearing the 'Staging site deleted' notice when the user clicks 'Add staging site'.

<img width="712" alt="image" src="https://user-images.githubusercontent.com/36432/235468270-4a418637-4093-411c-9b56-966e84e822d0.png">


## Testing Instructions

1. Navigate to 'Hosting Configuration'.
2. Click 'Add staging site'.
3. Verify the 'Staging site added.' notice appears as expected.
4. Click 'Delete staging site'.
5. Verify the 'Staging site added.' notice disappears on its own, and the 'Staging site deleted.' notice appears as expected.
6. Click 'Add staging site'.
7. Verify the 'Staging site deleted.' notice disappears on its own.