### PR TITLE
Woo Express: Memoize tasks list for post-upgrade screen

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/index.tsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
@@ -21,7 +22,10 @@ const TrialUpgradeConfirmation = () => {
 	const hasWCPay = useSelector(
 		( state ) => siteId && isPluginActive( state, siteId, 'woocommerce-payments' )
 	) as boolean;
-	const tasks = getConfirmationTasks( { translate, hasWCPay } );
+	const tasks = useMemo(
+		() => getConfirmationTasks( { translate, hasWCPay } ),
+		[ translate, hasWCPay ]
+	);
 
 	const taskActionUrlProps = {
 		siteName: selectedSite?.name ?? '',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75642

## Proposed Changes

* Follow up to #75642, memoize the tasks list for the post-upgrade screen for Essential/Performance plans to improve performance. Only recalculate when translate or hasWCPay changes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* On a Woo Express Trial site, upgrade to Essential or Performance and complete checkout.
* You'll be brought to this screen:

<img width="1097" alt="Screen Shot 2023-05-03 at 11 15 16 AM" src="https://user-images.githubusercontent.com/2124984/235960222-a3a6ea85-3d65-4c61-9932-b0119fe9e486.png">

* Ensure the tasks still show and link to the appropriate places, including the Payments task, which should link to the WC Payments page if coming from a country that supports it (like the US).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
