### PR TITLE
E2E: update regex of `waitForResponse` when waiting for the EditorPage to initially load.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -160,10 +160,12 @@ export class EditorPage {
 		// Given these constraints, a decent stand-in is to wait for the following factors.
 		await Promise.all( [
 			// Wait for the URL to include either a post/page (iframed) or post-new.php (un-iframed).
-			this.page.waitForURL( /(post|page|post-new.php)/, { timeout: timeout } ),
+			this.page.waitForURL( /(post-new\.php|post|page)/, { timeout: timeout } ),
 			// Wait for response from the post-new.php endpoint (new post/page).
-			// Wait for response from `posts/id`, `pages/id` or `post.php` (existing post/page).
-			this.page.waitForResponse( /((post-new.php)|(posts|pages)\/[\d]+|(post.php))/, {
+			// Wait for response from `posts/post_id`, `pages/post_id` for existing post/page
+			// on Simple sites.
+			// Wait for response from `post.php` endpoint for existing post/page on Atomic.
+			this.page.waitForResponse( /((post-new\.php)|(post\.php)|(posts|pages)\/[\d]+)/, {
 				timeout: timeout,
 			} ),
 		] );

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -160,7 +160,7 @@ export class EditorPage {
 		// it is a fairly good stand-in.
 		await Promise.all( [
 			this.page.waitForURL( /(post|page|post-new.php)/ ),
-			this.page.waitForResponse( /.*posts.*/, { timeout: timeout } ),
+			this.page.waitForResponse( /(.*posts.*|pages)/, { timeout: timeout } ),
 		] );
 
 		// Dismiss the Welcome Tour.

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -160,7 +160,7 @@ export class EditorPage {
 		// it is a fairly good stand-in.
 		await Promise.all( [
 			this.page.waitForURL( /(post|page|post-new.php)/ ),
-			this.page.waitForResponse( /(.*posts.*|pages)/, { timeout: timeout } ),
+			this.page.waitForResponse( /post-new.php/, { timeout: timeout } ),
 		] );
 
 		// Dismiss the Welcome Tour.

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -160,7 +160,7 @@ export class EditorPage {
 		// it is a fairly good stand-in.
 		await Promise.all( [
 			this.page.waitForURL( /(post|page|post-new.php)/ ),
-			this.page.waitForResponse( /post-new.php/, { timeout: timeout } ),
+			this.page.waitForResponse( /((post-new.php)|(posts|pages)\/[\d]+)/, { timeout: timeout } ),
 		] );
 
 		// Dismiss the Welcome Tour.

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -160,7 +160,7 @@ export class EditorPage {
 		// Given these constraints, a decent stand-in is to wait for the following factors.
 		await Promise.all( [
 			// Wait for the URL to include either a post/page (iframed) or post-new.php (un-iframed).
-			this.page.waitForURL( /(post-new\.php|post|page)/, { timeout: timeout } ),
+			this.page.waitForURL( /\/(post-new\.php|post|page)/, { timeout: timeout } ),
 			// Wait for response from the post-new.php endpoint (new post/page).
 			// Wait for response from `posts/post_id`, `pages/post_id` for existing post/page
 			// on Simple sites.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #76501.

## Proposed Changes

This PR updates the regex pattern in the `EditorPage.waitUntilLoaded` method.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Gutenberg E2E Simple Edge (desktop)
  - [x] Gutenberg E2E Simple Edge (mobile)
  - [x] Gutenberg E2E Simple Prod (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
