### PR TITLE
Iterated on visual changes for blog-onboarding

### DIFF
--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -378,3 +378,11 @@ body.is-section-signup.is-white-signup {
 		}
 	}
 }
+
+.search-component .search-filters__dropdown-filters button {
+	background-color: transparent;
+	border-color: transparent;
+	border-radius: 0;
+	border-right: none;
+	border-left: none;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -436,7 +436,10 @@ export function getEnhancedTasks(
 								  } );
 							window.location.assign( destinationUrl );
 						},
-						badgeText: domainUpsellCompleted ? '' : translate( 'Upgrade plan' ),
+						badgeText:
+							domainUpsellCompleted || isStartWritingFlow( flow || null )
+								? ''
+								: translate( 'Upgrade plan' ),
 					};
 					break;
 				case 'verify_email':


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2202-gh-Automattic/dotcom-forge

## Proposed Changes

* Removed Upgrade Plan label from writing flow:

<img width="453" alt="image" src="https://user-images.githubusercontent.com/1044309/235923287-ea03c740-2ae7-4aa5-9dd6-f118d4b25a37.png">


* Removed unnecessary border on filter button:

![image](https://user-images.githubusercontent.com/1044309/235922347-694b5281-5ea7-42e4-8bfa-55e307e764f1.png)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the filter button border works as expected for the choose-domain option in the writing flow:

<img width="892" alt="image" src="https://user-images.githubusercontent.com/1044309/235922858-3cc31f76-c981-4487-b1a4-5fd40ac44293.png">


* Ensure the filter button border works as expected for domain upsell (from the left panel):

<img width="993" alt="image" src="https://user-images.githubusercontent.com/1044309/235922631-b38d613d-7e7c-45da-a529-86fe81638fe7.png">

* Open the domain upsell without the extra parameter (domainAndPlanPackage=true) and make sure the border still appears in the filter button:

<img width="976" alt="image" src="https://user-images.githubusercontent.com/1044309/235923901-6eab0f02-4170-4c5a-aad5-a1b78fda0b4b.png">
