### PR TITLE
Woo Express: Fix My Plan page description for Video and audio posts section

### DIFF
--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -45,7 +45,7 @@ function getDescription( plan, translate ) {
 		// Translators: %(planName)s is the name of the plan, %(storageLimit)d is the storage limit in GB.
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-				'directly to your site — the Woo Express %(planName)s Plan has %(storageLimit)d GB storage.',
+				'directly to your site — the Woo Express: %(planName)s plan has %(storageLimit)d GB storage.',
 			{
 				args: {
 					planName: wooExpressPlan.getTitle(),

--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -45,7 +45,7 @@ function getDescription( plan, translate ) {
 		// Translators: %(planName)s is the name of the plan, %(storageLimit)d is the storage limit in GB.
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-				'directly to your site — the Woo Express %(planName)s Plan has %(storageLimit)d%% GB storage.',
+				'directly to your site — the Woo Express %(planName)s Plan has %(storageLimit)d GB storage.',
 			{
 				args: {
 					planName: wooExpressPlan.getTitle(),

--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -1,5 +1,9 @@
 import {
+	getPlan,
 	isProPlan,
+	isWooExpressMediumPlan,
+	isWooExpressPlan,
+	isWooExpressSmallPlan,
 	isWpComBusinessPlan,
 	isWpComEcommercePlan,
 	isWpComPremiumPlan,
@@ -28,6 +32,26 @@ function getDescription( plan, translate ) {
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
 				'directly to your site — the Pro Plan has 50 GB storage.'
+		);
+	}
+	if ( isWooExpressPlan( plan ) ) {
+		const wooExpressPlan = getPlan( plan );
+		let wooExpressStorageLimit = 3;
+		if ( isWooExpressMediumPlan( plan ) ) {
+			wooExpressStorageLimit = 200;
+		} else if ( isWooExpressSmallPlan( plan ) ) {
+			wooExpressStorageLimit = 50;
+		}
+		// Translators: %(planName)s is the name of the plan, %(storageLimit)d is the storage limit in GB.
+		return translate(
+			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
+				'directly to your site — the Woo Express %(planName)s Plan has %(storageLimit)d%% GB storage.',
+			{
+				args: {
+					planName: wooExpressPlan.getTitle(),
+					storageLimit: wooExpressStorageLimit,
+				},
+			}
 		);
 	}
 	if ( isWpComEcommercePlan( plan ) ) {


### PR DESCRIPTION
Closes #76513

## Proposed Changes

* Fixes the name of the plan in the **Video and audio posts**  section on the My Plan page.
* Fixes the storage limit for the Essential plan in the **Video and audio posts**  section on the My Plan page.

## Testing Instructions

#### Essential Plan

* Navigate to `/plans/my-plan/{SITE-SLUG}` on a site with the Woo Express Essential plan
* The video **Video and audio posts** sections should make reference to the Woo Express Essential plan, and the storage limit should be 50GB.

<img width="535" alt="Screen Shot 2023-05-04 at 08 54 50" src="https://user-images.githubusercontent.com/1234758/236196607-7289bcf8-524e-4927-b8e6-419f079993e5.png">

#### Performance Plan
* Navigate to `/plans/my-plan/{SITE-SLUG}` on a site with the Woo Express Performance plan
* The video **Video and audio posts** sections should make reference to the Woo Express Performance plan, and the storage limit should be 200GB.

<img width="539" alt="Screen Shot 2023-05-04 at 08 54 39" src="https://user-images.githubusercontent.com/1234758/236196656-77f594d7-7d6c-48e3-8894-9675556b2267.png">
