### PR TITLE
Odyssey Widget: remove external link icon

### DIFF
--- a/apps/odyssey-stats/package.json
+++ b/apps/odyssey-stats/package.json
@@ -35,7 +35,6 @@
 		"@automattic/components": "workspace:^",
 		"@tanstack/react-query": "4.29.1",
 		"@wordpress/data": "^7.6.0",
-		"@wordpress/icons": "^9.22.0",
 		"calypso": "workspace:^",
 		"classnames": "^2.3.1",
 		"debug": "^4.3.4",

--- a/apps/odyssey-stats/src/widget/highlights.jsx
+++ b/apps/odyssey-stats/src/widget/highlights.jsx
@@ -1,5 +1,4 @@
 import { formattedNumber } from '@automattic/components';
-import { Icon, external } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
@@ -45,7 +44,6 @@ function ItemWrapper( { odysseyStatsBaseUrl, siteId, isItemLink, item } ) {
 			} ) }
 		>
 			{ renderedItem }
-			<Icon className="stats-icon" icon={ external } size={ 18 } />
 		</a>
 	) : (
 		renderedItem

--- a/yarn.lock
+++ b/yarn.lock
@@ -1141,7 +1141,6 @@ __metadata:
     "@tanstack/react-query": 4.29.1
     "@wordpress/data": ^7.6.0
     "@wordpress/dependency-extraction-webpack-plugin": ^4.5.0
-    "@wordpress/icons": ^9.22.0
     "@wordpress/scripts": ^24.6.0
     autoprefixer: ^10.2.5
     babel-jest: ^27.5


### PR DESCRIPTION
Related to #76480 

## Proposed Changes

Remove external link icon as the links are on-site.

## Testing Instructions

* Build Jetpack if necessary: `jetpack build plugins/jetpack`.
* Run `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev` under `calypso/apps/odyssey-stats`.
- Open `/wp-admin/index.php` on a site with Jetpack bleeding edge
- Ensure link in Top Posts/Pages don't have external icons

<img width="262" alt="image" src="https://user-images.githubusercontent.com/1425433/235567926-23fd2902-6f70-4b32-a885-e14cf73c9b65.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
