### PR TITLE
Launchpad: Update getEnhancedTasks

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/checklist-item.tsx
@@ -9,7 +9,7 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 	const { id, completed, disabled, title, subtitle, actionDispatch, warning } = task;
 
 	// Display chevron if task is incomplete. Don't display chevron and badge at the same time.
-	const shouldDisplayChevron = ! completed && ! disabled && ! task.badgeText;
+	const shouldDisplayChevron = ! completed && ! disabled && ! task.badge_text;
 
 	const handlePrimaryAction = () => {
 		localStorage.removeItem( 'launchpad_siteSlug' );
@@ -67,7 +67,7 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 						<span className="launchpad__checklist-item-text">{ title }</span>
 						{ subtitle && <p className="launchpad__checklist-item-subtext">{ subtitle }</p> }
 					</div>
-					{ task.badgeText ? <Badge type="info-blue">{ task.badgeText }</Badge> : null }
+					{ task.badge_text ? <Badge type="info-blue">{ task.badge_text }</Badge> : null }
 					{ shouldDisplayChevron && (
 						<Gridicon
 							aria-label={ translate( 'Task enabled' ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -138,7 +138,6 @@ export function getEnhancedTasks(
 					break;
 				case 'plan_selected':
 					taskData = {
-						title: translate( 'Choose a plan' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							if ( displayGlobalStylesWarning ) {
@@ -184,7 +183,6 @@ export function getEnhancedTasks(
 					break;
 				case 'first_post_published':
 					taskData = {
-						title: translate( 'Write your first post' ),
 						disabled: mustVerifyEmailBeforePosting || isStartWritingFlow( flow || null ) || false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
@@ -240,7 +238,6 @@ export function getEnhancedTasks(
 					break;
 				case 'link_in_bio_launched':
 					taskData = {
-						isLaunchTask: true,
 						actionDispatch: () => {
 							if ( site?.ID ) {
 								const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE );
@@ -263,7 +260,6 @@ export function getEnhancedTasks(
 					break;
 				case 'site_launched':
 					taskData = {
-						isLaunchTask: true,
 						actionDispatch: () => {
 							if ( site?.ID ) {
 								const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -1,22 +1,16 @@
 import {
 	FEATURE_VIDEO_UPLOADS,
+	getPlan,
 	planHasFeature,
 	PLAN_PREMIUM,
 	FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
+	Plan,
 } from '@automattic/calypso-products';
-import {
-	isFreeFlow,
-	isBuildFlow,
-	isWriteFlow,
-	isNewsletterFlow,
-	isStartWritingFlow,
-	START_WRITING_FLOW,
-} from '@automattic/onboarding';
+import { isNewsletterFlow, isStartWritingFlow, START_WRITING_FLOW } from '@automattic/onboarding';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
-import { PLANS_LIST } from 'calypso/../packages/calypso-products/src/plans-list';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isVideoPressFlow } from 'calypso/signup/utils';
@@ -45,37 +39,33 @@ export function getEnhancedTasks(
 	checklistStatuses: LaunchpadStatuses = {},
 	planCartProductSlug?: string | null
 ) {
+	if ( ! tasks ) {
+		return [];
+	}
+
 	const enhancedTaskList: Task[] = [];
 
 	const productSlug =
 		( isStartWritingFlow( flow ) ? planCartProductSlug : null ) ?? site?.plan?.product_slug;
 
-	const translatedPlanName = productSlug ? PLANS_LIST[ productSlug ].getTitle() : '';
-
-	const linkInBioLinksEditCompleted =
-		site?.options?.launchpad_checklist_tasks_statuses?.links_edited || false;
-
-	const siteEditCompleted = site?.options?.launchpad_checklist_tasks_statuses?.site_edited || false;
+	const translatedPlanName = productSlug ? ( getPlan( productSlug ) as Plan ) : '';
 
 	// Todo: setupBlogCompleted should be updated to use a new checklistStatus instead of site_edited.
 	//  Explorers will update Jetpack definitions to make this possible, meanwhile we are using site_edited.
 	const setupBlogCompleted = checklistStatuses?.site_edited || false;
 
-	const siteLaunchCompleted =
-		site?.options?.launchpad_checklist_tasks_statuses?.site_launched || false;
-
-	const firstPostPublishedCompleted =
-		site?.options?.launchpad_checklist_tasks_statuses?.first_post_published || false;
-
-	const planCompleted = checklistStatuses.plan_completed || ! isStartWritingFlow( flow );
-
-	const videoPressUploadCompleted =
-		site?.options?.launchpad_checklist_tasks_statuses?.video_uploaded || false;
-
-	const allowUpdateDesign =
-		flow && ( isFreeFlow( flow ) || isBuildFlow( flow ) || isWriteFlow( flow ) );
-
 	const domainUpsellCompleted = isDomainUpsellCompleted( site, checklistStatuses );
+	const siteLaunchCompleted = Boolean(
+		tasks?.find( ( task ) => task.id === 'site_launched' )?.completed
+	);
+
+	const planCompleted =
+		Boolean( tasks?.find( ( task ) => task.id === 'site_launched' )?.completed ) ||
+		! isStartWritingFlow( flow );
+
+	const videoPressUploadCompleted = Boolean(
+		tasks?.find( ( task ) => task.id === 'video_uploaded' )?.completed
+	);
 
 	const mustVerifyEmailBeforePosting = isNewsletterFlow( flow || null ) && ! isEmailVerified;
 
@@ -87,20 +77,8 @@ export function getEnhancedTasks(
 				canvas: 'edit',
 		  } );
 
-	let planWarningText = displayGlobalStylesWarning
-		? translate(
-				'Your site contains custom colors that will only be visible once you upgrade to a Premium plan.'
-		  )
-		: '';
-
 	const isVideoPressFlowWithUnsupportedPlan =
 		isVideoPressFlow( flow ) && ! planHasFeature( productSlug as string, FEATURE_VIDEO_UPLOADS );
-
-	if ( isVideoPressFlowWithUnsupportedPlan ) {
-		planWarningText = translate(
-			'Upgrade to a plan with VideoPress support to upload your videos.'
-		);
-	}
 
 	const shouldDisplayWarning = displayGlobalStylesWarning || isVideoPressFlowWithUnsupportedPlan;
 
@@ -108,14 +86,8 @@ export function getEnhancedTasks(
 		tasks.map( ( task ) => {
 			let taskData = {};
 			switch ( task.id ) {
-				case 'setup_write':
-					taskData = {
-						title: translate( 'Set up your site' ),
-					};
-					break;
 				case 'setup_free':
 					taskData = {
-						title: translate( 'Personalize your site' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
@@ -143,7 +115,6 @@ export function getEnhancedTasks(
 					break;
 				case 'setup_newsletter':
 					taskData = {
-						title: translate( 'Personalize newsletter' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
@@ -154,17 +125,10 @@ export function getEnhancedTasks(
 						},
 					};
 					break;
-				case 'setup_general':
-					taskData = {
-						title: translate( 'Set up your site' ),
-					};
-					break;
 				case 'design_edited':
 					taskData = {
-						title: translate( 'Edit site design' ),
-						completed: siteEditCompleted,
 						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, siteEditCompleted, task.id );
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
 								addQueryArgs( `/site-editor/${ siteSlug }`, {
 									canvas: 'edit',
@@ -175,8 +139,6 @@ export function getEnhancedTasks(
 					break;
 				case 'plan_selected':
 					taskData = {
-						title: translate( 'Choose a plan' ),
-						subtitle: planWarningText,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							if ( displayGlobalStylesWarning ) {
@@ -200,7 +162,7 @@ export function getEnhancedTasks(
 
 							window.location.assign( plansUrl );
 						},
-						badgeText:
+						badge_text:
 							isVideoPressFlowWithUnsupportedPlan ||
 							( isStartWritingFlow( flow ) && ! planCompleted )
 								? null
@@ -212,7 +174,6 @@ export function getEnhancedTasks(
 					break;
 				case 'subscribers_added':
 					taskData = {
-						title: translate( 'Add subscribers' ),
 						actionDispatch: () => {
 							if ( goToStep ) {
 								recordTaskClickTracksEvent( flow, task.completed, task.id );
@@ -223,8 +184,6 @@ export function getEnhancedTasks(
 					break;
 				case 'first_post_published':
 					taskData = {
-						title: translate( 'Write your first post' ),
-						completed: firstPostPublishedCompleted,
 						disabled: mustVerifyEmailBeforePosting || isStartWritingFlow( flow || null ) || false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
@@ -234,8 +193,6 @@ export function getEnhancedTasks(
 					break;
 				case 'first_post_published_newsletter':
 					taskData = {
-						title: translate( 'Start writing' ),
-						completed: firstPostPublishedCompleted,
 						disabled: mustVerifyEmailBeforePosting || false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
@@ -245,8 +202,6 @@ export function getEnhancedTasks(
 					break;
 				case 'design_selected':
 					taskData = {
-						title: translate( 'Select a design' ),
-						disabled: ! allowUpdateDesign,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
@@ -260,7 +215,6 @@ export function getEnhancedTasks(
 					break;
 				case 'setup_link_in_bio':
 					taskData = {
-						title: translate( 'Personalize Link in Bio' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
@@ -273,10 +227,8 @@ export function getEnhancedTasks(
 					break;
 				case 'links_added':
 					taskData = {
-						title: translate( 'Add links' ),
-						completed: linkInBioLinksEditCompleted,
 						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, linkInBioLinksEditCompleted, task.id );
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
 								addQueryArgs( `/site-editor/${ siteSlug }`, {
 									canvas: 'edit',
@@ -287,9 +239,6 @@ export function getEnhancedTasks(
 					break;
 				case 'link_in_bio_launched':
 					taskData = {
-						title: translate( 'Launch your site' ),
-						completed: siteLaunchCompleted,
-						disabled: ! linkInBioLinksEditCompleted,
 						isLaunchTask: true,
 						actionDispatch: () => {
 							if ( site?.ID ) {
@@ -302,7 +251,7 @@ export function getEnhancedTasks(
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );
-									recordTaskClickTracksEvent( flow, siteLaunchCompleted, task.id );
+									recordTaskClickTracksEvent( flow, task.completed, task.id );
 									return { goToHome: true, siteSlug };
 								} );
 
@@ -313,8 +262,6 @@ export function getEnhancedTasks(
 					break;
 				case 'site_launched':
 					taskData = {
-						title: translate( 'Launch your site' ),
-						completed: siteLaunchCompleted,
 						isLaunchTask: true,
 						actionDispatch: () => {
 							if ( site?.ID ) {
@@ -353,7 +300,7 @@ export function getEnhancedTasks(
 
 									// Waits for half a second so that the loading screen doesn't flash away too quickly
 									await new Promise( ( res ) => setTimeout( res, 500 ) );
-									recordTaskClickTracksEvent( flow, siteLaunchCompleted, task.id );
+									recordTaskClickTracksEvent( flow, task.completed, task.id );
 									return { blogLaunched: true, siteSlug };
 								} );
 
@@ -362,18 +309,9 @@ export function getEnhancedTasks(
 						},
 					};
 					break;
-				case 'videopress_setup':
-					taskData = {
-						completed: true,
-						disabled: true,
-						title: translate( 'Set up your video site' ),
-					};
-					break;
 				case 'videopress_upload':
 					taskData = {
-						title: translate( 'Upload your first video' ),
 						actionUrl: launchpadUploadVideoLink,
-						completed: videoPressUploadCompleted,
 						disabled: isVideoPressFlowWithUnsupportedPlan || videoPressUploadCompleted,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
@@ -383,9 +321,6 @@ export function getEnhancedTasks(
 					break;
 				case 'videopress_launched':
 					taskData = {
-						title: translate( 'Launch site' ),
-						completed: siteLaunchCompleted,
-						disabled: ! videoPressUploadCompleted,
 						actionDispatch: () => {
 							if ( site?.ID ) {
 								const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE );
@@ -411,9 +346,6 @@ export function getEnhancedTasks(
 					break;
 				case 'domain_upsell':
 					taskData = {
-						title: translate( 'Choose a domain' ),
-						completed: domainUpsellCompleted,
-						disabled: false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, domainUpsellCompleted, task.id );
 
@@ -440,7 +372,7 @@ export function getEnhancedTasks(
 								  } );
 							window.location.assign( destinationUrl );
 						},
-						badgeText:
+						badge_text:
 							domainUpsellCompleted || isStartWritingFlow( flow || null )
 								? ''
 								: translate( 'Upgrade plan' ),
@@ -449,7 +381,6 @@ export function getEnhancedTasks(
 				case 'verify_email':
 					taskData = {
 						completed: isEmailVerified,
-						title: translate( 'Confirm email (check your inbox)' ),
 					};
 					break;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -138,6 +138,7 @@ export function getEnhancedTasks(
 					break;
 				case 'plan_selected':
 					taskData = {
+						title: translate( 'Choose a plan' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							if ( displayGlobalStylesWarning ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -67,6 +67,8 @@ export function getEnhancedTasks(
 		tasks?.find( ( task ) => task.id === 'video_uploaded' )?.completed
 	);
 
+	const domainUpsellCompleted = isDomainUpsellCompleted( site );
+
 	const mustVerifyEmailBeforePosting = isNewsletterFlow( flow || null ) && ! isEmailVerified;
 
 	const homePageId = site?.options?.page_on_front;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -1,16 +1,15 @@
 import {
 	FEATURE_VIDEO_UPLOADS,
-	getPlan,
 	planHasFeature,
 	PLAN_PREMIUM,
 	FEATURE_ADVANCED_DESIGN_CUSTOMIZATION,
-	Plan,
 } from '@automattic/calypso-products';
 import { isNewsletterFlow, isStartWritingFlow, START_WRITING_FLOW } from '@automattic/onboarding';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
+import { PLANS_LIST } from 'calypso/../packages/calypso-products/src/plans-list';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isVideoPressFlow } from 'calypso/signup/utils';
@@ -48,7 +47,7 @@ export function getEnhancedTasks(
 	const productSlug =
 		( isStartWritingFlow( flow ) ? planCartProductSlug : null ) ?? site?.plan?.product_slug;
 
-	const translatedPlanName = productSlug ? ( getPlan( productSlug ) as Plan ) : '';
+	const translatedPlanName = productSlug ? PLANS_LIST[ productSlug ].getTitle() : '';
 
 	// Todo: setupBlogCompleted should be updated to use a new checklistStatus instead of site_edited.
 	//  Explorers will update Jetpack definitions to make this possible, meanwhile we are using site_edited.
@@ -66,8 +65,6 @@ export function getEnhancedTasks(
 	const videoPressUploadCompleted = Boolean(
 		tasks?.find( ( task ) => task.id === 'video_uploaded' )?.completed
 	);
-
-	const domainUpsellCompleted = isDomainUpsellCompleted( site );
 
 	const mustVerifyEmailBeforePosting = isNewsletterFlow( flow || null ) && ! isEmailVerified;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -184,6 +184,7 @@ export function getEnhancedTasks(
 					break;
 				case 'first_post_published':
 					taskData = {
+						title: translate( 'Write your first post' ),
 						disabled: mustVerifyEmailBeforePosting || isStartWritingFlow( flow || null ) || false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -53,6 +53,9 @@ export function getEnhancedTasks(
 	//  Explorers will update Jetpack definitions to make this possible, meanwhile we are using site_edited.
 	const setupBlogCompleted = checklistStatuses?.site_edited || false;
 
+	const firstPostPublishedCompleted =
+		site?.options?.launchpad_checklist_tasks_statuses?.first_post_published || false;
+
 	const domainUpsellCompleted = isDomainUpsellCompleted( site, checklistStatuses );
 	const siteLaunchCompleted = Boolean(
 		tasks?.find( ( task ) => task.id === 'site_launched' )?.completed
@@ -138,6 +141,7 @@ export function getEnhancedTasks(
 					break;
 				case 'plan_selected':
 					taskData = {
+						title: isStartWritingFlow( flow ) ? translate( 'Choose a plan' ) : task.title,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							if ( displayGlobalStylesWarning ) {
@@ -183,6 +187,8 @@ export function getEnhancedTasks(
 					break;
 				case 'first_post_published':
 					taskData = {
+						title: isStartWritingFlow( flow ) ? translate( 'Write your first post' ) : task.title,
+						completed: isStartWritingFlow( flow ) ? firstPostPublishedCompleted : task.completed,
 						disabled: mustVerifyEmailBeforePosting || isStartWritingFlow( flow || null ) || false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
@@ -343,6 +349,8 @@ export function getEnhancedTasks(
 					break;
 				case 'domain_upsell':
 					taskData = {
+						title: isStartWritingFlow( flow ) ? translate( 'Choose a domain' ) : task.title,
+						completed: domainUpsellCompleted,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, domainUpsellCompleted, task.id );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/checklist-item.tsx
@@ -9,9 +9,9 @@ import { buildTask } from './lib/fixtures';
 describe( 'ChecklistItem', () => {
 	describe( 'when the task requires a badge', () => {
 		it( 'displays a badge', () => {
-			const badgeText = 'Badge Text';
-			render( <ChecklistItem task={ buildTask( { badgeText } ) } /> );
-			expect( screen.getByText( badgeText ) ).toBeTruthy();
+			const badge_text = 'Badge Text';
+			render( <ChecklistItem task={ buildTask( { badge_text } ) } /> );
+			expect( screen.getByText( badge_text ) ).toBeTruthy();
 		} );
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -35,7 +35,13 @@ jest.mock( '@automattic/data-stores', () => ( {
 		if ( siteIntentOption === 'free' ) {
 			checklist = [
 				{ id: 'foo_task', completed: false, disabled: true, title: 'Foo Task' },
-				{ id: 'domain_upsell', completed: false, disabled: false, title: 'Choose a domain' },
+				{
+					id: 'domain_upsell',
+					completed: false,
+					disabled: false,
+					title: 'Choose a domain',
+					badge_text: 'Upgrade plan',
+				},
 				{ id: 'foo_task_1', completed: true, disabled: true, title: 'Foo Task 1' },
 			];
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -196,7 +196,7 @@ describe( 'StepContent', () => {
 			expect( choosePlanListItem ).toHaveClass( 'completed' );
 			expect( addSubscribersListItem ).toHaveClass( 'completed' );
 			expect( confirmEmailListItem ).toHaveClass( 'pending' );
-			expect( firstPostListItem ).toHaveClass( 'pending' );
+			expect( firstPostListItem ).toHaveClass( 'completed' );
 		} );
 
 		it( 'renders skip to dashboard link', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -19,20 +19,6 @@ describe( 'Task Helpers', () => {
 				).toEqual( fakeTasks );
 			} );
 		} );
-		describe( 'when it is link_in_bio_launched task', () => {
-			it( 'then it receives launchtask property = true', () => {
-				const fakeTasks = [ buildTask( { id: 'link_in_bio_launched' } ) ];
-				const enhancedTasks = getEnhancedTasks(
-					fakeTasks,
-					'fake.wordpress.com',
-					null,
-					// eslint-disable-next-line @typescript-eslint/no-empty-function
-					() => {},
-					false
-				);
-				expect( enhancedTasks[ 0 ].isLaunchTask ).toEqual( true );
-			} );
-		} );
 		describe( 'when it is plan_selected task', () => {
 			it( 'marks plan_selected as incomplete if styles used but not part of plan', () => {
 				const fakeTasks = [ buildTask( { id: 'plan_selected', completed: true } ) ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -4,7 +4,7 @@ export interface Task {
 	disabled: boolean;
 	title?: string;
 	subtitle?: string;
-	badgeText?: string;
+	badge_text?: string;
 	actionDispatch?: () => void;
 	isLaunchTask?: boolean;
 	warning?: boolean;


### PR DESCRIPTION
Fixes #76478 

### Time Estimate
Review: Short
Test: Mid

### Summary
Update getEnhancedTasks to read task statuses from the endpoint

### Testing
1. Because the `launchpad/checklist` API isn't working at the moment, sandbox a site and apply this patch to the sandbox  https://github.com/Automattic/jetpack/pull/30397
1. Check out this branch and run `yarn` and `yarn start` if needed.
2. Start any new launchpad enabled site
   - Newsletter http://calypso.localhost:3000/setup/newsletter/intro
   - Link-in-Bio http://calypso.localhost:3000/setup/link-in-bio/intro
   - VideoPress http://calypso.localhost:3000/setup/videopress/intro
   - Build http://calypso.localhost:3000/start ( select `Other` as the site goal )
   - Write http://calypso.localhost:3000/start ( select `Write & Publish` as the site goal )
3. Navigate to the Launchpad by completing onboarding
4. Smoke test all flows and make sure everything works as expected. Pay attention to the domain upsell task specifically.