### PR TITLE
Launchpad: Update api requests in sidebar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -6,7 +6,6 @@ import { useRef, useState } from '@wordpress/element';
 import { Icon, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import { useLaunchpadChecklist } from 'calypso/../packages/help-center/src/hooks/use-launchpad-checklist';
 import { StepNavigationLink } from 'calypso/../packages/onboarding/src';
 import Badge from 'calypso/components/badge';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
@@ -51,14 +50,16 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 	let isDomainSSLProcessing: boolean | null = false;
 	const translate = useTranslate();
 	const site = useSite();
+	const siteIntentOption = site?.options?.site_intent;
 	const clipboardButtonEl = useRef< HTMLButtonElement >( null );
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 
 	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles( site?.ID );
 
 	const {
-		data: { site_intent: siteIntentOption, checklist_statuses: checklistStatuses },
-	} = useLaunchpad( siteSlug );
+		data: { checklist: launchpadChecklist, checklist_statuses: checklistStatuses },
+		isFetchedAfterMount,
+	} = useLaunchpad( siteSlug, siteIntentOption );
 
 	const selectedDomain = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),
@@ -68,11 +69,6 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 	const showDomain =
 		! isStartWritingFlow( flow ) ||
 		( checklistStatuses?.domain_upsell_deferred === true && selectedDomain );
-
-	const {
-		data: { checklist: launchpadChecklist },
-		isFetchedAfterMount,
-	} = useLaunchpadChecklist( siteSlug, siteIntentOption );
 
 	const isEmailVerified = useSelector( isCurrentUserEmailVerified );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -57,7 +57,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goNext, goToStep, flow }: S
 	const { globalStylesInUse, shouldLimitGlobalStyles } = usePremiumGlobalStyles( site?.ID );
 
 	const {
-		data: { checklist: launchpadChecklist, checklist_statuses: checklistStatuses },
+		data: { checklist_statuses: checklistStatuses, checklist: launchpadChecklist },
 		isFetchedAfterMount,
 	} = useLaunchpad( siteSlug, siteIntentOption );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -34,7 +34,7 @@ import type { SiteDetails } from '@automattic/data-stores';
  * generated in the REST API
  */
 export function getEnhancedTasks(
-	tasks: Task[] | null,
+	tasks: Task[] | null | undefined,
 	siteSlug: string | null,
 	site: SiteDetails | null,
 	submit: NavigationControls[ 'submit' ],

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import config from '@automattic/calypso-config';
-import { Site, useLaunchpad } from '@automattic/data-stores';
+import { Site } from '@automattic/data-stores';
 import { screen } from '@testing-library/react';
 import { useDispatch } from '@wordpress/data';
 import nock from 'nock';
@@ -26,16 +26,10 @@ jest.mock( 'calypso/state/sites/hooks/use-premium-global-styles', () => ( {
 
 jest.mock( '@automattic/data-stores', () => ( {
 	...jest.requireActual( '@automattic/data-stores' ),
-	useLaunchpad: jest.fn().mockReturnValue( {
-		data: { site_intent: 'build' },
-	} ),
-} ) );
-
-jest.mock( 'calypso/../packages/help-center/src/hooks/use-launchpad-checklist', () => ( {
-	useLaunchpadChecklist: ( siteSlug, siteIntentOption ) => {
+	useLaunchpad: ( siteSlug, siteIntentOption ) => {
 		let checklist = [
 			{ id: 'foo_task', completed: false, disabled: true, title: 'Foo Task' },
-			{ id: 'foo_task_1', completed: true, disabled: true, title: 'Foo Task' },
+			{ id: 'foo_task_1', completed: true, disabled: true, title: 'Foo Task 1' },
 		];
 
 		if ( siteIntentOption === 'free' ) {
@@ -46,8 +40,23 @@ jest.mock( 'calypso/../packages/help-center/src/hooks/use-launchpad-checklist', 
 			];
 		}
 
+		if ( siteIntentOption === 'newsletter' ) {
+			checklist = [
+				{
+					id: 'newsletter_setup',
+					completed: false,
+					disabled: true,
+					title: 'Personalize newsletter',
+				},
+				{ id: 'foo_task_1', completed: true, disabled: true, title: 'Foo Task 1' },
+			];
+		}
+
 		return {
-			data: { checklist },
+			data: {
+				site_intent: siteIntentOption,
+				checklist,
+			},
 			isFetchedAfterMount: true,
 		};
 	},
@@ -348,16 +357,10 @@ describe( 'Sidebar', () => {
 			it( 'displays the upgrade plan badge on the "Choose a domain" task for free flow', () => {
 				const freeFlowProps = { ...props, flow: 'free' };
 
-				// Change the useLaunchpad hook to return a free site.
-				( useLaunchpad as jest.Mock ).mockReturnValueOnce( {
-					data: {
-						site_intent: 'free',
-					},
-				} );
-
 				const siteDetails = buildSiteDetails( {
 					options: {
 						...defaultSiteDetails.options,
+						site_intent: 'free',
 					},
 					plan: {
 						is_free: true,
@@ -377,16 +380,10 @@ describe( 'Sidebar', () => {
 			it( 'does not display the upgrade plan badge on the "Choose a domain" task for free flow', () => {
 				const freeFlowProps = { ...props, flow: 'free' };
 
-				// Change the useLaunchpad hook to return a free site.
-				( useLaunchpad as jest.Mock ).mockReturnValueOnce( {
-					data: {
-						site_intent: 'free',
-					},
-				} );
-
 				const siteDetails = buildSiteDetails( {
 					options: {
 						...defaultSiteDetails.options,
+						site_intent: 'free',
 					},
 					plan: {
 						is_free: false,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import { useLaunchpad } from '@automattic/data-stores';
 import { NEWSLETTER_FLOW, START_WRITING_FLOW } from '@automattic/onboarding';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
@@ -15,7 +14,14 @@ import { setStore } from 'calypso/state/redux-store';
 import StepContent from '../step-content';
 import { defaultSiteDetails } from './lib/fixtures';
 
-const mockSite = defaultSiteDetails;
+const mockSite = {
+	...defaultSiteDetails,
+	options: {
+		...defaultSiteDetails.options,
+		site_intent: 'newsletter',
+	},
+};
+
 const siteSlug = 'testlinkinbio.wordpress.com';
 
 const stepContentProps = {
@@ -26,13 +32,6 @@ const stepContentProps = {
 	goToStep: () => {},
 	/* eslint-enable @typescript-eslint/no-empty-function */
 };
-
-jest.mock( '@automattic/data-stores', () => ( {
-	...jest.requireActual( '@automattic/data-stores' ),
-	useLaunchpad: jest.fn().mockReturnValue( {
-		data: { site_intent: 'newsletter' },
-	} ),
-} ) );
 
 jest.mock( 'calypso/landing/stepper/hooks/use-site', () => ( {
 	useSite: () => ( {
@@ -50,8 +49,9 @@ jest.mock( 'react-router-dom', () => ( {
 	} ) ),
 } ) );
 
-jest.mock( 'calypso/../packages/help-center/src/hooks/use-launchpad-checklist', () => ( {
-	useLaunchpadChecklist: ( siteSlug, siteIntentOption ) => {
+jest.mock( '@automattic/data-stores', () => ( {
+	...jest.requireActual( '@automattic/data-stores' ),
+	useLaunchpad: ( siteSlug, siteIntentOption ) => {
 		let checklist = [
 			{
 				id: 'setup_newsletter',
@@ -101,7 +101,10 @@ jest.mock( 'calypso/../packages/help-center/src/hooks/use-launchpad-checklist', 
 		}
 
 		return {
-			data: { checklist },
+			data: {
+				site_intent: siteIntentOption,
+				checklist,
+			},
 			isFetchedAfterMount: true,
 		};
 	},
@@ -220,12 +223,18 @@ describe( 'StepContent', () => {
 		} );
 
 		it( 'renders correct sidebar tasks', () => {
-			// Change the useLaunchpad hook to return a free site.
-			( useLaunchpad as jest.Mock ).mockReturnValueOnce( {
-				data: {
+			const mockStartWritingSite = {
+				...mockSite,
+				options: {
+					...mockSite.options,
 					site_intent: 'start-writing',
 				},
-			} );
+			};
+			jest.mock( 'calypso/landing/stepper/hooks/use-site', () => ( {
+				useSite: () => ( {
+					site: mockStartWritingSite,
+				} ),
+			} ) );
 			renderStepContent( false, START_WRITING_FLOW );
 
 			expect( screen.getByText( 'Write your first post' ) ).toBeInTheDocument();


### PR DESCRIPTION
### Proposed Changes

Resolves: https://github.com/Automattic/wp-calypso/issues/76469

We're consolidating all front end code to use shared methods/hooks from data-stores to fetch Launchpad data and checklists. This contributes to that effort by removing the temporary useLaunchpadChecklist hook from launchpad/index.tsx.

### Testing Instructions

This is a refactor, and behavior of Launchpad should continue to be the exact same as before. So we're effectively testing to ensure there are no regressive breakages. 

1. Checkout this branch and run yarn and yarn start. You no longer need to sandbox any Jetpack branches.
2. Create a Launchpad enabled site Here are urls to start various site types for convenience: 
   - http://calypso.localhost:3000/setup/free/intro
   - http://calypso.localhost:3000/setup/newsletter/intro
   - http://calypso.localhost:3000/setup/link-in-bio/intro
   - http://calypso.localhost:3000/start (for write/build)
3. Proceed to Launchpad. Complete various tasks and confirm all task statuses update as expected. 
4. Copy the launchpad url and launch the site. You should end up on My Home. Re-enter the launchpad url to try to load launchpad, and confirm you are redirected back to My Home. 
5. Consider testing one extra flow from step 3. 
6. Run unit tests with `yarn run test-client client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/` and confirm all tests pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)

NA Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
NA For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
