### PR TITLE
Launchpad: Show Steps Number in Help Center

### DIFF
--- a/packages/help-center/src/components/help-center-launchpad.scss
+++ b/packages/help-center/src/components/help-center-launchpad.scss
@@ -19,12 +19,6 @@
 		color: var(--studio-gray-100);
 		padding: 16px;
 
-		.circular__progress-bar {
-			.circular__progress-bar-text {
-				display: none;
-			}
-		}
-
 		.inline-help-launchpad-link-text {
 			font-size: 0.875rem;
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/76476

### Time Estimate
Testing: Short
Review: Short

### Summary
This PR adds back in the numbers for the circular progress bar in Help Center

![image](https://user-images.githubusercontent.com/20927667/235738439-561170d1-d095-42ca-859a-850c1c2f5a51.png)

### Testing Instructions
1. Create a new Launchpad site and sandbox it
2. Navigate to `apps/editing-toolkit` and run `yarn dev --sync`
3. Go to `http://calypso.localhost:3000/post/YOUR_SITE_SLUG`
4. Open the Help Center and confirm you can see the number of steps inside the circular progress bar