### PR TITLE
Do not treat Atomic sites as Jetpack in useValidCheckoutBackUrl

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-valid-checkout-back-url.ts
@@ -24,7 +24,9 @@ const getAllowedHosts = ( siteSlug?: string ) => {
 const useValidCheckoutBackUrl = ( siteSlug: string | undefined ): string | undefined => {
 	const { checkoutBackUrl } = useSelector( getInitialQueryArguments ) ?? {};
 	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug as string | null ) );
-	const jetpackSite = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const jetpackSite = useSelector( ( state ) =>
+		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
+	);
 	return useMemo( () => {
 		if ( ! checkoutBackUrl ) {
 			// For akismet specific checkout, if navigated with direct link


### PR DESCRIPTION
## Proposed Changes

`useValidCheckoutBackUrl()` is a function used to override the logic in the `leaveCheckout()` function when you click the "Go Back" button in checkout's empty cart view. It is also used for the "X" close button in the masterbar in all of checkout. Its name suggests that it is used for all checkout close URLs but in fact it only is used to override the normal behavior for Jetpack sites (and more recently, Akismet).

It looks like during its implementation, Atomic sites were not ignored in its logic. Therefore, it treats Atomic sites as Jetpack and redirects them to the Jetpack pricing page. This bug appears to have been introduced in https://github.com/Automattic/wp-calypso/pull/75834

In this diff we ignore Atomic sites for that logic, treating them as simple sites for the purpose of the "Go Back" and "X" buttons.

<img width="610" alt="Screenshot 2023-05-03 at 10 03 35 AM" src="https://user-images.githubusercontent.com/2036909/235939362-c5245d41-287a-49f3-a749-53c15b0269c6.png">


## Testing Instructions

- Visit `/checkout` for an Atomic site with an empty cart.
- Verify that when you click the "Go Back" button or the "X" button you are redirected to the `/plans` page.