### PR TITLE
Reader: updates design of isolated block editor instance

### DIFF
--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -16,6 +16,7 @@ const noop = () => {};
 
 export class SitesDropdown extends PureComponent {
 	static propTypes = {
+		compact: PropTypes.bool,
 		selectedSiteId: PropTypes.number,
 		showAllSites: PropTypes.bool,
 		onClose: PropTypes.func,
@@ -29,6 +30,7 @@ export class SitesDropdown extends PureComponent {
 	};
 
 	static defaultProps = {
+		compact: false,
 		showAllSites: false,
 		onClose: noop,
 		onSiteSelect: noop,
@@ -86,7 +88,11 @@ export class SitesDropdown extends PureComponent {
 						{ this.props.isPlaceholder ? (
 							<SitePlaceholder />
 						) : (
-							<Site siteId={ this.state.selectedSiteId } indicator={ false } />
+							<Site
+								siteId={ this.state.selectedSiteId }
+								indicator={ false }
+								compact={ this.props.compact }
+							/>
 						) }
 						{ this.props.hasMultipleSites && <Gridicon icon="chevron-down" /> }
 					</div>

--- a/client/data/posts/use-create-new-post.ts
+++ b/client/data/posts/use-create-new-post.ts
@@ -1,0 +1,33 @@
+import { Post } from '@wordpress/core-data';
+import { useCallback } from 'react';
+import { useMutation } from 'react-query';
+import wpcom from 'calypso/lib/wp';
+import { SiteId } from 'calypso/types';
+
+export default function useCreateNewPost( mutationOptions = {} ) {
+	const mutation = useMutation(
+		async ( { siteId, post }: { siteId: SiteId; post: Post } ) =>
+			wpcom.req.post(
+				`/sites/${ siteId }/posts`,
+				{
+					apiNamespace: 'wp/v2',
+				},
+				{
+					...post,
+					status: 'publish',
+				}
+			),
+		{
+			...mutationOptions,
+		}
+	);
+
+	const { mutate } = mutation;
+
+	const createNewPost = useCallback(
+		( siteId: SiteId, post: Post ) => mutate( { siteId, post } ),
+		[ mutate ]
+	);
+
+	return { createNewPost, ...mutation };
+}

--- a/client/package.json
+++ b/client/package.json
@@ -40,6 +40,7 @@
 		"@automattic/happychat-connection": "workspace:^",
 		"@automattic/help-center": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
+		"@automattic/isolated-block-editor": "2.22.x",
 		"@automattic/js-utils": "workspace:^",
 		"@automattic/language-picker": "workspace:^",
 		"@automattic/languages": "workspace:^",

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import AsyncLoad from 'calypso/components/async-load';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
 import Stream from 'calypso/reader/stream';
@@ -9,7 +8,6 @@ function FollowingStream( { ...props } ) {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<>
-			{ config.isEnabled( 'reader/editor' ) && <AsyncLoad require="calypso/reader/post-editor" /> }
 			<Stream { ...props }>
 				<FollowingIntro />
 			</Stream>

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import AsyncLoad from 'calypso/components/async-load';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
 import Stream from 'calypso/reader/stream';
@@ -8,6 +9,7 @@ function FollowingStream( { ...props } ) {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<>
+			{ config.isEnabled( 'reader/editor' ) && <AsyncLoad require="calypso/reader/post-editor" /> }
 			<Stream { ...props }>
 				<FollowingIntro />
 			</Stream>

--- a/client/reader/post-editor/index.jsx
+++ b/client/reader/post-editor/index.jsx
@@ -1,0 +1,79 @@
+import IsoloatedEditor, { ToolbarSlot } from '@automattic/isolated-block-editor';
+import { serialize } from '@wordpress/blocks';
+import { Button } from '@wordpress/components';
+import { select, useDispatch } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
+import useCreateNewPost from 'calypso/data/posts/use-create-new-post';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import '@automattic/isolated-block-editor/build-browser/core.css';
+import './style.scss';
+
+const noticeOptions = {
+	duration: 5000,
+	id: 'reader-post-editor-create-post-notice',
+	isDismissible: true,
+};
+
+function ReaderPostEditor() {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	// Use global redux store for Calypso state and actions
+	const reduxDispatch = useReduxDispatch();
+	const primarySiteId = useSelector( getPrimarySiteId );
+
+	const { createNewPost, isLoading } = useCreateNewPost( {
+		onSuccess: () => {
+			reduxDispatch( successNotice( translate( 'Post published!' ), noticeOptions ) );
+			dispatch( 'core/block-editor' ).resetBlocks( [] );
+		},
+		onError: ( error ) => {
+			const errorMessage = error?.message || translate( 'Something went wrong, please try again.' );
+			reduxDispatch( errorNotice( errorMessage, noticeOptions ) );
+		},
+	} );
+
+	const editorSettings = {
+		iso: {
+			moreMenu: false,
+			footer: true,
+		},
+		editor: {
+			bodyPlaceholder: translate( "What's on your mind?" ),
+			hasFixedToolbar: true,
+		},
+	};
+
+	function publishPost() {
+		const blocks = select( 'core/block-editor' ).getBlocks();
+
+		if ( blocks && blocks.length > 0 ) {
+			createNewPost( primarySiteId, {
+				content: serialize( blocks ),
+			} );
+		}
+	}
+
+	return (
+		<div className="reader-post-editor">
+			<div className="reader-post-editor__editor">
+				<IsoloatedEditor settings={ editorSettings }>
+					<ToolbarSlot>
+						<Button
+							className="reader-post-editor__publish-button"
+							isPrimary
+							onClick={ publishPost }
+							disabled={ isLoading }
+						>
+							{ isLoading ? translate( 'Publishing…' ) : translate( 'Publish' ) }
+						</Button>
+					</ToolbarSlot>
+				</IsoloatedEditor>
+			</div>
+		</div>
+	);
+}
+
+export default ReaderPostEditor;

--- a/client/reader/post-editor/index.jsx
+++ b/client/reader/post-editor/index.jsx
@@ -1,4 +1,4 @@
-import IsoloatedEditor, { ToolbarSlot } from '@automattic/isolated-block-editor';
+import IsoloatedEditor, { FooterSlot } from '@automattic/isolated-block-editor';
 import { serialize } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
 import { select, useDispatch } from '@wordpress/data';
@@ -37,8 +37,9 @@ function ReaderPostEditor() {
 
 	const editorSettings = {
 		iso: {
-			moreMenu: false,
 			footer: true,
+			header: false,
+			moreMenu: false,
 		},
 		editor: {
 			bodyPlaceholder: translate( "What's on your mind?" ),
@@ -60,7 +61,7 @@ function ReaderPostEditor() {
 		<div className="reader-post-editor">
 			<div className="reader-post-editor__editor">
 				<IsoloatedEditor settings={ editorSettings }>
-					<ToolbarSlot>
+					<FooterSlot>
 						<Button
 							className="reader-post-editor__publish-button"
 							isPrimary
@@ -69,7 +70,7 @@ function ReaderPostEditor() {
 						>
 							{ isLoading ? translate( 'Publishing…' ) : translate( 'Publish' ) }
 						</Button>
-					</ToolbarSlot>
+					</FooterSlot>
 				</IsoloatedEditor>
 			</div>
 		</div>

--- a/client/reader/post-editor/index.jsx
+++ b/client/reader/post-editor/index.jsx
@@ -9,6 +9,7 @@ import SitesDropdown from 'calypso/components/sites-dropdown';
 import useCreateNewPost from 'calypso/data/posts/use-create-new-post';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import PostFormatSelector from './post-format-selector';
 import '@automattic/isolated-block-editor/build-browser/core.css';
 import './style.scss';
 
@@ -66,13 +67,14 @@ function ReaderPostEditor() {
 			<div className="reader-post-editor__editor">
 				<IsoloatedEditor settings={ editorSettings }>
 					<FooterSlot>
+						<PostFormatSelector />
 						<Button
 							className="reader-post-editor__publish-button"
 							isPrimary
 							onClick={ publishPost }
 							disabled={ isLoading }
 						>
-							{ isLoading ? translate( 'Publishing…' ) : translate( 'Publish' ) }
+							{ isLoading ? translate( 'Posting…' ) : translate( 'Post' ) }
 						</Button>
 					</FooterSlot>
 				</IsoloatedEditor>

--- a/client/reader/post-editor/index.jsx
+++ b/client/reader/post-editor/index.jsx
@@ -2,8 +2,10 @@ import IsoloatedEditor, { FooterSlot } from '@automattic/isolated-block-editor';
 import { serialize } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
 import { select, useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
+import SitesDropdown from 'calypso/components/sites-dropdown';
 import useCreateNewPost from 'calypso/data/posts/use-create-new-post';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
@@ -23,6 +25,7 @@ function ReaderPostEditor() {
 	// Use global redux store for Calypso state and actions
 	const reduxDispatch = useReduxDispatch();
 	const primarySiteId = useSelector( getPrimarySiteId );
+	const [ siteId, setSiteId ] = useState( primarySiteId );
 
 	const { createNewPost, isLoading } = useCreateNewPost( {
 		onSuccess: () => {
@@ -51,7 +54,7 @@ function ReaderPostEditor() {
 		const blocks = select( 'core/block-editor' ).getBlocks();
 
 		if ( blocks && blocks.length > 0 ) {
-			createNewPost( primarySiteId, {
+			createNewPost( siteId, {
 				content: serialize( blocks ),
 			} );
 		}
@@ -59,6 +62,7 @@ function ReaderPostEditor() {
 
 	return (
 		<div className="reader-post-editor">
+			<SitesDropdown compact={ true } selectedSiteId={ siteId } onSiteSelect={ setSiteId } />
 			<div className="reader-post-editor__editor">
 				<IsoloatedEditor settings={ editorSettings }>
 					<FooterSlot>

--- a/client/reader/post-editor/post-format-selector.jsx
+++ b/client/reader/post-editor/post-format-selector.jsx
@@ -1,0 +1,61 @@
+import { useState } from '@wordpress/element';
+import { Icon, image, link, quote, paragraph, video } from '@wordpress/icons';
+import { translate } from 'i18n-calypso';
+import SegmentedControl from 'calypso/components/segmented-control';
+
+export default function PostFormatSelector() {
+	const [ format, setFormat ] = useState( 'text' );
+
+	function handleFormatClick( value ) {
+		setFormat( value );
+	}
+
+	return (
+		<SegmentedControl>
+			<SegmentedControl.Item
+				onClick={ () => handleFormatClick( 'text' ) }
+				selected={ format === 'text' }
+				value="text"
+			>
+				<Icon className="segmented-control__icon" icon={ paragraph } size={ 18 } />
+				<span className="segmented-control__label">{ translate( 'Text' ) }</span>
+			</SegmentedControl.Item>
+
+			<SegmentedControl.Item
+				onClick={ () => handleFormatClick( 'image' ) }
+				selected={ format === 'image' }
+				value="image"
+			>
+				<Icon className="segmented-control__icon" icon={ image } size={ 18 } />
+				<span className="segmented-control__label">{ translate( 'Image' ) }</span>
+			</SegmentedControl.Item>
+
+			<SegmentedControl.Item
+				onClick={ () => handleFormatClick( 'quote' ) }
+				selected={ format === 'quote' }
+				value="quote"
+			>
+				<Icon className="segmented-control__icon" icon={ quote } size={ 18 } />
+				<span className="segmented-control__label">{ translate( 'Quote' ) }</span>
+			</SegmentedControl.Item>
+
+			<SegmentedControl.Item
+				onClick={ () => handleFormatClick( 'link' ) }
+				selected={ format === 'link' }
+				value="link"
+			>
+				<Icon className="segmented-control__icon" icon={ link } size={ 18 } />
+				<span className="segmented-control__label">{ translate( 'Link' ) }</span>
+			</SegmentedControl.Item>
+
+			<SegmentedControl.Item
+				onClick={ () => handleFormatClick( 'video' ) }
+				selected={ format === 'video' }
+				value="video"
+			>
+				<Icon className="segmented-control__icon" icon={ video } size={ 18 } />
+				<span className="segmented-control__label">{ translate( 'Video' ) }</span>
+			</SegmentedControl.Item>
+		</SegmentedControl>
+	);
+}

--- a/client/reader/post-editor/post-format-selector.jsx
+++ b/client/reader/post-editor/post-format-selector.jsx
@@ -1,21 +1,81 @@
+import { createBlock, switchToBlockType } from '@wordpress/blocks';
+import { dispatch, select } from '@wordpress/data';
 import { useState } from '@wordpress/element';
-import { Icon, image, link, quote, paragraph, video } from '@wordpress/icons';
+import { Icon, image, quote, paragraph, video } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import SegmentedControl from 'calypso/components/segmented-control';
 
 export default function PostFormatSelector() {
-	const [ format, setFormat ] = useState( 'text' );
+	const [ format, setFormat ] = useState( 'paragraph' );
 
 	function handleFormatClick( value ) {
+		const { getBlocks } = select( 'core/block-editor' );
+		const { insertBlocks, removeBlock, replaceBlock, selectBlock } =
+			dispatch( 'core/block-editor' );
+		let blocks = getBlocks();
+		let newBlocks = null;
+		const hasBlocks = blocks && blocks.length > 0;
+		const toBlockName = `core/${ value }`;
+		const fromBlockName = hasBlocks ? blocks[ 0 ].name : null;
+
 		setFormat( value );
+
+		if ( ! hasBlocks ) {
+			newBlocks = [ createBlock( toBlockName ) ];
+			insertBlocks( newBlocks );
+			selectBlock( newBlocks[ 0 ].clientId );
+			return;
+		} else if ( toBlockName === fromBlockName ) {
+			return;
+		}
+
+		switch ( `${ fromBlockName }->${ toBlockName }` ) {
+			case 'core/paragraph->core/quote':
+				newBlocks = switchToBlockType( blocks[ 0 ], toBlockName );
+				replaceBlock( blocks[ 0 ].clientId, newBlocks );
+				break;
+			case 'core/paragraph->core/image':
+			case 'core/paragraph->core/video':
+				newBlocks = [ createBlock( toBlockName ) ];
+				insertBlocks( newBlocks, 0 );
+				break;
+			case 'core/quote->core/paragraph':
+				// "Unwrap" the quote block.
+				newBlocks = switchToBlockType( blocks[ 0 ], '*' );
+				replaceBlock( blocks[ 0 ].clientId, newBlocks );
+				break;
+			case 'core/quote->core/image':
+			case 'core/quote->core/video':
+				newBlocks = switchToBlockType( blocks[ 0 ], '*' );
+				replaceBlock( blocks[ 0 ].clientId, newBlocks );
+				newBlocks = [ createBlock( toBlockName ) ];
+				insertBlocks( newBlocks, 0 );
+				break;
+			case 'core/image->core/paragraph':
+			case 'core/image->core/quote':
+			case 'core/image->core/video':
+			case 'core/video->core/paragraph':
+			case 'core/video->core/image':
+			case 'core/video->core/quote':
+				removeBlock( blocks[ 0 ].clientId );
+				newBlocks = [ createBlock( toBlockName ) ];
+				blocks = getBlocks();
+				if ( newBlocks[ 0 ].name !== blocks[ 0 ].name ) {
+					insertBlocks( newBlocks, 0 );
+				}
+				break;
+		}
+
+		blocks = getBlocks();
+		selectBlock( blocks[ 0 ].clientId );
 	}
 
 	return (
 		<SegmentedControl>
 			<SegmentedControl.Item
-				onClick={ () => handleFormatClick( 'text' ) }
-				selected={ format === 'text' }
-				value="text"
+				onClick={ () => handleFormatClick( 'paragraph' ) }
+				selected={ format === 'paragraph' }
+				value="paragraph"
 			>
 				<Icon className="segmented-control__icon" icon={ paragraph } size={ 18 } />
 				<span className="segmented-control__label">{ translate( 'Text' ) }</span>
@@ -37,15 +97,6 @@ export default function PostFormatSelector() {
 			>
 				<Icon className="segmented-control__icon" icon={ quote } size={ 18 } />
 				<span className="segmented-control__label">{ translate( 'Quote' ) }</span>
-			</SegmentedControl.Item>
-
-			<SegmentedControl.Item
-				onClick={ () => handleFormatClick( 'link' ) }
-				selected={ format === 'link' }
-				value="link"
-			>
-				<Icon className="segmented-control__icon" icon={ link } size={ 18 } />
-				<span className="segmented-control__label">{ translate( 'Link' ) }</span>
 			</SegmentedControl.Item>
 
 			<SegmentedControl.Item

--- a/client/reader/post-editor/style.scss
+++ b/client/reader/post-editor/style.scss
@@ -1,0 +1,18 @@
+.reader-post-editor {
+	margin-bottom: 80px;
+
+	.components-menu-items__item-icon {
+		// Make sure menu icons display at the intended size.
+		height: 24px;
+		width: 24px;
+	}
+}
+
+.reader-post-editor__editor {
+	margin-bottom: 12px;
+	width: 100%;
+}
+
+.reader-post-editor__publish-button {
+	float: right;
+}

--- a/client/reader/post-editor/style.scss
+++ b/client/reader/post-editor/style.scss
@@ -2,7 +2,7 @@
 	margin-bottom: 80px;
 
 	.block-editor-writing-flow {
-		padding-top: 20px;
+		padding-top: 16px;
 	}
 
 	.components-menu-items__item-icon {
@@ -11,19 +11,80 @@
 		width: 24px;
 	}
 
+	.iso-editor {
+		border-radius: 4px;
+		min-height: 180px;
+		overflow: hidden;
+	}
+
+	.has-footer .interface-interface-skeleton__body {
+		padding-bottom: 40px;
+	}
+
 	.interface-interface-skeleton__footer {
+		border-top: unset;
 		box-sizing: border-box;
 		display: flex;
 		justify-content: flex-end;
 		padding: 8px;
 	}
 
-	.iso-editor {
-		min-height: 195px;
-	}
+	.sites-dropdown {
+		&.is-open {
+			height: 44px;
+		}
 
-	.has-footer .interface-interface-skeleton__body {
-		padding-bottom: 40px;
+		&__wrapper {
+			border: unset;
+			display: inline-block;
+			width: auto;
+
+			&:hover {
+				box-shadow: none;
+			}
+		}
+
+		&__selected {
+			border: 1px solid var(--color-neutral-10);
+			border-radius: 100px; // stylelint-disable-line scales/radii
+			display: inline-flex;
+		}
+
+		.site-icon {
+			border-radius: 50%;
+		}
+
+		.site__info {
+			width: auto;
+		}
+
+		.site.is-compact {
+			.site__title {
+				line-height: 24px;
+			}
+
+			.site__content {
+				padding: 6px;
+			}
+		}
+
+		.site-selector {
+			border: 1px solid var(--color-neutral-10);
+			border-radius: 4px;
+			margin-top: 6px;
+
+			&.is-large .site-selector__sites {
+				border: unset;
+			}
+
+			&.is-large .search {
+				margin-bottom: 0;
+			}
+		}
+
+		.gridicons-chevron-down {
+			margin-right: 10px;
+		}
 	}
 }
 

--- a/client/reader/post-editor/style.scss
+++ b/client/reader/post-editor/style.scss
@@ -1,5 +1,5 @@
 .reader-post-editor {
-	margin-bottom: 80px;
+	margin-top: 16px;
 
 	.block-editor-writing-flow {
 		// It's a small editor container--add a little space at the top.
@@ -52,6 +52,7 @@
 	}
 
 	.sites-dropdown {
+		margin-bottom: 6px;
 		&.is-open {
 			height: 44px;
 		}

--- a/client/reader/post-editor/style.scss
+++ b/client/reader/post-editor/style.scss
@@ -15,6 +15,11 @@
 		border-radius: 4px;
 		min-height: 180px;
 		overflow: hidden;
+
+		.block-editor-block-list__layout.is-root-container {
+			padding-left: 20px;
+			padding-right: 20px;
+		}
 	}
 
 	.has-footer .interface-interface-skeleton__body {
@@ -24,9 +29,14 @@
 	.interface-interface-skeleton__footer {
 		border-top: unset;
 		box-sizing: border-box;
-		display: flex;
-		justify-content: flex-end;
+		display: block;
 		padding: 8px;
+	}
+
+	.edit-post-layout__footer {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
 	}
 
 	.sites-dropdown {
@@ -86,9 +96,40 @@
 			margin-right: 10px;
 		}
 	}
+
+	.segmented-control__link {
+		border: unset !important;
+	}
+
+	.segmented-control__text {
+		align-items: center;
+		color: var(--color-neutral-50);
+		display: flex;
+		fill: var(--color-neutral-50);
+		flex-direction: column;
+		font-size: 0.75rem;
+	}
+
+	.is-selected .segmented-control__text {
+		color: var(--color-neutral-100);
+		fill: var(--color-neutral-100);
+	}
+
+	.segmented-control__icon {
+		margin-bottom: 2px;
+	}
+}
+
+.notouch .reader-post-editor .segmented-control__link:hover {
+	background-color: unset;
 }
 
 .reader-post-editor__editor {
 	margin-bottom: 12px;
 	width: 100%;
+}
+
+.reader-post-editor__publish-button {
+	margin-left: auto;
+	margin-right: 12px;
 }

--- a/client/reader/post-editor/style.scss
+++ b/client/reader/post-editor/style.scss
@@ -2,7 +2,13 @@
 	margin-bottom: 80px;
 
 	.block-editor-writing-flow {
+		// It's a small editor container--add a little space at the top.
 		padding-top: 16px;
+
+		// Hide the inline inserter to encourage use of a simple set of blocks (selected using the footer).
+		.block-editor-inserter {
+			display: none;
+		}
 	}
 
 	.components-menu-items__item-icon {
@@ -20,6 +26,11 @@
 			padding-left: 20px;
 			padding-right: 20px;
 		}
+
+		// Make sure placeholder content is aligned with actual blocks, to prevent layout shift.
+		.block-editor-block-list__layout:first-of-type .block-editor-default-block-appender__content {
+			margin-top: 0;
+		}
 	}
 
 	.has-footer .interface-interface-skeleton__body {
@@ -29,6 +40,7 @@
 	.interface-interface-skeleton__footer {
 		border-top: unset;
 		box-sizing: border-box;
+		// Unset flex layout on parent, to prevent issues with flex layout within child, .edit-post-layout__footer
 		display: block;
 		padding: 8px;
 	}

--- a/client/reader/post-editor/style.scss
+++ b/client/reader/post-editor/style.scss
@@ -1,18 +1,33 @@
 .reader-post-editor {
 	margin-bottom: 80px;
 
+	.block-editor-writing-flow {
+		padding-top: 20px;
+	}
+
 	.components-menu-items__item-icon {
 		// Make sure menu icons display at the intended size.
 		height: 24px;
 		width: 24px;
+	}
+
+	.interface-interface-skeleton__footer {
+		box-sizing: border-box;
+		display: flex;
+		justify-content: flex-end;
+		padding: 8px;
+	}
+
+	.iso-editor {
+		min-height: 195px;
+	}
+
+	.has-footer .interface-interface-skeleton__body {
+		padding-bottom: 40px;
 	}
 }
 
 .reader-post-editor__editor {
 	margin-bottom: 12px;
 	width: 100%;
-}
-
-.reader-post-editor__publish-button {
-	float: right;
 }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { findLast, times } from 'lodash';
@@ -6,6 +7,7 @@ import { createRef, Component, Fragment } from 'react';
 import * as React from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
+import AsyncLoad from 'calypso/components/async-load';
 import InfiniteList from 'calypso/components/infinite-list';
 import ListEnd from 'calypso/components/list-end';
 import SectionNav from 'calypso/components/section-nav';
@@ -489,18 +491,22 @@ class ReaderStream extends Component {
 		} else {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			const bodyContent = (
-				<InfiniteList
-					ref={ this.listRef }
-					className="reader__content"
-					items={ items }
-					lastPage={ lastPage }
-					fetchingNextPage={ isRequesting }
-					guessedItemHeight={ GUESSED_POST_HEIGHT }
-					fetchNextPage={ this.fetchNextPage }
-					getItemRef={ this.getPostRef }
-					renderItem={ this.renderPost }
-					renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
-				/>
+				<div className="reader__content">
+					{ config.isEnabled( 'reader/editor' ) && (
+						<AsyncLoad require="calypso/reader/post-editor" />
+					) }
+					<InfiniteList
+						ref={ this.listRef }
+						items={ items }
+						lastPage={ lastPage }
+						fetchingNextPage={ isRequesting }
+						guessedItemHeight={ GUESSED_POST_HEIGHT }
+						fetchNextPage={ this.fetchNextPage }
+						getItemRef={ this.getPostRef }
+						renderItem={ this.renderPost }
+						renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
+					/>
+				</div>
 			);
 
 			const sidebarContent = isTagPage ? (

--- a/config/development.json
+++ b/config/development.json
@@ -154,6 +154,7 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/comment-polling": false,
+		"reader/editor": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -126,6 +126,7 @@
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,
+		"reader/editor": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
 		"@types/wordpress__data-controls": "^2.30.0",
 		"@wordpress/base-styles": "^4.13.0",
 		"@wordpress/components": "^22.1.0",
+		"@wordpress/core-data": "^6.8.0",
 		"@wordpress/data": "^7.6.0",
 		"@wordpress/element": "^4.20.0",
 		"@wordpress/i18n": "^4.22.0",
@@ -304,7 +305,11 @@
 		"@wordpress/base-styles": "4.13.0",
 		"@wordpress/interface@^4.8.0": "patch:@wordpress/interface@npm%3A4.8.0#./.yarn/patches/@wordpress-interface-npm-4.8.0-8a39ad37cf.patch",
 		"@wordpress/data-controls": "2.22.0",
-		"@wordpress/element": "4.20.0"
+		"@wordpress/element": "4.20.0",
+		"@wordpress/block-editor": "10.4.0",
+		"@wordpress/block-library": "7.17.0",
+		"@wordpress/components": "22.1.0",
+		"@wordpress/keyboard-shortcuts": "3.20.0"
 	},
 	"packageManager": "yarn@3.2.3",
 	"dependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,6 +913,76 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/isolated-block-editor@npm:2.22.x":
+  version: 2.22.0
+  resolution: "@automattic/isolated-block-editor@npm:2.22.0"
+  dependencies:
+    "@wordpress/a11y": 3.23.0
+    "@wordpress/annotations": 2.23.0
+    "@wordpress/api-fetch": 6.20.0
+    "@wordpress/autop": 3.23.0
+    "@wordpress/base-styles": 4.14.0
+    "@wordpress/blob": 3.23.0
+    "@wordpress/block-editor": 10.2.0
+    "@wordpress/block-library": 7.16.0
+    "@wordpress/block-serialization-default-parser": 4.23.0
+    "@wordpress/block-serialization-spec-parser": 4.23.0
+    "@wordpress/blocks": 11.18.0
+    "@wordpress/components": 21.2.0
+    "@wordpress/compose": 5.17.0
+    "@wordpress/core-data": 5.2.0
+    "@wordpress/data": 7.3.0
+    "@wordpress/data-controls": 2.23.0
+    "@wordpress/date": 4.23.0
+    "@wordpress/deprecated": 3.23.0
+    "@wordpress/dom": 3.23.0
+    "@wordpress/dom-ready": 3.23.0
+    "@wordpress/edit-post": 6.16.0
+    "@wordpress/editor": 12.18.0
+    "@wordpress/element": 4.17.0
+    "@wordpress/escape-html": 2.23.0
+    "@wordpress/format-library": 3.17.0
+    "@wordpress/hooks": 3.19.0
+    "@wordpress/html-entities": 3.23.0
+    "@wordpress/i18n": 4.19.0
+    "@wordpress/icons": 9.10.0
+    "@wordpress/interface": 4.18.0
+    "@wordpress/is-shallow-equal": 4.23.0
+    "@wordpress/keyboard-shortcuts": 3.17.0
+    "@wordpress/keycodes": 3.23.0
+    "@wordpress/list-reusable-blocks": 4.0.0
+    "@wordpress/media-utils": 4.14.0
+    "@wordpress/notices": 3.23.0
+    "@wordpress/plugins": 5.0.0
+    "@wordpress/primitives": 3.21.0
+    "@wordpress/priority-queue": 2.23.0
+    "@wordpress/react-i18n": 3.21.0
+    "@wordpress/redux-routine": 4.23.0
+    "@wordpress/reusable-blocks": 4.0.0
+    "@wordpress/rich-text": 5.17.0
+    "@wordpress/server-side-render": 4.0.0
+    "@wordpress/shortcode": 3.23.0
+    "@wordpress/token-list": 2.23.0
+    "@wordpress/url": 3.24.0
+    "@wordpress/viewport": 5.0.0
+    "@wordpress/warning": 2.23.0
+    "@wordpress/wordcount": 3.23.0
+    classnames: ^2.3.2
+    debug: ^4.3.4
+    lib0: ^0.2.58
+    lodash: ^4.17.21
+    memize: ^1.1.0
+    react: 17.0.2
+    react-autosize-textarea: ^7.1.0
+    react-dom: 17.0.2
+    reakit-utils: ^0.15.2
+    redux-undo: ^1.0.1
+    uuid: ^9.0.0
+    yjs: ^13.5.44
+  checksum: 0d0edea78f61ef4f4f3a288f03a800c5b93f178c27df9798f7693c9d3200dfab71646b2039794055f74dccd4cc61fbd9f3bc013a074120950a498f90610fa1f0
+  languageName: node
+  linkType: hard
+
 "@automattic/jest-circus-allure-reporter@workspace:^, @automattic/jest-circus-allure-reporter@workspace:packages/jest-circus-allure-reporter":
   version: 0.0.0-use.local
   resolution: "@automattic/jest-circus-allure-reporter@workspace:packages/jest-circus-allure-reporter"
@@ -8214,6 +8284,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/a11y@npm:3.23.0":
+  version: 3.23.0
+  resolution: "@wordpress/a11y@npm:3.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/dom-ready": ^3.23.0
+    "@wordpress/i18n": ^4.23.0
+  checksum: f1fb59ac30c31537ad5765519b6278252ab3175dd24236ec10d509d12e4a8b545436a4333d59bdf98b6623fa0d36a56d70621c9fdd9d96d5966d97ac09601b88
+  languageName: node
+  linkType: hard
+
 "@wordpress/a11y@npm:^3.13.0, @wordpress/a11y@npm:^3.22.0, @wordpress/a11y@npm:^3.27.0":
   version: 3.27.0
   resolution: "@wordpress/a11y@npm:3.27.0"
@@ -8222,6 +8303,43 @@ __metadata:
     "@wordpress/dom-ready": ^3.27.0
     "@wordpress/i18n": ^4.27.0
   checksum: dc4c97f087d3d6dfa5e930ad6d1f8882c15d1461a600c38aeb052f2fcb351aff6d2679b13465ee898d35e4e0642ffb41f2e3cff0d1203ed089eb93404f539a8f
+  languageName: node
+  linkType: hard
+
+"@wordpress/a11y@npm:^3.19.0, @wordpress/a11y@npm:^3.20.0, @wordpress/a11y@npm:^3.21.0, @wordpress/a11y@npm:^3.23.0, @wordpress/a11y@npm:^3.31.0":
+  version: 3.31.0
+  resolution: "@wordpress/a11y@npm:3.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/dom-ready": ^3.31.0
+    "@wordpress/i18n": ^4.31.0
+  checksum: 3de5fab087959ce5fdf651c99d3511b3584a36ba99e491dfd1b5a7a29fa75708962c08892237e655f64d4287e11ef2f2d07adc5dd1d34a26bf936fad966f840e
+  languageName: node
+  linkType: hard
+
+"@wordpress/annotations@npm:2.23.0":
+  version: 2.23.0
+  resolution: "@wordpress/annotations@npm:2.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/data": ^8.0.0
+    "@wordpress/hooks": ^3.23.0
+    "@wordpress/i18n": ^4.23.0
+    "@wordpress/rich-text": ^6.0.0
+    rememo: ^4.0.0
+    uuid: ^8.3.0
+  checksum: 356b610a786ecbb1b9687471422c60a64a9d108c2466a02f3dd935a8f7ed59beaf73fbd1901d946b8c58df5d814570193cfbf6c9eac360124c806d73c990045e
+  languageName: node
+  linkType: hard
+
+"@wordpress/api-fetch@npm:6.20.0":
+  version: 6.20.0
+  resolution: "@wordpress/api-fetch@npm:6.20.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/i18n": ^4.23.0
+    "@wordpress/url": ^3.24.0
+  checksum: 4cd508fd3e56b94881ded1a000adbf585bb91cfdab7c9a1c99481b787889987d45450ef065cd4af82aeae90138e3319346b60848ae927018de2a7f6712a4eb5b
   languageName: node
   linkType: hard
 
@@ -8236,6 +8354,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/api-fetch@npm:^6.16.0, @wordpress/api-fetch@npm:^6.17.0, @wordpress/api-fetch@npm:^6.18.0, @wordpress/api-fetch@npm:^6.20.0, @wordpress/api-fetch@npm:^6.28.0":
+  version: 6.28.0
+  resolution: "@wordpress/api-fetch@npm:6.28.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/i18n": ^4.31.0
+    "@wordpress/url": ^3.32.0
+  checksum: 585c643a53efb24e2e8851c1f40663992e83fd1f6841cddaa63c63a1df03a003c05b76e7050566e49f4643d148ada02e6edb7aeef11196e0faf96f4fca0f4117
+  languageName: node
+  linkType: hard
+
 "@wordpress/api-fetch@npm:^6.19.0, @wordpress/api-fetch@npm:^6.24.0":
   version: 6.24.0
   resolution: "@wordpress/api-fetch@npm:6.24.0"
@@ -8244,6 +8373,24 @@ __metadata:
     "@wordpress/i18n": ^4.27.0
     "@wordpress/url": ^3.28.0
   checksum: fba338699e0f81cf53dc0e1341f9b5c68ca726b952fa834bf2ba88c8d5b46257014b34354a9791ca451df2c3a6a02d6badcca31c61810e72bd8e76ff400a0ff4
+  languageName: node
+  linkType: hard
+
+"@wordpress/autop@npm:3.23.0":
+  version: 3.23.0
+  resolution: "@wordpress/autop@npm:3.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 5401f17206871ac13108c588b49a8b0a172883b051ff1770866aae94bf578d030c33a8a67156b3d0d6617d079d8dfe5c294decfb940372894fae469f266d1d37
+  languageName: node
+  linkType: hard
+
+"@wordpress/autop@npm:^3.19.0, @wordpress/autop@npm:^3.20.0, @wordpress/autop@npm:^3.31.0":
+  version: 3.31.0
+  resolution: "@wordpress/autop@npm:3.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 4ea9f05c582a12286a278417cc053314732945292794603c024047a1a0139ca5ba7d1deed2f3e038ab02bf3b8851303a0b6379c1b3bfdbbd7c63cf54769825b6
   languageName: node
   linkType: hard
 
@@ -8299,6 +8446,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/blob@npm:3.23.0":
+  version: 3.23.0
+  resolution: "@wordpress/blob@npm:3.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: a0b3604a89cca6ad89fb4f4224c472d69048dd0d3480ef4c681ab1f08a2e0c6bebbb2ae2ff3f63e3d63c718c827980f77e18022bb124bea5d1e9f49438f998c0
+  languageName: node
+  linkType: hard
+
+"@wordpress/blob@npm:^3.19.0, @wordpress/blob@npm:^3.20.0, @wordpress/blob@npm:^3.21.0, @wordpress/blob@npm:^3.23.0, @wordpress/blob@npm:^3.31.0":
+  version: 3.31.0
+  resolution: "@wordpress/blob@npm:3.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: da9ef90b7a5d1ef954044f2851d86bf9d51237adb737b2467420f8970b12c5ea38e27e010736185f9eb59e7bc5f4097da3bfa1665a5b5a2df694d2917ab9f8da
+  languageName: node
+  linkType: hard
+
 "@wordpress/blob@npm:^3.22.0, @wordpress/blob@npm:^3.27.0":
   version: 3.27.0
   resolution: "@wordpress/blob@npm:3.27.0"
@@ -8308,38 +8473,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/block-editor@npm:^10.5.0":
-  version: 10.5.0
-  resolution: "@wordpress/block-editor@npm:10.5.0"
+"@wordpress/block-editor@npm:10.4.0":
+  version: 10.4.0
+  resolution: "@wordpress/block-editor@npm:10.4.0"
   dependencies:
     "@babel/runtime": ^7.16.0
     "@react-spring/web": ^9.4.5
-    "@wordpress/a11y": ^3.22.0
-    "@wordpress/api-fetch": ^6.19.0
-    "@wordpress/blob": ^3.22.0
-    "@wordpress/blocks": ^11.21.0
-    "@wordpress/components": ^22.1.0
-    "@wordpress/compose": ^5.20.0
-    "@wordpress/data": ^7.6.0
-    "@wordpress/date": ^4.22.0
-    "@wordpress/deprecated": ^3.22.0
-    "@wordpress/dom": ^3.22.0
-    "@wordpress/element": ^4.20.0
-    "@wordpress/hooks": ^3.22.0
-    "@wordpress/html-entities": ^3.22.0
-    "@wordpress/i18n": ^4.22.0
-    "@wordpress/icons": ^9.13.0
-    "@wordpress/is-shallow-equal": ^4.22.0
-    "@wordpress/keyboard-shortcuts": ^3.20.0
-    "@wordpress/keycodes": ^3.22.0
-    "@wordpress/notices": ^3.22.0
-    "@wordpress/rich-text": ^5.20.0
-    "@wordpress/shortcode": ^3.22.0
-    "@wordpress/style-engine": ^1.5.0
-    "@wordpress/token-list": ^2.22.0
-    "@wordpress/url": ^3.23.0
-    "@wordpress/warning": ^2.22.0
-    "@wordpress/wordcount": ^3.22.0
+    "@wordpress/a11y": ^3.21.0
+    "@wordpress/api-fetch": ^6.18.0
+    "@wordpress/blob": ^3.21.0
+    "@wordpress/blocks": ^11.20.0
+    "@wordpress/components": ^22.0.0
+    "@wordpress/compose": ^5.19.0
+    "@wordpress/data": ^7.5.0
+    "@wordpress/date": ^4.21.0
+    "@wordpress/deprecated": ^3.21.0
+    "@wordpress/dom": ^3.21.0
+    "@wordpress/element": ^4.19.0
+    "@wordpress/hooks": ^3.21.0
+    "@wordpress/html-entities": ^3.21.0
+    "@wordpress/i18n": ^4.21.0
+    "@wordpress/icons": ^9.12.0
+    "@wordpress/is-shallow-equal": ^4.21.0
+    "@wordpress/keyboard-shortcuts": ^3.19.0
+    "@wordpress/keycodes": ^3.21.0
+    "@wordpress/notices": ^3.21.0
+    "@wordpress/rich-text": ^5.19.0
+    "@wordpress/shortcode": ^3.21.0
+    "@wordpress/style-engine": ^1.4.0
+    "@wordpress/token-list": ^2.21.0
+    "@wordpress/url": ^3.22.0
+    "@wordpress/warning": ^2.21.0
+    "@wordpress/wordcount": ^3.21.0
     change-case: ^4.1.2
     classnames: ^2.3.1
     colord: ^2.7.0
@@ -8355,45 +8520,44 @@ __metadata:
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: 416c7a45b9a63fbc710fb4aaf29970fa8a4d31b11f8b20936476885e352336b7407326d7fd4562018d79162196949393f7a580ff32745de8c49124ebd0b34704
+  checksum: 1036617c98515cc4bdf7242f35540646ab411bb26899b84968c1900ad867b70aed424cfc0a119d51a8b6b3c007ee887bfc3db9f7bbeb17e446832959b990be26
   languageName: node
   linkType: hard
 
-"@wordpress/block-library@npm:^7.19.0":
-  version: 7.19.0
-  resolution: "@wordpress/block-library@npm:7.19.0"
+"@wordpress/block-library@npm:7.17.0":
+  version: 7.17.0
+  resolution: "@wordpress/block-library@npm:7.17.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-    "@wordpress/a11y": ^3.22.0
-    "@wordpress/api-fetch": ^6.19.0
-    "@wordpress/autop": ^3.22.0
-    "@wordpress/blob": ^3.22.0
-    "@wordpress/block-editor": ^10.5.0
-    "@wordpress/blocks": ^11.21.0
-    "@wordpress/components": ^22.1.0
-    "@wordpress/compose": ^5.20.0
-    "@wordpress/core-data": ^5.5.0
-    "@wordpress/data": ^7.6.0
-    "@wordpress/date": ^4.22.0
-    "@wordpress/deprecated": ^3.22.0
-    "@wordpress/dom": ^3.22.0
-    "@wordpress/element": ^4.20.0
-    "@wordpress/hooks": ^3.22.0
-    "@wordpress/html-entities": ^3.22.0
-    "@wordpress/i18n": ^4.22.0
-    "@wordpress/icons": ^9.13.0
-    "@wordpress/keycodes": ^3.22.0
-    "@wordpress/notices": ^3.22.0
-    "@wordpress/primitives": ^3.20.0
-    "@wordpress/reusable-blocks": ^3.20.0
-    "@wordpress/rich-text": ^5.20.0
-    "@wordpress/server-side-render": ^3.20.0
-    "@wordpress/url": ^3.23.0
-    "@wordpress/viewport": ^4.20.0
+    "@wordpress/a11y": ^3.20.0
+    "@wordpress/api-fetch": ^6.17.0
+    "@wordpress/autop": ^3.20.0
+    "@wordpress/blob": ^3.20.0
+    "@wordpress/block-editor": ^10.3.0
+    "@wordpress/blocks": ^11.19.0
+    "@wordpress/components": ^21.3.0
+    "@wordpress/compose": ^5.18.0
+    "@wordpress/core-data": ^5.3.0
+    "@wordpress/data": ^7.4.0
+    "@wordpress/date": ^4.20.0
+    "@wordpress/deprecated": ^3.20.0
+    "@wordpress/dom": ^3.20.0
+    "@wordpress/element": ^4.18.0
+    "@wordpress/hooks": ^3.20.0
+    "@wordpress/html-entities": ^3.20.0
+    "@wordpress/i18n": ^4.20.0
+    "@wordpress/icons": ^9.11.0
+    "@wordpress/keycodes": ^3.20.0
+    "@wordpress/notices": ^3.20.0
+    "@wordpress/primitives": ^3.18.0
+    "@wordpress/reusable-blocks": ^3.18.0
+    "@wordpress/rich-text": ^5.18.0
+    "@wordpress/server-side-render": ^3.18.0
+    "@wordpress/url": ^3.21.0
+    "@wordpress/viewport": ^4.18.0
     change-case: ^4.1.2
     classnames: ^2.3.1
     colord: ^2.7.0
-    escape-html: ^1.0.3
     fast-average-color: ^9.1.1
     lodash: ^4.17.21
     memize: ^1.1.0
@@ -8402,7 +8566,25 @@ __metadata:
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: 3b10d67b44245a27c2d295ab3cb30a9dcec476aa65156257fc627f8e20c3d2f66137e1a34dc8ab5c84b6716db4f848c132668530693137d0d4f2f445d0a18e13
+  checksum: 55df189e937ef14744ca2619133e370139e2781e07a7c1a5220d7b3213823bf4e4e3bb6de86c47b29bbabb834f01062ff6293acfea0be0b9a0467601bbfc4cc2
+  languageName: node
+  linkType: hard
+
+"@wordpress/block-serialization-default-parser@npm:4.23.0":
+  version: 4.23.0
+  resolution: "@wordpress/block-serialization-default-parser@npm:4.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 0a2c1370afa84a00d129d12ae2bdcdc4ce6416379390c8bdd0a4c62269175ad389ba89ee20037085f8451f10e3503e1591fdbf8ed16440169cccc8b78e0b099c
+  languageName: node
+  linkType: hard
+
+"@wordpress/block-serialization-default-parser@npm:^4.19.0, @wordpress/block-serialization-default-parser@npm:^4.31.0":
+  version: 4.31.0
+  resolution: "@wordpress/block-serialization-default-parser@npm:4.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 6995a13036e02bbe1761da0b08a8901637d137cc56c48a34008d708049264c3ec7c5302c5cd890418815180f91675789b96c57b02fa0ac5b0b97aa8f2229dfda
   languageName: node
   linkType: hard
 
@@ -8415,7 +8597,52 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/blocks@npm:^11.21.0":
+"@wordpress/block-serialization-spec-parser@npm:4.23.0":
+  version: 4.23.0
+  resolution: "@wordpress/block-serialization-spec-parser@npm:4.23.0"
+  dependencies:
+    pegjs: ^0.10.0
+    phpegjs: ^1.0.0-beta7
+  checksum: ddf3526bd1610e0df8933ab78743e0e52bcfe2ee95fa82d0b1db3be5b7482d8bebe34a6514c52357abf69f8d3950808b004559c079a3976a5a938997475390c8
+  languageName: node
+  linkType: hard
+
+"@wordpress/blocks@npm:11.18.0":
+  version: 11.18.0
+  resolution: "@wordpress/blocks@npm:11.18.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/autop": ^3.19.0
+    "@wordpress/blob": ^3.19.0
+    "@wordpress/block-serialization-default-parser": ^4.19.0
+    "@wordpress/compose": ^5.17.0
+    "@wordpress/data": ^7.3.0
+    "@wordpress/deprecated": ^3.19.0
+    "@wordpress/dom": ^3.19.0
+    "@wordpress/element": ^4.17.0
+    "@wordpress/hooks": ^3.19.0
+    "@wordpress/html-entities": ^3.19.0
+    "@wordpress/i18n": ^4.19.0
+    "@wordpress/is-shallow-equal": ^4.19.0
+    "@wordpress/shortcode": ^3.19.0
+    change-case: ^4.1.2
+    colord: ^2.7.0
+    hpq: ^1.3.0
+    is-plain-object: ^5.0.0
+    lodash: ^4.17.21
+    memize: ^1.1.0
+    rememo: ^4.0.0
+    remove-accents: ^0.4.2
+    showdown: ^1.9.1
+    simple-html-tokenizer: ^0.5.7
+    uuid: ^8.3.0
+  peerDependencies:
+    react: ^17.0.0
+  checksum: 2777e255fe1f875dfe42501dd9fcc398723767c2d44bf0c066970e831a451c972e0f81675bc98c231cc704e9fe4c20e3af9b04e56f8360593ad4d71331c7840f
+  languageName: node
+  linkType: hard
+
+"@wordpress/blocks@npm:^11.18.0, @wordpress/blocks@npm:^11.19.0, @wordpress/blocks@npm:^11.20.0, @wordpress/blocks@npm:^11.21.0":
   version: 11.21.0
   resolution: "@wordpress/blocks@npm:11.21.0"
   dependencies:
@@ -8447,6 +8674,43 @@ __metadata:
   peerDependencies:
     react: ^17.0.0
   checksum: 9f1d18ce55f3a3d61fb626a498f169dbc41cb1761a52d5b08d450b6c47a9355422a719bfbdd5c7e44649aa8ad6296678da656a7a3877b0e2ed19428a5acde6e6
+  languageName: node
+  linkType: hard
+
+"@wordpress/blocks@npm:^12.0.0, @wordpress/blocks@npm:^12.8.0":
+  version: 12.8.0
+  resolution: "@wordpress/blocks@npm:12.8.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/autop": ^3.31.0
+    "@wordpress/blob": ^3.31.0
+    "@wordpress/block-serialization-default-parser": ^4.31.0
+    "@wordpress/compose": ^6.8.0
+    "@wordpress/data": ^9.1.0
+    "@wordpress/deprecated": ^3.31.0
+    "@wordpress/dom": ^3.31.0
+    "@wordpress/element": ^5.8.0
+    "@wordpress/hooks": ^3.31.0
+    "@wordpress/html-entities": ^3.31.0
+    "@wordpress/i18n": ^4.31.0
+    "@wordpress/is-shallow-equal": ^4.31.0
+    "@wordpress/private-apis": ^0.13.0
+    "@wordpress/shortcode": ^3.31.0
+    change-case: ^4.1.2
+    colord: ^2.7.0
+    fast-deep-equal: ^3.1.3
+    hpq: ^1.3.0
+    is-plain-object: ^5.0.0
+    lodash: ^4.17.21
+    memize: ^1.1.0
+    rememo: ^4.0.0
+    remove-accents: ^0.4.2
+    showdown: ^1.9.1
+    simple-html-tokenizer: ^0.5.7
+    uuid: ^8.3.0
+  peerDependencies:
+    react: ^18.0.0
+  checksum: 48191a16f2b58b90b31810465bd126e6705cc50e669f48311dcd721a89673f58988ce47b85a314872c9778f287505b5e61df8cd4ba0659cbe8a61a2773ee6634
   languageName: node
   linkType: hard
 
@@ -8508,7 +8772,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/components@npm:^22.1.0":
+"@wordpress/components@npm:22.1.0":
   version: 22.1.0
   resolution: "@wordpress/components@npm:22.1.0"
   dependencies:
@@ -8561,7 +8825,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/compose@npm:^5.11.0, @wordpress/compose@npm:^5.20.0":
+"@wordpress/compose@npm:5.17.0":
+  version: 5.17.0
+  resolution: "@wordpress/compose@npm:5.17.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@types/mousetrap": ^1.6.8
+    "@wordpress/deprecated": ^3.19.0
+    "@wordpress/dom": ^3.19.0
+    "@wordpress/element": ^4.17.0
+    "@wordpress/is-shallow-equal": ^4.19.0
+    "@wordpress/keycodes": ^3.19.0
+    "@wordpress/priority-queue": ^2.19.0
+    change-case: ^4.1.2
+    clipboard: ^2.0.8
+    mousetrap: ^1.6.5
+    use-memo-one: ^1.1.1
+  peerDependencies:
+    react: ^17.0.0
+  checksum: 0fe1a88dabfa34a2095f46058e92008125a8802298707093a0344bd7e0e7882394e8d4090b602d6e0e28ce5e90e78c551b9d8adf65888c12952a3ac8cb9c16af
+  languageName: node
+  linkType: hard
+
+"@wordpress/compose@npm:^5.11.0, @wordpress/compose@npm:^5.17.0, @wordpress/compose@npm:^5.18.0, @wordpress/compose@npm:^5.19.0, @wordpress/compose@npm:^5.20.0":
   version: 5.20.0
   resolution: "@wordpress/compose@npm:5.20.0"
   dependencies:
@@ -8580,6 +8866,28 @@ __metadata:
   peerDependencies:
     react: ^17.0.0
   checksum: 0b5a745c9c2a4f6942bf04861e896f2607d7f78df6ef06a76c4f508d7334e482ec2003afd31c19e0dc657e1db31886c6ccd0f4410d4346940e9edbc0a7f00cc9
+  languageName: node
+  linkType: hard
+
+"@wordpress/compose@npm:^6.0.0, @wordpress/compose@npm:^6.6.0, @wordpress/compose@npm:^6.8.0":
+  version: 6.8.0
+  resolution: "@wordpress/compose@npm:6.8.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@types/mousetrap": ^1.6.8
+    "@wordpress/deprecated": ^3.31.0
+    "@wordpress/dom": ^3.31.0
+    "@wordpress/element": ^5.8.0
+    "@wordpress/is-shallow-equal": ^4.31.0
+    "@wordpress/keycodes": ^3.31.0
+    "@wordpress/priority-queue": ^2.31.0
+    change-case: ^4.1.2
+    clipboard: ^2.0.8
+    mousetrap: ^1.6.5
+    use-memo-one: ^1.1.1
+  peerDependencies:
+    react: ^18.0.0
+  checksum: a14701447e9dee4f92a2a16f4e50bc7c120520b9d08b2a29ee3cd3dc619f00f31f6174d29d3daaa9ac3cbcbf6cce71570a910389cfaf4618c95edbe060ea5676
   languageName: node
   linkType: hard
 
@@ -8605,7 +8913,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/core-data@npm:^5.5.0":
+"@wordpress/core-data@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@wordpress/core-data@npm:5.2.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/api-fetch": ^6.16.0
+    "@wordpress/blocks": ^11.18.0
+    "@wordpress/compose": ^5.17.0
+    "@wordpress/data": ^7.3.0
+    "@wordpress/deprecated": ^3.19.0
+    "@wordpress/element": ^4.17.0
+    "@wordpress/html-entities": ^3.19.0
+    "@wordpress/i18n": ^4.19.0
+    "@wordpress/is-shallow-equal": ^4.19.0
+    "@wordpress/url": ^3.20.0
+    change-case: ^4.1.2
+    equivalent-key-map: ^0.2.2
+    lodash: ^4.17.21
+    memize: ^1.1.0
+    rememo: ^4.0.0
+    uuid: ^8.3.0
+  peerDependencies:
+    react: ^17.0.0
+  checksum: 39d03a3280abd802dbe8af86aa65de1367bb4e87008e20b067038d3e056d4cb6bb6185c80e9e1e26a1650f15bb593802d4847da5761d168be9f8b7b68f3dcf86
+  languageName: node
+  linkType: hard
+
+"@wordpress/core-data@npm:^5.2.0, @wordpress/core-data@npm:^5.3.0, @wordpress/core-data@npm:^5.5.0":
   version: 5.5.0
   resolution: "@wordpress/core-data@npm:5.5.0"
   dependencies:
@@ -8632,6 +8967,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/core-data@npm:^6.0.0, @wordpress/core-data@npm:^6.8.0":
+  version: 6.8.0
+  resolution: "@wordpress/core-data@npm:6.8.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/api-fetch": ^6.28.0
+    "@wordpress/blocks": ^12.8.0
+    "@wordpress/compose": ^6.8.0
+    "@wordpress/data": ^9.1.0
+    "@wordpress/deprecated": ^3.31.0
+    "@wordpress/element": ^5.8.0
+    "@wordpress/html-entities": ^3.31.0
+    "@wordpress/i18n": ^4.31.0
+    "@wordpress/is-shallow-equal": ^4.31.0
+    "@wordpress/url": ^3.32.0
+    change-case: ^4.1.2
+    equivalent-key-map: ^0.2.2
+    fast-deep-equal: ^3.1.3
+    memize: ^1.1.0
+    rememo: ^4.0.0
+    uuid: ^8.3.0
+  peerDependencies:
+    react: ^18.0.0
+  checksum: 8337401295773da598c5322df79a6100686d6230de227cbeb754802dc7334f399886bec521d4a59f1762514e240bafcfac7d434de3c3ebe8036ab27bca8d3b21
+  languageName: node
+  linkType: hard
+
 "@wordpress/data-controls@npm:2.22.0":
   version: 2.22.0
   resolution: "@wordpress/data-controls@npm:2.22.0"
@@ -8646,7 +9008,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/data@npm:^7.6.0":
+"@wordpress/data@npm:7.3.0":
+  version: 7.3.0
+  resolution: "@wordpress/data@npm:7.3.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/compose": ^5.17.0
+    "@wordpress/deprecated": ^3.19.0
+    "@wordpress/element": ^4.17.0
+    "@wordpress/is-shallow-equal": ^4.19.0
+    "@wordpress/priority-queue": ^2.19.0
+    "@wordpress/redux-routine": ^4.19.0
+    equivalent-key-map: ^0.2.2
+    is-plain-object: ^5.0.0
+    is-promise: ^4.0.0
+    lodash: ^4.17.21
+    redux: ^4.1.2
+    turbo-combine-reducers: ^1.0.2
+    use-memo-one: ^1.1.1
+  peerDependencies:
+    react: ^17.0.0
+  checksum: 890729ca900f8b904a7232a012a147511242aa84f18f69f3bb59336cbbab543e881806af36c6ddcaddced70b55ab7d5ffa2af23d224fdfaf14270c0030f7c764
+  languageName: node
+  linkType: hard
+
+"@wordpress/data@npm:^7.3.0, @wordpress/data@npm:^7.4.0, @wordpress/data@npm:^7.5.0, @wordpress/data@npm:^7.6.0":
   version: 7.6.0
   resolution: "@wordpress/data@npm:7.6.0"
   dependencies:
@@ -8667,6 +9053,31 @@ __metadata:
   peerDependencies:
     react: ^17.0.0
   checksum: 9bfe31aaca62e3eb2516575300b764a42d6d7f020ceee89d33e28e183eec7c1f58dee30d171e9d1e186aa0bca3df5dd714dd9902614193d95983410077fa55b7
+  languageName: node
+  linkType: hard
+
+"@wordpress/data@npm:^8.0.0":
+  version: 8.6.0
+  resolution: "@wordpress/data@npm:8.6.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/compose": ^6.6.0
+    "@wordpress/deprecated": ^3.29.0
+    "@wordpress/element": ^5.6.0
+    "@wordpress/is-shallow-equal": ^4.29.0
+    "@wordpress/priority-queue": ^2.29.0
+    "@wordpress/private-apis": ^0.11.0
+    "@wordpress/redux-routine": ^4.29.0
+    deepmerge: ^4.3.0
+    equivalent-key-map: ^0.2.2
+    is-plain-object: ^5.0.0
+    is-promise: ^4.0.0
+    redux: ^4.1.2
+    turbo-combine-reducers: ^1.0.2
+    use-memo-one: ^1.1.1
+  peerDependencies:
+    react: ^18.0.0
+  checksum: 4462429e6e83c8d5be3b3d14e6e48678012ba81022498382c54825b26232c126bedced3b0496a784db6e0d2c50c92fb361ffc736b7303ab5d7acc2091612574a
   languageName: node
   linkType: hard
 
@@ -8695,6 +9106,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/data@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@wordpress/data@npm:9.1.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/compose": ^6.8.0
+    "@wordpress/deprecated": ^3.31.0
+    "@wordpress/element": ^5.8.0
+    "@wordpress/is-shallow-equal": ^4.31.0
+    "@wordpress/priority-queue": ^2.31.0
+    "@wordpress/private-apis": ^0.13.0
+    "@wordpress/redux-routine": ^4.31.0
+    deepmerge: ^4.3.0
+    equivalent-key-map: ^0.2.2
+    is-plain-object: ^5.0.0
+    is-promise: ^4.0.0
+    redux: ^4.1.2
+    turbo-combine-reducers: ^1.0.2
+    use-memo-one: ^1.1.1
+  peerDependencies:
+    react: ^18.0.0
+  checksum: c1995b40f020e52e648ce91c57eea1e5dbd60a3177e9d2acf4be550216fd1df6110bd0c897cf27e521fc634d8b4e9a5eb0332e7712728bfb8b68ddb11b38f62a
+  languageName: node
+  linkType: hard
+
+"@wordpress/date@npm:4.23.0":
+  version: 4.23.0
+  resolution: "@wordpress/date@npm:4.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/deprecated": ^3.23.0
+    moment: ^2.22.1
+    moment-timezone: ^0.5.31
+  checksum: a761c1905128cb9b77816c76427dc873fdd0060f5bebd22737f2dba565b63c87168e38bc5caef8df2ac0687939a62d071c1681e136839e986b5560ae6777b8d9
+  languageName: node
+  linkType: hard
+
 "@wordpress/date@npm:^4.13.0, @wordpress/date@npm:^4.22.0":
   version: 4.27.0
   resolution: "@wordpress/date@npm:4.27.0"
@@ -8704,6 +9152,18 @@ __metadata:
     moment: ^2.29.4
     moment-timezone: ^0.5.40
   checksum: adcfcd6936f6c504e6ea537b58a34cf1077ec0a35b4cff6ed1e7b7b2ebe378c60bc1cd8f700cbe6ba4b0ec548d505e144941cb317d769e924c932b1fa681ea65
+  languageName: node
+  linkType: hard
+
+"@wordpress/date@npm:^4.19.0, @wordpress/date@npm:^4.20.0, @wordpress/date@npm:^4.21.0":
+  version: 4.31.0
+  resolution: "@wordpress/date@npm:4.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/deprecated": ^3.31.0
+    moment: ^2.29.4
+    moment-timezone: ^0.5.40
+  checksum: 72598591509387c53395ed034bfbd700d2f60862cad28aaf5aae0acc19ea0f783ae2c0dc6688a0ae8867d138e8cbc18014c25e4a7a36bc67a111c8604a14e833
   languageName: node
   linkType: hard
 
@@ -8719,6 +9179,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/deprecated@npm:3.23.0":
+  version: 3.23.0
+  resolution: "@wordpress/deprecated@npm:3.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/hooks": ^3.23.0
+  checksum: 1f7a051a424c279a7d112dcec15777c8ebbb5a5fd9249f88af0e863c30fb8b04b069e0ccefecc6bc91d5c9a660d75aa775153e4d41b768d65d4b67d82f230930
+  languageName: node
+  linkType: hard
+
 "@wordpress/deprecated@npm:^3.13.0, @wordpress/deprecated@npm:^3.22.0, @wordpress/deprecated@npm:^3.27.0":
   version: 3.27.0
   resolution: "@wordpress/deprecated@npm:3.27.0"
@@ -8726,6 +9196,25 @@ __metadata:
     "@babel/runtime": ^7.16.0
     "@wordpress/hooks": ^3.27.0
   checksum: 1d95e20de156f354b013d8803b912b007e4625974c35784be47138e60447ac8fa43d508403e26d924e66397eaec8302f6e70205f29aec407b464bd97de4d9dc3
+  languageName: node
+  linkType: hard
+
+"@wordpress/deprecated@npm:^3.19.0, @wordpress/deprecated@npm:^3.20.0, @wordpress/deprecated@npm:^3.21.0, @wordpress/deprecated@npm:^3.23.0, @wordpress/deprecated@npm:^3.29.0, @wordpress/deprecated@npm:^3.31.0":
+  version: 3.31.0
+  resolution: "@wordpress/deprecated@npm:3.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/hooks": ^3.31.0
+  checksum: bafe16062e61c34b6faee1589e2a410b45f8f0e57d00494d19e66be4a47ae2404335b9ad67c110b6230d4c2fadca77a84f09604864622bdf95f42d18699e1a33
+  languageName: node
+  linkType: hard
+
+"@wordpress/dom-ready@npm:3.23.0":
+  version: 3.23.0
+  resolution: "@wordpress/dom-ready@npm:3.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 5d0d7989d2ae56d88ef59835d264d5d6f9f074d91526c9fbb01cc33e6ef40ecc9cc581e5e8eda0374a1991f1bde1dfdaeb172958a7faf0cadf7e4045c7ee6af8
   languageName: node
   linkType: hard
 
@@ -8738,6 +9227,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/dom-ready@npm:^3.23.0, @wordpress/dom-ready@npm:^3.31.0":
+  version: 3.31.0
+  resolution: "@wordpress/dom-ready@npm:3.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 23c2b76c86e751ffa204a5942de4a80fffe00782b0f84f90f4ed438179c595437ca535617a87b558d9731d2f6a483ca90e8be8fe22c597625dfb9eeb7179f0fc
+  languageName: node
+  linkType: hard
+
+"@wordpress/dom@npm:3.23.0":
+  version: 3.23.0
+  resolution: "@wordpress/dom@npm:3.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/deprecated": ^3.23.0
+  checksum: ad32c54fed924052be652ab0c89ca9b9b3b074010a9b5c7411f075eaf94c7c5ba637274c64eb136808acb7d641637103cc83e0b4a3ede08e0339919f93e74a65
+  languageName: node
+  linkType: hard
+
 "@wordpress/dom@npm:^3.13.0, @wordpress/dom@npm:^3.22.0, @wordpress/dom@npm:^3.27.0":
   version: 3.27.0
   resolution: "@wordpress/dom@npm:3.27.0"
@@ -8745,6 +9253,57 @@ __metadata:
     "@babel/runtime": ^7.16.0
     "@wordpress/deprecated": ^3.27.0
   checksum: 4e48d1347cfefc1b6f0959867f113015805447a11998ca0b9675e7f1578942dec4d23ebfcb4002582ed7bde3c14cca253b28a56d3bdc5e1be4e63c8b1411fb0f
+  languageName: node
+  linkType: hard
+
+"@wordpress/dom@npm:^3.19.0, @wordpress/dom@npm:^3.20.0, @wordpress/dom@npm:^3.21.0, @wordpress/dom@npm:^3.31.0":
+  version: 3.31.0
+  resolution: "@wordpress/dom@npm:3.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/deprecated": ^3.31.0
+  checksum: 65d68d41ed9876a89b5715bfeed083358b203a502eef6d39f75fbbf38ba79f05e15da9515515f8f7c45fa593ea6cb17efae18ba8c04439675ed61609ecb2f940
+  languageName: node
+  linkType: hard
+
+"@wordpress/edit-post@npm:6.16.0":
+  version: 6.16.0
+  resolution: "@wordpress/edit-post@npm:6.16.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/a11y": ^3.19.0
+    "@wordpress/api-fetch": ^6.16.0
+    "@wordpress/block-editor": ^10.2.0
+    "@wordpress/block-library": ^7.16.0
+    "@wordpress/blocks": ^11.18.0
+    "@wordpress/components": ^21.2.0
+    "@wordpress/compose": ^5.17.0
+    "@wordpress/core-data": ^5.2.0
+    "@wordpress/data": ^7.3.0
+    "@wordpress/deprecated": ^3.19.0
+    "@wordpress/editor": ^12.18.0
+    "@wordpress/element": ^4.17.0
+    "@wordpress/hooks": ^3.19.0
+    "@wordpress/i18n": ^4.19.0
+    "@wordpress/icons": ^9.10.0
+    "@wordpress/interface": ^4.18.0
+    "@wordpress/keyboard-shortcuts": ^3.17.0
+    "@wordpress/keycodes": ^3.19.0
+    "@wordpress/media-utils": ^4.10.0
+    "@wordpress/notices": ^3.19.0
+    "@wordpress/plugins": ^4.17.0
+    "@wordpress/preferences": ^2.11.0
+    "@wordpress/url": ^3.20.0
+    "@wordpress/viewport": ^4.17.0
+    "@wordpress/warning": ^2.19.0
+    classnames: ^2.3.1
+    lodash: ^4.17.21
+    memize: ^1.1.0
+    rememo: ^4.0.0
+  peerDependencies:
+    react: ^17.0.0
+    react-dom: ^17.0.0
+  checksum: 8ffe41912a6ee4c804678a1018648eb5b2e0869aac78aa00aa2182f441f8031b140ce9e14b40d9e5a9c29d798a37fa4755cd2ca7cb21f1f2739acd514204b646
   languageName: node
   linkType: hard
 
@@ -8835,7 +9394,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/editor@npm:^12.21.0":
+"@wordpress/editor@npm:12.18.0":
+  version: 12.18.0
+  resolution: "@wordpress/editor@npm:12.18.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/a11y": ^3.19.0
+    "@wordpress/api-fetch": ^6.16.0
+    "@wordpress/blob": ^3.19.0
+    "@wordpress/block-editor": ^10.2.0
+    "@wordpress/blocks": ^11.18.0
+    "@wordpress/components": ^21.2.0
+    "@wordpress/compose": ^5.17.0
+    "@wordpress/core-data": ^5.2.0
+    "@wordpress/data": ^7.3.0
+    "@wordpress/date": ^4.19.0
+    "@wordpress/deprecated": ^3.19.0
+    "@wordpress/element": ^4.17.0
+    "@wordpress/hooks": ^3.19.0
+    "@wordpress/html-entities": ^3.19.0
+    "@wordpress/i18n": ^4.19.0
+    "@wordpress/icons": ^9.10.0
+    "@wordpress/keyboard-shortcuts": ^3.17.0
+    "@wordpress/keycodes": ^3.19.0
+    "@wordpress/media-utils": ^4.10.0
+    "@wordpress/notices": ^3.19.0
+    "@wordpress/preferences": ^2.11.0
+    "@wordpress/reusable-blocks": ^3.17.0
+    "@wordpress/rich-text": ^5.17.0
+    "@wordpress/server-side-render": ^3.17.0
+    "@wordpress/url": ^3.20.0
+    "@wordpress/wordcount": ^3.19.0
+    classnames: ^2.3.1
+    lodash: ^4.17.21
+    memize: ^1.1.0
+    react-autosize-textarea: ^7.1.0
+    rememo: ^4.0.0
+    remove-accents: ^0.4.2
+  peerDependencies:
+    react: ^17.0.0
+    react-dom: ^17.0.0
+  checksum: 2e900a32ea1df8d668e559ce4b2bdd702f6943bc007a8d08f0f40ec2f48b14d080f0e59d69b86839206cb5cd69b24175b4b40550c43c9cd0829410f5406465ea
+  languageName: node
+  linkType: hard
+
+"@wordpress/editor@npm:^12.18.0, @wordpress/editor@npm:^12.21.0":
   version: 12.21.0
   resolution: "@wordpress/editor@npm:12.21.0"
   dependencies:
@@ -8935,12 +9538,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/escape-html@npm:2.23.0":
+  version: 2.23.0
+  resolution: "@wordpress/escape-html@npm:2.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 91686eaebad4a696e8d88db308da72114e50b676acf57cbcc5714e66348822382c16d3011924c74068536edf5fd84eb85ff0a98f84726cd262f8d067ae1cf192
+  languageName: node
+  linkType: hard
+
 "@wordpress/escape-html@npm:^2.13.0, @wordpress/escape-html@npm:^2.22.0, @wordpress/escape-html@npm:^2.9.0":
   version: 2.27.0
   resolution: "@wordpress/escape-html@npm:2.27.0"
   dependencies:
     "@babel/runtime": ^7.16.0
   checksum: e4fe71eb0b3233a2b3a61dd15ca0f34c53cd57a83a49a0f753519fefb6354ca22105bc38f3282e2fbfc44ed98a973ac62e65b95fe85f601022c551ea1ba0125d
+  languageName: node
+  linkType: hard
+
+"@wordpress/escape-html@npm:^2.19.0, @wordpress/escape-html@npm:^2.31.0":
+  version: 2.31.0
+  resolution: "@wordpress/escape-html@npm:2.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 8c95686deec8c0f787620390147fa630c3288e4c28790b7ee9715bf0db4b47374c5d99761d84f6b5c1823bb4f957fcea2e84266cacb70785f50e183779dcef9b
   languageName: node
   linkType: hard
 
@@ -8978,6 +9599,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/format-library@npm:3.17.0":
+  version: 3.17.0
+  resolution: "@wordpress/format-library@npm:3.17.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/a11y": ^3.19.0
+    "@wordpress/block-editor": ^10.2.0
+    "@wordpress/components": ^21.2.0
+    "@wordpress/compose": ^5.17.0
+    "@wordpress/data": ^7.3.0
+    "@wordpress/element": ^4.17.0
+    "@wordpress/html-entities": ^3.19.0
+    "@wordpress/i18n": ^4.19.0
+    "@wordpress/icons": ^9.10.0
+    "@wordpress/rich-text": ^5.17.0
+    "@wordpress/url": ^3.20.0
+  peerDependencies:
+    react: ^17.0.0
+    react-dom: ^17.0.0
+  checksum: de5c16c5859ade2d37da0abdbb7c9965ea38a28644b3044b20fcaf439b35fda1e39e6c7b78447be2d1e5c60f984c814e7debfa7b0f87bf6fbc02eb38cdff9a8e
+  languageName: node
+  linkType: hard
+
+"@wordpress/hooks@npm:3.19.0":
+  version: 3.19.0
+  resolution: "@wordpress/hooks@npm:3.19.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 4dedb4e5154ee04d80996a4c03ab36040132b445a2c45852d963f7f1c1d751c6271b5e02c0d28307673ab8837af6bccfc2e14ba4edb895477726024e3e4ef27e
+  languageName: node
+  linkType: hard
+
 "@wordpress/hooks@npm:^3.13.0, @wordpress/hooks@npm:^3.22.0, @wordpress/hooks@npm:^3.27.0, @wordpress/hooks@npm:^3.28.0, @wordpress/hooks@npm:^3.9.0":
   version: 3.28.0
   resolution: "@wordpress/hooks@npm:3.28.0"
@@ -8987,12 +9640,55 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/hooks@npm:^3.19.0, @wordpress/hooks@npm:^3.20.0, @wordpress/hooks@npm:^3.21.0, @wordpress/hooks@npm:^3.23.0, @wordpress/hooks@npm:^3.31.0":
+  version: 3.31.0
+  resolution: "@wordpress/hooks@npm:3.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 048f8d0e3c2a8668da498c77b4fd8a12daf8dbafcf8b123d5092f54e419513bf3dd87a7c94eb964f8b4e893c290077788986316799be0f9b1e1c2f3cf8962871
+  languageName: node
+  linkType: hard
+
+"@wordpress/html-entities@npm:3.23.0":
+  version: 3.23.0
+  resolution: "@wordpress/html-entities@npm:3.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: e6d92fdefd176b55fe2855459af4b480fbe9eeb2b5b81ab3c8d58ec780916f69b8f9824cf8a4f46808af00f8835683d2dd9f01845a37887961597e1bb0acf537
+  languageName: node
+  linkType: hard
+
+"@wordpress/html-entities@npm:^3.19.0, @wordpress/html-entities@npm:^3.20.0, @wordpress/html-entities@npm:^3.21.0, @wordpress/html-entities@npm:^3.31.0":
+  version: 3.31.0
+  resolution: "@wordpress/html-entities@npm:3.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 5724db46c8b8d0c3e34ffb8296872273ce154b97a2b718a95fa18ac9dbb45436a753d465b8aa978c1b2f57bcb4fad89f2c9b0ef1ab93a426ad4d8726e0cbbed7
+  languageName: node
+  linkType: hard
+
 "@wordpress/html-entities@npm:^3.22.0":
   version: 3.27.0
   resolution: "@wordpress/html-entities@npm:3.27.0"
   dependencies:
     "@babel/runtime": ^7.16.0
   checksum: 64406a45c0026ea6991e30d10c56f369774b51ef3724eacb4a1a9923bc03fb3ae26c4ec796fd9661a2f31c488aae57cf0d0731753446a4c1b67d731af205b6fb
+  languageName: node
+  linkType: hard
+
+"@wordpress/i18n@npm:4.19.0":
+  version: 4.19.0
+  resolution: "@wordpress/i18n@npm:4.19.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/hooks": ^3.19.0
+    gettext-parser: ^1.3.1
+    memize: ^1.1.0
+    sprintf-js: ^1.1.1
+    tannin: ^1.2.0
+  bin:
+    pot-to-php: tools/pot-to-php.js
+  checksum: 60b513779b52c1772e921b64c82b789c9055bd853c4a4604608bf8b4cec502dfe7bb0cffb03a97020fb319c41eda20a7736e8e6db3f4f61b7e9fa9ea3a075fb8
   languageName: node
   linkType: hard
 
@@ -9029,6 +9725,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/i18n@npm:^4.19.0, @wordpress/i18n@npm:^4.20.0, @wordpress/i18n@npm:^4.21.0, @wordpress/i18n@npm:^4.23.0, @wordpress/i18n@npm:^4.31.0":
+  version: 4.31.0
+  resolution: "@wordpress/i18n@npm:4.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/hooks": ^3.31.0
+    gettext-parser: ^1.3.1
+    memize: ^1.1.0
+    sprintf-js: ^1.1.1
+    tannin: ^1.2.0
+  bin:
+    pot-to-php: tools/pot-to-php.js
+  checksum: 1ab1bf607dacd80717e8866f45214afdc41b368e83453f04cfc8b4498efd9c85a8a270b57e52ebd3f31aebaeec9244573d0f54e74ee71c66a997cf6d683693e8
+  languageName: node
+  linkType: hard
+
+"@wordpress/icons@npm:9.10.0":
+  version: 9.10.0
+  resolution: "@wordpress/icons@npm:9.10.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/element": ^4.17.0
+    "@wordpress/primitives": ^3.17.0
+  checksum: 02626208109b9ec36bf1d05d233f8755ba8de0384306618b85aaeab2cdf5cf202347e90fcee90e0898a28e1b852d8e5a2a63b2760396c65783818f6dc5f7fddc
+  languageName: node
+  linkType: hard
+
 "@wordpress/icons@npm:^6.1.0":
   version: 6.3.0
   resolution: "@wordpress/icons@npm:6.3.0"
@@ -9040,7 +9763,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/icons@npm:^9.13.0, @wordpress/icons@npm:^9.22.0, @wordpress/icons@npm:^9.4.0":
+"@wordpress/icons@npm:^9.10.0, @wordpress/icons@npm:^9.11.0, @wordpress/icons@npm:^9.12.0, @wordpress/icons@npm:^9.14.0, @wordpress/icons@npm:^9.22.0":
   version: 9.22.0
   resolution: "@wordpress/icons@npm:9.22.0"
   dependencies:
@@ -9051,7 +9774,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/interface@npm:^4.21.0":
+"@wordpress/icons@npm:^9.13.0, @wordpress/icons@npm:^9.4.0":
+  version: 9.18.0
+  resolution: "@wordpress/icons@npm:9.18.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/element": ^5.4.0
+    "@wordpress/primitives": ^3.25.0
+  checksum: 4faa7d2698dc4a0740047c54913688b0b37e21f8ece9eafd09b6f34ec4d57eb8fd55e09cdf191ebe13abaa06d27ee27722e193e1f109bff16ec3da16b08f9caf
+  languageName: node
+  linkType: hard
+
+"@wordpress/interface@npm:4.18.0":
+  version: 4.18.0
+  resolution: "@wordpress/interface@npm:4.18.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/a11y": ^3.19.0
+    "@wordpress/components": ^21.2.0
+    "@wordpress/compose": ^5.17.0
+    "@wordpress/data": ^7.3.0
+    "@wordpress/deprecated": ^3.19.0
+    "@wordpress/element": ^4.17.0
+    "@wordpress/i18n": ^4.19.0
+    "@wordpress/icons": ^9.10.0
+    "@wordpress/plugins": ^4.17.0
+    "@wordpress/preferences": ^2.11.0
+    "@wordpress/viewport": ^4.17.0
+    classnames: ^2.3.1
+  peerDependencies:
+    react: ^17.0.0
+    react-dom: ^17.0.0
+  checksum: e0a0a386ed61aa08d82c3dc3909ded02f1a9feaa833a13b3945b587baae1a245e9f54f88bf045681a804cf2c41a8dea436a9c6098817bae34db7a6c199460b33
+  languageName: node
+  linkType: hard
+
+"@wordpress/interface@npm:^4.18.0, @wordpress/interface@npm:^4.21.0":
   version: 4.21.0
   resolution: "@wordpress/interface@npm:4.21.0"
   dependencies:
@@ -9075,12 +9833,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/is-shallow-equal@npm:4.23.0":
+  version: 4.23.0
+  resolution: "@wordpress/is-shallow-equal@npm:4.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 74786bf862c0b6c9024be31fc3a82180018b664f72aca37916f8f598c445cd05e1452f95e300833a1643e77bb3901ddfef57cd497c20dbcc49873804ff430dc8
+  languageName: node
+  linkType: hard
+
 "@wordpress/is-shallow-equal@npm:^4.13.0, @wordpress/is-shallow-equal@npm:^4.22.0, @wordpress/is-shallow-equal@npm:^4.27.0":
   version: 4.27.0
   resolution: "@wordpress/is-shallow-equal@npm:4.27.0"
   dependencies:
     "@babel/runtime": ^7.16.0
   checksum: 3833302891f98f3bc87f7d750393505e7d2a2fab52ae0cc7a81a3d16408fcbd73ddf6b6611ab7c191a66d8367d49a072a39ece780f830de3ae31412cf8699de6
+  languageName: node
+  linkType: hard
+
+"@wordpress/is-shallow-equal@npm:^4.19.0, @wordpress/is-shallow-equal@npm:^4.21.0, @wordpress/is-shallow-equal@npm:^4.29.0, @wordpress/is-shallow-equal@npm:^4.31.0":
+  version: 4.31.0
+  resolution: "@wordpress/is-shallow-equal@npm:4.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 3efb18b178dcf413c6f88ab301282b9f20038010dba5f6b75763d45a0e12409efa55034e4fd8e537f1c7a87476eb67b9283d89b6bb73652c9848864aaf9ee5e9
   languageName: node
   linkType: hard
 
@@ -9109,7 +9885,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/keyboard-shortcuts@npm:^3.20.0":
+"@wordpress/keyboard-shortcuts@npm:3.20.0":
   version: 3.20.0
   resolution: "@wordpress/keyboard-shortcuts@npm:3.20.0"
   dependencies:
@@ -9124,6 +9900,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/keycodes@npm:3.23.0":
+  version: 3.23.0
+  resolution: "@wordpress/keycodes@npm:3.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/i18n": ^4.23.0
+    change-case: ^4.1.2
+    lodash: ^4.17.21
+  checksum: ca91d3131e4d11a32a84d0d6dad0a97e10b799767a4624a6407032409f146e7830ca74d17715cc9c1db2c67dc949da3704c53319e602d6160a3803bee0684b8f
+  languageName: node
+  linkType: hard
+
 "@wordpress/keycodes@npm:^3.13.0, @wordpress/keycodes@npm:^3.22.0, @wordpress/keycodes@npm:^3.27.0":
   version: 3.27.0
   resolution: "@wordpress/keycodes@npm:3.27.0"
@@ -9132,6 +9920,61 @@ __metadata:
     "@wordpress/i18n": ^4.27.0
     change-case: ^4.1.2
   checksum: a285a3f42d89c5d0260914e8f7aac865b4404c761e9e3e874017c20554a073e77444672fa21c941b97ce2a8f1b5915bdf5fea9cd4f0bb943c7a58f00d418acb4
+  languageName: node
+  linkType: hard
+
+"@wordpress/keycodes@npm:^3.19.0, @wordpress/keycodes@npm:^3.20.0, @wordpress/keycodes@npm:^3.21.0, @wordpress/keycodes@npm:^3.31.0":
+  version: 3.31.0
+  resolution: "@wordpress/keycodes@npm:3.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/i18n": ^4.31.0
+    change-case: ^4.1.2
+  checksum: 6d0fe6634d3867fa7b52fb50f53b4794d27e505b6fa82df399b44c58f80b7fcad587ee8a0a7ba2e5588e013a61af7c6d5f42d060954e7c5af9fbbc55681557b6
+  languageName: node
+  linkType: hard
+
+"@wordpress/list-reusable-blocks@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@wordpress/list-reusable-blocks@npm:4.0.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/api-fetch": ^6.20.0
+    "@wordpress/components": ^23.0.0
+    "@wordpress/compose": ^6.0.0
+    "@wordpress/element": ^5.0.0
+    "@wordpress/i18n": ^4.23.0
+    change-case: ^4.1.2
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 8a9ecdbe718008d6416b7c870d7dbab06a1161880f1997d2ec6e49c547bd2bfe6d57671607b2679169d672d9e41459f274ec2df4f322be0604458d2e80f783c4
+  languageName: node
+  linkType: hard
+
+"@wordpress/media-utils@npm:4.14.0":
+  version: 4.14.0
+  resolution: "@wordpress/media-utils@npm:4.14.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/api-fetch": ^6.20.0
+    "@wordpress/blob": ^3.23.0
+    "@wordpress/element": ^5.0.0
+    "@wordpress/i18n": ^4.23.0
+  checksum: 6ba5b43892148f9495fddee5d960e0d5ef46646b22c29a1d72b85202fade5a78b634176763a3a26d2dfd8b03edf9fc96584c20acc9476612a979b163d6e91b93
+  languageName: node
+  linkType: hard
+
+"@wordpress/media-utils@npm:^4.10.0":
+  version: 4.22.0
+  resolution: "@wordpress/media-utils@npm:4.22.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/api-fetch": ^6.28.0
+    "@wordpress/blob": ^3.31.0
+    "@wordpress/element": ^5.8.0
+    "@wordpress/i18n": ^4.31.0
+  checksum: 27cc5640dc4cc110510fc948bec295872077adab8472985b9b542cad8ee03c778d11eab9ff8652b736cb1ec5944da0bdc698065629d40aad952167549b505d13
   languageName: node
   linkType: hard
 
@@ -9145,6 +9988,28 @@ __metadata:
     "@wordpress/element": ^5.4.0
     "@wordpress/i18n": ^4.27.0
   checksum: 2e3753eb67777df3326caf27487859271d062b44d8c61730f75d8b3956f5201bdf3d0a1bb75dcc164d8d4e8e302889d14e036c626280f3b2e2ac6259f0d44c7b
+  languageName: node
+  linkType: hard
+
+"@wordpress/notices@npm:3.23.0":
+  version: 3.23.0
+  resolution: "@wordpress/notices@npm:3.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/a11y": ^3.23.0
+    "@wordpress/data": ^8.0.0
+  checksum: 5a66096f16ff8ab72eb866ace554d295255766f3677b7c0afc27bcf10eb8ff8f75b496a74403d17111d2b67ff5b46073ecbc25df2a356d5c2650e07c4dde6b23
+  languageName: node
+  linkType: hard
+
+"@wordpress/notices@npm:^3.19.0, @wordpress/notices@npm:^3.20.0, @wordpress/notices@npm:^3.21.0, @wordpress/notices@npm:^3.23.0":
+  version: 3.31.0
+  resolution: "@wordpress/notices@npm:3.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/a11y": ^3.31.0
+    "@wordpress/data": ^9.1.0
+  checksum: 9b071dd48d96eb80023ef346585ddf5cf153d18bd70c9a66780113ed4fc459f9933fef0b080cae5eaa70a7e2fcca0ddbda9bd13edb348051ed7f31d38f3dab07
   languageName: node
   linkType: hard
 
@@ -9188,7 +10053,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/plugins@npm:^4.20.0":
+"@wordpress/plugins@npm:5.0.0":
+  version: 5.0.0
+  resolution: "@wordpress/plugins@npm:5.0.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/compose": ^6.0.0
+    "@wordpress/element": ^5.0.0
+    "@wordpress/hooks": ^3.23.0
+    "@wordpress/icons": ^9.14.0
+    memize: ^1.1.0
+  peerDependencies:
+    react: ^18.0.0
+  checksum: 38ef6d3acf908a443ac838a0c6adb19d4ea3ecefc13dbd991c53d853ddf6d2d8534f773f98d6596f3b38c301bc280462d93c4984dce0c147074311d6e3179eef
+  languageName: node
+  linkType: hard
+
+"@wordpress/plugins@npm:^4.17.0, @wordpress/plugins@npm:^4.20.0":
   version: 4.20.0
   resolution: "@wordpress/plugins@npm:4.20.0"
   dependencies:
@@ -9216,7 +10097,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/preferences@npm:^2.14.0":
+"@wordpress/preferences@npm:^2.11.0, @wordpress/preferences@npm:^2.14.0":
   version: 2.14.0
   resolution: "@wordpress/preferences@npm:2.14.0"
   dependencies:
@@ -9243,7 +10124,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/primitives@npm:^3.1.1, @wordpress/primitives@npm:^3.11.0, @wordpress/primitives@npm:^3.20.0, @wordpress/primitives@npm:^3.29.0":
+"@wordpress/primitives@npm:3.21.0":
+  version: 3.21.0
+  resolution: "@wordpress/primitives@npm:3.21.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/element": ^5.0.0
+    classnames: ^2.3.1
+  checksum: 4f9130ae34bece15d7dd453a36e570fd7330556674f60fe79933cd9a01129a5f216ba33d8f37af0d194b43b03ed113071564dcb63a706c02f8927663bc1368b3
+  languageName: node
+  linkType: hard
+
+"@wordpress/primitives@npm:^3.1.1, @wordpress/primitives@npm:^3.11.0, @wordpress/primitives@npm:^3.20.0, @wordpress/primitives@npm:^3.25.0":
+  version: 3.25.0
+  resolution: "@wordpress/primitives@npm:3.25.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/element": ^5.4.0
+    classnames: ^2.3.1
+  checksum: 72f570d9cc269c6827b56e8e6e000277c80495b329cb30706bdedf54462ce49b91d28f4418d71f4a3cda676b7c451359575c20c9640003aca2242cdd1420aadd
+  languageName: node
+  linkType: hard
+
+"@wordpress/primitives@npm:^3.17.0, @wordpress/primitives@npm:^3.18.0, @wordpress/primitives@npm:^3.29.0":
   version: 3.29.0
   resolution: "@wordpress/primitives@npm:3.29.0"
   dependencies:
@@ -9251,6 +10154,26 @@ __metadata:
     "@wordpress/element": ^5.8.0
     classnames: ^2.3.1
   checksum: e0e6113fcc0b6fba13ab34e6a277dae6b91ab08a98929358e5ba64dff658f046ed8d0e267cd54ebfe1da477e814da6c21d288d76a6cdf0103d70489f2434ad0d
+  languageName: node
+  linkType: hard
+
+"@wordpress/priority-queue@npm:2.23.0":
+  version: 2.23.0
+  resolution: "@wordpress/priority-queue@npm:2.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    requestidlecallback: ^0.3.0
+  checksum: 51a168913353401318b4acb739ce730d58540cc4853d8089fbb16d650ca2ff22291d1c389bf3a840f17d7b076ffbfd5dceabfb0bd1dfb972f95fb88d4616caae
+  languageName: node
+  linkType: hard
+
+"@wordpress/priority-queue@npm:^2.19.0, @wordpress/priority-queue@npm:^2.29.0, @wordpress/priority-queue@npm:^2.31.0":
+  version: 2.31.0
+  resolution: "@wordpress/priority-queue@npm:2.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    requestidlecallback: ^0.3.0
+  checksum: aa8160314102c7a9ad93b9e39441ea9211a4867d035c3a71cdd294d845f3564dab60b1cf7649019e6acbbb42d863da242c42c1906156f1d8c3508c20a8586811
   languageName: node
   linkType: hard
 
@@ -9264,12 +10187,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/private-apis@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@wordpress/private-apis@npm:0.11.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: d45457205978de2d6a30149cb31bf55ce9c857963b6f7830484fbf59b15ec0b9001efd918e1fb24525c80ff9fd54dc71fd11fe590999f31b97bea9889af8da06
+  languageName: node
+  linkType: hard
+
+"@wordpress/private-apis@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "@wordpress/private-apis@npm:0.13.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 52c50c405286a4ef579999240b5b305e276f17df52d4283a5cc4f74c24c28a72520bba596e2e920f29e1552f5b09ad3694e7e9ab2279d332819323683a056ead
+  languageName: node
+  linkType: hard
+
 "@wordpress/private-apis@npm:^0.9.0":
   version: 0.9.0
   resolution: "@wordpress/private-apis@npm:0.9.0"
   dependencies:
     "@babel/runtime": ^7.16.0
   checksum: e18f2fe7e226283664d3218c45583becd6f5e87e7f6431b0f5633de6d3624fa8f0941f2d2606023170ce318fcd9dff536a8e056029f436b206590f836fceae80
+  languageName: node
+  linkType: hard
+
+"@wordpress/react-i18n@npm:3.21.0":
+  version: 3.21.0
+  resolution: "@wordpress/react-i18n@npm:3.21.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/element": ^5.0.0
+    "@wordpress/i18n": ^4.23.0
+    utility-types: ^3.10.0
+  checksum: 9dc4005a65d8f51bb629af64399bb39aeba4a684d39e441909941a418afde74b34601a0c9e826b0d71d5c40afaf9fefe6d97f031ff0c6cb29d3a2c745627b4b1
   languageName: node
   linkType: hard
 
@@ -9294,6 +10247,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/redux-routine@npm:4.23.0":
+  version: 4.23.0
+  resolution: "@wordpress/redux-routine@npm:4.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    is-plain-object: ^5.0.0
+    is-promise: ^4.0.0
+    rungen: ^0.3.2
+  peerDependencies:
+    redux: ">=4"
+  checksum: 646ebdf28a56fd38594d41021b893976772d8a9622379a7d53f5844d7983b744b5856d76a921b9662ccd8d7541dc8952d6b1056eeb7c31eed87b4f2800d25133
+  languageName: node
+  linkType: hard
+
+"@wordpress/redux-routine@npm:^4.19.0, @wordpress/redux-routine@npm:^4.29.0, @wordpress/redux-routine@npm:^4.31.0":
+  version: 4.31.0
+  resolution: "@wordpress/redux-routine@npm:4.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    is-plain-object: ^5.0.0
+    is-promise: ^4.0.0
+    rungen: ^0.3.2
+  peerDependencies:
+    redux: ">=4"
+  checksum: 791ad1a467da99348b87dacc365dd49e8768784f0a637d68d527e884626b9d954f045385ff9e28dc37bdeffaf3c83530872ebd74da6f710b8f8841720f49264d
+  languageName: node
+  linkType: hard
+
 "@wordpress/redux-routine@npm:^4.22.0, @wordpress/redux-routine@npm:^4.27.0":
   version: 4.27.0
   resolution: "@wordpress/redux-routine@npm:4.27.0"
@@ -9308,7 +10289,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/reusable-blocks@npm:^3.20.0":
+"@wordpress/reusable-blocks@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@wordpress/reusable-blocks@npm:4.0.0"
+  dependencies:
+    "@wordpress/block-editor": ^11.0.0
+    "@wordpress/blocks": ^12.0.0
+    "@wordpress/components": ^23.0.0
+    "@wordpress/core-data": ^6.0.0
+    "@wordpress/data": ^8.0.0
+    "@wordpress/element": ^5.0.0
+    "@wordpress/i18n": ^4.23.0
+    "@wordpress/icons": ^9.14.0
+    "@wordpress/notices": ^3.23.0
+    "@wordpress/url": ^3.24.0
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 825ce2231be443b3979f6269fde2c7527fc9846c7b6a4373bb6d9cc955c53dd46a832c1b079bb4bcd7e0a84f54e340552c4fb7e03409d8f7b00be79a7a6ee23c
+  languageName: node
+  linkType: hard
+
+"@wordpress/reusable-blocks@npm:^3.17.0, @wordpress/reusable-blocks@npm:^3.18.0, @wordpress/reusable-blocks@npm:^3.20.0":
   version: 3.20.0
   resolution: "@wordpress/reusable-blocks@npm:3.20.0"
   dependencies:
@@ -9329,7 +10331,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/rich-text@npm:^5.11.0, @wordpress/rich-text@npm:^5.20.0":
+"@wordpress/rich-text@npm:5.17.0":
+  version: 5.17.0
+  resolution: "@wordpress/rich-text@npm:5.17.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/a11y": ^3.19.0
+    "@wordpress/compose": ^5.17.0
+    "@wordpress/data": ^7.3.0
+    "@wordpress/deprecated": ^3.19.0
+    "@wordpress/element": ^4.17.0
+    "@wordpress/escape-html": ^2.19.0
+    "@wordpress/i18n": ^4.19.0
+    "@wordpress/keycodes": ^3.19.0
+    memize: ^1.1.0
+    rememo: ^4.0.0
+  peerDependencies:
+    react: ^17.0.0
+  checksum: f1d2f78036a9d5bddb4170522f1e669801b23ec50d6150ea6673ef440ddf22c4083db6ebfbc0a24a610cc2f402dc7d47929b95fa2e6112a19a103425913c2bcf
+  languageName: node
+  linkType: hard
+
+"@wordpress/rich-text@npm:^5.11.0, @wordpress/rich-text@npm:^5.17.0, @wordpress/rich-text@npm:^5.18.0, @wordpress/rich-text@npm:^5.19.0, @wordpress/rich-text@npm:^5.20.0":
   version: 5.20.0
   resolution: "@wordpress/rich-text@npm:5.20.0"
   dependencies:
@@ -9347,6 +10370,27 @@ __metadata:
   peerDependencies:
     react: ^17.0.0
   checksum: 3022c9251c582867d3ea51021f48dd89d183a1db3068177bb0d19ad97f69f7ff47e2c8f86affe481b6d22e29f1350ba2aa1320fd0241e668fa9f60411073ebda
+  languageName: node
+  linkType: hard
+
+"@wordpress/rich-text@npm:^6.0.0":
+  version: 6.8.0
+  resolution: "@wordpress/rich-text@npm:6.8.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/a11y": ^3.31.0
+    "@wordpress/compose": ^6.8.0
+    "@wordpress/data": ^9.1.0
+    "@wordpress/deprecated": ^3.31.0
+    "@wordpress/element": ^5.8.0
+    "@wordpress/escape-html": ^2.31.0
+    "@wordpress/i18n": ^4.31.0
+    "@wordpress/keycodes": ^3.31.0
+    memize: ^1.1.0
+    rememo: ^4.0.0
+  peerDependencies:
+    react: ^18.0.0
+  checksum: 5c3858098f4e4c86bc2419d8ac1784642e497fbc5979b7a4d25a79526bbdaa990ce9cd43249ef32ba65d22ebc4e1299d74db3a79a0eae7ea96f221f2fc55c5ac
   languageName: node
   linkType: hard
 
@@ -9418,7 +10462,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/server-side-render@npm:^3.20.0":
+"@wordpress/server-side-render@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@wordpress/server-side-render@npm:4.0.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/api-fetch": ^6.20.0
+    "@wordpress/blocks": ^12.0.0
+    "@wordpress/components": ^23.0.0
+    "@wordpress/compose": ^6.0.0
+    "@wordpress/data": ^8.0.0
+    "@wordpress/deprecated": ^3.23.0
+    "@wordpress/element": ^5.0.0
+    "@wordpress/i18n": ^4.23.0
+    "@wordpress/url": ^3.24.0
+    fast-deep-equal: ^3.1.3
+    lodash: ^4.17.21
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: b316234c7583b1912d5906af906ba806e1ac6fc7b2969fb9be6db087c2c0e7b363621723657a749794f4d03d0dc0c514565275bd52adc441e61909a24125b4dc
+  languageName: node
+  linkType: hard
+
+"@wordpress/server-side-render@npm:^3.17.0, @wordpress/server-side-render@npm:^3.18.0, @wordpress/server-side-render@npm:^3.20.0":
   version: 3.20.0
   resolution: "@wordpress/server-side-render@npm:3.20.0"
   dependencies:
@@ -9440,6 +10507,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/shortcode@npm:3.23.0":
+  version: 3.23.0
+  resolution: "@wordpress/shortcode@npm:3.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    memize: ^1.1.0
+  checksum: 0384acf47e6c6db7de803d35e306a16dcac35a8130a91ecf60e2240a7339b477a3053fb616d9edd38c25f625d9efc2523b34a5577da29eb8b4ccee01af2d019a
+  languageName: node
+  linkType: hard
+
+"@wordpress/shortcode@npm:^3.19.0, @wordpress/shortcode@npm:^3.21.0, @wordpress/shortcode@npm:^3.31.0":
+  version: 3.31.0
+  resolution: "@wordpress/shortcode@npm:3.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    memize: ^1.1.0
+  checksum: a233a023b863c5317ac5d62036c603ec45d3e8eeda42dde5f450adc0da27b5472cdcc8c44f419558f391cdde8922be75715abf9ec7d23ffe19d886a7c7de5701
+  languageName: node
+  linkType: hard
+
 "@wordpress/shortcode@npm:^3.22.0":
   version: 3.27.0
   resolution: "@wordpress/shortcode@npm:3.27.0"
@@ -9447,6 +10534,16 @@ __metadata:
     "@babel/runtime": ^7.16.0
     memize: ^1.1.0
   checksum: 3d931c6fddaa43985fe3dc852afe9730f786917ca7f43c46eefc278988a5c0a10fd143d500965b9608fc33323f7c516b1c640c22a2baf883ccad35c2830d5c92
+  languageName: node
+  linkType: hard
+
+"@wordpress/style-engine@npm:^1.4.0":
+  version: 1.14.0
+  resolution: "@wordpress/style-engine@npm:1.14.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    lodash: ^4.17.21
+  checksum: cd4988962466d10a78c663382890d86091be5e310c4e654d636b8b5664c3fc90fa63ca08d6e884b7ab9d2113e3d9adc67f0dc50f04c71061db44ebb8e4fbd8ef
   languageName: node
   linkType: hard
 
@@ -9472,12 +10569,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/token-list@npm:^2.22.0":
-  version: 2.27.0
-  resolution: "@wordpress/token-list@npm:2.27.0"
+"@wordpress/token-list@npm:2.23.0":
+  version: 2.23.0
+  resolution: "@wordpress/token-list@npm:2.23.0"
   dependencies:
     "@babel/runtime": ^7.16.0
-  checksum: dade0bc27c7faa56cea7864900644a244319d5e45bdfa0a4574a7afdac8d6706a0743cf7e6d28d0f9a5c545ab6bc0c843ca328b1d1743547ab1b080fc5940643
+  checksum: 7e3c72d59ccb49204e3ca9cd8e90a6f7c5b95fac2a66c31e17e253cf55489ac211e92ccec38a47f7c2f78d9cb6c5116e5a0d7e962f4f6ac4bc0fa2136c7e51f3
+  languageName: node
+  linkType: hard
+
+"@wordpress/token-list@npm:^2.21.0":
+  version: 2.31.0
+  resolution: "@wordpress/token-list@npm:2.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: d27453a6b05c73db714b6ad9d29621b61e389967e4bcfd714acbb2ff765d6fd613a39206c8d2f09ab18f4a1c62d5ab08cd63e0d6a38fcb8360c0f51250891832
+  languageName: node
+  linkType: hard
+
+"@wordpress/url@npm:3.24.0":
+  version: 3.24.0
+  resolution: "@wordpress/url@npm:3.24.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    remove-accents: ^0.4.2
+  checksum: deed707d350598bafc5ec775966a507fdc7046620585a24331f22c05a2234b55c4cff67680a38324745c11a410154abe6f2ef8ccfd816c96094dd94f173f1594
+  languageName: node
+  linkType: hard
+
+"@wordpress/url@npm:^3.20.0, @wordpress/url@npm:^3.21.0, @wordpress/url@npm:^3.22.0, @wordpress/url@npm:^3.24.0, @wordpress/url@npm:^3.32.0":
+  version: 3.32.0
+  resolution: "@wordpress/url@npm:3.32.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    remove-accents: ^0.4.2
+  checksum: 1023ebf3819a3bf28ce259c9f43aa0852e61f2142a415f57771aa043f06a772d9572052a7b19b542081c2dabdc67dca09205766a89bfe8d2865807af0b8ddfff
   languageName: node
   linkType: hard
 
@@ -9491,7 +10617,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/viewport@npm:^4.20.0":
+"@wordpress/viewport@npm:5.0.0":
+  version: 5.0.0
+  resolution: "@wordpress/viewport@npm:5.0.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+    "@wordpress/compose": ^6.0.0
+    "@wordpress/data": ^8.0.0
+  peerDependencies:
+    react: ^18.0.0
+  checksum: 2de2d0677e66313ddeefdb1c6011fbc71c76cf9927ac184d0e7560f1c67362f44a011ace23bddeeebfbcf3b424065523accee20ffef35523c915b8075c314955
+  languageName: node
+  linkType: hard
+
+"@wordpress/viewport@npm:^4.17.0, @wordpress/viewport@npm:^4.18.0, @wordpress/viewport@npm:^4.20.0":
   version: 4.20.0
   resolution: "@wordpress/viewport@npm:4.20.0"
   dependencies:
@@ -9504,10 +10643,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/warning@npm:2.23.0":
+  version: 2.23.0
+  resolution: "@wordpress/warning@npm:2.23.0"
+  checksum: 9d1c5f7d06ad5791595d653bf1028b7027fbc56a27946ccab4974db32608e9d046b9afd8c94adb38e5cbf037a67bde61f4d0f74e3a1c5d3b1a618e899ca8951a
+  languageName: node
+  linkType: hard
+
 "@wordpress/warning@npm:^2.13.0, @wordpress/warning@npm:^2.22.0, @wordpress/warning@npm:^2.27.0":
   version: 2.27.0
   resolution: "@wordpress/warning@npm:2.27.0"
   checksum: 64df4b157c3ea592dd33ae293ca5e0020f0dace8047cd8d925aa396276b9656c48b3cca48e1564a9308321c69ce248fb382ac63b9571a5f684ddb6934dae0b09
+  languageName: node
+  linkType: hard
+
+"@wordpress/warning@npm:^2.19.0, @wordpress/warning@npm:^2.21.0":
+  version: 2.31.0
+  resolution: "@wordpress/warning@npm:2.31.0"
+  checksum: ce152911713a89dcbd843469b70f4b08408b846b33b5452561629f7db7bda35a36505d99069a7d31b403fe2bc362a73d6a167beb6e3600b63b7a603758ff82c3
+  languageName: node
+  linkType: hard
+
+"@wordpress/wordcount@npm:3.23.0":
+  version: 3.23.0
+  resolution: "@wordpress/wordcount@npm:3.23.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: 8f2d4706741391cb3cd34acf7993eb0bb424fd4c695d0c8dcdbff41ef3a013cfa7312c64b71f9a5c7464b201fbd6d762e080b455f0ecd72d1e006beb052a7230
+  languageName: node
+  linkType: hard
+
+"@wordpress/wordcount@npm:^3.19.0, @wordpress/wordcount@npm:^3.21.0":
+  version: 3.31.0
+  resolution: "@wordpress/wordcount@npm:3.31.0"
+  dependencies:
+    "@babel/runtime": ^7.16.0
+  checksum: d77158f6857617c8d6d0997bc21c6b1c9f4ee6e9fdf5809f1ec56c0feb6ab4b7ad931b9ae18e61795299bc0861b424e11d2530f34d419aeabce7c9bb67a711d2
   languageName: node
   linkType: hard
 
@@ -11810,6 +12981,7 @@ __metadata:
     "@automattic/happychat-connection": "workspace:^"
     "@automattic/help-center": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
+    "@automattic/isolated-block-editor": 2.22.x
     "@automattic/js-utils": "workspace:^"
     "@automattic/language-picker": "workspace:^"
     "@automattic/languages": "workspace:^"
@@ -20586,6 +21758,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"isomorphic.js@npm:^0.2.4":
+  version: 0.2.5
+  resolution: "isomorphic.js@npm:0.2.5"
+  checksum: 7cd268c8e58146a8160c8cd16596291fd1fbf3e8799a325f269accda9dc1238806e371ccef0b66fe2ad957209230c55997248d8b6d02cf2d7c575ffeb759c789
+  languageName: node
+  linkType: hard
+
 "isstream@npm:~0.1.2":
   version: 0.1.2
   resolution: "isstream@npm:0.1.2"
@@ -21909,6 +23088,18 @@ fsevents@^1.2.7:
     prelude-ls: ^1.2.1
     type-check: ~0.4.0
   checksum: effb03cad7c89dfa5bd4f6989364bfc79994c2042ec5966cb9b95990e2edee5cd8969ddf42616a0373ac49fac1403437deaf6e9050fbbaa3546093a59b9ac94e
+  languageName: node
+  linkType: hard
+
+"lib0@npm:^0.2.58, lib0@npm:^0.2.72":
+  version: 0.2.73
+  resolution: "lib0@npm:0.2.73"
+  dependencies:
+    isomorphic.js: ^0.2.4
+  bin:
+    0gentesthtml: bin/gentesthtml.js
+    0serve: bin/0serve.js
+  checksum: d09829e1f47378a77ceee6fd3ea8b7dfc0d687e0f2bea2305da41a0cecc0df9e765e693e2a9294499c47be24dea682273000a8d0311490833d69549d8a70d439
   languageName: node
   linkType: hard
 
@@ -23475,6 +24666,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"moment-timezone@npm:^0.5.31":
+  version: 0.5.43
+  resolution: "moment-timezone@npm:0.5.43"
+  dependencies:
+    moment: ^2.29.4
+  checksum: 6f42174e01398d135883fb45aa820e57f34b25aab5ea6c50998139d06f975ee4457275b5e331466b14bff4d830e681c267f9cc462f445eb9c2b84d04add829f6
+  languageName: node
+  linkType: hard
+
 "moment-timezone@npm:^0.5.40":
   version: 0.5.40
   resolution: "moment-timezone@npm:0.5.40"
@@ -23484,7 +24684,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"moment@npm:>= 2.9.0, moment@npm:>=1.6.0, moment@npm:^2.19.3, moment@npm:^2.26.0, moment@npm:^2.29.4":
+"moment@npm:>= 2.9.0, moment@npm:>=1.6.0, moment@npm:^2.19.3, moment@npm:^2.22.1, moment@npm:^2.26.0, moment@npm:^2.29.4":
   version: 2.29.4
   resolution: "moment@npm:2.29.4"
   checksum: 844c6f3ce42862ac9467c8ca4f5e48a00750078682cc5bda1bc0e50cc7ca88e2115a0f932d65a06e4a90e26cb78892be9b3ca3dd6546ca2c4d994cebb787fc2b
@@ -25241,6 +26441,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"pegjs@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "pegjs@npm:0.10.0"
+  bin:
+    pegjs: bin/pegjs
+  checksum: 51f2aee312cd506c37c21a88fee2d921ccae81697c7aa3e61f0ad8e370d8c37e2a86680993fce405f53337a56ad471f9e7f4377b2eb3c780d5cf6ae8a16ce0a5
+  languageName: node
+  linkType: hard
+
 "pend@npm:~1.2.0":
   version: 1.2.0
   resolution: "pend@npm:1.2.0"
@@ -25288,6 +26497,15 @@ fsevents@^1.2.7:
     typescript: ^4.7.4
   languageName: unknown
   linkType: soft
+
+"phpegjs@npm:^1.0.0-beta7":
+  version: 1.0.0-beta7
+  resolution: "phpegjs@npm:1.0.0-beta7"
+  peerDependencies:
+    pegjs: ^0.10.0
+  checksum: 15cdc5b0cebc4958771c1c651e54e6a4e439c08998eca74f7c91294e364061a1e9c3050de80192f43197522bedd49489d02b200c34dcc8716209603dda1f7dab
+  languageName: node
+  linkType: hard
 
 "phpunserialize@npm:^1.1.0":
   version: 1.1.0
@@ -26900,7 +28118,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-dom@npm:>=16.8 <18, react-dom@npm:^17.0.2":
+"react-dom@npm:17.0.2, react-dom@npm:>=16.8 <18, react-dom@npm:^17.0.2":
   version: 17.0.2
   resolution: "react-dom@npm:17.0.2"
   dependencies:
@@ -27376,7 +28594,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react@npm:>=16.8 <18, react@npm:^17.0.2":
+"react@npm:17.0.2, react@npm:>=16.8 <18, react@npm:^17.0.2":
   version: 17.0.2
   resolution: "react@npm:17.0.2"
   dependencies:
@@ -27732,6 +28950,13 @@ fsevents@^1.2.7:
   version: 2.3.0
   resolution: "redux-thunk@npm:2.3.0"
   checksum: fbf342e56809240af5f41257eee0dbba1b8165b611a1dd96d6d2831f84046e30f037a7e90cbff5636cd6e053d53237c4ed3287403f2c6d28fa1ad26543d7a016
+  languageName: node
+  linkType: hard
+
+"redux-undo@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "redux-undo@npm:1.0.1"
+  checksum: 0f882276c168f2c818be5e42e81f2d071ff48e8374bef4ce76859bf0ffc96e752039677dd36bbeed309b1635af236efa921abaea93f0ee45be71a6dd74581a09
   languageName: node
   linkType: hard
 
@@ -32819,6 +34044,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"uuid@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 8867e438990d1d33ac61093e2e4e3477a2148b844e4fa9e3c2360fa4399292429c4b6ec64537eb1659c97b2d10db349c673ad58b50e2824a11e0d3630de3c056
+  languageName: node
+  linkType: hard
+
 "v8-compile-cache@npm:^2.0.3, v8-compile-cache@npm:^2.3.0":
   version: 2.3.0
   resolution: "v8-compile-cache@npm:2.3.0"
@@ -33776,6 +35010,7 @@ fsevents@^1.2.7:
     "@typescript-eslint/parser": ^5.53.0
     "@wordpress/base-styles": ^4.13.0
     "@wordpress/components": ^22.1.0
+    "@wordpress/core-data": ^6.8.0
     "@wordpress/data": ^7.6.0
     "@wordpress/element": ^4.20.0
     "@wordpress/eslint-plugin": ^13.6.0
@@ -34420,6 +35655,15 @@ fsevents@^1.2.7:
   version: 0.1.2
   resolution: "yeast@npm:0.1.2"
   checksum: 74530f4ac042e6ff768cb4a35deb1330a092ad239e13f97989aa82496dfb73fcae689eec2f785af1ef904b92ca33cbbffe3d3a7ee937bf29aa033b970af728bb
+  languageName: node
+  linkType: hard
+
+"yjs@npm:^13.5.44":
+  version: 13.5.53
+  resolution: "yjs@npm:13.5.53"
+  dependencies:
+    lib0: ^0.2.72
+  checksum: d88c4ff059dd7498ecb13c3c6ad881e1d573897d91f47b01b9e3e0934b4f9ace40f802226df67f6bf1eef1f9b1194e1d5d4f3cf8e5c9970bfb3db30e8d737dac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

Extension of https://github.com/Automattic/wp-calypso/pull/75475.

Implements the initial design for a minimal editor at the top of the Reader feed.

<img width="1045" alt="Screenshot 2023-05-01 at 15 51 06" src="https://user-images.githubusercontent.com/1699996/235529020-3e5ee7f8-9cd9-41aa-adfa-cec7aa5975f1.png">

## Testing Instructions

* Load `/read` from this branch.
* Try publishing posts to different sites, using different formats, with the editor.


