### PR TITLE
Jetpack Pro Dashboard: implement UI to display the default email address in downtime monitoring settings

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/index.tsx
@@ -1,8 +1,59 @@
-export default function ConfigureEmailNotification() {
+import { Card } from '@automattic/components';
+import { CheckboxControl } from '@wordpress/components';
+import { useEffect, useState } from 'react';
+
+import './style.scss';
+
+interface EmailItem {
+	email: string;
+	name: string;
+	checked: boolean;
+}
+interface Props {
+	defaultEmailAddresses: Array< string >;
+}
+
+export default function ConfigureEmailNotification( { defaultEmailAddresses = [] }: Props ) {
+	const [ allEmailItems, setAllEmailItems ] = useState< EmailItem[] >( [] );
+
+	useEffect( () => {
+		if ( defaultEmailAddresses ) {
+			const allEmailItems = defaultEmailAddresses.map( ( email, index ) => ( {
+				email,
+				checked: index === 0, // FIXME: This should be dynamic.
+				name: 'Default Email', //FIXME: This should be dynamic.
+			} ) );
+			setAllEmailItems( allEmailItems );
+		}
+	}, [ defaultEmailAddresses ] );
+
+	const handleOnChange = () => {
+		if ( defaultEmailAddresses.length === 1 ) {
+			return;
+			// FIXME: We need to show a custom error message here.
+		}
+		// FIXME: Onselect of checkbox, we need to update the state of the checkbox.
+	};
+
+	const getCheckboxContent = ( item: EmailItem ) => (
+		<span className="configure-email-address__checkbox-content">
+			<div className="configure-email-address__checkbox-heading">{ item.email }</div>
+			<div className="configure-email-address__checkbox-sub-heading">{ item.name }</div>
+		</span>
+	);
+
 	return (
 		<>
-			<br />
-			Coming Soon
+			{ allEmailItems.map( ( item ) => (
+				<Card className="configure-email-address__card" key={ item.email } compact>
+					<CheckboxControl
+						className="configure-email-address__checkbox"
+						checked={ item.checked }
+						onChange={ handleOnChange }
+						label={ getCheckboxContent( item ) }
+					/>
+				</Card>
+			) ) }
 		</>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/configure-email-notification/style.scss
@@ -1,0 +1,42 @@
+.configure-email-address__card {
+	margin: 16px 0 0;
+	height: 60px;
+	display: flex;
+	align-items: center;
+	padding: 16px !important;
+}
+
+.configure-email-address__checkbox-content {
+	display: inline-block;
+}
+
+.configure-email-address__checkbox {
+	.components-checkbox-control__input:checked {
+		background: var(--studio-gray-80);
+		border-color: var(--studio-gray-80);
+	}
+
+	.components-checkbox-control__label {
+		font-weight: 500;
+	}
+
+	.components-base-control__field {
+		margin-bottom: 0;
+		display: flex;
+		align-items: center;
+	}
+}
+
+.configure-email-address__checkbox-heading {
+	font-weight: 500;
+	font-size: 0.875rem;
+	line-height: 18px;
+	color: var(--studio-gray-100);
+}
+
+.configure-email-address__checkbox-sub-heading {
+	font-weight: 400;
+	font-size: 0.75rem;
+	line-height: 18px;
+	color: var(--studio-gray-50);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/index.tsx
@@ -197,7 +197,9 @@ export default function NotificationSettings( {
 									<div className="notification-settings__content-sub-heading">
 										{ translate( 'Receive email notifications with one or more recipients.' ) }
 									</div>
-									{ enableEmailNotification && <ConfigureEmailNotification /> }
+									{ enableEmailNotification && (
+										<ConfigureEmailNotification defaultEmailAddresses={ addedEmailAddresses } />
+									) }
 								</>
 							) : (
 								<div className="notification-settings__content-sub-heading">


### PR DESCRIPTION
Related to 1204408201748644-as-1204484225044503

## Proposed Changes

This PR implements the UI to display the default email address in downtime monitoring settings. 

#### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/show-default-email-in-monitor-settings` and `yarn start-jetpack-cloud`
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Enable monitor if not enabled already.
4. Click on the clock icon next to the monitor toggle.
5. Verify that you can see the default email shown below. Please note the logic to checkbox onclick will be implemented in a different PR

<img width="449" alt="Screenshot 2023-05-04 at 1 42 44 PM" src="https://user-images.githubusercontent.com/10586875/236147471-5c9661fe-879a-4fc7-b661-8e44b5517a8b.png">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?