### PR TITLE
Subscribers form: change parent element from <p> to <div>

### DIFF
--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -404,9 +404,9 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		return (
 			isSelectedFileValid &&
 			! selectedFile && (
-				<p aria-label={ ariaLabelMsg } className="add-subscriber__form--disclaimer">
+				<div aria-label={ ariaLabelMsg } className="add-subscriber__form--disclaimer">
 					{ labelText }
-				</p>
+				</div>
 			)
 		);
 	}


### PR DESCRIPTION
## Proposed Changes

Updating the parent element as a `div` fixes the `validateDOMNesting` console warning in development mode. (it's not valid to have `div` as a descendant of `p`.

**NOTE:** It was not an option to have a simple button element without a `div` wrapper since we use the `FormFileUpload` component from the `@wordpress` package for file selector.

<img width="1216" alt="Screenshot 2023-05-03 at 23 30 50" src="https://user-images.githubusercontent.com/1241413/236054373-b408de40-6c69-403b-aa60-ea8bbcdfe563.png">

Closes #76421


## Testing Instructions

* At Calypso localhost development, got to /setup/newsletter
* Go to Subscribe step
* Check if the console contain warnings


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
