### PR TITLE
Adds "Copy this site" functionality to the agency dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/index.tsx
@@ -36,6 +36,7 @@ export default function SiteActions( { isLargeScreen = false, site, siteError }:
 	const siteUrl = site?.value?.url;
 	const siteUrlWithScheme = site?.value?.url_with_scheme;
 	const siteId = site?.value?.blog_id;
+	const siteHasBackup = site?.value?.has_backup;
 
 	const handleClickMenuItem = ( actionType: AllowedActionTypes ) => {
 		const eventName = getActionEventName( actionType, isLargeScreen );
@@ -78,6 +79,24 @@ export default function SiteActions( { isLargeScreen = false, site, siteError }:
 							className="site-actions__menu-item"
 						>
 							{ translate( 'View activity' ) }
+						</PopoverMenuItem>
+					</>
+				) }
+				{ siteHasBackup && (
+					<>
+						<PopoverMenuItem
+							onClick={ () => handleClickMenuItem( 'clone_site' ) }
+							href={ `/backup/${ siteUrl }/clone` }
+							className="site-actions__menu-item"
+						>
+							{ translate( 'Copy this site' ) }
+						</PopoverMenuItem>
+						<PopoverMenuItem
+							onClick={ () => handleClickMenuItem( 'site_settings' ) }
+							href={ `/settings/${ siteUrl }` }
+							className="site-actions__menu-item"
+						>
+							{ translate( 'Site settings' ) }
 						</PopoverMenuItem>
 					</>
 				) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-backup-staging/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-backup-staging/index.tsx
@@ -1,0 +1,48 @@
+import { useSelector } from 'react-redux';
+import QueryBackupStagingSite from 'calypso/components/data/query-backup-staging-site';
+import getBackupStagingSiteInfo from 'calypso/state/rewind/selectors/get-backup-staging-site-info';
+
+import './style.scss';
+
+const stagingIcon = (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width="18"
+		height="18"
+		fill="none"
+		viewBox="0 0 24 24"
+		className="staging-icon"
+	>
+		<path
+			fill="#4F3500"
+			fillRule="evenodd"
+			d="M16.365 4.868l-2.26 2.26.512 1.912 1.912.513 2.26-2.26a4 4 0 11-2.424-2.425z"
+			clipRule="evenodd"
+		></path>
+		<path
+			fill="#4F3500"
+			fillRule="evenodd"
+			d="M6.89 16.06a.5.5 0 10.706.708.5.5 0 00-.707-.707zM5.828 15a2 2 0 002.828 2.828l5.657-5.657a2 2 0 00-2.829-2.828L5.83 15z"
+			clipRule="evenodd"
+		></path>
+	</svg>
+);
+
+interface Props {
+	siteId: number;
+}
+
+export default function SiteBackupStaging( { siteId }: Props ) {
+	const stagingInfo = useSelector( ( state ) => getBackupStagingSiteInfo( state, siteId ) );
+
+	return (
+		<>
+			<QueryBackupStagingSite siteId={ siteId } />
+			{ stagingInfo?.staging ? (
+				<span className="site-backup-staging__staging-icon">{ stagingIcon }</span>
+			) : (
+				<></>
+			) }
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-backup-staging/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-backup-staging/style.scss
@@ -1,0 +1,8 @@
+.site-backup-staging__staging-icon {
+	svg {
+		background: var(--studio-yellow-20);
+		vertical-align: middle;
+		border-radius: 4px;
+		margin: 2px;
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-backup-staging/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-backup-staging/style.scss
@@ -3,6 +3,6 @@
 		background: var(--studio-yellow-20);
 		vertical-align: middle;
 		border-radius: 4px;
-		margin: 2px;
+		margin: 4px 2px 2px 2px;
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/test/site-card.tsx
@@ -12,6 +12,11 @@ import { siteColumns } from '../../utils';
 import SiteCard from '../index';
 import type { SiteData } from '../../types';
 
+jest.mock(
+	'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-backup-staging',
+	() => 'span'
+);
+
 describe( '<SiteCard>', () => {
 	beforeAll( () => {
 		window.matchMedia = jest.fn().mockImplementation( ( query ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
@@ -16,6 +16,11 @@ jest.mock( '@automattic/viewport-react', () => ( {
 	useBreakpoint: () => true,
 } ) );
 
+jest.mock(
+	'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-backup-staging',
+	() => 'span'
+);
+
 describe( '<SiteContent>', () => {
 	nock( 'https://public-api.wordpress.com' )
 		.persist()

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content.tsx
@@ -13,6 +13,7 @@ import { hasSelectedLicensesOfType } from 'calypso/state/jetpack-agency-dashboar
 import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import ToggleActivateMonitoring from '../downtime-monitoring/toggle-activate-monitoring';
 import SitesOverviewContext from './context';
+import SiteBackupStaging from './site-backup-staging';
 import SiteSelectCheckbox from './site-select-checkbox';
 import SiteSetFavorite from './site-set-favorite';
 import {
@@ -171,9 +172,12 @@ export default function SiteStatusContent( {
 						href={ `/activity-log/${ siteUrl }` }
 					>
 						{ siteUrl }
+						<SiteBackupStaging siteId={ siteId } />
 					</Button>
 				) : (
-					<span className="sites-overview__row-text">{ siteUrl }</span>
+					<span className="sites-overview__row-text">
+						{ siteUrl } <SiteBackupStaging siteId={ siteId } />
+					</span>
 				) }
 				<span className="sites-overview__overlay"></span>
 				{ errorContent }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/test/site-table-row.tsx
@@ -13,6 +13,11 @@ import { siteColumns } from '../../utils';
 import SiteTableRow from '../index';
 import type { SiteData } from '../../types';
 
+jest.mock(
+	'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-backup-staging',
+	() => 'span'
+);
+
 describe( '<SiteTableRow>', () => {
 	beforeAll( () => {
 		window.matchMedia = jest.fn().mockImplementation( ( query ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -13,6 +13,11 @@ import { siteColumns } from '../../utils';
 import SiteTable from '../index';
 import type { SiteData } from '../../types';
 
+jest.mock(
+	'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-backup-staging',
+	() => 'span'
+);
+
 describe( '<SiteTable>', () => {
 	beforeAll( () => {
 		window.matchMedia = jest.fn().mockImplementation( ( query ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -199,6 +199,7 @@
 	text-overflow: clip;
 	vertical-align: middle;
 	color: var(--studio-gray-100);
+	align-items: center;
 	@include break-zoomed-in {
 		width: calc(100% - 120px);
 		margin-inline-start: 8px;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -156,7 +156,13 @@ export type StatusTooltip = {
 	[ key in AllowedStatusTypes ]?: ReactChild;
 };
 
-export type AllowedActionTypes = 'issue_license' | 'view_activity' | 'view_site' | 'visit_wp_admin';
+export type AllowedActionTypes =
+	| 'issue_license'
+	| 'view_activity'
+	| 'view_site'
+	| 'visit_wp_admin'
+	| 'clone_site'
+	| 'site_settings';
 
 export type ActionEventNames = {
 	[ key in AllowedActionTypes ]: { small_screen: string; large_screen: string };

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/utils.ts
@@ -96,6 +96,14 @@ export const actionEventNames: ActionEventNames = {
 		large_screen: 'calypso_jetpack_agency_dashboard_visit_wp_admin_large_screen',
 		small_screen: 'calypso_jetpack_agency_dashboard_visit_wp_admin_small_screen',
 	},
+	clone_site: {
+		large_screen: 'calypso_jetpack_agency_dashboard_clone_site_large_screen',
+		small_screen: 'calypso_jetpack_agency_dashboard_clone_site_small_screen',
+	},
+	site_settings: {
+		large_screen: 'calypso_jetpack_agency_dashboard_site_settings_large_screen',
+		small_screen: 'calypso_jetpack_agency_dashboard_site_settings_small_screen',
+	},
 };
 
 // Returns event name based on the action type


### PR DESCRIPTION
This PR adds the Copy to Site functionalities to the Agency Dashboard

## Proposed Changes

* Shows an icon when a site has been set as staging.
<img width="316" alt="staging-icon2" src="https://user-images.githubusercontent.com/2747834/236248841-922f17b5-5011-4061-ab34-635bfe93678a.png">

* Adds "Copy to Site" and "Site settings" to the Agency Dashboard menu.
<img width="273" alt="menu" src="https://user-images.githubusercontent.com/2747834/236088927-0a425334-ca10-4df7-82ff-3473f6599b98.png">


## Testing Instructions


* Go to your Dashboard and check the menu. the new options will appear on sites with backups. 
* Set some of your sites as staging en verify the icon appears in the dashboard

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
