### PR TITLE
Blog onboarding: On the domain step CTAs should say “Select” not “Upgrade”

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -79,6 +79,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 					includeWordPressDotCom={ true }
 					offerUnavailableOption={ false } // TODO
 					showAlreadyOwnADomain={ true }
+					isSignupStep={ true }
 					basePath=""
 					products={ productsList }
 					vendor={ getSuggestionsVendor( {


### PR DESCRIPTION


Fixes https://github.com/Automattic/dotcom-forge/issues/2336

## Proposed Changes

On the start-writing flow the domain step CTAs should say “Select” not “Upgrade”.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/402286/236108299-5da822ab-12d0-4d05-af5b-f7e8a02caf25.png) | ![image](https://user-images.githubusercontent.com/402286/236108289-adb03e02-ccc8-4617-9434-b9cb81da8daf.png) |

## Testing Instructions

* Using a new user OR a user without any site, start the flow with [/setup/start-writing](http://calypso.localhost:3000/setup/start-writing).
* On the `Choose a domain` step, you should see `Select` instead of `Upgrade`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~~[Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?~~
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~~
- [ ] ~~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~~
- [ ] ~~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~~
