### PR TITLE
Domain Upsell: Use updateLaunchpadSettings from data-stores

### DIFF
--- a/client/landing/stepper/declarative-flow/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/domain-upsell.ts
@@ -1,12 +1,11 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
-import { OnboardSelect } from 'calypso/../packages/data-stores/src';
+import { OnboardSelect, updateLaunchpadSettings } from 'calypso/../packages/data-stores/src';
 import {
 	addPlanToCart,
 	addProductsToCart,
 	DOMAIN_UPSELL_FLOW,
 } from 'calypso/../packages/onboarding/src';
-import { updateLaunchpadSettings } from 'calypso/data/sites/use-launchpad';
 import { useQuery } from '../hooks/use-query';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { ONBOARD_STORE } from '../stores';

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -87,7 +87,7 @@ export const updateLaunchpadSettings = (
 				path: requestUrl,
 				apiNamespace: 'wpcom/v2',
 				method: 'PUT',
-				body: { settings },
+				body: settings,
 		  } )
 		: apiFetch( {
 				global: true,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/76470

### Time Estimate
Review: Short
Testing Short

### Summary
Use the updated version of updateLaunchpadSettings from `data-stores` for the domain upsell flow. Clicking on choose my domain later should complete the domain upsell task in the launchpad.

### Testing
1. Check out this branch and run `yarn` and `yarn start` if needed. 
2. Start a launchpad Free http://calypso.localhost:3000/setup/free/intro
3. Navigate to the Launchpad by completing onboarding
4. Ensure that clicking on domain upsell deferred still completes the domain upsell task