### PR TITLE
Monthly plan upsell: remove annual business plan upsell for users upgrading to premium annual through this upsell

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-create-payment-complete-callback.tsx
@@ -15,6 +15,7 @@ import {
 } from 'calypso/signup/storageUtils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { clearPurchases } from 'calypso/state/purchases/actions';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { fetchReceiptCompleted } from 'calypso/state/receipts/actions';
 import { isMonthlyToAnnualPostPurchaseExperimentUser } from 'calypso/state/selectors/is-monthly-to-annual-post-purchase-experiment-user';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -102,6 +103,8 @@ export default function useCreatePaymentCompleteCallback( {
 		isMonthlyToAnnualPostPurchaseExperimentUser( state )
 	);
 
+	const purchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
+
 	return useCallback(
 		( { paymentMethodId, transactionLastResponse }: PaymentEventCallbackArguments ): void => {
 			debug( 'payment completed successfully' );
@@ -137,6 +140,7 @@ export default function useCreatePaymentCompleteCallback( {
 				adminPageRedirect,
 				domains,
 				monthlyToAnnualPostPurchaseExperimentUser,
+				purchases,
 			};
 
 			debug( 'getThankYouUrl called with', getThankYouPageUrlArguments );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2230

## Proposed Changes

We want to Remove the Annual Business plan upsell if the user already came from the Monthly plan upsell with a Premium plan (Premium Monthly -> Premium Yearly)

We compare the most recent purchase to the plan in the shopping cart. If is upgrading from Premium Monthly to Yearly, we do not display the Business Upsell option.

## Before
https://user-images.githubusercontent.com/402286/235825139-7d72d194-ced8-45ec-86ff-1d3450f247d1.mp4

## After
https://user-images.githubusercontent.com/402286/235825132-e469e98a-efe7-420b-b351-25d55c109e89.mp4

## Testing Instructions



* An account on a free plan
* Go to `/plans/monthly/:siteSlug?flags=upsell/monthly-to-annual` to buy a monthly premium plan
* Should redirect to upsell page on checkout.
* Test Add to cart and buy it -> thank you page
* Test Consider later -> thank you page

## Todo
- [x] Write tests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
