### PR TITLE
Blog onboarding: Add post launch screen

### DIFF
--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -14,6 +14,7 @@ function FormattedHeader( {
 	className,
 	compactOnMobile,
 	align,
+	subHeaderAlign,
 	isSecondary,
 	hasScreenOptions,
 	children,
@@ -27,6 +28,9 @@ function FormattedHeader( {
 	} );
 
 	const headerClasses = classNames( 'formatted-header__title', { 'wp-brand-font': brandFont } );
+	const subtitleClasses = classNames( 'formatted-header__subtitle', {
+		'is-center-align': 'center' === subHeaderAlign,
+	} );
 	const tooltip = tooltipText && (
 		<InfoPopover icon="help-outline" position="right" iconSize={ 18 } showOnHover={ true }>
 			{ tooltipText }
@@ -47,7 +51,7 @@ function FormattedHeader( {
 					</h2>
 				) }
 				{ subHeaderText && (
-					<p className="formatted-header__subtitle">{ preventWidows( subHeaderText, 2 ) }</p>
+					<p className={ subtitleClasses }>{ preventWidows( subHeaderText, 2 ) }</p>
 				) }
 			</div>
 			{ children }
@@ -65,6 +69,7 @@ FormattedHeader.propTypes = {
 	compactOnMobile: PropTypes.bool,
 	isSecondary: PropTypes.bool,
 	align: PropTypes.oneOf( [ 'center', 'left', 'right' ] ),
+	subHeaderAlign: PropTypes.oneOf( [ 'center', null ] ),
 	hasScreenOptions: PropTypes.bool,
 	children: PropTypes.node,
 };
@@ -78,6 +83,7 @@ FormattedHeader.defaultProps = {
 	compactOnMobile: false,
 	isSecondary: false,
 	align: 'center',
+	subHeaderAlign: null,
 };
 
 export default FormattedHeader;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -84,6 +84,7 @@ button {
 .free,
 .with-theme-assembler,
 .setup-blog,
+.start-writing-done,
 .update-design {
 	padding: 60px 0 0;
 	box-sizing: border-box;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -17,7 +17,7 @@ import type { OnboardSelect, DomainSuggestion } from '@automattic/data-stores';
 import './style.scss';
 
 const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
-	const { setHideFreePlan, setDomainCartItem } = useDispatch( ONBOARD_STORE );
+	const { setHideFreePlan, setDomainCartItem, setDomain } = useDispatch( ONBOARD_STORE );
 	const { goNext, goBack, submit } = navigation;
 	const { __ } = useI18n();
 	const isVideoPressFlow = 'videopress' === flow;
@@ -30,7 +30,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		} ),
 		[]
 	);
-	const { setDomain } = useDispatch( ONBOARD_STORE );
+
 	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -53,6 +53,8 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 	};
 
 	const submitWithDomain = async ( suggestion: DomainSuggestion | undefined ) => {
+		setDomain( suggestion );
+
 		if ( suggestion?.is_free ) {
 			setHideFreePlan( false );
 			setDomainCartItem( undefined );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/index.tsx
@@ -2,6 +2,7 @@ import { Button, ConfettiAnimation } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import StartWritingDoneSitePreview from './site-preview';
@@ -12,6 +13,8 @@ import './styles.scss';
 const StartWritingDone: Step = () => {
 	const translate = useTranslate();
 	const siteSlug = useSiteSlugParam();
+	const site = useSite();
+
 	return (
 		<StepContainer
 			stepName="start-writing-done"
@@ -32,7 +35,7 @@ const StartWritingDone: Step = () => {
 					<ConfettiAnimation />
 					<div className="start-writing-done__top-content">
 						<div className="start-writing-done__top-content-main">
-							<div className="start-writing-done__top-content-title">Notes by Livro</div>
+							<div className="start-writing-done__top-content-title">{ site?.name }</div>
 							<div className="start-writing-done__top-content-description">{ siteSlug }</div>
 						</div>
 						<div className="start-writing-done__top-content-cta">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/index.tsx
@@ -1,9 +1,12 @@
 import { Button, ConfettiAnimation } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
+import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
+import { OnboardSelect } from 'calypso/../packages/data-stores/src';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import StartWritingDoneSitePreview from './site-preview';
 import type { Step } from '../../types';
@@ -14,6 +17,11 @@ const StartWritingDone: Step = () => {
 	const translate = useTranslate();
 	const siteSlug = useSiteSlugParam();
 	const site = useSite();
+
+	const selectedDomain = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),
+		[]
+	);
 
 	if ( ! site ) {
 		return null;
@@ -40,7 +48,9 @@ const StartWritingDone: Step = () => {
 					<div className="start-writing-done__top-content">
 						<div className="start-writing-done__top-content-main">
 							<div className="start-writing-done__top-content-title">{ site?.name }</div>
-							<div className="start-writing-done__top-content-description">{ siteSlug }</div>
+							<div className="start-writing-done__top-content-description">
+								{ selectedDomain?.domain_name }
+							</div>
 						</div>
 						<div className="start-writing-done__top-content-cta">
 							<Button

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/index.tsx
@@ -15,6 +15,10 @@ const StartWritingDone: Step = () => {
 	const siteSlug = useSiteSlugParam();
 	const site = useSite();
 
+	if ( ! site ) {
+		return null;
+	}
+
 	return (
 		<StepContainer
 			stepName="start-writing-done"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/index.tsx
@@ -1,0 +1,63 @@
+import { Button, ConfettiAnimation } from '@automattic/components';
+import { StepContainer } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import StartWritingDoneSitePreview from './site-preview';
+import type { Step } from '../../types';
+
+import './styles.scss';
+
+const StartWritingDone: Step = () => {
+	const translate = useTranslate();
+	const siteSlug = useSiteSlugParam();
+	return (
+		<StepContainer
+			stepName="start-writing-done"
+			isWideLayout={ true }
+			hideBack={ true }
+			flowName="free"
+			formattedHeader={
+				<FormattedHeader
+					id="start-writing-done-header"
+					headerText={ translate( 'Your blog’s ready!' ) }
+					subHeaderText={ translate( 'Now it’s time to connect your social accounts.' ) }
+					align="center"
+					subHeaderAlign="center"
+				/>
+			}
+			stepContent={
+				<>
+					<ConfettiAnimation />
+					<div className="start-writing-done__top-content">
+						<div className="start-writing-done__top-content-main">
+							<div className="start-writing-done__top-content-title">Notes by Livro</div>
+							<div className="start-writing-done__top-content-description">{ siteSlug }</div>
+						</div>
+						<div className="start-writing-done__top-content-cta">
+							<Button className="start-writing-done__top-content-cta-social" primary>
+								{ translate( 'Connect to social' ) }
+							</Button>
+							<Button
+								className="start-writing-done__top-content-cta-blog"
+								href={ `https://${ siteSlug }` }
+							>
+								{ translate( 'Visit your blog' ) }
+							</Button>
+						</div>
+					</div>
+					<StartWritingDoneSitePreview siteSlug={ siteSlug } />
+					<footer className="start-writing-done__footer">
+						<a className="start-writing-done__footer-link" href={ `/home/${ siteSlug }` }>
+							Go to dashboard
+						</a>
+					</footer>
+				</>
+			}
+			recordTracksEvent={ recordTracksEvent }
+		/>
+	);
+};
+
+export default StartWritingDone;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/index.tsx
@@ -39,7 +39,11 @@ const StartWritingDone: Step = () => {
 							<div className="start-writing-done__top-content-description">{ siteSlug }</div>
 						</div>
 						<div className="start-writing-done__top-content-cta">
-							<Button className="start-writing-done__top-content-cta-social" primary>
+							<Button
+								className="start-writing-done__top-content-cta-social"
+								primary
+								href={ `/marketing/connections/${ siteSlug }` }
+							>
 								{ translate( 'Connect to social' ) }
 							</Button>
 							<Button

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/site-preview.tsx
@@ -1,0 +1,69 @@
+import { DEVICE_TYPES } from '@automattic/components';
+import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import WebPreview from 'calypso/components/web-preview/component';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { useSitePreviewShareCode } from 'calypso/landing/stepper/hooks/use-site-preview-share-code';
+import { usePremiumGlobalStyles } from 'calypso/state/sites/hooks/use-premium-global-styles';
+import PreviewToolbar from '../design-setup/preview-toolbar';
+import type { Device } from '@automattic/components';
+
+const StartWritingDoneSitePreview = ( { siteSlug }: { siteSlug: string | null } ) => {
+	const translate = useTranslate();
+	const site = useSite();
+	const { globalStylesInUse } = usePremiumGlobalStyles( site?.ID );
+
+	const previewUrl = siteSlug ? 'https://' + siteSlug : null;
+	const devicesToShow: Device[] = [ DEVICE_TYPES.COMPUTER, DEVICE_TYPES.PHONE ];
+	const loadingMessage = translate( '{{strong}}One moment, please…{{/strong}} loading your site.', {
+		components: { strong: <strong /> },
+	} );
+
+	const { shareCode, isPreviewLinksLoading, isCreatingSitePreviewLinks } =
+		useSitePreviewShareCode();
+
+	function formatPreviewUrl() {
+		if ( ! previewUrl || isPreviewLinksLoading || isCreatingSitePreviewLinks ) {
+			return null;
+		}
+
+		return addQueryArgs( previewUrl, {
+			...( shareCode && { share: shareCode } ),
+			iframe: true,
+			theme_preview: true,
+			// hide the "Create your website with WordPress.com" banner
+			hide_banners: true,
+			// hide cookies popup
+			preview: true,
+			do_preview_no_interactions: false,
+			...( globalStylesInUse && { 'preview-global-styles': true } ),
+		} );
+	}
+
+	return (
+		<div className="launchpad__site-preview-wrapper">
+			<WebPreview
+				className="launchpad__-web-preview"
+				disableTabbing
+				showDeviceSwitcher={ false }
+				showPreview
+				showSEO={ true }
+				isContentOnly
+				externalUrl={ siteSlug }
+				previewUrl={ formatPreviewUrl() }
+				toolbarComponent={ PreviewToolbar }
+				showClose={ false }
+				showEdit={ false }
+				showExternal={ false }
+				loadingMessage={ loadingMessage }
+				translate={ translate }
+				defaultViewportDevice={ DEVICE_TYPES.COMPUTER }
+				devicesToShow={ devicesToShow }
+				showSiteAddressBar={ false }
+				enableEditOverlay={ false }
+			/>
+		</div>
+	);
+};
+
+export default StartWritingDoneSitePreview;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/styles.scss
@@ -11,11 +11,11 @@
 		.web-preview__inner {
 			width: 100%;
 			height: 680px;
-			@include break-xlarge {
-				width: 60%;
+
+			@include break-small {
+				width: 90%;
 				max-width: 1080px;
 				margin: 0 auto;
-
 			}
 		}
 	}
@@ -25,12 +25,12 @@
 		flex-direction: column;
 		margin: 0 16px;
 
-		@include break-xlarge {
+		@include break-small {
 			margin: 0 auto;
 			flex-direction: row;
 			align-items: center;
 			justify-content: space-between;
-			width: calc(60% - 64px);
+			width: calc(90% - 64px);
 			max-width: calc(1080px - 64px);
 			margin-bottom: 16px;
 		}
@@ -50,7 +50,7 @@
 			flex-direction: column;
 			margin-top: 24px;
 
-			@include break-xlarge {
+			@include break-small {
 				flex-direction: row-reverse;
 				margin-top: 0;
 			}
@@ -62,7 +62,7 @@
 		}
 
 		&-cta-social {
-			@include break-xlarge {
+			@include break-small {
 				margin-left: 16px;
 			}
 		}
@@ -70,7 +70,7 @@
 		&-cta-blog {
 			margin-top: 16px;
 			margin-bottom: 80px;
-			@include break-xlarge {
+			@include break-small {
 				margin: 0;
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/styles.scss
@@ -1,0 +1,88 @@
+@import "../style";
+
+.start-writing-done {
+	.step-container {
+		background: #fdfdfd;
+		padding: 0;
+		margin: 0;
+		max-width: none;
+		min-height: 100vh;
+
+		.web-preview__inner {
+			width: 100%;
+			height: 680px;
+			@include break-xlarge {
+				width: 60%;
+				max-width: 1080px;
+				margin: 0 auto;
+
+			}
+		}
+	}
+
+	&__top-content {
+		display: flex;
+		flex-direction: column;
+		margin: 0 16px;
+
+		@include break-xlarge {
+			margin: 0 auto;
+			flex-direction: row;
+			align-items: center;
+			justify-content: space-between;
+			width: calc(60% - 64px);
+			max-width: calc(1080px - 64px);
+			margin-bottom: 16px;
+		}
+
+		&-main {
+			display: flex;
+			flex-direction: column;
+		}
+
+		&-title {
+			font-weight: 500;
+			font-family: Inter, $sans;
+		}
+
+		&-cta {
+			display: flex;
+			flex-direction: column;
+			margin-top: 24px;
+
+			@include break-xlarge {
+				flex-direction: row-reverse;
+				margin-top: 0;
+			}
+
+			button {
+				border-radius: 4px;
+				font-weight: 500;
+			}
+		}
+
+		&-cta-social {
+			@include break-xlarge {
+				margin-left: 16px;
+			}
+		}
+
+		&-cta-blog {
+			margin-top: 16px;
+			margin-bottom: 80px;
+			@include break-xlarge {
+				margin: 0;
+			}
+		}
+	}
+
+	&__footer {
+		text-align: center;
+
+		a.start-writing-done__footer-link {
+			color: #101517;
+			text-decoration: underline;
+			font-weight: 500;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/start-writing-done/styles.scss
@@ -55,7 +55,7 @@
 				margin-top: 0;
 			}
 
-			button {
+			.button {
 				border-radius: 4px;
 				font-weight: 500;
 			}

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -2,7 +2,6 @@ import { OnboardSelect } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { START_WRITING_FLOW, addPlanToCart, addProductsToCart } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
-import { addQueryArgs } from '@wordpress/url';
 import { useSelector } from 'react-redux';
 import { updateLaunchpadSettings } from 'calypso/data/sites/use-launchpad';
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
@@ -43,6 +42,10 @@ const startWriting: Flow = {
 				slug: 'launchpad',
 				asyncComponent: () => import( './internals/steps-repository/launchpad' ),
 			},
+			{
+				slug: 'start-writing-done',
+				asyncComponent: () => import( './internals/steps-repository/start-writing-done' ),
+			},
 		];
 	},
 
@@ -59,10 +62,7 @@ const startWriting: Flow = {
 
 		async function submit( providedDependencies: ProvidedDependencies = {} ) {
 			recordSubmitStep( providedDependencies, '', flowName, currentStep );
-			const returnUrl = addQueryArgs( `/home/${ siteSlug }`, {
-				celebrateLaunch: true,
-				launchpadComplete: true,
-			} );
+			const returnUrl = `/setup/start-writing/start-writing-done?siteSlug=${ siteSlug }`;
 
 			switch ( currentStep ) {
 				case 'site-creation-step':

--- a/packages/onboarding/src/step-container/style.scss
+++ b/packages/onboarding/src/step-container/style.scss
@@ -103,6 +103,10 @@
 				margin-top: 16px;
 				line-height: 24px;
 
+				&.is-center-align {
+					text-align: center;
+				}
+
 				@include break-small {
 					margin-top: 8px;
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes 2253-gh-Automattic/dotcom-forge

## Proposed Changes

* Add post launch screen by utilizing the stepper framework
* Showing the selected domain when the user doesn't skip domain selection

**Important**: We still have one extra confetti effect, because of this issue (2367-gh-Automattic/dotcom-forge) that we'll handle as a follow-up.

## Testing Instructions

https://user-images.githubusercontent.com/6586048/236181041-7d946bdf-ffe4-4271-98aa-81816f70f823.mp4


![mobile](https://user-images.githubusercontent.com/6586048/236181785-b4e97bd4-d993-4865-a9ec-8cf25e21cad8.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Suggest creating an account and go through the whole flow `/setup/start-writing` (one without any items to checkout, and one with free plan)
* The page to directly go to post launch screen: `/setup/start-writing/start-writing-done?siteSlug=:siteSlug`
* Please test around the flow and see if it breaks

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?