### PR TITLE
Subscription Manager: if user is logged in, unfollow site has different endpoint

### DIFF
--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -139,7 +139,7 @@ export default function SiteRow( {
 						updateEmailMeNewComments( { blog_id: blog_ID, send_comments } )
 					}
 					updatingEmailMeNewComments={ updatingEmailMeNewComments }
-					onUnsubscribe={ () => unsubscribe( { blog_id: blog_ID } ) }
+					onUnsubscribe={ () => unsubscribe( { blog_id: blog_ID, url: url } ) }
 					unsubscribing={ unsubscribing }
 				/>
 			</span>

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -5,6 +5,7 @@ import { SiteSubscriptionsPages, SubscriptionManagerSubscriptionsCount } from '.
 
 type UnsubscribeParams = {
 	blog_id: number | string;
+	url?: string;
 };
 
 type UnsubscribeResponse = {
@@ -28,11 +29,22 @@ const useSiteUnsubscribeMutation = () => {
 				);
 			}
 
+			let path = `/read/site/${ params.blog_id }/post_email_subscriptions/delete`;
+			let apiVersion = '1.2';
+			let body = {};
+
+			if ( isLoggedIn ) {
+				path = `/read/following/mine/delete`;
+				apiVersion = '1.1';
+				body = { source: 'calypso', url: params.url };
+			}
+
 			const response = await callApi< UnsubscribeResponse >( {
-				path: `/read/site/${ params.blog_id }/post_email_subscriptions/delete`,
+				path,
 				method: 'POST',
 				isLoggedIn,
-				apiVersion: '1.2',
+				apiVersion,
+				body,
 			} );
 			if ( ! response.success ) {
 				throw new Error(

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -24,7 +24,9 @@ type SubscriptionManagerSiteSubscriptionsQueryProps = {
 };
 
 const sortByDateSubscribed = ( a: SiteSubscription, b: SiteSubscription ) =>
-	b.date_subscribed.getTime() - a.date_subscribed.getTime();
+	a.date_subscribed instanceof Date && b.date_subscribed instanceof Date
+		? b.date_subscribed.getTime() - a.date_subscribed.getTime()
+		: 0;
 
 const sortByLastUpdated = ( a: SiteSubscription, b: SiteSubscription ) =>
 	a.last_updated instanceof Date && b.last_updated instanceof Date


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/76395

## Proposed Changes

When the user of the Subscription Manager is internal, the endpoint used to unfollow a site should be the one used by the Reader. This PR makes that endpoint variable depending on the user being internal or external.

## Testing Instructions

1. Check out the PR.
2. Navigate to `client/server/pages/index.js` and temporarily add `return next();` to the line `833`:

![Markup on 2023-04-28 at 17:50:44](https://user-images.githubusercontent.com/25105483/235195033-4902bb9d-db57-43a4-b295-2d90feb6731f.png)

3. Build the app.
4. Log in to a test WordPress.com account that has some Site subscriptions.
5. Navigate to http://calypso.localhost:3000/subscriptions/sites.
6. Unfollow a site. The endpoint used should have this structure and body:
URL: `/rest/v1.1/read/following/mine/delete`
Body: `{"url":"[the URL of the site]","source":"calypso"}`
7. Open an incognito window and log in an external user.
8. go to http://calypso.localhost:3000/subscriptions/sites.
9. Unfollow a site. The endpoint shouldn't have body attached and it should have this URL structure: `/rest/v1.2/read/site/[id of the site]/post_email_subscriptions/delete`




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
