### PR TITLE
Subscriptions Management: Hide the right header menu items for logged-in users

### DIFF
--- a/client/landing/subscriptions/components/subscription-manager-page/subscription-manager-page.tsx
+++ b/client/landing/subscriptions/components/subscription-manager-page/subscription-manager-page.tsx
@@ -1,4 +1,6 @@
+import { SubscriptionManager } from '@automattic/data-stores';
 import { UniversalNavbarHeader } from '@automattic/wpcom-template-parts';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -9,12 +11,16 @@ import './styles.scss';
 
 const SubscriptionManagementPage = () => {
 	const translate = useTranslate();
+	const { isLoggedIn } = SubscriptionManager.useIsLoggedIn();
+
 	return (
 		<>
 			<UniversalNavbarHeader
-				className="subscription-manager-header"
+				className={ classNames( 'subscription-manager-header', {
+					'is-logged-in': isLoggedIn,
+				} ) }
 				variant="minimal"
-				isLoggedIn={ false }
+				isLoggedIn={ isLoggedIn }
 			/>
 			<Main className="subscription-manager__container">
 				<DocumentHead title="Subscriptions" />

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -833,6 +833,16 @@ $x-menu-heading-line-height-wide: $x-menu-heading-font-size-wide + 7px; /* 1 */
 			}
 		}
 	}
+
+	&.is-logged-in {
+		.masterbar-menu {
+			.masterbar {
+				.x-nav-list__right {
+					display: none;
+				}
+			}
+		}
+	}
 }
 
 /* End subscriptions section overrides */


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/76399.

## Proposed Changes

* hide the right header menu items (`Log In` and `Get Started`) for logged-in users

| Logged-in user | External user |
|--------|--------|
| ![Markup on 2023-05-04 at 12:41:12](https://user-images.githubusercontent.com/25105483/236182045-9885d9c6-02bc-4ed3-beed-ef24ba4f7fde.png) | ![Markup on 2023-05-04 at 12:42:00](https://user-images.githubusercontent.com/25105483/236182037-ab4b974d-53bb-4cf2-b0a3-cd45abc715c5.png) | 

## Testing Instructions

1. Check out the PR.
2. Navigate to `client/server/pages/index.js` and temporarily add `return next();` to the line `833`:

![Markup on 2023-04-28 at 17:50:44](https://user-images.githubusercontent.com/25105483/235195033-4902bb9d-db57-43a4-b295-2d90feb6731f.png)

3. Build the app.
4. Log in to a test WordPress.com account.
5. Navigate to http://calypso.localhost:3000/subscriptions/sites (or any other "subpage" like `/comments` or `/settings`).
6. The `Log In` and `Get Started` buttons in the header menu **should not be** visible.
7. Remove the temporary change that was introduced in the Step 2 and navigate to http://calypso.localhost:3000/subscriptions/sites as an **external** user (it is required to do the `subkey` dance 💃🏼🕺🏼 ).
8. The `Log In` and `Get Started` buttons in the header menu **should be** visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
