### PR TITLE
Sites: Only show the 'Deploy from GitHub' menu item when enabled

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -289,7 +289,7 @@ function useSubmenuItems( site: SiteExcerptData ) {
 				sectionName: 'staging_site',
 			},
 			{
-				condition: isA12n,
+				condition: isEnabled( 'github-integration-i1' ) && isA12n,
 				label: __( 'Deploy from GitHub' ),
 				href: `/hosting-config/${ siteSlug }#connect-github`,
 				sectionName: 'connect_github',


### PR DESCRIPTION
From https://github.com/Automattic/wp-calypso/pull/76533

## Proposed Changes

Only shows the 'Deploy from GitHub' item when the feature is enabled for the environment.

## Testing Instructions

1. Verify the "Deploy from GitHub" menu item still appears in your local environment.