### PR TITLE
Fix: Plans step broken UI in domain-upsell flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/index.tsx
@@ -50,7 +50,13 @@ const plans: Step = function Plans( { navigation, flow } ) {
 			isLargeSkipLayout={ false }
 			backLabelText={ getBackLabelText() }
 			hideBack={ shouldHideBackButton() }
-			stepContent={ <PlansWrapper flowName={ flow } onSubmit={ handleSubmit } /> }
+			stepContent={
+				<PlansWrapper
+					flowName={ flow }
+					onSubmit={ handleSubmit }
+					is2023PricingGridVisible={ is2023PricingGridVisible }
+				/>
+			}
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -40,6 +40,7 @@ interface Props {
 	flowName: string | null;
 	onSubmit: () => void;
 	plansLoaded: boolean;
+	is2023PricingGridVisible: boolean;
 }
 
 function getPlanTypes( flowName: string | null ) {
@@ -149,7 +150,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					isInVerticalScrollingPlansExperiment={ isInVerticalScrollingPlansExperiment }
 					shouldShowPlansFeatureComparison={ isDesktop } // Show feature comparison layout in signup flow and desktop resolutions
 					isReskinned={ isReskinned }
-					is2023PricingGridVisible={ isStartWritingFlow( props?.flowName ) ? true : false }
+					is2023PricingGridVisible={ props.is2023PricingGridVisible }
 				/>
 			</div>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -196,9 +196,6 @@
 }
 
 .start-writing {
-	.plans-features-main__group.is-2023-pricing-grid {
-		width: 100%;
-	}
 	#step-header {
 		margin: 0;
 	}

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -95,5 +95,9 @@ export const is2023PricingGridActivePage = (
 		return isPricingGridEnabled;
 	}
 
+	if ( currentRoutePath.startsWith( '/setup/start-writing' ) ) {
+		return isPricingGridEnabled;
+	}
+
 	return false;
 };


### PR DESCRIPTION
## Proposed Changes

This PR fixes the issue that in `/setup/domain-upsell` flow, the plans step UI is broken:
![dupb](https://user-images.githubusercontent.com/1269602/236116556-b623aa56-1542-4cca-a3dc-576ea5f9040e.jpg)


This bug seems to be from the changes made in https://github.com/Automattic/wp-calypso/pull/76559. (cc @paulopmt1 @DustyReagan )

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enter the domain-upsell flow. One way to do it is to create a new account in the [free site flow](https://wordpress.com/start/account/user?variationName=free&redirect_to=/setup/free/freeSetup), get to the Launchpad, and then click on "Choose a domain" ([screenshot](https://d.pr/i/86erOn)).
* Select a custom domain and proceed to the plans step. Verify that the plans step UI is rendered correctly in desktop and mobile.
* Follow the testing instructions in https://github.com/Automattic/wp-calypso/pull/76559 to verify the UI in the start-writing flow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
