### PR TITLE
Staging Sites: Allow installing free plugins on staging sites

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -69,6 +69,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, selectedSite?.ID ) );
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
 	const isWpcomStaging = useSelector( ( state ) => isSiteWpcomStaging( state, selectedSite?.ID ) );
+	const isDisabledForWpcomStaging = isWpcomStaging && isMarketplaceProduct;
 	const pluginFeature = isMarketplaceProduct
 		? WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS
 		: FEATURE_INSTALL_PLUGINS;
@@ -326,7 +327,7 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 						isWpcomStaging={ isWpcomStaging }
 					/>
 				</div>
-				{ isWpcomStaging && <StagingSiteNotice plugin={ plugin } /> }
+				{ isDisabledForWpcomStaging && <StagingSiteNotice plugin={ plugin } /> }
 				{ ! isJetpackSelfHosted && ! isMarketplaceProduct && (
 					<div className="plugin-details-cta__t-and-c">
 						{ translate(
@@ -387,6 +388,11 @@ function PrimaryButton( {
 	const dispatch = useDispatch();
 	const sectionName = useSelector( getSectionName );
 
+	const isMarketplaceProduct = useSelector( ( state ) =>
+		isMarketplaceProductSelector( state, plugin.slug )
+	);
+	const isDisabledForWpcomStaging = isWpcomStaging && isMarketplaceProduct;
+
 	const onClick = useCallback( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_plugin_details_get_started_click', {
@@ -434,7 +440,7 @@ function PrimaryButton( {
 		<CTAButton
 			plugin={ plugin }
 			hasEligibilityMessages={ hasEligibilityMessages }
-			disabled={ incompatiblePlugin || userCantManageTheSite || isWpcomStaging }
+			disabled={ incompatiblePlugin || userCantManageTheSite || isDisabledForWpcomStaging }
 		/>
 	);
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2349

## Proposed Changes

Restores the ability to install free plugins on staging sites:

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/36432/236194639-2d440705-a5a5-47ca-b788-4aaf2f1ad886.png">

Marketplace plugins still show the notice:

<img width="1181" alt="image" src="https://user-images.githubusercontent.com/36432/236194704-e5353ef2-697a-4042-a81c-cef4a85e4619.png">

## Testing Instructions

1. Create a new Business site and take it Atomic.
2. Navigate to Hosting Configuration and create a staging site.
3. Navigate to the staging site and click the Plugins side nav.
4. Navigate to a free plugin and verify it can be installed.
5. Navigate to a paid plugin and verify the banner still appears.

