### PR TITLE
Subscriptions Management: Create the "Email me new posts" toggle for the Sites page (logged-in user)

### DIFF
--- a/client/landing/subscriptions/components/settings-popover/site-settings/delivery-frequency-input.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/delivery-frequency-input.tsx
@@ -1,3 +1,4 @@
+import { SubscriptionManager } from '@automattic/data-stores';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -39,6 +40,7 @@ const DeliveryFrequencyInput = ( {
 	value: selectedValue,
 	isUpdating,
 }: DeliveryFrequencyInputProps ) => {
+	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
 	const translate = useTranslate();
 	const availableFrequencies = useMemo< DeliveryFrequencyKeyLabel[] >(
 		() => [
@@ -59,8 +61,15 @@ const DeliveryFrequencyInput = ( {
 	);
 
 	return (
-		<PopoverMenuItem itemComponent="div" className="settings-popover__delivery-frequency-item">
-			<p className="settings-popover__item-label">{ translate( 'Email me new posts' ) }</p>
+		<PopoverMenuItem
+			itemComponent="div"
+			className={ classNames( 'settings-popover__delivery-frequency-item', {
+				'is-logged-in': isLoggedIn,
+			} ) }
+		>
+			{ ! isLoggedIn && (
+				<p className="settings-popover__item-label">{ translate( 'Email me new posts' ) }</p>
+			) }
 			<SegmentedControl
 				className={ classNames( 'settings-popover__delivery-frequency-control', {
 					'is-loading': isUpdating,

--- a/client/landing/subscriptions/components/settings-popover/site-settings/delivery-frequency-input.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/delivery-frequency-input.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SegmentedControl from 'calypso/components/segmented-control';
 import type { SiteSubscriptionDeliveryFrequency } from '@automattic/data-stores/src/reader/types';
 
@@ -58,22 +59,25 @@ const DeliveryFrequencyInput = ( {
 	);
 
 	return (
-		<SegmentedControl
-			className={ classNames( 'settings-popover__delivery-frequency-control', {
-				'is-loading': isUpdating,
-			} ) }
-		>
-			{ availableFrequencies.map( ( { key, label }, index ) => (
-				<DeliveryFrequencyOption
-					selected={ selectedValue === key }
-					value={ key }
-					onChange={ onChange }
-					key={ index }
-				>
-					{ label }
-				</DeliveryFrequencyOption>
-			) ) }
-		</SegmentedControl>
+		<PopoverMenuItem itemComponent="div" className="settings-popover__delivery-frequency-item">
+			<p className="settings-popover__item-label">{ translate( 'Email me new posts' ) }</p>
+			<SegmentedControl
+				className={ classNames( 'settings-popover__delivery-frequency-control', {
+					'is-loading': isUpdating,
+				} ) }
+			>
+				{ availableFrequencies.map( ( { key, label }, index ) => (
+					<DeliveryFrequencyOption
+						selected={ selectedValue === key }
+						value={ key }
+						onChange={ onChange }
+						key={ index }
+					>
+						{ label }
+					</DeliveryFrequencyOption>
+				) ) }
+			</SegmentedControl>
+		</PopoverMenuItem>
 	);
 };
 

--- a/client/landing/subscriptions/components/settings-popover/site-settings/email-me-new-posts-toggle.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/email-me-new-posts-toggle.tsx
@@ -1,0 +1,43 @@
+import { ToggleControl as OriginalToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+
+// This is a fix to get around the fact that the original ToggleControl component doesn't support the disabled prop.
+// TODO: Remove this when the original ToggleControl component supports the disabled prop.
+const ToggleControl = OriginalToggleControl as React.ComponentType<
+	OriginalToggleControl.Props & {
+		disabled?: boolean;
+	}
+>;
+
+type EmailMeNewPostsToggleProps = {
+	value: boolean;
+	isUpdating: boolean;
+	onChange: ( value: boolean ) => void;
+};
+
+const EmailMeNewPostsToggle = ( {
+	value = false,
+	isUpdating = false,
+	onChange,
+}: EmailMeNewPostsToggleProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<PopoverMenuItem
+			itemComponent="div"
+			focusOnHover={ false }
+			className="settings-popover__email-me-new-posts-item"
+		>
+			<ToggleControl
+				className="settings-popover__email-me-new-posts-toggle"
+				label={ translate( 'Email me new posts' ) }
+				onChange={ () => onChange( ! value ) }
+				checked={ value }
+				disabled={ isUpdating }
+			/>
+		</PopoverMenuItem>
+	);
+};
+
+export default EmailMeNewPostsToggle;

--- a/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
@@ -1,6 +1,4 @@
 import { SubscriptionManager } from '@automattic/data-stores';
-import { useTranslate } from 'i18n-calypso';
-import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import Separator from 'calypso/components/popover-menu/separator';
 import SettingsPopover from '../settings-popover';
 import DeliveryFrequencyInput from './delivery-frequency-input';
@@ -30,7 +28,6 @@ const SiteSettings = ( {
 	unsubscribing,
 	updatingFrequency,
 }: SiteSettingsProps ) => {
-	const translate = useTranslate();
 	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
 
 	return (
@@ -45,14 +42,11 @@ const SiteSettings = ( {
 					<EmailMeNewPostsToggle value={ false } onChange={ () => null } isUpdating={ false } />
 				</>
 			) }
-			<PopoverMenuItem itemComponent="div" className="settings-popover__delivery-frequency-item">
-				<p className="settings-popover__item-label">{ translate( 'Email me new posts' ) }</p>
-				<DeliveryFrequencyInput
-					value={ deliveryFrequency }
-					onChange={ onDeliveryFrequencyChange }
-					isUpdating={ updatingFrequency }
-				/>
-			</PopoverMenuItem>
+			<DeliveryFrequencyInput
+				value={ deliveryFrequency }
+				onChange={ onDeliveryFrequencyChange }
+				isUpdating={ updatingFrequency }
+			/>
 			<Separator />
 			<UnsubscribeSiteButton unsubscribing={ unsubscribing } onUnsubscribe={ onUnsubscribe } />
 		</SettingsPopover>

--- a/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
@@ -48,11 +48,13 @@ const SiteSettings = ( {
 					/>
 				</>
 			) }
-			<DeliveryFrequencyInput
-				value={ deliveryFrequency }
-				onChange={ onDeliveryFrequencyChange }
-				isUpdating={ updatingFrequency }
-			/>
+			{ emailMeNewPosts && (
+				<DeliveryFrequencyInput
+					value={ deliveryFrequency }
+					onChange={ onDeliveryFrequencyChange }
+					isUpdating={ updatingFrequency }
+				/>
+			) }
 			<Separator />
 			<UnsubscribeSiteButton unsubscribing={ unsubscribing } onUnsubscribe={ onUnsubscribe } />
 		</SettingsPopover>

--- a/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
@@ -11,6 +11,7 @@ type SiteSettingsProps = {
 	notifyMeOfNewPosts: boolean;
 	onNotifyMeOfNewPostsChange: ( value: boolean ) => void;
 	updatingNotifyMeOfNewPosts: boolean;
+	emailMeNewPosts: boolean;
 	deliveryFrequency: SiteSubscriptionDeliveryFrequency;
 	onDeliveryFrequencyChange: ( value: SiteSubscriptionDeliveryFrequency ) => void;
 	onUnsubscribe: () => void;
@@ -22,6 +23,7 @@ const SiteSettings = ( {
 	notifyMeOfNewPosts,
 	onNotifyMeOfNewPostsChange,
 	updatingNotifyMeOfNewPosts,
+	emailMeNewPosts,
 	deliveryFrequency,
 	onDeliveryFrequencyChange,
 	onUnsubscribe,
@@ -39,7 +41,11 @@ const SiteSettings = ( {
 						onChange={ onNotifyMeOfNewPostsChange }
 						isUpdating={ updatingNotifyMeOfNewPosts }
 					/>
-					<EmailMeNewPostsToggle value={ false } onChange={ () => null } isUpdating={ false } />
+					<EmailMeNewPostsToggle
+						value={ emailMeNewPosts }
+						onChange={ () => null }
+						isUpdating={ false }
+					/>
 				</>
 			) }
 			<DeliveryFrequencyInput

--- a/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
@@ -12,6 +12,8 @@ type SiteSettingsProps = {
 	onNotifyMeOfNewPostsChange: ( value: boolean ) => void;
 	updatingNotifyMeOfNewPosts: boolean;
 	emailMeNewPosts: boolean;
+	onEmailMeNewPostsChange: ( value: boolean ) => void;
+	updatingEmailMeNewPosts: boolean;
 	deliveryFrequency: SiteSubscriptionDeliveryFrequency;
 	onDeliveryFrequencyChange: ( value: SiteSubscriptionDeliveryFrequency ) => void;
 	onUnsubscribe: () => void;
@@ -24,6 +26,8 @@ const SiteSettings = ( {
 	onNotifyMeOfNewPostsChange,
 	updatingNotifyMeOfNewPosts,
 	emailMeNewPosts,
+	onEmailMeNewPostsChange,
+	updatingEmailMeNewPosts,
 	deliveryFrequency,
 	onDeliveryFrequencyChange,
 	onUnsubscribe,
@@ -43,8 +47,8 @@ const SiteSettings = ( {
 					/>
 					<EmailMeNewPostsToggle
 						value={ emailMeNewPosts }
-						onChange={ () => null }
-						isUpdating={ false }
+						onChange={ onEmailMeNewPostsChange }
+						isUpdating={ updatingEmailMeNewPosts }
 					/>
 				</>
 			) }

--- a/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
+++ b/client/landing/subscriptions/components/settings-popover/site-settings/site-settings.tsx
@@ -4,6 +4,7 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import Separator from 'calypso/components/popover-menu/separator';
 import SettingsPopover from '../settings-popover';
 import DeliveryFrequencyInput from './delivery-frequency-input';
+import EmailMeNewPostsToggle from './email-me-new-posts-toggle';
 import NotifyMeOfNewPostsToggle from './notify-me-of-new-posts-toggle';
 import UnsubscribeSiteButton from './unsubscribe-site-button';
 import type { SiteSubscriptionDeliveryFrequency } from '@automattic/data-stores/src/reader/types';
@@ -35,11 +36,14 @@ const SiteSettings = ( {
 	return (
 		<SettingsPopover>
 			{ isLoggedIn && (
-				<NotifyMeOfNewPostsToggle
-					value={ notifyMeOfNewPosts }
-					onChange={ onNotifyMeOfNewPostsChange }
-					isUpdating={ updatingNotifyMeOfNewPosts }
-				/>
+				<>
+					<NotifyMeOfNewPostsToggle
+						value={ notifyMeOfNewPosts }
+						onChange={ onNotifyMeOfNewPostsChange }
+						isUpdating={ updatingNotifyMeOfNewPosts }
+					/>
+					<EmailMeNewPostsToggle value={ false } onChange={ () => null } isUpdating={ false } />
+				</>
 			) }
 			<PopoverMenuItem itemComponent="div" className="settings-popover__delivery-frequency-item">
 				<p className="settings-popover__item-label">{ translate( 'Email me new posts' ) }</p>

--- a/client/landing/subscriptions/components/settings-popover/styles.scss
+++ b/client/landing/subscriptions/components/settings-popover/styles.scss
@@ -40,6 +40,12 @@
 		}
 	}
 
+	.settings-popover__delivery-frequency-item {
+		&.is-logged-in {
+			padding-top: 0;
+		}
+	}
+
 	.settings-popover__item-button {
 		display: flex;
 		align-items: center;

--- a/client/landing/subscriptions/components/settings-popover/styles.scss
+++ b/client/landing/subscriptions/components/settings-popover/styles.scss
@@ -83,7 +83,13 @@
 		margin-bottom: 16px;
 	}
 
-	.settings-popover__notify-me-of-new-posts-toggle {
+	.settings-popover__email-me-new-posts-item {
+		padding-top: 0;
+		padding-bottom: 0;
+	}
+
+	.settings-popover__notify-me-of-new-posts-toggle,
+	.settings-popover__email-me-new-posts-toggle {
 		font-size: $font-body-small;
 		margin-bottom: 16px;
 

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -56,12 +56,14 @@ export default function SiteRow( {
 	);
 	const deliveryFrequencyLabel = useDeliveryFrequencyLabel( deliveryFrequencyValue );
 
+	const { mutate: updateNotifyMeOfNewPosts, isLoading: updatingNotifyMeOfNewPosts } =
+		SubscriptionManager.useSiteNotifyMeOfNewPostsMutation();
+	const { mutate: updateEmailMeNewPosts, isLoading: updatingEmailMeNewPosts } =
+		SubscriptionManager.useSiteEmailMeNewPostsMutation();
 	const { mutate: updateDeliveryFrequency, isLoading: updatingFrequency } =
 		SubscriptionManager.useSiteDeliveryFrequencyMutation();
 	const { mutate: unsubscribe, isLoading: unsubscribing } =
 		SubscriptionManager.useSiteUnsubscribeMutation();
-	const { mutate: updateNotifyMeOfNewPosts, isLoading: updatingNotifyMeOfNewPosts } =
-		SubscriptionManager.useSiteNotifyMeOfNewPostsMutation();
 
 	return (
 		<li className="row" role="row">
@@ -88,6 +90,10 @@ export default function SiteRow( {
 					}
 					updatingNotifyMeOfNewPosts={ updatingNotifyMeOfNewPosts }
 					emailMeNewPosts={ emailMeNewPosts }
+					updatingEmailMeNewPosts={ updatingEmailMeNewPosts }
+					onEmailMeNewPostsChange={ ( send_posts ) =>
+						updateEmailMeNewPosts( { blog_id: blog_ID, send_posts } )
+					}
 					deliveryFrequency={ deliveryFrequencyValue }
 					onDeliveryFrequencyChange={ ( delivery_frequency ) =>
 						updateDeliveryFrequency( { blog_id: blog_ID, delivery_frequency } )

--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -40,16 +40,21 @@ export default function SiteRow( {
 		return <Gridicon className="icon" icon="globe" size={ 48 } />;
 	}, [ site_icon, name ] );
 
+	const notifyMeOfNewPosts = useMemo(
+		() => delivery_methods?.notification?.send_posts,
+		[ delivery_methods?.notification?.send_posts ]
+	);
+
+	const emailMeNewPosts = useMemo(
+		() => delivery_methods?.email?.send_posts,
+		[ delivery_methods?.email?.send_posts ]
+	);
+
 	const deliveryFrequencyValue = useMemo(
 		() => delivery_methods?.email?.post_delivery_frequency as SiteSubscriptionDeliveryFrequency,
 		[ delivery_methods?.email?.post_delivery_frequency ]
 	);
 	const deliveryFrequencyLabel = useDeliveryFrequencyLabel( deliveryFrequencyValue );
-
-	const notifyMeOfNewPosts = useMemo(
-		() => delivery_methods?.notification?.send_posts,
-		[ delivery_methods?.notification?.send_posts ]
-	);
 
 	const { mutate: updateDeliveryFrequency, isLoading: updatingFrequency } =
 		SubscriptionManager.useSiteDeliveryFrequencyMutation();
@@ -82,6 +87,7 @@ export default function SiteRow( {
 						updateNotifyMeOfNewPosts( { blog_id: blog_ID, send_posts } )
 					}
 					updatingNotifyMeOfNewPosts={ updatingNotifyMeOfNewPosts }
+					emailMeNewPosts={ emailMeNewPosts }
 					deliveryFrequency={ deliveryFrequencyValue }
 					onDeliveryFrequencyChange={ ( delivery_frequency ) =>
 						updateDeliveryFrequency( { blog_id: blog_ID, delivery_frequency } )

--- a/packages/data-stores/src/reader/index.ts
+++ b/packages/data-stores/src/reader/index.ts
@@ -9,6 +9,7 @@ import {
 	usePendingPostConfirmMutation,
 	usePendingPostDeleteMutation,
 	useSiteNotifyMeOfNewPostsMutation,
+	useSiteEmailMeNewPostsMutation,
 } from './mutations';
 import {
 	PostSubscriptionsSortBy,
@@ -40,6 +41,7 @@ export const SubscriptionManager = {
 	usePendingPostConfirmMutation,
 	usePendingPostDeleteMutation,
 	useSiteNotifyMeOfNewPostsMutation,
+	useSiteEmailMeNewPostsMutation,
 	useIsLoggedIn,
 };
 

--- a/packages/data-stores/src/reader/mutations/index.ts
+++ b/packages/data-stores/src/reader/mutations/index.ts
@@ -7,3 +7,4 @@ export { default as usePendingSiteDeleteMutation } from './use-pending-site-dele
 export { default as usePendingPostConfirmMutation } from './use-pending-post-confirm-mutation';
 export { default as usePendingPostDeleteMutation } from './use-pending-post-delete-mutation';
 export { default as useSiteNotifyMeOfNewPostsMutation } from './use-site-notify-me-of-new-posts-mutation';
+export { default as useSiteEmailMeNewPostsMutation } from './use-site-email-me-new-posts-mutation';

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
@@ -1,0 +1,96 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { callApi } from '../helpers';
+import { useCacheKey, useIsLoggedIn } from '../hooks';
+import type { SiteSubscriptionsPages } from '../types';
+
+type SiteSubscriptionEmailMeNewPostsParams = {
+	send_posts: boolean;
+	blog_id: number | string;
+};
+
+type SiteSubscriptionEmailMeNewPostsResponse = {
+	success: boolean;
+	subscribed: boolean;
+};
+
+const useSiteEmailMeNewPostsMutation = () => {
+	const { isLoggedIn } = useIsLoggedIn();
+	const queryClient = useQueryClient();
+
+	const siteSubscriptionsCacheKey = useCacheKey( [ 'read', 'site-subscriptions' ] );
+
+	return useMutation(
+		async ( params: SiteSubscriptionEmailMeNewPostsParams ) => {
+			if ( ! params.blog_id || typeof params.send_posts !== 'boolean' ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while changing the "Email me new posts" setting.'
+				);
+			}
+
+			const action = params.send_posts ? 'new' : 'delete';
+
+			const response = await callApi< SiteSubscriptionEmailMeNewPostsResponse >( {
+				path: `/read/site/${ params.blog_id }/post_email_subscriptions/${ action }`,
+				method: 'POST',
+				body: {},
+				isLoggedIn,
+				apiVersion: '1.2',
+			} );
+			if ( ! response.success ) {
+				throw new Error(
+					// reminder: translate this string when we add it to the UI
+					'Something went wrong while changing the "Email me new posts" setting.'
+				);
+			}
+
+			return response;
+		},
+		{
+			onMutate: async ( params ) => {
+				await queryClient.cancelQueries( siteSubscriptionsCacheKey );
+
+				const previousSiteSubscriptions =
+					queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsCacheKey );
+
+				if ( previousSiteSubscriptions ) {
+					queryClient.setQueryData( siteSubscriptionsCacheKey, {
+						...previousSiteSubscriptions,
+						pages: previousSiteSubscriptions.pages.map( ( page ) => {
+							return {
+								...page,
+								subscriptions: page.subscriptions.map( ( siteSubscription ) => {
+									if ( siteSubscription.blog_ID === params.blog_id ) {
+										return {
+											...siteSubscription,
+											delivery_methods: {
+												...siteSubscription.delivery_methods,
+												email: {
+													...siteSubscription.delivery_methods?.email,
+													send_posts: params.send_posts,
+												},
+											},
+										};
+									}
+									return siteSubscription;
+								} ),
+							};
+						} ),
+					} );
+				}
+				return { previousSiteSubscriptions };
+			},
+
+			onError: ( err, params, context ) => {
+				if ( context?.previousSiteSubscriptions ) {
+					queryClient.setQueryData( siteSubscriptionsCacheKey, context.previousSiteSubscriptions );
+				}
+			},
+			onSettled: () => {
+				queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
+			},
+		}
+	);
+};
+
+export default useSiteEmailMeNewPostsMutation;


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/76489.

## Proposed Changes

The proposed changes add the "Email me new posts" toggle with everything it needs to work properly. The toggle is displayed to logged-in users only and if it is disabled, the Frequency settings below get removed as well (as they don't make sense with the "Email me new posts" setting disabled).

| Setting enabled | Setting disabled |
|--------|--------|
| ![Markup on 2023-05-02 at 16:56:32](https://user-images.githubusercontent.com/25105483/235718018-dd0fe102-d2b1-4b25-a33f-f7dab0778a20.png) | ![Markup on 2023-05-02 at 17:48:54](https://user-images.githubusercontent.com/25105483/235718020-5edfc001-1447-4e38-a44e-a43a269d6421.png) | 

For the external user nothing changes:

![Markup on 2023-05-02 at 16:41:08](https://user-images.githubusercontent.com/25105483/235717648-d9d274ac-a972-4c5c-885d-d84ed08b349a.png)

Main changes in bulletpoints:

* create `EmailMeNewPostsToggle` component
* create `useSiteEmailMeNewPostsMutation` mutation
* move `PopoverMenuItem` and `p` inside `DeliveryFrequencyInput` component to clean up the code

Design: inDLaEQV8jJ21O4WXawIsJ-fi-712_13475

ℹ️ The color of the toggle is blue (not black as in the design). The reason for this is that the toggle should respect user's color profile which our Subscriptions app doesn't support yet. I have created a separate task to address that issue: https://github.com/Automattic/wp-calypso/issues/76490.

## Testing Instructions

1. Check out the PR.
2. Navigate to `client/server/pages/index.js` and temporarily add `return next();` to the line `833`:

![Markup on 2023-04-28 at 17:50:44](https://user-images.githubusercontent.com/25105483/235195033-4902bb9d-db57-43a4-b295-2d90feb6731f.png)

3. Build the app.
4. Log in to a test WordPress.com account that has some Site subscriptions.
5. Navigate to http://calypso.localhost:3000/subscriptions/sites.
6. When you click on the settings menu on any of the sites, you should be able to switch the "Email me new posts" toggle.
7. The change should reflect to the same setting of the same site in the Reader at https://wordpress.com/following/manage.
8. Remove the temporary change that was introduced in the Step 2 and navigate to http://calypso.localhost:3000/subscriptions/sites as an **external** user (it is required to do the `subkey` dance 💃🏼🕺🏼 ).
9. The popup menu should work as expected - the "Email me new posts" toggle should not display.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
