### PR TITLE
Theme Detail Page: Theme preview should not block the logged-out footer

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -37,7 +37,6 @@ import SectionHeader from 'calypso/components/section-header';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
-import StickyPanel from 'calypso/components/sticky-panel';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
@@ -488,16 +487,14 @@ class ThemeSheet extends Component {
 		);
 
 		return (
-			<StickyPanel>
-				<div className="theme__sheet-web-preview">
-					<ThemeWebPreview
-						url={ url }
-						inlineCss={ baseStyleVariationInlineCss + selectedStyleVariationInlineCss }
-						isShowFrameBorder={ false }
-						isShowDeviceSwitcher={ false }
-					/>
-				</div>
-			</StickyPanel>
+			<div className="theme__sheet-web-preview">
+				<ThemeWebPreview
+					url={ url }
+					inlineCss={ baseStyleVariationInlineCss + selectedStyleVariationInlineCss }
+					isShowFrameBorder={ false }
+					isShowDeviceSwitcher={ false }
+				/>
+			</div>
 		);
 	};
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -8,11 +8,19 @@ $theme-sheet-content-max-width: 1462px;
 	}
 
 	.layout:not(.has-no-sidebar) .layout__content {
+		overflow: clip;
 		padding-top: var(--masterbar-height);
 
 		@include breakpoint-deprecated( "<960px" ) {
 			padding-left: 0;
 			padding-right: 0;
+		}
+
+		.theme__sheet-web-preview {
+			@include breakpoint-deprecated( ">960px" ) {
+				height: calc(100vh - 96px);
+				top: calc(var(--masterbar-height) + 16px);
+			}
 		}
 	}
 
@@ -241,30 +249,6 @@ $theme-sheet-content-max-width: 1462px;
 
 .theme__sheet-column-right {
 	grid-area: preview;
-
-	.sticky-panel {
-		width: 100%;
-
-		&.is-sticky .sticky-panel__content {
-			margin-top: 16px;
-
-			@include breakpoint-deprecated( "<960px" ) {
-				margin-top: 0;
-				position: relative;
-				top: auto !important;
-			}
-		}
-
-		.sticky-panel__content {
-			transition: all 200ms ease-in-out;
-		}
-
-		.sticky-panel__spacer {
-			@include breakpoint-deprecated( "<960px" ) {
-				display: none;
-			}
-		}
-	}
 }
 
 .theme__sheet-action-bar-container {
@@ -406,11 +390,12 @@ $theme-sheet-content-max-width: 1462px;
 
 .theme__sheet-web-preview {
 	pointer-events: none;
-	position: relative;
 
 	@include breakpoint-deprecated( ">960px" ) {
-		height: calc(100vh - 128px);
+		height: calc(100vh - 64px);
 		pointer-events: all;
+		position: sticky;
+		top: 16px;
 
 		.theme-preview__frame-wrapper .theme-preview__frame {
 			height: 200%;


### PR DESCRIPTION
## Proposed Changes

As reported in p1682626513803089-slack-CRWCHQGUB, the fixed theme preview in the Theme Detail page blocks the logged-out footer. Note that only themes with style variations have the fixed theme preview.

![image](https://user-images.githubusercontent.com/797888/235858083-b208799f-ee19-4adf-891d-71dc00640a28.png)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-out Theme Showcase.
* Scroll to the bottom of the page and ensure that the theme preview doesn't block the logged-out footer.
* Optional: Check the logged-in Theme Showcase, and ensure that the fixed theme preview works as before.
* Optional: Check the mobile view, and ensure that the theme preview works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?