### PR TITLE
Add back button if coming from theme activation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
@@ -14,6 +14,7 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ActionSection, StyledNextButton } from 'calypso/signup/steps/woocommerce-install';
+import { useComingFromThemeActivationParam } from '../../../../hooks/use-coming-from-theme-activation';
 import { useCountries } from '../../../../hooks/use-countries';
 import SupportCard from './support-card';
 import type { Step } from '../../types';
@@ -48,7 +49,7 @@ const CityZipRow = styled.div`
 `;
 
 const StoreAddress: Step = function StoreAddress( { navigation } ) {
-	const { goNext, submit } = navigation;
+	const { goBack, goNext, submit } = navigation;
 	const intent = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
 		[]
@@ -71,6 +72,8 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
 		[]
 	);
+
+	const comingFromThemeActivation = useComingFromThemeActivationParam();
 
 	const [ settingChanges, setSettingChanges ] = useState< {
 		[ key: string ]: string;
@@ -312,6 +315,7 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 			stepName="store-address"
 			className={ `is-step-${ intent }` }
 			goNext={ goNext }
+			goBack={ goBack }
 			isHorizontalLayout={ true }
 			formattedHeader={
 				<FormattedHeader
@@ -328,7 +332,7 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 			recordTracksEvent={ recordTracksEvent }
 			stepProgress={ stepProgress }
 			hideSkip
-			hideBack
+			hideBack={ ! comingFromThemeActivation }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -5,6 +5,7 @@ import { useDispatch as reduxDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { WRITE_INTENT_DEFAULT_DESIGN } from '../constants';
+import { useComingFromThemeActivationParam } from '../hooks/use-coming-from-theme-activation';
 import { useSite } from '../hooks/use-site';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
@@ -74,6 +75,7 @@ const pluginBundleFlow: Flow = {
 		const siteSlugParam = useSiteSlugParam();
 		const site = useSite();
 		const currentUser = useSelector( getCurrentUser );
+		const comingFromThemeActivation = useComingFromThemeActivationParam();
 
 		let siteSlug: string | null = null;
 		if ( siteSlugParam ) {
@@ -227,6 +229,9 @@ const pluginBundleFlow: Flow = {
 		}
 
 		const goBack = () => {
+			if ( comingFromThemeActivation ) {
+				return exitFlow( `/themes/${ siteSlug }` );
+			}
 			switch ( currentStep ) {
 				case 'businessInfo':
 					return navigate( 'storeAddress' );

--- a/client/landing/stepper/hooks/use-coming-from-theme-activation.ts
+++ b/client/landing/stepper/hooks/use-coming-from-theme-activation.ts
@@ -1,0 +1,5 @@
+import { useQuery } from './use-query';
+
+export function useComingFromThemeActivationParam(): boolean {
+	return useQuery().get( 'comingFromThemeActivation' ) === 'true';
+}

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -92,7 +92,7 @@ class ThanksModal extends Component {
 			// Redirect to plugin-bundle flow for themes including software (like woocommerce)
 			const { siteSlug, doesThemeBundleUsableSoftware } = this.props;
 			if ( doesThemeBundleUsableSoftware ) {
-				const dest = `/setup/plugin-bundle?siteSlug=${ siteSlug }`;
+				const dest = `/setup/plugin-bundle?siteSlug=${ siteSlug }&comingFromThemeActivation=true`;
 				window.location.replace( dest );
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/wp-calypso/issues/70070
The idea behind this PR is to give the user a way out of the plugin-bundle flow after activating a theme. 
This might not be the best approach but at least resolves a strange problem for the user while we sort out the best way to fix it. 

## Testing Instructions


* Apply this PR.
* Set up a site with a Business plan.
* Activate any WooCommerce theme (the ones with the badge <img width="188" alt="image" src="https://user-images.githubusercontent.com/375980/235519699-37bee646-fcb5-4c9e-8ec5-c6fba2d24ec4.png">)
* Select either of the options presented.
* Verify you land in the plugin-bundle flow but you are provided with a `Back` button:
<img width="891" alt="image" src="https://user-images.githubusercontent.com/375980/235519893-0b246742-1977-429b-abd0-0afd4adb249e.png">
* Click on the button and verify you land on the themes page for the site and the theme you selected is active.
* Go through the steps again and verify that removing the `comingFromThemeActivation=true` flag from the URL after you are redirected to the plugin-bundle flow removes the `Back` button.

