### PR TITLE
Subscription Manager: add "Paused" value in Email Frequency when no email subscription

### DIFF
--- a/client/landing/subscriptions/components/site-list/site-row.tsx
+++ b/client/landing/subscriptions/components/site-list/site-row.tsx
@@ -21,7 +21,7 @@ const useDeliveryFrequencyLabel = ( deliveryFrequencyValue: SiteSubscriptionDeli
 		[ translate ]
 	);
 
-	return deliveryFrequencyLabels[ deliveryFrequencyValue ];
+	return deliveryFrequencyLabels[ deliveryFrequencyValue ] || translate( 'Paused' );
 };
 
 export default function SiteRow( {

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -76,6 +76,14 @@ const useSiteSubscriptionsQuery = ( {
 								...subscription,
 								last_updated: new Date( subscription.last_updated ),
 								date_subscribed: new Date( subscription.date_subscribed ),
+								delivery_methods: {
+									...subscription.delivery_methods,
+									email: {
+										...subscription.delivery_methods.email,
+										post_delivery_frequency:
+											subscription.delivery_methods.email?.post_delivery_frequency ?? 'instantly',
+									},
+								},
 						  } ) )
 						: [],
 				};

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -76,14 +76,6 @@ const useSiteSubscriptionsQuery = ( {
 								...subscription,
 								last_updated: new Date( subscription.last_updated ),
 								date_subscribed: new Date( subscription.date_subscribed ),
-								delivery_methods: {
-									...subscription.delivery_methods,
-									email: {
-										...subscription.delivery_methods.email,
-										post_delivery_frequency:
-											subscription.delivery_methods.email?.post_delivery_frequency ?? 'instantly',
-									},
-								},
 						  } ) )
 						: [],
 				};


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/76397

## Proposed Changes

This change adds a "Paused" value to the "Email frequency" column on the Sites page on the new Subscription Manager:

<img width="1977" alt="Screenshot 2023-05-04 at 17 14 26" src="https://user-images.githubusercontent.com/3832570/236306816-2663443f-4e43-4890-b91e-b95e32876e78.png">

## Testing Instructions

1. Check out the PR.
2. Navigate to `client/server/pages/index.js` and temporarily add `return next();` to the line `833`:

![Markup on 2023-04-28 at 17:50:44](https://user-images.githubusercontent.com/25105483/235195033-4902bb9d-db57-43a4-b295-2d90feb6731f.png)

3. Build the app.
4. Log in to a test WordPress.com account that has some Site subscriptions.
5. Navigate to http://calypso.localhost:3000/subscriptions/sites.
6. You should see the column "Email frequency" with all its values.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?