### PR TITLE
Fix/videopress e2e flaky test

### DIFF
--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -3,6 +3,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, VIDEOPRESS_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
+import { useState } from 'react';
 import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
 import { useNewSiteVisibility } from 'calypso/landing/stepper/hooks/use-selected-plan';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
@@ -94,6 +95,8 @@ const videopress: Flow = {
 			[]
 		);
 
+		const [ isSiteCreationPending, setIsSiteCreationPending ] = useState( false );
+
 		const clearOnboardingSiteOptions = () => {
 			setSiteTitle( '' );
 			setSiteDescription( '' );
@@ -123,6 +126,12 @@ const videopress: Flow = {
 		};
 
 		const addVideoPressPendingAction = () => {
+			// only allow one call to this action to occur
+			if ( isSiteCreationPending ) {
+				return;
+			}
+			setIsSiteCreationPending( true );
+
 			setPendingAction( async () => {
 				setProgress( 0 );
 				try {

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -126,10 +126,15 @@ const videopress: Flow = {
 		};
 
 		const addVideoPressPendingAction = () => {
+			// if the supported plans haven't been received yet, wait for next rerender to try again.
+			if ( 0 === supportedPlans.length ) {
+				return;
+			}
 			// only allow one call to this action to occur
 			if ( isSiteCreationPending ) {
 				return;
 			}
+
 			setIsSiteCreationPending( true );
 
 			setPendingAction( async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/76264

## Proposed Changes

* ensure site creation only occurs once
* only attempt site creation after the plans array has been populated

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run the automated tests against your dev environment `yarn jest specs/onboarding/setup__videopress.ts`
   * ensure you setup your environment to run tests by following the readme in `test/e2e/README.md`
   * not sure if there is a better supported way of running tests against local environment, but I used [proxyman](https://proxyman.io/) to setup a proxy from wordpress.com -> calypso.localhost:3000 using the `Map Remote` feature 
<img width="1056" alt="image" src="https://user-images.githubusercontent.com/4081020/235666875-65b43b28-71a6-4939-8bfe-93d810c16a55.png">
* the test should pass
* Manually test onboarding at `/setup/videopress` through your dev environment, or the calypso.live links
* onboarding should succeed -- ensure you test all the way to launching the site, not just until purchase

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
