### PR TITLE
Updated strategy to close sidebar on first editor load

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/redirect-onboarding-user-after-publishing-post.js
@@ -14,7 +14,17 @@ export function redirectOnboardingUserAfterPublishingPost() {
 	const siteOrigin = getQueryArg( window.location.search, 'origin' );
 	const siteSlug = window.location.hostname;
 
-	dispatch( 'core/edit-post' ).closeGeneralSidebar();
+	const unsubscribeSidebar = subscribe( () => {
+		const isComplementaryAreaVisible = select( 'core/preferences' ).get(
+			'core/edit-post',
+			'isComplementaryAreaVisible'
+		);
+
+		if ( isComplementaryAreaVisible ) {
+			dispatch( 'core/edit-post' ).closeGeneralSidebar();
+			unsubscribeSidebar();
+		}
+	} );
 
 	const unsubscribe = subscribe( () => {
 		const isSavingPost = select( 'core/editor' ).isSavingPost();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2205-gh-Automattic/dotcom-forge

## Proposed Changes

* Only close the editor after it opens

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Important**: the issue is only reproduceble with new sites

* Apply this branch on your local Calypso
* Make sure `widgets.wp.com` is sandboxed.
* Follow the [wpcom-block-editor sync flow](https://github.com/Automattic/wp-calypso/tree/trunk/apps/wpcom-block-editor#dev-workflow). In summary: 
  - cd apps/wpcom-block-editor/src 
  - yarn dev --sync

* Using a new user OR a user without any site, start the flow with: [https://wordpress.com/setup/start-writing](https://wordpress.com/setup/start-writing). 
* You should see the sidebar closed

* Run test with this command: `yarn run jest apps/wpcom-block-editor/src/wpcom/features/test/redirect-onboarding-user-after-publishing-post.test.js`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?