### PR TITLE
Learn: mobile links and subscribe on content footer

### DIFF
--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -92,68 +92,6 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 		font-family: var(--wp--preset--font-family--system-font);
 	}
 
-	@media (max-width: $breakpoint-mobile) {
-		padding: 12px 24px !important;
-
-		h4 {
-			font-size: 1.25rem;
-			line-height: 26px;
-		}
-
-		p {
-			font-size: 0.875rem;
-			margin-top: 4px;
-			margin-bottom: 8px;
-			line-height: 20px;
-		}
-
-		.support-content-cta {
-			margin-bottom: 0;
-
-			.support-content-cta-left {
-				padding: 0 48px 16px 0;
-			}
-
-			.support-content-cta-right {
-				display: none;
-			}
-		}
-
-		.support-content-resources {
-			flex-direction: column;
-			gap: 8px;
-
-			.support-content-resource {
-				min-width: 317px;
-				padding: 16px 48px 16px 0;
-
-				.resource-link {
-					line-height: 20px;
-				}
-			}
-		}
-
-		.support-content-links-subscribe {
-			flex-direction: column;
-			padding-bottom: 36px;
-
-			.support-content-subscribe {
-				margin-top: 32px;
-			}
-
-			.support-content-subscribe-email {
-				padding: 10px 16px 10px 16px;
-				font-size: 0.875rem;
-				line-height: 20px;
-
-				&::placeholder {
-					font-size: 0.875rem;
-					line-height: 20px;
-				}
-			}
-		}
-	}
-
 	@media (min-width: $breakpoint-mobile) {
 		.support-content-resource {
 			flex-basis: 0;
@@ -224,6 +162,70 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 				&:hover {
 					opacity: 0.9;
+				}
+			}
+		}
+	}
+
+	@media (max-width: $breakpoint-mobile) {
+		padding: 12px 24px !important;
+
+		h4 {
+			font-size: 1.25rem;
+			line-height: 26px;
+		}
+
+		p {
+			font-size: 0.875rem;
+			margin-top: 4px;
+			margin-bottom: 8px;
+			line-height: 20px;
+		}
+
+		.support-content-cta {
+			margin-bottom: 0;
+
+			.support-content-cta-left {
+				padding: 0 48px 16px 0;
+			}
+
+			.support-content-cta-right {
+				display: none;
+			}
+		}
+
+		.support-content-resources {
+			flex-direction: column;
+			gap: 8px;
+
+			.support-content-resource {
+				min-width: 317px;
+				padding: 16px 48px 16px 0;
+
+				.resource-link {
+					line-height: 20px;
+				}
+			}
+		}
+
+		.support-content-links-subscribe {
+			flex-direction: column;
+			padding-bottom: 36px;
+
+			.support-content-subscribe {
+				margin-top: 32px;
+			}
+
+			.support-content-subscribe form {
+				.support-content-subscribe-email {
+					padding: 10px 16px 10px 16px;
+					font-size: 0.875rem;
+					line-height: 20px;
+
+					&::placeholder {
+						font-size: 0.875rem;
+						line-height: 20px;
+					}
 				}
 			}
 		}

--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -135,6 +135,22 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 		.support-content-links-subscribe {
 			flex-direction: column;
+			padding-bottom: 36px;
+
+			.support-content-subscribe {
+				margin-top: 32px;
+			}
+
+			.support-content-subscribe-email {
+				padding: 10px 16px 10px 16px;
+				font-size: 0.875rem;
+				line-height: 20px;
+
+				&::placeholder {
+					font-size: 0.875rem;
+					line-height: 20px;
+				}
+			}
 		}
 	}
 
@@ -199,8 +215,8 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 				border: none;
 				color: var(--color-primary-0);
 				cursor: pointer;
-				font-size: 1rem;
-				line-height: 1.3;
+				font-size: 0.875rem;
+				line-height: 20px;
 				margin: 0;
 				margin-left: 10px;
 				padding: 10px 24px;


### PR DESCRIPTION
## What
Update to the mobile design of the links and subscribe on the bottom of the content footer.

### Before
![image](https://user-images.githubusercontent.com/52076348/235636965-d86ebb37-fac1-496d-930b-f55d2d1649e3.png)

### After
![image](https://user-images.githubusercontent.com/52076348/235636592-383423b2-355e-4411-8244-5f65738915e6.png)


## Testing
1. Checkout branch, `cd apps/happy-blocks`and `yarn dev --sync`
2. Sandbox `learncft.wordpress.com` and visit the site
3. Switch to mobile and check the result