### PR TITLE
Start Writing Flow: Use Launchpad hook from data-stores

### DIFF
--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -1,9 +1,8 @@
-import { OnboardSelect } from '@automattic/data-stores';
+import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { START_WRITING_FLOW, addPlanToCart, addProductsToCart } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useSelector } from 'react-redux';
-import { updateLaunchpadSettings } from 'calypso/data/sites/use-launchpad';
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
 import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
 import {

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -93,6 +93,6 @@ export const updateLaunchpadSettings = (
 				global: true,
 				path: `/wpcom/v2${ requestUrl }`,
 				method: 'PUT',
-				data: { settings },
+				data: settings,
 		  } as APIFetchOptions );
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/76471

### Time Estimate
Review: Short
Testing Short

### Summary
Use the updated version of updateLaunchpadSettings from `data-stores` for the start writing flow

### Testing
WIP