### PR TITLE
Launchpad: Remove unnecessary launchpad task definition attributes

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -238,7 +238,6 @@ export function getEnhancedTasks(
 					break;
 				case 'link_in_bio_launched':
 					taskData = {
-						isLaunchTask: true,
 						actionDispatch: () => {
 							if ( site?.ID ) {
 								const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE );
@@ -261,7 +260,6 @@ export function getEnhancedTasks(
 					break;
 				case 'site_launched':
 					taskData = {
-						isLaunchTask: true,
 						actionDispatch: () => {
 							if ( site?.ID ) {
 								const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts
@@ -138,7 +138,6 @@ export function getEnhancedTasks(
 					break;
 				case 'plan_selected':
 					taskData = {
-						title: translate( 'Choose a plan' ),
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							if ( displayGlobalStylesWarning ) {
@@ -184,7 +183,6 @@ export function getEnhancedTasks(
 					break;
 				case 'first_post_published':
 					taskData = {
-						title: translate( 'Write your first post' ),
 						disabled: mustVerifyEmailBeforePosting || isStartWritingFlow( flow || null ) || false,
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
@@ -347,7 +345,6 @@ export function getEnhancedTasks(
 					break;
 				case 'domain_upsell':
 					taskData = {
-						title: translate( 'Choose a domain' ),
 						disabled:
 							isStartWritingFlow( flow ) && ( domainUpsellCompleted || ! setupBlogCompleted ),
 						actionDispatch: () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -414,4 +414,15 @@ describe( 'Sidebar', () => {
 			} );
 		} );
 	} );
+
+	describe( 'when the list of tasks has a task related to site launch', () => {
+		describe( 'and the site launch task is not disabled', () => {
+			it( 'displays the launch title', () => {
+				renderSidebar( props );
+
+				const title = screen.getByRole( 'heading', { name: /You're ready to link and launch/i } );
+				expect( title ).toBeVisible();
+			} );
+		} );
+	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/sidebar.tsx
@@ -414,15 +414,4 @@ describe( 'Sidebar', () => {
 			} );
 		} );
 	} );
-
-	describe( 'when the list of tasks has a task related to site launch', () => {
-		describe( 'and the site launch task is not disabled', () => {
-			it( 'displays the launch title', () => {
-				renderSidebar( props );
-
-				const title = screen.getByRole( 'heading', { name: /You're ready to link and launch/i } );
-				expect( title ).toBeVisible();
-			} );
-		} );
-	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import { useLaunchpad } from '@automattic/data-stores';
 import { NEWSLETTER_FLOW, START_WRITING_FLOW } from '@automattic/onboarding';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
@@ -26,13 +25,6 @@ const stepContentProps = {
 	goToStep: () => {},
 	/* eslint-enable @typescript-eslint/no-empty-function */
 };
-
-jest.mock( '@automattic/data-stores', () => ( {
-	...jest.requireActual( '@automattic/data-stores' ),
-	useLaunchpad: jest.fn().mockReturnValue( {
-		data: { site_intent: 'newsletter' },
-	} ),
-} ) );
 
 jest.mock( 'calypso/landing/stepper/hooks/use-site', () => ( {
 	useSite: () => ( {
@@ -217,32 +209,6 @@ describe( 'StepContent', () => {
 			expect(
 				screen.getByText( 'Keep up the momentum with these final steps.' )
 			).toBeInTheDocument();
-		} );
-
-		it( 'renders correct sidebar tasks', () => {
-			// Change the useLaunchpad hook to return a free site.
-			( useLaunchpad as jest.Mock ).mockReturnValueOnce( {
-				data: {
-					site_intent: 'start-writing',
-				},
-			} );
-			renderStepContent( false, START_WRITING_FLOW );
-
-			expect( screen.getByText( 'Write your first post' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Set up your blog' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Choose a domain' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Choose a plan' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Launch your blog' ) ).toBeInTheDocument();
-		} );
-
-		it( 'renders correct status for each task', () => {
-			renderStepContent( false, START_WRITING_FLOW );
-
-			const setupBlogListItem = screen.getByText( 'Set up your blog' ).closest( 'li' );
-			expect( setupBlogListItem ).toHaveClass( 'pending' );
-
-			const choosePlanListItem = screen.getByText( 'Choose a plan' ).closest( 'li' );
-			expect( choosePlanListItem ).toHaveClass( 'pending' );
 		} );
 
 		it( 'renders web preview section', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -20,20 +20,6 @@ describe( 'Task Helpers', () => {
 				).toEqual( fakeTasks );
 			} );
 		} );
-		describe( 'when it is link_in_bio_launched task', () => {
-			it( 'then it receives launchtask property = true', () => {
-				const fakeTasks = [ buildTask( { id: 'link_in_bio_launched' } ) ];
-				const enhancedTasks = getEnhancedTasks(
-					fakeTasks,
-					'fake.wordpress.com',
-					null,
-					// eslint-disable-next-line @typescript-eslint/no-empty-function
-					() => {},
-					false
-				);
-				expect( enhancedTasks[ 0 ].isLaunchTask ).toEqual( true );
-			} );
-		} );
 		describe( 'when it is plan_selected task', () => {
 			it( 'marks plan_selected as incomplete if styles used but not part of plan', () => {
 				const fakeTasks = [ buildTask( { id: 'plan_selected', completed: true } ) ];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/76467

## Proposed Changes

* We should refactor tests to no longer search for the presence of hardcoded tasks titles.
* The client's only responsibility, at this point, is to ensure that the task list renders whatever is provided from the API
* This PR removes unnecessary start-writing specs and unnecessary task definition titles

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this branch and run `yarn` and `yarn start` if needed. 
2. Start any new launchpad enabled free site http://calypso.localhost:3000/setup/free/intro 
3. Navigate to the Launchpad by completing onboarding
4. Smoke test the tasks and ensure that they're still working

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
