### PR TITLE
Category updates - Add the category All to view all patterns in the editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -91,13 +91,12 @@ class Block_Patterns_From_API {
 			// The category 'All' is created dinamically so all patterns are always added automatically.
 			$category_all = array(
 				'slug'        => 'all',
-				'title'       => 'All',
+				'label'       => 'All',
 				'description' => '',
 			);
 			// Add the category 'All' to $pattern_categories so its orderer and registered with the others.
 			$pattern_categories[ $category_all['slug'] ] = array(
-				'label'       => $category_all['title'],
-				'slug'        => $category_all['title'],
+				'label'       => $category_all['label'],
 				'description' => $category_all['description'],
 			);
 
@@ -108,6 +107,12 @@ class Block_Patterns_From_API {
 					return strnatcasecmp( $a['label'], $b['label'] );
 				}
 			);
+
+			// Move the Featured category to be the first category.
+			if ( isset( $pattern_categories['featured'] ) ) {
+				$featured_category  = $pattern_categories['featured'];
+				$pattern_categories = array( 'featured' => $featured_category ) + $pattern_categories;
+			}
 
 			// Register categories (and re-register existing categories).
 			foreach ( (array) $pattern_categories as $slug => $category_properties ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -66,6 +66,13 @@ class Block_Patterns_From_API {
 		// Used to track which patterns we successfully register.
 		$results = array();
 
+		// The category 'All' is created dynamically so all patterns are always added automatically.
+		$category_all = array(
+			'slug'        => 'all',
+			'label'       => __( 'All', 'full-site-editing' ),
+			'description' => __( 'Explore all patterns.', 'full-site-editing' ),
+		);
+
 		// For every pattern source site, fetch the patterns.
 		foreach ( $this->patterns_sources as $patterns_source ) {
 			$patterns_cache_key = $this->utils->get_patterns_cache_key( $patterns_source );
@@ -88,13 +95,7 @@ class Block_Patterns_From_API {
 
 			$pattern_categories = array_merge( $pattern_categories, $existing_categories );
 
-			// The category 'All' is created dinamically so all patterns are always added automatically.
-			$category_all = array(
-				'slug'        => 'all',
-				'label'       => __( 'All', 'full-site-editing' ),
-				'description' => __( 'Explore all patterns.', 'full-site-editing' ),
-			);
-			// Add the category 'All' to $pattern_categories so its orderer and registered with the others.
+			// Add the category 'All' to $pattern_categories so its ordered and registered with the others.
 			$pattern_categories[ $category_all['slug'] ] = array(
 				'label'       => $category_all['label'],
 				'description' => $category_all['description'],

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -88,6 +88,19 @@ class Block_Patterns_From_API {
 
 			$pattern_categories = array_merge( $pattern_categories, $existing_categories );
 
+			// The category 'All' is created dinamically so all patterns are always added automatically.
+			$category_all = array(
+				'slug'        => 'all',
+				'title'       => 'All',
+				'description' => '',
+			);
+			// Add the category 'All' to $pattern_categories so its orderer and registered with the others.
+			$pattern_categories[ $category_all['slug'] ] = array(
+				'label'       => $category_all['title'],
+				'slug'        => $category_all['title'],
+				'description' => $category_all['description'],
+			);
+
 			// Order categories alphabetically by their label.
 			uasort(
 				$pattern_categories,
@@ -95,12 +108,6 @@ class Block_Patterns_From_API {
 					return strnatcasecmp( $a['label'], $b['label'] );
 				}
 			);
-
-			// Move the Featured category to be the first category.
-			if ( isset( $pattern_categories['featured'] ) ) {
-				$featured_category  = $pattern_categories['featured'];
-				$pattern_categories = array( 'featured' => $featured_category ) + $pattern_categories;
-			}
 
 			// Register categories (and re-register existing categories).
 			foreach ( (array) $pattern_categories as $slug => $category_properties ) {
@@ -117,6 +124,9 @@ class Block_Patterns_From_API {
 					$viewport_width = $viewport_width < 320 ? 320 : $viewport_width;
 					$pattern_name   = self::PATTERN_NAMESPACE . $pattern['name'];
 					$block_types    = $this->utils->maybe_get_pattern_block_types_from_pattern_meta( $pattern );
+
+					// Add the category 'All' to all patterns.
+					$pattern['categories'][ $category_all['slug'] ] = $category_all;
 
 					$results[ $pattern_name ] = register_block_pattern(
 						$pattern_name,

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -91,8 +91,8 @@ class Block_Patterns_From_API {
 			// The category 'All' is created dinamically so all patterns are always added automatically.
 			$category_all = array(
 				'slug'        => 'all',
-				'label'       => 'All',
-				'description' => '',
+				'label'       => __( 'All', 'full-site-editing' ),
+				'description' => __( 'Explore all patterns.', 'full-site-editing' ),
 			);
 			// Add the category 'All' to $pattern_categories so its orderer and registered with the others.
 			$pattern_categories[ $category_all['slug'] ] = array(

--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -68,7 +68,7 @@ class Block_Patterns_From_API {
 
 		// The category 'All' is created dynamically so all patterns are always added automatically.
 		$category_all = array(
-			'slug'        => 'all',
+			'slug'        => 'featured',
 			'label'       => __( 'All', 'full-site-editing' ),
 			'description' => __( 'Explore all patterns.', 'full-site-editing' ),
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76451

## Proposed Changes

* Add the category `All` to view all patterns in the editor (from the ETK plugin)
* Use the description `Explore all patterns.`
* Translate the label and description.

### Editor's Pattern Inserter

|BEFORE|AFTER|
|---|---|
|<img width="710" alt="Screenshot 2566-05-04 at 14 31 44" src="https://user-images.githubusercontent.com/1881481/236139924-6f718346-42d2-4181-9bb6-00d9bc541469.png">|<img width="788" alt="Screenshot 2566-05-04 at 16 40 37" src="https://user-images.githubusercontent.com/1881481/236169092-49b2d354-4930-48a3-a024-34613b6b9006.png">|

### Editor's Pattern Explorer 

|BEFORE|AFTER|
|---|---|
|<img width="1728" alt="Screenshot 2566-05-04 at 14 45 10" src="https://user-images.githubusercontent.com/1881481/236141857-41062530-f1f0-4768-bee5-92df969e2cab.png">|<img width="1728" alt="Screenshot 2566-05-04 at 14 44 26" src="https://user-images.githubusercontent.com/1881481/236141909-6a63e72b-25c2-4291-af28-9e14c2613554.png">|

### Notes

- We want to move it to the top of the list if possible in a follow-up PR. It seems not possible because the sorting [happens in the browser](https://github.com/WordPress/gutenberg/blob/a441edb67811444a917ccef4ae02c2fa6f9840cb/packages/block-editor/src/components/inserter/block-patterns-tab.js#L73) and I haven't found a workaround for now.  
- We add the same feature in the Assembler in the PR #76587
- The description matches the button text to `Explore all patterns` located at the bottom of the category list:
 
<img width="350" alt="Screenshot 2566-05-04 at 16 37 24" src="https://user-images.githubusercontent.com/1881481/236168277-ca59f5d6-a323-4a12-8da0-4a35afcf5bff.png">

<img width="298" alt="Screenshot 2566-05-04 at 16 04 51" src="https://user-images.githubusercontent.com/1881481/236159509-d4b694b2-6992-4262-8be9-2a8fcf3e30f5.png">

- The name `All` is consistent with the `All` category in the Dotorg Pattern directory
<img width="909" alt="Screenshot 2566-05-04 at 14 35 45" src="https://user-images.githubusercontent.com/1881481/236140434-d7ac2ac1-c7de-40f7-8f7f-2d7fe5192a7a.png">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
### Install the ETK plugin from this branch

**Test on Simple sites**

* Sandbox your site
* Run `install-plugin.sh etk feat/add-all-patterns-category-in-editor`
* Don't forget to revert the ETK after testing with `install-plugin.sh etk --revert`

**Test on Atomic sites**

* Download the ETK plugin zip from Teamcity
* Upload it to an Atomic site and activate it


### Verify the changes
On Simple sites or Atomic sites when the ETK plugin is activated:

- Verify that you see the `All` category on the editor with all patterns when you scroll the list.
- Verify this change doesn't impact the performance  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
