### PR TITLE
Staging Sites: Remove feature flag

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -182,7 +182,6 @@ class Hosting extends Component {
 			const isGithubIntegrationEnabled =
 				isEnabled( 'github-integration-i1' ) && isAutomatticTeamMember( teams );
 			const WrapperComponent = isDisabled || isTransferring ? FeatureExample : Fragment;
-			const isStagingSiteEnabled = isEnabled( 'yolo/staging-sites-i1' );
 
 			return (
 				<>
@@ -197,7 +196,7 @@ class Hosting extends Component {
 							<Column type="main" className="hosting__main-layout-col">
 								<SFTPCard disabled={ isDisabled } />
 								<PhpMyAdminCard disabled={ isDisabled } />
-								{ isStagingSiteEnabled && ! isWpcomStagingSite && hasStagingSitesFeature && (
+								{ ! isWpcomStagingSite && hasStagingSitesFeature && (
 									<StagingSiteCard disabled={ isDisabled } />
 								) }
 								{ isWpcomStagingSite && siteId && (

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -265,7 +265,6 @@ function useSubmenuItems( site: SiteExcerptData ) {
 	const { __ } = useI18n();
 	const siteSlug = site.slug;
 	const isWpcomStagingSite = isStagingSite( site );
-	const isStagingSiteEnabled = isEnabled( 'yolo/staging-sites-i1' );
 	const hasStagingSitesFeature = useSafeSiteHasFeature( site.ID, FEATURE_SITE_STAGING_SITES );
 
 	useQueryReaderTeams();
@@ -284,7 +283,7 @@ function useSubmenuItems( site: SiteExcerptData ) {
 				sectionName: 'database_access',
 			},
 			{
-				condition: ! isWpcomStagingSite && isStagingSiteEnabled && hasStagingSitesFeature,
+				condition: ! isWpcomStagingSite && hasStagingSitesFeature,
 				label: __( 'Staging site' ),
 				href: `/hosting-config/${ siteSlug }#staging-site`,
 				sectionName: 'staging_site',
@@ -312,7 +311,7 @@ function useSubmenuItems( site: SiteExcerptData ) {
 				sectionName: 'logs',
 			},
 		].filter( ( { condition } ) => condition ?? true );
-	}, [ __, siteSlug, isWpcomStagingSite, isStagingSiteEnabled, hasStagingSitesFeature, isA12n ] );
+	}, [ __, siteSlug, isWpcomStagingSite, hasStagingSitesFeature, isA12n ] );
 }
 
 function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps ) {

--- a/config/development.json
+++ b/config/development.json
@@ -204,7 +204,6 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
-		"yolo/staging-sites-i1": true,
 		"newsletter/stats": true,
 		"newsletter/paid-subscribers": true,
 		"woa-logging": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -148,7 +148,6 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/staging-sites-i1": true,
 		"newsletter/stats": true,
 		"woa-logging": true,
 		"woa-logging-moved": true

--- a/config/production.json
+++ b/config/production.json
@@ -170,7 +170,6 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/staging-sites-i1": true,
 		"newsletter/stats": false,
 		"woa-logging": true,
 		"woa-logging-moved": true

--- a/config/stage.json
+++ b/config/stage.json
@@ -165,7 +165,6 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/staging-sites-i1": true,
 		"newsletter/stats": false,
 		"woa-logging": true,
 		"woa-logging-moved": true

--- a/config/test.json
+++ b/config/test.json
@@ -108,7 +108,6 @@
 		"upgrades/wpcom-monthly-plans": true,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
-		"yolo/staging-sites-i1": true,
 		"woa-logging": true,
 		"woa-logging-moved": true
 	}

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -177,7 +177,6 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/staging-sites-i1": true,
 		"woa-logging": true,
 		"woa-logging-moved": true
 	},


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2281

## Proposed Changes

Removes the `yolo/staging-sites-i1` feature flag now that the feature is launched.

## Testing Instructions

1. Navigate to the Hosting Configuration page and verify the Staging Sites card still appears.
2. Navigate to the Sites page and verify the Staging Sites ellipsis menu item still appears.