### PR TITLE
SMP: add guard when wpcom_staging_blog_ids is empty

### DIFF
--- a/packages/sites/src/use-sites-list-sorting.tsx
+++ b/packages/sites/src/use-sites-list-sorting.tsx
@@ -214,7 +214,7 @@ export function sortSitesByStaging< T extends SiteDetailsForSorting >( sites: T[
 		// So instead, we first sort them, and the list becomes:
 		// [3, 2, 1, 4]
 		site.options?.wpcom_staging_blog_ids
-			?.sort( ( a, b ) => {
+			?.sort?.( ( a, b ) => {
 				// If one of the two staging sites is filtered out, we should
 				// maintain the order of the remaining sites by moving it down
 				// in the list

--- a/packages/sites/tests/use-sites-list-sorting.test.ts
+++ b/packages/sites/tests/use-sites-list-sorting.test.ts
@@ -214,6 +214,27 @@ describe( 'useSitesSorting', () => {
 		},
 	];
 
+	const sitesWithEmptyStagingSites = [
+		{
+			ID: 1,
+			title: 'A',
+			options: {
+				updated_at: '2022-06-14T13:32:34+00:00',
+				wpcom_staging_blog_ids: '',
+			},
+			user_interactions: [ '2022-09-16', '2022-09-13', '2022-09-09' ],
+		},
+		{
+			ID: 4,
+			title: 'E',
+			options: {
+				updated_at: '2022-06-15T13:32:34+00:00',
+				wpcom_staging_blog_ids: '',
+			},
+			user_interactions: [ '2022-09-16', '2022-09-13', '2022-09-09' ],
+		},
+	];
+
 	test( 'should not sort sites if unsupported sortKey is provided', () => {
 		const { result } = renderHook( () =>
 			useSitesListSorting( filteredSites, {
@@ -438,5 +459,16 @@ describe( 'useSitesSorting', () => {
 		expect( result.current[ 0 ] ).toBe( filteredSites[ 1 ] );
 		expect( result.current[ 1 ] ).toBe( filteredSites[ 0 ] );
 		expect( result.current[ 2 ] ).toBe( filteredSites[ 2 ] );
+	} );
+
+	test( 'should not break when wpcom_staging_blog_ids is empty', () => {
+		const { result } = renderHook( () =>
+			useSitesListSorting( sitesWithEmptyStagingSites, {
+				sortKey: 'lastInteractedWith',
+				sortOrder: 'asc',
+			} )
+		);
+
+		expect( result.current.length ).toBe( 2 );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Check p1683013083758289-slack-C0347E545HR

## Proposed Changes

* Fix edge case when we receive unexpected data on `wpcom_staging_blog_ids`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* I added a new test case.
* The test should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?