### PR TITLE
Domain search: Update TLD recs for ecommerce sites to use ecommerce vendor string

### DIFF
--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -1,6 +1,6 @@
 import { isFreePlanProduct } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
-import { BackButton } from '@automattic/onboarding';
+import { BackButton, ECOMMERCE_FLOW } from '@automattic/onboarding';
 import { withShoppingCart } from '@automattic/shopping-cart';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -45,6 +45,11 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import isSiteOnMonthlyPlan from 'calypso/state/selectors/is-site-on-monthly-plan';
 import isSiteUpgradeable from 'calypso/state/selectors/is-site-upgradeable';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import {
+	isSiteOnECommerceTrial,
+	isSiteOnWooExpress,
+	isSiteOnEcommerce,
+} from 'calypso/state/sites/plans/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
@@ -236,6 +241,7 @@ class DomainSearch extends Component {
 			cart,
 			isDomainAndPlanPackageFlow,
 			isDomainUpsell,
+			isEcommerceSite,
 		} = this.props;
 
 		if ( ! selectedSite ) {
@@ -372,7 +378,9 @@ class DomainSearch extends Component {
 								selectedSite={ selectedSite }
 								basePath={ this.props.basePath }
 								products={ this.props.productsList }
-								vendor={ getSuggestionsVendor() }
+								vendor={ getSuggestionsVendor( {
+									flowName: isEcommerceSite ? ECOMMERCE_FLOW : '',
+								} ) }
 							/>
 						</EmailVerificationGate>
 					</div>
@@ -410,6 +418,10 @@ export default connect(
 				!! getCurrentQueryArguments( state )?.domainAndPlanPackage &&
 				!! getCurrentQueryArguments( state )?.domain,
 			isSiteOnFreePlan: site && isFreePlanProduct( site.plan ),
+			isEcommerceSite:
+				isSiteOnECommerceTrial( state, siteId ) ||
+				isSiteOnWooExpress( state, siteId ) ||
+				isSiteOnEcommerce( state, siteId ),
 		};
 	},
 	{

--- a/client/state/sites/plans/selectors/index.js
+++ b/client/state/sites/plans/selectors/index.js
@@ -17,4 +17,6 @@ export { default as isECommerceTrialExpired } from './is-ecommerce-trial-expired
 export { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors/is-requesting-site-plans';
 export { isSitePlanDiscounted } from 'calypso/state/sites/plans/selectors/is-site-plan-discounted';
 export { default as isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors/is-site-on-ecommerce-trial';
+export { default as isSiteOnWooExpress } from 'calypso/state/sites/plans/selectors/is-site-on-woo-express';
+export { default as isSiteOnEcommerce } from 'calypso/state/sites/plans/selectors/is-site-on-ecommerce';
 export { isIntroductoryOfferAppliedToPlanPrice } from 'calypso/state/sites/plans/selectors/is-introductory-offer-applied-to-plan-price';

--- a/client/state/sites/plans/selectors/is-site-on-ecommerce.ts
+++ b/client/state/sites/plans/selectors/is-site-on-ecommerce.ts
@@ -1,0 +1,31 @@
+import {
+	PLAN_ECOMMERCE,
+	PLAN_ECOMMERCE_MONTHLY,
+	PLAN_ECOMMERCE_2_YEARS,
+	PLAN_ECOMMERCE_3_YEARS,
+} from '@automattic/calypso-products';
+import { getCurrentPlan } from '.';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Checks whether the current site is on a paid Ecommerce plan.
+ *
+ * @param {AppState} state Global state tree
+ * @param {number} siteId - Site ID
+ * @returns {boolean} Returns true if the site is on a paid Ecommerce plan
+ */
+export default function isSiteOnEcommerce( state: AppState, siteId: number ) {
+	const currentPlan = getCurrentPlan( state, siteId );
+	const ecommercePlans = [
+		PLAN_ECOMMERCE,
+		PLAN_ECOMMERCE_MONTHLY,
+		PLAN_ECOMMERCE_2_YEARS,
+		PLAN_ECOMMERCE_3_YEARS,
+	];
+
+	if ( ! currentPlan ) {
+		return false;
+	}
+
+	return ecommercePlans.includes( currentPlan.productSlug );
+}

--- a/client/state/sites/plans/selectors/is-site-on-woo-express.ts
+++ b/client/state/sites/plans/selectors/is-site-on-woo-express.ts
@@ -1,0 +1,31 @@
+import {
+	PLAN_WOOEXPRESS_MEDIUM,
+	PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
+	PLAN_WOOEXPRESS_SMALL,
+	PLAN_WOOEXPRESS_SMALL_MONTHLY,
+} from '@automattic/calypso-products';
+import { getCurrentPlan } from '.';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Checks whether the current site is on a Woo Express plan.
+ *
+ * @param {AppState} state Global state tree
+ * @param {number} siteId - Site ID
+ * @returns {boolean} Returns true if the site is on a Woo Express plan
+ */
+export default function isSiteOnWooExpress( state: AppState, siteId: number ) {
+	const currentPlan = getCurrentPlan( state, siteId );
+	const wooExpressPlans = [
+		PLAN_WOOEXPRESS_MEDIUM,
+		PLAN_WOOEXPRESS_SMALL,
+		PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
+		PLAN_WOOEXPRESS_SMALL_MONTHLY,
+	];
+
+	if ( ! currentPlan ) {
+		return false;
+	}
+
+	return wooExpressPlans.includes( currentPlan.productSlug );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76461

## Proposed Changes

* Following up on #76464, this PR updates the vendor domain search string to `ecommerce` for all ecommerce-type sites (trial, ecommerce, Woo Express)
* Introduces two new selectors for ecommerce sites and Woo Express sites
* This updates the results when a user on one of these plans goes to `/domains` and searches so they don't see generic TLDs but ecommerce-related TLDs.
* I noticed this *doesn't* work when you navigate directly to `/domains/adds/[siteSlug]` -- maybe a minor detail, but needs more investigation. Can probably be fixed in a follow-up PR.

**Before**

<img width="1109" alt="Screen Shot 2023-05-01 at 12 11 44 PM" src="https://user-images.githubusercontent.com/2124984/235486238-4700e8b1-98f6-4bae-9eb9-cae78fa4e11c.png">

**After**

<img width="1101" alt="Screen Shot 2023-05-01 at 12 12 05 PM" src="https://user-images.githubusercontent.com/2124984/235486301-a34b1940-2c37-4476-a412-dc45e10372da.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/domains` on an Ecommerce trial, Ecommerce, or Woo Express site. Click "Search for a domain".
* You should see ecommerce-related TLDs suggested first.
* Navigate to `/domains` on a non-ecommerce site. Click "Search for a domain".
* You should see the default TLDs suggested first.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
