### PR TITLE
Launchpad: Remove useLaunchpadChecklist from sidebar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -5,7 +5,6 @@ import { useEffect } from '@wordpress/element';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
-import { useLaunchpadChecklist } from 'calypso/../packages/help-center/src/hooks/use-launchpad-checklist';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -35,19 +34,17 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	const siteSlug = useSiteSlugParam();
 	const verifiedParam = useQuery().get( 'verified' );
 	const site = useSite();
+	const siteIntentOption = site?.options?.site_intent;
+	const isSiteLaunched = site?.launch_status === 'launched' || false;
 	const {
 		isError: launchpadFetchError,
-		data: { launchpad_screen: launchpadScreenOption, site_intent: siteIntentOption } = {},
-	} = useLaunchpad( siteSlug );
-	const isSiteLaunched = site?.launch_status === 'launched' || false;
+		data: { launchpad_screen: launchpadScreenOption, checklist: launchpadChecklist } = {},
+	} = useLaunchpad( siteSlug, siteIntentOption );
+
 	const recordSignupComplete = useRecordSignupComplete( flow );
 	const dispatch = useDispatch();
 	const { saveSiteSettings } = useWPDispatch( SITE_STORE );
 	const isLoggedIn = useSelector( isUserLoggedIn );
-
-	const {
-		data: { checklist: launchpadChecklist },
-	} = useLaunchpadChecklist( siteSlug, siteIntentOption );
 
 	const fetchingSiteError = useSelect(
 		( select ) => ( select( SITE_STORE ) as SiteSelect ).getFetchingSiteError(),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -5,7 +5,6 @@ import { useRef, useState } from '@wordpress/element';
 import { Icon, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import { useLaunchpadChecklist } from 'calypso/../packages/help-center/src/hooks/use-launchpad-checklist';
 import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
 import Badge from 'calypso/components/badge';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
@@ -50,20 +49,16 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 	let isDomainSSLProcessing: boolean | null = false;
 	const translate = useTranslate();
 	const site = useSite();
+	const siteIntentOption = site?.options?.site_intent;
 	const clipboardButtonEl = useRef< HTMLButtonElement >( null );
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 
 	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles( site?.ID );
 
 	const {
-		data: { site_intent: siteIntentOption, checklist_statuses: checklistStatuses },
-	} = useLaunchpad( siteSlug );
-
-	const {
-		data: { checklist: launchpadChecklist },
+		data: { checklist: launchpadChecklist, checklist_statuses: checklistStatuses },
 		isFetchedAfterMount,
-	} = useLaunchpadChecklist( siteSlug, siteIntentOption );
-
+	} = useLaunchpad( siteSlug, siteIntentOption );
 	const isEmailVerified = useSelector( isCurrentUserEmailVerified );
 
 	const { title, launchTitle, subtitle } = getLaunchpadTranslations( flow );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -493,10 +493,10 @@ export function getArrayOfFilteredTasks(
  * @returns {boolean} - True if the final task for the given site checklist is completed
  */
 export function areLaunchpadTasksCompleted(
-	checklist: LaunchpadChecklist,
+	checklist: LaunchpadChecklist | null | undefined,
 	isSiteLaunched: boolean
 ) {
-	if ( ! Array.isArray( checklist ) ) {
+	if ( ! checklist || ! Array.isArray( checklist ) ) {
 		return false;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -34,7 +34,7 @@ import type { SiteDetails } from '@automattic/data-stores';
  * generated in the REST API
  */
 export function getEnhancedTasks(
-	tasks: Task[] | null,
+	tasks: Task[] | null | undefined,
 	siteSlug: string | null,
 	site: SiteDetails | null,
 	submit: NavigationControls[ 'submit' ],


### PR DESCRIPTION
### Proposed Changes

Resolves: https://github.com/Automattic/wp-calypso/issues/76469

We're consolidating all front end code to use shared methods/hooks from data-stores to fetch Launchpad data and checklists. This contributes to that effort by removing the temporary useLaunchpadChecklist hook from launchpad/index.tsx.

### Testing Instructions

This is a refactor, and behavior of Launchpad should continue to be the exact same as before. So we're effectively testing to ensure there are no regressive breakages. 

1. You'll need our latest backend jetpack-mu-plugin code from https://github.com/Automattic/jetpack/pull/30397. You can do that by running `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/launchpad-completion-logic`. IF that branch has already been merged to trunk, you'll get an error. You can use `bin/jetpack-downloader test jetpack-mu-wpcom-plugin trunk` to build and sync jetpack trunk to your sandbox. Sandbox public-api. 
2. Checkout this branch and run yarn and yarn start. 
3. Create a Launchpad enabled site and sandbox the _url of the test site_ you'll be working with. Here are urls to start various site types for convenience: 
   - http://calypso.localhost:3000/setup/free/intro
   - http://calypso.localhost:3000/setup/newsletter/intro
   - http://calypso.localhost:3000/setup/link-in-bio/intro
   - http://calypso.localhost:3000/start (for write/build)
4. Proceed to Launchpad. Then complete various tasks and confirm all task statuses update as expected. 
5. Copy the launchpad url, and then launch the site. You should end up on My Home. Re-enter the launchpad url to try to load launchpad, and confirm you are redirected back to My Home. 
6. Consider testing one extra flow from step 3. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
