### PR TITLE
wpcom-block-editor: Track search term when inserting a block or pattern

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -15,10 +15,54 @@ import {
 	findSavingSource,
 } from './utils';
 
+const INSERTERS = {
+	HEADER_INSERTER: 'header-inserter',
+	SLASH_INSERTER: 'slash-inserter',
+	QUICK_INSERTER: 'quick-inserter',
+	BLOCK_SWITCHER: 'block-switcher',
+	PAYMENTS_INTRO_BLOCK: 'payments-intro-block',
+	PATTERNS_EXPLORER: 'patterns-explorer',
+	PATTERN_SELECTION_MODAL: 'pattern-selection-modal',
+};
+
+const SELECTORS = {
+	/**
+	 * Explore all patterns modal
+	 */
+	PATTERNS_EXPLORER: '.block-editor-block-patterns-explorer',
+	PATTERNS_EXPLORER_SELECTED_CATEGORY:
+		'.block-editor-block-patterns-explorer__sidebar__categories-list__item.is-pressed',
+	PATTERNS_EXPLORER_SEARCH_INPUT: '.block-editor-block-patterns-explorer__search input',
+
+	/**
+	 * Pattern Inserter
+	 */
+	PATTERN_INSERTER_SELECTED_CATEGORY: '.block-editor-inserter__patterns-selected-category',
+	PATTERN_INSERTER_SEARCH_INPUT: '.block-editor-inserter__search input',
+
+	/**
+	 * Pattern Selection Modal
+	 */
+	PATTERN_SELECTION_MODAL: '.block-library-query-pattern__selection-modal',
+	PATTERN_SELECTION_MODAL_SEARCH_INPUT: '.block-library-query-pattern__selection-search input',
+
+	/**
+	 * Quick Inserter
+	 */
+	QUICK_INSERTER: '.block-editor-inserter__quick-inserter',
+	QUICK_INSERTER_SEARCH_INPUT: '.block-editor-inserter__quick-inserter input',
+
+	/**
+	 * Legacy block inserter
+	 */
+	LEGACY_BLOCK_INSERTER: '.block-editor-inserter__block-list',
+};
+
 // Debugger.
 const debug = debugFactory( 'wpcom-block-editor:tracking' );
 
 const noop = () => {};
+
 let ignoreNextReplaceBlocksAction = false;
 
 /**
@@ -71,10 +115,15 @@ const getTypeForBlockId = ( blockId ) => {
  * Guess which inserter was used to insert/replace blocks.
  *
  * @param {string[]|string} originalBlockIds ids or blocks that are being replaced
- * @returns {'header-inserter'|'slash-inserter'|'quick-inserter'|'block-switcher'|'payments-intro-block'|undefined} ID representing the insertion method that was used
+ * @returns {'header-inserter'|'slash-inserter'|'quick-inserter'|'block-switcher'|'payments-intro-block'|'patterns-explorer'|'pattern-selection-modal'|undefined} ID representing the insertion method that was used
  */
 const getBlockInserterUsed = ( originalBlockIds = [] ) => {
 	const clientIds = Array.isArray( originalBlockIds ) ? originalBlockIds : [ originalBlockIds ];
+
+	if ( document.querySelector( SELECTORS.PATTERNS_EXPLORER ) ) {
+		return INSERTERS.PATTERNS_EXPLORER;
+	}
+
 	// Check if the main inserter (opened using the [+] button in the header) is open.
 	// If it is then the block was inserted using this menu. This inserter closes
 	// automatically when the user tries to use another form of block insertion
@@ -87,14 +136,14 @@ const getBlockInserterUsed = ( originalBlockIds = [] ) => {
 			.querySelector( '.customize-widgets-layout__inserter-panel' )
 			?.contains( document.activeElement )
 	) {
-		return 'header-inserter';
+		return INSERTERS.HEADER_INSERTER;
 	}
 
 	// The block switcher open state is not stored in Redux, it's component state
 	// inside a <Dropdown>, so we can't access it. Work around this by checking if
 	// the DOM elements are present on the page while the block is being replaced.
 	if ( clientIds.length && document.querySelector( '.block-editor-block-switcher__container' ) ) {
-		return 'block-switcher';
+		return INSERTERS.BLOCK_SWITCHER;
 	}
 
 	// Inserting a block using a slash command is always a block replacement of
@@ -108,7 +157,7 @@ const getBlockInserterUsed = ( originalBlockIds = [] ) => {
 		select( 'core/block-editor' ).getBlockName( clientIds[ 0 ] ) === 'core/paragraph' &&
 		select( 'core/block-editor' ).getBlockAttributes( clientIds[ 0 ] ).content.startsWith( '/' )
 	) {
-		return 'slash-inserter';
+		return INSERTERS.SLASH_INSERTER;
 	}
 
 	// The quick inserter open state is not stored in Redux, it's component state
@@ -116,11 +165,11 @@ const getBlockInserterUsed = ( originalBlockIds = [] ) => {
 	// the DOM elements are present on the page while the block is being inserted.
 	if (
 		// The new quick-inserter UI, marked as __experimental
-		document.querySelector( '.block-editor-inserter__quick-inserter' ) ||
+		document.querySelector( SELECTORS.QUICK_INSERTER ) ||
 		// Legacy block inserter UI
-		document.querySelector( '.block-editor-inserter__block-list' )
+		document.querySelector( SELECTORS.LEGACY_BLOCK_INSERTER )
 	) {
-		return 'quick-inserter';
+		return INSERTERS.QUICK_INSERTER;
 	}
 
 	// This checks validates if we are inserting a block from the Payments Inserter block.
@@ -128,10 +177,41 @@ const getBlockInserterUsed = ( originalBlockIds = [] ) => {
 		clientIds.length === 1 &&
 		select( 'core/block-editor' ).getBlockName( clientIds[ 0 ] ) === 'jetpack/payments-intro'
 	) {
-		return 'payments-intro-block';
+		return INSERTERS.PAYMENTS_INTRO_BLOCK;
+	}
+
+	if ( document.querySelector( SELECTORS.PATTERN_SELECTION_MODAL ) ) {
+		return INSERTERS.PATTERN_SELECTION_MODAL;
 	}
 
 	return undefined;
+};
+
+/**
+ * Get the search term from the inserter.
+ *
+ * @param {string} inserter
+ * @returns {string} The search term
+ */
+const getBlockInserterSearchTerm = ( inserter ) => {
+	let searchInput;
+
+	switch ( inserter ) {
+		case INSERTERS.PATTERNS_EXPLORER:
+			searchInput = document.querySelector( SELECTORS.PATTERNS_EXPLORER_SEARCH_INPUT );
+			break;
+		case INSERTERS.HEADER_INSERTER:
+			searchInput = document.querySelector( SELECTORS.PATTERN_INSERTER_SEARCH_INPUT );
+			break;
+		case INSERTERS.QUICK_INSERTER:
+			searchInput = document.querySelector( SELECTORS.QUICK_INSERTER_SEARCH_INPUT );
+			break;
+		case INSERTERS.PATTERN_SELECTION_MODAL:
+			searchInput = document.querySelector( SELECTORS.PATTERN_SELECTION_MODAL_SEARCH_INPUT );
+			break;
+	}
+
+	return searchInput ? searchInput.value : '';
 };
 
 /**
@@ -252,15 +332,7 @@ const getBlocksTracker = ( eventName ) => ( blockIds, fromRootClientId, toRootCl
  * @returns {Object|null} The inserted pattern with its name and category if available.
  */
 const maybeTrackPatternInsertion = ( actionData, additionalData ) => {
-	const SELECTORS = {
-		// The selected category from the “Explore all patterns modal”
-		PATTERN_EXPLORER_SELECTED_CATEGORY:
-			'.block-editor-block-patterns-explorer__sidebar__categories-list__item.is-pressed',
-		// The selected category from the pattern inserter
-		PATTERN_INSERTER_SELECTED_CATEGORY: '.block-editor-inserter__patterns-selected-category',
-	};
-
-	const { rootClientId, blocks_replaced, insert_method } = additionalData;
+	const { rootClientId, blocks_replaced, insert_method, search_term } = additionalData;
 	const context = getBlockEventContextProperties( rootClientId );
 	const {
 		__experimentalBlockPatterns: patterns,
@@ -283,7 +355,7 @@ const maybeTrackPatternInsertion = ( actionData, additionalData ) => {
 
 	if ( patternName ) {
 		const categoryElement =
-			document.querySelector( SELECTORS.PATTERN_EXPLORER_SELECTED_CATEGORY ) ||
+			document.querySelector( SELECTORS.PATTERNS_EXPLORER_SELECTED_CATEGORY ) ||
 			document.querySelector( SELECTORS.PATTERN_INSERTER_SELECTED_CATEGORY );
 
 		const patternCategory = patternCategories.find(
@@ -295,6 +367,7 @@ const maybeTrackPatternInsertion = ( actionData, additionalData ) => {
 			pattern_category: patternCategory?.name,
 			blocks_replaced,
 			insert_method,
+			search_term,
 			...context,
 		} );
 
@@ -317,10 +390,12 @@ const maybeTrackPatternInsertion = ( actionData, additionalData ) => {
 const trackBlockInsertion = ( blocks, ...args ) => {
 	const [ , rootClientId ] = args;
 	const insert_method = getBlockInserterUsed();
+	const search_term = getBlockInserterSearchTerm( insert_method );
 	const insertedPattern = maybeTrackPatternInsertion( args, {
 		rootClientId,
 		blocks_replaced: false,
 		insert_method,
+		search_term,
 	} );
 	const context = getBlockEventContextProperties( rootClientId );
 
@@ -330,6 +405,7 @@ const trackBlockInsertion = ( blocks, ...args ) => {
 		pattern_name: insertedPattern?.name,
 		pattern_category: insertedPattern?.categoryName,
 		insert_method,
+		search_term,
 		...context,
 	} ) );
 };
@@ -369,10 +445,12 @@ const trackBlockReplacement = ( originalBlockIds, blocks, ...args ) => {
 		Array.isArray( originalBlockIds ) ? originalBlockIds[ 0 ] : originalBlockIds
 	);
 	const insert_method = getBlockInserterUsed( originalBlockIds );
+	const search_term = getBlockInserterSearchTerm( insert_method );
 	const insertedPattern = maybeTrackPatternInsertion( args, {
 		rootClientId,
 		blocks_replaced: true,
 		insert_method,
+		search_term,
 	} );
 	const context = getBlockEventContextProperties( rootClientId );
 
@@ -382,6 +460,7 @@ const trackBlockReplacement = ( originalBlockIds, blocks, ...args ) => {
 		pattern_name: insertedPattern?.name,
 		pattern_category: insertedPattern?.categoryName,
 		insert_method,
+		search_term,
 		...context,
 	} ) );
 };


### PR DESCRIPTION
This PR makes imporovmente is for the tracks events:
* `wpcom_pattern_inserted`
* `wpcom_block_picker_block_inserted`

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2176

| Header Inserter | Quick Inserter | Patterns Explorer | Pattern Selection Modal (Replacement) |
| - | - | - | - |
| ![image](https://user-images.githubusercontent.com/13596067/235845896-e2d59c18-14e9-44ca-82fa-d9107d484950.png) | ![image](https://user-images.githubusercontent.com/13596067/235845954-5313f30e-973c-4283-80cd-b9b9e82e8ba2.png) | ![image](https://user-images.githubusercontent.com/13596067/235846085-66762407-7f88-4282-9712-c344ae9c34a9.png) | ![image](https://user-images.githubusercontent.com/13596067/235847361-4cf0f9d2-60e4-4b7e-b1e6-abbace59efcd.png) |

## Proposed Changes

* As title, we also want to track the search term when people are inserting a pattern
* Also, we support more inserters such as `patterns-explorer` and `pattern-selection-modal`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* cd apps/wpcom-block-editor and run yarn dev --sync to apply the changes to your sandbox
* Sandbox widgets.wp.com
* Go to the site editor
* Open the pattern inserter
* Search for a pattern
* Insert a pattern
* Verify the event is fired with the correct search term

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
