### PR TITLE
Try claim your Gravatar

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -263,6 +263,7 @@ export class EditGravatar extends Component {
 			>
 				<QueryConnectedApplications />
 				<div
+					className="edit-gravatar__image-container-wrapper"
 					onClick={ () => this.handleUserClick( isEditImageOnGravatar, gravatarManagementLink ) }
 				>
 					<FilePicker accept="image/*" onPick={ this.onReceiveFile }>

--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -160,12 +160,12 @@
 }
 
 .edit-gravatar.is-edit-image-on-gravatar {
-	.file-picker {
-		pointer-events: none;
+	.edit-gravatar__image-container-wrapper {
+		cursor: pointer;
 	}
 
-	> div {
-		cursor: pointer;
+	.file-picker {
+		pointer-events: none;
 	}
 }
 

--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -159,6 +159,16 @@
 	}
 }
 
+.edit-gravatar.is-edit-image-on-gravatar {
+	.file-picker {
+		pointer-events: none;
+	}
+
+	> div {
+		cursor: pointer;
+	}
+}
+
 .edit-gravatar .drop-zone {
 	border-radius: 50%;
 	width: 150px;

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -66,7 +66,7 @@ class Profile extends Component {
 
 				<SectionHeader label={ this.props.translate( 'Profile' ) } />
 				<Card className="profile__settings">
-					<EditGravatar />
+					<EditGravatar editImageOnGravatar />
 
 					<form onSubmit={ this.props.submitForm } onChange={ this.props.markChanged }>
 						<FormFieldset>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p9lV3a-5P8-p2

## Proposed Changes

A quick demo of the "Claim your Gravatar" feature:

- For users who never log in to Gravatar: They can update their profile image by the image picker (current behavior)
- For Gravatar logged-in users: They will be redirected to the https://en.gravatar.com/emails/ page to edit their profile images

https://user-images.githubusercontent.com/21308003/236176586-f24dccd5-643d-4541-bd0d-7eec93076478.mov

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
