### PR TITLE
Category updates - Move core query patterns from the category Posts to Blog in the editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -48,12 +48,24 @@ class Block_Patterns_From_API {
 
 		$this->utils = empty( $utils ) ? new \A8C\FSE\Block_Patterns_Utils() : $utils;
 
+		$blog_category = array(
+			'blog' => __( 'Blog', 'full-site-editing' ),
+		);
+
 		// Add categories to this array using the core pattern name as the key for core patterns we wish to "recategorize".
 		$this->core_to_wpcom_categories_dictionary = array(
-			'core/quote' => array(
+			'core/quote'                                => array(
 				'quotes' => __( 'Quotes', 'full-site-editing' ),
 				'text'   => __( 'Text', 'full-site-editing' ),
 			),
+			// Move core query patterns from 'Posts' to 'Blog'.
+			'core/query-standard-posts'                 => $blog_category,
+			'core/query-medium-posts'                   => $blog_category,
+			'core/query-small-posts'                    => $blog_category,
+			'core/query-grid-posts'                     => $blog_category,
+			'core/query-large-title-posts'              => $blog_category,
+			'core/query-offset-posts'                   => $blog_category,
+			'core/social-links-shared-background-color' => $blog_category,
 		);
 	}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -48,24 +48,12 @@ class Block_Patterns_From_API {
 
 		$this->utils = empty( $utils ) ? new \A8C\FSE\Block_Patterns_Utils() : $utils;
 
-		$blog_category = array(
-			'blog' => __( 'Blog', 'full-site-editing' ),
-		);
-
 		// Add categories to this array using the core pattern name as the key for core patterns we wish to "recategorize".
 		$this->core_to_wpcom_categories_dictionary = array(
-			'core/quote'                                => array(
+			'core/quote' => array(
 				'quotes' => __( 'Quotes', 'full-site-editing' ),
 				'text'   => __( 'Text', 'full-site-editing' ),
 			),
-			// Move core query patterns from 'Posts' to 'Blog'.
-			'core/query-standard-posts'                 => $blog_category,
-			'core/query-medium-posts'                   => $blog_category,
-			'core/query-small-posts'                    => $blog_category,
-			'core/query-grid-posts'                     => $blog_category,
-			'core/query-large-title-posts'              => $blog_category,
-			'core/query-offset-posts'                   => $blog_category,
-			'core/social-links-shared-background-color' => $blog_category,
 		);
 	}
 
@@ -151,6 +139,8 @@ class Block_Patterns_From_API {
 		$this->update_core_patterns_with_wpcom_categories();
 
 		$this->update_pattern_post_types();
+
+		$this->update_query_patterns_with_blog_category();
 
 		return $results;
 	}
@@ -287,6 +277,26 @@ class Block_Patterns_From_API {
 				$pattern_name         = $pattern['name'];
 				unset( $pattern['name'] );
 				register_block_pattern( $pattern_name, $pattern );
+			}
+		}
+	}
+
+	/**
+	 * Ensure that all query or posts patterns use the category blog instead.
+	 */
+	private function update_query_patterns_with_blog_category() {
+		foreach ( \WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {
+			if ( ! isset( $pattern['categories'] ) ) {
+				continue;
+			}
+			if ( in_array( 'query', $pattern['categories'], true ) || in_array( 'posts', $pattern['categories'], true ) ) {
+				foreach ( $pattern['categories'] as &$category ) {
+					if ( in_array( $category, array( 'query', 'posts' ), true ) ) {
+						$category = 'blog';
+					}
+				}
+				unregister_block_pattern( $pattern['name'] );
+				register_block_pattern( $pattern['name'], $pattern );
 			}
 		}
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -103,7 +103,11 @@ class Block_Patterns_From_API {
 			}
 
 			// Register categories (and re-register existing categories).
-			foreach ( (array) $pattern_categories as $slug => $category_properties ) {
+			foreach ( (array) $pattern_categories as $slug => &$category_properties ) {
+				if ( 'blog' === $slug ) {
+					$category_properties['label']       = __( 'Blog Posts', 'full-site-editing' );
+					$category_properties['description'] = __( 'Display your latest posts in lists, grids or other layouts.', 'full-site-editing' );
+				}
 				register_block_pattern_category( $slug, $category_properties );
 			}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76451

## Proposed Changes

* Recategorize core query patterns from `Posts` to `Blog` in the editor (from the ETK plugin)

|BEFORE|AFTER|
|---|---|
|<img width="650" alt="Screenshot 2566-05-09 at 12 44 25" src="https://user-images.githubusercontent.com/1881481/237004796-32d85ffe-622a-4279-81bb-27b9c80b48b4.png">|<img width="652" alt="Screenshot 2566-05-09 at 12 40 28" src="https://user-images.githubusercontent.com/1881481/237004877-fa407f81-d19a-4923-9d7d-aa10b9c85d23.png">|


Note: these core query patterns are not listed on the Assembler because we fetch patterns from the Dotcom pattern library only. We should copy these patterns in the Dotcom pattern library and then avoid the duplication on the editor.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
### Install the ETK plugin from this branch

**Test on Simple sites**

* Sandbox your site
* Run `install-plugin.sh etk chore/recategorize-core-query-patterns`
* Don't forget to revert the ETK after testing with `install-plugin.sh etk --revert`

**Test on Atomic sites**

* Download the ETK plugin zip from Teamcity
* Upload it to an Atomic site and activate it


### Verify the changes
On Simple sites or Atomic sites when the ETK plugin is activated:

- Verify that you don't see the `Posts` category on the editor. 
- Verify that you see the seven core query patterns in the `Blog` category.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
