### PR TITLE
Social Previews: refactor Facebook components exports

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -1,6 +1,6 @@
 import { FEATURE_SEO_PREVIEW_TOOLS } from '@automattic/calypso-products';
 import {
-	FacebookPreview,
+	FacebookFullPreview,
 	TwitterPreview,
 	GoogleSearchPreview,
 	TYPE_WEBSITE,
@@ -128,7 +128,7 @@ const GooglePost = ( site, post, frontPageMetaDescription ) => (
 );
 
 const FacebookSite = ( site, frontPageMetaDescription ) => (
-	<FacebookPreview
+	<FacebookFullPreview
 		title={ site.name }
 		url={ site.URL }
 		description={ frontPageMetaDescription || getSeoExcerptForSite( site ) }
@@ -138,7 +138,7 @@ const FacebookSite = ( site, frontPageMetaDescription ) => (
 );
 
 const FacebookPost = ( site, post, frontPageMetaDescription ) => (
-	<FacebookPreview
+	<FacebookFullPreview
 		title={ get( post, 'seoTitle', '' ) }
 		url={ get( post, 'URL', '' ) }
 		description={ frontPageMetaDescription || getSeoExcerptForPost( post ) }

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -1,4 +1,4 @@
-import { FacebookPreview, TYPE_ARTICLE } from '@automattic/social-previews';
+import { FacebookFullPreview, TYPE_ARTICLE } from '@automattic/social-previews';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import striptags from 'striptags';
@@ -38,7 +38,7 @@ export class FacebookSharePreview extends PureComponent {
 		const originalExcerpt = rawContent.indexOf( rawExcerpt ) === 0 ? '' : articleExcerpt;
 
 		return (
-			<FacebookPreview
+			<FacebookFullPreview
 				url={ articleUrl }
 				title={ decodeEntities( seoTitle ) }
 				description={ decodeEntities( originalExcerpt || articleContent ) }

--- a/packages/social-previews/src/facebook-preview/default-link-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/default-link-preview.tsx
@@ -1,8 +1,8 @@
 import FacebookLinkPreview from './link-preview';
 import type { FacebookPreviewProps } from './types';
 
-const DefaultFacebookLinkPreview: React.FC< FacebookPreviewProps > = ( props ) => {
+const FacebookDefaultLinkPreview: React.FC< FacebookPreviewProps > = ( props ) => {
 	return <FacebookLinkPreview { ...props } compactDescription customText="" user={ undefined } />;
 };
 
-export default DefaultFacebookLinkPreview;
+export default FacebookDefaultLinkPreview;

--- a/packages/social-previews/src/facebook-preview/default-post-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/default-post-preview.tsx
@@ -9,7 +9,7 @@ type Props = FacebookPreviewProps & {
 	compactDescription?: boolean;
 };
 
-const DefaultFacebookPostPreview: React.FC< Props > = ( {
+const FacebookDefaultPostPreview: React.FC< Props > = ( {
 	url,
 	customImage,
 	user,
@@ -41,4 +41,4 @@ const DefaultFacebookPostPreview: React.FC< Props > = ( {
 	);
 };
 
-export default DefaultFacebookPostPreview;
+export default FacebookDefaultPostPreview;

--- a/packages/social-previews/src/facebook-preview/full-preview.tsx
+++ b/packages/social-previews/src/facebook-preview/full-preview.tsx
@@ -1,15 +1,15 @@
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import SectionHeading from '../shared/section-heading';
-import DefaultFacebookLinkPreview from './default-link-preview';
-import DefaultFacebookPostPreview from './default-post-preview';
+import FacebookDefaultLinkPreview from './default-link-preview';
+import FacebookDefaultPostPreview from './default-post-preview';
 import FacebookLinkPreview from './link-preview';
 import FacebookPostPreview from './post-preview';
 import type { FacebookPreviewProps } from './types';
 
 import './style.scss';
 
-export const FacebookPreview: React.FC< FacebookPreviewProps > = ( props ) => {
+const FacebookFullPreview: React.FC< FacebookPreviewProps > = ( props ) => {
 	const { customImage } = props;
 	const isPostPreview = !! customImage;
 
@@ -49,17 +49,13 @@ export const FacebookPreview: React.FC< FacebookPreviewProps > = ( props ) => {
 					</ExternalLink>
 				</p>
 				{ isPostPreview ? (
-					<DefaultFacebookPostPreview { ...props } />
+					<FacebookDefaultPostPreview { ...props } />
 				) : (
-					<DefaultFacebookLinkPreview { ...props } />
+					<FacebookDefaultLinkPreview { ...props } />
 				) }
 			</section>
 		</div>
 	);
 };
 
-export { default as FacebookDefaultLinkPreview } from './default-link-preview';
-export { default as FacebookDefaultPostPreview } from './default-post-preview';
-export { default as FacebookFullPreview } from './full-preview';
-export { default as FacebookLinkPreview } from './link-preview';
-export { default as FacebookPostPreview } from './post-preview';
+export default FacebookFullPreview;

--- a/packages/social-previews/src/index.ts
+++ b/packages/social-previews/src/index.ts
@@ -1,6 +1,6 @@
-export * from './facebook-preview';
 export * from './google-search-preview';
 export * from './twitter-preview';
 export * from './linkedin-preview';
 export * from './tumblr-preview';
+export * from './facebook-preview';
 export * from './constants';

--- a/packages/social-previews/test/index.js
+++ b/packages/social-previews/test/index.js
@@ -6,7 +6,7 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import {
-	FacebookPreview as Facebook,
+	FacebookLinkPreview as Facebook,
 	TwitterPreview as Twitter,
 	GoogleSearchPreview as Search,
 } from '../src';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR updates the Facebook preview exports in the `social-previews` package to export all preview components (the full preview and the 4 individual components). This conforms to the structure adopted in #76376.

In more details, the PR:
- Renames `FacebookPreview` to `FacebookFullPreview` for clarity (and moves it from `index.tsx` to `full-previews.tsx`).
- Makes the full preview component available, as well as the 4 individual preview components.
- Renames `DefaultFacebookLinkPreview` to `FacebookDefaultLinkPreview`, and `DefaultFacebookPostPreview` to `FacebookDefaultPostPreview` for consistency.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Prerequisites
- Make sure you have a Facebook account.
- Make sure you have a self-hosted site connected to Jetpack, with a subscription that includes Social.
- From the _Social_ or _My Jetpack_ page of your site WPadmin, activate Social.
- Then, connect your site to Facebook (check [these instructions](https://jetpack.com/support/jetpack-social/connecting-to-social-networks/) if you need help). You may need to create a test page.
- Spin up Calypso by running this branch locally or using a live link below

### Testing

- Create a new post from your site WPadmin
- Publish it
- Visit `/posts/:site` in Calypso
- You should see the newly created post under the _Published_ tab
- In the post menu, click _Share_, then press the _Preview_ button
<img width="500" alt="Screenshot 2023-04-11 at 4 47 11 PM" src="https://user-images.githubusercontent.com/1620183/231284467-7d3c5008-321b-444f-a3f9-8b732eaa323c.png">

- Select the Facebook preview
- Check it looks as it does in production and that there's no error in the console

<img width="400" alt="Screenshot 2023-04-20 at 9 24 52 AM" src="https://user-images.githubusercontent.com/1620183/233381452-e9ede166-f34c-4023-9c88-f81ddfb43425.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
