### PR TITLE
Themes: Redirect Woo themes to Thank You page

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -156,7 +156,7 @@
 		"subscription-management/sites-list-controls": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/display-thank-you-page": true,
-		"themes/display-thank-you-page-for-woo": false,
+		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -151,7 +151,7 @@
 		"subscription-management/sites-list-controls": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/display-thank-you-page": true,
-		"themes/display-thank-you-page-for-woo": false,
+		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,
 		"themes/subscription-purchases": false,
 		"themes/theme-switch-persist-template": false,


### PR DESCRIPTION
Updates the production flag that redirects the installation of Woo themes to the Marketplace Thank You page.

Related to 
- https://github.com/Automattic/wp-calypso/pull/76544

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Updates the production flag `themes/display-thank-you-page-for-woo` to `true` in production

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 The functionality was tested as part of https://github.com/Automattic/wp-calypso/pull/75887 so testing the update of the flag should be done directly in production. As part of this change, just make sure there are not unexpected errors with the following flow:
- Go to the themes page (/themes/:site) with a site that didn't have installed any Woo theme.
- Select a WooCommerce theme (e.g. `Tazza` or `Zaino`) and click on Activate
- A modal is displayed to replace or not the Home page. Continue with any of the options.
- You should be redirected to the WooCommerce on-boarding flow.
- Complete the flow.
- At the end of the flow, you should be redirected to the Marketplace Thank You Page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
