### PR TITLE
Pricing Plans Block: Update 'Commerce' display labels

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/index.jsx
+++ b/apps/happy-blocks/block-library/pricing-plans/index.jsx
@@ -66,8 +66,8 @@ function registerBlocks() {
 			},
 			{
 				name: 'ecommerce',
-				title: __( 'Upgrade eCommerce', 'happy-blocks' ),
-				description: __( 'Upgrade to eCommerce pricing plan', 'happy-blocks' ),
+				title: __( 'Upgrade Commerce', 'happy-blocks' ),
+				description: __( 'Upgrade to Commerce pricing plan', 'happy-blocks' ),
 				attributes: {
 					defaultProductSlug: PLAN_ECOMMERCE,
 				},

--- a/apps/happy-blocks/block-library/pricing-plans/index.php
+++ b/apps/happy-blocks/block-library/pricing-plans/index.php
@@ -13,13 +13,15 @@
  * @return void
  */
 function happyblocks_pricing_plans_enqueue_config_data() {
-	wp_register_script( 'a8c-happyblocks-pricing-plans', '', array(), '20221212', true );
-	wp_enqueue_script( 'a8c-happyblocks-pricing-plans' );
 	wp_add_inline_script(
-		'a8c-happyblocks-pricing-plans',
+		'happy-blocks-pricing-plans-editor-script',
 		sprintf(
 			'window.A8C_HAPPY_BLOCKS_CONFIG = %s;
-			window.configData ||= {};',
+			window.configData ||= {
+				features: {
+					"onboarding/2023-pricing-grid": true,
+				}
+			} ;',
 			wp_json_encode( happyblocks_pricing_plans_get_config() )
 		),
 		'before'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR updates the initialisation/configuration of the Pricing Plans block when outside of the Calypso context so that it enables the new naming for the 'Commerce' plan (previously named 'eCommerce').

We're also updating here some local labels/strings that made reference to 'eCommerce' so that now they're labeled as 'Commerce' too.
 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync these changes with `yarn dev --sync`
* Ensure you can insert the Commerce block (and it reads like that) by typing in the editor `/` and then `upgrade`
* Ensure once the block is inserted and rendered it shows 'Commerce' as the plan name/header in the block.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
