### PR TITLE
Purchases: Convert PurchaseMeta to TypeScript

### DIFF
--- a/client/components/user/index.tsx
+++ b/client/components/user/index.tsx
@@ -3,8 +3,8 @@ import Gravatar from 'calypso/components/gravatar';
 
 import './style.scss';
 
-const User = ( { user } ) => {
-	const name = user ? user.display_name || user.name : '';
+const User = ( { user }: { user: { display_name?: string; name?: string } } ) => {
+	const name = user ? user.display_name || user.name || '' : '';
 	return (
 		<div className="user" title={ name }>
 			<Gravatar size={ 26 } user={ user } />

--- a/client/lib/purchases/types.ts
+++ b/client/lib/purchases/types.ts
@@ -356,11 +356,14 @@ export interface MembershipSubscriptionsSite {
 }
 
 export interface Owner {
-	ID: string;
-	display_name: string;
+	ID: number;
+	display_name?: string;
 }
 export type GetChangePaymentMethodUrlFor = ( siteSlug: string, purchase: Purchase ) => string;
-export type GetManagePurchaseUrlFor = ( siteSlug: string, attachedToPurchaseId: string ) => string;
+export type GetManagePurchaseUrlFor = (
+	siteSlug: string,
+	attachedToPurchaseId: string | number
+) => string;
 
 export type RenderRenewsOrExpiresOn = ( args: {
 	moment: ReturnType< typeof useLocalizedMoment >;
@@ -368,9 +371,9 @@ export type RenderRenewsOrExpiresOn = ( args: {
 	siteSlug: string | undefined;
 	translate: ReturnType< typeof useTranslate >;
 	getManagePurchaseUrlFor: GetManagePurchaseUrlFor;
-} ) => string;
+} ) => JSX.Element | null;
 
 export type RenderRenewsOrExpiresOnLabel = ( args: {
 	purchase: Purchase;
 	translate: ReturnType< typeof useTranslate >;
-} ) => string;
+} ) => string | null;

--- a/client/me/purchases/manage-purchase/purchase-meta-owner.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-owner.tsx
@@ -2,7 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import UserItem from 'calypso/components/user';
 import type { Owner } from 'calypso/lib/purchases/types';
 
-function PurchaseMetaOwner( { owner }: { owner: Owner } ) {
+function PurchaseMetaOwner( { owner }: { owner: Owner | undefined | null } ) {
 	const translate = useTranslate();
 	if ( ! owner ) {
 		return null;

--- a/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-payment-details.tsx
@@ -4,13 +4,14 @@ import { isOneTimePurchase, isPaidWithCreditCard } from 'calypso/lib/purchases';
 import { useStoredPaymentMethods } from 'calypso/my-sites/checkout/composite-checkout/hooks/use-stored-payment-methods';
 import { canEditPaymentDetails } from '../utils';
 import PaymentInfoBlock from './payment-info-block';
+import type { SiteDetails } from '@automattic/data-stores';
 import type { Purchase, GetChangePaymentMethodUrlFor } from 'calypso/lib/purchases/types';
 
 interface PaymentProps {
 	purchase: Purchase;
 	getChangePaymentMethodUrlFor: GetChangePaymentMethodUrlFor;
 	siteSlug?: string;
-	site?: string;
+	site?: SiteDetails;
 	isAkismetPurchase: boolean;
 }
 

--- a/client/me/purchases/manage-purchase/purchase-meta-price.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-price.tsx
@@ -59,23 +59,27 @@ function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 		}
 
 		// translators: displayPrice is the price of the purchase with localized currency (i.e. "C$10")
-		return translate( '{{displayPrice/}} {{period}}(one-time){{/period}}', {
-			components: {
-				displayPrice: (
-					<span>
-						{ formatCurrency( priceInteger, currencyCode, {
-							stripZeros: true,
-							isSmallestUnit: true,
-						} ) }
-					</span>
-				),
-				period: <span className="manage-purchase__time-period" />,
-			},
-		} );
+		return (
+			<>
+				{ translate( '{{displayPrice/}} {{period}}(one-time){{/period}}', {
+					components: {
+						displayPrice: (
+							<span>
+								{ formatCurrency( priceInteger, currencyCode, {
+									stripZeros: true,
+									isSmallestUnit: true,
+								} ) }
+							</span>
+						),
+						period: <span className="manage-purchase__time-period" />,
+					},
+				} ) }
+			</>
+		);
 	}
 
 	if ( isIncludedWithPlan( purchase ) ) {
-		return translate( 'Free with Plan' );
+		return <>{ translate( 'Free with Plan' ) }</>;
 	}
 
 	const getPeriod = () => {
@@ -124,20 +128,24 @@ function PurchaseMetaPrice( { purchase }: { purchase: Purchase } ) {
 		}
 
 		//translators: displayPrice is the price of the purchase with localized currency (i.e. "C$10"), %(period)s is how long the plan is active (i.e. "year")
-		return translate( '{{displayPrice/}} {{period}}/ %(period)s{{/period}}', {
-			args: { period },
-			components: {
-				displayPrice: (
-					<span>
-						{ formatCurrency( priceInteger, currencyCode, {
-							stripZeros: true,
-							isSmallestUnit: true,
-						} ) }
-					</span>
-				),
-				period: <span className="manage-purchase__time-period" />,
-			},
-		} );
+		return (
+			<>
+				{ translate( '{{displayPrice/}} {{period}}/ %(period)s{{/period}}', {
+					args: { period },
+					components: {
+						displayPrice: (
+							<span>
+								{ formatCurrency( priceInteger, currencyCode, {
+									stripZeros: true,
+									isSmallestUnit: true,
+								} ) }
+							</span>
+						),
+						period: <span className="manage-purchase__time-period" />,
+					},
+				} ) }
+			</>
+		);
 	};
 
 	return getPriceLabel( getPeriod() );


### PR DESCRIPTION
## Proposed Changes

This PR converts the `PurchaseMeta` component to TypeScript while making as few functional changes as possible.

<img width="668" alt="Screenshot 2023-05-05 at 3 05 07 PM" src="https://user-images.githubusercontent.com/2036909/236547981-9906cae4-dd7b-4d8e-af15-e1a90daef4dd.png">


## Testing Instructions

- Visit `/me/purchases` for a site with at least one active purchase.
- Click a purchase to view its details view.
- Verify that the meta area (the bottom of the main card, containing "Owner", "Renewal Price", "Subscription Renewal", and "Payment method" blocks) is shown and everything looks the same on this branch as it does in production.