### PR TITLE
GitHub Integration: Only show in development and wpcalypso

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -179,7 +179,8 @@ class Hosting extends Component {
 		};
 
 		const getContent = () => {
-			const isGithubIntegrationEnabled = isAutomatticTeamMember( teams );
+			const isGithubIntegrationEnabled =
+				isEnabled( 'quake/github-integration-i1' ) && isAutomatticTeamMember( teams );
 			const WrapperComponent = isDisabled || isTransferring ? FeatureExample : Fragment;
 			const isStagingSiteEnabled = isEnabled( 'yolo/staging-sites-i1' );
 

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -180,7 +180,7 @@ class Hosting extends Component {
 
 		const getContent = () => {
 			const isGithubIntegrationEnabled =
-				isEnabled( 'quake/github-integration-i1' ) && isAutomatticTeamMember( teams );
+				isEnabled( 'github-integration-i1' ) && isAutomatticTeamMember( teams );
 			const WrapperComponent = isDisabled || isTransferring ? FeatureExample : Fragment;
 			const isStagingSiteEnabled = isEnabled( 'yolo/staging-sites-i1' );
 

--- a/config/development.json
+++ b/config/development.json
@@ -152,7 +152,7 @@
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,
-		"quake/github-integration-i1": true,
+		"github-integration-i1": true,
 		"reader": true,
 		"reader/comment-polling": false,
 		"reader/full-errors": true,

--- a/config/development.json
+++ b/config/development.json
@@ -152,6 +152,7 @@
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,
+		"quake/github-integration-i1": true,
 		"reader": true,
 		"reader/comment-polling": false,
 		"reader/full-errors": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -126,7 +126,7 @@
 		"pre-cancellation-modal": false,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
-		"quake/github-integration-i1": true,
+		"github-integration-i1": true,
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -126,6 +126,7 @@
 		"pre-cancellation-modal": false,
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
+		"quake/github-integration-i1": true,
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,


### PR DESCRIPTION
## Proposed Changes

Adds a `quake/github-integration-i1` feature flag so the GitHub integration only appears in development and wpcalypso environments.

It's confusing to have it appear in staging because it makes folks think the feature is available.

## Testing Instructions

1. Verify the "Deploy from GitHub" card still appears in your local environment.