### PR TITLE
Pricing page: Add storage limit FAQs in Backup lightbox.

### DIFF
--- a/client/my-sites/plans/jetpack-plans/faq/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/faq/index.tsx
@@ -106,7 +106,10 @@ const JetpackFAQ: FC = () => {
 							className="jetpack-faq__section"
 						>
 							{ translate(
-								"If your site's backup storage limit is reached, your older backups will be deleted. Depending on the size of your site and your site's backup storage limit, your site's backup retention period may be reduced down to 7 days of your most recent backups. You will still be able to restore existing backups, but new site updates will not be backed up until you free up storage or upgrade your storage limit."
+								'If your backup storage limit is reached, older backups will be deleted and, depending on your site’s size, the backup retention period (archive) might be reduced to %(monthlyDays)d days. This will affect how far back you can see backups in your activity log. Existing backups can still be restored, but new updates won’t be backed up until you upgrade or free up storage.',
+								{
+									args: { monthlyDays: 7 },
+								}
 							) }
 						</FoldableFAQ>
 					</li>

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/faq-list.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/faq-list.tsx
@@ -1,0 +1,48 @@
+import { FAQ } from '@automattic/calypso-products';
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import FoldableFAQ from 'calypso/components/foldable-faq';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+type FAQListProps = { items?: FAQ[] };
+
+const FAQList: React.FC< FAQListProps > = ( { items } ) => {
+	const dispatch = useDispatch();
+	const siteId = useSelector( getSelectedSiteId );
+
+	const onToggle = useCallback(
+		( faqArgs: { id: string; isExpanded: boolean } ) => {
+			const { id, isExpanded } = faqArgs;
+			const tracksArgs = {
+				site_id: siteId,
+				faq_id: id,
+			};
+
+			dispatch(
+				recordTracksEvent(
+					isExpanded ? 'calypso_plans_faq_open' : 'calypso_plans_faq_closed',
+					tracksArgs
+				)
+			);
+		},
+		[ siteId, dispatch ]
+	);
+
+	if ( ! items || ! items.length ) {
+		return null;
+	}
+
+	return (
+		<ul>
+			{ items.map( ( item ) => (
+				<li key={ item.id }>
+					<FoldableFAQ id={ item.id } question={ item.question } onToggle={ onToggle }>
+						{ item.answer }
+					</FoldableFAQ>
+				</li>
+			) ) }
+		</ul>
+	);
+};
+export default FAQList;

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/product-details.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/product-details.tsx
@@ -5,6 +5,7 @@ import FoldableCard from 'calypso/components/foldable-card';
 import { useIncludedProductDescriptionMap } from '../product-store/hooks/use-included-product-description-map';
 import { SelectorProduct } from '../types';
 import DescriptionList from './description-list';
+import FAQList from './faq-list';
 import IncludedProductList from './included-product-list';
 
 type ProductDetailsProps = {
@@ -61,6 +62,32 @@ const ProductDetails: React.FC< ProductDetailsProps > = ( { product } ) => {
 						{ index !== infoList.length - 1 && <hr /> }
 					</div>
 				) )
+			) }
+
+			{ product.faqs && !! product.faqs.length && (
+				<>
+					<hr />
+					<div className="product-lightbox__detail-list is-faq-list" key="faqs">
+						{ isMobile ? (
+							<FoldableCard
+								hideSummary
+								header={ translate( 'FAQs' ) }
+								clickableHeader={ true }
+								smooth
+								contentExpandedStyle={ contentStlye }
+							>
+								<div ref={ ref }>
+									<FAQList items={ product.faqs } />
+								</div>
+							</FoldableCard>
+						) : (
+							<>
+								<p>{ translate( 'FAQs' ) }</p>
+								<FAQList items={ product.faqs } />
+							</>
+						) }
+					</div>
+				</>
 			) }
 		</>
 	);

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/style.scss
@@ -77,6 +77,7 @@
 	overflow-y: auto;
 	background-color: var(--studio-white);
 	border-radius: 8px 0 0 8px; /* stylelint-disable-line scales/radii */
+	max-height: 85vh;
 
 	hr {
 		margin: 0.75rem 0;
@@ -178,7 +179,7 @@
 		margin: 0;
 	}
 
-	li {
+	&:not(.is-faq-list) li {
 		background: url(./icons/check.svg) no-repeat 0 2px;
 		padding-left: 20px;
 		font-weight: 400;
@@ -214,6 +215,34 @@
 
 	.foldable-card.card.is-expanded {
 		margin: 0;
+	}
+
+	.foldable-faq {
+		padding: 0;
+		margin-bottom: 8px;
+	}
+
+	.foldable-faq__question {
+		padding: 0;
+		min-height: 24px;
+
+		.gridicon {
+			width: 20px;
+			height: 20px;
+		}
+	}
+
+	.foldable-faq__question-text {
+		font-size: 1rem;
+		font-weight: 500;
+		padding: 0;
+		margin-inline-start: 4px;
+	}
+
+	.foldable-faq__answer {
+		border: none;
+		padding-inline-start: 24px;
+		padding-bottom: 0;
 	}
 }
 

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-included-product-description-map.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-included-product-description-map.tsx
@@ -26,7 +26,7 @@ export const useIncludedProductDescriptionMap = ( productSlug: string ) => {
 			...setTranslation(
 				[ PRODUCT_JETPACK_BACKUP_T1_YEARLY, PRODUCT_JETPACK_BACKUP_T1_MONTHLY ],
 				translate(
-					'Real-time backups as you edit. 10GB of cloud storage. {{span}}30-day{{/span}} activity log archive. Unlimited one-click restores.',
+					'Real-time backups as you edit. 10GB of cloud storage. {{span}}30-day{{/span}} activity log archive*. Unlimited one-click restores.',
 					{
 						components: {
 							span: <span />,

--- a/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
+++ b/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
@@ -27,9 +27,11 @@ import {
 	TERM_MONTHLY,
 	getJetpackProductWhatIsIncluded,
 	getJetpackProductBenefits,
+	getJetpackProductFAQs,
 	getJetpackProductRecommendedFor,
 	TERM_TRIENNIALLY,
 } from '@automattic/calypso-products';
+import { getHelpLink } from 'calypso/my-sites/plans-features-main/components/jetpack-faq';
 import buildCardFeaturesFromItem from './build-card-features-from-item';
 import {
 	EXTERNAL_PRODUCTS_LIST,
@@ -165,6 +167,7 @@ function itemToSelectorProduct(
 			buttonLabel: getJetpackProductCallToAction( item ),
 			whatIsIncluded: getJetpackProductWhatIsIncluded( item ),
 			benefits: getJetpackProductBenefits( item ),
+			faqs: getJetpackProductFAQs( item.product_slug, getHelpLink ),
 			recommendedFor: getJetpackProductRecommendedFor( item ),
 			monthlyProductSlug,
 			term: item.term,
@@ -207,6 +210,7 @@ function itemToSelectorProduct(
 				? getForCurrentCROIteration( item.getWhatIsIncluded )
 				: [],
 			benefits: item.getBenefits ? getForCurrentCROIteration( item.getBenefits ) : [],
+			faqs: getJetpackProductFAQs( productSlug, getHelpLink ),
 			recommendedFor: item.getRecommendedFor
 				? getForCurrentCROIteration( item.getRecommendedFor )
 				: [],

--- a/client/my-sites/plans/jetpack-plans/types.ts
+++ b/client/my-sites/plans/jetpack-plans/types.ts
@@ -7,6 +7,7 @@ import type {
 	TERM_TRIENNIALLY,
 	JetpackProductCategory,
 	JetpackTag,
+	FAQ,
 } from '@automattic/calypso-products';
 import type { Purchase } from 'calypso/lib/purchases/types';
 import type { TranslateResult } from 'i18n-calypso';
@@ -133,6 +134,7 @@ export interface SelectorProduct extends SelectorProductCost {
 	productsIncluded?: ReadonlyArray< string >;
 	whatIsIncluded?: Array< TranslateResult >;
 	benefits?: Array< TranslateResult >;
+	faqs?: Array< FAQ >;
 	recommendedFor?: Array< JetpackTag >;
 	forceNoYearlyUpgrade?: boolean;
 }

--- a/packages/calypso-products/src/get-jetpack-product-faqs.ts
+++ b/packages/calypso-products/src/get-jetpack-product-faqs.ts
@@ -1,0 +1,11 @@
+import { getJetpackProductsFAQs } from './translations';
+/**
+ * Get Jetpack product "FAQs" info based on the product slug.
+ */
+export function getJetpackProductFAQs(
+	product_slug: string,
+	getHelpLink: ( context: unknown ) => JSX.Element
+) {
+	const jetpackProductsFAQsInfo = getJetpackProductsFAQs( getHelpLink );
+	return jetpackProductsFAQsInfo[ product_slug ];
+}

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -12,6 +12,7 @@ export { getJetpackProductShortName } from './get-jetpack-product-short-name';
 export { getJetpackProductTagline } from './get-jetpack-product-tagline';
 export { getJetpackProductWhatIsIncluded } from './get-jetpack-product-what-is-included';
 export { getJetpackProductBenefits } from './get-jetpack-product-benefits';
+export { getJetpackProductFAQs } from './get-jetpack-product-faqs';
 export { getJetpackProductRecommendedFor } from './get-jetpack-product-recommended-for';
 export { getProductClass } from './get-product-class';
 export { getProductTermVariants } from './get-product-term-variants';

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -52,7 +52,7 @@ import {
 	PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_3TB_YEARLY,
 	PRODUCT_JETPACK_BACKUP_ADDON_STORAGE_5TB_YEARLY,
 } from './constants';
-import type { SelectorProductFeaturesItem } from './types';
+import type { FAQ, SelectorProductFeaturesItem } from './types';
 import type { TranslateResult } from 'i18n-calypso';
 
 // Translatable strings
@@ -734,7 +734,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		}
 	);
 
-	const backupIncludesInfoT1Log = translate( '30-day activity log archive' );
+	const backupIncludesInfoT1Log = translate( '30-day activity log archive*' );
 	const backupIncludesInfoT2Log = translate( '{{strong}}1 year{{/strong}} activity log archive', {
 		components: {
 			strong: <strong />,
@@ -952,6 +952,44 @@ export const getJetpackProductsBenefits = (): Record< string, Array< TranslateRe
 		[ PRODUCT_JETPACK_SOCIAL_BASIC_MONTHLY ]: socialBenefits,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED ]: socialAdvancedBenefits,
 		[ PRODUCT_JETPACK_SOCIAL_ADVANCED_MONTHLY ]: socialAdvancedBenefits,
+	};
+};
+
+export const getJetpackProductsFAQs = (
+	getHelpLink: ( context: unknown ) => JSX.Element
+): Record< string, Array< FAQ > > => {
+	const backupFAQs: Array< FAQ > = [
+		{
+			id: 'backup-storage-limits',
+			question: translate( '*How do backup storage limits work?' ),
+			answer: translate(
+				'If your backup storage limit is reached, older backups will be deleted and, depending on your site’s size, the backup retention period (archive) might be reduced to %(monthlyDays)d days. This will affect how far back you can see backups in your activity log. Existing backups can still be restored, but new updates won’t be backed up until you upgrade or free up storage.',
+				{
+					args: { monthlyDays: 7 },
+				}
+			),
+		},
+		{
+			id: 'cancellation-policy',
+			question: translate( 'What is your cancellation policy?' ),
+			answer: translate(
+				'If you are dissatisfied for any reason, we offer full refunds within %(annualDays)d days for yearly plans, and within %(monthlyDays)d days for monthly plans. If you have a question about our paid plans, {{helpLink}}please let us know{{/helpLink}}!',
+				{
+					args: { annualDays: 14, monthlyDays: 7 },
+					components: { helpLink: getHelpLink( 'cancellation' ) },
+				}
+			),
+		},
+	];
+	return {
+		[ PRODUCT_JETPACK_BACKUP_T1_YEARLY ]: backupFAQs,
+		[ PRODUCT_JETPACK_BACKUP_T1_MONTHLY ]: backupFAQs,
+		[ PRODUCT_JETPACK_BACKUP_T2_YEARLY ]: backupFAQs,
+		[ PRODUCT_JETPACK_BACKUP_T2_MONTHLY ]: backupFAQs,
+		[ PLAN_JETPACK_SECURITY_T1_MONTHLY ]: backupFAQs,
+		[ PLAN_JETPACK_SECURITY_T1_YEARLY ]: backupFAQs,
+		[ PLAN_JETPACK_SECURITY_T2_MONTHLY ]: backupFAQs,
+		[ PLAN_JETPACK_SECURITY_T2_YEARLY ]: backupFAQs,
 	};
 };
 

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -100,6 +100,13 @@ export interface JetpackTag {
 	tag: string;
 	label: TranslateResult;
 }
+
+export interface FAQ {
+	id: string;
+	question: TranslateResult;
+	answer: TranslateResult;
+}
+
 export interface JetpackPlan extends Plan {
 	getAnnualSlug?: () => JetpackPlanSlug;
 	getMonthlySlug?: () => JetpackPlanSlug;


### PR DESCRIPTION
This PR is related to the previous PR (#76025) I committed but was reverted due to breaking the Calypso with outdated import. The changes should be the same except for the faulty import.

<img width="1102" alt="Screen Shot 2023-04-20 at 7 24 24 PM" src="https://user-images.githubusercontent.com/56598660/233351975-1013af5c-3231-4c7b-bc97-917cb304b605.png">
<img width="1108" alt="Screen Shot 2023-04-20 at 7 25 15 PM" src="https://user-images.githubusercontent.com/56598660/233352187-becd229f-3479-4d5b-b80d-5f5690c1b733.png">



## Proposed Changes

* Update Calypso products to include Jetpack Backup FAQs info.
* Update Product Lightbox to render FAQ information if it exists on the product data.

## Testing Instructions

- Run git fetch && git checkout `feature/add-storage-limit-faqs-in-backup-lightbox`
- Run yarn start-jetpack-cloud
- Go to http://jetpack.cloud.localhost:3000/pricing or use the Jetpack Cloud live link and append /pricing.
- Click VaultPress Backup or Security bundle more info button
- Confirm that the FAQs are visible


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
