### PR TITLE
Blog onboarding: Updated plans page using 2023 model

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -1,8 +1,22 @@
 // import { subscribeIsDesktop } from '@automattic/viewport';
-import { getPlan, PLAN_FREE, is2023PricingGridActivePage } from '@automattic/calypso-products';
+import {
+	getPlan,
+	PLAN_FREE,
+	is2023PricingGridActivePage,
+	TYPE_FREE,
+	TYPE_PERSONAL,
+	TYPE_PREMIUM,
+	TYPE_BUSINESS,
+} from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
-import { DOMAIN_UPSELL_FLOW, isLinkInBioFlow, isNewsletterFlow } from '@automattic/onboarding';
+import {
+	DOMAIN_UPSELL_FLOW,
+	START_WRITING_FLOW,
+	isLinkInBioFlow,
+	isNewsletterFlow,
+	isStartWritingFlow,
+} from '@automattic/onboarding';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -28,6 +42,15 @@ interface Props {
 	plansLoaded: boolean;
 }
 
+function getPlanTypes( flowName: string | null ) {
+	switch ( flowName ) {
+		case START_WRITING_FLOW:
+			return [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS ];
+		default:
+			return undefined;
+	}
+}
+
 const PlansWrapper: React.FC< Props > = ( props ) => {
 	const { hideFreePlan, domainCartItem } = useSelect( ( select ) => {
 		return {
@@ -46,7 +69,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	const isReskinned = true;
 	const customerType = 'personal';
 	const isInVerticalScrollingPlansExperiment = true;
-	const planTypes = undefined;
+	const planTypes = getPlanTypes( props?.flowName );
 	const headerText = __( 'Choose a plan' );
 	const isInSignup = props?.flowName === DOMAIN_UPSELL_FLOW ? false : true;
 
@@ -126,6 +149,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 					shouldShowPlansFeatureComparison={ isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
 					isReskinned={ isReskinned }
+					is2023PricingGridVisible={ isStartWritingFlow( props?.flowName ) ? true : false }
 				/>
 			</div>
 		);
@@ -137,7 +161,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			return __( 'Choose your flavor of WordPress' );
 		}
 
-		if ( isNewsletterFlow( flowName ) ) {
+		if ( isNewsletterFlow( flowName ) || isStartWritingFlow( flowName ) ) {
 			return __( `There's a plan for you.` );
 		}
 
@@ -154,6 +178,10 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		const freePlanButton = (
 			<Button onClick={ handleFreePlanButtonClick } className="is-borderless" />
 		);
+
+		if ( isStartWritingFlow( flowName ) ) {
+			return;
+		}
 
 		if ( isNewsletterFlow( flowName ) ) {
 			return hideFreePlan

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -195,3 +195,6 @@
 	}
 }
 
+.start-writing .plans-features-main__group.is-2023-pricing-grid {
+	width: 100%;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -195,6 +195,11 @@
 	}
 }
 
-.start-writing .plans-features-main__group.is-2023-pricing-grid {
-	width: 100%;
+.start-writing {
+	.plans-features-main__group.is-2023-pricing-grid {
+		width: 100%;
+	}
+	#step-header {
+		margin: 0;
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 2331-gh-Automattic/dotcom-forge

## Proposed Changes

* Updated plans page using 2023 model
* We're not offering E-commerce or Enterprise plans
* Title and subtitle matches Figma
* We're not changing the plans label for now, here's more context: p1683146387972099/1683140404.645399-slack-CKZHG0QCR

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using a new user OR a user with no site, start the flow with: https://wordpress.com/setup/start-writing.
* At the plans selection, you should see the new 2023 plans model:

<img width="1531" alt="image" src="https://user-images.githubusercontent.com/1044309/236045929-bae26d3b-c16c-43e9-9817-804da8643df4.png">

* Ensure we're as close [as we can from Figma](https://user-images.githubusercontent.com/140841/235970615-35ddb81b-a495-45b0-89af-985654e24786.png).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?