### PR TITLE
Plans 2023: pass free-plan action overrides as prop + fix for domain upsell flow

### DIFF
--- a/client/my-sites/plan-features-2023-grid/components/actions.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/actions.tsx
@@ -2,7 +2,6 @@ import {
 	getPlanClass,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_P2_FREE,
-	isFreePlan,
 	is2023PricingGridActivePage,
 	TERM_BIENNIALLY,
 	TERM_TRIENNIALLY,
@@ -10,20 +9,17 @@ import {
 	TERM_ANNUALLY,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
-import { WpcomPlansUI } from '@automattic/data-stores';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
-import { useDispatch } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
 import classNames from 'classnames';
 import i18n, { localize, TranslateResult, useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getPlanBillPeriod } from 'calypso/state/plans/selectors';
-import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
+import type { PlanActionOverrides } from '../types';
 
 type PlanFeaturesActionsButtonProps = {
 	availableForPurchase: boolean;
@@ -46,6 +42,7 @@ type PlanFeaturesActionsButtonProps = {
 	isWpcomEnterpriseGridPlan: boolean;
 	isWooExpressPlusPlan?: boolean;
 	selectedSiteSlug: string | null;
+	planActionOverrides?: PlanActionOverrides;
 };
 
 const DummyDisabledButton = styled.div`
@@ -146,7 +143,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	currentSitePlanSlug,
 	buttonText,
 	forceDisplayButton,
-	selectedSiteSlug,
+	planActionOverrides,
 }: {
 	freePlan: boolean;
 	isPlaceholder: boolean;
@@ -161,10 +158,9 @@ const LoggedInPlansFeatureActionButton = ( {
 	buttonText?: string;
 	forceDisplayButton: boolean;
 	selectedSiteSlug: string | null;
+	planActionOverrides?: PlanActionOverrides;
 } ) => {
-	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
 	const translate = useTranslate();
-	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
 	const currentPlanBillPeriod = useSelector( ( state ) => {
 		return currentSitePlanSlug ? getPlanBillPeriod( state, currentSitePlanSlug ) : null;
 	} );
@@ -172,27 +168,15 @@ const LoggedInPlansFeatureActionButton = ( {
 		return planType ? getPlanBillPeriod( state, planType ) : null;
 	} );
 
-	const showDomainUpsellDialog = useCallback( () => {
-		setShowDomainUpsellDialog( true );
-	}, [ setShowDomainUpsellDialog ] );
-
 	if ( freePlan ) {
-		if ( currentSitePlanSlug && isFreePlan( currentSitePlanSlug ) ) {
-			if ( domainFromHomeUpsellFlow ) {
-				return (
-					<Button className={ classes } onClick={ showDomainUpsellDialog }>
-						{ translate( 'Keep my plan', { context: 'verb' } ) }
-					</Button>
-				);
-			}
-
+		if ( planActionOverrides?.loggedInFreePlan ) {
 			return (
 				<Button
 					className={ classes }
-					href={ `/add-ons/${ selectedSiteSlug }` }
-					disabled={ ! manageHref }
+					onClick={ planActionOverrides.loggedInFreePlan.callback }
+					disabled={ ! manageHref } // not sure why this is here
 				>
-					{ translate( 'Manage add-ons', { context: 'verb' } ) }
+					{ planActionOverrides.loggedInFreePlan.text }
 				</Button>
 			);
 		}
@@ -331,6 +315,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	isWpcomEnterpriseGridPlan = false,
 	isWooExpressPlusPlan = false,
 	selectedSiteSlug,
+	planActionOverrides,
 } ) => {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
@@ -432,6 +417,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			buttonText={ buttonText }
 			forceDisplayButton={ forceDisplayButton }
 			selectedSiteSlug={ selectedSiteSlug }
+			planActionOverrides={ planActionOverrides }
 		/>
 	);
 };

--- a/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
+++ b/client/my-sites/plan-features-2023-grid/components/plan-comparison-grid.tsx
@@ -36,6 +36,7 @@ import PlanFeatures2023GridBillingTimeframe from './billing-timeframe';
 import PlanFeatures2023GridHeaderPrice from './header-price';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import PopularBadge from './popular-badge';
+import type { PlanActionOverrides } from '../types';
 
 function DropdownIcon() {
 	return (
@@ -294,6 +295,7 @@ type PlanComparisonGridProps = {
 	selectedSiteSlug: string | null;
 	onUpgradeClick: ( properties: PlanProperties ) => void;
 	siteId?: number | null;
+	planActionOverrides?: PlanActionOverrides;
 };
 
 type PlanComparisonGridHeaderProps = {
@@ -310,6 +312,7 @@ type PlanComparisonGridHeaderProps = {
 	selectedSiteSlug: string | null;
 	onUpgradeClick: ( properties: PlanProperties ) => void;
 	siteId?: number | null;
+	planActionOverrides?: PlanActionOverrides;
 };
 
 type RestructuredFeatures = {
@@ -347,6 +350,7 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 	selectedSiteSlug,
 	isLargeCurrency,
 	onUpgradeClick,
+	planActionOverrides,
 } ) => {
 	const { planName, planConstantObj, availableForPurchase, current, ...planPropertiesObj } =
 		planProperties;
@@ -438,6 +442,7 @@ const PlanComparisonGridHeaderCell: React.FunctionComponent<
 				flowName={ flowName }
 				selectedSiteSlug={ selectedSiteSlug }
 				onUpgradeClick={ () => onUpgradeClick( planProperties ) }
+				planActionOverrides={ planActionOverrides }
 			/>
 		</Cell>
 	);
@@ -457,6 +462,7 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 	selectedSiteSlug,
 	onUpgradeClick,
 	siteId,
+	planActionOverrides,
 } ) => {
 	const allVisible = visiblePlansProperties.length === displayedPlansProperties.length;
 
@@ -490,6 +496,7 @@ const PlanComparisonGridHeader: React.FC< PlanComparisonGridHeaderProps > = ( {
 					onUpgradeClick={ onUpgradeClick }
 					isLaunchPage={ isLaunchPage }
 					isLargeCurrency={ isLargeCurrency }
+					planActionOverrides={ planActionOverrides }
 				/>
 			) ) }
 		</PlanRow>
@@ -675,6 +682,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 	selectedSiteSlug,
 	onUpgradeClick,
 	siteId,
+	planActionOverrides,
 } ) => {
 	const translate = useTranslate();
 	// Check to see if we have at least one Woo Express plan we're comparing.
@@ -894,6 +902,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 					selectedSiteSlug={ selectedSiteSlug }
 					onUpgradeClick={ onUpgradeClick }
 					siteId={ siteId }
+					planActionOverrides={ planActionOverrides }
 				/>
 				{ Object.values( featureGroupMap ).map( ( featureGroup: FeatureGroup ) => {
 					const features = featureGroup.get2023PricingGridSignupWpcomFeatures();
@@ -955,6 +964,7 @@ export const PlanComparisonGrid: React.FC< PlanComparisonGridProps > = ( {
 					selectedSiteSlug={ selectedSiteSlug }
 					onUpgradeClick={ onUpgradeClick }
 					siteId={ siteId }
+					planActionOverrides={ planActionOverrides }
 				/>
 			</Grid>
 

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -80,7 +80,6 @@ import useIsLargeCurrency from './hooks/use-is-large-currency';
 import { PlanProperties, TransformedFeatureObject } from './types';
 import { getStorageStringFromFeature } from './util';
 import type { PlanActionOverrides } from './types';
-import type { DomainSuggestion } from '@automattic/data-stores';
 import type { IAppState } from 'calypso/state/types';
 
 import './style.scss';
@@ -121,7 +120,6 @@ type PlanFeatures2023GridProps = {
 	currentSitePlanSlug?: string;
 	hidePlansFeatureComparison: boolean;
 	hideUnavailableFeatures: boolean;
-	replacePaidDomainWithFreeDomain: ( freeDomainSuggestion: DomainSuggestion ) => void;
 	planActionOverrides?: PlanActionOverrides;
 };
 

--- a/client/my-sites/plan-features-2023-grid/index.tsx
+++ b/client/my-sites/plan-features-2023-grid/index.tsx
@@ -79,6 +79,8 @@ import useHighlightLabel from './hooks/use-highlight-label';
 import useIsLargeCurrency from './hooks/use-is-large-currency';
 import { PlanProperties, TransformedFeatureObject } from './types';
 import { getStorageStringFromFeature } from './util';
+import type { PlanActionOverrides } from './types';
+import type { DomainSuggestion } from '@automattic/data-stores';
 import type { IAppState } from 'calypso/state/types';
 
 import './style.scss';
@@ -119,6 +121,8 @@ type PlanFeatures2023GridProps = {
 	currentSitePlanSlug?: string;
 	hidePlansFeatureComparison: boolean;
 	hideUnavailableFeatures: boolean;
+	replacePaidDomainWithFreeDomain: ( freeDomainSuggestion: DomainSuggestion ) => void;
+	planActionOverrides?: PlanActionOverrides;
 };
 
 type PlanFeatures2023GridConnectedProps = {
@@ -642,6 +646,7 @@ export class PlanFeatures2023Grid extends Component<
 			currentSitePlanSlug,
 			selectedSiteSlug,
 			translate,
+			planActionOverrides,
 		} = this.props;
 
 		return planPropertiesObj
@@ -690,6 +695,7 @@ export class PlanFeatures2023Grid extends Component<
 							currentSitePlanSlug={ currentSitePlanSlug }
 							selectedSiteSlug={ selectedSiteSlug }
 							buttonText={ buttonText }
+							planActionOverrides={ planActionOverrides }
 						/>
 					</Container>
 				);

--- a/client/my-sites/plan-features-2023-grid/types.ts
+++ b/client/my-sites/plan-features-2023-grid/types.ts
@@ -32,4 +32,12 @@ export type PlanProperties = {
 	availableForPurchase: boolean;
 	current?: boolean;
 	showMonthlyPrice: boolean;
+	planActionOverrides?: PlanActionOverrides;
 };
+
+export interface PlanActionOverrides {
+	loggedInFreePlan?: {
+		callback: () => void;
+		text: string;
+	};
+}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -78,8 +78,10 @@ import {
 import { FreePlanPaidDomainDialog } from './components/free-plan-paid-domain-dialog';
 import './style.scss';
 
-const OnboardingPricingGrid2023 = ( { plans, visiblePlans, ...props } ) => {
+const OnboardingPricingGrid2023 = ( props ) => {
 	const {
+		plans,
+		visiblePlans,
 		basePlansPath,
 		customerType,
 		domainName,
@@ -636,10 +638,10 @@ export class PlansFeaturesMain extends Component {
 	renderPlansGrid( plans, visiblePlans ) {
 		return this.props.is2023PricingGridVisible ? (
 			<OnboardingPricingGrid2023
+				{ ...this.props }
 				plans={ plans }
 				visiblePlans={ visiblePlans }
 				onUpgradeClick={ this.onUpgradeClick }
-				{ ...this.props }
 			/>
 		) : (
 			this.renderLegacyPricingGrid( plans, visiblePlans )

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -31,6 +31,9 @@ import {
 	is2023PricingGridActivePage,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import { WpcomPlansUI } from '@automattic/data-stores';
+import { useDispatch } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 import { hasTranslation } from '@wordpress/i18n';
 import warn from '@wordpress/warning';
 import classNames from 'classnames';
@@ -39,7 +42,7 @@ import { get } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import QueryPlans from 'calypso/components/data/query-plans';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
@@ -61,6 +64,7 @@ import { selectSiteId as selectHappychatSiteId } from 'calypso/state/help/action
 import { getProductDisplayCost } from 'calypso/state/products-list/selectors';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
+import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
@@ -73,6 +77,116 @@ import {
 } from 'calypso/state/sites/selectors';
 import { FreePlanPaidDomainDialog } from './components/free-plan-paid-domain-dialog';
 import './style.scss';
+
+const OnboardingPricingGrid2023 = ( { plans, visiblePlans, ...props } ) => {
+	const {
+		basePlansPath,
+		customerType,
+		domainName,
+		isInSignup,
+		isJetpack,
+		isLandingPage,
+		isLaunchPage,
+		flowName,
+		onUpgradeClick,
+		selectedFeature,
+		selectedPlan,
+		withDiscount,
+		discountEndDate,
+		redirectTo,
+		siteId,
+		plansWithScroll,
+		isReskinned,
+		isPlansInsideStepper,
+		intervalType,
+		planTypeSelectorProps,
+		hidePlansFeatureComparison,
+		replacePaidDomainWithFreeDomain,
+		sitePlanSlug,
+		translate,
+		siteSlug,
+	} = props;
+
+	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
+	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
+	const showDomainUpsellDialog = useCallback( () => {
+		setShowDomainUpsellDialog( true );
+	}, [ setShowDomainUpsellDialog ] );
+
+	let planActionOverrides;
+	if ( sitePlanSlug && isFreePlan( sitePlanSlug ) ) {
+		planActionOverrides = {
+			loggedInFreePlan: domainFromHomeUpsellFlow
+				? {
+						callback: showDomainUpsellDialog,
+						text: translate( 'Keep my plan', { context: 'verb' } ),
+				  }
+				: {
+						callback: () => {
+							page.redirect( `/add-ons/${ siteSlug }` );
+						},
+						text: translate( 'Manage add-ons', { context: 'verb' } ),
+				  },
+		};
+	}
+
+	const asyncProps = {
+		basePlansPath,
+		domainName,
+		isInSignup,
+		isLandingPage,
+		isLaunchPage,
+		onUpgradeClick,
+		plans,
+		flowName,
+		redirectTo,
+		visiblePlans,
+		selectedFeature,
+		selectedPlan,
+		withDiscount,
+		discountEndDate,
+		withScroll: plansWithScroll,
+		popularPlanSpec: getPopularPlanSpec( {
+			flowName,
+			customerType,
+			isJetpack,
+			availablePlans: visiblePlans,
+		} ),
+		siteId,
+		isReskinned,
+		isPlansInsideStepper,
+		intervalType,
+		hidePlansFeatureComparison,
+		replacePaidDomainWithFreeDomain,
+		currentSitePlanSlug: sitePlanSlug,
+		planActionOverrides,
+	};
+
+	const asyncPlanFeatures2023Grid = (
+		<AsyncLoad
+			require="calypso/my-sites/plan-features-2023-grid"
+			{ ...asyncProps }
+			planTypeSelectorProps={ planTypeSelectorProps }
+		/>
+	);
+
+	return (
+		<div
+			className={ classNames(
+				'plans-features-main__group',
+				'is-wpcom',
+				`is-customer-${ customerType }`,
+				'is-2023-pricing-grid',
+				{
+					'is-scrollable': plansWithScroll,
+				}
+			) }
+			data-e2e-plans="wpcom"
+		>
+			{ asyncPlanFeatures2023Grid }
+		</div>
+	);
+};
 
 export class PlansFeaturesMain extends Component {
 	state = {
@@ -148,88 +262,6 @@ export class PlansFeaturesMain extends Component {
 			/>
 		);
 	};
-
-	render2023OnboardingPricingGrid( plans, visiblePlans ) {
-		const {
-			basePlansPath,
-			customerType,
-			domainName,
-			isInSignup,
-			isJetpack,
-			isLandingPage,
-			isLaunchPage,
-			flowName,
-			selectedFeature,
-			selectedPlan,
-			withDiscount,
-			discountEndDate,
-			redirectTo,
-			siteId,
-			plansWithScroll,
-			isReskinned,
-			isPlansInsideStepper,
-			intervalType,
-			planTypeSelectorProps,
-			hidePlansFeatureComparison,
-			replacePaidDomainWithFreeDomain,
-			sitePlanSlug,
-		} = this.props;
-
-		const asyncProps = {
-			basePlansPath,
-			domainName,
-			isInSignup,
-			isLandingPage,
-			isLaunchPage,
-			onUpgradeClick: this.onUpgradeClick,
-			plans,
-			flowName,
-			redirectTo,
-			visiblePlans,
-			selectedFeature,
-			selectedPlan,
-			withDiscount,
-			discountEndDate,
-			withScroll: plansWithScroll,
-			popularPlanSpec: getPopularPlanSpec( {
-				flowName,
-				customerType,
-				isJetpack,
-				availablePlans: visiblePlans,
-			} ),
-			siteId,
-			isReskinned,
-			isPlansInsideStepper,
-			intervalType,
-			hidePlansFeatureComparison,
-			replacePaidDomainWithFreeDomain,
-			currentSitePlanSlug: sitePlanSlug,
-		};
-		const asyncPlanFeatures2023Grid = (
-			<AsyncLoad
-				require="calypso/my-sites/plan-features-2023-grid"
-				{ ...asyncProps }
-				planTypeSelectorProps={ planTypeSelectorProps }
-			/>
-		);
-
-		return (
-			<div
-				className={ classNames(
-					'plans-features-main__group',
-					'is-wpcom',
-					`is-customer-${ customerType }`,
-					'is-2023-pricing-grid',
-					{
-						'is-scrollable': plansWithScroll,
-					}
-				) }
-				data-e2e-plans="wpcom"
-			>
-				{ asyncPlanFeatures2023Grid }
-			</div>
-		);
-	}
 
 	// TODO:
 	// These legacy components should also be loaded in async.
@@ -602,9 +634,11 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	renderPlansGrid( plans, visiblePlans ) {
-		return this.props.is2023PricingGridVisible
-			? this.render2023OnboardingPricingGrid( plans, visiblePlans )
-			: this.renderLegacyPricingGrid( plans, visiblePlans );
+		return this.props.is2023PricingGridVisible ? (
+			<OnboardingPricingGrid2023 plans={ plans } visiblePlans={ visiblePlans } { ...this.props } />
+		) : (
+			this.renderLegacyPricingGrid( plans, visiblePlans )
+		);
 	}
 
 	render() {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -635,7 +635,12 @@ export class PlansFeaturesMain extends Component {
 
 	renderPlansGrid( plans, visiblePlans ) {
 		return this.props.is2023PricingGridVisible ? (
-			<OnboardingPricingGrid2023 plans={ plans } visiblePlans={ visiblePlans } { ...this.props } />
+			<OnboardingPricingGrid2023
+				plans={ plans }
+				visiblePlans={ visiblePlans }
+				onUpgradeClick={ this.onUpgradeClick }
+				{ ...this.props }
+			/>
 		) : (
 			this.renderLegacyPricingGrid( plans, visiblePlans )
 		);

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -42,6 +42,7 @@ import { getPlanSlug } from 'calypso/state/plans/selectors';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
@@ -349,6 +350,7 @@ class Plans extends Component {
 			isDomainUpsellSuggested,
 			isFreePlan,
 			currentPlanIntervalType,
+			domainFromHomeUpsellFlow,
 		} = this.props;
 
 		if ( ! selectedSite || this.isInvalidPlanInterval() || ! currentPlan ) {
@@ -398,10 +400,17 @@ class Plans extends Component {
 				<QueryContactDetailsCache />
 				<QueryPlans />
 				<TrackComponentView eventName="calypso_plans_view" />
-				{ isDomainUpsell && <DomainUpsellDialog domain={ selectedSite.slug } /> }
+				{ ( isDomainUpsell || domainFromHomeUpsellFlow ) && (
+					<DomainUpsellDialog domain={ selectedSite.slug } />
+				) }
 				{ canAccessPlans && (
 					<div>
-						{ ! isDomainAndPlanPackageFlow && <PlansHeader subHeaderText={ subHeaderText } /> }
+						{ ! isDomainAndPlanPackageFlow && (
+							<PlansHeader
+								domainFromHomeUpsellFlow={ domainFromHomeUpsellFlow }
+								subHeaderText={ subHeaderText }
+							/>
+						) }
 						{ isDomainAndPlanPackageFlow && (
 							<>
 								<div className="plans__header">
@@ -471,6 +480,7 @@ const ConnectedPlans = connect( ( state, props ) => {
 			!! getCurrentQueryArguments( state )?.domain,
 		isDomainUpsellSuggested: getCurrentQueryArguments( state )?.domain === 'true',
 		isFreePlan: isFreePlanProduct( currentPlan ),
+		domainFromHomeUpsellFlow: getDomainFromHomeUpsellInQuery( state ),
 	};
 } )( withCartKey( withShoppingCart( localize( withTrackingTool( 'HotJar' )( Plans ) ) ) ) );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76442

## Proposed Changes

Tackles one of the TODOs in https://github.com/Automattic/wp-calypso/pull/76442 -> https://github.com/Automattic/wp-calypso/pull/76442/files#r1182881397

- Add a bare provision for overriding some of the actions in the grid (which can be extended for overriding more actions if need be). This is done via a `PlanActionOverrides` optional prop.
- Moves the consuming end of the plans 2023 grid into a rough functional component inside `PlanFeaturesMain`. It's a minimal change to just get the wheels in motion. Something to be typed and extracted into its own file at a later time.
- Fixes the domain upsell dialog that's triggered via the `get_domain` query arg. This appears to have been broken for some time (or otherwise not cleaned up if for some reason it was decided as obsolete/unused). 🤔 

### Media

**No plan action override (paid site):**

<img width="500" alt="Screenshot 2023-05-03 at 2 37 07 PM" src="https://user-images.githubusercontent.com/1705499/235905571-c18453db-81d1-465c-be22-8508a41b6e2c.png">

**Free plan action override (free site):**

<img width="500" alt="Screenshot 2023-05-03 at 2 36 04 PM" src="https://user-images.githubusercontent.com/1705499/235905604-49807a8e-4650-49fe-b69f-60f10208975a.png">


**Free plan action override and domain upsell (`get_domain` query arg):**

<img width="500" alt="Screenshot 2023-05-03 at 2 36 36 PM" src="https://user-images.githubusercontent.com/1705499/235905620-d91bbf23-d3e5-4705-a565-2a41010f66dc.png">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/[site]` and `/start/plans` with a free plan and ensure the free plan action renders as expected
* For `/plans/[site]`, the free plan button should be:
    * `contact support` when current site is not on a free plan
    * `manage add-ons` when current site is on free plan -> should redirect to add-ons section
    * `keep my plan` when `?get_domain=foo.bar` query arg is added and current site is on free plan -> clicking on "keep my plan" should trigger the modal shown above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
