### PR TITLE
Social Previews: refactor full previews

### DIFF
--- a/packages/social-previews/src/shared/full-preview/index.tsx
+++ b/packages/social-previews/src/shared/full-preview/index.tsx
@@ -1,0 +1,64 @@
+import { ExternalLink } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import SectionHeading from '../section-heading';
+
+import './styles.scss';
+
+type Props = {
+	network: string;
+	postPreview: React.ReactNode;
+	linkPreview: React.ReactNode;
+	headingsLevel?: number;
+};
+
+const FullPreview: React.FC< Props > = ( { network, postPreview, linkPreview, headingsLevel } ) => {
+	const namespace = `${ network }-preview`;
+	const rootClassName = `social-preview ${ namespace }`;
+	const sectionClassName = `social-preview__section ${ namespace }__section`;
+
+	return (
+		<div className={ rootClassName }>
+			<section className={ sectionClassName }>
+				<SectionHeading level={ headingsLevel }>
+					{
+						// translators: a post in a social network
+						__( 'Your post', 'social-previews' )
+					}
+				</SectionHeading>
+				<p className="social-preview__section-desc">
+					{ sprintf(
+						// translators: %s is the name of a social network, e.g., Tumblr
+						__( 'This is what your social post will look like on %s:', 'social-previews' ),
+						network
+					) }
+				</p>
+				{ postPreview }
+			</section>
+			<section className={ sectionClassName }>
+				<SectionHeading level={ headingsLevel }>
+					{
+						// translators: a link previewed in a social network
+						__( 'Link preview', 'social-previews' )
+					}
+				</SectionHeading>
+				<p className="social-preview__section-desc">
+					{ sprintf(
+						// translators: %s is the name of a social network, e.g., Tumblr
+						__(
+							'This is what it will look like when someone shares the link to your WordPress post on %s.',
+							'social-previews'
+						),
+						network
+					) }
+					&nbsp;
+					<ExternalLink href="https://jetpack.com/support/jetpack-social-image-generator">
+						{ __( 'Learn more about links', 'social-previews' ) }
+					</ExternalLink>
+				</p>
+				{ linkPreview }
+			</section>
+		</div>
+	);
+};
+
+export default FullPreview;

--- a/packages/social-previews/src/shared/full-preview/styles.scss
+++ b/packages/social-previews/src/shared/full-preview/styles.scss
@@ -1,0 +1,34 @@
+$social-preview-text-color: #1e1e1e;
+$social-preview-light-text-color: #757575;
+
+.social-preview__section {
+	margin-bottom: 2rem;
+}
+
+.social-preview__section-heading {
+	margin-top: 0;
+	margin-bottom: 0.375rem;
+
+	color: $social-preview-text-color;
+
+	font-weight: 600;
+	font-size: 0.875rem;
+	line-height: 1.42;
+}
+
+.social-preview__section-desc {
+	margin-top: 0;
+	margin-bottom: 1rem;
+
+	color: $social-preview-light-text-color;
+
+	font-size: 0.75rem;
+	line-height: 1.33;
+
+	.components-external-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
+}
+


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR groups the code related to full previews in its own component.

## Testing Instructions

TBD

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
