### PR TITLE
Theme Showcase: Fix generating links that are causing HTTP 302 redirects 

### DIFF
--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -1,6 +1,10 @@
 import debugFactory from 'debug';
+import { logServerEvent } from 'calypso/lib/analytics/statsd-utils';
+import wpcom from 'calypso/lib/wp';
+import performanceMark from 'calypso/server/lib/performance-mark';
+import { THEME_FILTERS_ADD } from 'calypso/state/themes/action-types';
 import { requestTheme, setBackPath } from 'calypso/state/themes/actions';
-import { getTheme, getThemeRequestErrors } from 'calypso/state/themes/selectors';
+import { getTheme, getThemeFilters, getThemeRequestErrors } from 'calypso/state/themes/selectors';
 import ThemeSheetComponent from './main';
 import ThemeNotFoundError from './theme-not-found-error';
 
@@ -49,6 +53,38 @@ export function fetchThemeDetailsData( context, next ) {
 
 			const error = getThemeRequestErrors( context.store.getState(), themeSlug, 'wpcom' );
 			debug( `Error fetching WPCOM theme ${ themeSlug } details: `, error.message || error );
+		} )
+		.catch( next );
+}
+
+export function fetchThemeFilters( context, next ) {
+	if ( context.cachedMarkup ) {
+		debug( 'Skipping theme filter data fetch' );
+		return next();
+	}
+	performanceMark( context, 'fetchThemeFilters' );
+
+	const { store } = context;
+	const hasFilters = Object.keys( getThemeFilters( store.getState() ) ).length > 0;
+
+	logServerEvent( 'themes', {
+		name: `ssr.get_theme_filters_fetch_cache.${ hasFilters ? 'hit' : 'miss' }`,
+		type: 'counting',
+	} );
+
+	if ( hasFilters ) {
+		debug( 'found theme filters in cache' );
+		return next();
+	}
+
+	wpcom.req
+		.get( '/theme-filters', {
+			apiVersion: '1.2',
+			locale: context.lang, // Note: undefined will be omitted by the query string builder.
+		} )
+		.then( ( filters ) => {
+			store.dispatch( { type: THEME_FILTERS_ADD, filters } );
+			next();
 		} )
 		.catch( next );
 }

--- a/client/my-sites/theme/index.node.js
+++ b/client/my-sites/theme/index.node.js
@@ -1,7 +1,7 @@
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
-import { details, fetchThemeDetailsData, notFoundError } from './controller';
+import { details, fetchThemeDetailsData, fetchThemeFilters, notFoundError } from './controller';
 
 export default function ( router ) {
 	const langParam = getLanguageRouteParam();
@@ -10,6 +10,7 @@ export default function ( router ) {
 	router(
 		`/${ langParam }/theme/:slug/:section(setup|support)?/:site_id?`,
 		ssrSetupLocale,
+		fetchThemeFilters,
 		fetchThemeDetailsData,
 		details,
 		setHrefLangLinks,

--- a/client/my-sites/theme/theme-features-card.js
+++ b/client/my-sites/theme/theme-features-card.js
@@ -4,7 +4,7 @@ import { get, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
 import SectionHeader from 'calypso/components/section-header';
-import { isValidThemeFilterTerm } from 'calypso/state/themes/selectors';
+import { isAmbiguousThemeFilterTerm } from 'calypso/state/themes/selectors';
 
 const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onClick } ) => {
 	if ( isEmpty( features ) ) {
@@ -39,7 +39,7 @@ const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onCli
 export default connect( ( state, { taxonomies } ) => {
 	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 	const features = get( taxonomies, 'theme_feature', [] ).map( ( { name, slug } ) => {
-		const term = isValidThemeFilterTerm( state, slug ) ? slug : `feature:${ slug }`;
+		const term = isAmbiguousThemeFilterTerm( state, slug ) ? `feature:${ slug }` : slug;
 		return { name, slug, term };
 	} );
 	return { features };

--- a/client/my-sites/themes/validate-filters.js
+++ b/client/my-sites/themes/validate-filters.js
@@ -105,11 +105,7 @@ export function validateVertical( context, next ) {
  */
 export function sortFilterTerms( context, terms ) {
 	return terms
-		.map( ( term ) =>
-			// getThemeFilterStringFromTerm() attempts to recreate the full filter string "taxonomy:term".
-			// Thus, if the term is already the full string, we can simply return it.
-			! term.includes( ':' ) ? getThemeFilterStringFromTerm( context.store.getState(), term ) : term
-		)
+		.map( ( term ) => getThemeFilterStringFromTerm( context.store.getState(), term ) )
 		.sort()
 		.map( ( filter ) => getThemeFilterTermFromString( context.store.getState(), filter ) );
 }

--- a/client/my-sites/themes/validate-filters.js
+++ b/client/my-sites/themes/validate-filters.js
@@ -105,7 +105,11 @@ export function validateVertical( context, next ) {
  */
 export function sortFilterTerms( context, terms ) {
 	return terms
-		.map( ( term ) => getThemeFilterStringFromTerm( context.store.getState(), term ) )
+		.map( ( term ) =>
+			// getThemeFilterStringFromTerm() attempts to recreate the full filter string "taxonomy:term".
+			// Thus, if the term is already the full string, we can simply return it.
+			! term.includes( ':' ) ? getThemeFilterStringFromTerm( context.store.getState(), term ) : term
+		)
 		.sort()
 		.map( ( filter ) => getThemeFilterTermFromString( context.store.getState(), filter ) );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #75668

## Proposed Changes

This PR fixes an issue where some permalinks are returning HTTP 302 redirect status due to filter validation. See pdyEEc-st-p2#comment-703 for more context.

The issue is caused by the following logic in `client/my-sites/theme/theme-features-card.js`:
```js
const features = get( taxonomies, 'theme_feature', [] ).map( ( { name, slug } ) => {
	const term = isValidThemeFilterTerm( state, slug ) ? slug : `feature:${ slug }`;
	return { name, slug, term };
} );
```

The server-side rendered version will always return `feature:${ slug }`, since the theme filters are not properly loaded. This generates many permalinks that would be redirected because of filter validation.

To solve this issue, this PR does two things:

1. Ensure that the theme filters are properly fetched in SSR.
2. Use `isAmbiguousThemeFilterTerm` instead of `isValidThemeFilterTerm` to determine whether we need to add the `feature:` prefix.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Disable JavaScript in your browser.
* Head to any Theme Detail page. For instance, `/themes/hey`.
* Scroll down to the Features section, and ensure that the links are not prefixed with `feature:`, unless it's one of the following ambiguous filters: `feature:block-patterns`, `feature:one-column`, `feature:two-columns`, `feature:portfolio`, `feature:store`.
* Also ensure that having JavaScript enable works the same.

![Screenshot 2023-05-04 at 9 30 08 PM](https://user-images.githubusercontent.com/797888/236366584-df1cbef4-040a-4216-9af6-64eef052f68d.png)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?