### PR TITLE
Import focused flow: Skip preview step if it comes from move to wpcom plugin

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
@@ -1,14 +1,18 @@
-import React from 'react';
+import { useSelect } from '@wordpress/data';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { ReadyPreviewStep } from 'calypso/blocks/import/ready';
 import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { ImportWrapper } from '../import';
 import { BASE_ROUTE } from '../import/config';
 import { getFinalImporterUrl } from '../import/helper';
+import type { OnboardSelect } from '@automattic/data-stores';
+
 import './style.scss';
 
 const ImportReadyPreview: Step = function ImportStep( props ) {
@@ -17,14 +21,23 @@ const ImportReadyPreview: Step = function ImportStep( props ) {
 	const site = useSite();
 	const isAtomicSite = !! site?.options?.is_automated_transfer;
 	const urlData = useSelector( getUrlData );
+	const isMigrateFromWp = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIsMigrateFromWp(),
+		[]
+	);
 
 	/**
 	 ↓ Effects
 	 */
-	if ( ! urlData ) {
-		goToHomeStep();
-		return null;
-	}
+	// redirect to home step if urlData is not available
+	useEffect( () => {
+		! urlData && goToHomeStep();
+	}, [ urlData, navigation ] );
+
+	// redirect directly to importer page if it comes from move to wpcom plugin
+	useEffect( () => {
+		urlData && isMigrateFromWp && goToImporterPage();
+	}, [ urlData, isMigrateFromWp ] );
 
 	/**
 	 ↓ Methods
@@ -48,6 +61,10 @@ const ImportReadyPreview: Step = function ImportStep( props ) {
 	/**
 	 ↓ Renders
 	 */
+	if ( ! urlData ) {
+		return null;
+	}
+
 	return (
 		<ImportWrapper { ...props }>
 			<ReadyPreviewStep


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #76217

## Proposed Changes

* Skip the preview step if it comes from the "Move to WordPress.com" plugin

## Testing Instructions

* Create a `jurassic.ninja` website with the `Move to WordPress.com` plugin installed
* Press the `Get started` button
* Establish Jetpack connection
* Check if you ended up with Import type chooser screen

Before this change, it was a `Preview` screen and then an `Import type chooser`

<img width="1100" alt="Screenshot 2023-05-03 at 22 39 50" src="https://user-images.githubusercontent.com/1241413/236045020-b215da04-2a2e-4f76-a3bf-8e455169e7da.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
