### PR TITLE
Improve legacy GA tracking on Checkout sites

### DIFF
--- a/client/lib/akismet/is-akismet-checkout.ts
+++ b/client/lib/akismet/is-akismet-checkout.ts
@@ -1,0 +1,8 @@
+/*
+    The function isAkismetCheckout() is used to determine if the current page is a Akismet checkout page. 
+    It always returns false on the server side as window object is not available there (assumption that checkout pages are not rendered server-side).
+ */
+const isAkismetCheckout = () =>
+	'undefined' !== typeof document && window.location.pathname.startsWith( '/checkout/akismet' );
+
+export default isAkismetCheckout;

--- a/client/lib/analytics/ad-tracking/google-analytics.js
+++ b/client/lib/analytics/ad-tracking/google-analytics.js
@@ -65,7 +65,11 @@ export function fireGoogleAnalyticsPageView(
 		page_title: pageTitle,
 	};
 
-	window.gtag( 'config', getGaGtag( useJetpackGoogleAnalytics ), params );
+	window.gtag(
+		'config',
+		getGaGtag( useJetpackGoogleAnalytics, useAkismetGoogleAnalytics ),
+		params
+	);
 }
 
 /**

--- a/client/lib/analytics/utils/get-ga-gtag.ts
+++ b/client/lib/analytics/utils/get-ga-gtag.ts
@@ -1,3 +1,5 @@
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
+import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { TRACKING_IDS } from '../ad-tracking/constants';
 
@@ -6,8 +8,15 @@ import { TRACKING_IDS } from '../ad-tracking/constants';
  *
  * @returns The correct Gtag connected to GA environment
  */
-export const getGaGtag = ( isJetpackEnv = isJetpackCloud() ) => {
-	return ! isJetpackEnv
-		? TRACKING_IDS.wpcomGoogleAnalyticsGtag
-		: TRACKING_IDS.jetpackGoogleAnalyticsGtag;
+export const getGaGtag = (
+	isJetpackEnv = isJetpackCloud() || isJetpackCheckout(),
+	isAkismetEnv = isAkismetCheckout()
+) => {
+	if ( isJetpackEnv ) {
+		return TRACKING_IDS.jetpackGoogleAnalyticsGtag;
+	} else if ( isAkismetEnv ) {
+		return TRACKING_IDS.akismetGoogleAnalyticsGtag;
+	}
+
+	return TRACKING_IDS.wpcomGoogleAnalyticsGtag;
 };


### PR DESCRIPTION
## Proposed Changes

This PR improves legacy GA tracking on checkout pages and adds handling of Akismet GA accordingly.

## Testing Instructions

* Checkout the PR
* Run Calypso `yarn start`
* Go to https://tagassistant.google.com/
* Run tag assistant on `http://calypso.localhost:3000/checkout/akismet/ak_plus_yearly_1?flags=ad-tracking`
* Ensure that cookie banner is accepted (on gdpr/ccpa-compliant region)
* Notice that `UA-19309600-2` is active and reporting events

<img width="1284" alt="CleanShot 2023-05-02 at 14 46 36@2x" src="https://user-images.githubusercontent.com/8419292/235670228-72f97d3f-492b-4f2a-a9eb-9370f4fd5eeb.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
