### PR TITLE
Newsletter: small visual fix to checkbox

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/newsletter-setup/style.scss
@@ -38,8 +38,13 @@
 		font-size: $font-body;
 		flex-direction: row;
 
+		.form-checkbox {
+			margin-top: 5px;
+		}
+
 		.info-popover {
 			margin-left: 10px;
+			margin-top: -2px;
 		}
 	}
 }


### PR DESCRIPTION
Small fix as a follow up to https://github.com/Automattic/wp-calypso/pull/76042 where I left the checkbox visually a bit wonky.

## Proposed Changes

* Adds margins to elements within label to accommodate for `font-size: 1rem` instead of regular `0.875rem` that this component typically has. Kinda disliking the solution here but it's a fix.

**Before**

<img width="399" alt="Screenshot 2023-05-02 at 20 45 56" src="https://user-images.githubusercontent.com/87168/235745169-26cdc6a4-8713-4c60-9579-d509c6166a2f.png">

**After**

<img width="407" alt="image" src="https://user-images.githubusercontent.com/87168/235745114-d65aa558-9383-4d09-904f-7f3d15a38b5e.png">
<img width="394" alt="Screenshot 2023-05-02 at 20 46 14" src="https://user-images.githubusercontent.com/87168/235745138-77d859f0-f855-4bca-9fed-48c4ff043903.png">



## Testing Instructions

* Open `/setup/newsletter`
* See setup step, check the checkbox across desktop/mobile

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
