### PR TITLE
Site Assembler - Add a category to explore All patterns 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -2,6 +2,8 @@ export const PATTERN_SOURCE_SITE_ID = 174455321; // dotcompatterns
 export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
 export const SITE_TAGLINE = 'Site Tagline';
 export const PATTERN_TYPES = [ 'header', 'footer', 'section' ];
+// Workaround to put the category All in the first position using featured as slug
+export const CATEGORY_ALL_SLUG = 'featured';
 
 export const NAVIGATOR_PATHS = {
 	MAIN: '/',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-category-all.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-category-all.ts
@@ -1,0 +1,27 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { shuffle } from '@automattic/js-utils';
+import { useMemo } from 'react';
+import type { Pattern } from '../types';
+
+const useCategoryAll = ( dotcomPatterns: Pattern[] ) => {
+	// Add all patterns to the category All
+	return useMemo( () => {
+		if ( ! dotcomPatterns.length || ! isEnabled( 'pattern-assembler/all-patterns-category' ) ) {
+			return dotcomPatterns;
+		}
+		// Shuffle patterns for better stats of popular patterns
+		return shuffle(
+			dotcomPatterns.map( ( pattern ) => ( {
+				...pattern,
+				categories: {
+					...pattern.categories,
+					all: {
+						slug: 'all',
+					},
+				},
+			} ) )
+		);
+	}, [ dotcomPatterns ] );
+};
+
+export default useCategoryAll;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-category-all.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-category-all.ts
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { shuffle } from '@automattic/js-utils';
 import { useMemo } from 'react';
+import { CATEGORY_ALL_SLUG } from '../constants';
 import type { Pattern } from '../types';
 
 const useCategoryAll = ( dotcomPatterns: Pattern[] ) => {
@@ -16,7 +17,7 @@ const useCategoryAll = ( dotcomPatterns: Pattern[] ) => {
 				categories: {
 					...pattern.categories,
 					all: {
-						slug: 'all',
+						slug: CATEGORY_ALL_SLUG,
 					},
 				},
 			} ) )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-category-all.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-category-all.ts
@@ -16,7 +16,7 @@ const useCategoryAll = ( dotcomPatterns: Pattern[] ) => {
 				...pattern,
 				categories: {
 					...pattern.categories,
-					all: {
+					[ CATEGORY_ALL_SLUG ]: {
 						slug: CATEGORY_ALL_SLUG,
 					},
 				},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -315,7 +315,7 @@ const PatternAssembler = ( {
 		selectedCategory?: string | null
 	) => {
 		if ( selectedPattern ) {
-			// Inject the selected pattern category or the first category
+			// Inject the selected pattern category (except for 'all') or the first category
 			// because it's used in tracks and as pattern name in the list
 			const [ firstCategory ] = Object.keys( selectedPattern.categories );
 			selectedPattern.category = categories.find(
@@ -330,6 +330,10 @@ const PatternAssembler = ( {
 			} );
 
 			if ( 'section' === type ) {
+				if ( 'all' === selectedCategory ) {
+					// The category All is used for tracks events only
+					selectedPattern.category = categories.find( ( { name } ) => name === firstCategory );
+				}
 				if ( sectionPosition !== null ) {
 					replaceSection( selectedPattern );
 				} else {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -315,12 +315,24 @@ const PatternAssembler = ( {
 		selectedCategory?: string | null
 	) => {
 		if ( selectedPattern ) {
-			// Inject the selected pattern category (except for the category All)
-			// or the first category because it's used in tracks and as pattern name in the list
+			// Inject the selected pattern category or the first category
+			// to be used in tracks and as selected pattern name.
 			const [ firstCategory ] = Object.keys( selectedPattern.categories );
-			selectedPattern.category = categories.find(
-				( { name } ) => name === ( selectedCategory || firstCategory )
-			);
+			selectedPattern.category = categories.find( ( { name } ) => {
+				if ( selectedCategory === CATEGORY_ALL_SLUG ) {
+					return name === firstCategory;
+				}
+				return name === ( selectedCategory || firstCategory );
+			} );
+
+			if ( selectedCategory === CATEGORY_ALL_SLUG ) {
+				// Use 'all' rather than 'featured' as slug for tracks.
+				// Use the first category label as selected pattern name.
+				selectedPattern.category = {
+					name: 'all',
+					label: selectedPattern.category?.label,
+				};
+			}
 
 			trackEventPatternSelect( {
 				patternType: type,
@@ -330,10 +342,6 @@ const PatternAssembler = ( {
 			} );
 
 			if ( 'section' === type ) {
-				if ( CATEGORY_ALL_SLUG === selectedCategory ) {
-					// The category All is used for tracks events only
-					selectedPattern.category = categories.find( ( { name } ) => name === firstCategory );
-				}
 				if ( sectionPosition !== null ) {
 					replaceSection( selectedPattern );
 				} else {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -20,7 +20,7 @@ import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { SITE_STORE, ONBOARD_STORE } from '../../../../stores';
 import { recordSelectedDesign } from '../../analytics/record-design';
-import { SITE_TAGLINE, PATTERN_TYPES, NAVIGATOR_PATHS } from './constants';
+import { SITE_TAGLINE, PATTERN_TYPES, NAVIGATOR_PATHS, CATEGORY_ALL_SLUG } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import useGlobalStylesUpgradeModal from './hooks/use-global-styles-upgrade-modal';
 import usePatternCategories from './hooks/use-pattern-categories';
@@ -315,8 +315,8 @@ const PatternAssembler = ( {
 		selectedCategory?: string | null
 	) => {
 		if ( selectedPattern ) {
-			// Inject the selected pattern category (except for 'all') or the first category
-			// because it's used in tracks and as pattern name in the list
+			// Inject the selected pattern category (except for the category All)
+			// or the first category because it's used in tracks and as pattern name in the list
 			const [ firstCategory ] = Object.keys( selectedPattern.categories );
 			selectedPattern.category = categories.find(
 				( { name } ) => name === ( selectedCategory || firstCategory )
@@ -330,7 +330,7 @@ const PatternAssembler = ( {
 			} );
 
 			if ( 'section' === type ) {
-				if ( 'all' === selectedCategory ) {
+				if ( CATEGORY_ALL_SLUG === selectedCategory ) {
 					// The category All is used for tracks events only
 					selectedPattern.category = categories.find( ( { name } ) => name === firstCategory );
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/patterns-data.ts
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useMemo } from 'react';
+import useCategoryAll from './hooks/use-category-all';
 import useDotcomPatterns from './hooks/use-dotcom-patterns';
 import type { Pattern } from './types';
 
@@ -589,9 +590,10 @@ const useAllPatterns = ( lang: string | undefined ) => {
 	const sectionPatterns = useSectionPatterns();
 	const footerPatterns = useFooterPatterns( [] );
 	const dotcomPatterns = useDotcomPatterns( lang );
+	const patterns = useCategoryAll( dotcomPatterns );
 
 	if ( isEnabled( 'pattern-assembler/dotcompatterns' ) ) {
-		return dotcomPatterns;
+		return patterns;
 	}
 
 	return [ ...headerPatterns, ...sectionPatterns, ...footerPatterns ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-category-list.tsx
@@ -13,6 +13,7 @@ import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import useCategoriesOrder from './hooks/use-categories-order';
 import NavigatorHeader from './navigator-header';
 import PatternListPanel from './pattern-list-panel';
+import { replaceCategoryAllName } from './utils';
 import type { Pattern, Category } from './types';
 import './screen-category-list.scss';
 
@@ -63,7 +64,7 @@ const ScreenCategoryList = ( {
 
 	const trackEventCategoryClick = ( name: string ) => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_CATEGORY_LIST_CATEGORY_CLICK, {
-			pattern_category: name,
+			pattern_category: replaceCategoryAllName( name ),
 		} );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -21,4 +21,5 @@ export const getVariationType = (
 		? GlobalStylesVariationType.Premium
 		: GlobalStylesVariationType.Free;
 
-export const getCategoryName = ( name?: string ) => ( name === CATEGORY_ALL_SLUG ? 'all' : name );
+export const replaceCategoryAllName = ( name?: string ) =>
+	name === CATEGORY_ALL_SLUG ? 'all' : name;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -2,7 +2,7 @@ import {
 	DEFAULT_GLOBAL_STYLES_VARIATION_TITLE,
 	GlobalStylesVariationType,
 } from '@automattic/global-styles';
-import { PATTERN_SOURCE_SITE_ID } from './constants';
+import { PATTERN_SOURCE_SITE_ID, CATEGORY_ALL_SLUG } from './constants';
 import type { GlobalStylesObject } from '@automattic/global-styles';
 
 export const encodePatternId = ( patternId: number ) =>
@@ -20,3 +20,5 @@ export const getVariationType = (
 	variation && variation.title !== DEFAULT_GLOBAL_STYLES_VARIATION_TITLE
 		? GlobalStylesVariationType.Premium
 		: GlobalStylesVariationType.Free;
+
+export const getCategoryName = ( name?: string ) => ( name === CATEGORY_ALL_SLUG ? 'all' : name );

--- a/config/development.json
+++ b/config/development.json
@@ -132,6 +132,7 @@
 		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"pattern-assembler/all-patterns-category": true,
 		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/dotcompatterns": true,
 		"pattern-assembler/logged-out-showcase": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -84,6 +84,7 @@
 		"onboarding/import-light-url-screen": true,
 		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/all-patterns-category": true,
 		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/dotcompatterns": true,
 		"pattern-assembler/logged-out-showcase": true,

--- a/config/production.json
+++ b/config/production.json
@@ -99,6 +99,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/all-patterns-category": false,
 		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/dotcompatterns": true,
 		"pattern-assembler/logged-out-showcase": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -97,6 +97,7 @@
 		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"pattern-assembler/all-patterns-category": false,
 		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/dotcompatterns": true,
 		"pattern-assembler/logged-out-showcase": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -107,6 +107,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/2023-pricing-grid": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/all-patterns-category": true,
 		"pattern-assembler/color-and-fonts": true,
 		"pattern-assembler/dotcompatterns": true,
 		"pattern-assembler/logged-out-showcase": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #76451 #76580

## Proposed Changes


https://user-images.githubusercontent.com/1881481/236999478-dd421c9a-2df9-4aa0-809b-c7e7abb5822f.mov



* Add a category at the top of the list to explore `All` patterns in one list
* Shuffle the patterns in the category `All` to get better stats of popular patterns
* Use the feature flag `pattern-assembler/all-patterns-category` (enabled on calypso, horizon and dev envs)
* Use a real pattern category (the first in the `pattern.categories`) instead of the category `All` as the pattern name on the list of selected patterns
* All Tracks events work as usual, we use the category slug `all` for patterns selected from the `All` category 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**This PR depends on #76580 because the category `All` is registered from the ETK plugin.**

- Follow the testing instructions on #76580 to install the ETK plugin
- Create a new site with any plan
- Continue until the Design Picker
- Scroll down and click `Start designing`
- Click `Sections` > `Add patterns` > `All`
- Scroll the list to verify that all patterns are there
- Verify that this change doesn't impact the performance
- Add patterns from the `All` category and verify that on the list of selected patterns the name used is not `All` but a real pattern category
- Verify that `all` appears in the Tracks event properties `pattern_category` and `pattern_categories`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
