### PR TITLE
Add Jetpack and Akismet zendesk chat widgets to checkout

### DIFF
--- a/client/components/jetpack/jetpack-presales-chat-widget/index.tsx
+++ b/client/components/jetpack/jetpack-presales-chat-widget/index.tsx
@@ -1,58 +1,38 @@
 import config from '@automattic/calypso-config';
-import { useQuery } from '@tanstack/react-query';
-import { addQueryArgs } from '@wordpress/url';
 import { getLocaleSlug } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import ZendeskChat from 'calypso/components/presales-zendesk-chat';
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
+import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { useJpPresalesAvailabilityQuery } from 'calypso/lib/jetpack/use-jp-presales-availability-query';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import type { ConfigData } from '@automattic/create-calypso-config';
 
-type PresalesChatResponse = {
-	is_available: boolean;
-};
-
-export type KeyType = 'jpAgency' | 'jpGeneral';
+export type KeyType = 'jpAgency' | 'jpCheckout' | 'jpAkismet' | 'jpGeneral';
 
 export interface ZendeskJetpackChatProps {
 	keyType: KeyType;
 }
 
-//the API is rate limited if we hit the limit we'll back off and retry
-async function fetchWithRetry(
-	url: string,
-	options: RequestInit,
-	retries = 3,
-	delay = 30000
-): Promise< Response > {
-	try {
-		const response = await fetch( url, options );
+// The akismet chat key is included here because the availability for Akismet presales is in the same group as Jetpack (jp_presales)
+function get_config_chat_key( keyType: KeyType ): keyof ConfigData {
+	const chatWidgetKeyMap = {
+		jpAgency: 'zendesk_presales_chat_key_jp_agency_dashboard',
+		jpCheckout: 'zendesk_presales_chat_key_jp_checkout',
+		jpAkismet: 'zendesk_presales_chat_key_akismet',
+		jpGeneral: 'zendesk_presales_chat_key',
+	};
 
-		if ( response.status === 429 && retries > 0 ) {
-			await new Promise( ( resolve ) => setTimeout( resolve, delay ) );
-			return await fetchWithRetry( url, options, retries - 1, delay * 2 );
-		}
-
-		return response;
-	} catch ( error ) {
-		if ( retries > 0 ) {
-			await new Promise( ( resolve ) => setTimeout( resolve, delay ) );
-			return await fetchWithRetry( url, options, retries - 1, delay * 2 );
-		}
-		throw error;
-	}
+	return chatWidgetKeyMap[ keyType ] ?? 'zendesk_presales_chat_key';
 }
 
 export const ZendeskJetpackChat: React.VFC< { keyType: KeyType } > = ( { keyType } ) => {
 	const [ error, setError ] = useState( false );
-	const { data: isStaffed } = usePresalesAvailabilityQuery();
-	const zendeskChatKey = useMemo( () => {
-		return config(
-			keyType === 'jpAgency'
-				? 'zendesk_presales_chat_key_jp_agency_dashboard'
-				: 'zendesk_presales_chat_key'
-		) as keyof ConfigData;
+	const { data: isStaffed } = useJpPresalesAvailabilityQuery( setError );
+	const zendeskChatKey: string | false = useMemo( () => {
+		return config( get_config_chat_key( keyType ) );
 	}, [ keyType ] );
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const shouldShowZendeskPresalesChat = useMemo( () => {
@@ -60,46 +40,15 @@ export const ZendeskJetpackChat: React.VFC< { keyType: KeyType } > = ( { keyType
 			getLocaleSlug() ?? ''
 		);
 
+		const isCorrectContext =
+			( isAkismetCheckout() && keyType === 'jpAkismet' ) ||
+			( isJetpackCheckout() && keyType === 'jpCheckout' ) ||
+			( isJetpackCloud() && ( keyType === 'jpAgency' || keyType === 'jpGeneral' ) );
+
 		return config.isEnabled( 'jetpack/zendesk-chat-for-logged-in-users' )
-			? isEnglishLocale && isJetpackCloud() && isStaffed
-			: ! isLoggedIn && isEnglishLocale && isJetpackCloud() && isStaffed;
-	}, [ isStaffed, isLoggedIn ] );
-
-	function usePresalesAvailabilityQuery() {
-		//adding a safeguard to ensure if there's an unkown error with the widget it won't crash the whole app
-		try {
-			return useQuery< boolean, Error >(
-				[ 'presales-availability' ],
-				async () => {
-					const url = 'https://public-api.wordpress.com/wpcom/v2/presales/chat';
-					const queryObject = {
-						group: 'jp_presales',
-					};
-
-					const response = await fetchWithRetry(
-						addQueryArgs( url, queryObject as Record< string, string > ),
-						{
-							credentials: 'same-origin',
-							mode: 'cors',
-						}
-					);
-
-					if ( ! response.ok ) {
-						throw new Error( `API request failed with status ${ response.status }` );
-					}
-
-					const data: PresalesChatResponse = await response.json();
-					return data.is_available;
-				},
-				{
-					meta: { persist: false },
-				}
-			);
-		} catch ( error ) {
-			setError( true );
-			return { data: false };
-		}
-	}
+			? isEnglishLocale && isCorrectContext && isStaffed
+			: ! isLoggedIn && isEnglishLocale && isCorrectContext && isStaffed;
+	}, [ isStaffed, isLoggedIn, keyType ] );
 
 	if ( error ) {
 		return null;

--- a/client/components/jetpack/jetpack-presales-chat-widget/index.tsx
+++ b/client/components/jetpack/jetpack-presales-chat-widget/index.tsx
@@ -10,7 +10,7 @@ import { useJpPresalesAvailabilityQuery } from 'calypso/lib/jetpack/use-jp-presa
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import type { ConfigData } from '@automattic/create-calypso-config';
 
-export type KeyType = 'jpAgency' | 'jpCheckout' | 'jpAkismet' | 'jpGeneral';
+export type KeyType = 'jpAgency' | 'jpCheckout' | 'akismet' | 'jpGeneral';
 
 export interface ZendeskJetpackChatProps {
 	keyType: KeyType;
@@ -21,7 +21,7 @@ function get_config_chat_key( keyType: KeyType ): keyof ConfigData {
 	const chatWidgetKeyMap = {
 		jpAgency: 'zendesk_presales_chat_key_jp_agency_dashboard',
 		jpCheckout: 'zendesk_presales_chat_key_jp_checkout',
-		jpAkismet: 'zendesk_presales_chat_key_akismet',
+		akismet: 'zendesk_presales_chat_key_akismet',
 		jpGeneral: 'zendesk_presales_chat_key',
 	};
 
@@ -41,7 +41,7 @@ export const ZendeskJetpackChat: React.VFC< { keyType: KeyType } > = ( { keyType
 		);
 
 		const isCorrectContext =
-			( isAkismetCheckout() && keyType === 'jpAkismet' ) ||
+			( isAkismetCheckout() && keyType === 'akismet' ) ||
 			( isJetpackCheckout() && keyType === 'jpCheckout' ) ||
 			( isJetpackCloud() && ( keyType === 'jpAgency' || keyType === 'jpGeneral' ) );
 

--- a/client/lib/akismet/is-akismet-checkout.ts
+++ b/client/lib/akismet/is-akismet-checkout.ts
@@ -1,0 +1,8 @@
+/*
+    The function isAkismetCheckout() is used to determine if the current page is a Akismet checkout page. 
+    It always returns false on the server side as window object is not available there (assumption that checkout pages are not rendered server-side).
+ */
+const isAkismetCheckout = () =>
+	'undefined' !== typeof document && window.location.pathname.startsWith( '/checkout/akismet' );
+
+export default isAkismetCheckout;

--- a/client/lib/jetpack/use-jp-presales-availability-query.ts
+++ b/client/lib/jetpack/use-jp-presales-availability-query.ts
@@ -1,0 +1,68 @@
+import { useQuery } from '@tanstack/react-query';
+import { addQueryArgs } from '@wordpress/url';
+import type { SetStateAction, Dispatch } from 'react';
+
+type PresalesChatResponse = {
+	is_available: boolean;
+};
+
+//the API is rate limited if we hit the limit we'll back off and retry
+async function fetchWithRetry(
+	url: string,
+	options: RequestInit,
+	retries = 3,
+	delay = 30000
+): Promise< Response > {
+	try {
+		const response = await fetch( url, options );
+
+		if ( response.status === 429 && retries > 0 ) {
+			await new Promise( ( resolve ) => setTimeout( resolve, delay ) );
+			return await fetchWithRetry( url, options, retries - 1, delay * 2 );
+		}
+
+		return response;
+	} catch ( error ) {
+		if ( retries > 0 ) {
+			await new Promise( ( resolve ) => setTimeout( resolve, delay ) );
+			return await fetchWithRetry( url, options, retries - 1, delay * 2 );
+		}
+		throw error;
+	}
+}
+
+export function useJpPresalesAvailabilityQuery( setError?: Dispatch< SetStateAction< boolean > > ) {
+	//adding a safeguard to ensure if there's an unkown error with the widget it won't crash the whole app
+	try {
+		return useQuery< boolean, Error >(
+			[ 'presales-availability' ],
+			async () => {
+				const url = 'https://public-api.wordpress.com/wpcom/v2/presales/chat';
+				const queryObject = {
+					group: 'jp_presales',
+				};
+
+				const response = await fetchWithRetry(
+					addQueryArgs( url, queryObject as Record< string, string > ),
+					{
+						credentials: 'same-origin',
+						mode: 'cors',
+					}
+				);
+
+				if ( ! response.ok ) {
+					throw new Error( `API request failed with status ${ response.status }` );
+				}
+
+				const data: PresalesChatResponse = await response.json();
+				return data.is_available;
+			},
+			{
+				meta: { persist: false },
+			}
+		);
+	} catch ( error ) {
+		setError && setError( true );
+		return { data: false };
+	}
+}

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -200,7 +200,7 @@ export default function CheckoutHelpLink() {
 
 	const getZendeskChatWidget = () => {
 		if ( isAkismetCheckout() ) {
-			return <ZendeskJetpackChat keyType="jpAkismet" />;
+			return <ZendeskJetpackChat keyType="akismet" />;
 		}
 
 		if ( isJetpackCheckout() ) {

--- a/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
+++ b/client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx
@@ -196,8 +196,19 @@ export default function CheckoutHelpLink() {
 		zendeskPresalesChatKey &&
 		! purchasesAreBlocked;
 
+	// Show loading button if we haven't determined whether or not to show the Zendesk chat button yet.
+	const shouldShowLoadingButton =
+		! supportVariationDetermined && ! isJpPresalesStaffed && ! isPresalesZendeskChatEligible;
+	const isSitelessCheckout = isAkismetCheckout() || isJetpackCheckout();
+	const shouldShowZendeskChatWidget =
+		( isPresalesZendeskChatEligible && ! isSitelessCheckout ) ||
+		( isSitelessCheckout && isJpPresalesStaffed );
+
 	const hasDirectSupport = supportVariation !== SUPPORT_FORUM;
 
+	// For the siteless checkouts, we do not need to specifically check if isJpPresalesStaffed is true
+	// because if this function is being called during a siteless checkout session, shouldShowZendeskChatWidget
+	// already ensures that isJpPresalesStaffed is true.
 	const getZendeskChatWidget = () => {
 		if ( isAkismetCheckout() ) {
 			return <ZendeskJetpackChat keyType="akismet" />;
@@ -207,22 +218,21 @@ export default function CheckoutHelpLink() {
 			return <ZendeskJetpackChat keyType="jpCheckout" />;
 		}
 
-		if ( isPresalesZendeskChatEligible ) {
-			return (
-				<AsyncLoad
-					require="calypso/components/presales-zendesk-chat"
-					chatKey={ zendeskPresalesChatKey }
-				/>
-			);
-		}
+		// If we're not in a siteless checkout, we can use the regular wordpress themed Zendesk chat widget.
+		return (
+			<AsyncLoad
+				require="calypso/components/presales-zendesk-chat"
+				chatKey={ zendeskPresalesChatKey }
+			/>
+		);
 	};
 
 	// If pre-sales chat isn't available, use the inline help button instead.
 	return (
 		<CheckoutHelpLinkWrapper>
 			<QuerySupportTypes />
-			{ ! isPresalesZendeskChatEligible && ! supportVariationDetermined && <LoadingButton /> }
-			{ isPresalesZendeskChatEligible || isJpPresalesStaffed
+			{ shouldShowLoadingButton && <LoadingButton /> }
+			{ shouldShowZendeskChatWidget
 				? getZendeskChatWidget()
 				: supportVariationDetermined && (
 						<CheckoutSummaryHelpButton onClick={ handleHelpButtonClicked }>

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -36,6 +36,8 @@
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"zendesk_presales_chat_key": false,
+	"zendesk_presales_chat_key_akismet": false,
+	"zendesk_presales_chat_key_jp_checkout": false,
 	"zendesk_presales_chat_key_jp_agency_dashboard": false,
 	"upwork_support_locales": [
 		"de",

--- a/config/development.json
+++ b/config/development.json
@@ -25,6 +25,8 @@
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
+	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
+	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
@@ -94,6 +96,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/offer-complete-after-activation": false,
+		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/production.json
+++ b/config/production.json
@@ -15,6 +15,8 @@
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
+	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
+	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"features": {
 		"ad-tracking": true,
 		"akismet/siteless-checkout": true,
@@ -67,6 +69,7 @@
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack-social/advanced-plan": false,
 		"jetpack/offer-complete-after-activation": false,
+		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -13,6 +13,8 @@
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
+	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
+	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -66,6 +66,7 @@
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack-social/advanced-plan": true,
 		"jetpack/offer-complete-after-activation": false,
+		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -13,6 +13,8 @@
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
+	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",
+	"zendesk_presales_chat_key_jp_checkout": "7c42153f-f579-49ba-a33e-246b2d27fb93",
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
@@ -71,6 +73,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack-social/advanced-plan": false,
 		"jetpack/offer-complete-after-activation": false,
+		"jetpack/zendesk-chat-for-logged-in-users": true,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,


### PR DESCRIPTION
## Proposed Changes

This PR adds functionality to display the Jetpack or Akismet Zendesk chat widget based on which checkout they are in. Before, the Zendesk widget for wordpress.com would show in every checkout

There is a bit of refactoring to this in order for the checkout to function the same as before (hiding the support link when a support widget is visible). The availability query was moved to it's own file in order to conditionally hide the support link when specifically the Jetpack and Akismet chat widgets are available and rendered

## Testing Instructions

1. Checkout this branch
2. Sandbox `public-api.wordpress.com`
3. Go to this line in wpcom: fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Serfg%2Qncv%2Qcyhtvaf%2Sraqcbvagf%2Scerfnyrf.cuc%3Se%3Q77p6nr33%2375-og and update it to this
```php
'is_available' => true,
```
This ensures you will see the chat widget when testing
4. Start your local environments (calypso and jetpack cloud) via `yarn start` and `yarn start-jetpack-cloud-p`
5. If you are not already marked as a Partner and Agency, follow these instructions: PCYsg-zp9-p2 (this step is to ensure the chat widget is still rendering correctly on the agency dashboard).
6. Go to http://jetpack.cloud.localhost:3001/partner-portal/licenses and make sure the chat widget still shows up and is rendering the correct one (Jetpack)
![image](https://user-images.githubusercontent.com/65001528/236044477-907214e8-841b-4c3a-93f9-06339b237173.png)
7. Go to https://jetpack.cloud.localhost:3001/pricing and make sure a jetpack themed chat is also loaded
![image](https://user-images.githubusercontent.com/65001528/236045374-d91ccb18-72e6-4baf-a72d-d306c553399d.png)
8. Go to http://calypso.localhost:3000/checkout/akismet/ak_plus_yearly_2 and make sure an Akismet branded chat widget is rendered
![image](https://user-images.githubusercontent.com/65001528/236045442-8d5c163d-197c-4111-a644-4c5946ae1322.png)
9. Go to http://calypso.localhost:3000/checkout/jetpack/jetpack_backup_t1_yearly and make sure a jetpack themed widget is loaded
![image](https://user-images.githubusercontent.com/65001528/236045581-e2a9e9de-e2ea-492e-8fab-90fd585d3ff2.png)
10. Go to the file `client/my-sites/checkout/composite-checkout/components/checkout-help-link.tsx and update the line 210 to the following
```tsx
if ( true ) {
```
Now go to http://calypso.localhost:3000/checkout/business-bundle and select a site. Continue to checkout and ensure a wordpress themed chat widget is available
![image](https://user-images.githubusercontent.com/65001528/236046346-f9e34a08-8256-4138-b91e-a8f03f77af61.png)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?