### PR TITLE
Unlocks Unified Importer for Jetpack users

### DIFF
--- a/client/blocks/jetpack-plugin-update-warning/index.tsx
+++ b/client/blocks/jetpack-plugin-update-warning/index.tsx
@@ -1,9 +1,10 @@
 import { useTranslate } from 'i18n-calypso';
 import { FC, useCallback, useMemo, useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
 import Notice from 'calypso/components/notice';
 import { preventWidows } from 'calypso/lib/formatting';
+import version_compare from 'calypso/lib/version-compare';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
@@ -39,7 +40,7 @@ export const JetpackPluginUpdateWarning: FC< ExternalProps > = ( {
 	);
 
 	const hideWarning = useMemo(
-		() => siteJetpackVersion >= minJetpackVersion || ! pluginUpgradeUrl,
+		() => version_compare( siteJetpackVersion, minJetpackVersion, '>=' ) || ! pluginUpgradeUrl,
 		[ minJetpackVersion, pluginUpgradeUrl, siteJetpackVersion ]
 	);
 

--- a/client/lib/importer/importer-config.tsx
+++ b/client/lib/importer/importer-config.tsx
@@ -259,14 +259,16 @@ function getConfig(
 		weight: 0,
 	};
 
-	// TODO: remove the atomic once Jetpack 12.1 is deployed.
-	const hasUnifiedImporter = config.isEnabled( 'importer/unified' ) && !! args.isAtomic;
+	const hasUnifiedImporter = config.isEnabled( 'importer/unified' );
 
-	// For Jetpack sites, we don't support migration as destination,
-	// so we remove the override here.
+	// For Jetpack sites, we don't support migration as destination, so we remove the override here.
 	if ( hasUnifiedImporter && args.isJetpack && ! args.isAtomic ) {
-		importerConfig = { wordpress: importerConfig.wordpress };
 		delete importerConfig.wordpress.overrideDestination;
+	}
+
+	// For atomic sites filter out all importers except the WordPress ones if the Unified Importer is disabled.
+	if ( ! hasUnifiedImporter && args.isAtomic ) {
+		importerConfig = { wordpress: importerConfig.wordpress };
 	}
 
 	return importerConfig;

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -17,6 +17,7 @@ import SectionHeader from 'calypso/components/section-header';
 import { getImporterByKey, getImporters } from 'calypso/lib/importer/importer-config';
 import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
 import memoizeLast from 'calypso/lib/memoize-last';
+import version_compare from 'calypso/lib/version-compare';
 import BloggerImporter from 'calypso/my-sites/importer/importer-blogger';
 import MediumImporter from 'calypso/my-sites/importer/importer-medium';
 import SquarespaceImporter from 'calypso/my-sites/importer/importer-squarespace';
@@ -32,13 +33,12 @@ import {
 	isImporterStatusHydrated,
 } from 'calypso/state/imports/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { getSiteTitle, getSiteOption } from 'calypso/state/sites/selectors';
+import { getSiteOption, getSiteTitle } from 'calypso/state/sites/selectors';
 import {
 	getSelectedSite,
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-
 import './section-import.scss';
 
 /**
@@ -290,11 +290,14 @@ class SectionImport extends Component {
 			options: { is_wpcom_atomic: isAtomic },
 		} = site;
 
-		const jetpackVersionInCompatible =
-			this.props.siteJetpackVersion < JETPACK_IMPORT_MIN_PLUGIN_VERSION;
+		// Target site Jetpack version is not compatible with the importer.
+		const jetpackVersionInCompatible = version_compare(
+			this.props.siteJetpackVersion,
+			JETPACK_IMPORT_MIN_PLUGIN_VERSION,
+			'<'
+		);
 
-		// TODO: remove the atomic once Jetpack 12.1 is deployed.
-		const hasUnifiedImporter = isEnabled( 'importer/unified' ) && isAtomic;
+		const hasUnifiedImporter = isEnabled( 'importer/unified' );
 
 		return (
 			<Main>

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -57,8 +57,7 @@ const useSiteMenuItems = () => {
 
 	const hasSiteWithPlugins = useSelector( canAnySiteHavePlugins );
 
-	// TODO: remove the atomic once Jetpack 12.1 is deployed.
-	const hasUnifiedImporter = isEnabled( 'importer/unified' ) && isAtomic;
+	const hasUnifiedImporter = isEnabled( 'importer/unified' );
 
 	/**
 	 * When no site domain is provided, lets show only menu items that support all sites screens.


### PR DESCRIPTION
This PR unlocks the Unified Importer for Jetpack users.

## Proposed Changes

* Unlock the Unified Importer for Jetpack users.
* The version compare now is done using the `version_compare` function to have a more granular control[^1].

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

We have four scenarios to be tested here for the `http://calypso.localhost:3000/import/SITE_URL` page:

1. A **simple site**: a list of importers that call the simple importer.
2. An **atomic site**: a list of importers that call the Unified Importer.
3. A **Jetpack site** with minimum version **12.1:** a list of importers that call the Unified Importer.
4. A **Jetpack site** with version **12.0 or older**: a list of greyed-out importers and a warning that cite: "Your Jetpack plugin is out of date. To make sure you can import reliably, update Jetpack." (see screenshot).

For case three, a brand new JN site is ok.  For case four, if you already don't have one, you can create a JN site using a specific old enough version.

<img width="753" alt="image" src="https://user-images.githubusercontent.com/167611/235850790-00d3711d-6266-485f-afe9-e2a62675c038.png">

[^1]: https://www.php.net/manual/en/function.version-compare.php
