### PR TITLE
Plans 2023: pass currentSitePlanSlug as prop

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -29,7 +29,7 @@ type PlanFeaturesActionsButtonProps = {
 	availableForPurchase: boolean;
 	canUserPurchasePlan: boolean;
 	className: string;
-	currentSitePlanSlug: string;
+	currentSitePlanSlug?: string;
 	current: boolean;
 	forceDisplayButton?: boolean;
 	freePlan: boolean;

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -288,7 +288,7 @@ type PlanComparisonGridProps = {
 	isInSignup: boolean;
 	isLaunchPage?: boolean;
 	flowName: string;
-	currentSitePlanSlug: string;
+	currentSitePlanSlug?: string;
 	manageHref: string;
 	canUserPurchasePlan: boolean;
 	selectedSiteSlug: string | null;
@@ -303,7 +303,7 @@ type PlanComparisonGridHeaderProps = {
 	isFooter?: boolean;
 	flowName: string;
 	onPlanChange: ( currentPlan: string, event: ChangeEvent ) => void;
-	currentSitePlanSlug: string;
+	currentSitePlanSlug?: string;
 	manageHref: string;
 	canUserPurchasePlan: boolean;
 	selectedSiteSlug: string | null;
@@ -348,8 +348,12 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 } ) => {
 	const { planName, planConstantObj, availableForPurchase, current, ...planPropertiesObj } =
 		planProperties;
-	const highlightLabel = useHighlightLabel( planName, flowName );
-	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( visiblePlansProperties, flowName );
+	const highlightLabel = useHighlightLabel( { planName, flowName, currentSitePlanSlug } );
+	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
+		visiblePlans: visiblePlansProperties,
+		flowName,
+		currentSitePlanSlug,
+	} );
 	const headerClasses = classNames( 'plan-comparison-grid__header-cell', getPlanClass( planName ), {
 		'popular-plan-parent-class': highlightLabel,
 		'is-last-in-row': isLastInRow,
@@ -371,6 +375,7 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 				planName={ planName }
 				additionalClassName={ popularBadgeClasses }
 				flowName={ flowName }
+				currentSitePlanSlug={ currentSitePlanSlug }
 			/>
 			<PlanSelector>
 				{ showPlanSelect && (
@@ -495,6 +500,7 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	planName: string;
 	isStorageFeature: boolean;
 	flowName: string;
+	currentSitePlanSlug?: string;
 } > = ( {
 	feature,
 	visiblePlansProperties,
@@ -502,10 +508,15 @@ const PlanComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	planName,
 	isStorageFeature,
 	flowName,
+	currentSitePlanSlug,
 } ) => {
 	const translate = useTranslate();
-	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( visiblePlansProperties, flowName );
-	const highlightLabel = useHighlightLabel( planName, flowName );
+	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
+		visiblePlans: visiblePlansProperties,
+		flowName,
+		currentSitePlanSlug,
+	} );
+	const highlightLabel = useHighlightLabel( { planName, flowName, currentSitePlanSlug } );
 	const featureSlug = feature?.getSlug();
 	const hasFeature =
 		isStorageFeature ||
@@ -582,6 +593,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	restructuredFootnotes: RestructuredFootnotes;
 	isStorageFeature: boolean;
 	flowName: string;
+	currentSitePlanSlug?: string;
 } > = ( {
 	feature,
 	isHiddenInMobile,
@@ -591,6 +603,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	restructuredFootnotes,
 	isStorageFeature,
 	flowName,
+	currentSitePlanSlug,
 } ) => {
 	const translate = useTranslate();
 	const rowClasses = classNames( 'plan-comparison-grid__feature-group-row', {
@@ -638,6 +651,7 @@ const PlanComparisonGridFeatureGroupRow: React.FunctionComponent< {
 					planName={ planName }
 					isStorageFeature={ isStorageFeature }
 					flowName={ flowName }
+					currentSitePlanSlug={ currentSitePlanSlug }
 				/>
 			) ) }
 		</Row>
@@ -902,6 +916,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 									restructuredFootnotes={ restructuredFootnotes }
 									isStorageFeature={ false }
 									flowName={ flowName }
+									currentSitePlanSlug={ currentSitePlanSlug }
 								/>
 							) ) }
 							{ featureGroup.slug === FEATURE_GROUP_ESSENTIAL_FEATURES ? (
@@ -914,6 +929,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 									restructuredFootnotes={ restructuredFootnotes }
 									isStorageFeature={ true }
 									flowName={ flowName }
+									currentSitePlanSlug={ currentSitePlanSlug }
 								/>
 							) : null }
 						</div>

--- a/client/my-sites/plan-features-2023-grid/components/popular-badge.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/popular-badge.tsx
@@ -8,13 +8,14 @@ const PopularBadge: React.FunctionComponent< {
 	planName: string;
 	flowName: string;
 	additionalClassName?: string;
-} > = ( { isInSignup, planName, additionalClassName, flowName } ) => {
+	currentSitePlanSlug?: string;
+} > = ( { isInSignup, planName, additionalClassName, flowName, currentSitePlanSlug } ) => {
 	const classes = classNames(
 		'plan-features-2023-grid__popular-badge',
 		getPlanClass( planName ),
 		additionalClassName
 	);
-	const highlightLabel = useHighlightLabel( planName, flowName );
+	const highlightLabel = useHighlightLabel( { planName, flowName, currentSitePlanSlug } );
 
 	return (
 		<>

--- a/client/my-sites/plan-features-2023-grid/hooks/use-highlight-adjacency-matrix.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-highlight-adjacency-matrix.ts
@@ -1,8 +1,5 @@
 import { isBusinessPlan, isPersonalPlan, isPremiumPlan } from '@automattic/calypso-products';
 import { isNewsletterFlow, isLinkInBioFlow } from '@automattic/onboarding';
-import { useSelector } from 'react-redux';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { PlanProperties } from '../types';
 
 interface HighlightAdjacencyMatrix {
@@ -13,22 +10,23 @@ interface HighlightAdjacencyMatrix {
 	};
 }
 
-const useHighlightIndices = ( visiblePlans: PlanProperties[], flowName?: string | null ) => {
-	const selectedSiteId = useSelector( getSelectedSiteId );
-	const currentPlan = useSelector( ( state ) => getCurrentPlan( state, selectedSiteId ) );
+interface Props {
+	visiblePlans: PlanProperties[];
+	flowName: string;
+	currentSitePlanSlug?: string;
+}
 
+const useHighlightIndices = ( { visiblePlans, flowName, currentSitePlanSlug }: Props ) => {
 	return visiblePlans.reduce< number[] >( ( acc, { planName }, index ) => {
 		let isHighlight = false;
 
 		if ( flowName && isNewsletterFlow( flowName ) ) {
-			isHighlight = isPersonalPlan( planName ) || currentPlan?.productSlug === planName;
+			isHighlight = isPersonalPlan( planName ) || currentSitePlanSlug === planName;
 		} else if ( flowName && isLinkInBioFlow( flowName ) ) {
-			isHighlight = isPremiumPlan( planName ) || currentPlan?.productSlug === planName;
+			isHighlight = isPremiumPlan( planName ) || currentSitePlanSlug === planName;
 		} else {
 			isHighlight =
-				isBusinessPlan( planName ) ||
-				isPremiumPlan( planName ) ||
-				currentPlan?.productSlug === planName;
+				isBusinessPlan( planName ) || isPremiumPlan( planName ) || currentSitePlanSlug === planName;
 		}
 
 		if ( isHighlight ) {
@@ -39,8 +37,8 @@ const useHighlightIndices = ( visiblePlans: PlanProperties[], flowName?: string 
 	}, [] );
 };
 
-const useHighlightAdjacencyMatrix = ( visiblePlans: PlanProperties[], flowName: string ) => {
-	const highlightIndices = useHighlightIndices( visiblePlans, flowName );
+const useHighlightAdjacencyMatrix = ( { visiblePlans, flowName, currentSitePlanSlug }: Props ) => {
+	const highlightIndices = useHighlightIndices( { visiblePlans, flowName, currentSitePlanSlug } );
 	const adjacencyMatrix: HighlightAdjacencyMatrix = {};
 
 	visiblePlans.forEach( ( { planName }, index ) => {

--- a/client/my-sites/plan-features-2023-grid/hooks/use-highlight-label.ts
+++ b/client/my-sites/plan-features-2023-grid/hooks/use-highlight-label.ts
@@ -1,16 +1,17 @@
 import { isBusinessPlan, isPremiumPlan, isPersonalPlan } from '@automattic/calypso-products';
 import { isLinkInBioFlow, isNewsletterFlow } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isPopularPlan } from '../lib/is-popular-plan';
 
-const useHighlightLabel = ( planName: string, flowName?: string | null ) => {
+interface Props {
+	planName: string;
+	flowName?: string | null;
+	currentSitePlanSlug?: string;
+}
+
+const useHighlightLabel = ( { planName, flowName, currentSitePlanSlug }: Props ) => {
 	const translate = useTranslate();
-	const selectedSiteId = useSelector( getSelectedSiteId );
-	const currentPlan = useSelector( ( state ) => getCurrentPlan( state, selectedSiteId ) );
-	const isCurrentPlan = currentPlan?.productSlug === planName;
+	const isCurrentPlan = currentSitePlanSlug === planName;
 
 	if ( flowName && isNewsletterFlow( flowName ) ) {
 		if ( isPersonalPlan( planName ) ) {

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -61,9 +61,9 @@ import {
 	getPlanSlug,
 } from 'calypso/state/plans/selectors';
 import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
-import { getCurrentPlan, isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
+import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import isPlanAvailableForPurchase from 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase';
-import { getSiteSlug, isCurrentPlanPaid, isCurrentSitePlan } from 'calypso/state/sites/selectors';
+import { getSiteSlug, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
 import CalypsoShoppingCartProvider from '../checkout/calypso-shopping-cart-provider';
 import useIsLargeCurrency from '../plans/hooks/use-is-large-currency';
 import { getManagePurchaseUrlFor } from '../purchases/paths';
@@ -116,7 +116,7 @@ type PlanFeatures2023GridProps = {
 	placeholder?: string;
 	isLandingPage?: boolean;
 	intervalType: string;
-	currentSitePlanSlug: string;
+	currentSitePlanSlug?: string;
 	hidePlansFeatureComparison: boolean;
 	hideUnavailableFeatures: boolean;
 };
@@ -162,11 +162,24 @@ const PlanLogo: React.FunctionComponent< {
 	flowName: string;
 	isMobile?: boolean;
 	isInSignup: boolean;
-} > = ( { planPropertiesObj, planProperties, planIndex, isMobile, isInSignup, flowName } ) => {
+	currentSitePlanSlug?: string;
+} > = ( {
+	planPropertiesObj,
+	planProperties,
+	planIndex,
+	isMobile,
+	isInSignup,
+	flowName,
+	currentSitePlanSlug,
+} ) => {
 	const { planName, current } = planProperties;
 	const translate = useTranslate();
-	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( planPropertiesObj, flowName );
-	const highlightLabel = useHighlightLabel( planName, flowName );
+	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
+		visiblePlans: planPropertiesObj,
+		flowName,
+		currentSitePlanSlug,
+	} );
+	const highlightLabel = useHighlightLabel( { planName, flowName, currentSitePlanSlug } );
 	const headerClasses = classNames(
 		'plan-features-2023-grid__header-logo',
 		getPlanClass( planName )
@@ -198,6 +211,7 @@ const PlanLogo: React.FunctionComponent< {
 				planName={ planName }
 				additionalClassName={ popularBadgeClasses }
 				flowName={ flowName }
+				currentSitePlanSlug={ currentSitePlanSlug }
 			/>
 			<header className={ headerClasses }>
 				{ isBusinessPlan( planName ) && (
@@ -537,7 +551,7 @@ export class PlanFeatures2023Grid extends Component<
 	}
 
 	renderPlanLogos( planPropertiesObj: PlanProperties[], options?: PlanRowOptions ) {
-		const { isInSignup, flowName } = this.props;
+		const { isInSignup, flowName, currentSitePlanSlug } = this.props;
 
 		return planPropertiesObj
 			.filter( ( { isVisible } ) => isVisible )
@@ -551,6 +565,7 @@ export class PlanFeatures2023Grid extends Component<
 						isMobile={ options?.isMobile }
 						isInSignup={ isInSignup }
 						flowName={ flowName }
+						currentSitePlanSlug={ currentSitePlanSlug }
 					/>
 				);
 			} );
@@ -642,12 +657,12 @@ export class PlanFeatures2023Grid extends Component<
 
 				if (
 					isWooExpressMediumPlan( planName ) &&
-					! isWooExpressMediumPlan( currentSitePlanSlug )
+					! isWooExpressMediumPlan( currentSitePlanSlug || '' )
 				) {
 					buttonText = translate( 'Get Performance', { textOnly: true } );
 				} else if (
 					isWooExpressSmallPlan( planName ) &&
-					! isWooExpressSmallPlan( currentSitePlanSlug )
+					! isWooExpressSmallPlan( currentSitePlanSlug || '' )
 				) {
 					buttonText = translate( 'Get Essential', { textOnly: true } );
 				}
@@ -864,13 +879,20 @@ const withIsLargeCurrency = ( Component: LocalizedComponent< typeof PlanFeatures
 /* eslint-disable wpcalypso/redux-no-bound-selectors */
 const ConnectedPlanFeatures2023Grid = connect(
 	( state: IAppState, ownProps: PlanFeatures2023GridProps ) => {
-		const { placeholder, plans, isLandingPage, visiblePlans, isInSignup, siteId, flowName } =
-			ownProps;
+		const {
+			placeholder,
+			plans,
+			isLandingPage,
+			visiblePlans,
+			isInSignup,
+			siteId,
+			flowName,
+			currentSitePlanSlug,
+		} = ownProps;
 		const canUserPurchasePlan =
 			! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId );
 		const purchaseId = getCurrentPlanPurchaseId( state, siteId );
 		const selectedSiteSlug = getSiteSlug( state, siteId );
-		const currentSitePlan = getCurrentPlan( state, siteId );
 
 		const planProperties: PlanProperties[] = plans.map( ( plan: string ) => {
 			let isPlaceholder = false;
@@ -966,7 +988,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 					planConstantObj.get2023PricingGridSignupStorageOptions() ) ||
 				[];
 			const availableForPurchase = isInSignup || isPlanAvailableForPurchase( state, siteId, plan );
-			const isCurrentPlan = isCurrentSitePlan( state, siteId, planProductId ) ?? false;
+			const isCurrentPlan = currentSitePlanSlug === plan;
 			const isVisible = visiblePlans?.indexOf( plan ) !== -1;
 
 			return {
@@ -1001,7 +1023,7 @@ const ConnectedPlanFeatures2023Grid = connect(
 				: `/plans/my-plan/${ siteId }`;
 
 		return {
-			currentSitePlanSlug: currentSitePlan?.productSlug,
+			currentSitePlanSlug,
 			planProperties,
 			canUserPurchasePlan,
 			manageHref,

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -172,6 +172,7 @@ export class PlansFeaturesMain extends Component {
 			planTypeSelectorProps,
 			hidePlansFeatureComparison,
 			replacePaidDomainWithFreeDomain,
+			sitePlanSlug,
 		} = this.props;
 
 		const asyncProps = {
@@ -202,6 +203,7 @@ export class PlansFeaturesMain extends Component {
 			intervalType,
 			hidePlansFeatureComparison,
 			replacePaidDomainWithFreeDomain,
+			currentSitePlanSlug: sitePlanSlug,
 		};
 		const asyncPlanFeatures2023Grid = (
 			<AsyncLoad


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76442

## Proposed Changes

Tackles one of the TODOs in #76442. Updates plans grid to use `currentSitePlanSlug` from props.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/plans/[free | paid]` and `/start/plans` and ensure the grids render fine
- Ensure plans are highlighted as expected, with "Your plan" label where relevant and correctly rounded borders around the labels/badges

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
