### PR TITLE
Staging Sites: Tweak card layouts and add more 'Learn more' links

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -18,6 +18,7 @@ import { useAddStagingSiteMutation } from 'calypso/my-sites/hosting/staging-site
 import { useCheckStagingSiteStatus } from 'calypso/my-sites/hosting/staging-site-card/use-check-staging-site-status';
 import { useHasValidQuotaQuery } from 'calypso/my-sites/hosting/staging-site-card/use-has-valid-quota';
 import { useStagingSite } from 'calypso/my-sites/hosting/staging-site-card/use-staging-site';
+import SitesStagingBadge from 'calypso/sites-dashboard/components/sites-staging-badge';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -56,6 +57,22 @@ const SiteInfo = styled.div( {
 	display: 'flex',
 	flexDirection: 'column',
 	marginLeft: 10,
+} );
+
+const SiteNameContainer = styled.div( {
+	display: 'flex',
+	alignItems: 'center',
+} );
+
+const SiteName = styled.a( {
+	fontWeight: 500,
+	marginInlineEnd: '8px',
+	'&:hover': {
+		textDecoration: 'underline',
+	},
+	'&, &:hover, &:visited': {
+		color: 'var( --studio-gray-100 )',
+	},
 } );
 
 export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId, translate } ) => {
@@ -209,7 +226,7 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 			<>
 				<p>
 					{ translate(
-						'A staging site is a test version of your website you can use to preview and troubleshoot changes before applying them to your production site. {{a}}Learn more{{/a}}.',
+						'A staging site lets you preview and troubleshoot changes before updating the production site. {{a}}Learn more{{/a}}.',
 						{
 							components: {
 								a: <InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />,
@@ -237,11 +254,28 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 	const getManageStagingSiteContent = () => {
 		return (
 			<>
-				<p>{ translate( 'Your staging site is available at:' ) }</p>
+				<p>
+					{ translate(
+						'Your staging site lets you preview and troubleshoot changes before updating the production site. {{a}}Learn more{{/a}}.',
+						{
+							components: {
+								a: <InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />,
+							},
+						}
+					) }
+				</p>
 				<SiteRow>
 					<SiteIcon siteId={ stagingSite.id } size={ 40 } />
 					<SiteInfo>
-						<div>{ stagingSite.name }</div>
+						<SiteNameContainer>
+							<SiteName
+								href={ `/hosting-config/${ urlToSlug( stagingSite.url ) }` }
+								title={ __( 'Visit Dashboard' ) }
+							>
+								{ stagingSite.name }
+							</SiteName>
+							<SitesStagingBadge>{ translate( 'Staging' ) }</SitesStagingBadge>
+						</SiteNameContainer>
 						<div>
 							<a href={ stagingSite.url }>{ stagingSite.url }</a>
 						</div>

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -226,7 +226,7 @@ export const StagingSiteCard = ( { currentUserId, disabled, siteId, siteOwnerId,
 			<>
 				<p>
 					{ translate(
-						'A staging site lets you preview and troubleshoot changes before updating the production site. {{a}}Learn more{{/a}}.',
+						'A staging site is a test version of your website you can use to preview and troubleshoot changes before applying them to your production site. {{a}}Learn more{{/a}}.',
 						{
 							components: {
 								a: <InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />,

--- a/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
@@ -1,10 +1,11 @@
 import { Button, Card, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
+import { localize } from 'i18n-calypso';
 import { useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
-import SiteIcon from 'calypso/blocks/site-icon';
 import CardHeading from 'calypso/components/card-heading';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Notice from 'calypso/components/notice';
 import { urlToSlug } from 'calypso/lib/url';
 import { LoadingPlaceholder } from 'calypso/my-sites/hosting/staging-site-card/loading-placeholder';
@@ -15,19 +16,6 @@ import {
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 
-const SiteRow = styled.div( {
-	display: 'flex',
-	alignItems: 'center',
-	marginBottom: 24,
-	'.site-icon': { flexShrink: 0 },
-} );
-
-const SiteInfo = styled.div( {
-	display: 'flex',
-	flexDirection: 'column',
-	marginLeft: 10,
-} );
-
 const ActionButtons = styled.div( {
 	display: 'flex',
 	gap: '1em',
@@ -36,9 +24,10 @@ const ActionButtons = styled.div( {
 type CardProps = {
 	disabled: boolean;
 	siteId: number;
+	translate: ( text: string, args?: Record< string, unknown > ) => string;
 };
 
-function StagingSiteProductionCard( { disabled, siteId }: CardProps ) {
+function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps ) {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	const [ loadingError, setLoadingError ] = useState( null );
@@ -66,16 +55,16 @@ function StagingSiteProductionCard( { disabled, siteId }: CardProps ) {
 	const getManageStagingSiteContent = ( productionSite: ProductionSite ) => {
 		return (
 			<>
-				<p>{ __( 'The production site is available at:' ) }</p>
-				<SiteRow>
-					<SiteIcon siteId={ productionSite.id } size={ 40 } />
-					<SiteInfo>
-						<div>{ productionSite.name }</div>
-						<div>
-							<a href={ productionSite.url }>{ productionSite.url }</a>
-						</div>
-					</SiteInfo>
-				</SiteRow>
+				<p>
+					{ translate(
+						'This staging site lets you preview and troubleshoot changes before updating the production site. {{a}}Learn more{{/a}}.',
+						{
+							components: {
+								a: <InlineSupportLink supportContext="hosting-staging-site" showIcon={ false } />,
+							},
+						}
+					) }
+				</p>
 				<ActionButtons>
 					<Button
 						primary
@@ -119,4 +108,4 @@ export default connect( ( state ) => {
 	return {
 		currentUserId,
 	};
-} )( StagingSiteProductionCard );
+} )( localize( StagingSiteProductionCard ) );

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -39,7 +39,6 @@ import {
 	isCustomDomain,
 	isNotAtomicJetpack,
 	isP2Site,
-	isStagingSite,
 } from '../utils';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
@@ -264,7 +263,6 @@ const SiteDropdownMenu = styled( DropdownMenu )( {
 function useSubmenuItems( site: SiteExcerptData ) {
 	const { __ } = useI18n();
 	const siteSlug = site.slug;
-	const isWpcomStagingSite = isStagingSite( site );
 	const hasStagingSitesFeature = useSafeSiteHasFeature( site.ID, FEATURE_SITE_STAGING_SITES );
 
 	useQueryReaderTeams();
@@ -283,7 +281,7 @@ function useSubmenuItems( site: SiteExcerptData ) {
 				sectionName: 'database_access',
 			},
 			{
-				condition: ! isWpcomStagingSite && hasStagingSitesFeature,
+				condition: hasStagingSitesFeature,
 				label: __( 'Staging site' ),
 				href: `/hosting-config/${ siteSlug }#staging-site`,
 				sectionName: 'staging_site',
@@ -311,7 +309,7 @@ function useSubmenuItems( site: SiteExcerptData ) {
 				sectionName: 'logs',
 			},
 		].filter( ( { condition } ) => condition ?? true );
-	}, [ __, siteSlug, isWpcomStagingSite, hasStagingSitesFeature, isA12n ] );
+	}, [ __, siteSlug, hasStagingSitesFeature, isA12n ] );
 }
 
 function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2325
Fixes https://github.com/Automattic/dotcom-forge/issues/1964

## Proposed Changes

Tweaks the Staging Site card layouts and adds 'Learn more' to all states.

Also enables the 'Staging site' ellipsis menu item

### No staging site yet

<img width="770" alt="image" src="https://user-images.githubusercontent.com/36432/235965677-4ddded97-2722-4283-ae93-24b0eef5c3ef.png">

### Production site has staging site

<img width="760" alt="image" src="https://user-images.githubusercontent.com/36432/235964802-44883e39-8f09-492f-81f4-627593c07011.png">

### Staging site has production site

<img width="748" alt="image" src="https://user-images.githubusercontent.com/36432/235964863-91c61aad-d4e3-47af-91b8-8e8ac6ab1289.png">

## Testing Instructions

1. Create a new Business site and take it Atomic.
2. Navigate to the Hosting Configuration page.
3. Verify the 'No staging site' state appears as expected.
4. Click 'Add staging site'.
5. Verify the 'Production site has staging site' state appears as expected.
6. Click 'Manage staging site'.
7. Verify the 'Staging site has production site' state appears as expected.
8. Navigate to the Sites page.
9. Verify both sites have the 'Staging site' submenu link.