### PR TITLE
Ecommerce tailored flow: Update TLD vendor string for Woo Express and ecommerce flows

### DIFF
--- a/packages/domain-picker/src/utils/index.ts
+++ b/packages/domain-picker/src/utils/index.ts
@@ -1,4 +1,10 @@
-import { NEWSLETTER_FLOW, LINK_IN_BIO_FLOW, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
+import {
+	NEWSLETTER_FLOW,
+	LINK_IN_BIO_FLOW,
+	LINK_IN_BIO_TLD_FLOW,
+	ECOMMERCE_FLOW,
+	WOOEXPRESS_FLOW,
+} from '@automattic/onboarding';
 import type { DomainSuggestions } from '@automattic/data-stores';
 
 export function mockDomainSuggestion(
@@ -35,7 +41,12 @@ interface DomainSuggestionsVendorOptions {
 	isSignup?: boolean;
 	isDomainOnly?: boolean;
 	isPremium?: boolean;
-	flowName?: typeof NEWSLETTER_FLOW | typeof LINK_IN_BIO_FLOW | typeof LINK_IN_BIO_TLD_FLOW;
+	flowName?:
+		| typeof NEWSLETTER_FLOW
+		| typeof LINK_IN_BIO_FLOW
+		| typeof LINK_IN_BIO_TLD_FLOW
+		| typeof ECOMMERCE_FLOW
+		| typeof WOOEXPRESS_FLOW;
 }
 type DomainSuggestionsVendor =
 	| 'variation2_front'
@@ -43,7 +54,8 @@ type DomainSuggestionsVendor =
 	| 'variation8_front'
 	| 'link-in-bio'
 	| 'link-in-bio-tld'
-	| 'newsletter';
+	| 'newsletter'
+	| 'ecommerce';
 
 export function getDomainSuggestionsVendor(
 	options: DomainSuggestionsVendorOptions = {}
@@ -56,6 +68,9 @@ export function getDomainSuggestionsVendor(
 	}
 	if ( options.flowName === NEWSLETTER_FLOW ) {
 		return 'newsletter';
+	}
+	if ( options.flowName === ECOMMERCE_FLOW || options.flowName === WOOEXPRESS_FLOW ) {
+		return 'ecommerce';
 	}
 	if ( options.isSignup && ! options.isDomainOnly ) {
 		return 'variation4_front';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76461

## Proposed Changes

* Add the ecommerce and Woo Express signup flows to the domain vendor utilities with the `ecommerce` string so results pulled for those flows are relevant to ecommerce sites.
* Good to note that Woo Express doesn't currently have a domains step in the signup flow, so this change doesn't currently effect that flow. Maybe it's unnecessary for now?

**Before**

<img width="1277" alt="Screen Shot 2023-05-01 at 11 06 40 AM" src="https://user-images.githubusercontent.com/2124984/235476535-84907bc6-c32a-4540-949f-1c51e3c45b74.png">

**After**

<img width="1277" alt="Screen Shot 2023-05-01 at 11 06 20 AM" src="https://user-images.githubusercontent.com/2124984/235476564-98627c01-c0f9-4673-960e-888e7f26b8e2.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/setup/ecommerce`
* When you get to the Domains step, type in your site name and confirm that you see ecommerce-related TLDs suggested (things like `.tienda`, `.shop`, etc.) rather than the default TLD suggestions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
