### PR TITLE
Disable useThemeHeadstart if start-writing flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -119,6 +119,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 	const search = window.location.search;
 	const sourceSiteSlug = new URLSearchParams( search ).get( 'from' ) || '';
 	const { data: siteData } = useSiteQuery( sourceSiteSlug, isCopySiteFlow( flow ) );
+	const useThemeHeadstart = ! isStartWritingFlow( flow );
 
 	async function createSite() {
 		if ( isManageSiteFlow ) {
@@ -137,7 +138,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			siteVisibility,
 			blogTitle,
 			siteAccentColor,
-			true,
+			useThemeHeadstart,
 			username,
 			domainCartItem,
 			sourceSlug


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/2326

## Proposed Changes

* If the onbaording flow is start-writing we don't want to create "headstart" posts on the site.
* This PR will cause the start-writing site to be created with only 1 default "Hello world" post. We can then delete that single post from the endpoint. Seen here. D109753-code


Before | After
--|--
![235958863-2aea19c0-d9ff-4508-9470-f87492a93993](https://user-images.githubusercontent.com/140841/236049831-92c1ecd0-c8cb-4f2f-ae03-7a35e094aef0.png)  |  ![after-posts](https://user-images.githubusercontent.com/140841/236049905-ccea9f00-8981-405c-a713-61e455ad61f5.png)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this diff
* Create a new site using the start-writing flow. You can do that with a test user with 0 sites. Login with that user and go to http://calypso.localhost:3000/setup/start-writing/
* Double check we don't affect any existing flows or introduce regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
